### PR TITLE
feat: codeArbiter v2 — full framework + Claude Code hook enforcement

### DIFF
--- a/.agents/hooks/post-write-edit.sh
+++ b/.agents/hooks/post-write-edit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+which jq > /dev/null 2>&1 || exit 0
+INPUT=$(cat)
+FPATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // ""')
+
+# H-06: projectContext file modified — remind doc-governance
+if echo "$FPATH" | grep -qE '\.agents/projectContext/'; then
+  echo "REMINDER [H-06]: projectContext file modified. Run doc-governance Phase 2 (freshness check) and Phase 3 (conflict detection) before committing." >&2
+fi
+
+# H-07: dependency file changed — remind dependency-reviewer
+if echo "$FPATH" | grep -qE '(package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$'; then
+  echo "REMINDER [H-07]: Dependency file changed. Invoke dependency-reviewer agent before committing (AGENTS.md §5)." >&2
+fi
+
+# H-09: crypto pattern detected
+# Default conservative list; refine once .agents/projectContext/security-controls.md is populated
+if echo "$CONTENT" | grep -qiE '(createHash|createCipher|createHmac|\bmd5\b|\bsha1\b|\brc4\b|\bdes\b|3des|\bRSA\b|\bTLS\b|\.ssl\b|x509|bcrypt|crypto\.)'; then
+  echo "REMINDER [H-09]: Cryptographic pattern detected. Invoke crypto-compliance skill and auth-crypto-reviewer agent (AGENTS.md §5). Verify against .agents/projectContext/security-controls.md." >&2
+fi
+
+# H-10: possible hardcoded secret
+if echo "$CONTENT" | grep -qiE '\b(password|secret|token|api_key|apikey|private_key|passphrase|credential)\s*=\s*["'"'"'][^"'"'"']{4,}'; then
+  echo "REMINDER [H-10]: Possible hardcoded secret detected. Invoke secret-handling skill (secret-handling/SKILL.md Phase 1-2)." >&2
+fi
+
+exit 0

--- a/.agents/hooks/pre-bash.sh
+++ b/.agents/hooks/pre-bash.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+which jq > /dev/null 2>&1 || exit 0
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# H-01: no commit directly to main/master
+if echo "$CMD" | grep -qE 'git\s+commit'; then
+  BRANCH=$(git branch --show-current 2>/dev/null)
+  if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    echo "BLOCKED [H-01]: Direct commit to $BRANCH is prohibited (AGENTS.md §3). Create a feature branch." >&2
+    exit 1
+  fi
+fi
+
+# H-02: no force-push
+if echo "$CMD" | grep -qE 'git\s+push.*(--force|-f)(\s|$)'; then
+  echo "BLOCKED [H-02]: Force-push is prohibited (AGENTS.md §3)." >&2
+  exit 1
+fi
+
+# H-03: no wildcard git staging
+if echo "$CMD" | grep -qE 'git\s+add\s+(-A|\.)(\s|$)'; then
+  echo "BLOCKED [H-03]: git add -A and git add . are prohibited. Stage files explicitly (commit-gate/SKILL.md Phase 6)." >&2
+  exit 1
+fi
+
+exit 0

--- a/.agents/hooks/pre-edit.sh
+++ b/.agents/hooks/pre-edit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+which jq > /dev/null 2>&1 || exit 0
+INPUT=$(cat)
+FPATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+# H-04: stage file is write-protected even via Edit
+# Note: Edit on overrides.log is intentionally allowed (append-mode edits are fine per AGENTS.md §7)
+if echo "$FPATH" | grep -qE '\.agents/projectContext/stage$'; then
+  echo "BLOCKED [H-04]: .agents/projectContext/stage is write-protected. Use /stage command only (stage-gating/SKILL.md)." >&2
+  exit 1
+fi
+
+exit 0

--- a/.agents/hooks/pre-write.sh
+++ b/.agents/hooks/pre-write.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+which jq > /dev/null 2>&1 || exit 0
+INPUT=$(cat)
+FPATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+# H-04: stage file is write-protected
+if echo "$FPATH" | grep -qE '\.agents/projectContext/stage$'; then
+  echo "BLOCKED [H-04]: .agents/projectContext/stage is write-protected. Use /stage command only (stage-gating/SKILL.md)." >&2
+  exit 1
+fi
+
+# H-05: overrides.log is append-only; Write = full overwrite = blocked
+if echo "$FPATH" | grep -qE 'overrides\.log$'; then
+  echo "BLOCKED [H-05]: overrides.log is append-only. Use /override to add entries (AGENTS.md §7). Use Edit to append, not Write." >&2
+  exit 1
+fi
+
+exit 0

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+CONTEXT_FILE=".agents/projectContext/CONTEXT.md"
+
+if [ ! -f "$CONTEXT_FILE" ] || ! grep -q '<!--INITIALIZED-->' "$CONTEXT_FILE" 2>/dev/null; then
+  SRC=$(find . \
+    -not -path './.agents/*' \
+    -not -name 'AGENTS.md' \
+    -not -name 'CLAUDE.md' \
+    -not -name 'README.md' \
+    -not -name '.gitignore' \
+    -type f 2>/dev/null | head -1)
+  if [ -n "$SRC" ]; then
+    echo "STARTUP [H-08]: projectContext not initialized but source code exists. Run /create-context before any other command (AGENTS.md §1 Phase 2)."
+  else
+    echo "STARTUP [H-08]: No projectContext and no source code. Run /decompose to begin (AGENTS.md §1 Phase 1)."
+  fi
+fi
+
+exit 0

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "bash .agents/hooks/pre-bash.sh" }]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [{ "type": "command", "command": "bash .agents/hooks/pre-write.sh" }]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [{ "type": "command", "command": "bash .agents/hooks/pre-edit.sh" }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [{ "type": "command", "command": "bash .agents/hooks/post-write-edit.sh" }]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [{ "type": "command", "command": "bash .agents/hooks/post-write-edit.sh" }]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [{ "type": "command", "command": "bash .agents/hooks/session-start.sh" }]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,1 @@
+../.agents/settings.json


### PR DESCRIPTION
## Summary

- Delivers the complete codeArbiter v2 system: AGENTS.md orchestration layer, 18 agent definitions, 20 command definitions, 13 skill definitions, and projectContext scaffold
- Adds Claude Code hook enforcement (`H-01` through `H-10`) derived directly from AGENTS.md §3 hard rules and §5 routing triggers
- Introduces `.agents/settings.json` as the single source of truth for Claude Code settings; `.claude/settings.json` is a symlink shim consistent with the existing `.claude/` shim pattern

## Hook enforcement added

| Hook | Type | Enforces |
|------|------|---------|
| H-01 | Hard block | No `git commit` directly to `main`/`master` (AGENTS.md §3) |
| H-02 | Hard block | No `git push --force` on any branch (AGENTS.md §3) |
| H-03 | Hard block | No `git add -A` / `git add .` — explicit staging only (commit-gate Phase 6) |
| H-04 | Hard block | `.agents/projectContext/stage` is write-protected — only `/stage` command may change it |
| H-05 | Hard block | `overrides.log` cannot be overwritten — append (Edit) only (AGENTS.md §7) |
| H-06 | Advisory | Reminds to run doc-governance after editing any `projectContext/` file |
| H-07 | Advisory | Reminds to invoke dependency-reviewer after `package.json`/lock file changes |
| H-08 | Advisory | Session-start check: prompts `/decompose` or `/create-context` if projectContext uninitialized |
| H-09 | Advisory | Warns on crypto API patterns — flags for crypto-compliance skill review |
| H-10 | Advisory | Warns on hardcoded secret patterns — flags for secret-handling skill review |

## Notes

- All hook logic lives in `.agents/hooks/`; `.claude/settings.json` is a symlink only
- `projectContext/` files are placeholder stubs — run `/create-context` after merge to initialize
- H-09 uses a conservative default crypto pattern list; refine once `security-controls.md` is populated

https://claude.ai/code/session_019kzshdLBo5rgfwstRCfPG4

---
_Generated by [Claude Code](https://claude.ai/code/session_019kzshdLBo5rgfwstRCfPG4)_