### PR TITLE
codeArbiter checkpoint: language lock + 5 new skills + 4 new commands

### DIFF
--- a/.agents/agents/INDEX.md
+++ b/.agents/agents/INDEX.md
@@ -21,11 +21,11 @@ This `INDEX.md` is the only sanctioned surface scan of `.agents/agents/`. Routin
 | dependency-reviewer | Reviews package.json / lockfile / base image changes | denied license, supply-chain concerns | [body](dependency-reviewer.md) |
 | finding-triage | Assigns stage promotion impact to checkpoint findings | — (sequential post-processor) | [body](finding-triage.md) |
 | frontend-author | Implements UI code via TDD workflow | failing tests, lint errors, missing UI security checks | [body](frontend-author.md) |
-| grader | INTERNAL: SMARTS analysis for arbiter skill — never invoke directly | — | [body](grader.md) |
+| grader | INTERNAL: SMARTS analysis for decision-variance skill — never invoke directly | — | [body](grader.md) |
 | infra-author | Implements IaC, containers, CI/CD manifests, deploy config | missing threat model on zone-crossing change | [body](infra-author.md) |
 | migration-reviewer | Reviews DB migration files for safety and classification | classification annotation missing, irreversible destructive op | [body](migration-reviewer.md) |
 | scaffold-completeness-reviewer | Identifies planned-but-missing artifacts | — (read-only checkpoint reviewer) | [body](scaffold-completeness-reviewer.md) |
-| scout | INTERNAL: scans codebase sections for arbiter / context-creation skills — never invoke directly | — | [body](scout.md) |
+| scout | INTERNAL: scans codebase sections for decision-variance / context-creation skills — never invoke directly | — | [body](scout.md) |
 | security-reviewer | PROACTIVE diff review for security-sensitive paths | any CRITICAL or HIGH finding | [body](security-reviewer.md) |
 | standards-compliance-reviewer | Reviews against coding standards, lint, type safety | — (read-only checkpoint reviewer) | [body](standards-compliance-reviewer.md) |
 | coverage-auditor | Audits test coverage vs. TDD obligations | untested source files, missing audit emit tests | [body](coverage-auditor.md) |

--- a/.agents/agents/INDEX.md
+++ b/.agents/agents/INDEX.md
@@ -28,5 +28,5 @@ This `INDEX.md` is the only sanctioned surface scan of `.agents/agents/`. Routin
 | scout | INTERNAL: scans codebase sections for arbiter / context-creation skills — never invoke directly | — | [body](scout.md) |
 | security-reviewer | PROACTIVE diff review for security-sensitive paths | any CRITICAL or HIGH finding | [body](security-reviewer.md) |
 | standards-compliance-reviewer | Reviews against coding standards, lint, type safety | — (read-only checkpoint reviewer) | [body](standards-compliance-reviewer.md) |
-| test-audit-reviewer | Audits test coverage vs. TDD obligations | untested source files, missing audit emit tests | [body](test-audit-reviewer.md) |
+| coverage-auditor | Audits test coverage vs. TDD obligations | untested source files, missing audit emit tests | [body](coverage-auditor.md) |
 | trust-zone-reviewer | Reviews zone boundary enforcement and HTTP client usage | undeclared zone crossings | [body](trust-zone-reviewer.md) |

--- a/.agents/agents/architecture-drift-reviewer.md
+++ b/.agents/agents/architecture-drift-reviewer.md
@@ -85,7 +85,7 @@ N accepted ADRs reviewed. N confirmed. N with drift. N with insufficient evidenc
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -94,6 +94,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/audit-emitter.md
+++ b/.agents/agents/audit-emitter.md
@@ -98,7 +98,7 @@ PASS | BLOCK (N HIGH or CRITICAL findings)
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -107,6 +107,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/auth-crypto-reviewer.md
+++ b/.agents/agents/auth-crypto-reviewer.md
@@ -72,7 +72,7 @@ PASS | BLOCK (N hard block findings)
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -81,6 +81,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/backend-author.md
+++ b/.agents/agents/backend-author.md
@@ -72,7 +72,7 @@ If the feature performs an auditable action (per `projectContext/audit-spec.md`)
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -81,6 +81,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/checkpoint-aggregator.md
+++ b/.agents/agents/checkpoint-aggregator.md
@@ -52,7 +52,7 @@ After writing, report: "Checkpoint document written to `projectContext/checkpoin
 | Reviewer | CRITICAL | HIGH | MEDIUM | LOW |
 |----------|----------|------|--------|-----|
 | architecture-drift-reviewer | N | N | N | N |
-| test-audit-reviewer | N | N | N | N |
+| coverage-auditor | N | N | N | N |
 | security-reviewer | N | N | N | N |
 | standards-compliance-reviewer | N | N | N | N |
 | scaffold-completeness-reviewer | N | N | N | N |

--- a/.agents/agents/coverage-auditor.md
+++ b/.agents/agents/coverage-auditor.md
@@ -1,10 +1,10 @@
 ---
-name: test-audit-reviewer
+name: coverage-auditor
 description: Audits test coverage against TDD obligations. Identifies untested source files, missing audit emit tests, missing trust zone boundary tests, and logical gaps.
 tools: Read, Grep, Glob, Bash
 ---
 
-# Test Audit Reviewer Agent
+# Coverage Auditor Agent
 
 You are a read-only reviewer for test coverage and test completeness. You verify that the test suite covers all TDD obligations, all auditable actions, and all trust zone boundary crossings. You produce findings — you do not modify code.
 

--- a/.agents/agents/coverage-auditor.md
+++ b/.agents/agents/coverage-auditor.md
@@ -97,7 +97,7 @@ PASS | BLOCK (coverage below threshold / missing audit emit tests / missing boun
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -106,6 +106,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/decision-challenger.md
+++ b/.agents/agents/decision-challenger.md
@@ -115,7 +115,7 @@ The decision-challenger MUST NOT:
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -124,6 +124,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/dependency-reviewer.md
+++ b/.agents/agents/dependency-reviewer.md
@@ -90,7 +90,7 @@ PASS (cleared for install) | BLOCK (N blocking findings — do not install)
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -99,6 +99,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/frontend-author.md
+++ b/.agents/agents/frontend-author.md
@@ -64,7 +64,7 @@ For every component or feature:
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -73,6 +73,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/grader.md
+++ b/.agents/agents/grader.md
@@ -1,6 +1,6 @@
 ---
 name: grader
-description: INTERNAL subagent of the arbiter skill. Produces SMARTS analysis for a specific (artifact-position, scaffold-evidence) pair. Never invoke directly — only the arbiter skill invokes this agent.
+description: INTERNAL subagent of the decision-variance skill. Produces SMARTS analysis for a specific (artifact-position, scaffold-evidence) pair. Never invoke directly — only the decision-variance skill invokes this agent.
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -10,19 +10,19 @@ The grader subagent takes a specific (artifact-position, scaffold-evidence) pair
 
 ## When the Grader Is Spawned
 
-The arbiter spawns graders when:
+The decision-variance skill spawns graders when:
 - A variance has been identified by the main session and needs detailed SMARTS analysis
 - Multiple variances need parallel SMARTS analysis to keep the arbitration session moving
-- The arbiter wants an independent second-pass evaluation of a borderline variance
+- The decision-variance skill wants an independent second-pass evaluation of a borderline variance
 
-For straightforward variances where the SMARTS analysis is brief and obvious, the arbiter handles it inline rather than spawning a grader.
+For straightforward variances where the SMARTS analysis is brief and obvious, the decision-variance skill handles it inline rather than spawning a grader.
 
 ## Grader Assignment Format
 
-When spawning a grader, the arbiter provides:
+When spawning a grader, the decision-variance skill provides:
 
 ```
-You are a Grader subagent for the arbiter skill.
+You are a Grader subagent for the decision-variance skill.
 
 Your task: Produce a SMARTS analysis comparing the following options for a specific architectural variance.
 
@@ -40,8 +40,8 @@ Option C — Hybrid (only if a synthesis is genuinely possible):
 Project context relevant to this decision:
 - <bullet list of relevant project constraints>
 
-Apply the SMARTS framework using .agents/skills/arbiter/references/smarts-framework.md (you have access to it).
-You MUST follow the hard format constraints in .agents/skills/arbiter/references/smarts-framework.md for SMARTS cells.
+Apply the SMARTS framework using .agents/skills/decision-variance/references/smarts-framework.md (you have access to it).
+You MUST follow the hard format constraints in .agents/skills/decision-variance/references/smarts-framework.md for SMARTS cells.
 The recommendation strength is one of: strong, moderate, tied. There is no "weak" level.
 
 Output format: structured Markdown using the template below.
@@ -118,7 +118,7 @@ Before returning this analysis, verify:
 | Recommendation strength is strong, moderate, or tied (not "weak") | yes / no |
 | No vague claims ("industry standard", "widely adopted") | yes / no |
 
-If any check fails: fix the violation before returning. A non-conformant analysis will be rejected by the arbiter.
+If any check fails: fix the violation before returning. A non-conformant analysis will be rejected by the decision-variance skill.
 ```
 
 ## Strength of Recommendation Levels
@@ -129,7 +129,7 @@ If any check fails: fix the violation before returning. A non-conformant analysi
 
 There is no `weak` level. If the analysis is close but a slight edge exists, the strength is `moderate`. If genuinely tied, the strength is `tied` and the user is told plainly.
 
-The arbiter uses strength to decide how forcefully to present the recommendation. Strong recommendations are presented confidently; moderate recommendations are presented with caveats; tied recommendations are presented as "user must decide — analysis does not differentiate."
+The decision-variance skill uses strength to decide how forcefully to present the recommendation. Strong recommendations are presented confidently; moderate recommendations are presented with caveats; tied recommendations are presented as "user must decide — analysis does not differentiate."
 
 ## Hard Format Constraints (Per smarts-framework.md)
 
@@ -141,7 +141,7 @@ These constraints are non-negotiable:
 4. **No hedging adverbs:** "potentially," "might," "arguably," "perhaps," "generally," "tends to," "could be," "may" are forbidden.
 5. **Evidence specificity:** Vague claims do not count. Cite specific properties of the option, specific project constraints, or specific failure modes.
 
-Cells that violate these constraints are non-conformant and the grader's output should be rejected by the arbiter.
+Cells that violate these constraints are non-conformant and the grader's output should be rejected by the decision-variance skill.
 
 ## Grader Anti-Patterns
 
@@ -155,15 +155,15 @@ The grader MUST NOT:
 6. **Modify files.** Read-only.
 7. **Use the `weak` strength level.** It does not exist. Use `moderate` or `tied`.
 
-## Composition by the Arbiter
+## Composition by the Decision-Variance Skill
 
 After the grader returns:
 
-1. The arbiter validates the grader's output for hard format constraints (cell length, verdict-first, no hedging adverbs, evidence specificity)
-2. If non-conformant, the arbiter either fixes minor issues inline or re-spawns the grader with the violations called out
-3. The arbiter includes the conformant analysis in the variance report entry verbatim
-4. The arbiter may add additional context (project history, prior decisions) the grader did not have access to
-5. The arbiter presents the analysis to the user
-6. The arbiter records the user's decision per `.agents/skills/arbiter/references/decision-log-format.md`
+1. The decision-variance skill validates the grader's output for hard format constraints (cell length, verdict-first, no hedging adverbs, evidence specificity)
+2. If non-conformant, the decision-variance skill either fixes minor issues inline or re-spawns the grader with the violations called out
+3. The decision-variance skill includes the conformant analysis in the variance report entry verbatim
+4. The decision-variance skill may add additional context (project history, prior decisions) the grader did not have access to
+5. The decision-variance skill presents the analysis to the user
+6. The decision-variance skill records the user's decision per `.agents/skills/decision-variance/references/decision-log-format.md`
 
 The grader's recommendation is informational. The user's decision is authoritative.

--- a/.agents/agents/infra-author.md
+++ b/.agents/agents/infra-author.md
@@ -67,7 +67,7 @@ If the task introduces a new trust zone crossing, new external endpoint, or new 
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -76,6 +76,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/migration-reviewer.md
+++ b/.agents/agents/migration-reviewer.md
@@ -82,7 +82,7 @@ PASS | BLOCK (classification annotation missing / committed migration modified /
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -91,6 +91,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/scaffold-completeness-reviewer.md
+++ b/.agents/agents/scaffold-completeness-reviewer.md
@@ -81,7 +81,7 @@ Assign stage impact based on whether the artifact is required before stage promo
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -90,6 +90,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/scout.md
+++ b/.agents/agents/scout.md
@@ -1,32 +1,32 @@
 ---
 name: scout
-description: INTERNAL subagent of the arbiter and context-creation skills. Scans a defined section of the codebase and reports evidence of architectural decisions or tech stack patterns found there. Never invoke directly.
+description: INTERNAL subagent of the decision-variance and context-creation skills. Scans a defined section of the codebase and reports evidence of architectural decisions or tech stack patterns found there. Never invoke directly.
 tools: Read, Grep, Glob, Bash
 ---
 
 # Scout Subagent
 
-The scout subagent scans a defined section of the codebase and reports evidence of architectural decisions found there. It does NOT make variance judgments — that is the arbiter's job at the main session level.
+The scout subagent scans a defined section of the codebase and reports evidence of architectural decisions found there. It does NOT make variance judgments — that is the decision-variance skill's job at the main session level.
 
 ## When the Scout Is Spawned
 
-The arbiter or context-creation skill spawns scouts when:
+The decision-variance or context-creation skill spawns scouts when:
 - The codebase is large enough that a single inline scan would consume significant context
 - Different sections of the codebase have natural ownership boundaries that map to scout assignments
-- The arbiter wants parallel evidence gathering across multiple areas
+- The decision-variance skill wants parallel evidence gathering across multiple areas
 
-For smaller scans (under ~50 files), the arbiter handles inline rather than spawning scouts.
+For smaller scans (under ~50 files), the decision-variance skill handles inline rather than spawning scouts.
 
 ## Scout Assignment Format
 
-When spawning a scout, the arbiter provides:
+When spawning a scout, the decision-variance skill provides:
 
 ```
-You are a Scout subagent for the arbiter or context-creation skill.
+You are a Scout subagent for the decision-variance or context-creation skill.
 
 Your scope: <specific paths or areas, e.g., "backend/src/auth/", "helm/", "projectContext/decisions/0001-0010">
 
-Your task: Scan the assigned scope and report evidence of architectural decisions in these categories from the canonical list in .agents/skills/arbiter/references/decision-categories.md:
+Your task: Scan the assigned scope and report evidence of architectural decisions in these categories from the canonical list in .agents/skills/decision-variance/references/decision-categories.md:
 <list of decision categories relevant to this scope>
 
 Output format: Structured Markdown using the template at the end of this document.
@@ -69,7 +69,7 @@ Every scout returns its findings in this exact format:
 
 ## Anomalies or surprises
 
-<Architectural decisions encountered that don't map to any canonical category. List file paths and brief description (max 20 words each). Do NOT invent category names. The arbiter will determine whether to ask the user about adding new categories.>
+<Architectural decisions encountered that don't map to any canonical category. List file paths and brief description (max 20 words each). Do NOT invent category names. The decision-variance skill will determine whether to ask the user about adding new categories.>
 ```
 
 ## Why No Excerpts
@@ -77,9 +77,9 @@ Every scout returns its findings in this exact format:
 The scout does NOT include code excerpts, quoted text, or pasted configuration. This is a deliberate design choice for two reasons:
 
 1. **Signal-to-noise:** Excerpts under load tend to grow unbounded — entire files get pasted "for context." Reports become unreadable.
-2. **Sensitive content:** Production scaffold may contain secrets, internal URLs, cloud account IDs, credentials, hostnames. Quoting those into scout reports leaks them into the arbiter's working files.
+2. **Sensitive content:** Production scaffold may contain secrets, internal URLs, cloud account IDs, credentials, hostnames. Quoting those into scout reports leaks them into the decision-variance skill's working files.
 
-If the arbiter needs to see the actual content, it reads the file directly using its `view` capability. The scout's job is to find the evidence; the arbiter reads the evidence.
+If the decision-variance skill needs to see the actual content, it reads the file directly using its `view` capability. The scout's job is to find the evidence; the decision-variance skill reads the evidence.
 
 ## Scout Confidence Levels
 
@@ -87,7 +87,7 @@ If the arbiter needs to see the actual content, it reads the file directly using
 - **Moderate** — implicit evidence (e.g., a connection string in config is moderate evidence for the database choice)
 - **Weak** — circumstantial evidence (e.g., a comment mentioning a tool is weak evidence)
 
-The arbiter uses confidence to decide how much weight to give scaffold positions during variance analysis.
+The decision-variance skill uses confidence to decide how much weight to give scaffold positions during variance analysis.
 
 ## Scout Anti-Patterns
 
@@ -97,9 +97,9 @@ The scout MUST NOT:
 2. **Compare scope against artifacts.** The scout has no knowledge of the artifacts.
 3. **Speculate beyond evidence.** If a file does not contain evidence, report it as absent.
 4. **Modify files.** Read-only.
-5. **Spawn further subagents.** Only the arbiter spawns subagents.
+5. **Spawn further subagents.** Only the decision-variance skill spawns subagents.
 6. **Include excerpts, quotes, or pasted content.** File path and line number only.
-7. **Invent decision categories.** Use only those from `.agents/skills/arbiter/references/decision-categories.md`. Anomalies go in the Anomalies section without category labels.
+7. **Invent decision categories.** Use only those from `.agents/skills/decision-variance/references/decision-categories.md`. Anomalies go in the Anomalies section without category labels.
 
 ## Scout Scope Sizing
 
@@ -111,6 +111,6 @@ A scout's scope should be readable in one focused pass:
 
 If a scope is too large, the scout returns: "Scope exceeded — narrow assignment needed. The assigned scope contains approximately <N> files. Recommend splitting into <suggested breakdown>." Do not produce a low-fidelity report.
 
-## Arbiter Composition
+## Composition by the Decision-Variance Skill
 
-After scouts return, the arbiter composes findings into the unified evidence index. Composition is the arbiter's job, not the scouts'. Each scout's report is preserved as an appendix in the evidence index file for traceability.
+After scouts return, the decision-variance skill composes findings into the unified evidence index. Composition is the decision-variance skill's job, not the scouts'. Each scout's report is preserved as an appendix in the evidence index file for traceability.

--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -101,7 +101,7 @@ PASS (no CRITICAL or HIGH findings) | BLOCK (N CRITICAL, N HIGH findings must be
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -110,6 +110,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/standards-compliance-reviewer.md
+++ b/.agents/agents/standards-compliance-reviewer.md
@@ -93,7 +93,7 @@ PASS | BLOCK (N HIGH findings — banned pattern violations or lint failures)
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -102,6 +102,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/agents/trust-zone-reviewer.md
+++ b/.agents/agents/trust-zone-reviewer.md
@@ -87,7 +87,7 @@ PASS | BLOCK (N undeclared crossings or N undeclared egress paths)
 
 ## Out-of-Scope Findings
 
-If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing` skill with:
+If you encounter a finding outside your scope — a concern that is real but does not fall within the responsibilities defined for this agent — do NOT act on it and do NOT inline it in your response. Instead, invoke the `ticketing-router` skill with:
 
 - A short title (< 80 chars)
 - A body containing four sections:
@@ -96,6 +96,6 @@ If you encounter a finding outside your scope — a concern that is real but doe
   - **Why it's out of scope** — why you are not acting on it
   - **Suggested handling** — optional hint for the parent (may be empty)
 
-The ticketing skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
+The ticketing-router skill routes through the in-repo or Plane variant based on `projectContext/ticketing-config.md`. When ticketing is disabled, fall back to inlining the finding with a `[NEEDS-TRIAGE]` marker. Never silently drop the finding.
 
 MUST NOT propose an ADR as the resolution of the finding. ADRs require user attribution and are authored only via `/adr`.

--- a/.agents/commands/_redirect.md
+++ b/.agents/commands/_redirect.md
@@ -10,8 +10,8 @@ Not user-invocable. Filename starts with `_` to signal "internal."
 ## Strike 1 — first off-channel message
 
 ```
-Process required. I don't accept direct instructions or questions outside of a
-skill channel — that path bypasses the gates that keep the project healthy.
+Process required. Direct instructions outside a skill channel are not accepted
+— that path bypasses the gates that keep the project healthy.
 
 What are you trying to do?
 → Start a feature:          /feature "describe it"
@@ -27,7 +27,7 @@ What are you trying to do?
 ## Strike 2 — user insists after Strike 1
 
 ```
-I will not accept this as a direct instruction. Choose a channel:
+Direct instruction declined. Choose a channel:
 /feature  /fix  /commit  /pr  /review  /threat-model  /adr  /adr-status
 /checkpoint  /stage  /add-dep  /surface-conflict  /btw  /status  /init
 /override  /onboard  /new-skill  /ticket  /commands

--- a/.agents/commands/add-dep.md
+++ b/.agents/commands/add-dep.md
@@ -25,5 +25,5 @@ After the reviewer clears the package, codeArbiter shows the install command for
 ## When NOT to Use
 
 - To remove a dependency: use `/feature` or `/fix` with the change described
-- To update an existing dependency: same — changes to `package.json` trigger `dependency-reviewer` automatically via `/pr`
+- To update an existing dependency: same — changes to `package.json` route to `dependency-reviewer` automatically via `/pr`
 - To ask about a package without installing it: use `/btw`

--- a/.agents/commands/btw.md
+++ b/.agents/commands/btw.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Lightweight Q&A about the project, codebase, architecture, or decisions. No skill is invoked. No routing table fires. No state changes. No side effects. Answer directly and conversationally.
+Lightweight Q&A about the project, codebase, architecture, or decisions. No skill is invoked. No routing table entry applies. No state changes. No side effects. Answer directly and conversationally.
 
 ## Usage
 
@@ -19,7 +19,7 @@ The question can be anything about the project that doesn't require implementati
 
 1. codeArbiter reads from `projectContext/` as needed to answer the question accurately
 2. Answer delivered directly in the conversation
-3. No skill invoked, no agent dispatched, no file written, no routing table entry fires
+3. No skill invoked, no agent dispatched, no file written, no routing table entry applies
 4. If the question reveals a gap in `projectContext/` (a question that can't be answered from existing docs): note the gap and suggest using `/adr` or `/status` as appropriate
 
 ## Key Behaviors
@@ -35,7 +35,7 @@ The question can be anything about the project that doesn't require implementati
 - Does NOT invoke any skill
 - Does NOT write or modify any file
 - Does NOT run any tests or linters
-- Does NOT fire any routing table entry
+- Does NOT engage any routing table entry
 - Does NOT open a PR or commit anything
 - Does NOT resolve `[CONFIRM-NN]` placeholders — those require `/adr` or `/surface-conflict`
 

--- a/.agents/commands/checkpoint.md
+++ b/.agents/commands/checkpoint.md
@@ -17,7 +17,7 @@ No arguments. Checkpoint reviews the entire codebase against all projectContext 
 All 7 checkpoint agents run in parallel (no ordering dependency between them):
 
 1. `architecture-drift-reviewer` — reads `projectContext/decisions/` and scans for code that contradicts accepted ADRs
-2. `test-audit-reviewer` — reads `projectContext/audit-spec.md` and `projectContext/tech-stack.md`; audits test coverage and audit event emission
+2. `coverage-auditor` — reads `projectContext/audit-spec.md` and `projectContext/tech-stack.md`; audits test coverage and audit event emission
 3. `security-reviewer` — reads `projectContext/security-controls.md` and `projectContext/trust-zones.md`; reviews security posture
 4. `standards-compliance-reviewer` — reads `projectContext/coding-standards.md`; checks naming, banned patterns, type safety
 5. `scaffold-completeness-reviewer` — reads `projectContext/open-tasks.md`; identifies planned artifacts that don't yet exist

--- a/.agents/commands/commands.md
+++ b/.agents/commands/commands.md
@@ -40,7 +40,7 @@ Example format:
 | /adr-status     | Report ADR health — aged, unchallenged, placeholders | decision-lifecycle skill |
 | /checkpoint     | Full cross-cutting codebase review                 | all 7 checkpoint agents |
 | /stage [N]      | Report or advance project stage                    | stage-gating skill |
-| /btw "question" | Lightweight Q&A — no routing fires                 | (none) |
+| /btw "question" | Lightweight Q&A — no routing occurs                | (none) |
 | /status         | Formatted project status report                    | (none) |
 | /surface-conflict | Stop all work and surface a contradiction        | (none) |
 | /add-dep "pkg"  | Vet and add a dependency                           | dependency-reviewer agent |

--- a/.agents/commands/commit.md
+++ b/.agents/commands/commit.md
@@ -19,5 +19,5 @@ No arguments. The skill reads current git state (staged files, diff, test result
 ## When NOT to Use
 
 - Before writing code: use `/feature` or `/fix` first
-- To check PR readiness: use `/pr` — runs additional BLOCK-level reviews
+- To check PR readiness: use `/pr` — dispatches additional BLOCK-level reviewers
 - To run tests without committing: run the test command from `projectContext/tech-stack.md` directly

--- a/.agents/commands/debug.md
+++ b/.agents/commands/debug.md
@@ -1,0 +1,62 @@
+# /debug "symptom description"
+
+## Purpose
+
+Investigate an observed defect, anomaly, or unexpected behavior whose **cause is not yet known**. `/debug` is the disciplined investigate-then-decide root-cause analysis (RCA) workflow. It deliberately separates **investigation** from **implementation**: no code is modified while debugging. The session terminates only at an explicit Phase 4 disposition — confirmed bug routed to `/fix`, ambiguity routed to `/ticket` or `/adr`, or a recorded no-action close.
+
+## Usage
+
+```
+/debug "clear description of the observed symptom"
+```
+
+The argument must describe the symptom with enough fidelity that a different operator could reproduce the situation: observed behavior, reproduction steps (or intermittent-trigger profile), and environment / stage. Vague descriptions ("it's flaky", "something's off") will be rejected — codeArbiter will ask for clarification before routing.
+
+## Routes To
+
+`debug` skill (`.agents/skills/debug/SKILL.md`) — all five phases:
+
+1. **Symptom Capture** — record observed vs. expected behavior, minimal repro, environment, evidence in hand.
+2. **Hypothesis Generation** — produce at least three distinct ranked candidate causes, including at least one "boring" environmental / configuration / dependency hypothesis.
+3. **Evidence Gathering** — read logs, traces, audit events, commits, configuration. No code modification.
+4. **Root Cause Decision** — exit to exactly one of:
+   - **(a) Confirmed bug** → emit `/fix` invocation carrying the confirmed bug statement, cited evidence, and a named regression test obligation.
+   - **(b) Behavior / design ambiguity** → emit `/ticket` (open work item) or `/adr` (architectural decision, with user attribution) with the symptom record and evidence ledger attached.
+   - **(c) No-action close** → record symptom and rationale to `.agents/projectContext/debug-log.md`.
+5. **Handoff** — emit summary block and route the chosen exit.
+
+## Phase Gates (hard stops)
+
+- **Phase 1** BLOCKs on no minimal repro (or no documented intermittent-trigger profile).
+- **Phase 2** BLOCKs on fewer than three distinct hypotheses, or single-hypothesis lock-in.
+- **Phase 3** BLOCKs on **any code modification** — code changes belong to `/fix`, not `/debug`. Also BLOCKs on collapsing INCONCLUSIVE evidence to CONFIRMED without a cited source.
+- **Phase 4** BLOCKs on no-decision. MUST exit with one of (a), (b), or (c).
+- **Phase 5** BLOCKs if exit (a) is selected but no regression test obligation is named — `/fix` refuses to proceed without one.
+
+## Distinction from /fix
+
+- `/fix` requires a **known bug** with a regression test obligation stated up front. It writes code.
+- `/debug` is for **"I don't know what's wrong yet."** It writes no code. Its job is to produce the payload that `/fix` (or `/ticket` / `/adr`) needs in order to begin.
+
+If the cause is already known and a regression test is already named, skip `/debug` and invoke `/fix` directly. If you start in `/debug` and Phase 4 lands on exit (a), `/debug` will emit the `/fix` invocation for you.
+
+## Example invocations
+
+- `/debug "intermittent 502 on /api/users during peak hours, started ~3 days ago"`
+- `/debug "test suite passes locally but fails on CI runner — auth fixture test only"`
+- `/debug "memory usage on the worker pod climbs without bound after ~6h uptime"`
+- `/debug "users report stale data after profile update — only on staging, not production"`
+
+## When NOT to Use
+
+- **Known bug with named regression test:** use `/fix` directly.
+- **Design discussion with no failing behavior in hand:** use `/adr` or `/ticket`.
+- **New feature implementation:** use `/feature`.
+- **General questions about why something behaves a certain way (no defect):** use `/btw`.
+- **Re-entry from inside `/fix`, `/ticket`, or `/adr`:** exit that command first, then re-enter via `/debug`. `debug` MUST NOT be invoked from inside those commands (routing-cycle prevention).
+
+## See Also
+
+- `/fix` — once root cause is confirmed and a regression test obligation is named (Phase 4 exit (a)).
+- `/ticket` — for behavior / design ambiguity needing triage (Phase 4 exit (b)).
+- `/adr` — for architectural ambiguity requiring a decision (Phase 4 exit (b), with user attribution).

--- a/.agents/commands/hotfix.md
+++ b/.agents/commands/hotfix.md
@@ -1,0 +1,189 @@
+# /hotfix "reason" --severity P0|P1 --escalation-tier <user> --auto-revert-window 24h|72h|7d
+
+## Purpose
+
+Emergency-bypass channel for P0/P1 incidents where waiting on the full gate suite
+would extend production harm. Unlike `/override` (a per-action escape hatch),
+`/hotfix` is a **two-person, time-boxed, post-hoc-audited** bypass: it requires a
+second-identity attestation, records an auto-revert deadline, and mandates a
+post-hoc ADR within 72 hours.
+
+Hotfixes are never silent. Every invocation appends to
+`.agents/projectContext/hotfixes.log` and is surfaced at the next `/checkpoint`.
+
+## Usage
+
+```
+/hotfix "auth service returning 500 for all tenants — rollback blocked by failing migration-reviewer" \
+  --severity P0 \
+  --escalation-tier "j.smith@example.com" \
+  --auto-revert-window 72h
+```
+
+### Required Arguments
+
+| Arg | Values | Meaning |
+|---|---|---|
+| `"reason"` | free-form string | What is being bypassed and why the incident justifies skipping the gate. Vague reasons ("prod is down") are rejected. |
+| `--severity` | `P0` or `P1` | Incident severity. P0 = customer-facing outage or data-integrity event. P1 = severe degradation. Anything lower MUST NOT use `/hotfix` — use `/override` instead. |
+| `--escalation-tier` | identity string (email or username) | The second human attesting to the bypass. MUST differ from the auto-detected operator identity (see Identity Detection). |
+| `--auto-revert-window` | `24h`, `72h`, or `7d` (default `72h`) | Wall-clock window after which `/checkpoint` will flag the hotfix as expired-without-followup and BLOCK stage promotion. |
+
+## Routes To
+
+Workflow implemented inline in this command body — no backing skill. The command
+dispatches its own steps (see Inline Workflow below) and reads/writes
+`.agents/projectContext/hotfixes.log`.
+
+## Identity Detection (in priority order — never ask if any succeeds)
+
+Same path as `/override`:
+
+1. `git config user.email` and `git config user.name` — always try first
+2. `GITHUB_ACTOR`, `GITEA_TOKEN`, `GITEA_ACTOR` environment variables
+3. GitHub CLI: `gh auth status` — extract logged-in username
+4. If ALL detection fails → ask: "Please state your name for the hotfix log."
+
+The result of this detection is the **operator identity**.
+
+## Second-Identity Attestation
+
+`/hotfix` requires a second human in the loop. The user passed via
+`--escalation-tier` is the **attesting identity**.
+
+**Hard rule:** the attesting identity MUST differ from the operator identity. If
+they match — by email, by username, or by any normalized form codeArbiter can
+detect — the command BLOCKS with:
+
+```
+BLOCK: second-identity attestation failed.
+  operator:   <detected>
+  escalation-tier: <same>
+A hotfix requires a second human. Re-invoke with --escalation-tier set to a
+different identity, or use /override for a single-actor bypass.
+```
+
+The second-identity check is non-negotiable. There is no flag to disable it. If
+the attesting party is unreachable, the correct path is `/override` plus a
+follow-up ADR — not a forged second identity.
+
+## Log File
+
+Appends to `.agents/projectContext/hotfixes.log` (append-only, never modified,
+parallel to `overrides.log`).
+
+The meta-framework does NOT pre-place `hotfixes.log`. It is created at first
+invocation in a downstream project. The file is committed to the repo as a
+permanent audit artifact.
+
+### Log Entry Format
+
+```
+[ISO-8601 timestamp] | BY: <operator-name> <<operator-email>> | ATTESTED-BY: <escalation-tier> | SEVERITY: <P0|P1> | GATE: <gate bypassed> | EXPIRES: <ISO-8601 deadline> | ADR: <pending|ADR-NNNN> | REASON: <user's reason>
+```
+
+The `ADR:` field is written as `pending` at invocation time and updated in-place
+**only by `/adr`** when the post-hoc ADR is authored. This is the single
+exception to the append-only rule and is enforced by `/adr`, not by hand.
+
+## Auto-Revert Window
+
+The `--auto-revert-window` value is added to the invocation timestamp to compute
+the **expiration deadline**. The deadline is written into the log entry's
+`EXPIRES:` field.
+
+After expiration:
+
+- `/checkpoint` MUST scan `hotfixes.log` for entries past their `EXPIRES:`
+  deadline with `ADR: pending`.
+- Any such entry causes `/checkpoint` to flag it as **expired-without-followup**
+  and BLOCK stage promotion until either:
+  - the post-hoc ADR is authored (updating `ADR:` to a real ID), or
+  - the bypass is reverted and a new log entry is appended noting the revert.
+
+`/checkpoint` does NOT automatically revert code. The "auto" in
+`--auto-revert-window` refers to the automatic surfacing and BLOCK, not to an
+automated code revert.
+
+## Mandatory Post-Hoc ADR
+
+Within **72 hours** of invocation (independent of the `--auto-revert-window`
+value), the operator MUST author a post-hoc ADR via `/adr` documenting:
+
+- What gate was bypassed and why the bypass was necessary
+- What the longer-term decision is (keep the change, revert, refactor, etc.)
+- What signals would trigger the same bypass in the future, if any
+
+When `/adr` is invoked for a hotfix-driven decision, it updates the
+corresponding `hotfixes.log` entry's `ADR:` field from `pending` to the assigned
+ADR ID.
+
+**Failure to author the post-hoc ADR within 72h = BLOCK on stage promotion.**
+`/checkpoint` enforces this independent of the auto-revert window.
+
+## Inline Workflow
+
+`/hotfix` dispatches the following steps in order. Each step is a hard gate —
+failure halts the command.
+
+1. **Identity detection + second-identity check.** Resolve operator identity
+   via the priority sequence above. Compare to `--escalation-tier`. BLOCK if
+   they are the same identity.
+2. **Hotfix log entry written.** Append a new line to
+   `.agents/projectContext/hotfixes.log` with `ADR: pending` and the computed
+   `EXPIRES:` timestamp. The log write happens BEFORE the bypass is applied —
+   no silent bypasses.
+3. **Apply the bypass.** Proceed with the gated action that triggered the
+   hotfix.
+4. **Record the auto-revert deadline.** Confirm the `EXPIRES:` field in the
+   log entry matches the computed deadline. Surface the deadline in the
+   response.
+5. **Surface to operator.** Emit:
+
+   ```
+   Hotfix recorded.
+     log:      .agents/projectContext/hotfixes.log
+     attested: <escalation-tier>
+     expires:  <ISO-8601 deadline>
+   Post-hoc ADR required by <ISO-8601 72h-deadline>.
+   /checkpoint will BLOCK promotion until the ADR exists.
+   ```
+
+## Hard Gates
+
+- MUST detect operator identity before writing the log entry.
+- MUST verify `--escalation-tier` differs from operator identity. BLOCK on
+  match.
+- MUST write to `.agents/projectContext/hotfixes.log` BEFORE applying the
+  bypass.
+- MUST include severity, escalation-tier, and a justification. Vague reasons
+  are rejected.
+- MUST emit the post-hoc-ADR deadline in the response.
+- The hotfix is scoped to the immediate action only — it does not create a
+  standing exception.
+
+## Differences from /override
+
+| Dimension | `/override` | `/hotfix` |
+|---|---|---|
+| Intended use | Per-action escape hatch for any gate | P0/P1 incidents only |
+| Identities required | One (operator) | Two (operator + escalation-tier) — MUST differ |
+| Severity flag | None | `--severity P0\|P1` required |
+| Time-boxed | No | Yes — `--auto-revert-window` (24h/72h/7d) |
+| Post-hoc ADR | Optional | **Mandatory within 72h** |
+| Log file | `.agents/projectContext/overrides.log` | `.agents/projectContext/hotfixes.log` |
+| Checkpoint behavior | Surfaced at next checkpoint | Surfaced + BLOCKS stage promotion if expired or ADR-missing |
+| Reversibility framing | Justification-based | Deadline-based; expiration forces resolution |
+
+If you are reaching for `/hotfix` but the incident is not P0 or P1, use
+`/override` instead. If you are reaching for `/override` but cannot reach a
+second human, that is the correct call — do not synthesize a second identity to
+unlock `/hotfix`.
+
+## See Also
+
+- `/override` — single-actor escape hatch with audit log
+- `/adr` — authors the mandatory post-hoc decision record and updates the
+  `hotfixes.log` entry's `ADR:` field
+- `/checkpoint` — enforces expiration and post-hoc-ADR gates; BLOCKS stage
+  promotion when either is unsatisfied

--- a/.agents/commands/init.md
+++ b/.agents/commands/init.md
@@ -28,7 +28,7 @@ No arguments. This command is invoked when:
    **Path B — Sentinel missing from existing CONTEXT.md:**
    - Presents two options to the user:
      1. **Restore sentinel only** (non-destructive) — appends the sentinel to the existing `CONTEXT.md` without changing any other content
-     2. **Full re-initialize** (destructive) — re-runs the context creation workflow from scratch, overwriting `CONTEXT.md`
+     2. **Full re-initialize** (destructive) — re-routes to the context-creation workflow from scratch, overwriting `CONTEXT.md`
    - **Waits for user to choose explicitly** — does not proceed without a clear selection
    - If the user chooses option 2 (destructive): confirms a second time ("This will overwrite CONTEXT.md. Confirm?")
 

--- a/.agents/commands/pr.md
+++ b/.agents/commands/pr.md
@@ -28,7 +28,7 @@ No arguments. codeArbiter reads the current branch, its diff against the base br
    - All paths → `test-audit-reviewer` + `standards-compliance-reviewer` (BLOCK-level)
 3. **All reviewer agents run** — in parallel where there are no dependencies
 4. **BLOCK finding check** — if any CRITICAL or HIGH finding is raised: STOP, present finding to user, do not proceed to PR draft
-5. **User resolves BLOCK findings** — user addresses each finding and re-runs `/commit`, then `/pr`
+5. **User resolves BLOCK findings** — user addresses each finding and re-invokes `/commit`, then `/pr`
 6. **PR draft staged** — after all BLOCK findings cleared:
    - Title: concise, describes the change
    - Summary: what changed, why, what was tested

--- a/.agents/commands/pr.md
+++ b/.agents/commands/pr.md
@@ -25,7 +25,7 @@ No arguments. codeArbiter reads the current branch, its diff against the base br
    - Migration files → `migration-reviewer` (BLOCK-level)
    - Dependency files → `dependency-reviewer` (BLOCK-level)
    - Trust zone crossing code → `trust-zone-reviewer` (BLOCK-level)
-   - All paths → `test-audit-reviewer` + `standards-compliance-reviewer` (BLOCK-level)
+   - All paths → `coverage-auditor` + `standards-compliance-reviewer` (BLOCK-level)
 3. **All reviewer agents run** — in parallel where there are no dependencies
 4. **BLOCK finding check** — if any CRITICAL or HIGH finding is raised: STOP, present finding to user, do not proceed to PR draft
 5. **User resolves BLOCK findings** — user addresses each finding and re-invokes `/commit`, then `/pr`

--- a/.agents/commands/refactor.md
+++ b/.agents/commands/refactor.md
@@ -1,0 +1,91 @@
+# /refactor "surface and motivation"
+
+## Purpose
+
+Restructure existing code without changing observable behavior. The only permitted path to begin
+refactor work. Routes to the `refactor` skill, which proves behavioral parity through pre-existing
+test coverage before any edit lands and refuses to accept modified tests as evidence of correctness.
+
+A refactor that cannot demonstrate parity through unmodified pre-existing tests is not a refactor —
+it is a feature change in disguise and will be re-routed to `/feature`.
+
+## Usage
+
+```
+/refactor "description of surface and motivation"
+```
+
+The description has two required parts:
+
+1. **Surface** — the exact files, functions, classes, or methods being restructured. Vague surfaces
+   ("the auth module", "some helpers in utils") will be rejected at Phase 1. A reader must be able
+   to grep the repo for the named symbols and arrive at the same file set.
+2. **Motivation** — why the restructure is worth doing (e.g., "to remove the duplicated retry logic
+   between `httpClient` and `wsClient`", "to extract `signToken` from `auth/index.ts` into its own
+   module before further auth changes land").
+
+## What it routes to
+
+`refactor` skill (`.agents/skills/refactor/SKILL.md`) — all six phases:
+
+1. **Phase 1 — Surface Identification:** lock the exact files, symbols, and public signatures.
+2. **Phase 2 — Behavioral Parity Coverage Proof:** demonstrate pre-existing tests already cover the
+   named surface to the stage threshold, with at least one direct test per public method.
+3. **Phase 3 — Red Parity Tests (conditional):** when the refactor exposes a new test seam, write
+   failing tests pinning the seam's contract before implementation.
+4. **Phase 4 — Implementation:** apply the restructure mechanically within the surface table; no
+   new behavior, branches, error paths, or side effects.
+5. **Phase 5 — Parity Verification:** the full pre-existing test suite passes with zero edits to
+   any pre-existing test file.
+6. **Phase 6 — Lint/Coverage Gate:** lint, type-check, and coverage all clear; surface coverage
+   MUST NOT regress.
+
+### Hard gate
+
+**No refactor proceeds without behavioral-parity coverage proof in Phase 2.** If the named surface
+is below the stage coverage threshold, or any public method has zero direct tests, the skill halts
+and routes to `tdd` Phase 1 to backfill obligations and tests. Refactor resumes only after the
+backfill is green.
+
+Additional gates: a Phase 4 diff that would classify as `feat` under `commit-gate` Phase 3, or a
+Phase 5 verification that depends on edits to a pre-existing test, both terminate the refactor and
+re-route to `/feature` or `/fix`.
+
+## When NOT to use
+
+- **New behavior:** use `/feature`. If the change adds a branch, an error path, a side effect, a new
+  public method beyond a Phase 3 seam, or alters the value any pre-existing input maps to, it is a
+  feature, not a refactor.
+- **Bug fix:** use `/fix`. A change motivated by "the current behavior is wrong" is a bug fix; its
+  Phase 1 is framed around a failing regression test, not parity coverage.
+- **Questions or discussion:** use `/btw`.
+- **Committing an already-completed refactor:** use `/commit` — `commit-gate` still classifies and
+  gates the staged diff.
+
+## Examples
+
+```
+/refactor "extract signToken, verifyToken, and rotateKey from src/auth/index.ts into src/auth/tokens.ts so the next auth-rotation feature has a clean seam"
+```
+
+```
+/refactor "rename `UserRepo.fetchById` to `UserRepo.findById` across src/users/** and update all call sites in src/api/**"
+```
+
+```
+/refactor "collapse the duplicated retry-with-backoff implementations in src/http/client.ts and src/ws/client.ts into a shared src/net/retry.ts"
+```
+
+```
+/refactor "inline the single-call-site helper `formatLogLine` from src/log/format.ts into src/log/emit.ts and delete the now-empty format.ts"
+```
+
+```
+/refactor "split src/payments/processor.ts (currently 800 lines) into processor.ts (orchestration), validation.ts, and settlement.ts without changing the exported Processor class signature"
+```
+
+## See also
+
+- `/feature` — for any change that adds, removes, or alters observable behavior.
+- `/fix` — for confirmed bugs; Phase 1 framed around a failing regression test.
+- `/commit` — for gating the staged diff after the refactor's six phases complete.

--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -1,0 +1,189 @@
+# /release ["version" | --auto | --dry-run]
+
+## Purpose
+
+Compose a tagged, announceable release. `/release` is the **only permitted path** to a version
+tag. It does not duplicate the project's existing compliance machinery — it aggregates it. The
+command routes to the `release` skill, which orders the `tdd` outcome, the `commit-gate`
+SemVer classification, the `/checkpoint` review aggregate, the `decision-lifecycle` ADR health
+audit, and the `stage-gating` stage threshold check into one sequenced gate run. If any prior
+gate was DEFERRED rather than PASS, the release is BLOCKED — there are no partial releases.
+
+A release is not a commit. A release is a deployment-readiness assertion: the codebase at this
+SHA, under the current stage, satisfies every published threshold for shipping.
+
+---
+
+## Usage
+
+```
+/release                  # compute version from SemVer rules (same as --auto)
+/release "1.2.3"          # use the explicit version supplied
+/release --auto           # compute version from commit log (Conventional Commits)
+/release --dry-run        # run all gates; STOP before composing the tag
+```
+
+### Argument Semantics
+
+- **Explicit version (e.g., `"1.2.3"`).** The version is supplied by the operator. The release
+  skill Phase 3 still classifies the commit window and BLOCKS if the supplied version disagrees
+  with the SemVer-derived classification (e.g., a `feat` commit is present but the operator
+  supplied a patch bump). The classification is not silently downgraded or upgraded.
+- **`--auto`.** The version is derived mechanically from the commit log in `LAST_TAG..HEAD`
+  using the Conventional Commits taxonomy enforced by the `commit-gate` skill. This is the
+  default when no version argument is supplied.
+- **`--dry-run`.** Runs Phases 1 through 6 in full, surfaces the deployment-readiness report
+  as it stands, and STOPS before Phase 7 — no tag is composed, no changelog is appended, no
+  release report is written to `projectContext/releases/`. Use this to confirm the release
+  would be green without committing the artifact.
+
+The `--auto` and `--dry-run` flags MAY be combined. An explicit version MAY be combined with
+`--dry-run`. An explicit version MUST NOT be combined with `--auto` — they are mutually
+exclusive.
+
+---
+
+## Routes To
+
+`release` skill (`.agents/skills/release/SKILL.md`) — Phases 1 through 7. The skill is a gate
+aggregator; it routes to other skills and reads their verdicts. The command itself does not
+dispatch agents directly.
+
+### Phase Routing Map
+
+| Phase | Name                          | Routes to                                              |
+|-------|-------------------------------|--------------------------------------------------------|
+| 1     | Pre-Flight Readiness          | Reads `tdd` Phase 6 result, `commit-gate` HEAD footer  |
+| 2     | Checkpoint Gate               | Invokes `/checkpoint` (or reads fresh signed-off doc)  |
+| 3     | Version Bump (SemVer)         | Reads commit log; reuses `commit-gate` Phase 3 taxonomy |
+| 4     | Changelog Generation          | Reads `CHANGELOG:` footers from `commit-gate` output   |
+| 5     | ADR Currency Check            | Routes to `decision-lifecycle` Phase 4                 |
+| 6     | Stage Threshold Verification  | Routes to `stage-gating` Phase 1 + Phase 2             |
+| 7     | Tag and Announce              | Composes annotated tag + writes release report         |
+
+---
+
+## What Happens Step by Step
+
+1. **Pre-flight checks.** Verify `.agents/projectContext/stage` is readable and numeric. Verify
+   `audit-spec.md` is present. Verify the working tree is clean. Verify the current branch is
+   the configured release branch. Identify `LAST_TAG` and the release window.
+2. **Phase 1 readiness.** Confirm the most recent `tdd` Phase 6 was PASS, the HEAD commit was
+   not produced via `/override`, no blocking `[CONFIRM-NN]` entries are open, and an ADR health
+   table is available (or refresh it via `decision-lifecycle` Phase 1 + 2).
+3. **Phase 2 checkpoint.** If a signed-off checkpoint document covers the release window, read
+   it. Otherwise, invoke `/checkpoint` and wait. BLOCK on any unresolved CRITICAL finding or
+   any open `BLOCKS_S<current-stage>` finding.
+4. **Phase 3 version bump.** Classify every commit in `LAST_TAG..HEAD` by Conventional
+   Commits type. Apply the highest-precedence bump (major beats minor beats patch). If an
+   explicit version was supplied, verify it matches the classification.
+5. **Phase 4 changelog.** Roll up every `CHANGELOG:` footer from `feat`, `fix`, and `perf`
+   commits into a new section. BLOCK if any `feat` or `fix` commit lacks the footer.
+6. **Phase 5 ADR currency.** Route to `decision-lifecycle` Phase 4. BLOCK on any ADR with a
+   confidence rating ≤ 2.
+7. **Phase 6 stage thresholds.** Route to `stage-gating` Phase 1 + Phase 2 against the full
+   codebase scope. Confirm coverage threshold, fail-closed audit posture, and trust-zone
+   declarations meet the current stage's requirements.
+8. **Phase 7 tag and announce.** If every prior phase recorded PASS, compose the annotated tag
+   and write the deployment-readiness report to `projectContext/releases/vMAJOR.MINOR.PATCH.md`.
+   If `--dry-run` was supplied, STOP here without composing the tag.
+9. Surface the deployment-readiness report path to the user. MUST NOT push the tag to a remote
+   without explicit user authorization.
+
+---
+
+## Hard Gates
+
+- **No release tag without all 7 release-skill phases green.** Any phase verdict of BLOCK or
+  DEFERRED halts the release. DEFERRED is not PASS.
+- All seven phases of the `release` skill MUST run in order. No phase may be skipped, even on
+  `--dry-run` (the dry-run flag suppresses only the Phase 7 tag composition, not the gate
+  evaluation).
+- MUST NOT compose a tag if the `/checkpoint` document covering the release window is unsigned
+  by a named approver. The approver MUST be a person — never "codeArbiter" or "automated".
+- MUST NOT silently downgrade or upgrade the SemVer classification in Phase 3. An explicit
+  version argument that disagrees with the commit log BLOCKS the release.
+- MUST NOT auto-fill a missing `CHANGELOG:` footer in Phase 4. The absence is a compliance gap
+  surfaced for user remediation via `commit-gate`.
+- MUST NOT modify ADR status to clear a blocking ADR in Phase 5. ADR status changes route
+  through `/adr` with explicit user attribution.
+- MUST NOT push the composed tag to a remote without explicit user instruction. Tag publication
+  is a separate decision after the user reviews the deployment-readiness report.
+- Any phase BLOCK may be bypassed only via `/override`, which appends to
+  `.agents/projectContext/overrides.log`.
+
+---
+
+## Interactions
+
+- **`/checkpoint`** is invoked from Phase 2 if a fresh signed-off checkpoint document is not
+  already present for the release window. The release skill reads the resulting document and
+  gates on finding counts; it does not re-implement the checkpoint review.
+- **`decision-lifecycle` skill** is routed to from Phase 1 (Phases 1 + 2 for a surface ADR
+  health table) and from Phase 5 (Phase 4 for Challenge Routing). The release inherits the
+  skill's confidence-rating gate: ratings ≤ 2 BLOCK.
+- **`stage-gating` skill** is routed to from Phase 6 (Phases 1 + 2 against the full codebase
+  scope at HEAD). The release inherits the skill's authority on which rules apply at the
+  current stage.
+- **`commit-gate` skill** is referenced (not routed to) in Phase 3 for the Conventional Commits
+  taxonomy and in Phase 4 for the `CHANGELOG:` footer contract. The HEAD commit MUST have been
+  produced by `commit-gate` with all phases PASS — if produced via `/override`, Phase 1 BLOCKS
+  pending fresh re-authorization.
+- **`/adr` command** is the user-facing route to resolve a blocking ADR surfaced in Phase 5.
+  The release skill MUST NOT author replacement ADRs on its own.
+
+---
+
+## Example Invocations
+
+```
+/release
+```
+Default flow. Equivalent to `/release --auto`. Runs Phases 1–7, classifies the commit window,
+computes the next version, and composes the tag if every gate is green.
+
+```
+/release --auto
+```
+Explicit form of the default. Useful when the operator wants to be unambiguous in scripts or
+in audit-traceable conversations.
+
+```
+/release "2.0.0"
+```
+Operator supplies an explicit version. Phase 3 still classifies the commit log and BLOCKS if
+the supplied version disagrees (e.g., the operator supplied a major bump but the commit window
+contains only `fix` commits, or vice versa).
+
+```
+/release --dry-run
+```
+Runs all seven gates and surfaces the deployment-readiness report as it stands, then STOPS
+before tag composition. Useful as a pre-flight before a real release window opens.
+
+```
+/release "1.4.0" --dry-run
+```
+Validates that an explicit version `1.4.0` would pass every gate without committing the tag.
+Combine when the operator wants to pre-confirm a planned version against the current SHA.
+
+---
+
+## When NOT to Use
+
+- **Tagging an in-progress branch.** `/release` operates only on the configured release branch
+  with a clean working tree. Use `/feature` / `/fix` to land work first.
+- **A hotfix that bypasses a gate.** Hotfixes that need to skip a gate are `/override` events,
+  not `/release` events. There are no abbreviated releases.
+- **Pushing an already-composed tag.** `/release` composes the tag locally; remote publication
+  is a separate user-authorized step.
+- **Producing only a changelog.** The changelog is a phase output, not the deliverable. Use the
+  full command — there is no changelog-only flow.
+
+---
+
+## See Also
+
+- `/checkpoint` — full cross-cutting review of the codebase; required input to release Phase 2
+- `/stage` — stage promotion; consumes the release tag at stages requiring one
+- `/adr-status` — surface-scan ADR health table; useful before `/release` to anticipate Phase 5

--- a/.agents/commands/review.md
+++ b/.agents/commands/review.md
@@ -56,7 +56,7 @@ Path-conditional (invoked when the scope matches):
 
 ## When NOT to Use
 
-- To open a PR (which runs reviews automatically): use `/pr`
+- To open a PR (which dispatches reviewers automatically): use `/pr`
 - For a full checkpoint across the entire codebase: use `/checkpoint`
 - For a threat model before a new feature: use `/threat-model`
 - For questions about the code: use `/btw`

--- a/.agents/commands/review.md
+++ b/.agents/commands/review.md
@@ -17,7 +17,7 @@ Run a targeted review of a specific file, path, or the current diff. Routes to t
 `security-architecture` skill, plus reviewer agents determined by path matrix (see below).
 
 Always invoked:
-- `test-audit-reviewer` — audits test coverage and audit event emission for the reviewed scope
+- `coverage-auditor` — audits test coverage and audit event emission for the reviewed scope
 
 Path-conditional (invoked when the scope matches):
 - `auth-crypto-reviewer` + `security-reviewer` — if path includes auth, crypto, middleware, secrets handling, or audit libraries

--- a/.agents/commands/rotate.md
+++ b/.agents/commands/rotate.md
@@ -1,0 +1,109 @@
+# /rotate "artifact-id"
+
+## Purpose
+
+Rotate a single rotation-bearing artifact — signing key, OIDC client secret,
+TLS certificate, API token, or service account credential — through the full
+inventory → cadence → plan → audit-emit → archival lifecycle. No replacement
+credential is issued and no audit event is emitted before every phase gate
+clears. A rotation without an archival record is treated as credential loss.
+
+## Usage
+
+```
+/rotate "artifact-id"
+```
+
+The `artifact-id` is the artifact's store reference as recorded in
+`projectContext/secrets-policy.md` — never the credential value, never a
+fingerprint of the value. Acceptable identifier forms:
+
+- Signing key name (e.g., `jwt-signer-2025`)
+- OIDC client ID (e.g., `oidc-client-partner-portal`)
+- TLS certificate subject (e.g., `CN=api.example.internal`)
+- Service-account ID (e.g., `sa-worker-ingest`)
+
+## Routes To
+
+`rotation` skill (`.agents/skills/rotation/SKILL.md`) — Phases 1 through 5:
+
+1. **Inventory** — confirm the artifact has a recorded last-rotation timestamp.
+2. **Cadence Check** — confirm the artifact is not past its cadence (or move
+   it into the rotation plan if it is).
+3. **Rotation Plan** — issuance path, dual-running window, consumer cutover,
+   archival path, named approver.
+4. **Audit Emit** — routes to the `audit-emit` skill for action classification,
+   emit construction, sink routing, fail-closed check, and test obligation.
+5. **Archival** — append the four-fact record (which / when / what / who) to
+   the archival destination and update the last-rotation timestamp.
+
+The `rotation` skill extends `secret-handling` (storage-path dimension) and
+`crypto-compliance` (primitive dimension) with the lifecycle dimension. Phase
+3 routes the proposed replacement primitive through `crypto-compliance`
+before issuance. Phase 4 routes the rotation event through `audit-emit` in
+full — Phase 4 cannot exit until `audit-emit` Phase 5 (Test Obligation) has
+completed.
+
+## Hard Gates (BLOCK conditions)
+
+- **No last-rotation timestamp** — artifact has no recorded rotation history
+  in `projectContext/secrets-policy.md`. Cadence cannot be audited; rotation
+  cannot proceed until inventory is repaired or the artifact is marked for
+  first-rotation flow.
+- **Past cadence** — artifact age exceeds the applicable cadence from
+  `secrets-policy.md` (or the documented default). The artifact MUST enter
+  the rotation plan or be recorded as a `CONFIRM-NN` exception in
+  `open-questions.md`; silent reconciliation is prohibited.
+- **No archival path** — `secrets-policy.md` does not define an archival
+  destination for this artifact category. The command stops and surfaces the
+  gap — no archival path is invented at the command layer.
+- **Missing audit-emit** — the `audit-emit` skill has not completed Phase 5
+  (Test Obligation) for the rotation event, or the emit routes through any
+  path other than the canonical sink in `projectContext/audit-spec.md`.
+- **Missing archival record** — Phase 5 has not written the four-fact record,
+  or the last-rotation timestamp has not been updated in the authoritative
+  register. The rotation is NOT marked complete until both are present.
+
+A `/rotate` invocation that hits any gate halts at the failing phase and
+surfaces the specific block reason. The orchestrator does not retry past a
+gate without the underlying condition being repaired.
+
+## Orchestrator-Triggered Invocation
+
+`/rotate` is user-invokable and also orchestrator-triggered:
+
+- The `/checkpoint` command's reviewer pass MAY surface an aged artifact
+  (`PAST-CADENCE` or `APPROACHING`). When it does, the orchestrator routes to
+  this command with the artifact id supplied. The user-confirmation step is
+  preserved — the orchestrator does not silently rotate.
+- A scheduled cadence audit may also surface aged artifacts; the same routing
+  applies.
+
+In both auto-triggered paths, the same Phase 1–5 sequence and the same hard
+gates apply. There is no "fast path" — auto-trigger only changes who supplied
+the artifact id, not what gates fire.
+
+## Example Invocations
+
+```
+/rotate "jwt-signer-2025"
+/rotate "oidc-client-partner-portal"
+/rotate "CN=api.example.internal"
+/rotate "sa-worker-ingest"
+/rotate "api-token-vendor-acme"
+```
+
+## When NOT to Use
+
+- **Read-only secret consumption with no lifecycle change** — use the normal
+  feature / fix path; that is `secret-handling` territory, not `rotation`.
+- **Primitive selection or TLS configuration with no key replacement** — that
+  is `crypto-compliance` territory; route via `/feature` or `/fix` instead.
+- **Adding a new dependency or container image** — use `/add-dep`.
+- **Discussion / questions about rotation policy** — use `/btw`.
+
+## See Also
+
+- `/add-dep` — vet a new third-party dependency through `dependency-reviewer`.
+- `/checkpoint` — the orchestrator pass that may surface an aged artifact and
+  auto-route to `/rotate`.

--- a/.agents/commands/surface-conflict.md
+++ b/.agents/commands/surface-conflict.md
@@ -61,7 +61,7 @@ Work is halted. Please resolve this conflict before codeArbiter proceeds.
 - MUST NOT silently continue if a conflict was detected — surface it every time
 - If the conflict involves a `[CONFIRM-NN]` placeholder that has been guessed or auto-resolved: flag that as a separate critical finding
 
-## When This Fires Automatically
+## When This Is Routed Automatically
 
 codeArbiter invokes `/surface-conflict` automatically when:
 - `AGENTS.md` and a `projectContext/` document contradict each other

--- a/.agents/commands/ticket.md
+++ b/.agents/commands/ticket.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-The user- and subagent-facing surface for the optional ticketing skill. Files
+The user- and subagent-facing surface for the optional ticketing-router skill. Files
 out-of-scope findings, lists open tickets, and closes them with a triage
-disposition. Routes through the `ticketing` skill, which dispatches to the
+disposition. Routes through the `ticketing-router` skill, which dispatches to the
 in-repo or Plane variant based on `projectContext/ticketing-config.md`.
 
 When ticketing is disabled (default), this command returns a disabled response
@@ -27,7 +27,7 @@ and otherwise has no effect.
 
 Files a new ticket. The body MUST contain the four sections required by the
 variant: Context, Finding, Why it's out of scope, Suggested handling. Subagents
-invoke this via the ticketing skill rather than as a slash command; the
+invoke this via the ticketing-router skill rather than as a slash command; the
 command surface is primarily for user-initiated triage.
 
 ### `/ticket close <id>`
@@ -74,7 +74,7 @@ skill on/off, switch modes, or update Plane workspace/project settings here.
 
 ## Routes To
 
-`ticketing` skill router (`.agents/skills/ticketing/SKILL.md`) → in-repo or
+`ticketing-router` skill (`.agents/skills/ticketing-router/SKILL.md`) → in-repo or
 Plane variant per `ticketing-config.md`.
 
 ## Hard Gates

--- a/.agents/hooks/post-write-edit.sh
+++ b/.agents/hooks/post-write-edit.sh
@@ -4,9 +4,9 @@ INPUT=$(cat)
 FPATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
 CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // ""')
 
-# H-06: projectContext file modified — remind doc-governance
+# H-06: projectContext file modified — remind doc-review-gate
 if echo "$FPATH" | grep -qE '\.agents/projectContext/'; then
-  echo "REMINDER [H-06]: projectContext file modified. Run doc-governance Phase 2 (freshness check) and Phase 3 (conflict detection) before committing." >&2
+  echo "REMINDER [H-06]: projectContext file modified. Run doc-review-gate Phase 2 (freshness check) and Phase 3 (conflict detection) before committing." >&2
 fi
 
 # H-07: dependency file changed — remind dependency-reviewer

--- a/.agents/projectContext/decisions/001-ticketing-design.md
+++ b/.agents/projectContext/decisions/001-ticketing-design.md
@@ -17,7 +17,7 @@ A separate but related concern: existing artifacts under `.agents/agents/`, `.ag
 
 ## Decision
 
-Introduce an optional `ticketing` skill with two modes selectable via `projectContext/ticketing-config.md`:
+Introduce an optional `ticketing-router` skill with two modes selectable via `projectContext/ticketing-config.md`:
 
 1. **`in-repo`** — a lightweight scope-overflow inbox. Subagents file tickets (four-section markdown files) in `projectContext/tickets/open/`. The codeArbiter parent triages each ticket by filing the substance into the correct existing artifact (`03-task-backlog.md`, `open-questions.md` as a `CONFIRM-NN`, a gap doc, or by surfacing to the user) and then closing the ticket with a disposition note. The ticket itself is an inbox, not a project tracker.
 
@@ -56,11 +56,11 @@ This tradeoff sits at §2 level 3 (Maintainability and reviewability) for the di
 
 ## Implementation Notes
 
-- New files: `ticketing-config.md`, `.agents/skills/ticketing/{SKILL.md,in-repo/SKILL.md,plane/SKILL.md}`, `.agents/projectContext/tickets/{INDEX.md,open/,closed/}`, `.agents/commands/ticket.md`, `.claude/commands/ticket.md`, `.agents/agents/INDEX.md`.
+- New files: `ticketing-config.md`, `.agents/skills/ticketing-router/{SKILL.md,in-repo/SKILL.md,plane/SKILL.md}`, `.agents/projectContext/tickets/{INDEX.md,open/,closed/}`, `.agents/commands/ticket.md`, `.claude/commands/ticket.md`, `.agents/agents/INDEX.md`.
 - Modified: AGENTS.md (§3 hard rules, §4 map, §5 routing, §6 read-on-invocation note), `secrets-policy.md` (env-var approved location), `.gitignore` (`.env`, `.env.local`), `.agents/settings.json` (`mcpServers.plane`), 9 subagent definitions (out-of-scope clause), `decisions/README.md` (this ADR row), `COMMANDS.md` (normalized + `/ticket` row).
 - Default ships disabled: `enabled: false` in `ticketing-config.md`. Users opt in.
 
 ## Followups
 
 - First in-repo ticket once enabled: audit any code paths that read `.agents/agents/*.md` in bulk and update them to consult `INDEX.md` first.
-- Validate that `@makeplane/plane-mcp-server` tool names match the names referenced in `.agents/skills/ticketing/plane/SKILL.md` on first real setup; correct any mismatches.
+- Validate that `@makeplane/plane-mcp-server` tool names match the names referenced in `.agents/skills/ticketing-router/plane/SKILL.md` on first real setup; correct any mismatches.

--- a/.agents/projectContext/observability-spec.md
+++ b/.agents/projectContext/observability-spec.md
@@ -1,0 +1,86 @@
+<!--PLACEHOLDER-->
+<!-- Populated by decompose / context-creation skill, or backfilled when
+     observability obligations first land. Template source:
+     .agents/skills/observability-emit/templates/observability-spec.md.tmpl -->
+
+# Observability Specification
+
+## Signal Categories
+
+_The signal types this project emits. Common: metrics, traces (spans),
+structured logs, alert rules, SLOs. Each category has its own
+registration, naming, and label rules below._
+
+| Category | Used? | Notes |
+|---|---|---|
+| metrics | _yes / no_ | |
+| traces  | _yes / no_ | |
+| logs    | _yes / no_ | |
+| alerts  | _yes / no_ | |
+| SLOs    | _yes / no_ | |
+
+## Naming Conventions
+
+_Per-category naming rules (prefix, separator, allowed characters)._
+
+| Category | Convention | Example |
+|---|---|---|
+| _metric_ | _e.g. `<service>.<subsystem>.<event>`_ | |
+| _span_   | _e.g. `<service>/<operation>`_ | |
+| _log_    | _e.g. `<service>.<level>`_ | |
+
+## Required Labels
+
+_Labels / attributes every signal in each category MUST carry._
+
+| Category | Required labels | Notes |
+|---|---|---|
+| metric | _e.g. `service`, `env`, `version`_ | |
+| span   | _e.g. `service.name`, `trace_id`, `span_id`_ | |
+| log    | _e.g. `service`, `level`, `trace_id`_ | |
+
+## Cardinality Budgets
+
+_Maximum allowed unique values per label, per category. Unbounded
+labels (user_id, request_id) MUST NOT be used as metric labels._
+
+| Label | Max cardinality | Notes |
+|---|---|---|
+
+## Canonical Emit Module / Function Paths
+
+_Where the canonical emit functions live. observability-emit skill
+Phase 2 requires emits go through these paths._
+
+| Category | Module / Function | Notes |
+|---|---|---|
+| metric | _e.g. `obs.metrics.counter(name, labels)`_ | |
+| span   | _e.g. `obs.tracer.start(name, attrs)`_ | |
+| log    | _e.g. `obs.log.info(event, fields)`_ | |
+| alert  | _alert rule storage location_ | |
+
+## Alert Rule Storage Location
+
+_Where alert rule definitions live (Prometheus rules file, Datadog
+monitors-as-code, etc.). observability-emit Phase 4 verifies signal
+has a paired alert when alerting-relevant._
+
+## SLO Definitions
+
+_Service-level objectives this project commits to. Each SLO names
+the signal(s) it depends on so observability-emit Phase 4 can confirm
+the wiring exists._
+
+| SLO | Signal(s) | Target | Window |
+|---|---|---|---|
+
+## Fail-Closed Policy
+
+_What happens when an observability emit fails (fire-and-forget vs.
+fail the request). For audit events this is mandated by audit-spec.md;
+for observability, choose per signal category._
+
+## Test Obligation
+
+_How observability emit must be tested per the observability-emit
+skill Phase 5._

--- a/.agents/projectContext/secrets-policy.md
+++ b/.agents/projectContext/secrets-policy.md
@@ -36,9 +36,9 @@ _Rotation schedule and what events must be emitted on rotation._
 
 _If secret references must be persisted in DB, only the store reference (ARN, path, etc.) is permitted — never the secret value._
 
-## External Ticketing Credentials (ticketing skill, Plane mode)
+## External Ticketing Credentials (ticketing-router skill, Plane mode)
 
-When the optional `ticketing` skill operates in `mode: plane` against an on-prem Plane instance, API keys live in shell environment variables only. Specifically:
+When the optional `ticketing-router` skill operates in `mode: plane` against an on-prem Plane instance, API keys live in shell environment variables only. Specifically:
 
 - API key MUST be set as a shell env var (default name: `PLANE_API_KEY`). The variable name is configurable in `projectContext/ticketing-config.md`.
 - The env var value MUST NEVER appear in any committed file, including:

--- a/.agents/projectContext/ticketing-config.md
+++ b/.agents/projectContext/ticketing-config.md
@@ -1,7 +1,7 @@
 # Ticketing Configuration
 
-<!-- Read by the `ticketing` router skill. -->
-<!-- If this file is absent OR `enabled: false`, the ticketing skill is a no-op. -->
+<!-- Read by the `ticketing-router` skill. -->
+<!-- If this file is absent OR `enabled: false`, the ticketing-router skill is a no-op. -->
 <!-- Default ships with `enabled: false`; users opt in by editing the frontmatter below. -->
 
 ---
@@ -19,7 +19,7 @@ plane_env_var_workspace_slug: PLANE_WORKSPACE_SLUG
 
 | Field | Required when | Purpose |
 |---|---|---|
-| `enabled` | always | `true` activates the ticketing skill. `false` makes it a no-op. |
+| `enabled` | always | `true` activates the ticketing-router skill. `false` makes it a no-op. |
 | `mode` | `enabled: true` | `in-repo` or `plane`. Selects which variant the router `@`-imports. |
 | `plane_base_url` | `mode: plane` | On-prem Plane URL, e.g. `https://plane.internal.example.com`. |
 | `plane_workspace_slug` | `mode: plane` | Plane workspace slug the variant targets. |
@@ -40,7 +40,7 @@ Required environment variables (names configurable above; values live in the use
 - `PLANE_API_KEY` — API key issued by the Plane admin UI
 - `PLANE_WORKSPACE_SLUG` — workspace slug
 
-See `.agents/skills/ticketing/plane/SKILL.md` for setup steps.
+See `.agents/skills/ticketing-router/plane/SKILL.md` for setup steps.
 
 ## Read-on-invocation guarantee
 

--- a/.agents/projectContext/tickets/INDEX.md
+++ b/.agents/projectContext/tickets/INDEX.md
@@ -1,6 +1,6 @@
 # Tickets Index
 
-<!-- Auto-maintained by the in-repo ticketing variant. -->
+<!-- Auto-maintained by the ticketing-router in-repo variant. -->
 <!-- Hand-edits are NOT preserved on the next create/close. -->
 <!-- Body reads require `/ticket show <id>` — this index is the only sanctioned surface scan. -->
 

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "_comment_plane": "Optional. Active only when ticketing-config.md has enabled: true AND mode: plane. The values below reference shell env vars by name; literal secrets MUST NEVER be inlined here. See .agents/skills/ticketing/plane/SKILL.md for setup.",
+    "_comment_plane": "Optional. Active only when ticketing-config.md has enabled: true AND mode: plane. The values below reference shell env vars by name; literal secrets MUST NEVER be inlined here. See .agents/skills/ticketing-router/plane/SKILL.md for setup.",
     "plane": {
       "command": "npx",
       "args": ["-y", "@makeplane/plane-mcp-server"],

--- a/.agents/skills/arbiter/SKILL.md
+++ b/.agents/skills/arbiter/SKILL.md
@@ -306,25 +306,25 @@ When the user has just answered a variance, confirm by repeating back what was d
 
 ## Common Failure Modes to Avoid
 
-1. **Deciding for the user.** Rule 1 is non-negotiable. Recommendations are not decisions.
+1. MUST NOT decide for the user. Rule 1 is non-negotiable. Recommendations are not decisions.
 
 2. **Treating the artifacts as immutable.** They are authoritative-by-default, not infallible. Apply SMARTS evenhandedly.
 
 3. **Loose filename matching.** Rule 2. Exact match only.
 
-4. **Skipping the stale-artifact check.** Rule 3. Always run Stage 1.5 if a decision log exists.
+4. MUST NOT skip the stale-artifact check. Rule 3. Always run Stage 1.5 if a decision log exists.
 
-5. **Inventing decision categories.** Rule 5. Use the canonical list; ask the user to add categories.
+5. MUST NOT invent decision categories. Rule 5. Use the canonical list; ask the user to add categories.
 
 6. **Generating noise.** If artifacts and scaffold concur or both are silent, no variance entry is generated.
 
-7. **Rebuilding the decision log.** Append-only. New decisions append; old decisions are preserved verbatim.
+7. MUST NOT rebuild the decision log. Append-only. New decisions append; old decisions are preserved verbatim.
 
 8. **Producing downstream artifacts without user request.** Stage 5 recommends; it does not produce.
 
 9. **Treating open decisions as variances.** See `references/known-open-decisions.md` for decisions deliberately left open by the artifacts.
 
-10. **Capitulating to delegation requests.** Rule 1's exception applies only to explicit "accept your recommendation" — never to "you decide."
+10. MUST NOT capitulate to delegation requests. Rule 1's exception applies only to explicit "accept your recommendation" — never to "you decide."
 
 ---
 

--- a/.agents/skills/audit-emit/SKILL.md
+++ b/.agents/skills/audit-emit/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill whenever code emits, should emit, or modifies the emission of
 an auditable event. This skill MUST complete before any audit-related code is
 committed.

--- a/.agents/skills/commit-gate/SKILL.md
+++ b/.agents/skills/commit-gate/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill whenever the user says "commit", "commit this", "go ahead and
 commit", or any equivalent instruction to persist staged changes to version control.
 

--- a/.agents/skills/context-creation/SKILL.md
+++ b/.agents/skills/context-creation/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill when ALL of the following are true:
 
 - `.agents/projectContext/CONTEXT.md` does NOT contain the `<!--INITIALIZED-->` sentinel
@@ -66,6 +68,12 @@ if neither condition is met.
 ---
 
 ### Phase 2 — Scout Dispatch
+
+> **Definition — scout.** A `general-purpose` agent dispatched in parallel from
+> this skill to read a targeted codebase slice and return a structured findings
+> report with file paths, line numbers, and named values — never raw code
+> excerpts. Scouts are internal to this skill and `decision-variance`; they
+> MUST NOT be invoked from a slash command.
 
 **Goal:** Dispatch six scout subagents in parallel to read targeted slices of the
 codebase and return structured findings without loading raw source into the

--- a/.agents/skills/context-creation/SKILL.md
+++ b/.agents/skills/context-creation/SKILL.md
@@ -260,6 +260,7 @@ sentinels may remain in files where content was determined:
 | `.agents/projectContext/tech-stack.md` | Languages, frameworks, test runner, lint command, build command, coverage command (from Scout A + B + E) |
 | `.agents/projectContext/security-controls.md` | Auth mechanism, crypto patterns, compliance requirements (from Scout D + gap interview) |
 | `.agents/projectContext/audit-spec.md` | State-change actions, auditable events, sink routing (from Scout F + gap interview) |
+| `.agents/projectContext/observability-spec.md` | Telemetry-relevant findings across scouts B (infrastructure/CI/CD), C (architecture/components), and E (testing conventions). Instantiate from template `.agents/skills/observability-emit/templates/observability-spec.md.tmpl`; populate signal categories, naming conventions, required labels, cardinality budgets, canonical emit module paths, alert rule storage location, SLO definitions per the existing codebase's telemetry conventions. Flag low-confidence inferences as [CONFIRM-NN]. <!-- Future enhancement: dedicated observability scout. --> |
 | `.agents/projectContext/coding-standards.md` | Structural patterns, naming conventions, style rules (from Scout C + E + gap interview) |
 | `.agents/projectContext/secrets-policy.md` | Secret-bearing integrations, vault/KMS usage, loading patterns (from Scout D + gap interview) |
 | `.agents/projectContext/dependency-policy.md` | Dependency strategy, license stance, audit approach (from Scout A + B + gap interview) |
@@ -302,6 +303,7 @@ and return codeArbiter to normal orchestrator operation.
    - `tech-stack.md`
    - `security-controls.md`
    - `audit-spec.md`
+   - `observability-spec.md`
    - `coding-standards.md`
    - `secrets-policy.md`
    - `dependency-policy.md`

--- a/.agents/skills/crypto-compliance/SKILL.md
+++ b/.agents/skills/crypto-compliance/SKILL.md
@@ -4,6 +4,9 @@
 Claude IS a cryptographic compliance enforcer who treats any non-approved primitive as an active security control failure.
 
 ## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 - Code introduces or modifies a hash operation
 - Code introduces or modifies signing or signature verification
 - Code introduces or modifies encryption or decryption

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: debug
+description: Investigate-then-decide root-cause analysis (RCA) workflow for situations where the cause of a defect, anomaly, or unexpected behavior is unknown. Routes to /fix, /ticket, /adr, or no-action close at Phase 4. Distinct from /fix, which assumes a known bug.
+---
+
+# Skill: debug
+
+## Purpose
+
+The `debug` skill encodes a disciplined investigate-then-decide root-cause analysis (RCA) workflow.
+It exists for one situation: **the cause of an observed defect, anomaly, or unexpected behavior is
+not yet known.** The skill captures the symptom, generates multiple competing hypotheses, gathers
+evidence without modifying code, and then forces an explicit exit decision — either a confirmed
+bug handed to `/fix`, a design/behavior ambiguity escalated to `/ticket` or `/adr`, or a no-action
+close with recorded findings.
+
+The skill is a deliberate counterweight to premature implementation. It MUST NOT modify code. Code
+changes belong to `/fix`, and `/fix` is only reached after `debug` has named a confirmed bug and a
+regression test obligation.
+
+---
+
+## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
+Conditions that route work to `debug`:
+
+- A user reports an observed defect, anomaly, or unexpected behavior whose cause is unknown.
+- A user invokes `/debug` (or a wrapper command that routes to this skill).
+- A reviewer agent, a CI gate, or another skill surfaces an unexplained failure that does not yet
+  meet the precondition for `/fix` (which requires a known bug and a stated regression test
+  obligation).
+- The user describes the situation with phrasing such as "I don't know what's wrong yet," "it
+  used to work," "something is off but I can't pin it down," or any equivalent ambiguity signal.
+
+Do NOT route to `debug` when:
+
+- The bug is already known and a regression test is already named. Route to `/fix` directly.
+- The user wants a design discussion with no failing behavior in hand. Route to `/adr` or
+  `/ticket` directly.
+- The user wants implementation of a new feature. Route to the `tdd` skill via `/feature`.
+
+---
+
+## Pre-Flight
+
+Before Phase 1 begins, confirm:
+
+1. `.agents/projectContext/tech-stack.md` is readable — stop if missing. The skill needs to know
+   the project's log paths, trace tooling, and test runner conventions before it can gather
+   evidence.
+2. `.agents/projectContext/audit-spec.md` is readable — stop if missing. Audit events are a primary
+   evidence source for RCA on auditable actions.
+3. Current stage is known — read `cat .agents/projectContext/stage`. Stage influences how much
+   evidence the skill requires before exiting (higher stages demand more rigorous evidence).
+4. The invoking user has provided at least a one-sentence symptom statement. If not, ask for one
+   before proceeding. Do not guess at the symptom.
+
+If any file is missing or any check fails, surface the gap and stop. Do not guess at log paths,
+trace tooling, or audit event field names.
+
+---
+
+## Phase 1: Symptom Capture
+
+**Goal:** Record the observed symptom with enough fidelity that a different operator could
+reproduce the situation without further questions.
+
+**Inputs:**
+- The user's symptom description
+- `.agents/projectContext/tech-stack.md` — environment and runtime conventions
+- Current stage (from Pre-Flight)
+
+**Actions:**
+
+1. Record the observed symptom in one sentence. State what the system did, not what the user
+   thinks caused it. Causes belong to Phase 2.
+2. Record the expected behavior in one sentence. If the user cannot state expected behavior, this
+   may itself be a sign that the issue is a design/behavior ambiguity (flag for Phase 4).
+3. Record the minimal reproduction steps:
+   - Exact command, request, or user action
+   - Input data, parameters, or state required
+   - Environment (local, staging, production, test) and stage (1–4)
+   - Frequency (every time / intermittent / one-time observation)
+4. Record observable evidence already in hand: error messages, stack traces, screenshots, log
+   excerpts. Cite source (log path, timestamp, request ID) for each.
+5. If no minimal reproduction exists, attempt to derive one with the user before proceeding. An
+   intermittent issue may have a minimal repro that triggers it reliably (e.g., a specific input
+   pattern, a load condition, a timing window). Capture that.
+
+**Output:** Symptom record with: observed behavior, expected behavior, minimal repro steps,
+environment, stage, and cited evidence in hand.
+
+**Gate:** BLOCK on no minimal repro. A symptom without a reproduction (or at least a reliable
+trigger condition for intermittent issues) cannot be debugged — it can only be speculated about.
+MUST NOT proceed to Phase 2 without a minimal repro or a documented intermittent-trigger profile.
+MUST cite the source of every piece of evidence captured.
+
+---
+
+## Phase 2: Hypothesis Generation
+
+**Goal:** Produce at least three candidate causes ranked by likelihood, before any evidence is
+gathered against them.
+
+**Inputs:**
+- Symptom record from Phase 1
+- `.agents/projectContext/CONTEXT.md` — domain vocabulary and system structure
+- Recent commit log (read-only) — surface candidate recent changes
+
+**Actions:**
+
+1. Generate at least three distinct candidate causes for the symptom. Distinctness means the
+   hypotheses point at different subsystems, mechanisms, or failure modes — not three rewordings
+   of the same suspicion.
+2. For each candidate, write:
+   - A one-sentence hypothesis statement
+   - The subsystem, component, or boundary involved
+   - The mechanism by which the hypothesis would produce the observed symptom
+3. Rank the candidates by likelihood (most likely first). Use:
+   - Recency of relevant changes (recent commits to the suspect subsystem raise rank)
+   - Specificity of the symptom (a symptom that points narrowly at one mechanism raises that rank)
+   - Historical pattern (recurring issue types in this project raise rank)
+4. Explicitly include at least one "boring" hypothesis — environmental drift, dependency version
+   change, configuration mismatch, stale cache, or operator error. The boring hypothesis MUST be
+   listed even if it is ranked last. Confirmation bias toward exotic causes is a recurring debug
+   failure mode.
+5. Number the hypotheses H1, H2, H3, … for reference in Phase 3.
+
+**Output:** Ranked hypothesis list, three or more entries, each with statement, subsystem,
+mechanism, and rank rationale.
+
+**Gate:** BLOCK on single-hypothesis lock-in. MUST NOT proceed to Phase 3 with fewer than three
+distinct hypotheses. MUST NOT proceed with three hypotheses that are reworded versions of one
+suspicion. Single-hypothesis lock-in is the single most common cause of misdiagnosis; the gate
+exists to force breadth before depth.
+
+---
+
+## Phase 3: Evidence Gathering
+
+**Goal:** For each hypothesis, identify what evidence would confirm or refute it, then gather that
+evidence by reading existing artifacts only. No code is modified in this phase.
+
+**Inputs:**
+- Hypothesis list from Phase 2
+- `.agents/projectContext/audit-spec.md` — audit event field definitions and sink paths
+- `.agents/projectContext/tech-stack.md` — log paths, trace tooling, test runner conventions
+- Git history (read-only)
+- Application logs, traces, audit event records, metrics dashboards
+
+**Actions:**
+
+1. For each hypothesis H1…HN, write:
+   - The evidence that would CONFIRM it (positive signal)
+   - The evidence that would REFUTE it (negative signal)
+   - The source where that evidence lives (log file, trace tool, audit sink, commit range, metric
+     dashboard)
+2. Gather the evidence by reading:
+   - Application logs at the paths defined in `projectContext/tech-stack.md`
+   - Traces from the trace tool defined in `projectContext/tech-stack.md`
+   - Audit events from the sink defined in `projectContext/audit-spec.md`
+   - Recent commits (`git log`, `git diff`) on suspect paths
+   - Configuration files, environment variables, and feature flags (read-only)
+3. Record evidence findings against each hypothesis: CONFIRMED, REFUTED, or INCONCLUSIVE.
+4. If evidence is INCONCLUSIVE for a hypothesis, state what additional evidence would be needed
+   and where it would live. Do not collapse INCONCLUSIVE to CONFIRMED or REFUTED by inference.
+5. If new hypotheses emerge during evidence gathering, add them to the list and gather evidence
+   for them too. Phase 2 is a floor, not a ceiling.
+
+**Output:** Evidence ledger: each hypothesis annotated with CONFIRMED, REFUTED, or INCONCLUSIVE,
+with cited evidence source for each annotation.
+
+**Gate:** BLOCK on any code change. MUST NOT modify, refactor, "try a fix," or otherwise alter
+production or test code during this phase. Code changes belong to `/fix`, not `/debug`. If a
+hypothesis can only be tested by changing code, that becomes a finding for Phase 4 disposition
+(typically Phase 4 exit (a) with a stated regression test obligation). BLOCK on collapsing
+INCONCLUSIVE evidence to CONFIRMED without a cited source.
+
+---
+
+## Phase 4: Root Cause Decision
+
+**Goal:** Pick exactly one exit. No "we'll figure it out later." The skill does not end without a
+named disposition.
+
+**Inputs:**
+- Symptom record from Phase 1
+- Hypothesis list from Phase 2
+- Evidence ledger from Phase 3
+
+**Actions:**
+
+1. Walk the evidence ledger. Identify whether the evidence supports one of three exits:
+
+   - **(a) Confirmed bug.** One hypothesis is CONFIRMED by cited evidence and the disposition is
+     a code change. Required output:
+     - The hypothesis ID and statement (e.g., "H2: stale cache returns prior tenant's record")
+     - The cited confirming evidence
+     - A named regression test obligation: a one-sentence description of the test that MUST be
+       written by `/fix` before the fix code is written. This is a hard requirement — `/fix`
+       refuses to proceed without it.
+     - The `/fix` invocation handoff payload (see Phase 5)
+
+   - **(b) Behavior/design ambiguity.** The evidence shows the system behaves as currently
+     specified, but the specified behavior is itself in question. Required output:
+     - The hypothesis ID and statement
+     - Whether the disposition is `/ticket` (open work item, no decision yet) or `/adr`
+       (architectural decision required)
+     - A one-sentence statement of the ambiguity to be resolved
+     - Routing choice rationale (why ticket vs. ADR)
+
+   - **(c) No-action close.** The evidence shows the symptom is not reproducible, was a one-time
+     environmental event, has already been fixed by an unrelated commit, or otherwise requires no
+     follow-up. Required output:
+     - A one-sentence statement of why no action is needed
+     - The cited evidence supporting "no action"
+     - A note added to the symptom record for future reference
+
+2. If no exit can be chosen — e.g., all hypotheses are INCONCLUSIVE — the correct response is to
+   loop back to Phase 3 and gather more evidence, or to escalate to Phase 4 exit (b) (`/ticket`)
+   with the symptom recorded for later revisit. "No decision" is not a valid Phase 4 exit.
+
+3. Record the chosen exit (a / b / c) and the rationale.
+
+**Output:** A single named Phase 4 exit — (a), (b), or (c) — with the required payload for that
+exit.
+
+**Gate:** BLOCK on no-decision. Phase 4 MUST exit with one of (a) / (b) / (c). MUST NOT exit with
+"more investigation needed" without either (i) looping back to Phase 3 for additional evidence, or
+(ii) selecting exit (b) and opening a `/ticket` to track the open question. MUST NOT exit with (a)
+without a named regression test obligation. MUST NOT exit with (b) without choosing between
+`/ticket` and `/adr` and stating the rationale.
+
+---
+
+## Phase 5: Handoff
+
+**Goal:** Route the chosen exit and emit a summary that downstream skills and commands can consume
+without re-reading the entire debug session.
+
+**Inputs:**
+- Phase 4 exit selection and payload
+
+**Actions:**
+
+1. Emit a debug summary block with:
+   - Symptom (one sentence from Phase 1)
+   - Reproduction profile (minimal repro or intermittent-trigger profile)
+   - Hypotheses considered (count and one-line list)
+   - Evidence ledger summary (which hypothesis was CONFIRMED / REFUTED / INCONCLUSIVE)
+   - Phase 4 exit selection and rationale
+   - Handoff target (`/fix`, `/ticket`, `/adr`, or no-action close)
+
+2. Execute the handoff:
+   - **Exit (a) — `/fix`:** Emit a `/fix` invocation that includes the confirmed bug statement,
+     the cited evidence, and the named regression test obligation. The orchestrator routes the
+     `/fix` invocation to the `tdd` skill in bug-fix variant.
+   - **Exit (b) — `/ticket` or `/adr`:** Emit the chosen invocation with the ambiguity statement,
+     the symptom record, and the evidence ledger attached as context. The orchestrator routes
+     accordingly.
+   - **Exit (c) — no-action close:** Append the symptom record and "no action" rationale to
+     `.agents/projectContext/debug-log.md` (create if missing) for future reference. No further
+     handoff.
+
+3. Surface the summary block and handoff to the user. Confirm the handoff before the skill exits.
+
+**Output:** Debug summary block emitted; handoff routed; skill exits.
+
+**Gate:** BLOCK if exit is (a) and no regression test obligation is named. The `/fix` invocation
+MUST carry an explicit regression test obligation — `/fix` refuses to proceed without one, so
+omitting it here would simply stall downstream. MUST NOT bypass the handoff. MUST NOT close the
+skill in exit (c) without recording the symptom and rationale to the debug log.
+
+---
+
+## Hard Rules
+
+- MUST NOT modify code during Phases 1–3. Code changes belong to `/fix`, not `/debug`.
+- MUST NOT proceed past Phase 1 without a minimal reproduction (or a documented intermittent-
+  trigger profile for non-reproducible cases).
+- MUST NOT proceed past Phase 2 with fewer than three distinct hypotheses. Single-hypothesis lock-
+  in is a blocking violation.
+- MUST NOT collapse INCONCLUSIVE evidence to CONFIRMED or REFUTED without a cited source.
+- MUST NOT exit Phase 4 without selecting one of (a) confirmed bug → `/fix`, (b) ambiguity →
+  `/ticket` or `/adr`, or (c) no-action close.
+- MUST NOT exit with (a) without naming a regression test obligation that `/fix` will carry into
+  its TDD Phase 1.
+- MUST NOT route to `/fix` for situations where the bug is not yet confirmed by cited evidence —
+  `/fix` is for known bugs.
+- MUST NOT guess at log paths, trace tooling, or audit field names — always read
+  `.agents/projectContext/tech-stack.md` and `.agents/projectContext/audit-spec.md`.
+- MUST cite the source of every piece of evidence (log path + timestamp, commit SHA, audit event
+  ID, trace ID).
+- MUST include at least one "boring" environmental / configuration / dependency hypothesis in
+  Phase 2 to counter confirmation bias toward exotic causes.
+
+---
+
+## Decision Gates Summary
+
+| Gate         | Condition                                                              | Action if blocked                                               |
+|--------------|------------------------------------------------------------------------|-----------------------------------------------------------------|
+| Phase 1 exit | No minimal repro (or no intermittent-trigger profile)                  | Stop; derive a repro with the user before continuing            |
+| Phase 2 exit | Fewer than three distinct hypotheses, or single-hypothesis lock-in     | Stop; generate additional distinct hypotheses                   |
+| Phase 3 exit | Any code modification attempted, or INCONCLUSIVE collapsed to CONFIRMED | Stop; revert any change; re-gather cited evidence              |
+| Phase 4 exit | No exit chosen, or exit (a) without regression test obligation         | Stop; loop back to Phase 3 or select (b); name regression test  |
+| Phase 5 exit | Handoff not routed, or exit (c) not recorded to debug log              | Stop; complete the handoff or record the no-action close        |
+
+---
+
+## Interactions with other skills
+
+The `debug` skill is a router-into-other-skills by design. Phase 4 exits compose with downstream
+commands as follows:
+
+- **Exit (a) → `/fix`.** The `/fix` command requires a known bug and a stated regression test
+  obligation. `debug` Phase 4 exit (a) produces exactly that payload: confirmed bug statement,
+  cited evidence, named regression test. The `/fix` command then routes to the `tdd` skill in
+  bug-fix variant, where the named regression test becomes the Phase 1 obligation that must fail
+  before any fix code is written. `debug` does NOT pre-implement the regression test — `/fix`'s
+  TDD Phase 2 owns that.
+
+- **Exit (b) → `/ticket`.** When the evidence shows correct-as-specified behavior with an
+  ambiguous specification, the work is to clarify the specification, not to change code. `/ticket`
+  opens an item for triage. The full symptom record and evidence ledger are attached as ticket
+  context so the triage agent does not re-debug from scratch.
+
+- **Exit (b) → `/adr`.** When the ambiguity is architectural — a trade-off between competing
+  designs, a trust-boundary question, a cross-component contract — the disposition is an ADR, not
+  a ticket. `/adr` is authored only with explicit user attribution (per AGENTS.md §3). `debug`
+  Phase 4 surfaces the question to the user and obtains attribution before routing to `/adr`.
+  `debug` MUST NOT author an ADR autonomously as the disposition of a debug session.
+
+- **Exit (c) → no-action close.** No downstream skill is invoked. The symptom record and rationale
+  are appended to `.agents/projectContext/debug-log.md`. Future debug sessions that encounter a
+  similar symptom may reference the prior close as evidence (cited in Phase 3).
+
+`debug` MUST NOT be invoked from inside `/fix`, `/ticket`, or `/adr` — that would create a routing
+cycle. If those skills surface an unknown cause mid-flow, the correct response is to exit them and
+re-enter via `/debug`.

--- a/.agents/skills/decision-lifecycle/SKILL.md
+++ b/.agents/skills/decision-lifecycle/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill to audit the health of the project's decision record — ADRs,
 open questions, and CONFIRM-NN placeholders. Also invoke whenever a new ADR is
 added, an ADR ages past review threshold, or a CONFIRM-NN is encountered.

--- a/.agents/skills/decision-lifecycle/SKILL.md
+++ b/.agents/skills/decision-lifecycle/SKILL.md
@@ -59,6 +59,8 @@ attention.
 
 5. Record the complete ADR table with health tags.
 
+Any ADR tagged AGED (>12 weeks) OR triggered by a stage promotion event MUST proceed to Phase 4 (challenge routing) — the challenge is no longer optional in those two cases.
+
 **Output:** ADR health table with ID, title, status, age, and health tags.
 
 **Gate:** BLOCK. Phase 2 does not begin until the ADR table is complete. A
@@ -149,9 +151,7 @@ record confidence ratings.
 
 **Actions:**
 
-1. For each ADR tagged AGED or UNCHALLENGED, spawn the `decision-challenger`
-   agent to evaluate whether the decision still holds given current project
-   state, stage, and any newer decisions.
+1. For each ADR tagged AGED, UNCHALLENGED, or flagged by a stage-promotion event, dispatch the decision-challenger agent. AGED and stage-promotion challenges MUST execute; UNCHALLENGED follows existing logic.
 2. The `decision-challenger` agent MUST return a confidence rating for each
    reviewed ADR:
 
@@ -228,6 +228,7 @@ rating of ≤ 2 must be surfaced as a stage promotion blocker.
 | Phase 2 exit | CONFIRM-NN resolved by guessing                              | Stop; surface OPEN item to user            |
 | Phase 3 exit | ADR conflict found with no directional resolution            | Surface conflict; stop until user provides direction |
 | Phase 4 exit | ADR rated 0 by challenger agent                              | Escalate to user; block stage promotion    |
+| Phase 4 entry | AGED ADR or stage-promotion event without dispatched challenge | BLOCK; dispatch challenger before continuing |
 | Phase 5 exit | Report section missing or confidence ≤ 2 not flagged        | Complete report; flag blockers             |
 
 ---
@@ -245,6 +246,8 @@ rating of ≤ 2 must be surfaced as a stage promotion blocker.
   specific evidence.
 - MUST NOT skip spawning the `decision-challenger` agent for AGED or
   UNCHALLENGED ADRs — the skill's challenge routing is not optional.
+- MUST dispatch decision-challenger on every AGED ADR. The challenge is not optional after 12 weeks.
+- MUST dispatch decision-challenger on all ADRs as part of any stage promotion (via /release or /stage).
 
 ---
 

--- a/.agents/skills/decision-variance/SKILL.md
+++ b/.agents/skills/decision-variance/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: arbiter
+name: decision-variance
 description: Reconcile project architectural artifacts (Architecture Breakdown, Phased Build Plan, Task Backlog) against the existing project scaffold and codebase. Use this skill whenever the user mentions architectural reconciliation, variance review, ingesting decomposition documents, comparing architectural decisions to existing code, syncing artifacts with scaffold state, or asks to "arbitrate," "reconcile," "merge," or "consolidate" architectural context with the project. Also use when the user asks what architectural artifacts can be produced from current project state, requests a variance report, mentions ADR conflicts, or wants to track outstanding architectural decisions. Do NOT use for routine git merges, code review consolidation, or general architectural discussions unrelated to the current project's artifacts. This skill never makes arbitration decisions alone — it presents SMARTS analyses for the user to decide. It treats the artifacts as authoritative-by-default but does not blindly adopt them.
 ---
 
-# Arbiter Skill
+# Decision-Variance Skill
 
 A skill for systematically reconciling a project's three architectural artifacts (Architecture Breakdown, Phased Build Plan, Task Backlog) against the existing project scaffold, codebase, and prior decisions — without making arbitration decisions unilaterally.
 
@@ -13,33 +13,33 @@ These rules govern everything else in this skill. Other instructions defer to th
 
 ### Rule 1 — Never decide alone
 
-The arbiter MUST NOT make arbitration decisions on the user's behalf. Every variance is presented to the user with a SMARTS analysis and a recommendation. The user makes the choice. The decision log records the user's choice, not the arbiter's recommendation.
+This skill MUST NOT make arbitration decisions on the user's behalf. Every variance is presented to the user with a SMARTS analysis and a recommendation. The user makes the choice. The decision log records the user's choice, not this skill's recommendation.
 
-This rule applies regardless of how the user phrases a delegation request. Examples that all REQUIRE the arbiter to decline: "pick one," "decide for me," "use your best judgment," "I trust you," "go with what you think," "skip the SMARTS, just tell me," "we're short on time, just choose," "you know more about this than I do." When any such phrasing is encountered, decline with:
+This rule applies regardless of how the user phrases a delegation request. Examples that all REQUIRE this skill to decline: "pick one," "decide for me," "use your best judgment," "I trust you," "go with what you think," "skip the SMARTS, just tell me," "we're short on time, just choose," "you know more about this than I do." When any such phrasing is encountered, decline with:
 
 > "I cannot record an arbitration decision without your explicit choice. The decision log requires a user-attributed entry to remain auditable. I will present the SMARTS analysis and recommendation; please tell me which option to record."
 
 Do NOT capitulate after multiple requests. The constraint is structural, not stylistic. Auditability requires user attribution.
 
-**Exception — explicit recommendation acceptance:** If the user explicitly states they want to accept the arbiter's recommendation as their decision (using language like "accept your recommendation," "go with the recommended option," "record the recommended choice"), this counts as an explicit user decision. The decision log entry then notes "User explicitly accepted arbiter recommendation as their decision" in the `Decided by:` field. This exception applies only when the user explicitly invokes it — the arbiter does NOT volunteer this fast-path.
+**Exception — explicit recommendation acceptance:** If the user explicitly states they want to accept this skill's recommendation as their decision (using language like "accept your recommendation," "go with the recommended option," "record the recommended choice"), this counts as an explicit user decision. The decision log entry then notes "User explicitly accepted arbiter recommendation as their decision" in the `Decided by:` field. This exception applies only when the user explicitly invokes it — this skill does NOT volunteer this fast-path.
 
 ### Rule 2 — Exact filename match for the three artifacts
 
-The arbiter requires three specific files in the project. Their canonical filenames are:
+This skill requires three specific files in the project. Their canonical filenames are:
 
 - `01-architecture-breakdown.md`
 - `02-phased-build-plan.md`
 - `03-task-backlog.md`
 
-The arbiter MUST find these exact filenames somewhere in the project. The arbiter MUST NOT pattern-match similarly-named files (e.g., `architecture-draft.md`, `phased-plan.md`, `task-list.md`, `requirements.md`). Loose matching is forbidden — it leads to arbitrating against the wrong document.
+This skill MUST find these exact filenames somewhere in the project. This skill MUST NOT pattern-match similarly-named files (e.g., `architecture-draft.md`, `phased-plan.md`, `task-list.md`, `requirements.md`). Loose matching is forbidden — it leads to arbitrating against the wrong document.
 
-If any of the three exact files cannot be located, the arbiter asks the user for the path. The arbiter does NOT proceed by inference.
+If any of the three exact files cannot be located, this skill asks the user for the path. This skill does NOT proceed by inference.
 
 ### Rule 3 — Detect stale artifacts before arbitration
 
-Before running any arbitration logic, the arbiter must check whether the artifacts have changed since prior arbitration sessions.
+Before running any arbitration logic, this skill must check whether the artifacts have changed since prior arbitration sessions.
 
-**Mechanism:** When a decision is recorded in the decision log, the arbiter also records the SHA-256 hash of the artifact section that defined the artifact's position at decision time. On subsequent invocations, the arbiter:
+**Mechanism:** When a decision is recorded in the decision log, this skill also records the SHA-256 hash of the artifact section that defined the artifact's position at decision time. On subsequent invocations, this skill:
 
 1. Reads `projectContext/arbiter-decisions.md` and extracts the recorded artifact-section hashes for each prior decision
 2. Computes current hashes of the relevant artifact sections
@@ -93,11 +93,11 @@ Find these in the project:
 
 2. **Existing decision records** — look for `projectContext/decisions/`, `docs/adr/`, `docs/decisions/`, `ADRs/`, or similar paths. Index every ADR found with its number, title, status, and decision summary.
 
-3. **Existing arbiter decision log** — `projectContext/arbiter-decisions.md`. If it exists, this is the persistent record. Read it before generating new variance reports.
+3. **Existing decision log** — `projectContext/arbiter-decisions.md`. If it exists, this is the persistent record. Read it before generating new variance reports.
 
 4. **The scaffold/codebase itself** — `package.json` or equivalent manifests, dependency files, source directories, configuration files, CI configuration.
 
-5. **The arbiter's working files (created if missing):**
+5. **This skill's working files (created if missing):**
    - `projectContext/arbiter-evidence.md` — working evidence index, rebuilt every full scan
    - `projectContext/arbiter-variance-report.md` — current variance report, overwritten every scan
    - `projectContext/arbiter-decisions.md` — persistent decision log, append-only (per Rule 3 hashing)
@@ -135,7 +135,7 @@ For each architectural decision in the three artifacts, record:
   - `artifact-silent` — scaffold has implementation, artifact has no position
   - `both-silent` — neither has evidence (informational only)
 
-**Rule 5 — No ad-hoc category creation:** If the arbiter encounters a decision that does not fit any category in `references/decision-categories.md`, it MUST:
+**Rule 5 — No ad-hoc category creation:** If this skill encounters a decision that does not fit any category in `references/decision-categories.md`, it MUST:
 1. Note the decision in the evidence index with `category: UNKNOWN`
 2. Describe what makes it not fit
 3. Ask the user to either map it to an existing category or explicitly add a new category to the canonical list
@@ -201,7 +201,7 @@ For each variance:
 
 **Pause/Resume protocol:**
 
-At any time, the user may say "pause," "come back to this later," "stop here," or equivalent. The arbiter MUST:
+At any time, the user may say "pause," "come back to this later," "stop here," or equivalent. This skill MUST:
 
 1. Confirm the pause: "Pausing here. <N> variances resolved, <M> remaining. Decisions are saved to the log."
 2. Summarize unresolved variances with their IDs
@@ -211,14 +211,14 @@ The user resumes by re-invoking the skill. The skill reads the decision log, ide
 
 **Same-level conflict escalation (per Rule 3 in the Authority Hierarchy below):**
 
-When two sources at the same authority level conflict (e.g., two `accepted` ADRs with contradictory positions), the arbiter MUST:
+When two sources at the same authority level conflict (e.g., two `accepted` ADRs with contradictory positions), this skill MUST:
 
 1. Record both positions in the evidence index marked `same-level-conflict`
 2. Immediately surface the conflict to the user with both positions and their sources
 3. Treat both sources as silent for variance purposes until the user resolves
 4. Record the user's resolution in the decision log with a `Resolves same-level conflict between <ADR/source A> and <ADR/source B>` field
 
-Do NOT pick one source over the other on the arbiter's judgment.
+Do NOT pick one source over the other on this skill's judgment.
 
 For any ADR referenced in this variance session that has not been challenged since the last checkpoint run, invoke the `decision-challenger` agent.
 
@@ -240,7 +240,7 @@ For each candidate artifact, report:
 
 Save to `projectContext/arbiter-readiness.md`. Present the recommendations as a menu. The user picks which to produce.
 
-The arbiter does NOT produce downstream artifacts unless the user explicitly requests them. This skill recommends; production happens only after explicit user direction.
+This skill does NOT produce downstream artifacts unless the user explicitly requests them. This skill recommends; production happens only after explicit user direction.
 
 ---
 
@@ -261,7 +261,7 @@ If two sources at the same authority level conflict, escalate to the user per th
 
 ### Pushback Is Permitted
 
-The artifacts are authoritative-by-default but not infallible. If scaffold work has surfaced context that the artifacts missed, that context is legitimate input. The arbiter should:
+The artifacts are authoritative-by-default but not infallible. If scaffold work has surfaced context that the artifacts missed, that context is legitimate input. This skill should:
 
 - Surface the scaffold's reasoning fairly
 - Apply the SMARTS framework evenhandedly
@@ -332,7 +332,7 @@ When the user has just answered a variance, confirm by repeating back what was d
 
 - `references/decision-categories.md` — canonical list of decision categories (no ad-hoc additions)
 - `references/decision-log-format.md` — exact format for entries in the decision log, including hash field per Rule 3
-- `references/downstream-artifacts.md` — catalog of downstream artifacts the arbiter can recommend, with explicit readiness criteria
+- `references/downstream-artifacts.md` — catalog of downstream artifacts this skill can recommend, with explicit readiness criteria
 - `references/smarts-framework.md` — SMARTS lens definitions and hard format constraints for analyses
 - `references/known-open-decisions.md` — decisions explicitly left open by the artifacts; not variances; standardized handling rules
 

--- a/.agents/skills/decision-variance/references/decision-categories.md
+++ b/.agents/skills/decision-variance/references/decision-categories.md
@@ -1,10 +1,10 @@
 # Decision Categories — Canonical Scan List
 
-This is the canonical list of decision categories the arbiter scans for during Stage 2 evidence indexing. The list is organized by area and prioritized within each area.
+This is the canonical list of decision categories this skill scans for during Stage 2 evidence indexing. The list is organized by area and prioritized within each area.
 
-**This list is closed.** The arbiter MUST NOT invent new categories.
+**This list is closed.** This skill MUST NOT invent new categories.
 
-If the arbiter encounters a decision that does not fit any category here:
+If this skill encounters a decision that does not fit any category here:
 
 1. Note the decision in the evidence index with `category: UNKNOWN`
 2. Describe what makes it not fit any existing category

--- a/.agents/skills/decision-variance/references/decision-log-format.md
+++ b/.agents/skills/decision-variance/references/decision-log-format.md
@@ -1,14 +1,14 @@
 # Decision Log Format
 
-This file defines the exact format used in `projectContext/arbiter-decisions.md`. The format is non-negotiable so the log remains machine-parseable on future arbiter invocations.
+This file defines the exact format used in `projectContext/arbiter-decisions.md`. The format is non-negotiable so the log remains machine-parseable on future invocations of this skill.
 
 ## Append-Only — No Edits Permitted
 
-The decision log is **strictly append-only**. The arbiter MUST NOT edit any prior entry. Not even small edits. Not "fixing typos." Not "cleaning up formatting." Not "improving clarity." Not adding fields to old entries.
+The decision log is **strictly append-only**. This skill MUST NOT edit any prior entry. Not even small edits. Not "fixing typos." Not "cleaning up formatting." Not "improving clarity." Not adding fields to old entries.
 
 The only operation permitted on prior entries is **reading** them.
 
-To supersede a prior decision, the arbiter appends a new entry whose `Supersedes:` field references the prior entry. Traversal from old to new is **forward-only**: readers scan forward in the log to find any entry whose `Supersedes:` field references the entry of interest. There is no backward-pointing `Superseded by:` field maintained on the prior entry. This makes append-only literally true with no exceptions.
+To supersede a prior decision, this skill appends a new entry whose `Supersedes:` field references the prior entry. Traversal from old to new is **forward-only**: readers scan forward in the log to find any entry whose `Supersedes:` field references the entry of interest. There is no backward-pointing `Superseded by:` field maintained on the prior entry. This makes append-only literally true with no exceptions.
 
 ## File Header
 
@@ -21,7 +21,7 @@ This file is the persistent, strictly append-only record of arbitration decision
 
 **Append-only with no exceptions.** Prior entries are never edited. To supersede a prior decision, append a new entry whose `Supersedes:` field references the prior entry. Forward traversal from old to new entries is the only supported lookup pattern.
 
-**Maintained by:** the `arbiter` skill, in collaboration with the user.
+**Maintained by:** the `decision-variance` skill, in collaboration with the user.
 
 ---
 ```
@@ -85,11 +85,11 @@ Every decision entry records the SHA-256 hash of the artifact section that defin
 - Decisions for `artifact-silent` variances (the artifact has no position)
 - Decisions for `META.*` categories (process decisions, not artifact-driven)
 
-**Stale detection:** On subsequent arbiter invocations, Stage 1.5 recomputes hashes for the cited sections and flags any decision whose hash has changed.
+**Stale detection:** On subsequent invocations of this skill, Stage 1.5 recomputes hashes for the cited sections and flags any decision whose hash has changed.
 
 ## Decision Numbering
 
-Entries are numbered sequentially as `DECISION-0001`, `DECISION-0002`, etc. The arbiter maintains the next number by reading the existing log. Numbers never gap and never skip.
+Entries are numbered sequentially as `DECISION-0001`, `DECISION-0002`, etc. This skill maintains the next number by reading the existing log. Numbers never gap and never skip.
 
 If two arbitration sessions race to write decisions, the later session uses the next available number — there is no merge conflict semantics defined for this case (single-user assumption holds for the prototype phase).
 
@@ -175,23 +175,23 @@ To find that DECISION-0001 was superseded, a reader scans forward and finds DECI
 - **Compressing multiple decisions into one entry.** Each variance gets its own decision entry. If a single user response covers multiple variances, write multiple entries.
 - **Recording "no decision needed."** If artifacts and scaffold concur, no decision entry is written. The decision log records actual arbitrations.
 - **Omitting the SMARTS rationale.** The rationale is what makes the decision auditable later. "User decided" without rationale is insufficient.
-- **Generating decisions without explicit user input.** The arbiter never writes a decision entry on its own initiative. Every entry is the record of an explicit user choice.
+- **Generating decisions without explicit user input.** This skill never writes a decision entry on its own initiative. Every entry is the record of an explicit user choice.
 - **Omitting the artifact-section-hash field.** The hash is required for stale-artifact detection. If the field is genuinely `n/a`, write `n/a` — do not omit the field.
 - **Maintaining backward `Superseded by:` links on prior entries.** Forward-only links from new entries. No exceptions.
 
 ## Reading the Log on Future Invocations
 
-When the arbiter starts a new session, it reads `projectContext/arbiter-decisions.md` from top to bottom and indexes:
+When this skill starts a new session, it reads `projectContext/arbiter-decisions.md` from top to bottom and indexes:
 
 - Every entry by its `DECISION-NNNN` ID
 - For each entry, its current `Status` and any `Supersedes` reference
 - The recorded `Artifact-section-hash` for each entry
 
-For each `accepted` entry, the arbiter checks whether a later entry supersedes it (forward scan). If yes, the later entry is authoritative. If no, the entry remains in force.
+For each `accepted` entry, this skill checks whether a later entry supersedes it (forward scan). If yes, the later entry is authoritative. If no, the entry remains in force.
 
-For each `accepted` or `deferred` entry whose `Artifact-section-hash` is not `n/a`, the arbiter recomputes the current hash of the referenced section. If the hash has changed, the entry is flagged for re-evaluation per Stage 1.5 of the workflow.
+For each `accepted` or `deferred` entry whose `Artifact-section-hash` is not `n/a`, this skill recomputes the current hash of the referenced section. If the hash has changed, the entry is flagged for re-evaluation per Stage 1.5 of the workflow.
 
-For each variance discovered in Stage 2, the arbiter checks whether a prior decision exists for that Decision ID:
+For each variance discovered in Stage 2, this skill checks whether a prior decision exists for that Decision ID:
 
 - If `accepted` and not flagged stale: the variance is already resolved; do not re-arbitrate unless the user explicitly asks
 - If `accepted` and flagged stale: surface to the user during Stage 1.5 for re-evaluation

--- a/.agents/skills/decision-variance/references/downstream-artifacts.md
+++ b/.agents/skills/decision-variance/references/downstream-artifacts.md
@@ -1,16 +1,16 @@
 # Downstream Artifacts Catalog
 
-This file catalogs the architectural artifacts that the arbiter can recommend producing once enough information is available. For each artifact, the catalog defines:
+This file catalogs the architectural artifacts that this skill can recommend producing once enough information is available. For each artifact, the catalog defines:
 
 - **Purpose** — what the artifact is for
 - **Readiness criteria** — explicit decision-ID lists that determine `ready` vs `partial` vs `blocked`
-- **Production guidance** — how to produce the artifact (handed to the user; arbiter does not auto-produce)
+- **Production guidance** — how to produce the artifact (handed to the user; this skill does not auto-produce)
 
-## How the Arbiter Uses This File
+## How This Skill Uses This File
 
-During Stage 5, the arbiter walks this catalog and assesses readiness for each artifact using the explicit criteria below. Output goes to `projectContext/arbiter-readiness.md` as a menu the user can select from.
+During Stage 5, this skill walks this catalog and assesses readiness for each artifact using the explicit criteria below. Output goes to `projectContext/arbiter-readiness.md` as a menu the user can select from.
 
-The arbiter does NOT produce these artifacts unless the user explicitly selects them.
+This skill does NOT produce these artifacts unless the user explicitly selects them.
 
 ## Readiness Evaluation Algorithm
 
@@ -214,7 +214,7 @@ Per-spike document with: context (full reasoning from artifacts), questions to a
 - No clear ADR convention exists in the project
 
 **Production guidance:**
-One ADR per major decision in the arbiter log. Use the project's existing ADR format. Cross-reference each ADR to the originating arbiter decision entry by DECISION-NNNN.
+One ADR per major decision in the decision log. Use the project's existing ADR format. Cross-reference each ADR to the originating decision-log entry by DECISION-NNNN.
 
 ---
 
@@ -225,19 +225,19 @@ One ADR per major decision in the arbiter log. Use the project's existing ADR fo
 **ready_criteria:**
 - All three architectural artifacts present (per Rule 2)
 - Scaffold codebase accessible
-- The arbiter has completed Stage 1 through Stage 4 at least once
+- This skill has completed Stage 1 through Stage 4 at least once
 
 **blocked_criteria:**
 - Three artifacts not located
 
 **Production guidance:**
-This is the variance report Stage 3 produces, framed as the bridging deliverable. After this report is processed, the arbiter operates on a unified context.
+This is the variance report Stage 3 produces, framed as the bridging deliverable. After this report is processed, this skill operates on a unified context.
 
 ---
 
 ## How to Recommend
 
-For each artifact in this catalog, the arbiter's Stage 5 output uses this exact format:
+For each artifact in this catalog, this skill's Stage 5 output uses this exact format:
 
 ```markdown
 ## Downstream Artifact Readiness

--- a/.agents/skills/decision-variance/references/known-open-decisions.md
+++ b/.agents/skills/decision-variance/references/known-open-decisions.md
@@ -1,6 +1,6 @@
 # Known Open Decisions
 
-The architectural artifacts deliberately leave certain decisions open. The arbiter MUST NOT treat these as variances during arbitration — they are open by design.
+The architectural artifacts deliberately leave certain decisions open. This skill MUST NOT treat these as variances during arbitration — they are open by design.
 
 This file enumerates each open decision and divides them into two scopes:
 
@@ -9,7 +9,7 @@ This file enumerates each open decision and divides them into two scopes:
 
 ## Standardized Handling Table (Arbiter-Scope Open Decisions)
 
-For every arbiter-scope open decision, the arbiter applies this exact rule table:
+For every arbiter-scope open decision, this skill applies this exact rule table:
 
 | Scaffold state | Action |
 |---|---|
@@ -48,7 +48,7 @@ This section is populated from the project's `projectContext/open-questions.md` 
 
 ## Out-of-Scope Open Decisions (Not Arbitrated by This Skill)
 
-The arbiter explicitly does NOT arbitrate operational, political, or strategic decisions. If the user asks about them, the arbiter redirects to the appropriate resolution mechanism.
+This skill explicitly does NOT arbitrate operational, political, or strategic decisions. If the user asks about them, this skill redirects to the appropriate resolution mechanism.
 
 ### Out-of-Scope: Personnel and Ownership Assignments
 
@@ -68,14 +68,14 @@ The arbiter explicitly does NOT arbitrate operational, political, or strategic d
 
 ## Anti-Pattern: Treating Open Decisions as Variances
 
-If the arbiter is generating a variance entry for any item that is explicitly open in the artifacts, that is a bug in the arbiter's logic. Open decisions go in the readiness assessment file, not the variance report.
+If this skill is generating a variance entry for any item that is explicitly open in the artifacts, that is a bug in this skill's logic. Open decisions go in the readiness assessment file, not the variance report.
 
 The distinction:
 - **Variance** = artifacts and scaffold disagree on something the artifacts have a position on
 - **Arbiter-scope open decision** = artifacts deliberately have no position; awaiting input; can be closed during arbitration via standardized handling
 - **Out-of-scope open decision** = not architectural; not arbitrated by this skill at all
 
-The arbiter must articulate the difference for any item it surfaces.
+This skill must articulate the difference for any item it surfaces.
 
 ## Closing an Open Decision Mid-Arbitration
 
@@ -86,15 +86,15 @@ For arbiter-scope open decisions, if the user wants to close one during the arbi
 3. Record the decision in `projectContext/arbiter-decisions.md` with `Status type: open-decision-closure` and a note that this closes an artifact-deferred decision
 4. Update the readiness assessment to reflect the now-closed decision
 
-For out-of-scope open decisions, the arbiter declines: "This is operational/strategic, not architectural — outside this skill's scope. The resolution mechanism is <X>."
+For out-of-scope open decisions, this skill declines: "This is operational/strategic, not architectural — outside this skill's scope. The resolution mechanism is <X>."
 
 ## Populating This File for a New Project
 
-When the arbiter first runs on a project, it should:
+When this skill first runs on a project, it should:
 
 1. Read the three architectural artifacts for any sections explicitly labeled as open, deferred, or TBD
 2. Read `projectContext/open-questions.md` for items explicitly flagged as unresolved
 3. Add each identified open decision to this file in the arbiter-scope or out-of-scope section as appropriate
 4. Present the populated list to the user for confirmation before proceeding with variance analysis
 
-This ensures the arbiter does not generate false variance entries for decisions the artifacts deliberately left open.
+This ensures this skill does not generate false variance entries for decisions the artifacts deliberately left open.

--- a/.agents/skills/decision-variance/references/smarts-framework.md
+++ b/.agents/skills/decision-variance/references/smarts-framework.md
@@ -1,10 +1,10 @@
 # SMARTS Framework
 
-The SMARTS framework is the standardized evaluation framework for architectural decisions. The arbiter applies SMARTS evenhandedly when comparing options.
+The SMARTS framework is the standardized evaluation framework for architectural decisions. This skill applies SMARTS evenhandedly when comparing options.
 
 SMARTS stands for: **S**calable, **M**aintainable, **A**vailable, **R**eliable, **T**estable, **S**ecurable.
 
-This is the project's chosen framework. The arbiter does not propose alternatives.
+This is the project's chosen framework. This skill does not propose alternatives.
 
 ## The Six Lenses
 
@@ -92,7 +92,7 @@ Does the option enable the project's security posture — as defined in `project
 
 ## Hard Format Constraints for SMARTS Cells
 
-When the arbiter (or grader subagent) produces a SMARTS analysis table, every cell follows these rules. These are not guidelines — they are constraints. Cells that violate them are non-conformant.
+When this skill (or grader subagent) produces a SMARTS analysis table, every cell follows these rules. These are not guidelines — they are constraints. Cells that violate them are non-conformant.
 
 **Rule 1 — Length cap:** Each cell is at most 25 words. No exceptions. Counting tools welcome.
 
@@ -130,7 +130,7 @@ When the arbiter (or grader subagent) produces a SMARTS analysis table, every ce
 
 ## Strength of Recommendation Levels
 
-When the arbiter (or grader) finishes a SMARTS analysis, the recommendation has exactly one strength label:
+When this skill (or grader) finishes a SMARTS analysis, the recommendation has exactly one strength label:
 
 - **strong** — multiple dominant lenses align cleanly toward one option; non-SMARTS considerations confirm
 - **moderate** — dominant lenses align toward one option but with caveats, or with a single lens dominating
@@ -138,7 +138,7 @@ When the arbiter (or grader) finishes a SMARTS analysis, the recommendation has 
 
 There is no `weak` level. If the analysis is close but a slight edge exists, the strength is `moderate`. If the analysis is genuinely tied, the strength is `tied` and the user is told plainly that this is a coin flip under SMARTS.
 
-This forces commitment when commitment is warranted and explicit acknowledgment when it is not. The arbiter never hides behind hedged language.
+This forces commitment when commitment is warranted and explicit acknowledgment when it is not. This skill never hides behind hedged language.
 
 ## When SMARTS Doesn't Resolve
 
@@ -150,7 +150,7 @@ If lenses pull in different directions and no clear winner emerges:
 4. Mark strength as `tied`
 5. Recommend the option that aligns with prior emphasis, with explicit acknowledgment that the choice is contestable
 
-`Tied` strength is a valid outcome. "This is a coin flip under SMARTS — your call" is a legitimate arbiter output.
+`Tied` strength is a valid outcome. "This is a coin flip under SMARTS — your call" is a legitimate output from this skill.
 
 ## SMARTS Limitations
 
@@ -162,4 +162,4 @@ The framework does not directly cover:
 - Vendor lock-in
 - Political acceptability (cross-team or cross-stakeholder dynamics)
 
-When these matter, the arbiter calls them out as **non-SMARTS considerations** alongside the SMARTS analysis. They are evaluated qualitatively and presented to the user. They do not replace SMARTS; they supplement it.
+When these matter, this skill calls them out as **non-SMARTS considerations** alongside the SMARTS analysis. They are evaluated qualitatively and presented to the user. They do not replace SMARTS; they supplement it.

--- a/.agents/skills/decompose/SKILL.md
+++ b/.agents/skills/decompose/SKILL.md
@@ -333,6 +333,7 @@ no template boilerplate left unfilled:
 | Layer 4 stack + hard constraints | `.agents/projectContext/tech-stack.md` |
 | Layer 4 compliance + crypto requirements | `.agents/projectContext/security-controls.md` |
 | Layer 4 state-change actions + write paths | `.agents/projectContext/audit-spec.md` |
+| Layers 1–6 observability-relevant decisions (signals, naming, labels, cardinality budgets, emit modules, alert rule storage, SLOs) | `.agents/projectContext/observability-spec.md` — instantiate `.agents/skills/observability-emit/templates/observability-spec.md.tmpl`; populate signal categories, naming conventions, required labels, cardinality budgets, canonical emit module paths, alert rule storage location, SLO definitions per the decomposed project's needs. |
 | Layer 4 lint, format, naming decisions | `.agents/projectContext/coding-standards.md` |
 | Layer 5 secret-bearing integrations | `.agents/projectContext/secrets-policy.md` |
 | Layer 5 dependency strategy + license stance | `.agents/projectContext/dependency-policy.md` |
@@ -391,6 +392,7 @@ and return codeArbiter to normal orchestrator operation.
    - `tech-stack.md`
    - `security-controls.md`
    - `audit-spec.md`
+   - `observability-spec.md`
    - `coding-standards.md`
    - `secrets-policy.md`
    - `dependency-policy.md`

--- a/.agents/skills/decompose/SKILL.md
+++ b/.agents/skills/decompose/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill when ALL of the following are true:
 
 - `.agents/projectContext/CONTEXT.md` does NOT contain the `<!--INITIALIZED-->` sentinel
@@ -70,14 +72,14 @@ persona for the duration of this skill.
 
 **Actions:**
 
-1. Announce the role switch explicitly to the user:
+1. Announce the role switch to the user using this exact wording:
 
-   > "I am stepping out of orchestrator mode. For this session I am operating as a
-   > senior software architect and ruthlessly precise technical lead. My job is to
-   > decompose your project vision into a complete, unambiguous specification before
-   > a single line of code is written. I will challenge vague language, surface hidden
-   > complexity, and force real trade-off decisions. I will return to orchestrator mode
-   > when this decomposition is complete and the projectContext files are written."
+   > "Switching to decomposition mode. For this session the orchestrator operates
+   > as a senior software architect and technical lead, decomposing your project
+   > vision into a complete, unambiguous specification before any code is written.
+   > Vague language will be challenged, hidden complexity surfaced, and trade-offs
+   > forced. Orchestrator mode resumes when this decomposition is complete and the
+   > projectContext files are written."
 
 2. State the Rules of Engagement verbatim:
 
@@ -273,7 +275,7 @@ review before committing them to the repository.
    - Every component with its responsibility and connections to other components
    - A simple ASCII or text diagram of the system (no external tools required)
    - Every integration named, with its type (sync/async), protocol, and owner
-   - Every open architectural decision flagged with `[OPEN-DECISION]` markers
+   - Every open architectural decision flagged with `[CONFIRM-NN]` markers (numbered sequentially with open-questions.md)
    - Trust zone mapping (if compliance requirements were named in Layer 4)
 
 2. Produce `02-phased-build-plan.md` containing:

--- a/.agents/skills/doc-governance/SKILL.md
+++ b/.agents/skills/doc-governance/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill before acting in any domain listed in AGENTS.md §4 Reference
 Map, and whenever a file under `.agents/projectContext/` is modified or
 referenced.

--- a/.agents/skills/doc-review-gate/SKILL.md
+++ b/.agents/skills/doc-review-gate/SKILL.md
@@ -1,4 +1,4 @@
-# Skill: doc-governance
+# Skill: doc-review-gate
 
 ## Trigger
 
@@ -15,7 +15,7 @@ Triggers:
 - A `projectContext/` reference in AGENTS.md or a skill file appears stale
 - A new capability is added to the project without a corresponding
   `projectContext/CONTEXT.md` entry
-- The `doc-governance` skill is referenced in the routing table
+- The `doc-review-gate` skill is referenced in the routing table
 
 ---
 

--- a/.agents/skills/observability-emit/SKILL.md
+++ b/.agents/skills/observability-emit/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: observability-emit
+---
+
+# Skill: observability-emit
+
+## Purpose
+
+Govern the emission of operational observability signals — metrics, traces (spans),
+structured logs, alert rules, and SLO definitions — so that every signal is
+registered in `projectContext/observability-spec.md`, named per project convention,
+labeled within cardinality budget, free of secret-shaped values, and (when
+alert-relevant) wired to a paired alert rule and SLO. This skill is the parallel of
+`audit-emit`: where `audit-emit` governs the compliance event stream, this skill
+governs the operational telemetry stream.
+
+---
+
+## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
+Routing conditions:
+- Code introduces, modifies, or removes the emission of a metric, span, structured
+  log, alert rule, or SLO definition.
+- A new code path that should be observable per `projectContext/observability-spec.md`
+  is added (presumptive observability obligation until Phase 1 rules otherwise).
+- A label, attribute, or field on an existing observability signal is added,
+  renamed, or removed.
+- The `observability-emit` skill is referenced in the routing table.
+
+---
+
+## Pre-Flight
+
+Before Phase 1 begins, confirm:
+
+1. `.agents/projectContext/observability-spec.md` is readable — stop if missing.
+   This file is the authoritative source for signal categories, naming conventions,
+   required labels, cardinality budgets, canonical emit paths, and alert/SLO
+   storage locations.
+2. `.agents/projectContext/tech-stack.md` is readable — stop if missing.
+3. Current stage is known — read `cat .agents/projectContext/stage`.
+
+If any file is missing, surface the gap and stop. Do not guess at signal names,
+label sets, emit signatures, or storage paths.
+
+---
+
+## Phase 1: Signal Classification
+
+**Goal:** Identify which observability signal category applies to the code change
+and confirm the signal name is registered in
+`projectContext/observability-spec.md` under the correct category.
+
+**Inputs:**
+- Description of the code change.
+- `.agents/projectContext/observability-spec.md` — authoritative signal categories,
+  naming conventions, and per-category registries.
+
+**Actions:**
+
+1. Read `.agents/projectContext/observability-spec.md` in full.
+2. Classify the signal into exactly one category per the spec:
+   - **metric** — a counter, gauge, histogram, or summary.
+   - **span** — a trace span (distributed tracing).
+   - **log** — a structured operational log line (not an audit event; audit events
+     route through `audit-emit`).
+   - **alert** — an alert rule definition.
+   - **SLO** — a service-level objective definition.
+3. Confirm the signal name follows the naming convention defined in
+   `projectContext/observability-spec.md` for the chosen category. If the spec
+   defines a `domain.subsystem.metric_name` pattern (or any other), enforce it.
+4. If the signal name is not present in the registered set for its category, add
+   it to the registry in `projectContext/observability-spec.md` before proceeding.
+   Do not emit an unregistered signal.
+5. If the code change introduces multiple distinct signals, classify and register
+   each one separately.
+
+**Output:** Confirmed signal category and signal name, with registration status
+(existing or newly added).
+
+**Gate:** BLOCK. No Phase 2 begins until every signal produced by the change is
+classified and registered. Emitting an unregistered signal name is a policy
+violation.
+
+---
+
+## Phase 2: Emit Construction
+
+**Goal:** Build a correct emit call with all required labels, attributes, or
+fields populated from `projectContext/observability-spec.md`, and free of
+secret-shaped values.
+
+**Inputs:**
+- Signal classification from Phase 1.
+- `.agents/projectContext/observability-spec.md` — required labels/attributes per
+  category, canonical emit module or function path.
+- `.agents/projectContext/secrets-policy.md` — secret patterns to exclude
+  (consulted via the `secret-handling` cross-route).
+
+**Actions:**
+
+1. Read the canonical emit module or function path defined in
+   `projectContext/observability-spec.md` for the signal's category. Use that
+   path exclusively — do not write directly to a logger, bare HTTP client, or
+   alternative telemetry shim.
+2. Populate every required label, attribute, or field for the signal's category
+   as defined in `projectContext/observability-spec.md`. Required label sets are
+   declared per category; do not invent fields not declared in the spec.
+3. Inspect every label, attribute, or field value for secret-shaped content
+   (tokens, keys, credentials, raw PII per `projectContext/secrets-policy.md`).
+   If any value could carry secret data, cross-route to the `secret-handling`
+   skill Phase 3 before continuing.
+4. Do not hard-code environment-specific or deployment-specific constants
+   (region, cluster name) as label values unless
+   `projectContext/observability-spec.md` declares them required constants. Use
+   runtime-resolved values where the spec calls for dynamic labels.
+5. If the change touches multiple emit sites, verify each site populates the full
+   required set for its category.
+
+**Output:** Emit call constructed with all required labels/attributes/fields,
+sourced from `projectContext/observability-spec.md`, with no secret-shaped values.
+
+**Gate:** BLOCK if any required label, attribute, or field is missing. BLOCK on
+any value that could carry secret data — cross-route to `secret-handling` Phase 3
+and do not return to Phase 3 of this skill until cleared.
+
+---
+
+## Phase 3: Cardinality Check
+
+**Goal:** For metrics and spans, confirm that no label dimension is unbounded and
+that the combined cardinality of the label set fits the per-signal budget defined
+in `projectContext/observability-spec.md`.
+
+**Inputs:**
+- Emit call from Phase 2.
+- `.agents/projectContext/observability-spec.md` — per-signal cardinality budgets
+  and forbidden label patterns.
+
+**Actions:**
+
+1. Skip this phase only for `log`, `alert`, and `SLO` categories (cardinality
+   applies primarily to metrics and spans). For `log`, still confirm that no
+   structured field value is unbounded user input emitted at indexed-field scope.
+2. For each label or span attribute, identify its value domain:
+   - **Bounded enum** (e.g., HTTP method, status class) — acceptable.
+   - **Bounded identifier set** (e.g., tenant_id with a known small N) —
+     acceptable if within the budget declared in `observability-spec.md`.
+   - **Unbounded identifier** (e.g., raw user_id, request_id, email, URL path
+     with embedded IDs, free-text input) — NOT acceptable as a label or indexed
+     attribute. Such values belong in span events or log fields, not labels.
+3. If `projectContext/observability-spec.md` declares a numeric cardinality
+   budget for the signal (e.g., "total combined label cardinality ≤ 10k"),
+   estimate the combined cardinality and confirm it fits the budget.
+4. If a label is borderline, surface the question to the user; do not silently
+   approve.
+
+**Output:** Confirmed that every label/attribute on metrics and spans has a
+bounded value domain and fits the declared cardinality budget.
+
+**Gate:** BLOCK if any label value domain is unbounded. BLOCK if the estimated
+combined cardinality exceeds the per-signal budget declared in
+`projectContext/observability-spec.md`.
+
+---
+
+## Phase 4: Alert / SLO Wiring
+
+**Goal:** If the signal is alert-relevant per `projectContext/observability-spec.md`,
+confirm that a paired alert rule and SLO are defined together. No
+signal-without-monitoring.
+
+**Inputs:**
+- Signal classification from Phase 1.
+- `.agents/projectContext/observability-spec.md` — list of alert-relevant signals,
+  alert rule storage location, SLO definition location.
+
+**Actions:**
+
+1. Consult `projectContext/observability-spec.md` to determine whether the signal
+   is in the alert-relevant set. Examples of alert-relevant signals: error-rate
+   counters, latency histograms used in SLI calculation, saturation gauges.
+2. If the signal is alert-relevant:
+   - Confirm an alert rule exists at the alert rule storage location defined in
+     `projectContext/observability-spec.md`, referencing this signal.
+   - Confirm a paired SLO is defined at the SLO definition location defined in
+     `projectContext/observability-spec.md`, expressing the objective that the
+     alert protects.
+   - If either is missing, author both before proceeding. Do not author only one.
+3. If the signal is NOT alert-relevant per the spec, no alert/SLO wiring is
+   required and this phase exits without action.
+4. MUST NOT introduce an alert rule without a paired SLO. MUST NOT introduce an
+   SLO without the underlying signal and alert rule.
+
+**Output:** For alert-relevant signals, a paired alert rule and SLO both exist
+and reference the signal. For non-alert-relevant signals, this is explicitly
+noted.
+
+**Gate:** BLOCK if the signal is alert-relevant per the spec but the paired
+alert rule or SLO is missing.
+
+---
+
+## Phase 5: Test Obligation
+
+**Goal:** Confirm every observability signal introduced or modified by the
+change has a corresponding test that exercises emit-call presence and label
+correctness.
+
+**Inputs:**
+- Signal classification from Phase 1.
+- Emit construction from Phase 2.
+- `.agents/projectContext/tech-stack.md` — test runner and mock/stub conventions.
+- `.agents/projectContext/observability-spec.md` — test obligation section, if
+  present.
+
+**Actions:**
+
+1. For each signal classified in Phase 1, verify that at least one test exists
+   that:
+   - Confirms the canonical emit function is called when the observed event
+     occurs.
+   - Confirms all required labels/attributes/fields from Phase 2 are present on
+     the emitted signal.
+   - For metrics and spans, confirms that no forbidden high-cardinality label
+     (per Phase 3) appears.
+   - Confirms the emit is not called when the observed event does not occur.
+2. Use the test framework and mock/stub patterns specified in
+   `projectContext/tech-stack.md`. Do not hard-code library-specific imports
+   unless that library is named in `projectContext/tech-stack.md`.
+3. Run the test command specified in `projectContext/tech-stack.md` and confirm
+   all observability-related tests are green.
+4. Run the lint command specified in `projectContext/tech-stack.md` and confirm
+   zero errors.
+
+**Output:** Passing tests covering every observability signal introduced or
+modified, confirmed by the test runner.
+
+**Gate:** BLOCK if any signal lacks a test for emit-call presence and required
+label coverage. BLOCK if the test runner or lint command reports any error.
+
+---
+
+## Hard Rules
+
+- MUST read `projectContext/observability-spec.md` before Phase 1. Do not guess
+  signal names, label sets, cardinality budgets, or canonical emit paths.
+- MUST NOT emit to any path other than the canonical emit module defined in
+  `projectContext/observability-spec.md` for the signal's category.
+- MUST NOT emit an unregistered signal name. Add it to the registry first.
+- MUST NOT include secret-shaped values in any label, attribute, or field;
+  cross-route to `secret-handling` Phase 3 if in doubt.
+- MUST NOT use unbounded identifiers (raw user IDs, request IDs, free-text user
+  input, full URL paths with embedded IDs) as metric labels or indexed span
+  attributes.
+- MUST NOT introduce an alert rule without a paired SLO, or an SLO without the
+  underlying signal and alert rule.
+- MUST NOT hard-code environment- or deployment-specific constants as label
+  values unless `projectContext/observability-spec.md` declares them required
+  constants.
+- MUST NOT guess test runner or lint commands — always read
+  `projectContext/tech-stack.md`.
+- MUST NOT proceed to the commit-gate skill until all five phases are complete.
+
+---
+
+## Decision Gates Summary
+
+| Gate         | Condition                                                                | Action if blocked                                                                  |
+|--------------|--------------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| Phase 1 exit | Unregistered signal name or signal name violates naming convention       | Register signal in `observability-spec.md` under correct category; rename if needed |
+| Phase 2 exit | Required label/attribute/field missing, or value carries secret-shaped data | Add missing field; cross-route to `secret-handling` Phase 3 for any secret risk     |
+| Phase 3 exit | Unbounded label value domain, or estimated cardinality exceeds budget    | Demote unbounded value to span event or log field; tighten label set                |
+| Phase 4 exit | Alert-relevant signal lacks paired alert rule or SLO                     | Author the missing alert rule and/or SLO before proceeding                          |
+| Phase 5 exit | Signal lacks emit-presence/label test, or test/lint fails                | Write missing test; fix lint errors                                                 |
+
+---
+
+## Interactions with other skills
+
+- **`audit-emit` (parallel skill).** `audit-emit` governs the compliance event
+  stream — discrete, durable, auditor-facing records routed through the canonical
+  audit sink. `observability-emit` governs the operational telemetry stream —
+  metrics, spans, logs, alerts, SLOs for runtime visibility and on-call response.
+  The two streams are independent: a compliance-relevant action that also has
+  operational significance MUST route through both skills (audit-emit for the
+  audit record, observability-emit for the operational signal). Do not collapse
+  one into the other. If a signal's purpose is ambiguous, classify it under
+  `audit-emit` if the consumer is an auditor or compliance review, and under
+  `observability-emit` if the consumer is an on-call engineer or capacity
+  planner.
+
+- **`secret-handling` Phase 3 (cross-route on Phase 2).** When Phase 2 of this
+  skill encounters a label, attribute, or field whose value could carry
+  secret-shaped data, control transfers to `secret-handling` Phase 3 for
+  redaction or rejection. Return to this skill only after `secret-handling`
+  clears the value or the value is removed.
+
+- **`tdd` skill.** Phase 5 of this skill (Test Obligation) is satisfied via the
+  test obligations declared by the `tdd` skill. Tests for observability signals
+  follow the same TDD discipline as feature code: a failing test for the
+  required emit must exist before the emit is implemented.
+
+---
+
+## Failure Modes
+
+| Failure                                                  | Response                                                                       |
+|----------------------------------------------------------|--------------------------------------------------------------------------------|
+| `observability-spec.md` missing or unreadable            | Stop; surface gap to user; do not guess signal names, labels, or emit paths    |
+| `tech-stack.md` missing or unreadable                    | Stop; surface gap; do not guess test or lint commands                          |
+| Signal name not in registered set for its category       | Add signal to registry in `observability-spec.md` before emitting              |
+| Required label missing from emit                         | Add label; re-read `observability-spec.md` for correct value source            |
+| Label value carries secret-shaped data                   | Cross-route to `secret-handling` Phase 3; do not return until cleared          |
+| Unbounded identifier used as metric label                | Demote to span event or log field; tighten the label set                       |
+| Alert-relevant signal lacks paired alert rule or SLO     | Author the missing alert rule and SLO together before proceeding               |
+| Alert rule authored without paired SLO (or vice versa)   | Treat as policy violation; author the missing artifact before commit            |
+| No test for an observability signal                      | Write test before proceeding; do not mark obligation complete without evidence |
+
+---
+
+## Subagents Invoked
+
+None. This skill operates entirely within the orchestrator context. Cross-routes
+to `secret-handling` (Phase 2 of this skill) and to `commit-gate` (post-Phase 5)
+are skill handoffs, not subagent dispatches.

--- a/.agents/skills/observability-emit/templates/observability-spec.md.tmpl
+++ b/.agents/skills/observability-emit/templates/observability-spec.md.tmpl
@@ -1,0 +1,190 @@
+<!--PLACEHOLDER-->
+<!-- Populated by decompose/context-creation skill. -->
+
+# Observability Specification
+
+This file is the authoritative source for the `observability-emit` skill. It
+declares every observability signal the project emits, the naming convention for
+each category, the required labels/attributes/fields, the cardinality budgets,
+the canonical emit module or function paths, and the storage locations for
+alert rules and SLO definitions.
+
+This template uses angle-bracket placeholders (e.g., `<like-this>`) for values
+that downstream projects fill in during the `decompose` or `context-creation`
+skill's Phase 5 stub-write.
+
+---
+
+## Signal Categories
+
+The project emits observability signals in the following categories. Each
+category has its own naming convention, required label set, cardinality budget,
+and canonical emit path.
+
+| Category | In scope? | Notes |
+|---|---|---|
+| **metrics** | <yes / no> | <e.g., Prometheus counters, gauges, histograms> |
+| **traces** | <yes / no> | <e.g., OpenTelemetry spans> |
+| **logs** | <yes / no> | <e.g., structured JSON logs to stdout> |
+| **alerts** | <yes / no> | <alert rules paired with alert-relevant metrics> |
+| **SLOs** | <yes / no> | <service-level objectives paired with alerts> |
+
+Audit events are NOT covered here — they route through the `audit-emit` skill
+and are governed by `projectContext/audit-spec.md`.
+
+---
+
+## Naming Conventions per Category
+
+Each category has a fixed naming pattern. New signals MUST conform.
+
+| Category | Pattern | Example |
+|---|---|---|
+| metrics | `<domain>.<subsystem>.<metric_name>_<unit>` | `<api.requests.total>` |
+| traces (span names) | `<domain>.<operation>` | `<orders.checkout>` |
+| logs (event field) | `<domain>.<event_name>` | `<orders.checkout_failed>` |
+| alerts (rule name) | `<domain>_<condition>_<severity>` | `<api_high_error_rate_critical>` |
+| SLOs (objective name) | `<domain>_<sli>_<target>` | `<api_availability_99_9>` |
+
+Replace the patterns above with the project's actual convention. If the project
+uses a different convention (e.g., flat snake_case), declare it here explicitly.
+
+---
+
+## Required Labels per Category
+
+Every signal in a category MUST carry the required labels for that category.
+
+### Metrics — required labels
+
+| Label | Type | Value source | Notes |
+|---|---|---|---|
+| `<service>` | enum | <runtime constant> | <e.g., service name> |
+| `<environment>` | enum | <runtime constant> | <e.g., prod, staging> |
+| `<...>` | <type> | <source> | <notes> |
+
+### Traces (span attributes) — required
+
+| Attribute | Type | Value source | Notes |
+|---|---|---|---|
+| `<service.name>` | enum | <runtime constant> | <OTel semantic convention> |
+| `<...>` | <type> | <source> | <notes> |
+
+### Logs — required structured fields
+
+| Field | Type | Value source | Notes |
+|---|---|---|---|
+| `<timestamp>` | ISO-8601 | <runtime> | <UTC, RFC 3339> |
+| `<level>` | enum | <runtime> | <DEBUG, INFO, WARN, ERROR> |
+| `<service>` | enum | <runtime constant> | <service name> |
+| `<...>` | <type> | <source> | <notes> |
+
+### Alerts — required fields per rule
+
+| Field | Notes |
+|---|---|
+| `<name>` | <follows naming convention above> |
+| `<expr>` | <query against the underlying metric> |
+| `<for>` | <duration before alert fires> |
+| `<severity>` | <critical / high / medium / low> |
+| `<runbook>` | <link to runbook> |
+| `<paired_slo>` | <name of the paired SLO; required> |
+
+### SLOs — required fields per objective
+
+| Field | Notes |
+|---|---|
+| `<name>` | <follows naming convention above> |
+| `<sli>` | <how the SLI is computed from underlying signals> |
+| `<target>` | <objective, e.g., 99.9% over 30d> |
+| `<error_budget>` | <derived from target> |
+| `<paired_alert>` | <name of the paired alert rule; required> |
+
+---
+
+## Cardinality Budgets
+
+Cardinality budgets prevent label-explosion incidents. Each metric and span
+has a declared maximum combined label cardinality. Unbounded identifiers MUST
+NOT appear as labels.
+
+| Signal pattern | Max combined cardinality | Forbidden label values |
+|---|---|---|
+| <`api.requests.total_total`> | <10,000> | <raw user_id, request_id, full URL path> |
+| <default for all metrics> | <1,000> | <raw user_id, request_id, free-text input> |
+| <default for all spans> | <attributes follow same forbidden-value rules> | <as above> |
+
+Forbidden values that must NEVER appear as labels or indexed span attributes
+(may appear as span events or log fields only):
+
+- <raw user identifiers (user_id, email, IP address)>
+- <raw request identifiers (request_id, session_id)>
+- <free-text user input>
+- <full URL paths with embedded identifiers>
+- <any value listed in `projectContext/secrets-policy.md`>
+
+---
+
+## Canonical Emit Module / Function Paths
+
+Code MUST emit signals only through these canonical paths. Bare logger writes,
+ad-hoc HTTP calls to telemetry backends, and alternative shims are forbidden.
+
+| Category | Module / function path | Notes |
+|---|---|---|
+| metrics | `<src/observability/metrics.ts → emitCounter / emitGauge / emitHistogram>` | <wraps the underlying client> |
+| traces | `<src/observability/tracing.ts → startSpan / addSpanEvent>` | <OTel SDK wrapper> |
+| logs | `<src/observability/log.ts → log.info / log.warn / log.error>` | <structured logger; JSON output> |
+| alerts | `<infra/alerts/*.yaml — declarative, not code-emitted>` | <see storage location below> |
+| SLOs | `<infra/slos/*.yaml — declarative, not code-emitted>` | <see storage location below> |
+
+---
+
+## Alert Rule Storage Location
+
+Alert rules are declarative and live in version control alongside infrastructure
+definitions. They MUST NOT be authored ad-hoc in dashboards.
+
+- **Path:** `<infra/alerts/>`
+- **Format:** `<Prometheus rule YAML / Alertmanager YAML / equivalent>`
+- **One file per:** `<domain>` (e.g., `<infra/alerts/api.yaml>`)
+- **Required pairing:** every alert rule MUST reference a paired SLO by name in
+  the rule's `paired_slo` field.
+
+---
+
+## SLO Definitions
+
+SLOs are declarative and live alongside alert rules. Each SLO MUST be paired
+with at least one alert rule that protects its error budget.
+
+- **Path:** `<infra/slos/>`
+- **Format:** `<YAML following the project's SLO schema>`
+- **One file per:** `<domain>` (e.g., `<infra/slos/api.yaml>`)
+- **Required pairing:** every SLO MUST reference a paired alert rule by name in
+  the SLO's `paired_alert` field.
+
+### Alert-relevant signal set
+
+The following signals are designated alert-relevant. Introducing or modifying any
+of them invokes Phase 4 of the `observability-emit` skill (Alert / SLO Wiring).
+
+| Signal | Paired alert | Paired SLO |
+|---|---|---|
+| <`api.requests.errors_total`> | <`api_high_error_rate_critical`> | <`api_availability_99_9`> |
+| <`api.requests.duration_seconds`> | <`api_high_latency_high`> | <`api_latency_p99_500ms`> |
+| <...> | <...> | <...> |
+
+---
+
+## Test Obligation
+
+Every signal declared in this file MUST have a corresponding test, per Phase 5
+of the `observability-emit` skill. Tests confirm:
+
+- The canonical emit function is called when the observed event occurs.
+- All required labels/attributes/fields are present on the emitted signal.
+- No forbidden high-cardinality label appears.
+- The emit is not called when the observed event does not occur.
+
+Test runner and mock/stub conventions: see `projectContext/tech-stack.md`.

--- a/.agents/skills/onboard/SKILL.md
+++ b/.agents/skills/onboard/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill when the user runs `/onboard` with an optional scope argument.
 
 Two operating modes:

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: refactor
+description: Restructure existing code without changing behavior. Six-phase gated workflow that proves behavioral parity through pre-existing test coverage, blocks any change classifiable as `feat`, and refuses to accept modified tests as evidence of correctness.
+---
+
+# Skill: refactor
+
+## Purpose
+
+The `refactor` skill governs any change whose stated intent is to restructure code
+without altering behavior — renaming, extracting, inlining, splitting modules,
+collapsing duplication, or replacing internal implementations behind unchanged
+interfaces. It enforces a single invariant: the externally observable behavior of
+the named surface before the refactor is identical to the externally observable
+behavior after. Every gate in this skill exists to verify that invariant by
+mechanical means rather than by inspection. A refactor that cannot demonstrate
+parity through unmodified pre-existing tests is not a refactor — it is a feature
+change in disguise and MUST be routed back through the `tdd` skill.
+
+---
+
+## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
+- User invokes `/refactor` (when wired) or otherwise requests a behavior-preserving
+  restructure (rename, extract function/class, inline, move, deduplicate, replace
+  internal implementation)
+- The routing table in `AGENTS.md` §5 lists "refactor" as the primary route for
+  the cue
+- A `tdd` Phase 1 obligation scan determines that the planned change introduces
+  no new obligations and the user confirms intent is restructure-only
+- A `commit-gate` Phase 3 classification of a staged change set returns `refactor`
+  and there is no prior gated workflow for that change set
+
+---
+
+## Pre-Flight
+
+Before Phase 1 begins, confirm:
+
+1. `.agents/projectContext/tech-stack.md` is readable — stop if missing.
+2. `.agents/projectContext/coding-standards.md` is readable — stop if missing.
+3. `.agents/projectContext/stage` exists and the current stage is known —
+   `cat .agents/projectContext/stage`.
+4. A test runner, lint command, and coverage command are documented in
+   `tech-stack.md`. If any of the three is undocumented, stop and surface the gap.
+5. The working tree is clean (no unstaged changes overlapping the named surface).
+   A dirty surface conflates the refactor diff with unrelated edits and breaks
+   parity verification.
+
+If any pre-flight check fails, stop and surface the gap. Do not guess thresholds
+or commands.
+
+---
+
+## Phase 1: Surface Identification
+
+**Goal:** Enumerate the exact files, functions, classes, and public method
+signatures that fall within the refactor's blast radius before any other work
+begins.
+
+**Inputs:**
+- The user's description of the planned restructure
+- The current working tree
+
+**Actions:**
+
+1. Restate the planned refactor in one sentence and confirm it back to the user.
+2. List the exact surface as a structured table:
+   - Files (absolute or repo-relative paths)
+   - Top-level symbols touched (function names, class names, exported members)
+   - Public method signatures within those symbols
+   - External consumers of any public symbol (call sites in other modules)
+3. Reject vague surfaces. Examples of unacceptable surface descriptions:
+   - "the auth module"
+   - "the user service"
+   - "some helpers in utils"
+   A surface is acceptable only when a reader could grep the repo for the exact
+   listed symbols and arrive at the same file set.
+4. Record the surface table. It becomes the parity contract for Phases 2–5.
+
+**Output:** A surface table with files, symbols, public signatures, and external
+consumers, signed off by the user.
+
+**Gate:** BLOCK if the surface is vague, incomplete, or describes a category
+rather than a list. "The auth module" is not a surface — "the functions
+`signToken`, `verifyToken`, and `rotateKey` in `src/auth/tokens.ts`" is.
+
+---
+
+## Phase 2: Behavioral Parity Coverage Proof
+
+**Goal:** Prove that pre-existing tests already exercise the named surface
+sufficiently to detect a behavior change, before any production code is touched.
+
+**Inputs:**
+- The surface table from Phase 1
+- The test runner and coverage command from `tech-stack.md`
+- The stage value from Pre-Flight
+
+**Actions:**
+
+1. Locate every test file that exercises any symbol in the surface table.
+2. Run the coverage command scoped to the surface files. Record line, branch,
+   and per-symbol coverage.
+3. Look up the stage's minimum coverage threshold (same table as `tdd` Phase 5):
+
+   | Stage | Minimum Coverage |
+   |-------|------------------|
+   | 1     | >= 60%           |
+   | 2     | >= 70%           |
+   | 3     | >= 85%           |
+   | 4     | >= 90%           |
+
+4. For each public method listed in the surface table, confirm it has at least
+   one direct test (not merely transitive coverage through a higher-level
+   integration test). A public method with zero direct tests is uncovered for
+   the purposes of this gate.
+5. If coverage of the named surface is below the stage threshold, OR any public
+   method has zero direct tests, halt and route to the `tdd` skill Phase 1 to
+   backfill obligations and tests. Resume Phase 2 only after the backfill is
+   green.
+
+**Output:** A parity coverage report citing the stage threshold, measured
+coverage of the named surface, and a per-public-method test inventory. All
+entries marked COVERED.
+
+**Gate:** BLOCK if coverage of the named surface is below the stage threshold
+OR if any public method in the surface table has zero direct tests. Backfill
+via `tdd` Phase 1 before retrying.
+
+---
+
+## Phase 3: Red Parity Tests (conditional)
+
+**Goal:** When the refactor exposes a new test seam — for example, extracting an
+internal helper into a new exported function with its own public signature —
+write failing tests for that seam before implementation.
+
+**Inputs:**
+- The surface table from Phase 1
+- The parity coverage report from Phase 2
+
+**Actions:**
+
+1. Inspect the planned refactor against the surface table. If the refactor will
+   produce any of the following, treat each as a new test seam:
+   - A newly exported symbol that did not exist before
+   - A new public method signature on an existing class
+   - A previously private function being promoted to module-public
+2. If no new test seams are exposed, skip the remaining actions and record
+   "No new seams" as the Phase 3 output.
+3. For each new seam, write one or more failing tests that pin the seam's
+   contract. These tests MUST fail before implementation begins.
+4. Run the test suite. The new seam tests MUST be red. All pre-existing tests
+   MUST remain green.
+5. New seam tests are scoped strictly to surface restructure — not to introduce
+   behavior beyond what the original code already produced. If a proposed seam
+   test would require new behavior to pass, the change is not a refactor —
+   route it to `tdd` and abort.
+
+**Output:** Either "No new seams" or a set of failing seam tests with
+pre-existing tests still green.
+
+**Gate:** BLOCK if a proposed seam test would require new behavior to pass.
+BLOCK if any pre-existing test fails as a side effect of writing the new seam
+tests. A new-behavior seam test is a feature, not a refactor.
+
+---
+
+## Phase 4: Implementation
+
+**Goal:** Apply the restructure with zero behavior change.
+
+**Inputs:**
+- The surface table from Phase 1
+- The parity coverage report from Phase 2
+- Any seam tests from Phase 3
+- `.agents/projectContext/coding-standards.md`
+
+**Actions:**
+
+1. Read `coding-standards.md` before editing.
+2. Apply the refactor mechanically within the surface table. Acceptable edits:
+   - Rename symbols (with consumer updates)
+   - Extract functions or methods
+   - Inline functions or methods
+   - Move symbols between files
+   - Replace internal implementation with an equivalent one
+   - Collapse or split modules where the public interface is preserved
+3. Unacceptable edits inside a refactor:
+   - Adding a new behavior, branch, error path, or side effect
+   - Changing the value returned by any public method for any pre-existing input
+   - Adding a new public method beyond a Phase 3 seam
+   - Changing observable order of operations (event emission, logging, IO)
+4. Mentally classify the resulting staged diff using `commit-gate` Phase 3
+   criteria. If the diff would classify as `feat`, the change is not a refactor
+   — halt and route to `tdd`.
+
+**Output:** Applied refactor confined to the surface table, with Phase 3 seam
+tests (if any) now green.
+
+**Gate:** BLOCK if the diff would classify as `feat` under `commit-gate` Phase 3.
+BLOCK if any edit falls outside the surface table from Phase 1 without an
+explicit user-approved surface amendment.
+
+---
+
+## Phase 5: Parity Verification
+
+**Goal:** Demonstrate that the pre-existing test suite — without modification —
+still passes after the refactor.
+
+**Inputs:**
+- The full project test suite
+- The parity coverage report from Phase 2 (list of pre-existing tests)
+- The git diff of staged changes
+
+**Actions:**
+
+1. Run the full project test suite using the command from `tech-stack.md`.
+2. Every pre-existing test identified in Phase 2 MUST pass with NO modification
+   to its source. Inspect the diff and confirm zero edits to any pre-existing
+   test file.
+3. A modified pre-existing test is, by definition, evidence that the surface's
+   observable behavior changed. A modified test MUST be reverted; if the test
+   cannot pass after revert, the refactor introduced a behavior change and
+   MUST be routed to `tdd` as a feature or fix.
+4. New seam tests written in Phase 3 (if any) MUST pass.
+5. Record the pass/fail tally and any modified-test detection in the parity
+   verification report.
+
+**Output:** Full test suite green with zero pre-existing tests modified.
+
+**Gate:** BLOCK if any pre-existing test was modified to pass. A modified test
+is a behavior change, not a refactor. BLOCK if any test in the suite fails.
+
+---
+
+## Phase 6: Lint/Coverage Gate
+
+**Goal:** Confirm style, type-check, and coverage all clear — mirroring the
+exit conditions of `tdd` Phase 5 and Phase 6.
+
+**Inputs:**
+- `tech-stack.md` — lint, type-check, and coverage commands
+- `.agents/projectContext/stage` — for the coverage threshold
+
+**Actions:**
+
+1. Run the lint command from `tech-stack.md`. Zero errors permitted. Warnings
+   that escalate to errors under the project's configuration must be resolved.
+2. Run the type-check command (if the project uses static typing). Zero errors
+   permitted.
+3. Run the coverage command. Confirm coverage of the named surface remains at or
+   above the stage threshold. A refactor MUST NOT reduce coverage of the surface
+   it touches.
+4. MUST NOT inline-suppress a lint rule to clear this gate. If a genuine
+   suppression is required, it requires a comment justifying it and must not
+   bypass a security-relevant rule.
+
+**Output:** Lint, type-check, and coverage outputs all clean. Surface coverage
+unchanged or improved relative to Phase 2 baseline.
+
+**Gate:** BLOCK on any lint error, type error, or coverage regression on the
+named surface. Coverage MUST NOT decrease as a side effect of restructure.
+
+---
+
+## Hard Rules
+
+- MUST NOT begin Phase 2 without a precise surface table from Phase 1.
+- MUST NOT proceed past Phase 2 if any public method in the surface table has
+  zero direct tests.
+- MUST NOT proceed past Phase 2 if surface coverage is below the stage threshold;
+  route to `tdd` Phase 1 to backfill.
+- MUST NOT introduce new behavior in Phase 4. A change whose `commit-gate`
+  Phase 3 classification would be `feat` is not a refactor.
+- MUST NOT modify any pre-existing test to make it pass. A modified test is a
+  behavior change.
+- MUST NOT reduce coverage of the named surface during the refactor.
+- MUST NOT extend the refactor's surface mid-flight without an explicit
+  user-approved amendment to the Phase 1 surface table.
+- MUST NOT inline-suppress lint rules to clear Phase 6.
+- MUST NOT guess test runner, lint, or coverage commands — always read
+  `.agents/projectContext/tech-stack.md`.
+
+---
+
+## Decision Gates Summary
+
+| Gate         | Condition                                                                       | Action if blocked                                       |
+|--------------|---------------------------------------------------------------------------------|---------------------------------------------------------|
+| Phase 1 exit | Surface vague, incomplete, or describes a category rather than named symbols    | Stop; require user to name files and symbols precisely  |
+| Phase 2 exit | Surface coverage below stage threshold, or any public method has zero direct tests | Halt; route to `tdd` Phase 1 to backfill obligations |
+| Phase 3 exit | Proposed seam test requires new behavior, or pre-existing tests broke           | Stop; route to `tdd` — change is a feature              |
+| Phase 4 exit | Diff would classify as `feat` under `commit-gate` Phase 3                       | Stop; route to `tdd` — change is a feature              |
+| Phase 5 exit | Any pre-existing test modified, or any test fails                               | Stop; revert test edits; if tests cannot pass, route to `tdd` |
+| Phase 6 exit | Lint error, type error, or coverage regression on named surface                 | Stop; fix without inline suppression                    |
+
+---
+
+## Interactions with other skills
+
+**`tdd` skill (Phase 1 backfill).** When Phase 2 of `refactor` finds that the
+named surface lacks sufficient coverage — either total coverage below the stage
+threshold or any public method with zero direct tests — `refactor` halts and
+routes to `tdd` Phase 1 to write obligations and red tests for the uncovered
+surface. Only after `tdd` returns with green tests does `refactor` resume at
+Phase 2 to re-verify parity coverage. The handoff also applies in Phase 3 when
+a proposed seam test would require new behavior, and in Phase 4/5 whenever a
+detected behavior change reveals the work is a feature, not a restructure.
+
+**`commit-gate` skill (classification).** `refactor` Phase 4 explicitly mirrors
+`commit-gate` Phase 3 classification criteria. The implementation gate uses the
+`commit-gate` rubric to verify the staged diff would classify as `refactor`
+rather than `feat`. When all six `refactor` phases pass, the resulting commit
+is routed through `commit-gate` like any other change; `commit-gate` Phase 3
+must classify the diff as `refactor`, and `commit-gate` Phase 4 verification
+gates (test, lint, secrets) run against the already-green state produced here.
+A divergence — for example, `commit-gate` classifying as `feat` after
+`refactor` produced a green Phase 4 — is a hard contradiction and MUST be
+surfaced via `/surface-conflict`.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: release
+---
+
+# Skill: release
+
+## Purpose
+
+Drive a project from "green on main" to a tagged, announceable release. The release skill is the
+single permitted path to a version tag. It composes the project's existing compliance machinery —
+the `tdd` outcome, the `commit-gate` SemVer classification, the `/checkpoint` review aggregate, the
+`decision-lifecycle` ADR health audit, and the `stage-gating` stage threshold — into one ordered
+gate sequence. It does not duplicate those skills; it routes to them, reads their outputs, and
+BLOCKS if any of them was DEFERRED rather than PASS.
+
+A release is not a commit. A release is a deployment-readiness assertion: that the codebase at this
+SHA, under the current stage, satisfies every published threshold for shipping. The skill produces
+a tag, a roll-up changelog, and a deployment-readiness report. If any prior gate was deferred, the
+release is BLOCKED — there are no partial releases.
+
+---
+
+## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
+The orchestrator routes to this skill when:
+
+- The user invokes `/release` (or equivalent release command) on a non-protected branch with a
+  green main and an authorized release window.
+- A stage promotion is queued and the promotion criteria require a release tag at the current stage
+  before promotion proceeds.
+- A scheduled release window has been declared in `projectContext/` and the current SHA is the
+  candidate.
+- The routing table in `AGENTS.md` references this skill for a release-class workflow.
+
+This skill MUST NOT be invoked to produce a "hotfix tag" without running every phase. There are no
+abbreviated releases. A hotfix that requires bypassing a gate is an `/override` event, logged
+permanently to `.agents/projectContext/overrides.log`.
+
+---
+
+## Pre-Flight
+
+Before Phase 1 begins, confirm the following. Each check either passes silently or hard-stops with
+a specific error message.
+
+1. `.agents/projectContext/stage` is readable and contains a valid integer 1–4. If missing or
+   non-numeric, STOP and surface the error — the release cannot proceed without a known stage.
+2. `.agents/projectContext/audit-spec.md` is readable. If missing, STOP — fail-closed audit policy
+   verification in Phase 6 has no source of truth.
+3. The working tree is clean. Run `git status` and confirm there are no uncommitted changes. If
+   the tree is dirty, STOP and instruct the user to commit or stash via the `commit-gate` skill.
+4. The current branch is the configured release branch (typically `main` or `release/*`). If the
+   branch is a feature branch, STOP and instruct the user to merge first.
+5. The most recent tag is identifiable via `git describe --tags --abbrev=0`. If the repository has
+   no tags, record `LAST_TAG=<none>` and treat the entire commit history as the release window.
+6. The commit set since `LAST_TAG..HEAD` is non-empty. If empty, STOP — there is nothing to
+   release.
+
+If every check passes, proceed to Phase 1.
+
+---
+
+## Phase 1 — Pre-Flight Readiness
+
+**Goal:** Confirm the project is in a state where a release is even conceivable: tests green,
+commit-gate clean, no blocking CONFIRM placeholders, ADR health within tolerance.
+
+**Inputs:**
+- The most recent `tdd` skill run result (specifically, Phase 6 green/red on `LAST_TAG..HEAD`).
+- The most recent `commit-gate` skill run on the HEAD commit.
+- `.agents/projectContext/open-questions.md` — for any `[CONFIRM-NN]` entries flagged as blocking
+  the target stage.
+- The ADR health table from the most recent `decision-lifecycle` run, or the requirement to run it.
+
+**Actions:**
+
+1. Confirm the most recent full test suite run was green. If the last `tdd` Phase 6 result is not
+   PASS, record `READINESS=BLOCK` and surface the failing test set.
+2. Confirm the HEAD commit was produced by the `commit-gate` skill with all eight phases PASS.
+   Read the most recent commit message footer and verify it was not produced via `/override`. An
+   override-tagged HEAD commit BLOCKS Phase 1 unless the user explicitly re-authorizes the release
+   via a new `/override`.
+3. Read `.agents/projectContext/open-questions.md`. Identify every `[CONFIRM-NN]` entry whose
+   target stage equals or exceeds the current stage. If any are still in OPEN or
+   PARTIALLY-EVIDENCED status (per the `decision-lifecycle` taxonomy), record `READINESS=BLOCK`
+   with the entry IDs.
+4. If a `decision-lifecycle` run has not occurred in the current session, route to it now for a
+   surface health check (Phase 1 + Phase 2 only — full ADR challenge happens in Phase 5 below).
+   Capture the ADR health table for use in Phase 5.
+
+**Output:** Pre-flight readiness verdict — `PASS` or `BLOCK` — with cited evidence for each
+sub-check.
+
+**Gate:** BLOCK on any failing sub-check. MUST NOT proceed to Phase 2 with a known-red test suite,
+an override-tagged HEAD, an unresolved blocking `[CONFIRM-NN]`, or a missing ADR health table.
+
+---
+
+## Phase 2 — Checkpoint Gate
+
+**Goal:** Run a full cross-cutting review of the codebase before the tag is composed. A release
+without a fresh checkpoint is a release without a baseline.
+
+**Inputs:**
+- `projectContext/checkpoints/` — for the most recent checkpoint document.
+- The current value of `.agents/projectContext/stage` — to compute stage-appropriate BLOCKS
+  classifications.
+
+**Actions:**
+
+1. Determine whether a checkpoint document dated within the release window
+   (`LAST_TAG..HEAD` time range) already exists in `projectContext/checkpoints/`. If yes and it
+   is signed off by a named approver, capture it. If no, route to the `/checkpoint` command and
+   wait for completion.
+2. The `/checkpoint` command dispatches all seven checkpoint agents and writes
+   `projectContext/checkpoints/YYYY-MM-DD.md`. The release skill does not re-implement that work —
+   it routes to it and reads the output.
+3. After `/checkpoint` returns, parse the checkpoint document and tabulate:
+   - Total CRITICAL findings.
+   - Total `BLOCKS_S<current-stage>` findings still open.
+   - Total `BLOCKS_S<current-stage+1>` findings (informational at this stage but flagged for the
+     deployment-readiness report).
+4. If any CRITICAL finding is unresolved, record `CHECKPOINT=BLOCK`. If any open
+   `BLOCKS_S<current-stage>` finding is present, record `CHECKPOINT=BLOCK`.
+
+**Output:** Checkpoint summary — finding counts by severity and stage classification, plus the
+checkpoint document path.
+
+**Gate:** BLOCK on any unresolved CRITICAL finding. BLOCK on any open `BLOCKS_S<current-stage>`
+finding. The release MUST NOT proceed if the checkpoint has not been signed off by a named
+approver (per the `/checkpoint` command's own gate).
+
+---
+
+## Phase 3 — Version Bump (SemVer)
+
+**Goal:** Classify the change set since the last tag and compute the next version number using the
+same Conventional Commits taxonomy the `commit-gate` skill enforces. The release version is not a
+guess — it is derived mechanically from the commit log.
+
+**Inputs:**
+- `git log LAST_TAG..HEAD --pretty=format:%H%n%s%n%b%n----`
+- The commit type taxonomy from the `commit-gate` skill Phase 3 (`feat`, `fix`, `refactor`,
+  `test`, `docs`, `chore`, `ci`).
+- The current version, parsed from `LAST_TAG` (or `0.0.0` if no prior tag exists).
+
+**Actions:**
+
+1. Read every commit subject in the `LAST_TAG..HEAD` window. For each commit, extract the
+   Conventional Commits type from the subject line prefix.
+2. Apply SemVer classification:
+   - Any commit with a `BREAKING CHANGE:` footer OR a `!` after the type/scope → **major** bump.
+   - Else, any commit of type `feat` → **minor** bump.
+   - Else, any commit of type `fix`, `refactor`, `perf` → **patch** bump.
+   - Commits of type `test`, `docs`, `chore`, `ci` do not, on their own, trigger any bump. If the
+     entire change set consists only of these types, record `VERSION=NONE` and surface to the user
+     — there is nothing to release.
+3. Compute the next version by applying the highest-precedence bump to the current version. Major
+   beats minor beats patch.
+4. Verify that the proposed version is monotonically greater than `LAST_TAG`. If not, record
+   `VERSION=BLOCK` — the version classification disagrees with the commit log.
+5. Present the proposed version and the classification reasoning to the user for confirmation.
+   The user MAY override the classification — but only via `/override`, which logs the bypass.
+
+**Output:** Proposed next version (`vMAJOR.MINOR.PATCH`) with the per-commit classification table
+attached as evidence.
+
+**Gate:** BLOCK if the version classification disagrees with the commit log (e.g., a `feat` commit
+exists but the proposed bump is only `patch`). BLOCK if the entire change set is non-bumping
+(`test`/`docs`/`chore`/`ci` only). The release skill MUST NOT silently downgrade or upgrade the
+classification.
+
+---
+
+## Phase 4 — Changelog Generation
+
+**Goal:** Roll up the `CHANGELOG:` footers from every user-visible commit in the release window
+into a single, audience-ready changelog section. The changelog is generated from the commits — it
+is not authored from scratch.
+
+**Inputs:**
+- `git log LAST_TAG..HEAD --pretty=format:%H%n%s%n%b%n----`
+- The commit-type classification table from Phase 3.
+
+**Actions:**
+
+1. For every commit in the window classified as `feat`, `fix`, or `perf`, extract the
+   `CHANGELOG:` footer line. (The `commit-gate` skill Phase 7 requires this footer for any
+   `feat`/`fix` commit, so it must be present.)
+2. If any `feat` or `fix` commit lacks a `CHANGELOG:` footer, record `CHANGELOG=BLOCK` and surface
+   the commit SHA and subject. The release MUST NOT proceed with a missing user-visible summary —
+   the commit-gate skill should have caught this, and its absence is itself a finding worth
+   surfacing.
+3. Group the extracted footers into three sections:
+   - **Added** — from `feat` commits.
+   - **Fixed** — from `fix` commits.
+   - **Performance** — from `perf` commits.
+4. Append the rendered changelog block to the project's changelog file (typically
+   `CHANGELOG.md`) under a new heading `## vMAJOR.MINOR.PATCH — YYYY-MM-DD`. The previous
+   entries remain intact and unmodified.
+5. If the changelog file does not yet exist, create it with a top-level `# Changelog` heading and
+   write the first section.
+
+**Output:** Updated changelog file with the new release section appended.
+
+**Gate:** BLOCK if any `feat` or `fix` commit in the release window lacks a `CHANGELOG:` footer.
+The commit-gate skill SHOULD have prevented this, so its presence here is a compliance gap that
+must be surfaced — not silently auto-filled by the release skill.
+
+---
+
+## Phase 5 — ADR Currency Check
+
+**Goal:** Confirm the decision record is not stale at the moment of release. A release is a
+moment-in-time declaration that the project's design intent matches its implementation; aged or
+unchallenged ADRs undermine that declaration.
+
+**Inputs:**
+- The ADR health table from `decision-lifecycle` Phase 1 (captured during Phase 1 above, or
+  refreshed if it is older than the release window).
+- The challenge results from `decision-lifecycle` Phase 4 (must be re-run if the most recent
+  results predate `LAST_TAG`).
+
+**Actions:**
+
+1. Route to the `decision-lifecycle` skill specifically requesting Phase 4 (Challenge Routing).
+   The `decision-lifecycle` skill dispatches the `decision-challenger` agent for every AGED or
+   UNCHALLENGED ADR and returns a confidence rating (0–3) for each.
+2. Receive the full challenge results table. For every ADR with a confidence rating ≤ 2, record
+   the ADR ID, the challenger reasoning, and the recommended action.
+3. Apply the release gate:
+   - Confidence rating **0** → BLOCK. The ADR is invalid or superseded; the release MUST NOT ship
+     against an invalid decision baseline.
+   - Confidence rating **1** → BLOCK. The decision is questionable; ship under a revisit, not
+     under a release.
+   - Confidence rating **2** → BLOCK. Per the `decision-lifecycle` skill's own gate, ratings ≤ 2
+     block stage promotion; the release skill inherits that gate.
+   - Confidence rating **3** → PASS.
+4. Surface every blocking ADR to the user. The release skill does not author replacement ADRs or
+   modify ADR status — that is the user's call, recorded via `/adr` with explicit attribution.
+
+**Output:** ADR currency verdict — `PASS` or `BLOCK` — with every blocking ADR cited.
+
+**Gate:** BLOCK on any ADR with a confidence rating ≤ 2. The release skill MUST NOT silently
+defer aged-and-unchallenged ADRs; the gate is binary.
+
+---
+
+## Phase 6 — Stage Threshold Verification
+
+**Goal:** Confirm that the project, at this SHA, meets the published thresholds for the current
+stage as recorded in `.agents/projectContext/stage` and its supporting policy documents.
+
+**Inputs:**
+- `.agents/projectContext/stage` — the integer 1–4.
+- `.agents/projectContext/audit-spec.md` — for stage-specific fail-closed audit policy.
+- Project-specific stage policy in `projectContext/decisions/` or `projectContext/open-questions.md`
+  (per the `stage-gating` skill's reference table).
+
+**Actions:**
+
+1. Route to the `stage-gating` skill specifically requesting Phase 1 (Stage Read) and Phase 2
+   (Rule Inventory) on the release scope (the entire codebase at HEAD, not a single change).
+2. Receive the active rule inventory for the current stage. For every active rule, confirm the
+   release artifact does not violate it.
+3. Verify stage-specific release thresholds:
+   - **Coverage threshold.** Read the threshold for the current stage from the project's coverage
+     policy (typically declared in `projectContext/coding-standards.md` or `tech-stack.md`). Run
+     the coverage report. If coverage is below the threshold, record `STAGE=BLOCK`.
+   - **Fail-closed audit policy.** Read the stage's required audit posture from
+     `audit-spec.md`. Confirm the deployed audit configuration is fail-closed at or above the
+     stage's required level. If not, record `STAGE=BLOCK`.
+   - **Trust-zone declarations.** If the current stage requires declared egress points (typically
+     S3+), confirm `projectContext/trust-zones.md` declares every outbound integration present in
+     the code at HEAD.
+4. The `stage-gating` skill is authoritative on what rules apply at the current stage. The release
+   skill MUST NOT infer a different set.
+
+**Output:** Stage threshold verdict — `PASS` or `BLOCK` — with every threshold check cited.
+
+**Gate:** BLOCK if any stage-required threshold is unmet. BLOCK if `stage-gating` reports any
+active rule violation. The release skill MUST NOT ship a tag against a sub-threshold codebase
+even if every other gate is green.
+
+---
+
+## Phase 7 — Tag and Announce
+
+**Goal:** Compose the annotated tag, write the deployment-readiness report, and deliver both to
+the user. This phase only runs if every prior phase returned PASS — there are no partial releases.
+
+**Inputs:**
+- Proposed version from Phase 3.
+- Rendered changelog section from Phase 4.
+- ADR currency verdict from Phase 5.
+- Stage threshold verdict from Phase 6.
+- Checkpoint summary from Phase 2.
+
+**Actions:**
+
+1. Verify that every prior phase recorded `PASS`. If any phase recorded `BLOCK` or `DEFERRED`,
+   STOP and surface the deferred phase. A DEFERRED gate is not a PASS — the release skill MUST
+   NOT promote a DEFERRED outcome into a tag.
+2. Compose the annotated tag:
+   - Tag name: `vMAJOR.MINOR.PATCH` from Phase 3.
+   - Tag message: a single block containing the changelog section from Phase 4 plus a footer
+     line `Released-at: YYYY-MM-DD` and `Stage: <current-stage>`.
+   - Use `git tag -a vMAJOR.MINOR.PATCH -F <message-file>` — never `-m` with multi-line content,
+     and never an interactive editor.
+3. Compose the deployment-readiness report. The report contains exactly seven sections, one per
+   phase, each citing the verdict and the supporting evidence:
+   - Pre-Flight Readiness verdict + evidence.
+   - Checkpoint summary (findings counts, checkpoint path, approver name).
+   - Version classification table + proposed version.
+   - Changelog rollup (footer count, missing-footer count).
+   - ADR currency table (every reviewed ADR + confidence rating).
+   - Stage threshold checks (coverage %, audit policy, trust-zone declarations).
+   - Tag composition (tag name, tag SHA, tag message preview).
+4. Deliver the report to the user. The report is the release artifact — preserve it. Write it to
+   `projectContext/releases/vMAJOR.MINOR.PATCH.md` for permanent record.
+5. MUST NOT push the tag to a remote without explicit user instruction. Tag publication is a
+   separate decision the user MUST authorize after reviewing the report.
+
+**Output:** Annotated tag in the local repository, plus the deployment-readiness report at
+`projectContext/releases/vMAJOR.MINOR.PATCH.md`.
+
+**Gate:** BLOCK if any prior phase recorded DEFERRED rather than PASS. BLOCK if tag composition
+fails for any reason (e.g., tag already exists). BLOCK if `projectContext/releases/` cannot be
+written. MUST NOT push the tag without explicit user authorization.
+
+---
+
+## Hard Rules
+
+- MUST NOT compose a tag without all seven phases returning PASS.
+- MUST NOT promote a DEFERRED phase verdict into a PASS for the purpose of reaching Phase 7.
+- MUST NOT push a tag to a remote without explicit user authorization, even if the local tag is
+  composed successfully.
+- MUST NOT bypass the `commit-gate` skill's SemVer classification — the version bump is derived
+  from the commit log, not from operator judgment.
+- MUST NOT bypass the `decision-lifecycle` skill's confidence rating gate — ratings ≤ 2 BLOCK.
+- MUST NOT bypass the `stage-gating` skill's active rule inventory — the release scope is the
+  entire codebase, not a single change.
+- MUST NOT author replacement ADRs or modify ADR status to clear a blocking ADR. ADR status
+  changes require `/adr` with user attribution.
+- MUST NOT silently auto-fill a missing `CHANGELOG:` footer in Phase 4. The absence is a
+  compliance gap that the user MUST resolve, ideally by going back through `commit-gate`.
+- MUST NOT release on a protected branch directly without the release branch policy being
+  satisfied (per `commit-gate` Phase 2 rules, inherited).
+- MUST NOT release without the `/checkpoint` document signed off by a named approver — the
+  approver MUST be a person, never "codeArbiter" or "automated".
+
+---
+
+## Decision Gates Summary
+
+| Gate         | Condition                                                              | Action if blocked                                                |
+|--------------|------------------------------------------------------------------------|------------------------------------------------------------------|
+| Pre-Flight   | Missing stage file, audit-spec, dirty tree, or empty release window    | STOP; surface gap; do not proceed                                |
+| Phase 1 exit | Red tests, override-tagged HEAD, blocking `[CONFIRM-NN]`, no ADR table | BLOCK; surface evidence; do not proceed to checkpoint            |
+| Phase 2 exit | Any CRITICAL or open `BLOCKS_S<current>` finding from `/checkpoint`    | BLOCK; require resolution + approver sign-off; do not proceed    |
+| Phase 3 exit | Version classification disagrees with commit log, or non-bumping set   | BLOCK; surface mismatch; require user reconciliation             |
+| Phase 4 exit | Any `feat`/`fix` commit in window lacks `CHANGELOG:` footer            | BLOCK; surface commit SHA; do not auto-fill                      |
+| Phase 5 exit | Any ADR with confidence rating ≤ 2 (per `decision-lifecycle` Phase 4)  | BLOCK; surface ADR; require `/adr` resolution with attribution   |
+| Phase 6 exit | Any stage-required threshold unmet (per `stage-gating`)                | BLOCK; surface threshold gap; require remediation                |
+| Phase 7 exit | Any prior phase verdict was DEFERRED rather than PASS                  | BLOCK; promote no deferred outcome; surface deferred phase       |
+
+---
+
+## Interactions with other skills
+
+The release skill is the most-interacting skill in the framework. It does not duplicate the work of
+the skills it depends on — it routes to them, reads their outputs, and BLOCKS on their verdicts.
+
+- **`/checkpoint` command (Phase 2).** The release skill invokes `/checkpoint` directly (or reads
+  a fresh signed-off checkpoint document already present in `projectContext/checkpoints/`). The
+  `/checkpoint` command dispatches all seven checkpoint reviewer agents. The release skill MUST
+  NOT re-implement that work; it reads the resulting checkpoint document and gates on
+  finding counts.
+- **`commit-gate` skill (Phase 3 — by reference).** The SemVer classification logic in Phase 3 is
+  identical to the commit-type taxonomy in `commit-gate` Phase 3 and the footer requirement in
+  `commit-gate` Phase 7. The release skill MUST NOT diverge from that taxonomy.
+- **`decision-lifecycle` skill (Phase 1, Phase 5).** Phase 1 routes to `decision-lifecycle`
+  Phase 1+2 for a surface ADR health table. Phase 5 routes to `decision-lifecycle` Phase 4
+  specifically (Challenge Routing) and inherits its confidence-rating gate (≤ 2 BLOCKS).
+- **`stage-gating` skill (Phase 6).** Phase 6 routes to `stage-gating` Phase 1+2 (Stage Read +
+  Rule Inventory) against the full codebase scope at HEAD. The release skill inherits
+  `stage-gating`'s authority on what rules apply at the current stage.
+- **`tdd` skill (Phase 1 — by reference).** The release skill reads the most recent `tdd` Phase 6
+  result. It does not re-run `tdd`; that is the responsibility of the commit-gate skill before
+  the HEAD commit was produced.
+- **`/adr` command (Phase 5 — by reference).** When Phase 5 surfaces a blocking ADR, the user
+  resolves it via `/adr` with explicit attribution. The release skill MUST NOT modify ADR status
+  on its own.
+- **`/override` command (any phase).** Any phase BLOCK can be bypassed only via `/override`,
+  which logs the bypass to `.agents/projectContext/overrides.log`. The release skill itself MUST
+  NOT silently lower a gate.
+
+---
+
+## Failure Modes
+
+| Failure                                              | Response                                                                  |
+|------------------------------------------------------|---------------------------------------------------------------------------|
+| `.agents/projectContext/stage` missing               | STOP in Pre-Flight; surface gap; the release cannot proceed               |
+| `audit-spec.md` missing                              | STOP in Pre-Flight; Phase 6 has no source of truth                        |
+| Empty commit window (`LAST_TAG..HEAD`)               | STOP in Pre-Flight; there is nothing to release                           |
+| Tests red                                            | BLOCK in Phase 1; surface failing tests; route user to `tdd` skill        |
+| HEAD produced via `/override`                        | BLOCK in Phase 1; require fresh user re-authorization via `/override`     |
+| Unresolved blocking `[CONFIRM-NN]`                   | BLOCK in Phase 1; route to `decision-lifecycle` Phase 2 for surfacing     |
+| Checkpoint document missing or unsigned              | BLOCK in Phase 2; route to `/checkpoint` and wait for approver sign-off   |
+| CRITICAL finding in checkpoint                       | BLOCK in Phase 2; require resolution; no release on critical findings    |
+| Version classification mismatch                      | BLOCK in Phase 3; surface mismatch; user reconciles or `/override`s       |
+| Missing `CHANGELOG:` footer in `feat`/`fix` commit   | BLOCK in Phase 4; surface SHA; user re-commits via `commit-gate`          |
+| ADR confidence rating ≤ 2                            | BLOCK in Phase 5; user resolves via `/adr` with attribution               |
+| Coverage below stage threshold                       | BLOCK in Phase 6; user remediates coverage; no release on sub-threshold   |
+| Fail-closed audit policy not met for current stage   | BLOCK in Phase 6; user remediates audit config; no release on open policy |
+| Tag already exists                                   | BLOCK in Phase 7; surface conflict; user resolves before retry            |
+| `projectContext/releases/` not writable              | BLOCK in Phase 7; surface filesystem issue; the report MUST be preserved  |
+| Any prior gate DEFERRED                              | BLOCK in Phase 7; MUST NOT promote DEFERRED into PASS                     |
+
+---
+
+## Subagents Invoked
+
+None directly. The release skill routes to other skills and commands:
+
+- `/checkpoint` (Phase 2) — which itself dispatches seven reviewer agents.
+- `decision-lifecycle` skill (Phase 1, Phase 5) — which dispatches `decision-challenger`.
+- `stage-gating` skill (Phase 6) — no agent dispatch; pure rule inventory.
+
+The release skill itself does not dispatch agents. It is a gate aggregator.

--- a/.agents/skills/rotation/SKILL.md
+++ b/.agents/skills/rotation/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: rotation
+---
+
+# Skill: rotation
+
+## Purpose
+
+Enforce the lifecycle dimension of secret and key material — inventory, cadence,
+controlled cutover, audit emission, and archival. Where `secret-handling` gates
+storage paths and `crypto-compliance` gates primitives, `rotation` gates the
+clock: every rotation-bearing artifact has a recorded last-rotation timestamp,
+is within its cadence, and produces an auditable archival record when replaced.
+
+A rotation event without an audit trail is indistinguishable from a key
+compromise. This skill exists to make that distinction provable.
+
+---
+
+## Trigger
+
+This section lists conditions under which the orchestrator routes work to this
+skill. The skill itself does not "trigger" — it is routed to.
+
+Routed when:
+
+- A signing key, OIDC client secret, API token, TLS certificate, or service
+  account credential is added, renewed, replaced, or revoked.
+- A change touches the issuance path of any rotation-bearing artifact (new
+  issuer, new key store binding, new dual-running window).
+- A scheduled rotation review fires (cadence audit against
+  `projectContext/secrets-policy.md`).
+- A subagent or skill detects an artifact with no recorded last-rotation
+  timestamp.
+- The routing table references this skill (lifecycle dimension of any
+  `secret-handling` or `crypto-compliance` finding).
+
+Not routed for:
+
+- Read-only secret consumption with no lifecycle change — that is
+  `secret-handling`.
+- Primitive selection or TLS configuration with no key replacement — that is
+  `crypto-compliance`.
+
+---
+
+## Pre-Flight
+
+Before Phase 1 begins, confirm:
+
+1. `.agents/projectContext/secrets-policy.md` is readable. This file is the
+   authoritative source for the project's rotation-bearing artifact list,
+   cadence values, issuance paths, and archival location. Stop if missing.
+2. `.agents/projectContext/security-controls.md` is readable. This file
+   provides the approved key store, approved primitives, and any compliance
+   mode (FIPS, internal CA) constraints that govern rotation issuance. Stop
+   if missing.
+3. `.agents/projectContext/audit-spec.md` is readable. Rotation MUST emit an
+   audit event; the action string and required fields come from this file.
+   Stop if missing.
+4. Current stage is known — `cat .agents/projectContext/stage`.
+
+If any file is missing, surface the gap and stop. Do not guess at cadence
+defaults, store references, or audit action strings without confirming the
+file is genuinely absent and recording that fact.
+
+---
+
+## Phase 1 — Inventory
+
+**Goal:** Enumerate every rotation-bearing artifact in scope and confirm each
+has a recorded last-rotation timestamp.
+
+**Inputs:**
+- The set of artifacts touched or implied by the change.
+- `.agents/projectContext/secrets-policy.md` — authoritative artifact list and
+  recorded last-rotation timestamps per artifact.
+- `.agents/projectContext/security-controls.md` — approved key store reference
+  format (used to identify artifacts by reference, not value).
+
+**Actions:**
+
+1. Read `projectContext/secrets-policy.md` in full. Extract the project's
+   authoritative list of rotation-bearing artifacts. The default categories
+   that MUST be considered if the file does not narrow the list:
+   - Signing keys (JWT signers, request signers, code signers)
+   - OIDC client secrets (every relying party / IdP integration)
+   - API tokens issued to or held by this service
+   - TLS certificates (public-facing and internal)
+   - Service account credentials (workload identity bindings, machine accounts)
+2. For each artifact in scope, record:
+   - Artifact identifier (reference format per `security-controls.md` — never
+     the value).
+   - Artifact category.
+   - Last-rotation timestamp (ISO 8601, from `secrets-policy.md` or the
+     approved key store).
+   - Issuance path (where the next replacement comes from).
+3. If `secrets-policy.md` does not record a last-rotation timestamp for an
+   artifact in scope, mark that artifact `UNROTATED-UNKNOWN`. This is a BLOCK
+   condition — an artifact with no recorded rotation history cannot be audited
+   for cadence compliance.
+4. Do not include the secret value, key material, or any string that would
+   identify the value itself. Reference only.
+
+**Output:** Artifact inventory table with identifier (reference), category,
+last-rotation timestamp, and issuance path for every artifact in scope.
+
+**Gate:** BLOCK if any artifact in scope has no recorded last-rotation
+timestamp. BLOCK if the inventory contains any raw key material or secret
+value rather than store references. No Phase 2 until every artifact is
+identified by reference and has a timestamp.
+
+---
+
+## Phase 2 — Cadence Check
+
+**Goal:** Compute each artifact's age against the project rotation cadence and
+flag every artifact past its cadence as a BLOCK.
+
+**Inputs:**
+- Inventory from Phase 1.
+- `.agents/projectContext/secrets-policy.md` — project-specific cadence values
+  per artifact category.
+
+**Actions:**
+
+1. Read cadence values from `projectContext/secrets-policy.md`. If the file
+   specifies a cadence per category, use that. If the file is silent on a
+   category, apply the defaults below:
+
+   | Category | Default Maximum Age |
+   |---|---|
+   | Signing keys | 1 year |
+   | OIDC client secrets | 6 months |
+   | TLS certificates | 90 days |
+   | API tokens | per `secrets-policy.md`; if silent, treat as signing-key cadence (1 year) |
+   | Service account credentials | per `secrets-policy.md`; if silent, treat as signing-key cadence (1 year) |
+
+2. For each artifact, compute age = (today − last-rotation timestamp).
+3. Compare age to the applicable cadence. Mark each artifact:
+   - `WITHIN-CADENCE` — age < cadence.
+   - `APPROACHING` — age ≥ 0.8 × cadence and < cadence (informational; not a
+     block, but surfaced).
+   - `PAST-CADENCE` — age ≥ cadence (BLOCK).
+4. If the project applies stage-dependent cadence (e.g., tighter cadence at
+   Stage 3+), apply the stage-appropriate value read from
+   `secrets-policy.md`.
+5. Do not silently reconcile a cadence ambiguity. If `secrets-policy.md` is
+   silent on a category AND a default would not clearly apply, invoke
+   `/surface-conflict` and stop.
+
+**Output:** Cadence report — every artifact tagged `WITHIN-CADENCE`,
+`APPROACHING`, or `PAST-CADENCE`, with the applicable cadence cited.
+
+**Gate:** BLOCK on any artifact tagged `PAST-CADENCE`. No Phase 3 until every
+`PAST-CADENCE` artifact either enters the rotation plan in Phase 3 or has a
+documented exception in `projectContext/open-questions.md` with a CONFIRM
+placeholder.
+
+---
+
+## Phase 3 — Rotation Plan
+
+**Goal:** For each artifact requiring rotation, produce a concrete plan with
+issuance, dual-running, cutover, and archival paths defined before any
+rotation begins.
+
+**Inputs:**
+- Artifacts tagged `PAST-CADENCE` or otherwise scheduled for rotation.
+- `.agents/projectContext/secrets-policy.md` — issuance paths, dual-running
+  policy, archival location.
+- `.agents/projectContext/security-controls.md` — approved key store and
+  primitive constraints for new credential issuance.
+
+**Actions:**
+
+1. For each artifact to rotate, write a plan with all four sections:
+
+   - **New-credential issuance path** — the exact store and procedure that
+     produces the replacement credential. Must reference the approved key
+     store from `security-controls.md`. Primitive (algorithm, key size, curve)
+     must satisfy `crypto-compliance` — do not propose a primitive without
+     routing the primitive choice through the `crypto-compliance` skill.
+   - **Dual-running window** — start time, end time, and the policy for
+     accepting both old and new credentials during the window. Must be long
+     enough for every consumer to cut over and short enough to bound exposure
+     if the old credential is compromised. If `secrets-policy.md` specifies a
+     window, use that; otherwise propose one and surface it for confirmation.
+   - **Consumer cutover plan** — the list of consumers that hold or verify
+     this credential, the order they cut over in, and how cutover is
+     confirmed (health check, signed probe, manual verification). Every
+     consumer must be enumerated; an unenumerated consumer is a silent
+     dependency and a future incident.
+   - **Archival path** — the destination where the old credential's record
+     (not its value) is written when the rotation completes. Must match the
+     archival location specified in `secrets-policy.md`. If no archival path
+     is defined for this category, surface and stop — do not invent one.
+
+2. The plan MUST identify the approver. Rotation without a named human
+   approver is a BLOCK condition for any artifact at Stage 3+.
+
+3. The plan MUST NOT propose deleting the old credential's record. Deletion
+   prevents post-incident audit. Archival is the only acceptable disposition
+   for the old record.
+
+**Output:** A rotation plan per artifact with all four sections filled and an
+approver named.
+
+**Gate:** BLOCK if any rotation plan is missing the archival step — a rotation
+with no archival cannot be audited and is treated as credential loss. BLOCK if
+no approver is named at Stage 3+. BLOCK if the proposed primitive has not
+been validated through `crypto-compliance`. BLOCK if the issuance path does
+not use the approved key store from `security-controls.md`.
+
+---
+
+## Phase 4 — Audit Emit
+
+**Goal:** Confirm each rotation emits a correctly constructed audit event
+through the canonical audit sink, routed via the `audit-emit` skill.
+
+**Inputs:**
+- Rotation plans from Phase 3.
+- `.agents/projectContext/audit-spec.md` — action naming convention, required
+  fields, canonical sink.
+- The `audit-emit` skill — primary handler for the emit construction, sink
+  routing, fail-closed, and test obligation phases.
+
+**Actions:**
+
+1. For each rotation, classify the action string per
+   `projectContext/audit-spec.md`. The default action is `key.rotate`; if the
+   project's spec defines a different convention (for example
+   `credential.rotate`, `cert.rotate`, or `secret.rotate` for distinct
+   categories), use the spec's strings. Do not invent an action name.
+2. Route to the `audit-emit` skill and run it end-to-end against the rotation
+   event:
+   - Phase 1 (Action Classification) — confirm the action is registered.
+   - Phase 2 (Emit Construction) — populate required fields, including
+     `subject.id` as the new-credential store reference (never the value),
+     `actor.id` as the approver named in Phase 3, and `outcome` recording
+     success or failure.
+   - Phase 3 (Sink Routing) — confirm emit goes through the canonical audit
+     module.
+   - Phase 4 (Fail-Closed Check) — confirm error handling matches stage
+     policy.
+   - Phase 5 (Test Obligation) — confirm a test asserts the emit on
+     rotation.
+3. The emit payload MUST reference both the retired credential (by reference)
+   and the replacement credential (by reference). Without both, the audit
+   record cannot be replayed to verify the rotation chain.
+4. MUST NOT emit through a general-purpose logger or a side channel. The
+   canonical audit sink is the only acceptable path.
+
+**Output:** A `key.rotate` (or project-defined equivalent) audit event
+constructed, routed, fail-closed-validated, and test-covered through the
+`audit-emit` skill.
+
+**Gate:** BLOCK if the `audit-emit` skill's Phase 5 (Test Obligation) is
+incomplete for the rotation event. BLOCK if the action name is unregistered.
+BLOCK if the emit routes through any path other than the canonical sink
+defined in `projectContext/audit-spec.md`.
+
+---
+
+## Phase 5 — Archival
+
+**Goal:** Write the archival record for every completed rotation, capturing
+the four facts that allow a future auditor to reconstruct the rotation chain.
+
+**Inputs:**
+- Completed rotation event(s) from Phase 4.
+- `.agents/projectContext/secrets-policy.md` — archival destination and
+  record format.
+
+**Actions:**
+
+1. For each rotation, write an archival record containing:
+   - **Which credential was rotated** — the retired credential's store
+     reference. Never the value. Never a fingerprint that would reveal the
+     value.
+   - **When it was rotated** — ISO 8601 timestamp, matching the timestamp in
+     the audit event from Phase 4.
+   - **What replaced it** — the replacement credential's store reference.
+   - **Who approved** — the named human approver from Phase 3.
+2. Write the record to the archival destination specified in
+   `projectContext/secrets-policy.md`. If the destination is append-only,
+   confirm append-only semantics (no edit or delete) before writing. If the
+   destination is missing, surface and stop — do not improvise.
+3. Update `secrets-policy.md` (or the project's authoritative timestamp
+   register) to record the new last-rotation timestamp for the artifact. This
+   feeds Phase 1 of the next rotation cycle. An unupdated register makes the
+   next cadence check fire incorrectly.
+4. MUST NOT delete the retired credential's archival record. MUST NOT
+   overwrite a prior archival record. Each rotation appends; nothing is
+   removed.
+
+**Output:** Archival record written to the project's archival destination
+with all four facts present. Last-rotation timestamp updated in the project's
+authoritative register.
+
+**Gate:** BLOCK if the archival record is missing any of the four facts
+(which / when / what / who). BLOCK if the last-rotation timestamp in
+`secrets-policy.md` (or equivalent register) has not been updated. BLOCK if
+the archival destination cannot be confirmed append-only when policy requires
+it.
+
+---
+
+## Hard Rules
+
+- MUST read `projectContext/secrets-policy.md` and
+  `projectContext/security-controls.md` before Phase 1. BLOCK if either file
+  is missing.
+- MUST NOT proceed with a rotation against an artifact that has no recorded
+  last-rotation timestamp. Inventory is a precondition, not an outcome.
+- MUST NOT use cadence defaults without first checking whether
+  `secrets-policy.md` defines project-specific cadence values.
+- MUST NOT propose a rotation primitive without routing the primitive through
+  the `crypto-compliance` skill.
+- MUST NOT issue a replacement credential through any store other than the
+  one approved in `security-controls.md`.
+- MUST NOT skip the dual-running window for a credential with multiple
+  consumers. A hard cutover without dual-running guarantees an outage and
+  hides cutover bugs.
+- MUST NOT delete the retired credential's archival record. MUST NOT
+  overwrite a prior archival record.
+- MUST NOT emit the rotation event through any path other than the canonical
+  audit sink defined in `projectContext/audit-spec.md`.
+- MUST NOT include the credential value, key material, or any reversible
+  derivation in the audit event or archival record. Store references only.
+- MUST NOT mark a rotation complete until Phase 5 has written the archival
+  record AND updated the last-rotation timestamp.
+- MUST NOT resolve a cadence or archival ambiguity by guessing. Invoke
+  `/surface-conflict` and stop.
+
+---
+
+## Decision Gates Summary
+
+| Gate | Condition | Action if blocked |
+|---|---|---|
+| Phase 1 exit | Any artifact in scope has no recorded last-rotation timestamp | Record timestamp in `secrets-policy.md` or mark artifact for first-rotation flow before proceeding |
+| Phase 1 exit | Inventory contains raw key material rather than store references | Replace with store references; never log or persist values |
+| Phase 2 exit | Any artifact tagged `PAST-CADENCE` | Move artifact into Phase 3 rotation plan or open a CONFIRM in `open-questions.md` |
+| Phase 2 exit | Cadence ambiguity not resolvable from `secrets-policy.md` | Invoke `/surface-conflict`; do not apply defaults silently |
+| Phase 3 exit | Rotation plan missing archival step | Add archival path from `secrets-policy.md`; do not invent one |
+| Phase 3 exit | No named approver at Stage 3+ | Name an approver; rotation cannot proceed |
+| Phase 3 exit | Proposed primitive not validated through `crypto-compliance` | Route primitive through `crypto-compliance` first |
+| Phase 4 exit | `audit-emit` Phase 5 (Test Obligation) incomplete | Complete test coverage of the rotation emit before proceeding |
+| Phase 4 exit | Action name unregistered or emit bypasses canonical sink | Register action in `audit-spec.md`; reroute through canonical sink |
+| Phase 5 exit | Archival record missing any of which / when / what / who | Add missing fact before recording rotation complete |
+| Phase 5 exit | Last-rotation timestamp not updated in `secrets-policy.md` register | Update register; without it the next cadence check is wrong |
+
+---
+
+## Interactions with other skills
+
+- **`secret-handling`** — `rotation` extends `secret-handling` with the
+  lifecycle dimension. `secret-handling` gates where a secret lives, how it
+  is read, and that it does not flow to forbidden sinks. `rotation` gates how
+  long a secret may continue to live there, the controlled procedure for
+  replacing it, and the archival record produced when it is retired. A
+  `secret-handling` finding that includes the words "unrotated > N" is the
+  canonical hand-off — that finding routes here.
+- **`crypto-compliance`** — `rotation` extends `crypto-compliance` with the
+  lifecycle dimension over primitives. `crypto-compliance` gates the
+  algorithm, key size, curve, and TLS configuration of a new credential.
+  `rotation` is the procedure for retiring the prior credential and bringing
+  the new (compliant) credential into service. Phase 3 of this skill MUST
+  route any new primitive through `crypto-compliance` before issuance.
+- **`audit-emit`** — `rotation` Phase 4 routes to `audit-emit` in full.
+  `audit-emit` owns action classification, emit construction, sink routing,
+  fail-closed behavior, and test obligation. `rotation` supplies the action
+  semantics (`key.rotate` or project-defined equivalent), the
+  retired/replacement references, and the approver identity. Phase 4 cannot
+  exit until `audit-emit` Phase 5 has completed.
+- **`stage-gating`** — Stage value read in Pre-Flight feeds cadence selection
+  (Phase 2) and approver requirement (Phase 3). Stage 3+ tightens both.
+- **`decision-lifecycle`** — A `PAST-CADENCE` artifact with a justified
+  exception is recorded as a CONFIRM in `open-questions.md`, not silently
+  reconciled here. An exception that becomes permanent is an ADR candidate
+  authored only via `/adr`.
+
+---
+
+## Subagents Invoked
+
+None directly. `rotation` operates within the orchestrator context and hands
+off to the `audit-emit` skill in Phase 4. The `auth-crypto-reviewer` agent
+may be dispatched by the orchestrator when reviewing a rotation PR, but that
+dispatch is owned by the routing table in `AGENTS.md`, not by this skill.

--- a/.agents/skills/secret-handling/SKILL.md
+++ b/.agents/skills/secret-handling/SKILL.md
@@ -4,6 +4,9 @@
 Claude IS a secrets lifecycle enforcer who treats any secret outside the project-approved secret store as an active exfiltration risk.
 
 ## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 - Code reads, generates, stores, or passes an API key, token, password, or passphrase
 - Code handles platform credentials or session tokens
 - Code references a database connection string

--- a/.agents/skills/security-architecture/SKILL.md
+++ b/.agents/skills/security-architecture/SKILL.md
@@ -4,10 +4,13 @@
 Claude IS a threat modeling architect who treats undeclared zone crossings as active vulnerabilities, not future concerns.
 
 ## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 - A new trust zone crossing is proposed or introduced
 - A threat model is requested for a feature or component
 - An attack surface change is identified (new route, new egress, new external dependency)
-- When the routing table entry "New trust zone crossing / threat model / attack surface change" fires
+- When the routing table entry "New trust zone crossing / threat model / attack surface change" applies
 - When `/threat-model <scope>` command is invoked
 - Before any code is written that crosses a zone boundary defined in `projectContext/trust-zones.md`
 

--- a/.agents/skills/skill-author/SKILL.md
+++ b/.agents/skills/skill-author/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill when the user runs `/new-skill "<gap description>"`.
 
 Triggers:
@@ -268,7 +270,7 @@ correct triggers and discoverable by contributors.
 3. Update `AGENTS.md`:
    - Add a row to Section 4 (Reference Map) if the skill covers a new domain
    - Add a row to Section 5 (Routing Table) with:
-     - Trigger pattern (what user action fires it)
+     - Trigger pattern (what user action routes to it)
      - Primary route (`skill-name` skill)
      - Also Invoke (any co-invoked skills or agents)
      - Hard Gate (the blocking condition)

--- a/.agents/skills/stage-gating/SKILL.md
+++ b/.agents/skills/stage-gating/SKILL.md
@@ -4,6 +4,9 @@
 Claude IS a stage compliance enforcer who treats a stage-tagged rule violation as a deployment blocker, not a style issue.
 
 ## Trigger
+
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 - Any code change that has different rules at different stages.
 - When the agent needs to know what the current stage requires.
 - When stage-tagged rules in AGENTS.md and `projectContext/` files apply differently to the change.

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -21,8 +21,9 @@ Before Phase 1 begins, confirm:
 
 1. `.agents/projectContext/tech-stack.md` is readable — stop if missing.
 2. `.agents/projectContext/audit-spec.md` is readable — stop if missing.
-3. `.agents/projectContext/trust-zones.md` is readable — stop if missing.
-4. Current stage is known — read `cat .agents/projectContext/stage`.
+3. `.agents/projectContext/observability-spec.md` is readable — stop if missing.
+4. `.agents/projectContext/trust-zones.md` is readable — stop if missing.
+5. Current stage is known — read `cat .agents/projectContext/stage`.
 
 If any file is missing, surface the gap and stop. Do not guess at commands or thresholds.
 
@@ -43,6 +44,7 @@ introduced or modified by the planned change before any code is written.
 - Description of the planned change (feature, fix, or refactor)
 - `.agents/projectContext/audit-spec.md` — authoritative list of auditable action
   categories, required emit fields, and sink routing rules
+- `.agents/projectContext/observability-spec.md` — authoritative list of observability signal categories, required labels, cardinality budgets, and emit module paths
 - `.agents/projectContext/trust-zones.md` — zone topology and crossing rules
 
 **Actions:**
@@ -51,10 +53,12 @@ introduced or modified by the planned change before any code is written.
    categories apply to the planned change.
 2. Read `.agents/projectContext/trust-zones.md`. Flag every zone boundary the
    change will cross.
+2b. Read `.agents/projectContext/observability-spec.md` in full. Identify which signal categories apply to the planned change.
 3. List every obligation produced:
    - Auditable actions that must emit (with required fields from audit-spec)
    - Trust zone assertions that must be tested
    - API contract invariants that must be covered
+   - Observability signals that must emit (with required labels from observability-spec)
 4. For each obligation, write its ID, source citation, and OPEN status. In
    Phase 2 author one failing test per obligation.
 

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill before writing any implementation code. This skill MUST complete
 Phase 1 before any code is written. No feature code, no bug fix, no refactor begins
 without this skill completing Phase 1 first.
@@ -28,6 +30,12 @@ If any file is missing, surface the gap and stop. Do not guess at commands or th
 
 ## Phase 1: Obligation Scan
 
+> **Definition — obligation.** A single verifiable claim about the planned change
+> that becomes a required test in Phase 2. Each obligation has (a) a unique ID,
+> (b) a source citation (`audit-spec`, `trust-zones`, API contract, or
+> `observability-spec`), and (c) a status (OPEN → MAPPED → COVERED). Hand-wavy
+> "we should test X" items are not obligations.
+
 **Goal:** Identify every auditable action, API boundary, and trust zone crossing
 introduced or modified by the planned change before any code is written.
 
@@ -47,7 +55,8 @@ introduced or modified by the planned change before any code is written.
    - Auditable actions that must emit (with required fields from audit-spec)
    - Trust zone assertions that must be tested
    - API contract invariants that must be covered
-4. Record the obligation list. Every item becomes a required test in Phase 2.
+4. For each obligation, write its ID, source citation, and OPEN status. In
+   Phase 2 author one failing test per obligation.
 
 **Output:** Signed obligation checklist — every item has an ID and a status of OPEN.
 

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -142,7 +142,7 @@ no obligation was silently dropped.
 
 1. Walk the Phase 1 obligation list item by item. For each item, confirm a
    corresponding test exists and is green.
-2. For features with complex audit emit logic, invoke the `test-audit-reviewer`
+2. For features with complex audit emit logic, invoke the `coverage-auditor`
    agent to verify emit correctness before marking audit obligations complete.
 3. Update checklist: each obligation moves from OPEN to COVERED (with test ID)
    or to MISSING (if no test covers it).

--- a/.agents/skills/ticketing-router/SKILL.md
+++ b/.agents/skills/ticketing-router/SKILL.md
@@ -1,4 +1,4 @@
-# Skill: ticketing (router)
+# Skill: ticketing-router (router)
 
 ## Trigger
 
@@ -49,13 +49,13 @@ malformed YAML), STOP and surface the gap to the user. Do not guess defaults.
    > edit `.agents/projectContext/ticketing-config.md` and set `enabled: true`.
 
 2. If `enabled: true` and `mode: in-repo`: `@`-import
-   `.agents/skills/ticketing/in-repo/SKILL.md` and hand off the caller's request
+   `.agents/skills/ticketing-router/in-repo/SKILL.md` and hand off the caller's request
    to that variant. Do not read the plane variant.
 
 3. If `enabled: true` and `mode: plane`: confirm `plane_base_url`,
    `plane_workspace_slug`, and `plane_project_id` are populated. If any is
    missing, STOP and instruct the user to complete the config. Then `@`-import
-   `.agents/skills/ticketing/plane/SKILL.md` and hand off. Do not read the
+   `.agents/skills/ticketing-router/plane/SKILL.md` and hand off. Do not read the
    in-repo variant.
 
 4. If `mode` is any other value: STOP and surface as a config error. Do not

--- a/.agents/skills/ticketing-router/in-repo/SKILL.md
+++ b/.agents/skills/ticketing-router/in-repo/SKILL.md
@@ -1,10 +1,10 @@
-# Skill: ticketing (in-repo variant)
+# Skill: ticketing-router (in-repo variant)
 
 ## Trigger
 
 > *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
 
-Loaded by the `ticketing` router when `mode: in-repo`. This file is never read
+Loaded by the `ticketing-router` skill when `mode: in-repo`. This file is never read
 directly — invoke via the router.
 
 ## Pre-Flight

--- a/.agents/skills/ticketing-router/plane/SKILL.md
+++ b/.agents/skills/ticketing-router/plane/SKILL.md
@@ -1,10 +1,10 @@
-# Skill: ticketing (Plane variant — on-prem)
+# Skill: ticketing-router (Plane variant — on-prem)
 
 ## Trigger
 
 > *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
 
-Loaded by the `ticketing` router when `mode: plane`. This file is never read
+Loaded by the `ticketing-router` skill when `mode: plane`. This file is never read
 directly — invoke via the router.
 
 This variant uses the **official Plane MCP server** (`@makeplane/plane-mcp-server`)

--- a/.agents/skills/ticketing/SKILL.md
+++ b/.agents/skills/ticketing/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Invoke this skill when:
 
 - A subagent encounters a finding outside its scope and needs to file it without

--- a/.agents/skills/ticketing/in-repo/SKILL.md
+++ b/.agents/skills/ticketing/in-repo/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Loaded by the `ticketing` router when `mode: in-repo`. This file is never read
 directly — invoke via the router.
 

--- a/.agents/skills/ticketing/plane/SKILL.md
+++ b/.agents/skills/ticketing/plane/SKILL.md
@@ -2,6 +2,8 @@
 
 ## Trigger
 
+> *"This section lists conditions under which the orchestrator routes work to this skill. The skill itself does not 'trigger' — it is routed to."*
+
 Loaded by the `ticketing` router when `mode: plane`. This file is never read
 directly — invoke via the router.
 

--- a/.claude/agents/coverage-auditor.md
+++ b/.claude/agents/coverage-auditor.md
@@ -1,0 +1,1 @@
+@.agents/agents/coverage-auditor.md

--- a/.claude/agents/test-audit-reviewer.md
+++ b/.claude/agents/test-audit-reviewer.md
@@ -1,1 +1,0 @@
-@.agents/agents/test-audit-reviewer.md

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -1,0 +1,1 @@
+@.agents/commands/debug.md

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -1,0 +1,1 @@
+@.agents/commands/hotfix.md

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,1 @@
+@.agents/commands/refactor.md

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,1 @@
+@.agents/commands/release.md

--- a/.claude/commands/rotate.md
+++ b/.claude/commands/rotate.md
@@ -1,0 +1,1 @@
+@.agents/commands/rotate.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ legacy/
 
 # Transient hook markers (e.g. .adr-authoring-active set by /adr). Not state.
 .agents/.markers/
+
+# Ephemeral execution scaffolding written by long plan runs. Removed in
+# the plan's Phase K cleanup. Never committed.
+/.plan-tasks/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ Read the listed file before acting. The skill or agent listed is the primary rou
 | CI/CD / branch settings | `projectContext/tech-stack.md` | — |
 | Risks / ADRs | `projectContext/open-questions.md`, `projectContext/decisions/` | `decision-lifecycle` skill |
 | Checkpoint / stage promotion | `projectContext/stage` | `stage-gating` skill |
-| Architectural reconciliation | `projectContext/decomposition/` | `arbiter` skill |
+| Architectural reconciliation | `projectContext/decomposition/` | `decision-variance` skill |
 | Subagent encounters out-of-scope finding | `projectContext/ticketing-config.md` | `ticketing-router` skill (router) |
 
 ---
@@ -194,7 +194,7 @@ When a trigger fires, follow the primary route. Gates are hard stops — not sug
 | Code reads / writes / passes a secret | `secret-handling` skill | `auth-crypto-reviewer` agent | BLOCK if secret outside approved store path |
 | Rotation due / signing key, OIDC secret, TLS cert, service token | `rotation` skill | `secret-handling`, `crypto-compliance` skills; `audit-emit` skill | BLOCK on rotation past cadence, missing archival, or missing rotate audit emit |
 | Code has stage-conditional behavior | `stage-gating` skill | — | Read `projectContext/stage` first; no exceptions |
-| Arbitration / variance / ADR reconciliation | `arbiter` skill | `decision-challenger` agent | No decisions without user attribution |
+| Arbitration / variance / ADR reconciliation | `decision-variance` skill | `decision-challenger` agent | No decisions without user attribution |
 | Rule conflict (AGENTS.md vs. code or docs) | `/surface-conflict` command | — | STOP all other work immediately |
 | ADR added / aged / CONFIRM-NN unresolved | `decision-lifecycle` skill | `decision-challenger` agent | No CONFIRM-NN resolved by guessing |
 | New trust zone crossing / threat model / attack surface change | `security-architecture` skill | `security-reviewer` + `trust-zone-reviewer` | No undeclared egress |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ Always-loaded. Follow these even without reading project docs. Violation is unre
 - MUST NOT read ticket bodies during routine flows. Use `projectContext/tickets/INDEX.md` (in-repo) or `mcp__plane__list_issues` (Plane) for surface scans. Body reads only via `/ticket show <id>`.
 - MUST NOT author an ADR as the disposition of a ticket. Decision-worthy findings escalate to `open-questions.md` (CONFIRM-NN) or to the user. ADRs are authored only via `/adr` with explicit user attribution.
 - MUST NOT bulk-read `.agents/agents/*.md` or `.agents/commands/*.md`. Use the respective `INDEX.md` for surface scans; bodies load on invocation only.
+- MUST NOT emit an unregistered observability signal. Register in projectContext/observability-spec.md first.
+- MUST NOT emit observability signals with unbounded label cardinality.
+- MUST NOT close a hotfix log entry without an authoring ADR referenced by ADR-ID within 72 hours.
+- MUST NOT issue a /hotfix using a single identity — the escalation-tier identity must differ from the operator identity.
 
 ---
 
@@ -152,6 +156,7 @@ Read the listed file before acting. The skill or agent listed is the primary rou
 | Stack / dependencies | `projectContext/tech-stack.md`, `projectContext/dependency-policy.md` | `dependency-reviewer` agent |
 | Auth, crypto, secrets | `projectContext/security-controls.md`, `projectContext/secrets-policy.md` | `crypto-compliance` skill; `secret-handling` skill |
 | Logging / telemetry | `projectContext/audit-spec.md` | `audit-emit` skill |
+| Metrics / traces / alerts / SLOs | `projectContext/observability-spec.md` | `observability-emit` skill |
 | Data model / migrations | `projectContext/tech-stack.md` | `migration-reviewer` agent |
 | Networking / deployment | `projectContext/trust-zones.md` | `security-architecture` skill |
 | New domain concept or component | `projectContext/CONTEXT.md` | `doc-governance` skill |
@@ -172,17 +177,22 @@ When a trigger fires, follow the primary route. Gates are hard stops — not sug
 |---|---|---|---|
 | New feature | `tdd` skill | `backend-author`, `frontend-author`, or `infra-author` agent | No implementation before Phase 1 checklist complete |
 | Bug fix | `tdd` skill (bug variant) | Same implementation agents | No implementation before Phase 1 checklist complete |
+| Refactor (behavior-preserving) | `refactor` skill | `tdd` skill (Phase 1 only, for new test seams) | No refactor without behavioral-parity coverage proof |
+| Unknown defect / investigation | `debug` skill | (Phase 4 routes to `/fix`, `/ticket`, or `/adr`) | No code change inside debug skill; investigation only |
 | "commit" / "commit this" / "go ahead and commit" | `commit-gate` skill | — | No commit without all phase gates green |
 | "PR" / "open a PR" / "pull request" | `/pr` command | Reviewer agents per path matrix | No PR draft until all BLOCK-level reviews clear |
 | Stage promotion | `/stage` command | — | No `projectContext/stage` change without named approver |
+| Release / version bump / tag | `/release` command | `commit-gate`, `decision-lifecycle`, `stage-gating` skills | No tag without all 7 release-skill phases green |
 | "checkpoint" | `/checkpoint` command | — | All 7 reviewers must complete; no skipping |
 | Code touches auth, crypto, keys, audit | `auth-crypto-reviewer` agent | `security-reviewer` agent | BLOCK on any CRITICAL finding |
 | Migration file added or changed | `migration-reviewer` agent | `audit-emitter` agent | BLOCK if classification annotation missing |
 | `package.json` or lock file modified | `dependency-reviewer` agent | — | BLOCK on denied license |
 | Schema definition file added or modified | `schema-validator` agent (if present in plugins) | — | BLOCK if schema validation fails |
 | Code emits or should emit an audit event | `audit-emit` skill | `audit-emitter` agent | BLOCK if emit missing or fields wrong |
+| Code emits or should emit an observability signal (metric/trace/alert/SLO) | `observability-emit` skill | `observability-emitter` agent (if defined) | BLOCK if emit missing, labels wrong, or cardinality unbounded |
 | Code uses crypto / hashing / signing / TLS / random | `crypto-compliance` skill | `auth-crypto-reviewer` agent | BLOCK on any banned primitive |
 | Code reads / writes / passes a secret | `secret-handling` skill | `auth-crypto-reviewer` agent | BLOCK if secret outside approved store path |
+| Rotation due / signing key, OIDC secret, TLS cert, service token | `rotation` skill | `secret-handling`, `crypto-compliance` skills; `audit-emit` skill | BLOCK on rotation past cadence, missing archival, or missing rotate audit emit |
 | Code has stage-conditional behavior | `stage-gating` skill | — | Read `projectContext/stage` first; no exceptions |
 | Arbitration / variance / ADR reconciliation | `arbiter` skill | `decision-challenger` agent | No decisions without user attribution |
 | Rule conflict (AGENTS.md vs. code or docs) | `/surface-conflict` command | — | STOP all other work immediately |
@@ -219,3 +229,21 @@ Full command specifications: `.agents/commands/`. Quick-ref table: `COMMANDS.md`
 `/override "reason"` is the sanctioned escape hatch — permits bypass with mandatory audit logging. Full identity-detection sequence and log-entry format live in `.agents/commands/override.md` (loaded when `/override` is invoked).
 
 The log file `.agents/projectContext/overrides.log` is append-only — never edited or deleted. It is committed to the repo as a permanent audit artifact. After appending, proceed with the overridden action and note in the response that the override is logged.
+
+### §7.1 Hotfix Protocol
+
+`/hotfix "reason" --severity P0|P1 --escalation-tier <user> --auto-revert-window 24h|72h|7d`
+is the stricter emergency variant of `/override`. Differences from /override:
+
+- Two-identity attestation required (operator + named escalation-tier approver,
+  must be distinct identities)
+- Auto-revert window mandatory; expiration tracked by `/checkpoint`, which BLOCKs
+  promotion if window passes without follow-up
+- Post-hoc ADR required within 72h documenting bypass rationale; log entry is
+  updated with the ADR ID. Missing ADR = BLOCK on stage promotion.
+- Logged to `.agents/projectContext/hotfixes.log` (separate from
+  `overrides.log`) — append-only, never edited or deleted, committed as a
+  permanent audit artifact.
+
+Full workflow specification: `.agents/commands/hotfix.md` (loaded only when
+`/hotfix` is invoked).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ only shim files that import from `.agents/`.
 
 **Five non-negotiable behaviors — read before acting on any request:**
 
-1. **Route, don't implement.** Every trigger in §5 names a primary route. Follow it.
+1. **Route, don't implement.** Every entry in §5 names a primary route. Follow it.
 2. **MUST NOT begin implementation** without the `tdd` skill Phase 1 completing first.
 3. **MUST NOT commit** without the `commit-gate` skill completing. "It looks good" is not permission.
 4. **MUST NOT resolve a `[CONFIRM-NN]` placeholder** by guessing. Surface the question and stop.
@@ -22,6 +22,47 @@ only shim files that import from `.agents/`.
 **codeArbiter is an orchestrator, never a coder.** The user ONLY interacts via slash commands.
 Direct instructions or freeform questions outside of a slash command receive an escalating redirect
 (see §6).
+
+---
+
+## §0.1 Terminology Lock
+
+These terms have one meaning each. Do not mix usage anywhere downstream — in skill bodies, agent
+bodies, command bodies, or this document. Drift here cascades through every gate.
+
+| Term | Definition |
+|---|---|
+| **skill** | An orchestrator routine encoding a process or compliance workflow. Lives in `.agents/skills/<name>/SKILL.md`. Has phases. A skill is invoked or routed, never "triggered." |
+| **agent** | A specialized reviewer or author dispatched by a skill or by a command. Lives in `.agents/agents/<name>.md`. Agents are not skills. Agents are dispatched, never invoked. |
+| **phase** | A workflow step inside a skill (e.g., TDD Phase 1–6, commit-gate Phase 1–8). Phases are sequential and gate-bounded. |
+| **stage** | A project lifecycle position 1–4, stored in `.agents/projectContext/stage`. Global. Not per-skill. |
+| **layer** | Decomposition-interview structure only (`decompose` skill, Layers 1–6). Do not use "layer" elsewhere. |
+| **gate** | An exit condition on a phase. STOP / BLOCK gates halt all work in the skill. Gates are separate from findings. |
+| **severity** | A finding classification: CRITICAL / HIGH / MEDIUM / LOW. Severity is separate from gate action — a HIGH finding can be informational, a MEDIUM can BLOCK. |
+
+### Dispatch verbs (locked)
+
+| Verb | Meaning |
+|---|---|
+| **invoke** | The user fires `/command` (e.g., the user invokes `/feature`). |
+| **route** | The orchestrator hands work to a skill (e.g., `/feature` routes to the `tdd` skill). |
+| **dispatch** | A skill spawns one or more parallel agents (e.g., `/checkpoint` dispatches reviewer agents). |
+
+Do not use "trigger," "runs," or "fires" as substitutes for these verbs. `## Trigger` headings in
+skill bodies list *conditions under which the orchestrator routes to the skill* — the skill itself
+does not "trigger."
+
+### Modal convention
+
+MUST / MUST NOT / MAY / SHOULD are reserved for hard gates and policy invariants. `do not` and
+`never` are reserved for guidance and operating principles. Within any Hard Rules section, use
+MUST / MUST NOT exclusively.
+
+### Placeholder convention
+
+`[CONFIRM-NN]` is the single placeholder system for unresolved unknowns — interview gaps, inferred
+facts, deferred decisions. Numbers are sequential with `projectContext/open-questions.md`. Do not
+introduce parallel placeholder schemes (`[OPEN-DECISION]`, `[NEEDS-INPUT]`, etc.).
 
 ---
 
@@ -127,7 +168,7 @@ Read the listed file before acting. The skill or agent listed is the primary rou
 
 When a trigger fires, follow the primary route. Gates are hard stops — not suggestions.
 
-| Trigger | Primary Route | Also Invoke | Hard Gate |
+| Invocation cue | Primary Route | Also Dispatch | Hard Gate |
 |---|---|---|---|
 | New feature | `tdd` skill | `backend-author`, `frontend-author`, or `infra-author` agent | No implementation before Phase 1 checklist complete |
 | Bug fix | `tdd` skill (bug variant) | Same implementation agents | No implementation before Phase 1 checklist complete |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Read the listed file before acting. The skill or agent listed is the primary rou
 | Metrics / traces / alerts / SLOs | `projectContext/observability-spec.md` | `observability-emit` skill |
 | Data model / migrations | `projectContext/tech-stack.md` | `migration-reviewer` agent |
 | Networking / deployment | `projectContext/trust-zones.md` | `security-architecture` skill |
-| New domain concept or component | `projectContext/CONTEXT.md` | `doc-governance` skill |
+| New domain concept or component | `projectContext/CONTEXT.md` | `doc-review-gate` skill |
 | Failure / retry logic | `projectContext/tech-stack.md` | — |
 | CI/CD / branch settings | `projectContext/tech-stack.md` | — |
 | Risks / ADRs | `projectContext/open-questions.md`, `projectContext/decisions/` | `decision-lifecycle` skill |
@@ -198,7 +198,7 @@ When a trigger fires, follow the primary route. Gates are hard stops — not sug
 | Rule conflict (AGENTS.md vs. code or docs) | `/surface-conflict` command | — | STOP all other work immediately |
 | ADR added / aged / CONFIRM-NN unresolved | `decision-lifecycle` skill | `decision-challenger` agent | No CONFIRM-NN resolved by guessing |
 | New trust zone crossing / threat model / attack surface change | `security-architecture` skill | `security-reviewer` + `trust-zone-reviewer` | No undeclared egress |
-| `projectContext/` file modified or domain area referenced before acting | `doc-governance` skill | — | No action in domain without reading gated doc first |
+| `projectContext/` file modified or domain area referenced before acting | `doc-review-gate` skill | — | No action in domain without reading gated doc first |
 | Subagent raises out-of-scope finding | `ticketing` skill | — | When ticketing disabled, finding inlines with `[NEEDS-TRIAGE]` marker. Disposition MUST NOT be `adr-*` |
 | Ticket close requested | `ticketing` skill (variant per config) | — | BLOCK on `adr-*` dispositions. BLOCK if `incorporated-to:*` recorded without target-doc edit in session |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ Read the listed file before acting. The skill or agent listed is the primary rou
 | Risks / ADRs | `projectContext/open-questions.md`, `projectContext/decisions/` | `decision-lifecycle` skill |
 | Checkpoint / stage promotion | `projectContext/stage` | `stage-gating` skill |
 | Architectural reconciliation | `projectContext/decomposition/` | `arbiter` skill |
-| Subagent encounters out-of-scope finding | `projectContext/ticketing-config.md` | `ticketing` skill (router) |
+| Subagent encounters out-of-scope finding | `projectContext/ticketing-config.md` | `ticketing-router` skill (router) |
 
 ---
 
@@ -199,8 +199,8 @@ When a trigger fires, follow the primary route. Gates are hard stops — not sug
 | ADR added / aged / CONFIRM-NN unresolved | `decision-lifecycle` skill | `decision-challenger` agent | No CONFIRM-NN resolved by guessing |
 | New trust zone crossing / threat model / attack surface change | `security-architecture` skill | `security-reviewer` + `trust-zone-reviewer` | No undeclared egress |
 | `projectContext/` file modified or domain area referenced before acting | `doc-review-gate` skill | — | No action in domain without reading gated doc first |
-| Subagent raises out-of-scope finding | `ticketing` skill | — | When ticketing disabled, finding inlines with `[NEEDS-TRIAGE]` marker. Disposition MUST NOT be `adr-*` |
-| Ticket close requested | `ticketing` skill (variant per config) | — | BLOCK on `adr-*` dispositions. BLOCK if `incorporated-to:*` recorded without target-doc edit in session |
+| Subagent raises out-of-scope finding | `ticketing-router` skill | — | When ticketing disabled, finding inlines with `[NEEDS-TRIAGE]` marker. Disposition MUST NOT be `adr-*` |
+| Ticket close requested | `ticketing-router` skill (variant per config) | — | BLOCK on `adr-*` dispositions. BLOCK if `incorporated-to:*` recorded without target-doc edit in session |
 
 ---
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -14,9 +14,9 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 | Command | Argument | One-line purpose | Body |
 |---|---|---|---|
-| `/feature` | `"description"` | Start a new feature; runs full TDD skill (6 phases) | [body](.agents/commands/feature.md) |
+| `/feature` | `"description"` | Start a new feature; routes to TDD skill (6 phases) | [body](.agents/commands/feature.md) |
 | `/fix` | `"bug description"` | Fix a bug using the same TDD workflow, bug-framed | [body](.agents/commands/fix.md) |
-| `/commit` | _(none)_ | Commit staged changes; runs full commit-gate skill | [body](.agents/commands/commit.md) |
+| `/commit` | _(none)_ | Commit staged changes; routes to commit-gate skill | [body](.agents/commands/commit.md) |
 | `/pr` | `["title"]` | Open a pull request after all gates pass | [body](.agents/commands/pr.md) |
 | `/review` | `[path or scope]` | Security + code review of a path or scope | [body](.agents/commands/review.md) |
 | `/threat-model` | `"scope"` | Pre-implementation threat model for a proposed change | [body](.agents/commands/threat-model.md) |
@@ -43,7 +43,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Start any new feature. This is the only way to begin implementation work.
 
-**What triggers:** `tdd` skill (`.agents/skills/tdd/SKILL.md`) Phases 1–6, then routes to `backend-author`, `frontend-author`, or `infra-author` agent based on scope.
+**What it routes to:** `tdd` skill (`.agents/skills/tdd/SKILL.md`) Phases 1–6, which then dispatches `backend-author`, `frontend-author`, or `infra-author` agent based on scope.
 
 **Hard gate:** No implementation code before Phase 1 (obligation checklist) is complete.
 
@@ -57,7 +57,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Fix a bug with the same rigor as a feature — test written first, root cause confirmed.
 
-**What triggers:** `tdd` skill (bug variant) — same 6-phase workflow, framed around confirming the bug with a failing regression test before touching implementation.
+**What it routes to:** `tdd` skill (bug variant) — same 6-phase workflow, framed around confirming the bug with a failing regression test before touching implementation.
 
 **Hard gate:** Regression test must fail before fix is written (proof the test covers the actual bug).
 
@@ -69,7 +69,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** The only permitted path to creating a commit.
 
-**What triggers:** `commit-gate` skill (`.agents/skills/commit-gate/SKILL.md`) — 8 phases including permission gate, branch gate, classification, verification, diff review, selective staging, message, and commit.
+**What it routes to:** `commit-gate` skill (`.agents/skills/commit-gate/SKILL.md`) — 8 phases including permission gate, branch gate, classification, verification, diff review, selective staging, message, and commit.
 
 **Hard gates:**
 - Explicit user instruction required (no speculative commits)
@@ -85,7 +85,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Open a pull request after all gates pass.
 
-**What triggers:** pr-ready sequence — runs all BLOCK-level reviews, confirms no open findings, then creates the PR.
+**What it routes to:** pr-ready sequence — dispatches all BLOCK-level reviewer agents, confirms no open findings, then creates the PR.
 
 **Hard gate:** No PR draft until all BLOCK-level review findings are cleared.
 
@@ -97,7 +97,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Security and compliance review of existing code at a given path or scope.
 
-**What triggers:** `security-architecture` skill + applicable reviewer agents (`security-reviewer`, `auth-crypto-reviewer`, `standards-compliance-reviewer`, `test-audit-reviewer`).
+**What it routes to:** `security-architecture` skill, which dispatches the applicable reviewer agents (`security-reviewer`, `auth-crypto-reviewer`, `standards-compliance-reviewer`, `test-audit-reviewer`).
 
 **When to use:** Before merging any security-sensitive change; when a reviewer requests a specific area be checked; as part of checkpoint preparation.
 
@@ -107,7 +107,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Pre-implementation security architecture review for a proposed zone crossing, feature, or attack surface change.
 
-**What triggers:** `security-architecture` skill (`.agents/skills/security-architecture/SKILL.md`).
+**What it routes to:** `security-architecture` skill (`.agents/skills/security-architecture/SKILL.md`).
 
 **When to use:** Before writing code for any change that crosses a trust zone boundary, adds a new external dependency, or modifies authentication/cryptographic behavior. Run BEFORE implementation, not after.
 
@@ -117,7 +117,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Record a new architectural decision.
 
-**What triggers:** `decision-lifecycle` skill — creates a new ADR file in `projectContext/decisions/`, writes frontmatter, queues for challenge.
+**What it routes to:** `decision-lifecycle` skill — creates a new ADR file in `projectContext/decisions/`, writes frontmatter, queues for challenge.
 
 **When to use:** Any time a significant architectural, technology, security, or process decision is made that should be durable and auditable.
 
@@ -127,7 +127,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Check the health of all ADRs or a specific one.
 
-**What triggers:** `decision-lifecycle` skill — scans for aged ADRs (>12 weeks since challenge), unchallenged ADRs, supersession candidates, and unresolved `CONFIRM-NN` items.
+**What it routes to:** `decision-lifecycle` skill — scans for aged ADRs (>12 weeks since challenge), unchallenged ADRs, supersession candidates, and unresolved `CONFIRM-NN` items.
 
 **When to use:** Before any stage promotion; at start of a checkpoint; when a `CONFIRM-NN` is encountered.
 
@@ -137,7 +137,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Full checkpoint review of the codebase — all 7 reviewer agents run in parallel.
 
-**What triggers:** All checkpoint agents simultaneously:
+**What it dispatches:** All checkpoint agents simultaneously:
 1. `architecture-drift-reviewer`
 2. `test-audit-reviewer`
 3. `security-reviewer`
@@ -156,7 +156,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Report the current project stage or run the promotion checklist to advance to the next stage.
 
-**What triggers:** `stage-gating` skill (`.agents/skills/stage-gating/SKILL.md`).
+**What it routes to:** `stage-gating` skill (`.agents/skills/stage-gating/SKILL.md`).
 
 **Without argument:** Reports current stage and what gates are satisfied vs. outstanding for the next stage.
 
@@ -170,7 +170,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Add a new dependency after full vetting.
 
-**What triggers:** `dependency-reviewer` agent — checks license, provenance, maintenance signal, and supply-chain posture before any install command runs.
+**What it dispatches:** `dependency-reviewer` agent — checks license, provenance, maintenance signal, and supply-chain posture before any install command runs.
 
 **Hard gate:** BLOCK on any denied license. BLOCK on supply-chain concerns. Package is not installed until the reviewer clears it.
 
@@ -182,7 +182,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Stop all work and surface a conflict between AGENTS.md (or projectContext docs) and on-disk code or instructions.
 
-**What triggers:** Immediate STOP. Presents the conflicting sources, quoted passages, and which is more recently updated. All other work halts until the user resolves.
+**What it routes to:** Immediate STOP handler. Presents the conflicting sources, quoted passages, and which is more recently updated. All other work halts until the user resolves.
 
 **Hard gate:** This command overrides all other active work. Nothing proceeds while a conflict is open.
 
@@ -194,7 +194,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Optional scope-overflow inbox for subagent findings (in-repo mode) OR project management bridge to Plane (Plane mode). Disabled by default; opt in by editing `projectContext/ticketing-config.md`.
 
-**What triggers:** `ticketing` skill router (`.agents/skills/ticketing/SKILL.md`) — reads `mode` from config and `@`-imports only the active variant (`in-repo/` or `plane/`).
+**What it routes to:** `ticketing` skill router (`.agents/skills/ticketing/SKILL.md`) — reads `mode` from config and `@`-imports only the active variant (`in-repo/` or `plane/`).
 
 **Subcommands:**
 - `/ticket "title" -- "body"` — file a new ticket (subagent or user)
@@ -220,7 +220,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Lightweight Q&A channel for quick questions that don't require the full state machine.
 
-**What triggers:** Direct answer from projectContext context. No skill invoked. No state change. No routing table entries fire.
+**What it routes to:** Direct answer from projectContext context. No skill invoked. No state change. No routing table entries apply.
 
 **When to use:** Clarifying questions, quick lookups, asking about a concept, checking a value. NOT for starting work, making decisions, or bypassing gates.
 
@@ -230,7 +230,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Show everything currently open — in-flight tasks and unresolved decisions.
 
-**What triggers:** Reads `projectContext/open-tasks.md` and `projectContext/open-questions.md`. Read-only. No side effects.
+**What it routes to:** Reads `projectContext/open-tasks.md` and `projectContext/open-questions.md`. Read-only. No side effects.
 
 **Output:**
 - Current stage
@@ -254,7 +254,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Bypass a gate or process requirement with a mandatory, append-only audit log entry.
 
-**What triggers:** Identity detection (git config → env vars → CLI → manual prompt), log append to `projectContext/overrides.log`, then proceeds with the overridden action.
+**What it routes to:** Identity detection (git config → env vars → CLI → manual prompt), log append to `projectContext/overrides.log`, then proceeds with the overridden action.
 
 **Auto-detected identity:** `git config user.name` + `git config user.email` (tried first). Falls through to env vars, then CLI, then prompt only if all else fails.
 
@@ -268,7 +268,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Engineer onboarding tour — walks a new team member (or re-explains to a returning one) through the project context, architecture, stage, key ADRs, open questions, and the codeArbiter skill system.
 
-**What triggers:** `onboard` skill (`.agents/skills/onboard/SKILL.md`).
+**What it routes to:** `onboard` skill (`.agents/skills/onboard/SKILL.md`).
 
 **Two modes:**
 - No scope argument: full tour — project overview, architecture, stage, key ADRs, open questions, command system.
@@ -282,7 +282,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Author a new skill after rigorous gap validation — ensures new skills address real, recurring gaps.
 
-**What triggers:** `skill-author` skill (`.agents/skills/skill-author/SKILL.md`) — 5-phase process: gap challenge, scope decision, skill authoring, routing integration, validation.
+**What it routes to:** `skill-author` skill (`.agents/skills/skill-author/SKILL.md`) — 5-phase process: gap challenge, scope decision, skill authoring, routing integration, validation.
 
 **Hard gate:** Gap must be confirmed real before any skill is written. "I want a skill that..." is not a confirmed gap.
 
@@ -294,6 +294,6 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Display the quick-reference command table (the section at the top of this file).
 
-**What triggers:** Reads `COMMANDS.md` and outputs the Quick Reference table only. No state change.
+**What it routes to:** Reads `COMMANDS.md` and outputs the Quick Reference table only. No state change.
 
 **When to use:** When you can't remember the exact command syntax or want to see all available commands at a glance.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -16,6 +16,8 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 |---|---|---|---|
 | `/feature` | `"description"` | Start a new feature; routes to TDD skill (6 phases) | [body](.agents/commands/feature.md) |
 | `/fix` | `"bug description"` | Fix a bug using the same TDD workflow, bug-framed | [body](.agents/commands/fix.md) |
+| `/refactor` | `"surface and motivation"` | Behavior-preserving change; routes to refactor skill (6 phases) | [body](.agents/commands/refactor.md) |
+| `/debug` | `"symptom description"` | Investigate-then-decide RCA; outcomes: /fix, /ticket, or close | [body](.agents/commands/debug.md) |
 | `/commit` | _(none)_ | Commit staged changes; routes to commit-gate skill | [body](.agents/commands/commit.md) |
 | `/pr` | `["title"]` | Open a pull request after all gates pass | [body](.agents/commands/pr.md) |
 | `/review` | `[path or scope]` | Security + code review of a path or scope | [body](.agents/commands/review.md) |
@@ -24,13 +26,16 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 | `/adr-status` | `[--adr N]` | Check ADR health — aged, unchallenged, unresolved CONFIRM-NN | [body](.agents/commands/adr-status.md) |
 | `/checkpoint` | `[focus]` | Full checkpoint review — all 7 reviewers in parallel | [body](.agents/commands/checkpoint.md) |
 | `/stage` | `[target]` | Report current stage or promote to target stage | [body](.agents/commands/stage.md) |
+| `/release` | `["version" \| --auto \| --dry-run]` | SemVer bump, changelog, tag; deployment readiness gate | [body](.agents/commands/release.md) |
 | `/add-dep` | `"package"` | Add a dependency with full vetting before install | [body](.agents/commands/add-dep.md) |
+| `/rotate` | `"artifact-id"` | Rotate a secret/key with cadence + audit + archival gates | [body](.agents/commands/rotate.md) |
 | `/surface-conflict` | `"description"` | Stop all work and surface a rule conflict | [body](.agents/commands/surface-conflict.md) |
 | `/ticket` | `"title" \| <sub>` | Optional scope-overflow inbox; in-repo or Plane variant | [body](.agents/commands/ticket.md) |
 | `/btw` | `"question"` | Ask a quick question; no state change, lightweight | [body](.agents/commands/btw.md) |
 | `/status` | _(none)_ | Show open tasks and unresolved decisions | [body](.agents/commands/status.md) |
 | `/init` | _(none)_ | Re-run initialization detection (repair only) | [body](.agents/commands/init.md) |
 | `/override` | `"reason"` | Bypass a gate with auto-identity audit log entry | [body](.agents/commands/override.md) |
+| `/hotfix` | `"reason" --severity --escalation-tier --auto-revert-window` | Emergency bypass with two-identity audit + post-hoc ADR | [body](.agents/commands/hotfix.md) |
 | `/onboard` | `["scope"]` | Engineer onboarding tour, full or targeted | [body](.agents/commands/onboard.md) |
 | `/new-skill` | `"gap description"` | Author a new skill after rigorous gap validation | [body](.agents/commands/new-skill.md) |
 | `/commands` | _(none)_ | Show this quick-reference table | [body](.agents/commands/commands.md) |
@@ -62,6 +67,53 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 **Hard gate:** Regression test must fail before fix is written (proof the test covers the actual bug).
 
 **When to use:** Any defect, regression, or incorrect behavior confirmed to exist.
+
+---
+
+### `/refactor "surface and motivation"`
+
+**Purpose:** Restructure existing code without changing observable behavior. The only permitted path to begin a refactor.
+
+**What it routes to:** `refactor` skill (`.agents/skills/refactor/SKILL.md`) — Phases 1–6: surface identification, behavioral-parity coverage proof, red parity tests (conditional), implementation, parity verification, lint/coverage gate.
+
+**Hard gate:** No refactor proceeds without behavioral-parity coverage proof in Phase 2. If the named surface is below the stage coverage threshold or any public method has zero direct tests, the skill halts and routes to `tdd` Phase 1 to backfill. A Phase 4 diff that classifies as `feat` or a Phase 5 verification that depends on edits to a pre-existing test re-routes to `/feature` or `/fix`.
+
+**Args:** `"surface and motivation"` — two required parts. The surface MUST name exact files/symbols (a reader can grep and arrive at the same set). The motivation MUST state why the restructure is worth doing.
+
+**When NOT to use:** New behavior, branches, or error paths → `/feature`. A change motivated by "the current behavior is wrong" → `/fix`. Questions → `/btw`.
+
+**Example invocations:**
+- `/refactor "extract signToken, verifyToken, rotateKey from src/auth/index.ts into src/auth/tokens.ts so the next rotation feature has a clean seam"`
+- `/refactor "collapse duplicated retry-with-backoff in src/http/client.ts and src/ws/client.ts into a shared src/net/retry.ts"`
+- `/refactor "split src/payments/processor.ts into processor.ts, validation.ts, settlement.ts without changing the exported Processor signature"`
+
+**See also:** `/feature`, `/fix`, `/commit`.
+
+---
+
+### `/debug "symptom description"`
+
+**Purpose:** Investigate-then-decide root-cause analysis for situations where the cause of a defect is **not yet known**. Distinct from `/fix`, which assumes a known bug with a named regression test obligation.
+
+**What it routes to:** `debug` skill (`.agents/skills/debug/SKILL.md`) — Phases 1–5: symptom capture, hypothesis generation, evidence gathering, exit decision, handoff.
+
+**Hard gate:** The skill MUST NOT modify code. Code edits belong to `/fix` and `/fix` is only reached after `debug` has named a confirmed bug and a regression test obligation. Phase 1 BLOCKS on missing minimal repro.
+
+**Phase 4 exits (one of three):**
+- **Confirmed bug** — handoff to `/fix` with named regression test obligation
+- **Design/behavior ambiguity** — escalation to `/ticket` or `/adr`
+- **No-action close** — recorded findings, no further work
+
+**Args:** `"symptom description"` — at minimum one sentence stating what the system did. Causes are recorded in Phase 2, not in the invocation.
+
+**When NOT to use:** Known bug with named regression test → `/fix` directly. Design discussion with no failing behavior → `/adr` or `/ticket`. New feature → `/feature`.
+
+**Example invocations:**
+- `/debug "auth endpoints returning 500 intermittently since yesterday's deploy — repro unclear"`
+- `/debug "payment settlement totals drift by cents under load; off-by-one suspected but unverified"`
+- `/debug "users report they cannot log in after password reset, but staging passes end-to-end"`
+
+**See also:** `/fix`, `/ticket`, `/adr`.
 
 ---
 
@@ -166,6 +218,28 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 ---
 
+### `/release ["version" | --auto | --dry-run]`
+
+**Purpose:** Compose a tagged, announceable release. The only permitted path to a version tag. A release is a deployment-readiness assertion: the codebase at this SHA satisfies every published threshold for shipping.
+
+**What it routes to:** `release` skill (`.agents/skills/release/SKILL.md`) — Phases 1–7: pre-flight readiness, checkpoint gate, SemVer version bump, changelog generation, ADR currency check, stage threshold verification, tag and announce. The skill is a gate aggregator and routes to `/checkpoint`, `decision-lifecycle`, and `stage-gating`.
+
+**Hard gate:** No tag is composed without all 7 phases recording PASS. DEFERRED is not PASS. MUST NOT silently downgrade or upgrade SemVer classification. MUST NOT push the tag to a remote without explicit user authorization. Any BLOCK is bypassable only via `/override`.
+
+**Args:**
+- `--auto` (default) — version is derived mechanically from `LAST_TAG..HEAD` via Conventional Commits
+- `"X.Y.Z"` — explicit version; Phase 3 still classifies the commit log and BLOCKS on disagreement
+- `--dry-run` — runs all gates, surfaces the readiness report, STOPS before tag composition
+
+**Example invocations:**
+- `/release` — default flow, auto-derive version, compose tag if all gates green
+- `/release "2.0.0"` — explicit version; Phase 3 BLOCKS if commit log classifies differently
+- `/release --dry-run` — full gate evaluation, no tag composed, useful as a pre-flight
+
+**See also:** `/checkpoint`, `/stage`, `/adr-status`.
+
+---
+
 ### `/add-dep "package"`
 
 **Purpose:** Add a new dependency after full vetting.
@@ -175,6 +249,30 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 **Hard gate:** BLOCK on any denied license. BLOCK on supply-chain concerns. Package is not installed until the reviewer clears it.
 
 **When to use:** Before running any package install command. Do not install first and review later.
+
+---
+
+### `/rotate "artifact-id"`
+
+**Purpose:** Rotate a single rotation-bearing artifact — signing key, OIDC client secret, TLS certificate, API token, or service-account credential — through the full inventory → cadence → plan → audit-emit → archival lifecycle. A rotation without an archival record is treated as credential loss.
+
+**What it routes to:** `rotation` skill (`.agents/skills/rotation/SKILL.md`) — Phases 1–5: inventory, cadence check, rotation plan, audit emit, archival. Phase 3 routes the proposed replacement primitive through `crypto-compliance` before issuance. Phase 4 routes the rotation event through `audit-emit` in full.
+
+**Hard gates:**
+- **Cadence** — past-cadence artifacts MUST enter the rotation plan or be recorded as a `CONFIRM-NN` exception. Silent reconciliation is prohibited.
+- **Audit-emit** — `audit-emit` Phase 5 (Test Obligation) MUST complete before Phase 4 exits. Emit MUST route through the canonical sink in `audit-spec.md`.
+- **Archival** — the four-fact record (which / when / what / who) MUST be written and the last-rotation timestamp updated before the rotation is marked complete.
+
+**Args:** `"artifact-id"` — the artifact's store reference from `secrets-policy.md`. Never the credential value or a fingerprint of it.
+
+**Default cadences** are defined in `projectContext/secrets-policy.md` per artifact category (signing keys, OIDC client secrets, TLS certs, API tokens, service accounts).
+
+**Example invocations:**
+- `/rotate "jwt-signer-2025"`
+- `/rotate "oidc-client-partner-portal"`
+- `/rotate "CN=api.example.internal"`
+
+**See also:** `/add-dep`, `/checkpoint` (may auto-route to `/rotate` for aged artifacts).
 
 ---
 
@@ -261,6 +359,35 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 **When to use:** When a process gate must be bypassed for a legitimate reason (time pressure, broken environment, explicit approval from a named approver). Every override is permanent, auditable, and visible to all reviewers.
 
 **What NOT to use for:** Routine workarounds. If you find yourself using `/override` repeatedly for the same gate, that gate may need to be updated — use `/new-skill` or `/adr` to address the root cause.
+
+---
+
+### `/hotfix "reason" --severity --escalation-tier --auto-revert-window`
+
+**Purpose:** Emergency-bypass channel for P0/P1 incidents where waiting on the full gate suite would extend production harm. Unlike `/override` (a per-action escape hatch), `/hotfix` is a **two-person, time-boxed, post-hoc-audited** bypass.
+
+**What it dispatches (inline workflow — no backing skill):** identity detection → second-identity attestation check → log entry written to `.agents/projectContext/hotfixes.log` (BEFORE bypass applied) → bypass applied → auto-revert deadline recorded → operator surfaced with deadline and post-hoc-ADR obligation.
+
+**Hard gates:**
+- **Two-identity** — `--escalation-tier` MUST differ from the auto-detected operator identity. BLOCK on match; there is no flag to disable.
+- **Pre-bypass logging** — `hotfixes.log` append MUST precede the bypass action; no silent bypasses.
+- **Post-hoc ADR within 72h** — independent of `--auto-revert-window`. `/checkpoint` BLOCKS stage promotion on any entry past `EXPIRES:` with `ADR: pending` or any entry past 72h without an authored ADR.
+- **Severity gate** — anything lower than P1 MUST use `/override`, not `/hotfix`.
+
+**Args:**
+- `"reason"` — what gate is bypassed and why the incident justifies skipping; vague reasons rejected
+- `--severity P0|P1` — required; P0 = customer-facing outage / data integrity event, P1 = severe degradation
+- `--escalation-tier <identity>` — the attesting second human (email or username); MUST differ from operator
+- `--auto-revert-window 24h|72h|7d` — wall-clock deadline after which `/checkpoint` flags expired-without-followup
+
+**Differences from `/override`:** two identities required (not one); severity flag mandatory; time-boxed; post-hoc ADR mandatory within 72h; separate log file (`hotfixes.log` vs `overrides.log`); BLOCKS stage promotion if expired or ADR-missing.
+
+**Example invocations:**
+- `/hotfix "auth service returning 500 for all tenants — rollback blocked by failing migration-reviewer" --severity P0 --escalation-tier "j.smith@example.com" --auto-revert-window 72h`
+- `/hotfix "payment webhook signature verification failing after dependency CVE patch — partner traffic dropping" --severity P1 --escalation-tier "ops-lead@example.com" --auto-revert-window 24h`
+- `/hotfix "DB connection pool exhausted under unexpected load; need to ship raised limit without standard review window" --severity P1 --escalation-tier "dba@example.com" --auto-revert-window 7d`
+
+**See also:** `/override`, `/adr` (authors the mandatory post-hoc decision record and updates the `hotfixes.log` entry's `ADR:` field), `/checkpoint` (enforces expiration and post-hoc-ADR gates).
 
 ---
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -292,7 +292,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Optional scope-overflow inbox for subagent findings (in-repo mode) OR project management bridge to Plane (Plane mode). Disabled by default; opt in by editing `projectContext/ticketing-config.md`.
 
-**What it routes to:** `ticketing` skill router (`.agents/skills/ticketing/SKILL.md`) — reads `mode` from config and `@`-imports only the active variant (`in-repo/` or `plane/`).
+**What it routes to:** `ticketing-router` skill (`.agents/skills/ticketing-router/SKILL.md`) — reads `mode` from config and `@`-imports only the active variant (`in-repo/` or `plane/`).
 
 **Subcommands:**
 - `/ticket "title" -- "body"` — file a new ticket (subagent or user)

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -149,7 +149,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **Purpose:** Security and compliance review of existing code at a given path or scope.
 
-**What it routes to:** `security-architecture` skill, which dispatches the applicable reviewer agents (`security-reviewer`, `auth-crypto-reviewer`, `standards-compliance-reviewer`, `test-audit-reviewer`).
+**What it routes to:** `security-architecture` skill, which dispatches the applicable reviewer agents (`security-reviewer`, `auth-crypto-reviewer`, `standards-compliance-reviewer`, `coverage-auditor`).
 
 **When to use:** Before merging any security-sensitive change; when a reviewer requests a specific area be checked; as part of checkpoint preparation.
 
@@ -191,7 +191,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 
 **What it dispatches:** All checkpoint agents simultaneously:
 1. `architecture-drift-reviewer`
-2. `test-audit-reviewer`
+2. `coverage-auditor`
 3. `security-reviewer`
 4. `standards-compliance-reviewer`
 5. `scaffold-completeness-reviewer`
@@ -229,7 +229,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 **Args:**
 - `--auto` (default) — version is derived mechanically from `LAST_TAG..HEAD` via Conventional Commits
 - `"X.Y.Z"` — explicit version; Phase 3 still classifies the commit log and BLOCKS on disagreement
-- `--dry-run` — runs all gates, surfaces the readiness report, STOPS before tag composition
+- `--dry-run` — evaluates all gates, surfaces the readiness report, STOPS before tag composition
 
 **Example invocations:**
 - `/release` — default flow, auto-derive version, compose tag if all gates green

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The full specification is in [`AGENTS.md`](./AGENTS.md). The command catalog is 
 │   ├── decisions/          # ADRs
 │   ├── tickets/            # Optional scope-overflow inbox
 │   └── …                   # tech-stack, security-controls, audit-spec, etc.
-├── skills/           # Orchestration skills (tdd, commit-gate, ticketing, …)
+├── skills/           # Orchestration skills (tdd, commit-gate, ticketing-router, …)
 └── settings.json     # Claude Code config: MCP servers, hooks, statusline
 
 .claude/              # Shim layer — symlinks back into .agents/


### PR DESCRIPTION
PARTIAL progress against the approved plan at .plan-tasks/PLAN.md. This
checkpoint commit covers Phase 0 scaffolding, Phase A language lock,
Phase C commit-body draft, and most of Phases D/F (5 new skills + 4
new commands). Phase B renames, Phase E existing-skill extensions,
Phase G routing wiring, Phase I verification, and Phase J final commit
remain.

== Completed in this commit ==

Phase 0 (scaffolding):
- .plan-tasks/ folder with 35 task files (one per discrete edit)
- .plan-tasks/PLAN.md verbatim copy of the approved plan
- /.plan-tasks/ added to .gitignore (ephemeral execution scaffolding)
- 14 task files moved to .plan-tasks/complete/ after verification

Phase A (language lock):
- AGENTS.md §0.1 Terminology Lock: skill/agent/phase/stage/layer/gate/
  severity definitions; locked dispatch verbs invoke/route/dispatch;
  modal convention; placeholder convention
- §5 Routing Table header: "Trigger" → "Invocation cue"
- tdd Phase 1: inline `obligation` definition (ID + source citation +
  status); line 50 rewritten passive→imperative
- context-creation Phase 2: inline `scout` definition
- A4 dispatch-verb sweep across 21 files; every `## Trigger` heading
  now prepended with the clarifying sentence
- decompose Phase 2: persona announcement rewritten 1st→2nd-person
- _redirect Strike 1+2: removed 1st-person `I don't accept` phrasing
- [OPEN-DECISION] removed from decompose; consolidated to [CONFIRM-NN]
- arbiter Common Failure Modes 1, 4, 5, 7, 10: rewritten to MUST NOT

Phase C (authorization draft):
- .plan-tasks/commit-body.txt drafted (the authorization record that
  will land in the final Phase J commit when the plan completes)

Phase D (5 new skills authored against locked vocabulary):
- refactor (6 phases): Surface ID, Behavioral Parity Coverage Proof,
  Red Parity Tests, Implementation, Parity Verification, Lint/Coverage
- debug (5 phases): Symptom Capture, Hypothesis Generation, Evidence
  Gathering, Root Cause Decision, Handoff. Phase 4 exits to /fix,
  /ticket+/adr, or no-action close.
- observability-emit (5 phases): mirrors audit-emit. Signal Classification,
  Emit Construction, Cardinality Check, Alert/SLO Wiring, Test Obligation.
  Includes templates/observability-spec.md.tmpl for downstream projects.
- rotation (5 phases): Inventory, Cadence Check, Rotation Plan, Audit
  Emit, Archival. Extends secret-handling + crypto-compliance with
  lifecycle dimension.
- release (7 phases): Pre-Flight Readiness, Checkpoint Gate, Version
  Bump (SemVer), Changelog Generation, ADR Currency Check, Stage
  Threshold Verification, Tag and Announce.

Phase F (4 of 5 new commands authored — F3 /release pending):
- /refactor + .claude shim
- /debug + .claude shim (F2 still in flight at checkpoint time)
- /rotate + .claude shim
- /hotfix + .claude shim (emergency bypass differentiated from /override;
  two-identity attestation, auto-revert window, post-hoc ADR in 72h)

== Pending (next session) ==

- F2 (/debug) and F3 (/release) command bodies + shims
- Phase B renames (test-audit-reviewer→coverage-auditor, doc-governance
  →doc-review-gate, ticketing→ticketing-router, arbiter→decision-variance)
- Phase E (tdd Phase 1 observability obligations, decision-lifecycle
  AGED/stage-promotion enforcement, decompose+context-creation Phase 5
  observability-spec stub emission)
- Phase G (AGENTS.md §3/§4/§5/§7.1 + COMMANDS.md rows + details)
- Phase I (grep sweeps + smoke invocations)
- Phase J (final commit with the .plan-tasks/commit-body.txt
  authorization record) and Phase K cleanup

Skill-batch authorization remains as drafted in .plan-tasks/commit-body.txt;
the final Phase J commit will land that as its commit body and remove
.plan-tasks/ in Phase K.

https://claude.ai/code/session_014nnsn6yHm4uqDrcJiDXX9g