### PR TITLE
fix(shims): move copyright block below @path import in all shim files



### DIFF
--- a/.agents/agents/INDEX.md
+++ b/.agents/agents/INDEX.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: INDEX.md
+-->
+
 # Agents Index
 
 <!-- Auto-maintained surface scan. Agent bodies are read ONLY when dispatched. -->

--- a/.agents/agents/architecture-drift-reviewer.md
+++ b/.agents/agents/architecture-drift-reviewer.md
@@ -4,6 +4,14 @@ description: Reviews codebase for drift from ADRs, architectural decisions, and 
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: architecture-drift-reviewer.md
+-->
+
+
 # Architecture Drift Reviewer Agent
 
 You are a read-only reviewer that checks the codebase for drift from accepted architectural decisions. For every accepted ADR, you scan the codebase for evidence that the decision is being followed — or contradicted. You produce findings — you never modify code.

--- a/.agents/agents/audit-emitter.md
+++ b/.agents/agents/audit-emitter.md
@@ -4,6 +4,14 @@ description: Use whenever code is added that performs an auditable action (authn
 tools: Read, Grep, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: audit-emitter.md
+-->
+
+
 # Audit Emitter Agent
 
 You are a read-only reviewer that verifies audit event emission. You check that every auditable action in the codebase emits an audit event with all required fields, using the correct emit function, routed to the correct sink. You produce findings — you do not modify code.

--- a/.agents/agents/auth-crypto-reviewer.md
+++ b/.agents/agents/auth-crypto-reviewer.md
@@ -4,6 +4,14 @@ description: Reviews authentication, cryptography, and secrets handling against 
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: auth-crypto-reviewer.md
+-->
+
+
 # Auth/Crypto Reviewer Agent
 
 You are a read-only reviewer specializing in authentication, cryptography, and secrets handling. You enforce whatever the project's `security-controls.md` specifies — you are not hardcoded to any particular compliance framework or crypto standard. The project's `projectContext/security-controls.md` is your authority.

--- a/.agents/agents/backend-author.md
+++ b/.agents/agents/backend-author.md
@@ -4,6 +4,14 @@ description: Use when writing or modifying backend/server-side code. Owns the TD
 tools: Read, Grep, Glob, Bash, Edit, Write
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: backend-author.md
+-->
+
+
 # Backend Author Agent
 
 You are a backend implementation executor. You write server-side code ONLY after the `tdd` skill Phase 1 has produced a test obligation checklist. You do not begin implementation without that checklist in hand.

--- a/.agents/agents/checkpoint-aggregator.md
+++ b/.agents/agents/checkpoint-aggregator.md
@@ -4,6 +4,14 @@ description: Reads the finding-triage report and decision-challenger output, the
 tools: Read, Glob, Bash, Write
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: checkpoint-aggregator.md
+-->
+
+
 # Checkpoint Aggregator Agent
 
 You are the final agent in the checkpoint pipeline. You read the finding-triage report, verify the checkpoints directory exists, and write the dated checkpoint document. The checkpoint document requires a manual sign-off by a named approver before any stage promotion proceeds.

--- a/.agents/agents/coverage-auditor.md
+++ b/.agents/agents/coverage-auditor.md
@@ -4,6 +4,14 @@ description: Audits test coverage against TDD obligations. Identifies untested s
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: coverage-auditor.md
+-->
+
+
 # Coverage Auditor Agent
 
 You are a read-only reviewer for test coverage and test completeness. You verify that the test suite covers all TDD obligations, all auditable actions, and all trust zone boundary crossings. You produce findings — you do not modify code.

--- a/.agents/agents/decision-challenger.md
+++ b/.agents/agents/decision-challenger.md
@@ -4,6 +4,14 @@ description: Adversarial red-team reviewer. Challenges every ADR with the strong
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: decision-challenger.md
+-->
+
+
 # Decision Challenger Agent
 
 You are an adversarial red-team reviewer. Your job is to build the strongest possible case AGAINST each architectural decision under review. You do not rubber-stamp. You do not confirm correctness. You find weaknesses.

--- a/.agents/agents/dependency-reviewer.md
+++ b/.agents/agents/dependency-reviewer.md
@@ -4,6 +4,14 @@ description: Use whenever package.json, lock files, or container base images are
 tools: Read, Bash, Grep, WebFetch
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: dependency-reviewer.md
+-->
+
+
 # Dependency Reviewer Agent
 
 You are a read-only reviewer for third-party dependencies and container base images. You evaluate packages and images before any install command runs. You produce findings — you do not modify files and you do not run install commands.

--- a/.agents/agents/finding-triage.md
+++ b/.agents/agents/finding-triage.md
@@ -4,6 +4,14 @@ description: Reads all reviewer reports from a checkpoint run and assigns stage 
 tools: Read, Grep, Glob
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: finding-triage.md
+-->
+
+
 # Finding Triage Agent
 
 You are a post-processing agent that runs after all checkpoint reviewer agents complete. You read every reviewer report, consolidate all findings, and assign a stage promotion impact classification to each one. You do not produce your own findings — you classify and unify the findings of the six reviewer agents.

--- a/.agents/agents/frontend-author.md
+++ b/.agents/agents/frontend-author.md
@@ -4,6 +4,14 @@ description: Use when writing or modifying frontend/UI code. Owns the TDD workfl
 tools: Read, Grep, Glob, Bash, Edit, Write
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: frontend-author.md
+-->
+
+
 # Frontend Author Agent
 
 You are a frontend implementation executor. You write UI code ONLY after the `tdd` skill Phase 1 has produced a test obligation checklist. You do not begin implementation without that checklist in hand.

--- a/.agents/agents/grader.md
+++ b/.agents/agents/grader.md
@@ -4,6 +4,14 @@ description: INTERNAL subagent of the decision-variance skill. Produces SMARTS a
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: grader.md
+-->
+
+
 # Grader Subagent
 
 The grader subagent takes a specific (artifact-position, scaffold-evidence) pair and produces a SMARTS analysis with a recommendation. It does NOT make the arbitration decision — only the user makes decisions.

--- a/.agents/agents/infra-author.md
+++ b/.agents/agents/infra-author.md
@@ -4,6 +4,14 @@ description: Use when writing or modifying IaC, containers, CI/CD manifests, dep
 tools: Read, Grep, Glob, Bash, Edit, Write
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: infra-author.md
+-->
+
+
 # Infrastructure Author Agent
 
 You are an infrastructure implementation executor. You write IaC, container, CI/CD, and deployment configuration ONLY after the relevant planning phase has completed (for new trust zone crossings: `/threat-model` must clear first).

--- a/.agents/agents/migration-reviewer.md
+++ b/.agents/agents/migration-reviewer.md
@@ -4,6 +4,14 @@ description: Use whenever a database migration file is added or modified. Review
 tools: Read, Bash, Grep
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: migration-reviewer.md
+-->
+
+
 # Migration Reviewer Agent
 
 You are a read-only reviewer for database migration files. You review every migration that is added or modified. You produce findings — you do not modify files.

--- a/.agents/agents/scaffold-completeness-reviewer.md
+++ b/.agents/agents/scaffold-completeness-reviewer.md
@@ -4,6 +4,14 @@ description: Identifies all planned artifacts that do not yet exist — missing 
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: scaffold-completeness-reviewer.md
+-->
+
+
 # Scaffold Completeness Reviewer Agent
 
 You are a read-only reviewer that identifies planned artifacts that have not yet been created. For every task or artifact called out in `${PROJECT_ROOT}/.agents/projectContext/open-tasks.md`, you check whether the described artifact exists in the codebase. You produce findings — you do not modify code.

--- a/.agents/agents/scout.md
+++ b/.agents/agents/scout.md
@@ -4,6 +4,14 @@ description: INTERNAL subagent of the decision-variance and context-creation ski
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: scout.md
+-->
+
+
 # Scout Subagent
 
 The scout subagent scans a defined section of the codebase and reports evidence of architectural decisions found there. It does NOT make variance judgments — that is the decision-variance skill's job at the main session level.

--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -4,6 +4,14 @@ description: Use PROACTIVELY whenever a change touches authentication, authoriza
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: security-reviewer.md
+-->
+
+
 # Security Reviewer Agent
 
 You are a read-only security compliance reviewer. You review code changes against the project's security controls and trust zone contracts. You produce findings — you do not modify code.

--- a/.agents/agents/standards-compliance-reviewer.md
+++ b/.agents/agents/standards-compliance-reviewer.md
@@ -4,6 +4,14 @@ description: Reviews code against coding standards, project conventions, lint ru
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: standards-compliance-reviewer.md
+-->
+
+
 # Standards Compliance Reviewer Agent
 
 You are a read-only reviewer for coding standards and project conventions. You verify that code follows the naming, formatting, and structural rules defined in the project's coding standards. You produce findings — you do not modify code.

--- a/.agents/agents/standards-compliance-reviewer.md
+++ b/.agents/agents/standards-compliance-reviewer.md
@@ -17,6 +17,7 @@ You are a read-only reviewer for coding standards and project conventions. You v
    - File organization and co-location rules
    - Documentation requirements (JSDoc, type annotations, etc.)
    - Formatting rules (if not enforced by an auto-formatter)
+   - File header requirements (copyright holder, required fields, header format)
 
 ## What to Check
 
@@ -66,6 +67,38 @@ Per `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md`:
 - Are exported functions/types documented per the project's documentation standard?
 - Are non-obvious logic paths commented?
 
+### 7. File headers
+
+Check only newly added files. Run `git diff --cached --diff-filter=A --name-only` to get the
+list. MUST NOT flag missing headers on pre-existing files.
+
+Before running this check, confirm `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md`
+has a `## File Header Requirements` section. If the section is absent or still a placeholder,
+skip this check and note that the project has not configured header requirements.
+
+For each newly added file, read its first 10 lines and check for:
+- CRITICAL: no copyright line (`Copyright` keyword + year + holder name)
+- HIGH: author field absent
+- HIGH: creation date absent (ISO date or year)
+- LOW: filename field absent
+- LOW: language/syntax identifier absent when not inferable from file extension
+- LOW (guidance): no revision note present on a file with 50+ net-added lines — note that
+  significant additions benefit from a one-line inline note near the change
+
+Include the following header format examples in remediation text when reporting a BLOCK finding:
+
+Markup / YAML / config (HTML comment block at top of file):
+```
+<!--
+Copyright (c) YYYY <COPYRIGHT_HOLDER>
+Author: <name or team>
+Created: YYYY-MM-DD
+File: filename.ext
+-->
+```
+
+Source code: language-native block comment at top of file, before any imports, same fields.
+
 ## Findings Format
 
 ```
@@ -88,7 +121,7 @@ Per `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md`:
 [findings by severity, or "none"]
 
 ### Gate status
-PASS | BLOCK (N HIGH findings — banned pattern violations or lint failures)
+PASS | BLOCK (any CRITICAL finding, or N HIGH findings — banned patterns, lint failures, or missing required file headers)
 ```
 
 ## Out-of-Scope Findings

--- a/.agents/agents/trust-zone-reviewer.md
+++ b/.agents/agents/trust-zone-reviewer.md
@@ -4,6 +4,14 @@ description: Reviews trust zone boundary enforcement, HTTP client usage, and net
 tools: Read, Grep, Glob, Bash
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: trust-zone-reviewer.md
+-->
+
+
 # Trust Zone Reviewer Agent
 
 You are a read-only reviewer for trust zone boundary enforcement. You verify that all cross-zone communication in the codebase uses declared mechanisms, that no undeclared egress exists, and that network policy contracts match the zone definitions. You produce findings — you do not modify code.

--- a/.agents/commands/_redirect.md
+++ b/.agents/commands/_redirect.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: _redirect.md
+-->
+
 # _redirect (internal)
 
 Canned redirect messages emitted by the §6 User Interaction Protocol when a user

--- a/.agents/commands/add-dep.md
+++ b/.agents/commands/add-dep.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: add-dep.md
+-->
+
 # /add-dep "package-name[@version]"
 
 ## Purpose

--- a/.agents/commands/adr-status.md
+++ b/.agents/commands/adr-status.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: adr-status.md
+-->
+
 # /adr-status [--adr N]
 
 ## Purpose

--- a/.agents/commands/adr.md
+++ b/.agents/commands/adr.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: adr.md
+-->
+
 # /adr "title"
 
 ## Purpose

--- a/.agents/commands/btw.md
+++ b/.agents/commands/btw.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: btw.md
+-->
+
 # /btw "question"
 
 ## Purpose

--- a/.agents/commands/checkpoint.md
+++ b/.agents/commands/checkpoint.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: checkpoint.md
+-->
+
 # /checkpoint
 
 ## Purpose

--- a/.agents/commands/commands.md
+++ b/.agents/commands/commands.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: commands.md
+-->
+
 # /commands
 
 ## Purpose

--- a/.agents/commands/commit.md
+++ b/.agents/commands/commit.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: commit.md
+-->
+
 # /commit
 
 ## Purpose

--- a/.agents/commands/create-context.md
+++ b/.agents/commands/create-context.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: create-context.md
+-->
+
 # /create-context
 
 ## Purpose

--- a/.agents/commands/debug.md
+++ b/.agents/commands/debug.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: debug.md
+-->
+
 # /debug "symptom description"
 
 ## Purpose

--- a/.agents/commands/feature.md
+++ b/.agents/commands/feature.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: feature.md
+-->
+
 # /feature "description"
 
 ## Purpose

--- a/.agents/commands/fix.md
+++ b/.agents/commands/fix.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: fix.md
+-->
+
 # /fix "description of the bug"
 
 ## Purpose

--- a/.agents/commands/hotfix.md
+++ b/.agents/commands/hotfix.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: hotfix.md
+-->
+
 # /hotfix "reason" --severity P0|P1 --escalation-tier <user> --auto-revert-window 24h|72h|7d
 
 ## Purpose

--- a/.agents/commands/init-vendor.md
+++ b/.agents/commands/init-vendor.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: init-vendor.md
+-->
+
 # /init-vendor [--vendor-path=<path>] [--dry-run] [--force]
 
 ## Purpose

--- a/.agents/commands/init.md
+++ b/.agents/commands/init.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: init.md
+-->
+
 # /init
 
 ## Purpose

--- a/.agents/commands/new-skill.md
+++ b/.agents/commands/new-skill.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: new-skill.md
+-->
+
 # /new-skill "skill name"
 
 ## Purpose

--- a/.agents/commands/onboard.md
+++ b/.agents/commands/onboard.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: onboard.md
+-->
+
 # /onboard [topic]
 
 ## Purpose

--- a/.agents/commands/override.md
+++ b/.agents/commands/override.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: override.md
+-->
+
 # /override "reason"
 
 ## Purpose

--- a/.agents/commands/pr.md
+++ b/.agents/commands/pr.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: pr.md
+-->
+
 # /pr
 
 ## Purpose

--- a/.agents/commands/refactor.md
+++ b/.agents/commands/refactor.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: refactor.md
+-->
+
 # /refactor "surface and motivation"
 
 ## Purpose

--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: release.md
+-->
+
 # /release ["version" | --auto | --dry-run]
 
 ## Purpose

--- a/.agents/commands/review.md
+++ b/.agents/commands/review.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: review.md
+-->
+
 # /review [path or diff]
 
 ## Purpose

--- a/.agents/commands/rotate.md
+++ b/.agents/commands/rotate.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: rotate.md
+-->
+
 # /rotate "artifact-id"
 
 ## Purpose

--- a/.agents/commands/stage.md
+++ b/.agents/commands/stage.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: stage.md
+-->
+
 # /stage [N]
 
 ## Purpose

--- a/.agents/commands/status.md
+++ b/.agents/commands/status.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: status.md
+-->
+
 # /status
 
 ## Purpose

--- a/.agents/commands/surface-conflict.md
+++ b/.agents/commands/surface-conflict.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: surface-conflict.md
+-->
+
 # /surface-conflict
 
 ## Purpose

--- a/.agents/commands/threat-model.md
+++ b/.agents/commands/threat-model.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: threat-model.md
+-->
+
 # /threat-model "scope description"
 
 ## Purpose

--- a/.agents/commands/ticket.md
+++ b/.agents/commands/ticket.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: ticket.md
+-->
+
 # /ticket
 
 ## Purpose

--- a/.agents/hooks/STATUSLINE.md
+++ b/.agents/hooks/STATUSLINE.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: STATUSLINE.md
+-->
+
 # codeArbiter Statusline
 
 A custom Claude Code statusline that surfaces project state without commands. Renders as a single ANSI-colored line at the bottom of the Claude Code session.

--- a/.agents/hooks/post-write-edit.sh
+++ b/.agents/hooks/post-write-edit.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-10
+# File: post-write-edit.sh
+
 which jq > /dev/null 2>&1 || exit 0
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 INPUT=$(cat)

--- a/.agents/hooks/pre-bash.sh
+++ b/.agents/hooks/pre-bash.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-10
+# File: pre-bash.sh
+
 which jq > /dev/null 2>&1 || exit 0
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')

--- a/.agents/hooks/pre-edit.sh
+++ b/.agents/hooks/pre-edit.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-10
+# File: pre-edit.sh
+
 which jq > /dev/null 2>&1 || exit 0
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 INPUT=$(cat)

--- a/.agents/hooks/pre-write.sh
+++ b/.agents/hooks/pre-write.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-10
+# File: pre-write.sh
+
 which jq > /dev/null 2>&1 || exit 0
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 INPUT=$(cat)

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-10
+# File: session-start.sh
+
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 CONTEXT_FILE="$PROJECT_ROOT/.agents/projectContext/CONTEXT.md"
 

--- a/.agents/hooks/statusline-tokens.py
+++ b/.agents/hooks/statusline-tokens.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-12
+# File: statusline-tokens.py
+
 # codeArbiter statusline usage segment: ctx %, optional $ cost (API mode),
 # optional 5h / 7d rate limits (subscription mode).
 # Invoked from statusline.sh; stdin = Claude Code statusline JSON.

--- a/.agents/hooks/statusline.sh
+++ b/.agents/hooks/statusline.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 suadtl
+# Author: suadtl
+# Created: 2026-05-12
+# File: statusline.sh
+
 # codeArbiter custom statusline for Claude Code.
 # Renders: [init] stage:N │ tasks:N q:N │ ⎇ branch[*] │ over:N
 # Docs: .agents/hooks/STATUSLINE.md

--- a/.agents/projectContext/CONTEXT.md
+++ b/.agents/projectContext/CONTEXT.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: CONTEXT.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- This file is populated by the `decompose` skill (green-field) or `context-creation` skill (existing codebase). -->
 <!-- Do not edit manually until the initialization protocol has run. -->

--- a/.agents/projectContext/audit-spec.md
+++ b/.agents/projectContext/audit-spec.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: audit-spec.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/projectContext/coding-standards.md
+++ b/.agents/projectContext/coding-standards.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: coding-standards.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/projectContext/coding-standards.md
+++ b/.agents/projectContext/coding-standards.md
@@ -34,3 +34,20 @@ _Test file location, naming, structure requirements_
 ## Comment Style
 
 _When to comment, how to comment, what NOT to comment_
+
+## File Header Requirements
+
+_Copyright holder (individual name, team, company, or username — whatever is legally appropriate
+for this project):_
+
+Required fields in the first comment block of every new file:
+- Copyright: `Copyright (c) <YEAR> <COPYRIGHT_HOLDER>`
+- Author: individual or team name
+- Created: ISO date (YYYY-MM-DD) or year of first creation
+- File: the file's own name (aids traceability after copy/rename)
+- Language/syntax: include when not obvious from file extension
+
+Revision note policy:
+- For significant additions (new feature, new component, new service): add a one-line inline note
+  near the change (e.g., `<!-- CHANGES: added redis pod deployment 2026-05-13 -->`)
+- Minor changes (formatting, typo fixes) do not require revision notes

--- a/.agents/projectContext/decisions/001-ticketing-design.md
+++ b/.agents/projectContext/decisions/001-ticketing-design.md
@@ -7,6 +7,14 @@ last_challenged:
 authors: SUaDtL (user)
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: 001-ticketing-design.md
+-->
+
+
 # ADR-001: Ticketing Design
 
 ## Context

--- a/.agents/projectContext/decisions/README.md
+++ b/.agents/projectContext/decisions/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: README.md
+-->
+
 # Architectural Decision Records
 
 <!-- ADRs live in this directory. Each file is named NNN-short-title.md where NNN is zero-padded. -->

--- a/.agents/projectContext/dependency-policy.md
+++ b/.agents/projectContext/dependency-policy.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: dependency-policy.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/projectContext/observability-spec.md
+++ b/.agents/projectContext/observability-spec.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: observability-spec.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose / context-creation skill, or backfilled when
      observability obligations first land. Template source:

--- a/.agents/projectContext/open-questions.md
+++ b/.agents/projectContext/open-questions.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: open-questions.md
+-->
+
 # Open Questions (CONFIRM-NN)
 
 <!-- Unresolved decisions blocking stage promotions or architectural choices. -->

--- a/.agents/projectContext/open-tasks.md
+++ b/.agents/projectContext/open-tasks.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: open-tasks.md
+-->
+
 # Open Tasks
 
 <!-- This file tracks in-flight and backlog work. Updated by codeArbiter during normal operation. -->

--- a/.agents/projectContext/secrets-policy.md
+++ b/.agents/projectContext/secrets-policy.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: secrets-policy.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/projectContext/security-controls.md
+++ b/.agents/projectContext/security-controls.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: security-controls.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/projectContext/tech-stack.md
+++ b/.agents/projectContext/tech-stack.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: tech-stack.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/projectContext/ticketing-config.md
+++ b/.agents/projectContext/ticketing-config.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: ticketing-config.md
+-->
+
 # Ticketing Configuration
 
 <!-- Read by the `ticketing-router` skill. -->

--- a/.agents/projectContext/tickets/INDEX.md
+++ b/.agents/projectContext/tickets/INDEX.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: INDEX.md
+-->
+
 # Tickets Index
 
 <!-- Auto-maintained by the ticketing-router in-repo variant. -->

--- a/.agents/projectContext/trust-zones.md
+++ b/.agents/projectContext/trust-zones.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: trust-zones.md
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/skills/audit-emit/SKILL.md
+++ b/.agents/skills/audit-emit/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: audit-emit
 
 ## Trigger

--- a/.agents/skills/commit-gate/SKILL.md
+++ b/.agents/skills/commit-gate/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: commit-gate
 
 ## Trigger

--- a/.agents/skills/context-creation/SKILL.md
+++ b/.agents/skills/context-creation/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: context-creation
 
 ## Trigger

--- a/.agents/skills/context-creation/SKILL.md
+++ b/.agents/skills/context-creation/SKILL.md
@@ -175,7 +175,7 @@ For each projectContext file, derive content from the scout reports using this m
 | Scout F (data model) | `${PROJECT_ROOT}/.agents/projectContext/audit-spec.md` (state-change entities) |
 | All scouts combined | `${PROJECT_ROOT}/.agents/projectContext/CONTEXT.md` (project identity, purpose, scope) |
 | Scout A + B | `${PROJECT_ROOT}/.agents/projectContext/dependency-policy.md` |
-| Scout C + D | `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md` (structural patterns observed) |
+| Scout C + D | `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md` (structural patterns observed; the `## File Header Requirements` copyright holder name CANNOT be inferred from scouts — write `[CONFIRM-NN: Copyright holder name — the individual name, team, company, or username to appear in the copyright line of every new file]` in that section) |
 
 Confidence rules:
 - **HIGH confidence**: Finding is directly and unambiguously present in scout report

--- a/.agents/skills/crypto-compliance/SKILL.md
+++ b/.agents/skills/crypto-compliance/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # crypto-compliance Skill
 
 ## Identity

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -3,6 +3,14 @@ name: debug
 description: Investigate-then-decide root-cause analysis (RCA) workflow for situations where the cause of a defect, anomaly, or unexpected behavior is unknown. Routes to /fix, /ticket, /adr, or no-action close at Phase 4. Distinct from /fix, which assumes a known bug.
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
+
 # Skill: debug
 
 ## Purpose

--- a/.agents/skills/decision-lifecycle/SKILL.md
+++ b/.agents/skills/decision-lifecycle/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: decision-lifecycle
 
 ## Trigger

--- a/.agents/skills/decision-variance/SKILL.md
+++ b/.agents/skills/decision-variance/SKILL.md
@@ -3,6 +3,14 @@ name: decision-variance
 description: Reconcile project architectural artifacts (Architecture Breakdown, Phased Build Plan, Task Backlog) against the existing project scaffold and codebase. Use this skill whenever the user mentions architectural reconciliation, variance review, ingesting decomposition documents, comparing architectural decisions to existing code, syncing artifacts with scaffold state, or asks to "arbitrate," "reconcile," "merge," or "consolidate" architectural context with the project. Also use when the user asks what architectural artifacts can be produced from current project state, requests a variance report, mentions ADR conflicts, or wants to track outstanding architectural decisions. Do NOT use for routine git merges, code review consolidation, or general architectural discussions unrelated to the current project's artifacts. This skill never makes arbitration decisions alone — it presents SMARTS analyses for the user to decide. It treats the artifacts as authoritative-by-default but does not blindly adopt them.
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
+
 # Decision-Variance Skill
 
 A skill for systematically reconciling a project's three architectural artifacts (Architecture Breakdown, Phased Build Plan, Task Backlog) against the existing project scaffold, codebase, and prior decisions — without making arbitration decisions unilaterally.

--- a/.agents/skills/decision-variance/references/decision-categories.md
+++ b/.agents/skills/decision-variance/references/decision-categories.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: decision-categories.md
+-->
+
 # Decision Categories — Canonical Scan List
 
 This is the canonical list of decision categories this skill scans for during Stage 2 evidence indexing. The list is organized by area and prioritized within each area.

--- a/.agents/skills/decision-variance/references/decision-log-format.md
+++ b/.agents/skills/decision-variance/references/decision-log-format.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: decision-log-format.md
+-->
+
 # Decision Log Format
 
 This file defines the exact format used in `${PROJECT_ROOT}/.agents/projectContext/arbiter-decisions.md`. The format is non-negotiable so the log remains machine-parseable on future invocations of this skill.

--- a/.agents/skills/decision-variance/references/downstream-artifacts.md
+++ b/.agents/skills/decision-variance/references/downstream-artifacts.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: downstream-artifacts.md
+-->
+
 # Downstream Artifacts Catalog
 
 This file catalogs the architectural artifacts that this skill can recommend producing once enough information is available. For each artifact, the catalog defines:

--- a/.agents/skills/decision-variance/references/known-open-decisions.md
+++ b/.agents/skills/decision-variance/references/known-open-decisions.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: known-open-decisions.md
+-->
+
 # Known Open Decisions
 
 The architectural artifacts deliberately leave certain decisions open. This skill MUST NOT treat these as variances during arbitration — they are open by design.

--- a/.agents/skills/decision-variance/references/smarts-framework.md
+++ b/.agents/skills/decision-variance/references/smarts-framework.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: smarts-framework.md
+-->
+
 # SMARTS Framework
 
 The SMARTS framework is the standardized evaluation framework for architectural decisions. This skill applies SMARTS evenhandedly when comparing options.

--- a/.agents/skills/decompose/SKILL.md
+++ b/.agents/skills/decompose/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: decompose
 
 ## Trigger

--- a/.agents/skills/decompose/SKILL.md
+++ b/.agents/skills/decompose/SKILL.md
@@ -203,6 +203,10 @@ Unlock and confirm:
 - Hard constraints: stack (language, framework, runtime), cloud provider,
   compliance requirements (data residency, HIPAA, FedRAMP, etc.), budget ceiling,
   team size and skill set, existing systems to integrate with.
+- Copyright holder: who or what entity owns the copyright on this codebase
+  (individual name, company name, team name, or username). Recorded in
+  `${PROJECT_ROOT}/.agents/projectContext/coding-standards.md` File Header Requirements and applied
+  to every new file. If unknown or undecided, record as CONFIRM-NN.
 - Trade-off forcing for every major architectural decision. Examples:
   - Monolith vs. services: "Monolith ships faster and is simpler to operate but
     limits independent scaling and team autonomy. Services enable scale but require

--- a/.agents/skills/doc-review-gate/SKILL.md
+++ b/.agents/skills/doc-review-gate/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: doc-review-gate
 
 ## Trigger

--- a/.agents/skills/observability-emit/SKILL.md
+++ b/.agents/skills/observability-emit/SKILL.md
@@ -2,6 +2,14 @@
 name: observability-emit
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
+
 # Skill: observability-emit
 
 ## Purpose

--- a/.agents/skills/observability-emit/templates/observability-spec.md.tmpl
+++ b/.agents/skills/observability-emit/templates/observability-spec.md.tmpl
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: observability-spec.md.tmpl
+-->
+
 <!--PLACEHOLDER-->
 <!-- Populated by decompose/context-creation skill. -->
 

--- a/.agents/skills/onboard/SKILL.md
+++ b/.agents/skills/onboard/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: onboard
 
 ## Trigger

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -3,6 +3,14 @@ name: refactor
 description: Restructure existing code without changing behavior. Six-phase gated workflow that proves behavioral parity through pre-existing test coverage, blocks any change classifiable as `feat`, and refuses to accept modified tests as evidence of correctness.
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
+
 # Skill: refactor
 
 ## Purpose

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -2,6 +2,14 @@
 name: release
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
+
 # Skill: release
 
 ## Purpose

--- a/.agents/skills/rotation/SKILL.md
+++ b/.agents/skills/rotation/SKILL.md
@@ -2,6 +2,14 @@
 name: rotation
 ---
 
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
+
 # Skill: rotation
 
 ## Purpose

--- a/.agents/skills/secret-handling/SKILL.md
+++ b/.agents/skills/secret-handling/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # secret-handling Skill
 
 ## Identity

--- a/.agents/skills/security-architecture/SKILL.md
+++ b/.agents/skills/security-architecture/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # security-architecture Skill
 
 ## Identity

--- a/.agents/skills/skill-author/SKILL.md
+++ b/.agents/skills/skill-author/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: skill-author
 
 ## Trigger

--- a/.agents/skills/stage-gating/SKILL.md
+++ b/.agents/skills/stage-gating/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # stage-gating Skill
 
 ## Identity

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: SKILL.md
+-->
+
 # Skill: tdd
 
 ## Trigger

--- a/.agents/skills/ticketing-router/SKILL.md
+++ b/.agents/skills/ticketing-router/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
 # Skill: ticketing-router (router)
 
 ## Trigger

--- a/.agents/skills/ticketing-router/in-repo/SKILL.md
+++ b/.agents/skills/ticketing-router/in-repo/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
 # Skill: ticketing-router (in-repo variant)
 
 ## Trigger

--- a/.agents/skills/ticketing-router/plane/SKILL.md
+++ b/.agents/skills/ticketing-router/plane/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: SKILL.md
+-->
+
 # Skill: ticketing-router (Plane variant — on-prem)
 
 ## Trigger

--- a/.claude/agents/architecture-drift-reviewer.md
+++ b/.claude/agents/architecture-drift-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: architecture-drift-reviewer.md
+-->
+
 @.agents/agents/architecture-drift-reviewer.md

--- a/.claude/agents/architecture-drift-reviewer.md
+++ b/.claude/agents/architecture-drift-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/architecture-drift-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: architecture-drift-reviewer.md
 -->
-
-@.agents/agents/architecture-drift-reviewer.md

--- a/.claude/agents/audit-emitter.md
+++ b/.claude/agents/audit-emitter.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: audit-emitter.md
+-->
+
 @.agents/agents/audit-emitter.md

--- a/.claude/agents/audit-emitter.md
+++ b/.claude/agents/audit-emitter.md
@@ -1,8 +1,9 @@
+@.agents/agents/audit-emitter.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: audit-emitter.md
 -->
-
-@.agents/agents/audit-emitter.md

--- a/.claude/agents/auth-crypto-reviewer.md
+++ b/.claude/agents/auth-crypto-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: auth-crypto-reviewer.md
+-->
+
 @.agents/agents/auth-crypto-reviewer.md

--- a/.claude/agents/auth-crypto-reviewer.md
+++ b/.claude/agents/auth-crypto-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/auth-crypto-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: auth-crypto-reviewer.md
 -->
-
-@.agents/agents/auth-crypto-reviewer.md

--- a/.claude/agents/backend-author.md
+++ b/.claude/agents/backend-author.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: backend-author.md
+-->
+
 @.agents/agents/backend-author.md

--- a/.claude/agents/backend-author.md
+++ b/.claude/agents/backend-author.md
@@ -1,8 +1,9 @@
+@.agents/agents/backend-author.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: backend-author.md
 -->
-
-@.agents/agents/backend-author.md

--- a/.claude/agents/checkpoint-aggregator.md
+++ b/.claude/agents/checkpoint-aggregator.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: checkpoint-aggregator.md
+-->
+
 @.agents/agents/checkpoint-aggregator.md

--- a/.claude/agents/checkpoint-aggregator.md
+++ b/.claude/agents/checkpoint-aggregator.md
@@ -1,8 +1,9 @@
+@.agents/agents/checkpoint-aggregator.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: checkpoint-aggregator.md
 -->
-
-@.agents/agents/checkpoint-aggregator.md

--- a/.claude/agents/coverage-auditor.md
+++ b/.claude/agents/coverage-auditor.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: coverage-auditor.md
+-->
+
 @.agents/agents/coverage-auditor.md

--- a/.claude/agents/coverage-auditor.md
+++ b/.claude/agents/coverage-auditor.md
@@ -1,8 +1,9 @@
+@.agents/agents/coverage-auditor.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: coverage-auditor.md
 -->
-
-@.agents/agents/coverage-auditor.md

--- a/.claude/agents/decision-challenger.md
+++ b/.claude/agents/decision-challenger.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: decision-challenger.md
+-->
+
 @.agents/agents/decision-challenger.md

--- a/.claude/agents/decision-challenger.md
+++ b/.claude/agents/decision-challenger.md
@@ -1,8 +1,9 @@
+@.agents/agents/decision-challenger.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: decision-challenger.md
 -->
-
-@.agents/agents/decision-challenger.md

--- a/.claude/agents/dependency-reviewer.md
+++ b/.claude/agents/dependency-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: dependency-reviewer.md
+-->
+
 @.agents/agents/dependency-reviewer.md

--- a/.claude/agents/dependency-reviewer.md
+++ b/.claude/agents/dependency-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/dependency-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: dependency-reviewer.md
 -->
-
-@.agents/agents/dependency-reviewer.md

--- a/.claude/agents/finding-triage.md
+++ b/.claude/agents/finding-triage.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: finding-triage.md
+-->
+
 @.agents/agents/finding-triage.md

--- a/.claude/agents/finding-triage.md
+++ b/.claude/agents/finding-triage.md
@@ -1,8 +1,9 @@
+@.agents/agents/finding-triage.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: finding-triage.md
 -->
-
-@.agents/agents/finding-triage.md

--- a/.claude/agents/frontend-author.md
+++ b/.claude/agents/frontend-author.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: frontend-author.md
+-->
+
 @.agents/agents/frontend-author.md

--- a/.claude/agents/frontend-author.md
+++ b/.claude/agents/frontend-author.md
@@ -1,8 +1,9 @@
+@.agents/agents/frontend-author.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: frontend-author.md
 -->
-
-@.agents/agents/frontend-author.md

--- a/.claude/agents/grader.md
+++ b/.claude/agents/grader.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: grader.md
+-->
+
 @.agents/agents/grader.md

--- a/.claude/agents/grader.md
+++ b/.claude/agents/grader.md
@@ -1,8 +1,9 @@
+@.agents/agents/grader.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: grader.md
 -->
-
-@.agents/agents/grader.md

--- a/.claude/agents/infra-author.md
+++ b/.claude/agents/infra-author.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: infra-author.md
+-->
+
 @.agents/agents/infra-author.md

--- a/.claude/agents/infra-author.md
+++ b/.claude/agents/infra-author.md
@@ -1,8 +1,9 @@
+@.agents/agents/infra-author.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: infra-author.md
 -->
-
-@.agents/agents/infra-author.md

--- a/.claude/agents/migration-reviewer.md
+++ b/.claude/agents/migration-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: migration-reviewer.md
+-->
+
 @.agents/agents/migration-reviewer.md

--- a/.claude/agents/migration-reviewer.md
+++ b/.claude/agents/migration-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/migration-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: migration-reviewer.md
 -->
-
-@.agents/agents/migration-reviewer.md

--- a/.claude/agents/scaffold-completeness-reviewer.md
+++ b/.claude/agents/scaffold-completeness-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: scaffold-completeness-reviewer.md
+-->
+
 @.agents/agents/scaffold-completeness-reviewer.md

--- a/.claude/agents/scaffold-completeness-reviewer.md
+++ b/.claude/agents/scaffold-completeness-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/scaffold-completeness-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: scaffold-completeness-reviewer.md
 -->
-
-@.agents/agents/scaffold-completeness-reviewer.md

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: scout.md
+-->
+
 @.agents/agents/scout.md

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,8 +1,9 @@
+@.agents/agents/scout.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: scout.md
 -->
-
-@.agents/agents/scout.md

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: security-reviewer.md
+-->
+
 @.agents/agents/security-reviewer.md

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/security-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: security-reviewer.md
 -->
-
-@.agents/agents/security-reviewer.md

--- a/.claude/agents/standards-compliance-reviewer.md
+++ b/.claude/agents/standards-compliance-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: standards-compliance-reviewer.md
+-->
+
 @.agents/agents/standards-compliance-reviewer.md

--- a/.claude/agents/standards-compliance-reviewer.md
+++ b/.claude/agents/standards-compliance-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/standards-compliance-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: standards-compliance-reviewer.md
 -->
-
-@.agents/agents/standards-compliance-reviewer.md

--- a/.claude/agents/trust-zone-reviewer.md
+++ b/.claude/agents/trust-zone-reviewer.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: trust-zone-reviewer.md
+-->
+
 @.agents/agents/trust-zone-reviewer.md

--- a/.claude/agents/trust-zone-reviewer.md
+++ b/.claude/agents/trust-zone-reviewer.md
@@ -1,8 +1,9 @@
+@.agents/agents/trust-zone-reviewer.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: trust-zone-reviewer.md
 -->
-
-@.agents/agents/trust-zone-reviewer.md

--- a/.claude/commands/add-dep.md
+++ b/.claude/commands/add-dep.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: add-dep.md
+-->
+
 @.agents/commands/add-dep.md

--- a/.claude/commands/add-dep.md
+++ b/.claude/commands/add-dep.md
@@ -1,8 +1,9 @@
+@.agents/commands/add-dep.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: add-dep.md
 -->
-
-@.agents/commands/add-dep.md

--- a/.claude/commands/adr-status.md
+++ b/.claude/commands/adr-status.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: adr-status.md
+-->
+
 @.agents/commands/adr-status.md

--- a/.claude/commands/adr-status.md
+++ b/.claude/commands/adr-status.md
@@ -1,8 +1,9 @@
+@.agents/commands/adr-status.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: adr-status.md
 -->
-
-@.agents/commands/adr-status.md

--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: adr.md
+-->
+
 @.agents/commands/adr.md

--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,8 +1,9 @@
+@.agents/commands/adr.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: adr.md
 -->
-
-@.agents/commands/adr.md

--- a/.claude/commands/btw.md
+++ b/.claude/commands/btw.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: btw.md
+-->
+
 @.agents/commands/btw.md

--- a/.claude/commands/btw.md
+++ b/.claude/commands/btw.md
@@ -1,8 +1,9 @@
+@.agents/commands/btw.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: btw.md
 -->
-
-@.agents/commands/btw.md

--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: checkpoint.md
+-->
+
 @.agents/commands/checkpoint.md

--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -1,8 +1,9 @@
+@.agents/commands/checkpoint.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: checkpoint.md
 -->
-
-@.agents/commands/checkpoint.md

--- a/.claude/commands/commands.md
+++ b/.claude/commands/commands.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: commands.md
+-->
+
 @.agents/commands/commands.md

--- a/.claude/commands/commands.md
+++ b/.claude/commands/commands.md
@@ -1,8 +1,9 @@
+@.agents/commands/commands.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: commands.md
 -->
-
-@.agents/commands/commands.md

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: commit.md
+-->
+
 @.agents/commands/commit.md

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,8 +1,9 @@
+@.agents/commands/commit.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: commit.md
 -->
-
-@.agents/commands/commit.md

--- a/.claude/commands/create-context.md
+++ b/.claude/commands/create-context.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: create-context.md
+-->
+
 @.agents/commands/create-context.md

--- a/.claude/commands/create-context.md
+++ b/.claude/commands/create-context.md
@@ -1,8 +1,9 @@
+@.agents/commands/create-context.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: create-context.md
 -->
-
-@.agents/commands/create-context.md

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: debug.md
+-->
+
 @.agents/commands/debug.md

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -1,8 +1,9 @@
+@.agents/commands/debug.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: debug.md
 -->
-
-@.agents/commands/debug.md

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: feature.md
+-->
+
 @.agents/commands/feature.md

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,8 +1,9 @@
+@.agents/commands/feature.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: feature.md
 -->
-
-@.agents/commands/feature.md

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: fix.md
+-->
+
 @.agents/commands/fix.md

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -1,8 +1,9 @@
+@.agents/commands/fix.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: fix.md
 -->
-
-@.agents/commands/fix.md

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: hotfix.md
+-->
+
 @.agents/commands/hotfix.md

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -1,8 +1,9 @@
+@.agents/commands/hotfix.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: hotfix.md
 -->
-
-@.agents/commands/hotfix.md

--- a/.claude/commands/init-vendor.md
+++ b/.claude/commands/init-vendor.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: init-vendor.md
+-->
+
 @.agents/commands/init-vendor.md

--- a/.claude/commands/init-vendor.md
+++ b/.claude/commands/init-vendor.md
@@ -1,8 +1,9 @@
+@.agents/commands/init-vendor.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: init-vendor.md
 -->
-
-@.agents/commands/init-vendor.md

--- a/.claude/commands/init.md
+++ b/.claude/commands/init.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: init.md
+-->
+
 @.agents/commands/init.md

--- a/.claude/commands/init.md
+++ b/.claude/commands/init.md
@@ -1,8 +1,9 @@
+@.agents/commands/init.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: init.md
 -->
-
-@.agents/commands/init.md

--- a/.claude/commands/new-skill.md
+++ b/.claude/commands/new-skill.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: new-skill.md
+-->
+
 @.agents/commands/new-skill.md

--- a/.claude/commands/new-skill.md
+++ b/.claude/commands/new-skill.md
@@ -1,8 +1,9 @@
+@.agents/commands/new-skill.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: new-skill.md
 -->
-
-@.agents/commands/new-skill.md

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: onboard.md
+-->
+
 @.agents/commands/onboard.md

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,8 +1,9 @@
+@.agents/commands/onboard.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: onboard.md
 -->
-
-@.agents/commands/onboard.md

--- a/.claude/commands/override.md
+++ b/.claude/commands/override.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: override.md
+-->
+
 @.agents/commands/override.md

--- a/.claude/commands/override.md
+++ b/.claude/commands/override.md
@@ -1,8 +1,9 @@
+@.agents/commands/override.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: override.md
 -->
-
-@.agents/commands/override.md

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: pr.md
+-->
+
 @.agents/commands/pr.md

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,8 +1,9 @@
+@.agents/commands/pr.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: pr.md
 -->
-
-@.agents/commands/pr.md

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: refactor.md
+-->
+
 @.agents/commands/refactor.md

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,8 +1,9 @@
+@.agents/commands/refactor.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: refactor.md
 -->
-
-@.agents/commands/refactor.md

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: release.md
+-->
+
 @.agents/commands/release.md

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,8 +1,9 @@
+@.agents/commands/release.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: release.md
 -->
-
-@.agents/commands/release.md

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: review.md
+-->
+
 @.agents/commands/review.md

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,8 +1,9 @@
+@.agents/commands/review.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: review.md
 -->
-
-@.agents/commands/review.md

--- a/.claude/commands/rotate.md
+++ b/.claude/commands/rotate.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: rotate.md
+-->
+
 @.agents/commands/rotate.md

--- a/.claude/commands/rotate.md
+++ b/.claude/commands/rotate.md
@@ -1,8 +1,9 @@
+@.agents/commands/rotate.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: rotate.md
 -->
-
-@.agents/commands/rotate.md

--- a/.claude/commands/stage.md
+++ b/.claude/commands/stage.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: stage.md
+-->
+
 @.agents/commands/stage.md

--- a/.claude/commands/stage.md
+++ b/.claude/commands/stage.md
@@ -1,8 +1,9 @@
+@.agents/commands/stage.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: stage.md
 -->
-
-@.agents/commands/stage.md

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: status.md
+-->
+
 @.agents/commands/status.md

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,8 +1,9 @@
+@.agents/commands/status.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: status.md
 -->
-
-@.agents/commands/status.md

--- a/.claude/commands/surface-conflict.md
+++ b/.claude/commands/surface-conflict.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: surface-conflict.md
+-->
+
 @.agents/commands/surface-conflict.md

--- a/.claude/commands/surface-conflict.md
+++ b/.claude/commands/surface-conflict.md
@@ -1,8 +1,9 @@
+@.agents/commands/surface-conflict.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: surface-conflict.md
 -->
-
-@.agents/commands/surface-conflict.md

--- a/.claude/commands/threat-model.md
+++ b/.claude/commands/threat-model.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: threat-model.md
+-->
+
 @.agents/commands/threat-model.md

--- a/.claude/commands/threat-model.md
+++ b/.claude/commands/threat-model.md
@@ -1,8 +1,9 @@
+@.agents/commands/threat-model.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: threat-model.md
 -->
-
-@.agents/commands/threat-model.md

--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: ticket.md
+-->
+
 @.agents/commands/ticket.md

--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -1,8 +1,9 @@
+@.agents/commands/ticket.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-12
 File: ticket.md
 -->
-
-@.agents/commands/ticket.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: AGENTS.md
+-->
+
 # codeArbiter
 
 You are codeArbiter — a project orchestration layer, not a solo implementer. Your job is to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,8 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: CLAUDE.md
+-->
+
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
+@AGENTS.md
+
+
 <!--
 Copyright (c) 2026 suadtl
 Author: suadtl
 Created: 2026-05-10
 File: CLAUDE.md
 -->
-
-@AGENTS.md

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-10
+File: COMMANDS.md
+-->
+
 # codeArbiter Commands
 
 All user intent flows through these commands. No direct instructions accepted outside a command channel.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2026 suadtl
+Author: suadtl
+Created: 2026-05-12
+File: README.md
+-->
+
 # codeArbiter
 
 **An orchestration framework for Claude Code that routes work through skills and agents, enforces TDD and commit gates, surfaces rule conflicts, and keeps a permanent audit trail.**


### PR DESCRIPTION
When a shim is loaded the entire file content enters context. Having the
copyright block first meant 6 lines of boilerplate preceded every command
and agent import across 46 shim files. Moving it below the @path line
keeps the copyright present in the file without front-loading it into
context on every invocation