### PR TITLE
feat(standards): enforce copyright headers on new files via checkpoint

### DIFF
--- a/.agents/agents/standards-compliance-reviewer.md
+++ b/.agents/agents/standards-compliance-reviewer.md
@@ -17,6 +17,7 @@ You are a read-only reviewer for coding standards and project conventions. You v
    - File organization and co-location rules
    - Documentation requirements (JSDoc, type annotations, etc.)
    - Formatting rules (if not enforced by an auto-formatter)
+   - File header requirements (copyright holder, required fields, header format)
 
 ## What to Check
 
@@ -66,6 +67,38 @@ Per `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md`:
 - Are exported functions/types documented per the project's documentation standard?
 - Are non-obvious logic paths commented?
 
+### 7. File headers
+
+Check only newly added files. Run `git diff --cached --diff-filter=A --name-only` to get the
+list. MUST NOT flag missing headers on pre-existing files.
+
+Before running this check, confirm `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md`
+has a `## File Header Requirements` section. If the section is absent or still a placeholder,
+skip this check and note that the project has not configured header requirements.
+
+For each newly added file, read its first 10 lines and check for:
+- CRITICAL: no copyright line (`Copyright` keyword + year + holder name)
+- HIGH: author field absent
+- HIGH: creation date absent (ISO date or year)
+- LOW: filename field absent
+- LOW: language/syntax identifier absent when not inferable from file extension
+- LOW (guidance): no revision note present on a file with 50+ net-added lines — note that
+  significant additions benefit from a one-line inline note near the change
+
+Include the following header format examples in remediation text when reporting a BLOCK finding:
+
+Markup / YAML / config (HTML comment block at top of file):
+```
+<!--
+Copyright (c) YYYY <COPYRIGHT_HOLDER>
+Author: <name or team>
+Created: YYYY-MM-DD
+File: filename.ext
+-->
+```
+
+Source code: language-native block comment at top of file, before any imports, same fields.
+
 ## Findings Format
 
 ```
@@ -88,7 +121,7 @@ Per `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md`:
 [findings by severity, or "none"]
 
 ### Gate status
-PASS | BLOCK (N HIGH findings — banned pattern violations or lint failures)
+PASS | BLOCK (any CRITICAL finding, or N HIGH findings — banned patterns, lint failures, or missing required file headers)
 ```
 
 ## Out-of-Scope Findings

--- a/.agents/projectContext/coding-standards.md
+++ b/.agents/projectContext/coding-standards.md
@@ -34,3 +34,20 @@ _Test file location, naming, structure requirements_
 ## Comment Style
 
 _When to comment, how to comment, what NOT to comment_
+
+## File Header Requirements
+
+_Copyright holder (individual name, team, company, or username — whatever is legally appropriate
+for this project):_
+
+Required fields in the first comment block of every new file:
+- Copyright: `Copyright (c) <YEAR> <COPYRIGHT_HOLDER>`
+- Author: individual or team name
+- Created: ISO date (YYYY-MM-DD) or year of first creation
+- File: the file's own name (aids traceability after copy/rename)
+- Language/syntax: include when not obvious from file extension
+
+Revision note policy:
+- For significant additions (new feature, new component, new service): add a one-line inline note
+  near the change (e.g., `<!-- CHANGES: added redis pod deployment 2026-05-13 -->`)
+- Minor changes (formatting, typo fixes) do not require revision notes

--- a/.agents/skills/context-creation/SKILL.md
+++ b/.agents/skills/context-creation/SKILL.md
@@ -175,7 +175,7 @@ For each projectContext file, derive content from the scout reports using this m
 | Scout F (data model) | `${PROJECT_ROOT}/.agents/projectContext/audit-spec.md` (state-change entities) |
 | All scouts combined | `${PROJECT_ROOT}/.agents/projectContext/CONTEXT.md` (project identity, purpose, scope) |
 | Scout A + B | `${PROJECT_ROOT}/.agents/projectContext/dependency-policy.md` |
-| Scout C + D | `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md` (structural patterns observed) |
+| Scout C + D | `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md` (structural patterns observed; the `## File Header Requirements` copyright holder name CANNOT be inferred from scouts — write `[CONFIRM-NN: Copyright holder name — the individual name, team, company, or username to appear in the copyright line of every new file]` in that section) |
 
 Confidence rules:
 - **HIGH confidence**: Finding is directly and unambiguously present in scout report

--- a/.agents/skills/decompose/SKILL.md
+++ b/.agents/skills/decompose/SKILL.md
@@ -203,6 +203,10 @@ Unlock and confirm:
 - Hard constraints: stack (language, framework, runtime), cloud provider,
   compliance requirements (data residency, HIPAA, FedRAMP, etc.), budget ceiling,
   team size and skill set, existing systems to integrate with.
+- Copyright holder: who or what entity owns the copyright on this codebase
+  (individual name, company name, team name, or username). Recorded in
+  `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md` File Header Requirements and applied
+  to every new file. If unknown or undecided, record as CONFIRM-NN.
 - Trade-off forcing for every major architectural decision. Examples:
   - Monolith vs. services: "Monolith ships faster and is simpler to operate but
     limits independent scaling and team autonomy. Services enable scale but require


### PR DESCRIPTION
Adds a File Header Requirements section to coding-standards.md that
consuming projects populate with their copyright holder and format
preferences. Extends standards-compliance-reviewer with a new section 7
that checks newly added files for copyright notice, author, and creation
date at checkpoint, BLOCKing on CRITICAL/HIGH absences and providing LOW
guidance for revision notes on large additions.

CHANGELOG: projects using codeArbiter will now have copyright header
compliance checked at every /checkpoint for any newly added files.

Closes #8

https://claude.ai/code/session_01YcCrruTj2o4jkL3WabJa5u