### PR TITLE
feat(commands): add missing /decompose command file and register entry points

### DIFF
--- a/.agents/commands/_redirect.md
+++ b/.agents/commands/_redirect.md
@@ -21,6 +21,7 @@ Process required. Direct instructions outside a skill channel are not accepted
 — that path bypasses the gates that keep the project healthy.
 
 What are you trying to do?
+→ Start a new project:      /decompose
 → Start a feature:          /feature "describe it"
 → Ask a question:           /btw "your question"
 → Fix a bug:                /fix "describe it"
@@ -35,9 +36,10 @@ What are you trying to do?
 
 ```
 Direct instruction declined. Choose a channel:
-/feature  /fix  /commit  /pr  /review  /threat-model  /adr  /adr-status
-/checkpoint  /stage  /add-dep  /surface-conflict  /btw  /status  /init
-/override  /onboard  /new-skill  /ticket  /commands
+/decompose  /create-context  /feature  /fix  /commit  /pr  /review
+/threat-model  /adr  /adr-status  /checkpoint  /stage  /add-dep
+/surface-conflict  /btw  /status  /init  /override  /onboard  /new-skill
+/ticket  /commands
 Or use /override "reason" to bypass with logging.
 ```
 

--- a/.agents/commands/decompose.md
+++ b/.agents/commands/decompose.md
@@ -1,0 +1,59 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-14
+File: decompose.md
+-->
+
+# /decompose
+
+## Purpose
+
+Bootstrap the projectContext for a green-field project — one with no meaningful
+source code yet. Routes to the `decompose` skill, which conducts a layered
+interview to elicit purpose, scope, primary users, domain vocabulary, and
+architectural constraints, then writes the full
+`${PROJECT_ROOT}/.agents/projectContext/` file set and locks the project as
+initialized.
+
+This is the **only permitted path** to initialize projectContext when no
+meaningful source code exists. For an existing codebase, use `/create-context`
+instead.
+
+## Usage
+
+```
+/decompose
+```
+
+No arguments. The skill interviews the user; it does not need a starting
+artifact, though one (e.g., a project handoff summary) may be supplied freely
+during the interview phases.
+
+## Routes To
+
+`decompose` skill (`${FRAMEWORK_ROOT}/.agents/skills/decompose/SKILL.md`) —
+all six phases:
+
+| Phase | What happens |
+|---|---|
+| 1 — Pre-Flight Confirmation | Confirms green-field state; verifies no source code and no existing initialization sentinel |
+| 2 — Persona Adoption | codeArbiter adopts the decomposer persona for the interview |
+| 3 — Layered Interview (Layers 1–6) | Structured elicitation across the six decomposition layers |
+| 4 — Synthesis | Interview responses → draft projectContext files; low-confidence inferences flagged as `[CONFIRM-NN]` |
+| 5 — projectContext Population | All files written to `${PROJECT_ROOT}/.agents/projectContext/` |
+| 6 — Initialization Lock | `<!--INITIALIZED-->` sentinel written; full file tree displayed |
+
+## Hard Gates
+
+- BLOCK if `<!--INITIALIZED-->` already present in `${PROJECT_ROOT}/.agents/projectContext/CONTEXT.md` — context exists; route to normal operation instead
+- BLOCK if meaningful source code is detected — route to `/create-context` instead
+- BLOCK if any `[CONFIRM-NN]` item exits Phase 4 without being resolved or explicitly deferred
+- BLOCK if `<!--INITIALIZED-->` sentinel is not written before Phase 6 closes
+
+## When NOT to Use
+
+- **Context already initialized:** check `/status` or look for `<!--INITIALIZED-->` in `CONTEXT.md`
+- **Existing codebase (source code present):** use `/create-context`
+- **Broken / partially initialized state:** use `/init` (repair only — restores sentinel without re-running the interview)
+- **Update a specific projectContext file:** edit `${PROJECT_ROOT}/.agents/projectContext/` directly or use `/feature`

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -40,6 +40,7 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 | `/ticket` | `"title" \| <sub>` | Optional scope-overflow inbox; in-repo or Plane variant | [body](${FRAMEWORK_ROOT}/.agents/commands/ticket.md) |
 | `/btw` | `"question"` | Ask a quick question; no state change, lightweight | [body](${FRAMEWORK_ROOT}/.agents/commands/btw.md) |
 | `/status` | _(none)_ | Show open tasks and unresolved decisions | [body](${FRAMEWORK_ROOT}/.agents/commands/status.md) |
+| `/decompose` | _(none)_ | Bootstrap projectContext for a green-field project (no source code yet) | [body](${FRAMEWORK_ROOT}/.agents/commands/decompose.md) |
 | `/create-context` | _(none)_ | Bootstrap projectContext for an existing codebase (brownfield init) | [body](${FRAMEWORK_ROOT}/.agents/commands/create-context.md) |
 | `/init` | _(none)_ | Re-run initialization detection (repair only) | [body](${FRAMEWORK_ROOT}/.agents/commands/init.md) |
 | `/override` | `"reason"` | Bypass a gate with auto-identity audit log entry | [body](${FRAMEWORK_ROOT}/.agents/commands/override.md) |
@@ -343,6 +344,16 @@ Row shape: `Command | Argument | One-line purpose | Body`. Open a body only when
 - In-flight tasks (from `open-tasks.md`)
 - Unresolved `CONFIRM-NN` items (from `open-questions.md`)
 - Any override entries from `overrides.log` in the current session
+
+---
+
+### `/decompose`
+
+**Purpose:** Green-field projectContext initialization. Conducts a layered interview (Layers 1–6) to elicit purpose, scope, primary users, domain vocabulary, and architectural constraints, then writes the full `${PROJECT_ROOT}/.agents/projectContext/` file set and the `<!--INITIALIZED-->` sentinel.
+
+**What it routes to:** `decompose` skill (`${FRAMEWORK_ROOT}/.agents/skills/decompose/SKILL.md`) — Phases 1–6.
+
+**Two blockers before it runs:** `<!--INITIALIZED-->` must be absent (context not yet created) AND no meaningful source code may be present (otherwise route to `/create-context`).
 
 ---
 


### PR DESCRIPTION
Changes:
- New .agents/commands/decompose.md modeled on create-context.md
- _redirect.md Strike 1: added "Start a new project: /decompose"
- _redirect.md Strike 2: prepended /decompose and /create-context (the
  latter was likewise missing from the channel list — same omission class)
- COMMANDS.md: added /decompose row to the surface table and a detail
  section above /create-context