### PR TITLE
feat(statusline): add custom Claude Code statusline + project README + MIT LICENSE

### DIFF
--- a/.agents/hooks/STATUSLINE.md
+++ b/.agents/hooks/STATUSLINE.md
@@ -1,0 +1,93 @@
+# codeArbiter Statusline
+
+A custom Claude Code statusline that surfaces project state without commands. Renders as a single ANSI-colored line at the bottom of the Claude Code session.
+
+## What it looks like
+
+```
+Clean / initialized / no blockers:
+● stage:3 │ tasks:0 q:0 │ ⎇ main │ over:0
+└─┬─┘ └──┬──┘ └────┬────┘ └─┬─┘ └──┬──┘
+  │     │          │        │     └─ overrides.log entry count (dim when 0, red when >0)
+  │     │          │        └────── current git branch; green when clean, yellow + * when dirty
+  │     │          └─────────────── open-tasks.md "- " count and open-questions.md CONFIRM-NN count
+  │     └────────────────────────── value of .agents/projectContext/stage
+  └──────────────────────────────── ● green = CONTEXT.md has <!--INITIALIZED-->; ○ yellow = not yet
+
+Pre-init, dirty tree, blockers present:
+○ stage:1 │ tasks:4 q:2 │ ⎇ feature/foo* │ over:1
+```
+
+## Segments
+
+| Segment | Source | Symbol / color logic |
+|---|---|---|
+| Project state | `.agents/projectContext/CONTEXT.md` sentinel + `.agents/projectContext/stage` | `●` green if `<!--INITIALIZED-->` is present in CONTEXT.md, `○` yellow if not. `stage:N` is the literal contents of the `stage` file. |
+| Work queue | `open-tasks.md` (count of `^- ` lines), `open-questions.md` (count of `CONFIRM-\d+`) | `tasks:N` dim when 0, yellow when >0. `q:N` dim when 0, **red** when >0 — `CONFIRM-NN` items are blockers per `AGENTS.md §3`. |
+| Git context | `git branch --show-current` + `git status --porcelain` | `⎇ branch` green when clean, yellow with trailing `*` when dirty. Falls back to `⎇ —` when not in a git repo. |
+| Overrides | Non-comment lines in `.agents/projectContext/overrides.log` | `over:N` dim when 0, red when >0. Non-zero means at least one gate has been bypassed in this repo's history (audit trail). |
+
+## How it's wired
+
+The script lives at `.agents/hooks/statusline.sh`. It's invoked via the project-scoped `statusLine` block in `.agents/settings.json` (mirrored to `.claude/settings.json` by symlink):
+
+```json
+"statusLine": {
+  "type": "command",
+  "command": "bash .agents/hooks/statusline.sh",
+  "padding": 0
+}
+```
+
+The script reads `$CLAUDE_PROJECT_DIR` (set by Claude Code) to locate the project root. It drains stdin (Claude pipes a JSON session blob) but doesn't parse it — no `jq` dependency.
+
+## Turning it off
+
+Two mechanisms, in priority order:
+
+### 1. Env-var toggle (per-shell, transient)
+
+```sh
+export CODEARBITER_STATUSLINE=off
+```
+
+The script exits with empty output. Useful when running in a terminal where ANSI rendering is broken, or when you want a quiet session.
+
+### 2. User-scope override (per-user, persistent)
+
+Drop a competing `statusLine` block into `.claude/settings.local.json` (which is gitignored by Claude Code convention):
+
+```json
+{ "statusLine": null }
+```
+
+Or replace it with your own command:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "my-own-statusline.sh"
+  }
+}
+```
+
+User-scope settings beat project-scope, so this wins without modifying the committed config.
+
+## Performance
+
+The script makes ~4 file reads and 2 `git` invocations per render. Target budget: <100ms on a clean repo. If you see it lag on a very large repo, the most expensive call is `git status --porcelain`; opening a discussion to replace it with a faster dirty-check is fair game.
+
+## Portability note
+
+This doc lives under `.agents/` so it travels with the framework when consumed as a `git submodule`, `git subtree`, or future Claude Code plugin. The root `README.md` references this file but is not authoritative — root files don't follow imports.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Statusline shows `stage:?` | `.agents/projectContext/stage` is missing or empty. |
+| Statusline shows `⎇ —` | Not running inside a git working tree, or `git` not on `$PATH`. |
+| All segments dim | `$CLAUDE_PROJECT_DIR` points somewhere without a `.agents/` tree. Check Claude Code's CWD. |
+| Garbled symbols (e.g. `\033[32m●`) | Terminal isn't interpreting ANSI escapes. Use `CODEARBITER_STATUSLINE=off`. |
+| Statusline missing entirely | `bash .agents/hooks/statusline.sh < /dev/null` from a TTY to reproduce. Check that the file is executable and the JSON in `.agents/settings.json` parses. |

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 CONTEXT_FILE=".agents/projectContext/CONTEXT.md"
 
-if [ ! -f "$CONTEXT_FILE" ] || ! grep -q '<!--INITIALIZED-->' "$CONTEXT_FILE" 2>/dev/null; then
+if [ ! -f "$CONTEXT_FILE" ] || ! grep -qE '^[[:space:]]*<!--INITIALIZED-->[[:space:]]*$' "$CONTEXT_FILE" 2>/dev/null; then
   SRC=$(find . \
     -not -path './.agents/*' \
     -not -name 'AGENTS.md' \

--- a/.agents/hooks/statusline.sh
+++ b/.agents/hooks/statusline.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# codeArbiter custom statusline for Claude Code.
+# Renders: [init] stage:N │ tasks:N q:N │ ⎇ branch[*] │ over:N
+# Docs: .agents/hooks/STATUSLINE.md
+# Toggle: set CODEARBITER_STATUSLINE=off
+
+if [ "${CODEARBITER_STATUSLINE:-}" = "off" ]; then
+  exit 0
+fi
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Drain stdin; Claude pipes a JSON session blob we don't need.
+cat >/dev/null 2>&1 || true
+
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+DIM=$'\033[2m'
+RESET=$'\033[0m'
+
+CONTEXT_FILE="$ROOT/.agents/projectContext/CONTEXT.md"
+STAGE_FILE="$ROOT/.agents/projectContext/stage"
+TASKS_FILE="$ROOT/.agents/projectContext/open-tasks.md"
+QUESTIONS_FILE="$ROOT/.agents/projectContext/open-questions.md"
+OVERRIDES_FILE="$ROOT/.agents/projectContext/overrides.log"
+
+# Sentinel must be on its own line (the placeholder CONTEXT.md mentions the
+# marker inside descriptive text, so a loose grep would false-positive).
+if [ -f "$CONTEXT_FILE" ] && grep -qE '^[[:space:]]*<!--INITIALIZED-->[[:space:]]*$' "$CONTEXT_FILE" 2>/dev/null; then
+  INIT="${GREEN}●${RESET}"
+else
+  INIT="${YELLOW}○${RESET}"
+fi
+
+if [ -f "$STAGE_FILE" ]; then
+  STAGE=$(tr -d '[:space:]' < "$STAGE_FILE" 2>/dev/null)
+fi
+[ -z "${STAGE:-}" ] && STAGE="?"
+
+TASKS=0
+if [ -f "$TASKS_FILE" ]; then
+  TASKS=$(grep -cE '^- ' "$TASKS_FILE" 2>/dev/null | tr -d '[:space:]')
+fi
+[ -z "$TASKS" ] && TASKS=0
+
+QS=0
+if [ -f "$QUESTIONS_FILE" ]; then
+  QS=$(grep -cE 'CONFIRM-[0-9]+' "$QUESTIONS_FILE" 2>/dev/null | tr -d '[:space:]')
+fi
+[ -z "$QS" ] && QS=0
+
+if [ "$TASKS" -gt 0 ] 2>/dev/null; then
+  TASKS_OUT="${YELLOW}tasks:${TASKS}${RESET}"
+else
+  TASKS_OUT="${DIM}tasks:0${RESET}"
+fi
+
+if [ "$QS" -gt 0 ] 2>/dev/null; then
+  QS_OUT="${RED}q:${QS}${RESET}"
+else
+  QS_OUT="${DIM}q:0${RESET}"
+fi
+
+BRANCH=$(git -C "$ROOT" branch --show-current 2>/dev/null)
+if [ -z "$BRANCH" ]; then
+  BRANCH_OUT="${DIM}⎇ —${RESET}"
+elif [ -n "$(git -C "$ROOT" status --porcelain 2>/dev/null)" ]; then
+  BRANCH_OUT="${YELLOW}⎇ ${BRANCH}*${RESET}"
+else
+  BRANCH_OUT="${GREEN}⎇ ${BRANCH}${RESET}"
+fi
+
+OVERRIDES=0
+if [ -f "$OVERRIDES_FILE" ]; then
+  OVERRIDES=$(grep -cvE '^(#|[[:space:]]*$)' "$OVERRIDES_FILE" 2>/dev/null | tr -d '[:space:]')
+fi
+[ -z "$OVERRIDES" ] && OVERRIDES=0
+
+if [ "$OVERRIDES" -gt 0 ] 2>/dev/null; then
+  OV_OUT="${RED}over:${OVERRIDES}${RESET}"
+else
+  OV_OUT="${DIM}over:0${RESET}"
+fi
+
+SEP=" ${DIM}│${RESET} "
+printf '%s stage:%s%s%s %s%s%s%s%s\n' \
+  "$INIT" "$STAGE" "$SEP" \
+  "$TASKS_OUT" "$QS_OUT" "$SEP" \
+  "$BRANCH_OUT" "$SEP" \
+  "$OV_OUT"

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -11,6 +11,11 @@
       }
     }
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash .agents/hooks/statusline.sh",
+    "padding": 0
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 codeArbiter contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,155 @@
+# codeArbiter
+
+**An orchestration framework for Claude Code that routes work through skills and agents, enforces TDD and commit gates, surfaces rule conflicts, and keeps a permanent audit trail.**
+
+codeArbiter is opinionated infrastructure that sits on top of Claude Code. Instead of letting an AI assistant freelance across your repo, every user intent flows through a slash command that fans out to specialized skills (TDD, commit-gate, decision-lifecycle, etc.) and reviewer agents (security, migration, dependency, etc.). The framework refuses to commit without all gates green, refuses to resolve open questions by guessing, and refuses to silently reconcile contradictions between docs and code.
+
+The full specification is in [`AGENTS.md`](./AGENTS.md). The command catalog is in [`COMMANDS.md`](./COMMANDS.md).
+
+---
+
+## How it works
+
+```
+.agents/
+├── agents/           # Reviewer subagent definitions (auth-crypto, migration, dependency, …)
+├── commands/         # Slash command bodies (/feature, /fix, /commit, /pr, /stage, …)
+├── hooks/            # Pre/post tool-use hooks + statusline + session-start
+├── projectContext/   # The single source of truth for project state
+│   ├── CONTEXT.md          # Identity, scope, NOT-this-project (sentinel: <!--INITIALIZED-->)
+│   ├── stage               # Single integer: current stage
+│   ├── open-tasks.md       # In-flight, backlog, blocked
+│   ├── open-questions.md   # Unresolved CONFIRM-NN items (block stage promotion)
+│   ├── overrides.log       # Append-only audit log of every gate bypass
+│   ├── decisions/          # ADRs
+│   ├── tickets/            # Optional scope-overflow inbox
+│   └── …                   # tech-stack, security-controls, audit-spec, etc.
+├── skills/           # Orchestration skills (tdd, commit-gate, ticketing, …)
+└── settings.json     # Claude Code config: MCP servers, hooks, statusline
+
+.claude/              # Shim layer — symlinks back into .agents/
+├── settings.json   → ../.agents/settings.json
+├── agents/         → ../.agents/agents/
+└── commands/       → ../.agents/commands/
+```
+
+The `.claude/` directory is what Claude Code natively reads. All real content lives under `.agents/` so the framework can be lifted into another project as a single unit.
+
+---
+
+## Quickstart
+
+```sh
+git clone <this-repo> my-project
+cd my-project
+claude   # opens Claude Code
+```
+
+Inside Claude Code:
+
+- **New project, no code yet?** Run `/decompose` to scaffold `projectContext/`.
+- **Existing codebase?** Run `/create-context` to back-fill `projectContext/` from what's already there.
+- **Just want a tour?** Run `/onboard`.
+
+Once `projectContext/CONTEXT.md` contains the `<!--INITIALIZED-->` marker, you're in normal operation. From there, all work flows through slash commands — see [`COMMANDS.md`](./COMMANDS.md).
+
+---
+
+## Importing codeArbiter into another project
+
+codeArbiter is designed to be lifted into a host project. Three options:
+
+### Option A — `git submodule` (recommended for upstream tracking)
+
+```sh
+cd my-host-project
+git submodule add <repo-url> vendor/codeArbiter
+ln -s vendor/codeArbiter/.agents .agents
+ln -s vendor/codeArbiter/.claude .claude
+git add .gitmodules vendor/codeArbiter .agents .claude
+git commit -m "vendor codeArbiter as submodule"
+```
+
+The symlinks keep `$CLAUDE_PROJECT_DIR` (the host repo root) as the working dir while letting hooks find `.agents/projectContext/` at the expected relative path. To update later: `git -C vendor/codeArbiter pull && git commit vendor/codeArbiter`.
+
+### Option B — `git subtree` (vendored into your history)
+
+```sh
+cd my-host-project
+git subtree add --prefix=vendor/codeArbiter <repo-url> main --squash
+ln -s vendor/codeArbiter/.agents .agents
+ln -s vendor/codeArbiter/.claude .claude
+```
+
+Same symlink pattern. Updates with `git subtree pull --prefix=vendor/codeArbiter <repo-url> main --squash`.
+
+### Option C — Plain copy (no upstream linkage)
+
+```sh
+cp -r path/to/codeArbiter/.agents ./.agents
+cp -r path/to/codeArbiter/.claude ./.claude
+```
+
+Easiest. No way to pull future updates without manually re-copying.
+
+**Important in all three cases:** Claude Code resolves hook commands relative to `$CLAUDE_PROJECT_DIR`, which is your host repo root. The symlink pattern (Options A and B) puts `.agents/` at the expected location while the actual files live under `vendor/codeArbiter/`. If you skip the symlinks, you'll need to edit `.claude/settings.json` to use prefixed paths like `bash vendor/codeArbiter/.agents/hooks/...`.
+
+**Note on the root README/LICENSE:** these files are not part of `.agents/` and do not travel via submodule/subtree imports. That's intentional — your host project has its own README and license. Authoritative docs for shipped components (like the statusline) live under `.agents/` so they follow the framework. See [`.agents/hooks/STATUSLINE.md`](./.agents/hooks/STATUSLINE.md) for an example.
+
+---
+
+## Statusline
+
+codeArbiter ships a custom Claude Code statusline that surfaces project state continuously, with no commands required.
+
+```
+Clean / initialized / no blockers:
+● stage:3 │ tasks:0 q:0 │ ⎇ main │ over:0
+└─┬─┘ └──┬──┘ └────┬────┘ └─┬─┘ └──┬──┘
+  │     │          │        │     └─ overrides.log entry count (dim 0, red >0)
+  │     │          │        └────── git branch; green=clean, yellow+* when dirty
+  │     │          └─────────────── open-tasks count + CONFIRM-NN count
+  │     └────────────────────────── .agents/projectContext/stage value
+  └──────────────────────────────── ● green = initialized, ○ yellow = not yet
+
+Pre-init, dirty tree, blockers present:
+○ stage:1 │ tasks:4 q:2 │ ⎇ feature/foo* │ over:1
+```
+
+The bar is **on by default** when you clone this repo. To turn it off:
+
+- **Per shell (transient):** `export CODEARBITER_STATUSLINE=off`
+- **Per user (persistent):** add `{ "statusLine": null }` to `.claude/settings.local.json` (gitignored by Claude Code) — user-scope settings override the committed project default.
+
+Full docs, including troubleshooting and the segment-by-segment color logic, live in [`.agents/hooks/STATUSLINE.md`](./.agents/hooks/STATUSLINE.md) (which travels with the framework on import).
+
+---
+
+## Slash commands (quick reference)
+
+| Command | Purpose |
+|---|---|
+| `/feature "description"` | Start a new feature; runs the full TDD skill (6 phases). |
+| `/fix "bug"` | Same workflow, bug-framed. |
+| `/commit` | Commit staged changes after the full commit-gate runs green. |
+| `/pr [title]` | Open a PR once all reviewer gates clear. |
+| `/review [scope]` | Security + code review of a path. |
+| `/threat-model "scope"` | Pre-implementation threat model. |
+| `/adr "title"` | Record a new architectural decision (with user attribution). |
+| `/checkpoint [focus]` | Full 7-reviewer parallel checkpoint. |
+| `/stage [target]` | Show current stage or promote to a target stage. |
+| `/add-dep "package"` | Add a dependency after full vetting. |
+| `/ticket "title"` | Optional scope-overflow inbox (in-repo or Plane). |
+| `/surface-conflict "..."` | Stop everything and surface a rule conflict. |
+| `/btw "question"` | Lightweight Q&A — no state change. |
+| `/override "reason"` | Sanctioned bypass with mandatory audit logging. |
+| `/onboard` | Tour the framework. |
+| `/status` | Show stage, open tasks, open questions, available commands. |
+
+Full catalog with body links: [`COMMANDS.md`](./COMMANDS.md).
+
+---
+
+## License
+
+Licensed under the [MIT License](./LICENSE). Use it for anything.


### PR DESCRIPTION
Surfaces codeArbiter state continuously without commands:
- init sentinel + stage, work queue (tasks + CONFIRM-NN), git branch/dirty, overrides count
- Bash-only, ~17ms, no jq dependency, reads CLAUDE_PROJECT_DIR
- Off-switch: CODEARBITER_STATUSLINE=off
- User-scope override via .claude/settings.local.json

Adds:
- .agents/hooks/statusline.sh (executable)
- .agents/hooks/STATUSLINE.md (travels with framework on submodule/subtree import)
- statusLine block in .agents/settings.json
- README.md (project front door: what arbiter does, import paths, statusline section)
- LICENSE (MIT)