### PR TITLE
fix(hook): exclude vendor tree and framework artifacts from H-08 source-code check

### DIFF
--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -7,14 +7,37 @@
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 CONTEXT_FILE="$PROJECT_ROOT/.agents/projectContext/CONTEXT.md"
 
+# Derive FRAMEWORK_ROOT. In vendored mode .agents is a symlink into the
+# framework submodule (e.g. vendor/codearbiter/.agents); in monolith mode
+# .agents is a real directory at PROJECT_ROOT and FRAMEWORK_ROOT collapses to
+# PROJECT_ROOT. The vendor tree is framework-owned, not consumer source, so it
+# must not satisfy the "meaningful source code" check.
+FRAMEWORK_ROOT="$PROJECT_ROOT"
+if [ -L "$PROJECT_ROOT/.agents" ]; then
+  LINK_TARGET=$(readlink "$PROJECT_ROOT/.agents")
+  case "$LINK_TARGET" in
+    /*) AGENTS_DIR="$LINK_TARGET" ;;
+    *)  AGENTS_DIR="$PROJECT_ROOT/$LINK_TARGET" ;;
+  esac
+  FRAMEWORK_ROOT=$(dirname "$AGENTS_DIR")
+fi
+
 if [ ! -f "$CONTEXT_FILE" ] || ! grep -qE '^[[:space:]]*<!--INITIALIZED-->[[:space:]]*$' "$CONTEXT_FILE" 2>/dev/null; then
-  SRC=$(find "$PROJECT_ROOT" \
-    -not -path "$PROJECT_ROOT/.agents/*" \
-    -not -name 'AGENTS.md' \
-    -not -name 'CLAUDE.md' \
-    -not -name 'README.md' \
-    -not -name '.gitignore' \
-    -type f 2>/dev/null | head -1)
+  FIND_ARGS=(
+    -not -path "$PROJECT_ROOT/.git/*"
+    -not -path "$PROJECT_ROOT/.agents/*"
+    -not -path "$PROJECT_ROOT/.claude/*"
+    -not -name 'AGENTS.md'
+    -not -name 'CLAUDE.md'
+    -not -name 'README.md'
+    -not -name 'LICENSE'
+    -not -name '.gitignore'
+    -not -name '.gitmodules'
+  )
+  if [ "$FRAMEWORK_ROOT" != "$PROJECT_ROOT" ]; then
+    FIND_ARGS+=(-not -path "$FRAMEWORK_ROOT/*")
+  fi
+  SRC=$(find "$PROJECT_ROOT" "${FIND_ARGS[@]}" -type f 2>/dev/null | head -1)
   if [ -n "$SRC" ]; then
     echo "STARTUP [H-08]: projectContext not initialized but source code exists. Run /create-context before any other command (AGENTS.md §1 Phase 2)."
   else

--- a/.agents/skills/context-creation/SKILL.md
+++ b/.agents/skills/context-creation/SKILL.md
@@ -15,8 +15,9 @@ Invoke this skill when ALL of the following are true:
 
 - `${PROJECT_ROOT}/.agents/projectContext/CONTEXT.md` does NOT contain the `<!--INITIALIZED-->` sentinel
 - Meaningful source code DOES exist in the repository (defined as: files outside
-  `.agents/`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `.gitignore`, and standard
-  dotfiles/tooling configs)
+  `.git/`, `.agents/`, `.claude/`, the vendored framework tree if any (e.g.
+  `vendor/codearbiter/`), `AGENTS.md`, `CLAUDE.md`, `README.md`, `LICENSE`,
+  `.gitignore`, `.gitmodules`, and standard dotfiles/tooling configs)
 
 This is the brownfield path. When no meaningful source code exists, route to the
 `decompose` skill instead.
@@ -36,9 +37,11 @@ Before Phase 1 begins, confirm in order:
    stop immediately — context already exists. Inform the user and route to normal
    operation (Phase 3 of the startup protocol).
 2. Check for meaningful source code: scan the repository root for files or directories
-   that are not `.agents/`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `.gitignore`, or
-   standard tooling dotfiles (`.editorconfig`, `.prettierrc`, etc.). Meaningful source
-   code MUST be present. If none is found, stop and route to the `decompose` skill.
+   that are not `.git/`, `.agents/`, `.claude/`, the vendored framework tree if any
+   (e.g. `vendor/codearbiter/`), `AGENTS.md`, `CLAUDE.md`, `README.md`, `LICENSE`,
+   `.gitignore`, `.gitmodules`, or standard tooling dotfiles (`.editorconfig`,
+   `.prettierrc`, etc.). Meaningful source code MUST be present. If none is found,
+   stop and route to the `decompose` skill.
 3. Confirm `${PROJECT_ROOT}/.agents/projectContext/` directory exists and is writable. If not, surface
    the gap and stop.
 

--- a/.agents/skills/decompose/SKILL.md
+++ b/.agents/skills/decompose/SKILL.md
@@ -15,8 +15,9 @@ Invoke this skill when ALL of the following are true:
 
 - `${PROJECT_ROOT}/.agents/projectContext/CONTEXT.md` does NOT contain the `<!--INITIALIZED-->` sentinel
 - No meaningful source code exists in the repository (defined as: no files outside
-  `.agents/`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `.gitignore`, and standard
-  dotfiles/tooling configs)
+  `.git/`, `.agents/`, `.claude/`, the vendored framework tree if any (e.g.
+  `vendor/codearbiter/`), `AGENTS.md`, `CLAUDE.md`, `README.md`, `LICENSE`,
+  `.gitignore`, `.gitmodules`, and standard dotfiles/tooling configs)
 
 This is the greenfield path. When meaningful source code exists, route to the
 `context-creation` skill instead.
@@ -36,10 +37,11 @@ Before Phase 1 begins, confirm in order:
    stop immediately — context already exists. Inform the user and route to normal
    operation (Phase 3 of the startup protocol).
 2. Check for meaningful source code: scan the repository root for files or directories
-   that are not `.agents/`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `.gitignore`, or
-   standard tooling dotfiles (`.editorconfig`, `.prettierrc`, etc.). If any such files
-   exist, stop. Do not proceed. Inform the user that source code was detected and route
-   to the `context-creation` skill.
+   that are not `.git/`, `.agents/`, `.claude/`, the vendored framework tree if any
+   (e.g. `vendor/codearbiter/`), `AGENTS.md`, `CLAUDE.md`, `README.md`, `LICENSE`,
+   `.gitignore`, `.gitmodules`, or standard tooling dotfiles (`.editorconfig`,
+   `.prettierrc`, etc.). If any such files exist, stop. Do not proceed. Inform the user
+   that source code was detected and route to the `context-creation` skill.
 3. Confirm `${PROJECT_ROOT}/.agents/projectContext/` directory exists and is writable. If not, surface
    the gap and stop.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,9 @@ On every startup, run this detection sequence BEFORE doing anything else.
 
         YES → go to Phase 3 (Normal Operation)
         NO  → does meaningful source code exist?
-              (files outside .agents/, AGENTS.md, CLAUDE.md, README.md, .gitignore)
+              (files outside .git/, .agents/, .claude/, the vendored framework
+              tree if any, AGENTS.md, CLAUDE.md, README.md, LICENSE,
+              .gitignore, .gitmodules)
 
               YES → Phase 2 (Context Creation)
               NO  → Phase 1 (Decompose)


### PR DESCRIPTION

The session-start H-08 detector treated a fresh vendored-mode consumer as
having "meaningful source code" because the framework submodule at
vendor/codearbiter/ plus .git/ contents satisfied the find scan, falsely
routing the user to /create-context when /decompose is correct.
- Derive FRAMEWORK_ROOT from the .agents symlink; in vendored mode prune
  the framework tree from the source-code scan, in monolith mode collapse
  to PROJECT_ROOT and behave as before.
- Add .git/, .claude/, LICENSE, .gitmodules to the static exclusion list
  — all framework-derived or VCS metadata, never user source. .git/ also
  fixes a latent bug in the prior detector that only happened to "work"
  because real source masked .git/HEAD asthe first find match.
- Sync AGENTS.md §1 detection prose and the matching references in
  decompose/SKILL.md and context-creation/SKILL.md so doc and code agree
  (per the §3 Hard Rule against silent reconciliation).

Verified on a fresh vendored consumer (homeCadence with .agents → vendor
symlink, no source yet): hook now correctly emits the "no source code →
/decompose" variant instead of falsely routing to /create-context.