### PR TITLE
feat(ticketing): add optional scope-overflow inbox + Plane MCP integration

### DIFF
--- a/.agents/agents/INDEX.md
+++ b/.agents/agents/INDEX.md
@@ -1,0 +1,32 @@
+# Agents Index
+
+<!-- Auto-maintained surface scan. Agent bodies are read ONLY when dispatched. -->
+<!-- See AGENTS.md §3 and §6: bulk reads of `.agents/agents/*.md` are prohibited. -->
+<!-- Use this index for routing decisions; open bodies on invocation. -->
+
+## Read-on-invocation guarantee
+
+This `INDEX.md` is the only sanctioned surface scan of `.agents/agents/`. Routing decisions in AGENTS.md §4 and §5 reference agents by name; their bodies are loaded only when the named agent is dispatched.
+
+## Index
+
+| Agent | One-line role | BLOCKs on | Body |
+|---|---|---|---|
+| architecture-drift-reviewer | Surfaces drift from ADRs and documented patterns | — (read-only) | [body](architecture-drift-reviewer.md) |
+| audit-emitter | Verifies audit event emission for new auditable actions | missing emit, missing required fields | [body](audit-emitter.md) |
+| auth-crypto-reviewer | Reviews authn, crypto, secrets handling against security controls | banned primitives, exposed secrets, shell injection | [body](auth-crypto-reviewer.md) |
+| backend-author | Implements backend/API code via TDD workflow | failing tests, lint errors, missing audit emit | [body](backend-author.md) |
+| checkpoint-aggregator | Writes dated checkpoint doc from triage + challenger output | — (aggregator, not a blocker) | [body](checkpoint-aggregator.md) |
+| decision-challenger | Adversarial red-team review of ADRs (SMARTS, confidence 1–5) | — (surfaces, does not block) | [body](decision-challenger.md) |
+| dependency-reviewer | Reviews package.json / lockfile / base image changes | denied license, supply-chain concerns | [body](dependency-reviewer.md) |
+| finding-triage | Assigns stage promotion impact to checkpoint findings | — (sequential post-processor) | [body](finding-triage.md) |
+| frontend-author | Implements UI code via TDD workflow | failing tests, lint errors, missing UI security checks | [body](frontend-author.md) |
+| grader | INTERNAL: SMARTS analysis for arbiter skill — never invoke directly | — | [body](grader.md) |
+| infra-author | Implements IaC, containers, CI/CD manifests, deploy config | missing threat model on zone-crossing change | [body](infra-author.md) |
+| migration-reviewer | Reviews DB migration files for safety and classification | classification annotation missing, irreversible destructive op | [body](migration-reviewer.md) |
+| scaffold-completeness-reviewer | Identifies planned-but-missing artifacts | — (read-only checkpoint reviewer) | [body](scaffold-completeness-reviewer.md) |
+| scout | INTERNAL: scans codebase sections for arbiter / context-creation skills — never invoke directly | — | [body](scout.md) |
+| security-reviewer | PROACTIVE diff review for security-sensitive paths | any CRITICAL or HIGH finding | [body](security-reviewer.md) |
+| standards-compliance-reviewer | Reviews against coding standards, lint, type safety | — (read-only checkpoint reviewer) | [body](standards-compliance-reviewer.md) |
+| test-audit-reviewer | Audits test coverage vs. TDD obligations | untested source files, missing audit emit tests | [body](test-audit-reviewer.md) |
+| trust-zone-reviewer | Reviews zone boundary enforcement and HTTP client usage | undeclared zone crossings | [body](trust-zone-reviewer.md) |

--- a/.agents/agents/architecture-drift-reviewer.md
+++ b/.agents/agents/architecture-drift-reviewer.md
@@ -82,3 +82,18 @@ Severity guidance:
 ### Summary
 N accepted ADRs reviewed. N confirmed. N with drift. N with insufficient evidence.
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/audit-emitter.md
+++ b/.agents/agents/audit-emitter.md
@@ -95,3 +95,18 @@ For the event type being emitted (per `projectContext/audit-spec.md`):
 ### Gate status
 PASS | BLOCK (N HIGH or CRITICAL findings)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/auth-crypto-reviewer.md
+++ b/.agents/agents/auth-crypto-reviewer.md
@@ -69,3 +69,18 @@ The following are hard blocks regardless of context. No finding at this level is
 ### Gate status
 PASS | BLOCK (N hard block findings)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/backend-author.md
+++ b/.agents/agents/backend-author.md
@@ -69,3 +69,18 @@ If the feature performs an auditable action (per `projectContext/audit-spec.md`)
 - Change touches auth, crypto, keys, middleware, audit → `security-reviewer` (before staging)
 - Change adds or modifies a DB migration file → `migration-reviewer`
 - Change emits an audit event → `audit-emitter`
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/decision-challenger.md
+++ b/.agents/agents/decision-challenger.md
@@ -112,3 +112,18 @@ The decision-challenger MUST NOT:
 - REVISIT (confidence 2–3): N
 - ESCALATE (confidence 1): N
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/dependency-reviewer.md
+++ b/.agents/agents/dependency-reviewer.md
@@ -87,3 +87,18 @@ Flag suspicious install scripts as HIGH.
 ### Gate status
 PASS (cleared for install) | BLOCK (N blocking findings — do not install)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/frontend-author.md
+++ b/.agents/agents/frontend-author.md
@@ -61,3 +61,18 @@ For every component or feature:
 
 - Change touches API calls, authentication flow, or zone-crossing code → `trust-zone-reviewer`
 - Change adds a new dependency → go through `/add-dep` before writing code that depends on it
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/infra-author.md
+++ b/.agents/agents/infra-author.md
@@ -64,3 +64,18 @@ If the task introduces a new trust zone crossing, new external endpoint, or new 
 2. Surface the requirement to the user: "This change introduces [X]. A threat model is required before implementation."
 3. After `/threat-model` produces a CLEAR TO IMPLEMENT status: proceed with implementation
 4. Reference the threat model output in the PR description
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/migration-reviewer.md
+++ b/.agents/agents/migration-reviewer.md
@@ -79,3 +79,18 @@ Flag these as MEDIUM — they are not blockers but must be addressed before prod
 ### Gate status
 PASS | BLOCK (classification annotation missing / committed migration modified / irreversible destructive op)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/scaffold-completeness-reviewer.md
+++ b/.agents/agents/scaffold-completeness-reviewer.md
@@ -78,3 +78,18 @@ Assign stage impact based on whether the artifact is required before stage promo
 ### Blocked tasks (informational)
 [list or "none"]
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -98,3 +98,18 @@ After reviewing all applicable findings, output:
 ### PR gate status
 PASS (no CRITICAL or HIGH findings) | BLOCK (N CRITICAL, N HIGH findings must be resolved)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/standards-compliance-reviewer.md
+++ b/.agents/agents/standards-compliance-reviewer.md
@@ -90,3 +90,18 @@ Per `projectContext/coding-standards.md`:
 ### Gate status
 PASS | BLOCK (N HIGH findings — banned pattern violations or lint failures)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/test-audit-reviewer.md
+++ b/.agents/agents/test-audit-reviewer.md
@@ -94,3 +94,18 @@ Current: <N>% | Threshold: <N>% | Status: PASS | BELOW THRESHOLD
 ### Gate status
 PASS | BLOCK (coverage below threshold / missing audit emit tests / missing boundary tests)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/trust-zone-reviewer.md
+++ b/.agents/agents/trust-zone-reviewer.md
@@ -84,3 +84,18 @@ For frontend code:
 ### Gate status
 PASS | BLOCK (N undeclared crossings or N undeclared egress paths)
 ```
+
+## Out-of-Scope Findings
+
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+
+- A short title (< 80 chars)
+- A body containing four sections:
+  - **Context** — what you were doing when you noticed the finding
+  - **Finding** — the observation itself
+  - **Why it's out of scope** — why you are not acting on it
+  - **Suggested handling** — optional hint for the parent (may be empty)
+
+The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+
+MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/commands/adr.md
+++ b/.agents/commands/adr.md
@@ -18,6 +18,13 @@ The title should name the decision clearly: what was decided, not what was consi
 
 ## What Happens Step by Step
 
+0. **Activate authoring marker.** Before any other step, run
+   `mkdir -p .agents/.markers && touch .agents/.markers/adr-authoring-active`.
+   The H-11 PreToolUse hook (`.agents/hooks/pre-write.sh`, `.agents/hooks/pre-edit.sh`)
+   blocks Writes and Edits to `.agents/projectContext/decisions/*.md` unless this
+   marker is present and fresh (modified within the last 30 minutes). The marker
+   is removed at Step 7 below; if /adr aborts midway the marker may persist
+   until cleaned up or ages out.
 1. `decision-lifecycle` skill opens — collects context from the user:
    - What decision needs to be made or was just made?
    - What context forced this decision?
@@ -33,6 +40,7 @@ The title should name the decision clearly: what was decided, not what was consi
 4. ADR registered in `projectContext/decisions/README.md` — index entry added
 5. ADR queued for challenge — `decision-challenger` agent is notified at next `/checkpoint`
 6. Any `[CONFIRM-NN]` placeholders left open are registered in `projectContext/open-questions.md`
+7. **Deactivate authoring marker.** Run `rm -f .agents/.markers/adr-authoring-active` to close the authoring window. Subsequent ADR file edits will be blocked by H-11 until another `/adr` invocation refreshes the marker.
 
 ## ADR File Structure
 

--- a/.agents/commands/ticket.md
+++ b/.agents/commands/ticket.md
@@ -1,0 +1,105 @@
+# /ticket
+
+## Purpose
+
+The user- and subagent-facing surface for the optional ticketing skill. Files
+out-of-scope findings, lists open tickets, and closes them with a triage
+disposition. Routes through the `ticketing` skill, which dispatches to the
+in-repo or Plane variant based on `projectContext/ticketing-config.md`.
+
+When ticketing is disabled (default), this command returns a disabled response
+and otherwise has no effect.
+
+## Subcommands
+
+```
+/ticket "title" -- "finding body"     # open a new ticket
+/ticket close <id>                    # interactive close, prompts for disposition
+/ticket show <id>                     # read a ticket body explicitly
+/ticket list                          # surface scan from INDEX (in-repo) or Plane list
+/ticket move <id> <state>             # (Plane mode only) transition issue state
+/ticket config                        # open ticketing-config.md for editing
+```
+
+## What Each Subcommand Does
+
+### `/ticket "title" -- "finding body"`
+
+Files a new ticket. The body MUST contain the four sections required by the
+variant: Context, Finding, Why it's out of scope, Suggested handling. Subagents
+invoke this via the ticketing skill rather than as a slash command; the
+command surface is primarily for user-initiated triage.
+
+### `/ticket close <id>`
+
+Interactive close. The command prompts for a disposition from the fixed set
+(see below). It does NOT file the substance into the destination doc — that is
+the caller's (parent's) responsibility BEFORE close. The close just records
+that the substance landed.
+
+**Valid dispositions:**
+
+- `incorporated-to:03-task-backlog`
+- `incorporated-to:open-tasks`
+- `incorporated-to:gap-doc`
+- `escalated-to:open-questions` (a CONFIRM-NN was appended)
+- `escalated-to:user` (raised synchronously)
+- `duplicate-of:<id>`
+- `rejected`
+- `other` (requires non-empty note)
+
+**REJECTED dispositions:**
+- `adr-opened:*`, `adr:*`, or any ADR-creation value. ADRs require user
+  attribution and are authored only via `/adr`.
+
+### `/ticket show <id>`
+
+Opens the ticket body. This is the only sanctioned way to read a ticket body —
+`/status` and `/ticket list` use the INDEX only.
+
+### `/ticket list`
+
+Surface scan. In-repo mode reads `tickets/INDEX.md`. Plane mode calls the MCP
+`list_issues` tool with a filter for open states. Neither reads bodies.
+
+### `/ticket move <id> <state>` (Plane mode only)
+
+Manual transition of a Plane work item to a named state. No-op in in-repo
+mode (the in-repo model has only `open` and `closed`).
+
+### `/ticket config`
+
+Opens `.agents/projectContext/ticketing-config.md` for editing. Toggle the
+skill on/off, switch modes, or update Plane workspace/project settings here.
+
+## Routes To
+
+`ticketing` skill router (`.agents/skills/ticketing/SKILL.md`) → in-repo or
+Plane variant per `ticketing-config.md`.
+
+## Hard Gates
+
+- MUST NOT read ticket bodies during `list`. Use `show` for explicit body
+  reads.
+- MUST NOT accept any `adr-*` disposition on close.
+- MUST NOT close an `incorporated-to:*` ticket without confirming the target
+  doc received the substance.
+- Plane mode MUST NOT fall back to direct Plane REST calls if the MCP server is
+  unavailable. Append to `ticketing-sync-failures.md` and continue.
+
+## When NOT to Use
+
+- For starting a new feature: use `/feature` — that command auto-creates a
+  Plane work item (in Plane mode) without needing `/ticket`.
+- For ADRs or decisions: use `/adr` or `/surface-conflict`.
+- For commits: use `/commit`.
+- For `CONFIRM-NN` items: use `/adr` or `/adr-status`.
+
+## Disabled State
+
+If `ticketing-config.md` has `enabled: false` (the default) or is absent, every
+subcommand returns:
+
+> Ticketing is disabled. Findings that would normally be filed as tickets are
+> inlined in agent output with a `[NEEDS-TRIAGE]` marker. To enable, edit
+> `.agents/projectContext/ticketing-config.md` and set `enabled: true`.

--- a/.agents/hooks/pre-edit.sh
+++ b/.agents/hooks/pre-edit.sh
@@ -2,12 +2,34 @@
 which jq > /dev/null 2>&1 || exit 0
 INPUT=$(cat)
 FPATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+NEW=$(echo "$INPUT" | jq -r '.tool_input.new_string // ""')
 
 # H-04: stage file is write-protected even via Edit
 # Note: Edit on overrides.log is intentionally allowed (append-mode edits are fine per AGENTS.md §7)
 if echo "$FPATH" | grep -qE '\.agents/projectContext/stage$'; then
   echo "BLOCKED [H-04]: .agents/projectContext/stage is write-protected. Use /stage command only (stage-gating/SKILL.md)." >&2
   exit 1
+fi
+
+# H-11: ADRs may only be authored via /adr (decision-lifecycle skill writes the marker)
+if echo "$FPATH" | grep -qE '\.agents/projectContext/decisions/[0-9]+-.+\.md$'; then
+  MARKER=".agents/.markers/adr-authoring-active"
+  if [ ! -f "$MARKER" ]; then
+    echo "BLOCKED [H-11]: ADR files may only be edited via /adr (AGENTS.md §3). Run /adr to author or revise an ADR with user attribution." >&2
+    exit 1
+  fi
+  if [ -n "$(find "$MARKER" -mmin +30 2>/dev/null)" ]; then
+    echo "BLOCKED [H-11]: ADR authoring marker is stale (>30 min). Re-run /adr to refresh the authoring session." >&2
+    exit 1
+  fi
+fi
+
+# H-12: closed-ticket files may not carry adr-opened:* dispositions (Edit may insert one)
+if echo "$FPATH" | grep -qE '\.agents/projectContext/tickets/closed/.+\.md$'; then
+  if echo "$NEW" | grep -qE '^disposition:[[:space:]]*adr-opened:'; then
+    echo "BLOCKED [H-12]: 'adr-opened:*' is not a valid ticket disposition (AGENTS.md §3). Decision-worthy findings escalate to open-questions.md (CONFIRM-NN) or to the user. ADRs are authored only via /adr." >&2
+    exit 1
+  fi
 fi
 
 exit 0

--- a/.agents/hooks/pre-write.sh
+++ b/.agents/hooks/pre-write.sh
@@ -2,6 +2,7 @@
 which jq > /dev/null 2>&1 || exit 0
 INPUT=$(cat)
 FPATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // ""')
 
 # H-04: stage file is write-protected
 if echo "$FPATH" | grep -qE '\.agents/projectContext/stage$'; then
@@ -13,6 +14,28 @@ fi
 if echo "$FPATH" | grep -qE 'overrides\.log$'; then
   echo "BLOCKED [H-05]: overrides.log is append-only. Use /override to add entries (AGENTS.md §7). Use Edit to append, not Write." >&2
   exit 1
+fi
+
+# H-11: ADRs may only be authored via /adr (decision-lifecycle skill writes the marker)
+if echo "$FPATH" | grep -qE '\.agents/projectContext/decisions/[0-9]+-.+\.md$'; then
+  MARKER=".agents/.markers/adr-authoring-active"
+  if [ ! -f "$MARKER" ]; then
+    echo "BLOCKED [H-11]: ADR files may only be created via /adr (AGENTS.md §3). Run /adr to author an ADR with user attribution. Subagent-authored ADRs are prohibited." >&2
+    exit 1
+  fi
+  # Stale marker (>30 min): treat as no marker
+  if [ -n "$(find "$MARKER" -mmin +30 2>/dev/null)" ]; then
+    echo "BLOCKED [H-11]: ADR authoring marker is stale (>30 min). Re-run /adr to refresh the authoring session." >&2
+    exit 1
+  fi
+fi
+
+# H-12: closed-ticket files may not carry adr-opened:* dispositions
+if echo "$FPATH" | grep -qE '\.agents/projectContext/tickets/closed/.+\.md$'; then
+  if echo "$CONTENT" | grep -qE '^disposition:[[:space:]]*adr-opened:'; then
+    echo "BLOCKED [H-12]: 'adr-opened:*' is not a valid ticket disposition (AGENTS.md §3). Decision-worthy findings escalate to open-questions.md (CONFIRM-NN) or to the user. ADRs are authored only via /adr." >&2
+    exit 1
+  fi
 fi
 
 exit 0

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -16,4 +16,18 @@ if [ ! -f "$CONTEXT_FILE" ] || ! grep -q '<!--INITIALIZED-->' "$CONTEXT_FILE" 2>
   fi
 fi
 
+# H-15: surface tickets open more than 7 days
+TICKET_DIR=".agents/projectContext/tickets/open"
+if [ -d "$TICKET_DIR" ]; then
+  STALE=$(find "$TICKET_DIR" -maxdepth 1 -name '*.md' -mtime +7 2>/dev/null | sort)
+  if [ -n "$STALE" ]; then
+    COUNT=$(echo "$STALE" | wc -l | tr -d ' ')
+    echo "STARTUP [H-15]: $COUNT open ticket(s) idle >7 days. Run '/ticket list' to triage:"
+    echo "$STALE" | while read -r f; do
+      ID=$(basename "$f" .md)
+      echo "  - $ID"
+    done
+  fi
+fi
+
 exit 0

--- a/.agents/projectContext/decisions/001-ticketing-design.md
+++ b/.agents/projectContext/decisions/001-ticketing-design.md
@@ -1,0 +1,66 @@
+---
+id: ADR-001
+title: Ticketing design — in-repo scope-overflow inbox + optional Plane on-prem
+status: proposed
+date: 2026-05-12
+last_challenged:
+authors: SUaDtL (user)
+---
+
+# ADR-001: Ticketing Design
+
+## Context
+
+codeArbiter previously had no clean channel for a subagent to log a finding that fell outside its scope. Such findings either inlined into the agent's response (lost in transcript), got tossed into `open-tasks.md` (which is general task tracking, not provenance-stamped overflow), or were silently dropped. The framework needed a sanctioned inbox for these out-of-scope observations.
+
+A separate but related concern: existing artifacts under `.agents/agents/`, `.agents/commands/`, and `.agents/projectContext/decisions/` are routinely read by agents during routing, even when only a one-line description is required. Eagerly loading bodies of artifacts that are only invoked occasionally is context-wasteful.
+
+## Decision
+
+Introduce an optional `ticketing` skill with two modes selectable via `projectContext/ticketing-config.md`:
+
+1. **`in-repo`** — a lightweight scope-overflow inbox. Subagents file tickets (four-section markdown files) in `projectContext/tickets/open/`. The codeArbiter parent triages each ticket by filing the substance into the correct existing artifact (`03-task-backlog.md`, `open-questions.md` as a `CONFIRM-NN`, a gap doc, or by surfacing to the user) and then closing the ticket with a disposition note. The ticket itself is an inbox, not a project tracker.
+
+2. **`plane`** — uses the official Plane MCP server (`@makeplane/plane-mcp-server`) to write to a self-hosted Plane instance. Tickets become Plane work items; `/feature` and `/fix` auto-create work items; `commit-gate` Phase 8 auto-comments with the commit SHA; PR merge auto-transitions to done.
+
+The skill is structured as a **thin router** that reads `mode` from config and `@`-imports only the variant in use. The unused variant is never loaded.
+
+A strict **no-read-without-reason** rule applies. The router exposes `INDEX.md` (in-repo) or `mcp__plane__list_issues` (Plane) for cheap surface scans; ticket bodies open only via explicit `/ticket show <id>`. This same pattern is retrofitted to `.agents/agents/` (new `INDEX.md`), `.agents/commands/` (existing `COMMANDS.md` formalized as the index), and `.agents/projectContext/decisions/` (existing `README.md` index schema populated).
+
+**Disposition vocabulary explicitly excludes ADR authoring.** A ticket close cannot result in a new ADR. Decision-worthy findings escalate to `open-questions.md` (as a `CONFIRM-NN`) or to the user. ADRs are authored only via `/adr` with explicit user attribution, consistent with AGENTS.md §5's existing "No decisions without user attribution" gate.
+
+**Plane authentication is API-key-based via shell environment variables**, not OAuth. The official `@makeplane/plane-mcp-server` supports OAuth only for Plane Cloud; on-prem instances use API keys passed through env vars (`PLANE_API_URL`, `PLANE_API_KEY`, `PLANE_WORKSPACE_SLUG`). The `mcpServers` entry in `.claude/settings.json` references these env vars by name (`${PLANE_API_KEY}`), never inlining values. No token files are stored on disk under the framework's management.
+
+## Alternatives Considered
+
+- **Custom Plane REST adapter.** Rebuilds what `@makeplane/plane-mcp-server` already maintains. Rejected: maintenance burden and security surface (token file handling, chmod checks) we don't need to own. The MCP server costs us an MCP-capable-runner requirement but Claude Code is fine.
+- **External integration with Jira or OpenProject at v1.** Deferred. Plane is sufficient for v1; Jira/OpenProject can be added as additional variants if needed without changing the router design.
+- **Bulk `[NEEDS-TRIAGE]` markers inlined in agent output (no separate inbox).** Rejected: loses provenance, hard to triage, lossy across long sessions. The inbox model preserves the four-section context per finding.
+- **Make ticketing always-on rather than opt-in.** Rejected: the framework should ship with `enabled: false` so that projects without a ticketing need don't carry the conceptual weight.
+- **Permit `adr-opened:*` as a ticket disposition.** Rejected (this was an explicit user correction during planning): allowing parent agents to auto-author ADRs from subagent findings violates AGENTS.md §5's user-attribution requirement for decisions and would launder unattributed decisions into the project's permanent record.
+
+## Consequences
+
+**Positive:**
+- Subagents have a sanctioned channel for out-of-scope observations. No more silent drops or transcript-only mentions.
+- Context cost stays low. The router only loads the active variant; routine flows scan indexes, not bodies.
+- The retrofits (`agents/INDEX.md`, formalized `COMMANDS.md`, populated `decisions/README.md`) extend the same pattern to high-traffic artifact directories.
+- Plane integration is thin (a contract over MCP tools), so swapping or upgrading the MCP server is low-cost.
+
+**Negative / Tradeoffs:**
+- Plane mode constrains us to MCP-capable runners. Arbitrary CI agents that lack MCP support cannot use Plane mode; in-repo mode remains the zero-dependency fallback.
+- The router + variant pattern is new for this repo. Other skills may adopt it, but each adoption is judgment-by-judgment.
+- The ADR-disposition prohibition means decision-worthy findings take a two-step path: ticket → CONFIRM-NN → ADR. That's the desired flow but adds latency vs. an auto-author shortcut.
+
+This tradeoff sits at §2 level 3 (Maintainability and reviewability) for the disposition prohibition and §2 level 1 (Security and compliance) for the credential-handling decision — see AGENTS.md §2 for the hierarchy.
+
+## Implementation Notes
+
+- New files: `ticketing-config.md`, `.agents/skills/ticketing/{SKILL.md,in-repo/SKILL.md,plane/SKILL.md}`, `.agents/projectContext/tickets/{INDEX.md,open/,closed/}`, `.agents/commands/ticket.md`, `.claude/commands/ticket.md`, `.agents/agents/INDEX.md`.
+- Modified: AGENTS.md (§3 hard rules, §4 map, §5 routing, §6 read-on-invocation note), `secrets-policy.md` (env-var approved location), `.gitignore` (`.env`, `.env.local`), `.agents/settings.json` (`mcpServers.plane`), 9 subagent definitions (out-of-scope clause), `decisions/README.md` (this ADR row), `COMMANDS.md` (normalized + `/ticket` row).
+- Default ships disabled: `enabled: false` in `ticketing-config.md`. Users opt in.
+
+## Followups
+
+- First in-repo ticket once enabled: audit any code paths that read `.agents/agents/*.md` in bulk and update them to consult `INDEX.md` first.
+- Validate that `@makeplane/plane-mcp-server` tool names match the names referenced in `.agents/skills/ticketing/plane/SKILL.md` on first real setup; correct any mismatches.

--- a/.agents/projectContext/decisions/README.md
+++ b/.agents/projectContext/decisions/README.md
@@ -4,12 +4,15 @@
 <!-- Created by the `decision-lifecycle` skill via the /adr command. -->
 <!-- Never delete an ADR — superseded ADRs are updated with status: superseded and a pointer to the superseding ADR. -->
 
+## Read-on-invocation guarantee
+
+This README is the surface scan. ADR bodies are read ONLY when an ADR is explicitly referenced by ID (e.g. "ADR-007") or accessed via `/adr-status --adr N`. Routine flows MUST NOT bulk-read this directory.
+
 ## Index
 
-| ADR | Title | Status | Date | Last Challenged |
-|---|---|---|---|---|
-
-_No ADRs yet. Use `/adr "decision title"` to record the first architectural decision._
+| ADR | Title | Status | Date | Last Challenged | Body |
+|---|---|---|---|---|---|
+| ADR-001 | Ticketing design — in-repo scope-overflow inbox + optional Plane on-prem | proposed | 2026-05-12 | — | [body](001-ticketing-design.md) |
 
 ## Status Values
 

--- a/.agents/projectContext/secrets-policy.md
+++ b/.agents/projectContext/secrets-policy.md
@@ -35,3 +35,17 @@ _Rotation schedule and what events must be emitted on rotation._
 ## DB Storage Rule
 
 _If secret references must be persisted in DB, only the store reference (ARN, path, etc.) is permitted — never the secret value._
+
+## External Ticketing Credentials (ticketing skill, Plane mode)
+
+When the optional `ticketing` skill operates in `mode: plane` against an on-prem Plane instance, API keys live in shell environment variables only. Specifically:
+
+- API key MUST be set as a shell env var (default name: `PLANE_API_KEY`). The variable name is configurable in `projectContext/ticketing-config.md`.
+- The env var value MUST NEVER appear in any committed file, including:
+  - `.claude/settings.json` or `.agents/settings.json` — the `mcpServers` entry references the env var by name (`${PLANE_API_KEY}`), not by value.
+  - `ticketing-config.md` — stores only the env var NAME, never its value.
+  - Any agent prompt, log, or ticket body.
+- Approved storage locations for the env var value: the user's shell rc file (`.bashrc`, `.zshrc`) or a manually-sourced gitignored file at `~/.config/codeArbiter/plane.env`.
+- The same rule applies to any other ticketing-related credentials (`PLANE_API_URL`, `PLANE_WORKSPACE_SLUG`): values are env-var-only.
+
+Rotation: when the API key is rotated in Plane, export the new value in the shell and restart the MCP server. No repo change is required.

--- a/.agents/projectContext/ticketing-config.md
+++ b/.agents/projectContext/ticketing-config.md
@@ -1,0 +1,47 @@
+# Ticketing Configuration
+
+<!-- Read by the `ticketing` router skill. -->
+<!-- If this file is absent OR `enabled: false`, the ticketing skill is a no-op. -->
+<!-- Default ships with `enabled: false`; users opt in by editing the frontmatter below. -->
+
+---
+enabled: false
+mode: in-repo
+plane_base_url:
+plane_workspace_slug:
+plane_project_id:
+plane_env_var_api_key: PLANE_API_KEY
+plane_env_var_api_url: PLANE_API_URL
+plane_env_var_workspace_slug: PLANE_WORKSPACE_SLUG
+---
+
+## Field Reference
+
+| Field | Required when | Purpose |
+|---|---|---|
+| `enabled` | always | `true` activates the ticketing skill. `false` makes it a no-op. |
+| `mode` | `enabled: true` | `in-repo` or `plane`. Selects which variant the router `@`-imports. |
+| `plane_base_url` | `mode: plane` | On-prem Plane URL, e.g. `https://plane.internal.example.com`. |
+| `plane_workspace_slug` | `mode: plane` | Plane workspace slug the variant targets. |
+| `plane_project_id` | `mode: plane` | Plane project ID the variant targets. |
+| `plane_env_var_*` | `mode: plane` | Names of shell env vars the MCP server reads. Values NEVER appear in this file. |
+
+## Mode: `in-repo`
+
+A lightweight scope-overflow inbox. Subagents file findings as tickets in `projectContext/tickets/open/`. The parent reads each ticket, decides where the substance belongs (a task backlog entry, a `CONFIRM-NN` in `open-questions.md`, a gap doc, or a synchronous user escalation), files the substance there, and closes the ticket with a disposition note. The ticket itself is not a project tracker — it's an inbox.
+
+## Mode: `plane`
+
+Uses the official Plane MCP server (`@makeplane/plane-mcp-server`) over MCP. **We run Plane on-prem, so authentication is via API key supplied through environment variables** — OAuth is Plane Cloud only.
+
+Required environment variables (names configurable above; values live in the user's shell, never in this file or any committed file):
+
+- `PLANE_API_URL` — the on-prem Plane base URL
+- `PLANE_API_KEY` — API key issued by the Plane admin UI
+- `PLANE_WORKSPACE_SLUG` — workspace slug
+
+See `.agents/skills/ticketing/plane/SKILL.md` for setup steps.
+
+## Read-on-invocation guarantee
+
+The router skill reads only the frontmatter from this file on every invocation. It `@`-imports the variant matching `mode` and never loads the unused variant. When `enabled: false`, neither variant is loaded.

--- a/.agents/projectContext/tickets/INDEX.md
+++ b/.agents/projectContext/tickets/INDEX.md
@@ -1,0 +1,13 @@
+# Tickets Index
+
+<!-- Auto-maintained by the in-repo ticketing variant. -->
+<!-- Hand-edits are NOT preserved on the next create/close. -->
+<!-- Body reads require `/ticket show <id>` — this index is the only sanctioned surface scan. -->
+
+## Open
+
+_None._
+
+## Recently closed (last 30 days)
+
+_None._

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -1,4 +1,16 @@
 {
+  "mcpServers": {
+    "_comment_plane": "Optional. Active only when ticketing-config.md has enabled: true AND mode: plane. The values below reference shell env vars by name; literal secrets MUST NEVER be inlined here. See .agents/skills/ticketing/plane/SKILL.md for setup.",
+    "plane": {
+      "command": "npx",
+      "args": ["-y", "@makeplane/plane-mcp-server"],
+      "env": {
+        "PLANE_API_URL": "${PLANE_API_URL}",
+        "PLANE_API_KEY": "${PLANE_API_KEY}",
+        "PLANE_WORKSPACE_SLUG": "${PLANE_WORKSPACE_SLUG}"
+      }
+    }
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.agents/skills/ticketing/SKILL.md
+++ b/.agents/skills/ticketing/SKILL.md
@@ -1,0 +1,93 @@
+# Skill: ticketing (router)
+
+## Trigger
+
+Invoke this skill when:
+
+- A subagent encounters a finding outside its scope and needs to file it without
+  inlining it (per the subagent out-of-scope contract).
+- The user runs any `/ticket` subcommand (`open`, `close`, `show`, `list`, `config`).
+- The codeArbiter parent needs to file, triage, or close a scope-overflow inbox item.
+
+This skill is a **thin router**. It reads `projectContext/ticketing-config.md`,
+selects the variant by `mode`, and `@`-imports only that variant's `SKILL.md`. It
+never loads both variants in the same session. When ticketing is disabled, no
+variant is loaded.
+
+---
+
+## Pre-Flight
+
+Before any routing decision, confirm:
+
+1. `.agents/projectContext/ticketing-config.md` is readable. If absent, treat
+   ticketing as disabled and return the disabled response below.
+2. Read only the frontmatter (top YAML block) of the config file. Do not read
+   the prose body — the field reference is for humans, not for routing.
+
+If the file is unreadable for reasons other than absence (permission error,
+malformed YAML), STOP and surface the gap to the user. Do not guess defaults.
+
+---
+
+## Phase 1: Resolve mode
+
+**Goal:** Determine whether to invoke a variant and which one.
+
+**Inputs:**
+- Frontmatter of `projectContext/ticketing-config.md`
+
+**Actions:**
+
+1. If `enabled: false` (or field absent): emit the disabled response and return.
+   The disabled response is:
+
+   > Ticketing is disabled. Findings that would normally be filed as tickets
+   > are inlined in agent output with a `[NEEDS-TRIAGE]` marker. To enable,
+   > edit `.agents/projectContext/ticketing-config.md` and set `enabled: true`.
+
+2. If `enabled: true` and `mode: in-repo`: `@`-import
+   `.agents/skills/ticketing/in-repo/SKILL.md` and hand off the caller's request
+   to that variant. Do not read the plane variant.
+
+3. If `enabled: true` and `mode: plane`: confirm `plane_base_url`,
+   `plane_workspace_slug`, and `plane_project_id` are populated. If any is
+   missing, STOP and instruct the user to complete the config. Then `@`-import
+   `.agents/skills/ticketing/plane/SKILL.md` and hand off. Do not read the
+   in-repo variant.
+
+4. If `mode` is any other value: STOP and surface as a config error. Do not
+   guess a default.
+
+**Output:** Variant loaded and caller's operation delegated, OR disabled
+response returned.
+
+**Gate:** BLOCK if both variants are loaded in the same invocation. BLOCK if
+the disabled state silently loads a variant.
+
+---
+
+## Hard Rules
+
+- MUST read only the frontmatter of `ticketing-config.md`. The prose body is
+  for human reference and is NOT part of the routing contract.
+- MUST NOT load both variants in the same session. The router is a one-way
+  dispatch.
+- MUST NOT guess a default `mode`. An invalid or missing `mode` is a config
+  error to surface, not a silent fallback.
+- MUST NOT read ticket bodies, write tickets, or call MCP tools directly. The
+  router has no operational logic — variants own all behavior.
+- MUST NOT silently disable ticketing because of a config parse error. Surface
+  the error.
+
+---
+
+## Failure Modes
+
+| Failure | Response |
+|---|---|
+| `ticketing-config.md` absent | Treat as disabled; emit disabled response |
+| Config unreadable / malformed YAML | STOP; surface gap; do not guess defaults |
+| `enabled: true` but `mode` missing or unknown | STOP; surface as config error |
+| `mode: plane` but Plane fields missing | STOP; instruct user to complete config |
+| Variant `SKILL.md` missing on disk | STOP; surface as install gap |

--- a/.agents/skills/ticketing/in-repo/SKILL.md
+++ b/.agents/skills/ticketing/in-repo/SKILL.md
@@ -1,0 +1,196 @@
+# Skill: ticketing (in-repo variant)
+
+## Trigger
+
+Loaded by the `ticketing` router when `mode: in-repo`. This file is never read
+directly — invoke via the router.
+
+## Pre-Flight
+
+Before any operation:
+
+1. Confirm `.agents/projectContext/tickets/` exists. If absent, create it on
+   first ticket open: `tickets/`, `tickets/open/`, `tickets/closed/`,
+   `tickets/INDEX.md`.
+2. For close/show/list: confirm `INDEX.md` exists; refuse with a clear message
+   if it does not.
+
+---
+
+## Operations
+
+### Open (file a new ticket)
+
+**Caller contract:** a subagent or `/ticket` command provides:
+- `title` (short, < 80 chars)
+- `body` populated for all four required sections
+
+**Actions:**
+
+1. Compute `id = <YYYY-MM-DD>-<NNN>` where `<NNN>` is the next zero-padded
+   integer not already used today. Scan both `open/` and `closed/` to compute.
+2. Compute `slug` from the title: lowercase, non-alphanumerics to `-`, trim,
+   truncate to 40 chars.
+3. Write `tickets/open/<id>-<slug>.md` with this exact frontmatter and body
+   shape (no extra fields, no extra sections):
+
+   ```yaml
+   ---
+   id: <id>
+   title: <title>
+   opened_by: <caller agent name> via <caller skill or command>
+   opened_at: <ISO-8601 UTC>
+   status: open
+   disposition:
+   disposition_note:
+   closed_at:
+   closed_by:
+   ---
+
+   ## Context
+   <what the caller was doing when it noticed the finding>
+
+   ## Finding
+   <the out-of-scope observation>
+
+   ## Why it's out of scope
+   <why the caller did not act on it>
+
+   ## Suggested handling (optional)
+   <hint, if any — may be empty>
+   ```
+
+4. Append a row to `tickets/INDEX.md` under `## Open`:
+
+   `- <id> | <title> | opened by <caller> | <opened_at-date>`
+
+5. Return the `id` to the caller. Do not echo the ticket body back.
+
+**Gate:** BLOCK if any of the four sections is empty (`Suggested handling` may
+contain a single dash but must exist as a section).
+
+### Close (file substance to its real home, then close ticket)
+
+**Caller contract:** the parent (codeArbiter) runs `/ticket close <id>` and
+specifies a disposition.
+
+**Actions:**
+
+1. Locate the ticket file in `tickets/open/`. If not found, STOP and surface.
+2. Prompt the parent for a disposition from this exact set:
+
+   - `incorporated-to:03-task-backlog` — substance filed into
+     `projectContext/decomposition/03-task-backlog.md`
+   - `incorporated-to:open-tasks` — substance filed into
+     `projectContext/open-tasks.md`
+   - `incorporated-to:gap-doc` — recorded as a known gap (no immediate action)
+   - `escalated-to:open-questions` — a `CONFIRM-NN` was appended to
+     `projectContext/open-questions.md`
+   - `escalated-to:user` — surfaced synchronously to the user
+   - `duplicate-of:<other-ticket-id>`
+   - `rejected`
+   - `other` (requires a non-empty `disposition_note`)
+
+3. **REJECT** any disposition starting with `adr-opened:` or `adr:`. ADRs
+   require user attribution per AGENTS.md §3 and may never be created as a
+   disposition. If the parent attempts this, refuse and re-prompt.
+
+4. If `incorporated-to:*` or `escalated-to:open-questions`: confirm the target
+   file has been updated with the substance BEFORE closing. The close
+   operation does not file the substance — that is the parent's job. The
+   close just records that it happened.
+
+5. Update the ticket frontmatter:
+   - `status: closed`
+   - `disposition: <chosen value>`
+   - `disposition_note: <free text, required for 'other'>`
+   - `closed_at: <ISO-8601 UTC>`
+   - `closed_by: <name from git config user.name>`
+
+6. `git mv` (or equivalent file move) the ticket from `open/` to `closed/`.
+
+7. Update `INDEX.md`:
+   - Remove the row from `## Open`.
+   - Insert a row at the top of `## Recently closed (last 30 days)`:
+     `- <id> | <title> | disposition: <disposition> | <closed_at-date>`
+   - Prune rows older than 30 days from the recently-closed section. The full
+     files remain in `closed/` regardless.
+
+**Gate:** BLOCK on any `adr-*` disposition attempt. BLOCK if `other` is chosen
+without a `disposition_note`. BLOCK if `incorporated-to:*` is recorded but the
+target file shows no corresponding edit in the current session.
+
+### Show (read one ticket body)
+
+**Caller contract:** `/ticket show <id>`.
+
+**Actions:**
+
+1. Locate the ticket in `open/` or `closed/`. If not found, STOP.
+2. Output the full file contents to the user verbatim.
+3. Do not update the index. Do not read other tickets.
+
+### List (surface scan)
+
+**Caller contract:** `/ticket list` or `/status`.
+
+**Actions:**
+
+1. Read `INDEX.md` only. Do not open any file under `open/` or `closed/`.
+2. Output the index contents verbatim.
+
+**Gate:** BLOCK if the caller asks for body details — redirect them to
+`/ticket show <id>`.
+
+---
+
+## INDEX.md format (authoritative)
+
+```markdown
+# Tickets Index
+
+<!-- Auto-maintained by the in-repo ticketing variant. Hand-edits are not -->
+<!-- preserved on the next create/close. -->
+
+## Open
+
+- <id> | <title> | opened by <caller> | <opened-date>
+
+## Recently closed (last 30 days)
+
+- <id> | <title> | disposition: <disposition> | <closed-date>
+```
+
+When no tickets exist in a section, leave a single placeholder line:
+`_None._`
+
+---
+
+## Hard Rules
+
+- MUST NOT read ticket bodies unless the caller invoked `show`. `list` and
+  surface scans use `INDEX.md` only.
+- MUST NOT accept `adr-opened:*`, `adr:*`, or any ADR-creation disposition.
+  ADRs require user attribution and are authored only via `/adr`.
+- MUST NOT close a ticket marked `incorporated-to:*` without confirming the
+  target file received the substance.
+- MUST NOT modify frontmatter fields other than the close-time fields listed
+  in the Close operation. Other fields are immutable once written.
+- MUST NOT delete ticket files. Closed tickets remain in `closed/`
+  indefinitely.
+- MUST NOT bulk-read `open/*` or `closed/*` for any operation. INDEX is the
+  surface contract.
+
+---
+
+## Failure Modes
+
+| Failure | Response |
+|---|---|
+| `tickets/` missing | Create on first open |
+| `INDEX.md` missing on close/show/list | STOP; instruct user to re-init via `/ticket list` after a fresh open |
+| Ticket id not found on close/show | STOP; surface |
+| Required body section empty on open | BLOCK; ask caller to populate |
+| Disposition is `adr-*` | REJECT; re-prompt |
+| `other` disposition without note | BLOCK; require note |
+| `incorporated-to:*` without target file edit in session | BLOCK; require the parent to file the substance first |

--- a/.agents/skills/ticketing/plane/SKILL.md
+++ b/.agents/skills/ticketing/plane/SKILL.md
@@ -1,0 +1,191 @@
+# Skill: ticketing (Plane variant — on-prem)
+
+## Trigger
+
+Loaded by the `ticketing` router when `mode: plane`. This file is never read
+directly — invoke via the router.
+
+This variant uses the **official Plane MCP server** (`@makeplane/plane-mcp-server`)
+to talk to a self-hosted (on-prem) Plane instance over MCP. Auth is API-key-based
+(OAuth in the upstream server is Plane Cloud only). Credentials live in shell
+environment variables, never in the repo.
+
+---
+
+## Pre-Flight
+
+Before any operation:
+
+1. Confirm the MCP server is registered in `.claude/settings.json` (or
+   `.agents/settings.json` — they are symlinked) under
+   `mcpServers.plane`. If absent, STOP and instruct the user to follow the
+   setup steps below.
+
+2. Confirm the `mcp__plane__*` tool family is available in the current session.
+   These tools are deferred — load schemas via `ToolSearch` on first use:
+
+   ```
+   ToolSearch query="select:mcp__plane__list_projects,mcp__plane__create_issue,mcp__plane__update_issue,mcp__plane__add_issue_comment,mcp__plane__list_issues"
+   ```
+
+   Exact tool names are determined by the installed `@makeplane/plane-mcp-server`
+   version. If `ToolSearch` returns no matches for the `mcp__plane__` prefix,
+   the MCP server is not running — STOP.
+
+3. Confirm the env vars named in `ticketing-config.md` are non-empty in the
+   MCP server process environment. The variant cannot read the user's shell
+   directly, but if any MCP call returns an auth or URL error, treat it as
+   evidence the env vars are missing or wrong.
+
+4. Read from `ticketing-config.md` (frontmatter only): `plane_base_url`,
+   `plane_workspace_slug`, `plane_project_id`. Pass `workspace_slug` and
+   `project_id` to every MCP tool call that requires them.
+
+---
+
+## Operations
+
+### Open (create a work item)
+
+**Caller contract:** a subagent (out-of-scope finding) or a `/feature` / `/fix`
+/ `/ticket open` invocation provides title and body.
+
+**Actions:**
+
+1. Compose the work item description from the same four sections used by the
+   in-repo variant (Context / Finding / Why out of scope / Suggested handling).
+   For `/feature` and `/fix`: use the command description as the body.
+2. Call the MCP tool that creates a work item (`mcp__plane__create_issue` or
+   the equivalent from the installed server) with `workspace_slug`,
+   `project_id`, `title`, and `description`.
+3. Capture the returned issue ID and short URL.
+4. Hand the issue ID back to the caller. For `/feature` and `/fix`, the parent
+   threads the ID into the commit message and PR body during subsequent gates.
+
+**Gate:** BLOCK on MCP call failure — see Failure Modes below for the
+fallback (`ticketing-sync-failures.md`).
+
+### Comment (used by commit-gate Phase 8)
+
+**Caller contract:** `commit-gate` Phase 8 produces a committed SHA and the
+issue ID associated with the work.
+
+**Actions:**
+
+1. Call the MCP comment tool with the issue ID and a body of the form:
+   `Committed: <SHA> (<commit subject>)`.
+2. Return success/failure to the caller. Do not block the commit gate on this
+   call — log and continue per the failure mode.
+
+### Transition (used on PR merge)
+
+**Caller contract:** PR-merge handling determines that an issue is now `done`.
+
+**Actions:**
+
+1. Call the MCP transition tool with the issue ID and the project's `done`
+   state (read state ID from the MCP `list_states` tool the first time per
+   session; cache for the session).
+2. Return success/failure. Do not block on failure.
+
+### List (surface scan)
+
+**Caller contract:** `/ticket list` or `/status`.
+
+**Actions:**
+
+1. Call the MCP `list_issues` tool with a filter restricting to open states.
+2. Output one line per issue: `<id> | <title> | <state> | <updated-date>`.
+3. Do NOT fetch full bodies. The output is the index equivalent for Plane mode.
+
+**Gate:** BLOCK if the caller asks for body details — redirect to a Plane
+URL or `mcp__plane__get_issue` invoked explicitly.
+
+### Move (manual transition)
+
+**Caller contract:** `/ticket move <id> <state>`.
+
+**Actions:** call the MCP transition tool with the user-supplied state name.
+
+---
+
+## Setup (one-time, documented for the user)
+
+1. **Issue an API key in your on-prem Plane instance.** Plane admin UI →
+   workspace settings → API tokens. Scope to the target workspace; record the
+   key in your password manager.
+
+2. **Export the env vars in your shell.** Add to `~/.bashrc`, `~/.zshrc`, or
+   `~/.config/codeArbiter/plane.env` (gitignored, sourced manually). Example:
+
+   ```sh
+   export PLANE_API_URL="https://plane.internal.example.com"
+   export PLANE_API_KEY="<your-api-key>"
+   export PLANE_WORKSPACE_SLUG="<your-workspace-slug>"
+   ```
+
+3. **Register the MCP server.** Confirm `.claude/settings.json` has under
+   `mcpServers`:
+
+   ```json
+   "plane": {
+     "command": "npx",
+     "args": ["-y", "@makeplane/plane-mcp-server"],
+     "env": {
+       "PLANE_API_URL": "${PLANE_API_URL}",
+       "PLANE_API_KEY": "${PLANE_API_KEY}",
+       "PLANE_WORKSPACE_SLUG": "${PLANE_WORKSPACE_SLUG}"
+     }
+   }
+   ```
+
+   The literal `${VAR}` references the shell env var by name; the MCP runner
+   substitutes the value at process spawn time. The value never appears in any
+   committed file.
+
+4. **Fill `ticketing-config.md`.** Set `enabled: true`, `mode: plane`, and
+   populate `plane_base_url`, `plane_workspace_slug`, `plane_project_id`.
+
+5. **Start a fresh Claude Code session.** Confirm `mcp__plane__*` tools appear
+   via `ToolSearch`.
+
+---
+
+## Hard Rules
+
+- MUST NOT store any API key, token, or credential in `ticketing-config.md`,
+  in any tracked file, in any committed file, or in any LLM prompt. Env vars
+  only.
+- MUST NOT pass env var values through the agent text — reference them by
+  name (`${PLANE_API_KEY}`) in settings.json, never inline.
+- MUST NOT call the Plane REST API directly. Always go through the MCP server.
+- MUST NOT block `/feature`, `/fix`, `/commit`, or `/pr` on MCP failures.
+  Log, queue, and continue.
+- MUST NOT read work item bodies during `list` or surface scans. Body reads
+  require explicit user intent.
+- MUST NOT author an ADR as a side-effect of any Plane operation.
+
+---
+
+## Failure Modes
+
+| Failure | Response |
+|---|---|
+| MCP server not running / not registered | STOP; instruct user to run setup steps |
+| `ToolSearch` returns no `mcp__plane__*` matches | STOP; same as above |
+| Auth error from MCP (401 / 403) | Append entry to `projectContext/ticketing-sync-failures.md`; instruct user to verify `PLANE_API_KEY` env var |
+| Network / Plane on-prem unreachable | Append to `ticketing-sync-failures.md`; do NOT block the calling workflow |
+| Issue ID not found on comment/transition | Append to `ticketing-sync-failures.md`; surface to caller as a warning |
+| Workspace or project ID missing in config | STOP; instruct user to populate `ticketing-config.md` |
+
+### `ticketing-sync-failures.md` format
+
+Append-only at `.agents/projectContext/ticketing-sync-failures.md`:
+
+```
+[ISO-8601] | OP: <create_issue|comment|transition|list|move> | ARGS: <short summary> | ERROR: <short error text>
+```
+
+The variant retries each pending entry on its next successful MCP call. After
+three consecutive retry failures for the same op, surface a `[NEEDS-TRIAGE]`
+note to the user and stop retrying that entry.

--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -1,0 +1,1 @@
+@.agents/commands/ticket.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 legacy/
+
+# Local environment files. Ticketing skill (Plane mode) credentials live in
+# shell env vars; if sourced from a file, that file MUST be gitignored.
+.env
+.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ legacy/
 # shell env vars; if sourced from a file, that file MUST be gitignored.
 .env
 .env.local
+
+# Transient hook markers (e.g. .adr-authoring-active set by /adr). Not state.
+.agents/.markers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ Always-loaded. Follow these even without reading project docs. Violation is unre
 - MUST NOT commit if the project test suite is not green.
 - MUST NOT begin implementation without `tdd` skill Phase 1 completing first.
 - MUST NOT commit without `commit-gate` skill completing. "It looks good" is not permission.
+- MUST NOT read ticket bodies during routine flows. Use `projectContext/tickets/INDEX.md` (in-repo) or `mcp__plane__list_issues` (Plane) for surface scans. Body reads only via `/ticket show <id>`.
+- MUST NOT author an ADR as the disposition of a ticket. Decision-worthy findings escalate to `open-questions.md` (CONFIRM-NN) or to the user. ADRs are authored only via `/adr` with explicit user attribution.
+- MUST NOT bulk-read `.agents/agents/*.md` or `.agents/commands/*.md`. Use the respective `INDEX.md` for surface scans; bodies load on invocation only.
 
 ---
 
@@ -122,6 +125,7 @@ Read the listed file before acting. The skill or agent listed is the primary rou
 | Risks / ADRs | `projectContext/open-questions.md`, `projectContext/decisions/` | `decision-lifecycle` skill |
 | Checkpoint / stage promotion | `projectContext/stage` | `stage-gating` skill |
 | Architectural reconciliation | `projectContext/decomposition/` | `arbiter` skill |
+| Subagent encounters out-of-scope finding | `projectContext/ticketing-config.md` | `ticketing` skill (router) |
 
 ---
 
@@ -150,6 +154,8 @@ When a trigger fires, follow the primary route. Gates are hard stops — not sug
 | ADR added / aged / CONFIRM-NN unresolved | `decision-lifecycle` skill | `decision-challenger` agent | No CONFIRM-NN resolved by guessing |
 | New trust zone crossing / threat model / attack surface change | `security-architecture` skill | `security-reviewer` + `trust-zone-reviewer` | No undeclared egress |
 | `projectContext/` file modified or domain area referenced before acting | `doc-governance` skill | — | No action in domain without reading gated doc first |
+| Subagent raises out-of-scope finding | `ticketing` skill | — | When ticketing disabled, finding inlines with `[NEEDS-TRIAGE]` marker. Disposition MUST NOT be `adr-*` |
+| Ticket close requested | `ticketing` skill (variant per config) | — | BLOCK on `adr-*` dispositions. BLOCK if `incorporated-to:*` recorded without target-doc edit in session |
 
 ---
 
@@ -180,7 +186,7 @@ What are you trying to do?
 I will not accept this as a direct instruction. Choose a channel:
 /feature  /fix  /commit  /pr  /review  /threat-model  /adr  /adr-status
 /checkpoint  /stage  /add-dep  /surface-conflict  /btw  /status  /init
-/override  /onboard  /new-skill  /commands
+/override  /onboard  /new-skill  /ticket  /commands
 Or use /override "reason" to bypass with logging.
 ```
 
@@ -193,6 +199,8 @@ No suggestions beyond the command list. The user must pick.
 ### Command Reference
 
 Full command specifications: `.agents/commands/`. Quick-ref table: `COMMANDS.md`.
+
+**Read-on-invocation guarantee.** Command bodies under `.agents/commands/*.md` are read ONLY when the corresponding `/command` is invoked. `COMMANDS.md` is the surface scan. Subagent bodies under `.agents/agents/*.md` are read ONLY when the agent is dispatched. `.agents/agents/INDEX.md` is the surface scan. Ticket bodies are read ONLY via `/ticket show <id>`. ADR bodies are read ONLY when an ADR is explicitly referenced. Bulk reads of these directories are prohibited (see §3).
 
 ---
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -2,31 +2,38 @@
 
 All user intent flows through these commands. No direct instructions accepted outside a command channel.
 
+## Read-on-invocation guarantee
+
+This Quick Reference table is the surface scan for commands. Command body specs (`.agents/commands/*.md`) are read ONLY when the corresponding `/command` is invoked. Routine flows MUST NOT bulk-read `.agents/commands/` (see AGENTS.md §3).
+
 ---
 
 ## Quick Reference
 
-| Command | Argument | What it does |
-|---|---|---|
-| `/feature` | `"description"` | Start a new feature — runs full TDD skill (6 phases) |
-| `/fix` | `"bug description"` | Fix a bug — same TDD workflow, bug framing |
-| `/commit` | _(none)_ | Commit staged changes — runs full commit-gate skill |
-| `/pr` | `["title"]` | Open a pull request — runs all gates first |
-| `/review` | `[path or scope]` | Security + code review of a path or scope |
-| `/threat-model` | `"scope"` | Pre-implementation threat model for a proposed change |
-| `/adr` | `"decision title"` | Record a new architectural decision |
-| `/adr-status` | `[--adr N]` | Check ADR health — aged, unchallenged, unresolved CONFIRM-NN |
-| `/checkpoint` | `[focus]` | Full checkpoint review — all 7 agents in parallel |
-| `/stage` | `[target]` | Report current stage or promote to target stage |
-| `/add-dep` | `"package"` | Add a dependency — full vetting before install |
-| `/surface-conflict` | `"description"` | Stop all work and surface a rule conflict |
-| `/btw` | `"question"` | Ask a quick question — no state change, lightweight |
-| `/status` | _(none)_ | Show open tasks and unresolved decisions |
-| `/init` | _(none)_ | Re-run initialization detection (repair only) |
-| `/override` | `"reason"` | Bypass a gate — auto-detects identity, appends to overrides.log |
-| `/onboard` | `["scope"]` | Engineer onboarding tour — full or targeted scope |
-| `/new-skill` | `"gap description"` | Author a new skill after gap validation |
-| `/commands` | _(none)_ | Show this quick-reference table |
+Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when the user invokes the command.
+
+| Command | Argument | One-line purpose | Body |
+|---|---|---|---|
+| `/feature` | `"description"` | Start a new feature; runs full TDD skill (6 phases) | [body](.agents/commands/feature.md) |
+| `/fix` | `"bug description"` | Fix a bug using the same TDD workflow, bug-framed | [body](.agents/commands/fix.md) |
+| `/commit` | _(none)_ | Commit staged changes; runs full commit-gate skill | [body](.agents/commands/commit.md) |
+| `/pr` | `["title"]` | Open a pull request after all gates pass | [body](.agents/commands/pr.md) |
+| `/review` | `[path or scope]` | Security + code review of a path or scope | [body](.agents/commands/review.md) |
+| `/threat-model` | `"scope"` | Pre-implementation threat model for a proposed change | [body](.agents/commands/threat-model.md) |
+| `/adr` | `"decision title"` | Record a new architectural decision with user attribution | [body](.agents/commands/adr.md) |
+| `/adr-status` | `[--adr N]` | Check ADR health — aged, unchallenged, unresolved CONFIRM-NN | [body](.agents/commands/adr-status.md) |
+| `/checkpoint` | `[focus]` | Full checkpoint review — all 7 reviewers in parallel | [body](.agents/commands/checkpoint.md) |
+| `/stage` | `[target]` | Report current stage or promote to target stage | [body](.agents/commands/stage.md) |
+| `/add-dep` | `"package"` | Add a dependency with full vetting before install | [body](.agents/commands/add-dep.md) |
+| `/surface-conflict` | `"description"` | Stop all work and surface a rule conflict | [body](.agents/commands/surface-conflict.md) |
+| `/ticket` | `"title" \| <sub>` | Optional scope-overflow inbox; in-repo or Plane variant | [body](.agents/commands/ticket.md) |
+| `/btw` | `"question"` | Ask a quick question; no state change, lightweight | [body](.agents/commands/btw.md) |
+| `/status` | _(none)_ | Show open tasks and unresolved decisions | [body](.agents/commands/status.md) |
+| `/init` | _(none)_ | Re-run initialization detection (repair only) | [body](.agents/commands/init.md) |
+| `/override` | `"reason"` | Bypass a gate with auto-identity audit log entry | [body](.agents/commands/override.md) |
+| `/onboard` | `["scope"]` | Engineer onboarding tour, full or targeted | [body](.agents/commands/onboard.md) |
+| `/new-skill` | `"gap description"` | Author a new skill after rigorous gap validation | [body](.agents/commands/new-skill.md) |
+| `/commands` | _(none)_ | Show this quick-reference table | [body](.agents/commands/commands.md) |
 
 ---
 
@@ -180,6 +187,32 @@ All user intent flows through these commands. No direct instructions accepted ou
 **Hard gate:** This command overrides all other active work. Nothing proceeds while a conflict is open.
 
 **When to use:** Any time you observe a rule in AGENTS.md contradicted by code, by a projectContext doc, or by another rule. Do not silently resolve — always surface.
+
+---
+
+### `/ticket "title" | <subcommand>`
+
+**Purpose:** Optional scope-overflow inbox for subagent findings (in-repo mode) OR project management bridge to Plane (Plane mode). Disabled by default; opt in by editing `projectContext/ticketing-config.md`.
+
+**What triggers:** `ticketing` skill router (`.agents/skills/ticketing/SKILL.md`) — reads `mode` from config and `@`-imports only the active variant (`in-repo/` or `plane/`).
+
+**Subcommands:**
+- `/ticket "title" -- "body"` — file a new ticket (subagent or user)
+- `/ticket close <id>` — interactive close with disposition prompt
+- `/ticket show <id>` — read a ticket body explicitly
+- `/ticket list` — surface scan via INDEX (in-repo) or `mcp__plane__list_issues` (Plane)
+- `/ticket move <id> <state>` — Plane-only manual transition
+- `/ticket config` — edit `ticketing-config.md`
+
+**Hard gates:**
+- BLOCK on any `adr-*` disposition. ADRs require user attribution and are authored only via `/adr`.
+- BLOCK if `incorporated-to:*` close is recorded without the target doc having been edited in the current session.
+- Plane mode never falls back to direct REST. MCP failures append to `ticketing-sync-failures.md` and continue.
+
+**When NOT to use:**
+- Decision-worthy concerns: use `/adr` instead of filing a ticket
+- Confirmed bugs: use `/fix` instead
+- Quick questions: use `/btw`
 
 ---
 


### PR DESCRIPTION
Adds the `ticketing` skill (router → in-repo or plane variant) for subagents
to file out-of-scope findings without inlining them. In-repo mode is a
lightweight inbox in projectContext/tickets/; the parent triages each ticket
by filing the substance into the right existing artifact and closing with a
disposition. Plane mode uses the official @makeplane/plane-mcp-server over
MCP against an on-prem Plane instance, with API-key auth via shell env vars.

Ships disabled by default. Opt in via projectContext/ticketing-config.md.

Hard rules added (AGENTS.md §3):
- MUST NOT read ticket bodies during routine flows (INDEX-only surface scans)
- MUST NOT author ADRs as a ticket disposition (user attribution required)
- MUST NOT bulk-read .agents/agents/*.md or .agents/commands/*.md

Index-pattern retrofits (3 of 3 from the approved plan):
- .agents/agents/INDEX.md (new)
- COMMANDS.md row shape normalized + read-on-invocation note
- decisions/README.md schema populated by the first ADR (ADR-001)

ADR-001 documents the design, the router/variant precedent, the Plane MCP
choice over a custom REST adapter, and the explicit prohibition on ADR
auto-creation from ticket dispositions.

9 subagent definitions gain an Out-of-Scope Findings clause directing them
to invoke the ticketing skill rather than inlining or dropping findings.

Secrets handling (Plane mode): API key lives in shell env var PLANE_API_KEY
only. settings.json references it by name via ${PLANE_API_KEY}; literal
values never appear in any committed file. secrets-policy.md updated;
.gitignore gains .env / .env.local.

https://claude.ai/code/session_013pmfzTMmpACtLRuHc87NBf