### PR TITLE
perf(framework): cut ~250 lines from codeArbiter for token efficiency

### DIFF
--- a/.agents/commands/_redirect.md
+++ b/.agents/commands/_redirect.md
@@ -1,0 +1,37 @@
+# _redirect (internal)
+
+Canned redirect messages emitted by the §6 User Interaction Protocol when a user
+sends a direct instruction outside a slash command. Loaded only when needed.
+
+Not user-invocable. Filename starts with `_` to signal "internal."
+
+---
+
+## Strike 1 — first off-channel message
+
+```
+Process required. I don't accept direct instructions or questions outside of a
+skill channel — that path bypasses the gates that keep the project healthy.
+
+What are you trying to do?
+→ Start a feature:          /feature "describe it"
+→ Ask a question:           /btw "your question"
+→ Fix a bug:                /fix "describe it"
+→ Bypass with audit trail:  /override "reason"
+→ See everything open:      /status
+→ See all commands:         /commands
+```
+
+---
+
+## Strike 2 — user insists after Strike 1
+
+```
+I will not accept this as a direct instruction. Choose a channel:
+/feature  /fix  /commit  /pr  /review  /threat-model  /adr  /adr-status
+/checkpoint  /stage  /add-dep  /surface-conflict  /btw  /status  /init
+/override  /onboard  /new-skill  /ticket  /commands
+Or use /override "reason" to bypass with logging.
+```
+
+No suggestions beyond the command list. The user must pick.

--- a/.agents/commands/add-dep.md
+++ b/.agents/commands/add-dep.md
@@ -9,48 +9,21 @@ Vet and add a new third-party dependency. No install command runs before the `de
 ```
 /add-dep "express@5.0.0"
 /add-dep "lodash"          # latest version, reviewer checks it
-/add-dep "some-image:tag"  # for container base images
+/add-dep "some-image:tag"  # container base images
 ```
 
 Specify the exact version if you have one. If no version is specified, the reviewer evaluates the latest available version.
 
 ## Routes To
 
-`dependency-reviewer` agent (`.agents/agents/dependency-reviewer.md`).
+`dependency-reviewer` agent (`.agents/agents/dependency-reviewer.md`). Agent reads `projectContext/dependency-policy.md` for allowed licenses, denied licenses, provenance requirements, and CVE policy.
 
-## What Happens Step by Step
+## After approval
 
-1. codeArbiter reads `projectContext/dependency-policy.md` for: allowed licenses, denied licenses, provenance requirements, source requirements
-2. `dependency-reviewer` agent evaluates the package:
-   - **License check** — is the license in the allowed list? BLOCK if denied
-   - **Provenance check** — is the package from an approved registry/source?
-   - **Maintenance signal** — last release date, open issues, maintainer activity (flag if unmaintained per policy)
-   - **CVE check** — runs audit command from `projectContext/tech-stack.md`; BLOCK on critical CVE without documented justification
-   - **Supply chain posture** — does the package have unusual install scripts, unusual permissions, or a suspicious dependency tree?
-3. Findings presented to user
-4. If BLOCK findings: STOP — do not proceed until user resolves
-5. If PASS: codeArbiter presents the install command; user confirms
-6. Install command runs
-7. Lock file updated
-8. Change staged for `/commit`
-
-## Hard Gates
-
-- MUST NOT run `npm install` (or equivalent) before the reviewer clears the package
-- BLOCK on any denied license — no exceptions without an explicit override log entry
-- BLOCK on known critical CVE without a documented justification in `projectContext/dependency-policy.md`
-- BLOCK if the package is not from an approved source per the policy
-- If the reviewer cannot determine the license: treat as BLOCK until license is confirmed
-
-## After Approval
-
-Once the reviewer clears the package:
-- The install command is shown to the user for confirmation
-- After user confirms, the package is installed and the lock file is updated
-- The lock file change MUST be committed alongside the `package.json` change — never commit one without the other
+After the reviewer clears the package, codeArbiter shows the install command for user confirmation. The lock file change MUST be committed alongside the `package.json` change — never one without the other.
 
 ## When NOT to Use
 
-- To remove a dependency: use `/feature` or `/fix` with the relevant change described
-- To update an existing dependency: same as above — changes to `package.json` trigger `dependency-reviewer` automatically via `/pr`
+- To remove a dependency: use `/feature` or `/fix` with the change described
+- To update an existing dependency: same — changes to `package.json` trigger `dependency-reviewer` automatically via `/pr`
 - To ask about a package without installing it: use `/btw`

--- a/.agents/commands/adr.md
+++ b/.agents/commands/adr.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Create a new Architecture Decision Record. Invokes the `decision-lifecycle` skill to author the ADR, register it, and queue it for challenge. ADRs document significant architectural decisions with context, alternatives considered, and the rationale for the chosen path.
+Create a new Architecture Decision Record. Invokes the `decision-lifecycle` skill to author the ADR, register it, and queue it for challenge.
 
 ## Usage
 
@@ -10,39 +10,33 @@ Create a new Architecture Decision Record. Invokes the `decision-lifecycle` skil
 /adr "title of the decision"
 ```
 
-The title should name the decision clearly: what was decided, not what was considered. Example: `"Use PostgreSQL as the primary database"` not `"Database selection"`.
+Title should name the decision clearly: what was decided, not what was considered. Example: `"Use PostgreSQL as the primary database"` not `"Database selection"`.
 
 ## Routes To
 
 `decision-lifecycle` skill (`.agents/skills/decision-lifecycle/SKILL.md`).
 
-## What Happens Step by Step
+## Command-owned mechanics
 
-0. **Activate authoring marker.** Before any other step, run
-   `mkdir -p .agents/.markers && touch .agents/.markers/adr-authoring-active`.
-   The H-11 PreToolUse hook (`.agents/hooks/pre-write.sh`, `.agents/hooks/pre-edit.sh`)
-   blocks Writes and Edits to `.agents/projectContext/decisions/*.md` unless this
-   marker is present and fresh (modified within the last 30 minutes). The marker
-   is removed at Step 7 below; if /adr aborts midway the marker may persist
-   until cleaned up or ages out.
-1. `decision-lifecycle` skill opens — collects context from the user:
-   - What decision needs to be made or was just made?
-   - What context forced this decision?
-   - What alternatives were considered?
-   - What are the consequences?
-2. ADR file created at `projectContext/decisions/000N-<slugified-title>.md` with frontmatter:
-   ```yaml
-   status: proposed
-   date: YYYY-MM-DD
-   title: <title>
-   ```
-3. ADR body authored with sections: Context, Decision, Alternatives considered, Consequences, Risks
-4. ADR registered in `projectContext/decisions/README.md` — index entry added
-5. ADR queued for challenge — `decision-challenger` agent is notified at next `/checkpoint`
-6. Any `[CONFIRM-NN]` placeholders left open are registered in `projectContext/open-questions.md`
-7. **Deactivate authoring marker.** Run `rm -f .agents/.markers/adr-authoring-active` to close the authoring window. Subsequent ADR file edits will be blocked by H-11 until another `/adr` invocation refreshes the marker.
+**Authoring marker (H-11).** Before invoking the skill, run:
 
-## ADR File Structure
+```
+mkdir -p .agents/.markers && touch .agents/.markers/adr-authoring-active
+```
+
+The H-11 PreToolUse hook (`.agents/hooks/pre-write.sh`, `.agents/hooks/pre-edit.sh`) blocks Writes and Edits to `.agents/projectContext/decisions/*.md` unless this marker is present and fresh (modified within the last 30 minutes).
+
+After the skill completes Step 7 (or if `/adr` aborts), remove the marker:
+
+```
+rm -f .agents/.markers/adr-authoring-active
+```
+
+If the command aborts midway, the marker may persist until cleaned up or ages out.
+
+**ADR file path.** Created at `projectContext/decisions/000N-<slugified-title>.md` with sequential numbering — check `projectContext/decisions/README.md` for the next number.
+
+**ADR file template.**
 
 ```markdown
 ---
@@ -83,24 +77,10 @@ Proposed
 <List any open questions that need resolution before this ADR can move to "accepted">
 ```
 
-## Hard Gates
-
-- MUST NOT resolve any `[CONFIRM-NN]` placeholder by guessing — surface the question and stop
-- ADR numbering MUST be sequential — check `projectContext/decisions/README.md` for the next number
-- If an ADR contradicts an existing accepted ADR: invoke `/surface-conflict` before proceeding
-- ADR status starts at `proposed` — only the user can advance it to `accepted` or `superseded`
-
-## ADR Status Lifecycle
-
-```
-proposed → accepted → (optionally) superseded
-         → rejected
-```
-
-Status transitions require user confirmation. codeArbiter does not advance ADR status without explicit user instruction.
+**Status lifecycle.** `proposed → accepted → (optionally) superseded` or `→ rejected`. Status transitions require explicit user instruction — codeArbiter does not advance ADR status on its own.
 
 ## When NOT to Use
 
-- To check the health of existing ADRs: use `/adr-status`
-- To challenge an existing ADR: use `/checkpoint` (which invokes `decision-challenger`)
-- To ask about an architectural decision without recording it: use `/btw`
+- Check health of existing ADRs: `/adr-status`
+- Challenge an existing ADR: `/checkpoint` (invokes `decision-challenger`)
+- Ask about a decision without recording it: `/btw`

--- a/.agents/commands/commit.md
+++ b/.agents/commands/commit.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Run the full commit gate before any `git commit` command executes. This command invokes the `commit-gate` skill (all 8 phases). No direct git commands are issued by codeArbiter without the skill completing first. "It looks good" is not permission to commit.
+Run the full commit gate before any `git commit`. No direct git commands are issued by codeArbiter without the `commit-gate` skill completing first. "It looks good" is not permission to commit.
 
 ## Usage
 
@@ -10,45 +10,14 @@ Run the full commit gate before any `git commit` command executes. This command 
 /commit
 ```
 
-No arguments. The commit-gate skill reads the current git state (staged files, diff, test results) and determines whether all gates are green.
+No arguments. The skill reads current git state (staged files, diff, test results) and determines whether all gates are green.
 
 ## Routes To
 
-`commit-gate` skill (`.agents/skills/commit-gate/SKILL.md`) — all 8 phases.
-
-## What the Skill Does (8 Phases)
-
-The `commit-gate` skill runs these phases in order — **all must pass**:
-
-1. **Staged content check** — verifies staged files contain no secrets, no banned patterns, no accidentally staged files (e.g., `.env`, lock files that shouldn't change)
-2. **Test gate** — runs the full test suite using the command in `projectContext/tech-stack.md`; MUST be green
-3. **Coverage gate** — checks coverage meets the threshold for the current stage (read from `projectContext/stage`)
-4. **Lint gate** — runs the lint command from `projectContext/tech-stack.md`; MUST be clean
-5. **Type-check gate** — runs type-check command if applicable; MUST be clean
-6. **Security scan** — runs secrets scan against staged diff; BLOCK on any secret
-7. **Commit message check** — verifies message is present, meaningful, and follows project conventions from `projectContext/coding-standards.md`
-8. **Final confirmation** — all 7 phases green; outputs commit command for user to confirm
-
-## Hard Gates
-
-- MUST NOT execute `git commit` without all 8 phases green
-- MUST NOT skip, bypass, or `continue-on-error` any phase
-- If test suite is not green: STOP, surface the failing tests, do not proceed
-- If a secret is found in staged diff: STOP, surface the finding, do not proceed
-- If coverage is below the stage threshold: STOP, surface the gap, do not proceed
-- "The tests were green a moment ago" is NOT sufficient — tests must run in this session
-
-## After All Gates Pass
-
-The skill outputs:
-- Summary of what was verified
-- Proposed commit message
-- The exact `git commit` command
-
-The user must confirm before the commit executes.
+`commit-gate` skill (`.agents/skills/commit-gate/SKILL.md`) — all phases. Skill is canonical for phases, gates, and output format.
 
 ## When NOT to Use
 
 - Before writing code: use `/feature` or `/fix` first
-- To check PR readiness: use `/pr` — it runs additional BLOCK-level reviews
+- To check PR readiness: use `/pr` — runs additional BLOCK-level reviews
 - To run tests without committing: run the test command from `projectContext/tech-stack.md` directly

--- a/.agents/commands/feature.md
+++ b/.agents/commands/feature.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Start a new feature. This is the **only permitted path** to begin implementation work. Invoking `/feature` triggers the full TDD workflow and routes to the appropriate implementation agent. No code may be written before Phase 1 of the `tdd` skill completes.
+Start a new feature. This is the **only permitted path** to begin implementation work. Invokes the full TDD workflow and routes to the appropriate implementation agent. No code may be written before `tdd` skill Phase 1 completes.
 
 ## Usage
 
@@ -10,47 +10,21 @@ Start a new feature. This is the **only permitted path** to begin implementation
 /feature "clear description of the feature"
 ```
 
-The description must be specific enough to determine scope (backend, frontend, infra, or multi-area). Vague descriptions like "improve things" will be rejected — codeArbiter will ask for clarification before proceeding.
+The description must be specific enough to determine scope (backend, frontend, infra, or multi-area). Vague descriptions like "improve things" will be rejected — codeArbiter will ask for clarification.
 
 ## Routes To
 
-`tdd` skill (`.agents/skills/tdd/SKILL.md`) — all 6 phases.
+`tdd` skill (`.agents/skills/tdd/SKILL.md`) — all phases. After Phase 1, codeArbiter routes to one of:
 
-## Implementation Agent
+- `backend-author` — backend / API / service code
+- `frontend-author` — UI / frontend code
+- `infra-author` — IaC, containers, CI/CD manifests
 
-After Phase 1 (obligation checklist) is complete, codeArbiter routes to one of:
-
-- `backend-author` — for backend/API/service code
-- `frontend-author` — for UI/frontend code
-- `infra-author` — for IaC, containers, CI/CD manifests
-
-Agent selection is based on the feature scope described. If scope spans multiple agents, they are coordinated **sequentially** — each agent must complete its TDD workflow before the next begins. The full test suite must pass between agent transitions.
-
-## What Happens Step by Step
-
-1. Phase 1 (obligation checklist) runs — identifies all test obligations before any code is written
-2. codeArbiter selects the implementation agent(s) based on scope
-3. Selected agent reads `projectContext/tech-stack.md` and `projectContext/coding-standards.md`
-4. Agent writes failing tests for every Phase 1 obligation
-5. Agent confirms each test fails for the right reason
-6. Agent writes minimum implementation to make tests pass
-7. Full test suite runs — must be green before proceeding
-8. Lint and type-check run — must pass before proceeding
-9. Phase 6 (commit readiness check) — hands off to `/commit` if all gates pass
-
-## Hard Gates
-
-- MUST NOT begin implementation before Phase 1 (obligation checklist) is complete
-- Implementation agent MUST read `projectContext/tech-stack.md` before writing any code
-- Test MUST be written and confirmed **failing** before any implementation code is written
-- Full test suite MUST be green before staging any file
-- Lint and type-check MUST pass before staging any file
-- If a security-sensitive path is touched (auth, crypto, secrets, middleware, audit), `security-reviewer` agent is invoked before the commit gate
+If scope spans multiple agents, they run sequentially. Full test suite must pass between transitions.
 
 ## When NOT to Use
 
 - **Bug fixes:** use `/fix` — Phase 1 is framed differently (regression test first)
-- **Questions / discussion:** use `/btw` — no routing table fires
+- **Questions / discussion:** use `/btw`
 - **Committing existing work:** use `/commit`
 - **Dependencies:** use `/add-dep`
-- **IaC-only infrastructure work with no application code:** `/feature` still applies — `infra-author` is the routed agent

--- a/.agents/commands/fix.md
+++ b/.agents/commands/fix.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Fix a confirmed bug. The only permitted path to begin bug-fix implementation work. Phase 1 of the `tdd` skill is framed specifically around **confirming the bug with a failing regression test** before any fix code is written. If the bug cannot be confirmed with a failing test, stop and surface the question to the user.
+Fix a confirmed bug. The only permitted path to begin bug-fix implementation work. Routes to the `tdd` skill with Phase 1 framed specifically around **confirming the bug with a failing regression test** before any fix code is written.
 
 ## Usage
 
@@ -10,54 +10,24 @@ Fix a confirmed bug. The only permitted path to begin bug-fix implementation wor
 /fix "clear description of the bug — what is happening vs. what should happen"
 ```
 
-Include observed behavior and expected behavior. If a stack trace or reproduction steps are available, include them. Vague descriptions like "it's broken" will be rejected — codeArbiter will ask for a reproduction case.
+Include observed behavior and expected behavior. Include a stack trace or reproduction steps when available. Vague descriptions ("it's broken") will be rejected.
 
 ## Routes To
 
-`tdd` skill (`.agents/skills/tdd/SKILL.md`) — all 6 phases, with Phase 1 framed for bug confirmation.
+`tdd` skill (`.agents/skills/tdd/SKILL.md`) — all phases, Phase 1 framed for bug confirmation. Implementation agent (`backend-author`, `frontend-author`, or `infra-author`) selected by where the bug lives.
 
-## Implementation Agent
+## Phase 1 framing for bug fixes (differs from /feature)
 
-After Phase 1 completes, codeArbiter routes to:
+1. **Confirm the bug is real** — reproduce it consistently
+2. **Identify the root cause** — which code path produces the wrong behavior
+3. **Write a regression test** — fails in the current state for the exact wrong reason the bug causes (not just any failure)
+4. **Confirm the regression test fails for the right reason** — failure message matches the described bug, not an unrelated error
 
-- `backend-author` — for backend/server-side bugs
-- `frontend-author` — for UI/frontend bugs
-- `infra-author` — for infrastructure/deployment bugs
-
-Agent selection is based on where the bug lives. If the bug spans layers (e.g., a frontend display issue caused by a backend response shape problem), agents are coordinated sequentially — fix the root cause layer first, then the surface layer.
-
-## Phase 1 for Bug Fixes (Different from /feature)
-
-Phase 1 is specifically framed as:
-
-1. **Confirm the bug is real** — can it be reproduced consistently?
-2. **Identify the root cause** — which code path produces the wrong behavior?
-3. **Write a regression test** — a test that fails in the current state for the exact wrong reason the bug causes (not just any failure)
-4. **Confirm the regression test fails for the right reason** — the failure message must match the described bug, not an unrelated error
-
-Only after steps 1–4 are complete does implementation begin.
-
-## What Happens Step by Step
-
-1. Phase 1 — bug confirmed, root cause identified, regression test written and verified failing for the right reason
-2. Implementation agent selected based on where the bug lives
-3. Agent reads `projectContext/tech-stack.md` and `projectContext/coding-standards.md`
-4. Agent writes minimum fix to make the regression test pass — no extra scope
-5. Full test suite runs — regression test now green, no previously passing tests broken
-6. Lint and type-check run — must pass
-7. Phase 6 (commit readiness) — hands off to `/commit`
-
-## Hard Gates
-
-- MUST NOT write fix code before the regression test is written and confirmed failing for the right reason
-- Regression test MUST fail because of the described bug — not for an unrelated reason
-- Fix MUST NOT change behavior outside the bug's scope (no scope creep in a fix)
-- Full test suite MUST be green — no regressions allowed
-- If the fix touches auth, crypto, secrets, middleware, or audit code: `security-reviewer` and `auth-crypto-reviewer` are invoked before the commit gate
+Implementation begins only after steps 1–4 complete. If the bug cannot be confirmed with a failing test, STOP and surface the question.
 
 ## When NOT to Use
 
 - **New features:** use `/feature`
 - **Refactoring without a bug:** use `/feature` with a description of the refactor
 - **Questions about why something behaves a certain way:** use `/btw`
-- **Committing already-written fix code:** use `/commit` (but Phase 1 gates still apply to the existing code)
+- **Committing already-written fix code:** use `/commit` (Phase 1 gates still apply to the existing code)

--- a/.agents/commands/onboard.md
+++ b/.agents/commands/onboard.md
@@ -2,53 +2,24 @@
 
 ## Purpose
 
-Interactive onboarding tour of the project for new contributors or new AI sessions. Invokes the `onboard` skill. Two modes: full tour (no argument) or targeted deep-dive (with a topic argument). Stays conversational until the user exits or asks to switch topics.
+Interactive onboarding tour of the project for new contributors or new AI sessions. Two modes: full tour (no argument) or targeted deep-dive (with a topic). Stays conversational until the user exits or switches topics. Read-only — never writes or modifies any file.
 
 ## Usage
 
 ```
 /onboard                    # full tour — covers all major areas
-/onboard architecture       # targeted: trust zones, ADRs, key design decisions
-/onboard security           # targeted: security controls, threat model, secrets policy
-/onboard workflow           # targeted: commands, TDD workflow, commit/PR flow
-/onboard stack              # targeted: tech stack, dependencies, test runner
-/onboard decisions          # targeted: ADR index, accepted decisions, open questions
+/onboard architecture       # trust zones, ADRs, key design decisions
+/onboard security           # security controls, threat model, secrets policy
+/onboard workflow           # commands, TDD workflow, commit/PR flow
+/onboard stack              # tech stack, dependencies, test runner
+/onboard decisions          # ADR index, accepted decisions, open questions
 ```
 
 ## Routes To
 
 `onboard` skill (`.agents/skills/onboard/SKILL.md`).
 
-## Full Tour Mode
-
-When invoked without an argument, the skill covers:
-
-1. **Project identity** — what this project does, its current stage, primary contributors
-2. **Tech stack** — language, framework, test runner, key dependencies (from `projectContext/tech-stack.md`)
-3. **Architecture** — trust zones, zone boundaries, key patterns (from `projectContext/trust-zones.md`)
-4. **Security posture** — compliance level, key controls, what is and isn't allowed (from `projectContext/security-controls.md`)
-5. **Workflow** — how features get built (TDD), how commits happen, how PRs open (from `AGENTS.md` command table)
-6. **Open decisions** — ADRs that are proposed but not yet accepted, open `[CONFIRM-NN]` questions
-7. **Open tasks** — what is in-flight vs. backlog (from `projectContext/open-tasks.md`)
-
-The skill pauses after each topic and asks: "Ready to continue, or do you want to explore this topic further?"
-
-## Targeted Mode
-
-When invoked with a topic argument:
-
-1. Skill reads the relevant `projectContext/` documents for that topic
-2. Delivers a focused explanation of that area
-3. Offers to answer follow-up questions in the same session
-4. Remains in conversational mode until the user types "done" or invokes another command
-
-## Key Behaviors
-
-- **Read-only** — onboard never writes or modifies any file
-- **Conversational** — responses are human-readable paragraphs, not machine-formatted reports
-- **Honest about gaps** — if `projectContext/` is missing a document that should exist, the skill names the gap
-- **Does not start implementation** — if the user asks "how do I build X?" during onboarding, the skill explains the process and suggests using `/feature` rather than starting implementation inline
-- **No gates** — this command is always safe to invoke; no routing table entries fire
+The topic argument scopes which `projectContext/` documents the skill reads. Without an argument, the skill walks the full set with a pause-and-confirm rhythm between topics.
 
 ## When NOT to Use
 

--- a/.agents/commands/override.md
+++ b/.agents/commands/override.md
@@ -1,8 +1,10 @@
-# /override "description of what is being overridden and why"
+# /override "reason"
 
 ## Purpose
 
-Explicitly override a codeArbiter gate or hard rule. Overrides are always logged, always visible, and never silent. This command implements the full override protocol from `AGENTS.md` §7. It does not bypass logging — using `/override` is a deliberate, traceable act.
+Sanctioned escape hatch from a codeArbiter gate or hard rule. Bypass is permitted
+only with mandatory audit logging. Overrides are always logged, always visible,
+never silent. Using `/override` is a deliberate, traceable act.
 
 ## Usage
 
@@ -15,44 +17,56 @@ The description MUST include:
 - Why the override is justified
 - Who is authorizing it (a person, not "codeArbiter")
 
-Vague overrides ("just skip it") are rejected — codeArbiter will ask for a specific justification.
+Vague overrides ("just skip it") are rejected — codeArbiter will ask for a specific
+justification.
 
-## What Happens Step by Step
+## Routes To
 
-1. **Identity detection** — codeArbiter auto-detects the authorizing identity in this order:
-   - `git config user.name` / `git config user.email`
-   - Environment variable (e.g., `$OVERRIDE_IDENTITY` or `$USER`)
-   - CLI session identity if available
-   - Prompt: asks the user to confirm their name if none of the above resolves
-2. **Override record written** — appended to `projectContext/overrides.log`:
-   ```
-   [YYYY-MM-DD HH:MM] <identity> — override: <what was overridden> — reason: <justification>
-   ```
-3. **Overridden action proceeds** — the specified gate or check is bypassed for this action only
-4. **User notified** — codeArbiter confirms the override is logged and visible to reviewers
+Override protocol implemented in this command body (no skill). Reads/writes
+`.agents/projectContext/overrides.log`.
 
-## Override Log Format
+## Identity Detection (in priority order — never ask if any succeeds)
 
-Each entry in `projectContext/overrides.log`:
+1. `git config user.email` and `git config user.name` — always try first
+2. `GITHUB_ACTOR`, `GITEA_TOKEN`, `GITEA_ACTOR` environment variables
+3. GitHub CLI: `gh auth status` — extract logged-in username
+4. If ALL detection fails → ask: "Please state your name for the override log."
+
+## Log Entry Format
+
+Appends to `.agents/projectContext/overrides.log` (append-only, never modified):
 
 ```
-[2024-01-15 14:32] Jane Smith (jane@example.com) — override: security-reviewer gate on /pr — reason: reviewed manually, see PR comment thread — authorized by: Jane Smith
+[ISO-8601 timestamp] | BY: <git-user-name> <<git-user-email>> | PLATFORM: <github|gitea|unknown> | GATE: <gate bypassed> | REASON: <user's reason>
 ```
+
+`overrides.log` is append-only. No entry is ever edited or deleted. This file is
+committed to the repo — it is a permanent audit artifact.
 
 ## Hard Gates
 
-- MUST write to `projectContext/overrides.log` before proceeding — the log entry is not optional
-- MUST include an authorizing identity — "codeArbiter" or "automated" are not valid identities
+- MUST write to `.agents/projectContext/overrides.log` before proceeding — the log
+  entry is not optional
+- MUST include an authorizing identity — "codeArbiter" or "automated" are not valid
+  identities
 - MUST include a justification — "because I said so" is not accepted
-- The override is scoped to the immediate action only — it does not create a standing exception
-- If the override involves a security-critical gate (auth, crypto, secrets): codeArbiter surfaces a warning before proceeding and asks for confirmation a second time
+- The override is scoped to the immediate action only — it does not create a
+  standing exception
+- If the override involves a security-critical gate (auth, crypto, secrets):
+  surface a warning before proceeding and ask for confirmation a second time
+
+## After Appending
+
+Proceed with the overridden action. Note in the response that the override is
+logged and visible to all reviewers.
 
 ## Visibility
 
 Override log entries are:
 - Visible to all reviewers at the next `/checkpoint`
-- Included in PR descriptions when the override affects a gate that `/pr` would normally enforce
-- Permanent — entries are never deleted from `projectContext/overrides.log`
+- Included in PR descriptions when the override affects a gate that `/pr` would
+  normally enforce
+- Permanent — entries are never deleted from `.agents/projectContext/overrides.log`
 
 ## When NOT to Use
 

--- a/.agents/commands/stage.md
+++ b/.agents/commands/stage.md
@@ -2,46 +2,26 @@
 
 ## Purpose
 
-Report the current project stage, or run the promotion checklist to advance to a target stage. Invokes the `stage-gating` skill. Stage promotions require a signed-off checkpoint document and a named approver — codeArbiter cannot promote a stage on its own authority.
+Report the current project stage, or run the promotion checklist to advance to a target stage. Stage promotions require a signed-off checkpoint and a named approver — codeArbiter cannot promote a stage on its own authority.
 
 ## Usage
 
 ```
-/stage          # reports current stage from projectContext/stage
-/stage 2        # runs full promotion checklist from current stage to Stage 2
-/stage 3        # runs full promotion checklist from current stage to Stage 3
+/stage          # report current stage from projectContext/stage
+/stage 2        # run promotion checklist: current → Stage 2
+/stage 3        # run promotion checklist: current → Stage 3
 ```
 
 ## Routes To
 
 `stage-gating` skill (`.agents/skills/stage-gating/SKILL.md`).
 
-## Without Target (Status Report Mode)
+- **No argument:** status-report mode. Reads `projectContext/stage` and most recent `projectContext/checkpoints/*` doc; reports stage, last checkpoint date, unresolved `BLOCKS_S[N+1]` findings.
+- **With target N:** promotion mode. Skill verifies sign-off, resolves blocks, then requires user confirmation before updating `projectContext/stage`.
 
-When invoked without an argument:
+## Command-owned reference
 
-1. Reads `projectContext/stage` — current stage number and name
-2. Reads `projectContext/checkpoints/` — most recent checkpoint document
-3. Reports:
-   - Current stage
-   - Date of most recent signed-off checkpoint
-   - Any `BLOCKS_S[N+1]` findings from the most recent checkpoint that are unresolved
-
-## With Target (Promotion Mode)
-
-When invoked with a target stage number:
-
-1. `stage-gating` skill reads `projectContext/stage` — confirms promotion is to the next stage only (no skipping)
-2. Reads the most recent checkpoint document from `projectContext/checkpoints/`
-3. Verifies the checkpoint sign-off block is complete (named approver, signed off)
-4. Verifies all `BLOCKS_S[target]` findings from the checkpoint are resolved
-5. Verifies any stage-specific criteria from `projectContext/open-questions.md` are resolved
-6. If all gates pass: presents the proposed stage change to the user for confirmation
-7. User confirms → `projectContext/stage` updated to target stage number
-
-## Stage Table
-
-Stage table lives in `projectContext/stage-definitions.md` (or equivalent). The generic progression:
+Generic stage progression (project-specific criteria in `projectContext/stage-definitions.md`):
 
 | Stage | Typical Promotion Trigger |
 |-------|--------------------------|
@@ -49,16 +29,6 @@ Stage table lives in `projectContext/stage-definitions.md` (or equivalent). The 
 | 2 | First non-team user; OR codebase threshold reached; OR contributor count threshold |
 | 3 | Customer-adjacent environment; OR sensitive data introduced; OR external assessor named |
 | 4 | Production deployment; OR multi-tenant; OR formal security boundary declared |
-
-Read `projectContext/stage-definitions.md` for the exact criteria defined for this project.
-
-## Hard Gates
-
-- MUST NOT skip stages — promotion is always to the immediately next stage
-- MUST NOT update `projectContext/stage` without a signed-off checkpoint
-- MUST NOT update `projectContext/stage` while `BLOCKS_S[target]` findings are unresolved
-- MUST NOT update `projectContext/stage` without naming an approver
-- Named approver MUST be a person, not "codeArbiter" or "automated"
 
 ## When NOT to Use
 

--- a/.agents/commands/threat-model.md
+++ b/.agents/commands/threat-model.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Run a pre-implementation security architecture review for a proposed feature, zone crossing, or attack surface change. STRIDE analysis. Must run **before** implementation begins whenever new trust zone crossings, new external endpoints, new secrets handling paths, or new authentication/authorization flows are introduced.
+Pre-implementation security architecture review for a proposed feature, zone crossing, or attack surface change. STRIDE analysis. Must run **before** implementation begins whenever new trust zone crossings, new external endpoints, new secrets handling paths, or new auth/authz flows are introduced. Read-only — does not modify any file.
 
 ## Usage
 
@@ -10,33 +10,17 @@ Run a pre-implementation security architecture review for a proposed feature, zo
 /threat-model "description of what is being built or changed"
 ```
 
-The description should include: what the component does, which trust zones it touches, what data it handles, and which actors interact with it.
+Description should include: what the component does, which trust zones it touches, what data it handles, which actors interact with it.
 
 ## Routes To
 
-`security-architecture` skill (`.agents/skills/security-architecture/SKILL.md`).
+`security-architecture` skill (`.agents/skills/security-architecture/SKILL.md`). Skill reads:
 
-Also reads:
 - `projectContext/trust-zones.md` — required before any analysis begins
-- `projectContext/security-controls.md` — compliance requirements and controls
-- `projectContext/decisions/` — existing ADRs relevant to security posture
+- `projectContext/security-controls.md` — compliance requirements
+- `projectContext/decisions/` — existing security-relevant ADRs
 
-## What Happens Step by Step
-
-1. codeArbiter reads `projectContext/trust-zones.md` — full read required before analysis
-2. `security-architecture` skill identifies all trust zone crossings the proposed change introduces or modifies
-3. STRIDE analysis runs for each crossing:
-   - **S**poofing — can an actor impersonate another? What controls prevent it?
-   - **T**ampering — can data be modified in transit or at rest? What controls prevent it?
-   - **R**epudiation — can actions be denied? What audit controls exist?
-   - **I**nformation disclosure — what data is exposed? To which actors? Is it classified?
-   - **D**enial of service — can the crossing be overwhelmed or blocked?
-   - **E**levation of privilege — can the crossing be used to gain unauthorized permissions?
-4. For each identified threat: threat description, likelihood, impact, mitigating control (or "none — needs control")
-5. Undeclared egress check — any network path not in `projectContext/trust-zones.md` is flagged as BLOCK
-6. Output: threat model report with findings and recommended controls
-
-## Output Structure
+## Output format
 
 ```
 ## Scope
@@ -61,17 +45,8 @@ Also reads:
 CLEAR TO IMPLEMENT | BLOCKED — resolve findings first
 ```
 
-## Hard Gates
-
-- MUST run BEFORE implementation begins for any new trust zone crossing
-- MUST run BEFORE implementation begins for any new external endpoint
-- MUST run BEFORE implementation begins for any new secrets handling path
-- Any undeclared egress BLOCKS implementation — must be declared in `projectContext/trust-zones.md` first
-- If status is BLOCKED: implementation MUST NOT begin until user resolves each blocking finding
-- This command is read-only — it does not modify any file
-
 ## When NOT to Use
 
-- For reviewing already-written code: use `/review`
-- For a full checkpoint: use `/checkpoint`
-- For a question about trust zones: use `/btw`
+- Reviewing already-written code: `/review`
+- Full checkpoint: `/checkpoint`
+- Question about trust zones: `/btw`

--- a/.agents/hooks/STATUSLINE.md
+++ b/.agents/hooks/STATUSLINE.md
@@ -5,17 +5,19 @@ A custom Claude Code statusline that surfaces project state without commands. Re
 ## What it looks like
 
 ```
-Clean / initialized / no blockers:
-● stage:3 │ tasks:0 q:0 │ ⎇ main │ over:0
-└─┬─┘ └──┬──┘ └────┬────┘ └─┬─┘ └──┬──┘
+Clean / initialized / no blockers / fresh context, subscription user:
+● stage:3 │ tasks:0 q:0 │ ⎇ main │ over:0 │ ctx:6% 5h:23% 7d:41%
+└─┬─┘ └──┬──┘ └────┬────┘ └─┬─┘ └──┬──┘ └────────┬────────┘
+  │     │          │        │     │              └─ context window %, plus $cost (API mode)
+  │     │          │        │     │                 or 5h/7d rate limits (subscription)
   │     │          │        │     └─ overrides.log entry count (dim when 0, red when >0)
   │     │          │        └────── current git branch; green when clean, yellow + * when dirty
   │     │          └─────────────── open-tasks.md "- " count and open-questions.md CONFIRM-NN count
   │     └────────────────────────── value of .agents/projectContext/stage
   └──────────────────────────────── ● green = CONTEXT.md has <!--INITIALIZED-->; ○ yellow = not yet
 
-Pre-init, dirty tree, blockers present:
-○ stage:1 │ tasks:4 q:2 │ ⎇ feature/foo* │ over:1
+API user, context approaching compaction:
+○ stage:1 │ tasks:4 q:2 │ ⎇ feature/foo* │ over:1 │ ctx:92% $4.27
 ```
 
 ## Segments
@@ -26,10 +28,11 @@ Pre-init, dirty tree, blockers present:
 | Work queue | `open-tasks.md` (count of `^- ` lines), `open-questions.md` (count of `CONFIRM-\d+`) | `tasks:N` dim when 0, yellow when >0. `q:N` dim when 0, **red** when >0 — `CONFIRM-NN` items are blockers per `AGENTS.md §3`. |
 | Git context | `git branch --show-current` + `git status --porcelain` | `⎇ branch` green when clean, yellow with trailing `*` when dirty. Falls back to `⎇ —` when not in a git repo. |
 | Overrides | Non-comment lines in `.agents/projectContext/overrides.log` | `over:N` dim when 0, red when >0. Non-zero means at least one gate has been bypassed in this repo's history (audit trail). |
+| Usage | Claude Code's statusline stdin JSON (`context_window.used_percentage`, `cost.total_cost_usd`, `rate_limits.{five_hour,seven_day}.used_percentage`), routed through `.agents/hooks/statusline-tokens.py` | `ctx:N%` reflects the current context window load from the latest API response. Color band: dim `<50%`, yellow `50–74%`, bright yellow `75–89%`, red `≥90%`. **API mode** (`$ANTHROPIC_API_KEY` set & non-empty) appends ` $X.XX` from `cost.total_cost_usd` (always dim). **Subscription mode** (no `ANTHROPIC_API_KEY`) appends ` 5h:N% 7d:N%` from `rate_limits.*` when present (Pro/Max only, after the first API response in the session); each window uses the same color band as `ctx:`. Auto-compaction handles the overflow case — the red band is just a heads-up to wrap up cleanly before it kicks in. The whole segment is silently omitted when stdin is empty / malformed, when `python3` is missing, or before the first API response. |
 
 ## How it's wired
 
-The script lives at `.agents/hooks/statusline.sh`. It's invoked via the project-scoped `statusLine` block in `.agents/settings.json` (mirrored to `.claude/settings.json` by symlink):
+The script lives at `.agents/hooks/statusline.sh`. It now *uses* (no longer drains) the JSON session blob Claude Code pipes on stdin, fanning it out to `.agents/hooks/statusline-tokens.py` (Python 3 stdlib only — no `jq` dependency). It's invoked via the project-scoped `statusLine` block in `.agents/settings.json` (mirrored to `.claude/settings.json` by symlink):
 
 ```json
 "statusLine": {
@@ -39,7 +42,7 @@ The script lives at `.agents/hooks/statusline.sh`. It's invoked via the project-
 }
 ```
 
-The script reads `$CLAUDE_PROJECT_DIR` (set by Claude Code) to locate the project root. It drains stdin (Claude pipes a JSON session blob) but doesn't parse it — no `jq` dependency.
+The script reads `$CLAUDE_PROJECT_DIR` (set by Claude Code) to locate the project root. It captures the JSON blob Claude pipes on stdin and forwards it to `statusline-tokens.py` for the `ctx:` / `$cost` / rate-limit segment. The Python helper uses stdlib only; if `python3` is missing, the usage segment is silently dropped and the rest of the line still renders.
 
 ## Turning it off
 
@@ -76,7 +79,7 @@ User-scope settings beat project-scope, so this wins without modifying the commi
 
 ## Performance
 
-The script makes ~4 file reads and 2 `git` invocations per render. Target budget: <100ms on a clean repo. If you see it lag on a very large repo, the most expensive call is `git status --porcelain`; opening a discussion to replace it with a faster dirty-check is fair game.
+The script makes ~4 file reads, 2 `git` invocations, and 1 `python3` exec per render. Target budget: <100ms on a clean repo (measured ~50ms locally with the usage helper active). If you see it lag on a very large repo, the most expensive call is `git status --porcelain`; opening a discussion to replace it with a faster dirty-check is fair game.
 
 ## Portability note
 
@@ -91,3 +94,6 @@ This doc lives under `.agents/` so it travels with the framework when consumed a
 | All segments dim | `$CLAUDE_PROJECT_DIR` points somewhere without a `.agents/` tree. Check Claude Code's CWD. |
 | Garbled symbols (e.g. `\033[32m●`) | Terminal isn't interpreting ANSI escapes. Use `CODEARBITER_STATUSLINE=off`. |
 | Statusline missing entirely | `bash .agents/hooks/statusline.sh < /dev/null` from a TTY to reproduce. Check that the file is executable and the JSON in `.agents/settings.json` parses. |
+| No `ctx:N%` segment | (a) `python3` is not on `$PATH`, (b) Claude Code hasn't sent its first API response yet (`context_window` is `null` early in the session and after `/compact`), or (c) the statusline was invoked outside Claude Code so stdin was empty. Confirm with `echo '{"context_window":{"used_percentage":50}}' \| bash .agents/hooks/statusline.sh`. |
+| No `$X.XX` in API mode | `cost.total_cost_usd` is 0 (nothing billed yet) or `$ANTHROPIC_API_KEY` is unset. The variable is checked at *render time*, not session start — `export`-ing it after launch takes effect on the next render. |
+| No `5h:N% 7d:N%` in subscription mode | The `rate_limits` object appears only for Claude.ai Pro/Max subscribers and only after the first API response in the session. Each window can be independently absent. |

--- a/.agents/hooks/statusline-tokens.py
+++ b/.agents/hooks/statusline-tokens.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# codeArbiter statusline usage segment: ctx %, optional $ cost (API mode),
+# optional 5h / 7d rate limits (subscription mode).
+# Invoked from statusline.sh; stdin = Claude Code statusline JSON.
+# Docs: .agents/hooks/STATUSLINE.md
+
+import json
+import os
+import sys
+
+
+def color_for_pct(pct):
+    if pct is None:
+        return "\033[2m"
+    if pct < 50:
+        return "\033[2m"
+    if pct < 75:
+        return "\033[33m"
+    if pct < 90:
+        return "\033[1;33m"
+    return "\033[1;31m"
+
+
+RESET = "\033[0m"
+DIM = "\033[2m"
+
+
+def fmt_pct(pct):
+    if pct is None:
+        return None
+    return f"{int(pct)}"
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return
+
+    cw = data.get("context_window") or {}
+    pct = cw.get("used_percentage")
+    if pct is None and isinstance(cw.get("current_usage"), dict):
+        cu = cw["current_usage"]
+        size = cw.get("context_window_size") or 200000
+        used = (cu.get("input_tokens") or 0) + (cu.get("cache_creation_input_tokens") or 0) + (cu.get("cache_read_input_tokens") or 0)
+        if size > 0 and used > 0:
+            pct = (used / size) * 100
+
+    parts = []
+    if pct is not None:
+        parts.append(f"{color_for_pct(pct)}ctx:{fmt_pct(pct)}%{RESET}")
+
+    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        cost = (data.get("cost") or {}).get("total_cost_usd")
+        if isinstance(cost, (int, float)) and cost > 0:
+            parts.append(f"{DIM}${cost:.2f}{RESET}")
+    else:
+        rl = data.get("rate_limits") or {}
+        for label, key in (("5h", "five_hour"), ("7d", "seven_day")):
+            window = rl.get(key) or {}
+            wpct = window.get("used_percentage")
+            if isinstance(wpct, (int, float)):
+                parts.append(f"{color_for_pct(wpct)}{label}:{int(wpct)}%{RESET}")
+
+    if parts:
+        sys.stdout.write(" ".join(parts))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/hooks/statusline.sh
+++ b/.agents/hooks/statusline.sh
@@ -10,8 +10,9 @@ fi
 
 ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 
-# Drain stdin; Claude pipes a JSON session blob we don't need.
-cat >/dev/null 2>&1 || true
+# Claude pipes a JSON session blob (model, context_window, cost, rate_limits, …).
+# Capture once so we can fan it out to the usage helper.
+STDIN=$(cat 2>/dev/null || true)
 
 GREEN=$'\033[32m'
 YELLOW=$'\033[33m'
@@ -84,8 +85,22 @@ else
 fi
 
 SEP=" ${DIM}│${RESET} "
-printf '%s stage:%s%s%s %s%s%s%s%s\n' \
-  "$INIT" "$STAGE" "$SEP" \
-  "$TASKS_OUT" "$QS_OUT" "$SEP" \
-  "$BRANCH_OUT" "$SEP" \
-  "$OV_OUT"
+
+USAGE_OUT=""
+if [ -n "$STDIN" ] && command -v python3 >/dev/null 2>&1; then
+  USAGE_OUT=$(printf '%s' "$STDIN" | python3 "$ROOT/.agents/hooks/statusline-tokens.py" 2>/dev/null || true)
+fi
+
+if [ -n "$USAGE_OUT" ]; then
+  printf '%s stage:%s%s%s %s%s%s%s%s%s%s\n' \
+    "$INIT" "$STAGE" "$SEP" \
+    "$TASKS_OUT" "$QS_OUT" "$SEP" \
+    "$BRANCH_OUT" "$SEP" \
+    "$OV_OUT" "$SEP" "$USAGE_OUT"
+else
+  printf '%s stage:%s%s%s %s%s%s%s%s\n' \
+    "$INIT" "$STAGE" "$SEP" \
+    "$TASKS_OUT" "$QS_OUT" "$SEP" \
+    "$BRANCH_OUT" "$SEP" \
+    "$OV_OUT"
+fi

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -41,7 +41,7 @@
         "hooks": [{ "type": "command", "command": "bash .agents/hooks/post-write-edit.sh" }]
       }
     ],
-    "UserPromptSubmit": [
+    "SessionStart": [
       {
         "hooks": [{ "type": "command", "command": "bash .agents/hooks/session-start.sh" }]
       }

--- a/.agents/skills/stage-gating/SKILL.md
+++ b/.agents/skills/stage-gating/SKILL.md
@@ -55,6 +55,8 @@ Every active rule must appear. SATISFIED means the rule applies and the code com
 - MUST NOT infer stage from anything other than `cat .agents/projectContext/stage`.
 - MUST NOT allow stage-conditional security bypasses without invoking /surface-conflict.
 - MUST NOT skip the rule inventory — every tagged rule must be checked.
+- MUST NOT skip stages on promotion — target stage MUST be current + 1.
+- MUST NOT accept "codeArbiter", "automated", or any non-human identity as the named approver — approver MUST be a person.
 
 ## Reference: Stage Table
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,17 +55,11 @@ Full specification: `.agents/skills/context-creation/SKILL.md`.
 
 ### Phase 3 — Normal Operation
 
-projectContext complete (sentinel `<!--INITIALIZED-->` present).
+Sentinel `<!--INITIALIZED-->` present in `projectContext/CONTEXT.md`. Startup sequence:
 
-Startup sequence:
-1. Silently load all `.agents/projectContext/` files.
-2. Read `open-tasks.md` for in-flight items.
-3. Read `open-questions.md` for unresolved `CONFIRM-NN` items.
-4. Present to the user:
-   - Current stage (from `projectContext/stage`)
-   - Any blocking open questions (CONFIRM-NN)
-   - In-flight tasks (if any)
-   - Available commands (from `/commands`)
+1. Silently load `.agents/projectContext/` files.
+2. Read `open-tasks.md` and `open-questions.md`.
+3. Present: current stage (`projectContext/stage`), blocking CONFIRM-NN items, in-flight tasks, available commands.
 
 ---
 
@@ -165,32 +159,7 @@ When a trigger fires, follow the primary route. Gates are hard stops — not sug
 
 ### Escalating Redirect
 
-**Strike 1** — first direct message not via `/command`:
-
-```
-Process required. I don't accept direct instructions or questions outside of a
-skill channel — that path bypasses the gates that keep the project healthy.
-
-What are you trying to do?
-→ Start a feature:          /feature "describe it"
-→ Ask a question:           /btw "your question"
-→ Fix a bug:                /fix "describe it"
-→ Bypass with audit trail:  /override "reason"
-→ See everything open:      /status
-→ See all commands:         /commands
-```
-
-**Strike 2** — user insists after Strike 1:
-
-```
-I will not accept this as a direct instruction. Choose a channel:
-/feature  /fix  /commit  /pr  /review  /threat-model  /adr  /adr-status
-/checkpoint  /stage  /add-dep  /surface-conflict  /btw  /status  /init
-/override  /onboard  /new-skill  /ticket  /commands
-Or use /override "reason" to bypass with logging.
-```
-
-No suggestions beyond the command list. The user must pick.
+On the first direct message not via `/command`, emit the **Strike 1** message. If the user insists, emit the **Strike 2** message. Both message bodies live in `.agents/commands/_redirect.md` (loaded on demand). No suggestions beyond the command list — the user must pick.
 
 ### `/btw` Exception
 
@@ -206,23 +175,6 @@ Full command specifications: `.agents/commands/`. Quick-ref table: `COMMANDS.md`
 
 ## §7 Override Protocol
 
-`/override "reason"` is the sanctioned escape hatch. It permits bypass with mandatory audit logging.
+`/override "reason"` is the sanctioned escape hatch — permits bypass with mandatory audit logging. Full identity-detection sequence and log-entry format live in `.agents/commands/override.md` (loaded when `/override` is invoked).
 
-### Identity Detection (in priority order — never ask if any succeeds)
-
-1. `git config user.email` and `git config user.name` — always try first
-2. `GITHUB_ACTOR`, `GITEA_TOKEN`, `GITEA_ACTOR` environment variables
-3. GitHub CLI: `gh auth status` — extract logged-in username
-4. If ALL detection fails → ask: "Please state your name for the override log."
-
-### Log Entry Format
-
-Appends to `.agents/projectContext/overrides.log` (append-only, never modified):
-
-```
-[ISO-8601 timestamp] | BY: <git-user-name> <<git-user-email>> | PLATFORM: <github|gitea|unknown> | GATE: <gate bypassed> | REASON: <user's reason>
-```
-
-`overrides.log` is append-only. No entry is ever edited or deleted. This file is committed to the repo — it is a permanent audit artifact.
-
-After appending, proceed with the overridden action and note in the response that the override is logged and visible to all reviewers.
+The log file `.agents/projectContext/overrides.log` is append-only — never edited or deleted. It is committed to the repo as a permanent audit artifact. After appending, proceed with the overridden action and note in the response that the override is logged.


### PR DESCRIPTION
AGENTS.md (loaded on every session) shrinks 228 → 180 lines (-21%) by:
- compressing §1 Phase 3 prose
- moving §6 Strike-1/Strike-2 redirect templates to lazy-loaded
  .agents/commands/_redirect.md
- moving §7 identity-detection and log-entry-format detail into
  .agents/commands/override.md (loaded only on /override)

Eight thin command wrappers slim from 542 → 317 lines (-42%) by
removing sections that restated their underlying skill's phases and
hard gates. Slimmed: commit, feature, fix, adr, stage, onboard, add-dep,
threat-model. Each retains Purpose / Usage / Routes To / When NOT to
Use, plus command-owned mechanics where present (ADR template, /adr
H-11 marker steps, /threat-model output format, /stage promotion table).

session-start.sh hook moves from UserPromptSubmit (every prompt) to
SessionStart (once per session) — eliminates per-turn shell exec.

§3 Hard Rules, §5 Routing Table, §4 Reference Map, §0 and §2 in
AGENTS.md are untouched. Read-on-invocation guarantee preserved
(no @-imports of bodies in AGENTS.md or CLAUDE.md).

Semantic-drift port: two gates previously stated only in the /stage
wrapper ("no stage skipping" and "named approver must be a person")
moved into stage-gating SKILL.md Hard Rules so they remain enforced.

Net: -250 lines, no semantic change.

https://claude.ai/code/session_01JuAeMqn5AdoW9P4jPrrhBC