### PR TITLE
fix(vendor): keep consumer projectContext out of the framework submodule

### DIFF
--- a/.agents/commands/_paths.md
+++ b/.agents/commands/_paths.md
@@ -35,12 +35,22 @@ Two explicit roots govern every file path in framework files:
 
 **Worked example — vendored mode** (consumer mounts codeArbiter at `vendor/codearbiter/`):
 - `${FRAMEWORK_ROOT}/.agents/skills/tdd/SKILL.md` resolves to `vendor/codearbiter/.agents/skills/tdd/SKILL.md`
-- `${PROJECT_ROOT}/.agents/projectContext/audit-spec.md` resolves to `./.agents/projectContext/audit-spec.md` (the consumer's own projectContext)
-- The prefixes diverge; skills read from the framework installation while project data is read from the consumer's repo root.
+- `${PROJECT_ROOT}/.agents/projectContext/audit-spec.md` resolves to `./.agents/projectContext/audit-spec.md` (the consumer's own projectContext — a REAL directory at the consumer's project root, never a symlink into the vendor tree)
+- The prefixes diverge; skills read from the framework installation while project state is read from and written to the consumer's repo root.
 
-**Sentinel file:** `${FRAMEWORK_ROOT}/.agents/AGENTS-CODEARBITER-ROOT` — an empty marker file placed at the codeArbiter installation root. Shell hooks locate `FRAMEWORK_ROOT` at runtime by walking up from their script location until they find a directory containing `AGENTS-CODEARBITER-ROOT`.
+**Layout in vendored mode:** `${PROJECT_ROOT}/.agents/` is a real directory. Its framework-owned subdirs (`skills/`, `agents/`, `commands/`, `hooks/`, `settings.json`) are individual symlinks into `vendor/codearbiter/.agents/...`. Its `projectContext/` is a real directory. This wiring is what keeps consumer state in the consumer repo and the framework submodule clean. `/init-vendor` creates the entire structure.
 
-**Consumer install:** After adding codeArbiter as a submodule, run `/init-vendor [--vendor-path=vendor/codearbiter/]`. This copies `AGENTS.md` to `${PROJECT_ROOT}/AGENTS.md`, writes `${PROJECT_ROOT}/CLAUDE.md` containing `@AGENTS.md`, and generates the `.claude/commands/*.md` shim layer with the vendor path baked in. Re-run after every codeArbiter upgrade to keep `AGENTS.md` current. Default vendor path is `vendor/codearbiter/`.
+**Sentinel file:** `${FRAMEWORK_ROOT}/.agents/AGENTS-CODEARBITER-ROOT` — an empty marker file placed at the codeArbiter installation root. Shell hooks locate `FRAMEWORK_ROOT` at runtime by resolving their own script's physical path (`cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P`) and walking up until they find a directory containing `.agents/AGENTS-CODEARBITER-ROOT`. This works regardless of whether the script was invoked through a per-subdir symlink (vendored mode) or directly (monolith mode).
+
+**Consumer install:** After adding codeArbiter as a submodule, run `/init-vendor [--vendor-path=vendor/codearbiter/]`. This:
+1. Creates `${PROJECT_ROOT}/.agents/` as a real directory.
+2. Symlinks `${PROJECT_ROOT}/.agents/{skills,agents,commands,hooks,settings.json}` individually into the vendor path.
+3. Creates `${PROJECT_ROOT}/.agents/projectContext/` as a real consumer-owned directory.
+4. Symlinks `${PROJECT_ROOT}/.claude/settings.json` to `../.agents/settings.json`.
+5. Copies `${FRAMEWORK_ROOT}/AGENTS.md` to `${PROJECT_ROOT}/AGENTS.md` and writes `${PROJECT_ROOT}/CLAUDE.md` containing `@AGENTS.md`.
+6. Generates the `${PROJECT_ROOT}/.claude/commands/*.md` shim layer with the vendor path baked in.
+
+Re-run with `--force` after every codeArbiter upgrade to keep `AGENTS.md` and shims current. Default vendor path is `vendor/codearbiter/`.
 
 ## Self-edit mode (cross-reference)
 

--- a/.agents/commands/init-vendor.md
+++ b/.agents/commands/init-vendor.md
@@ -9,9 +9,16 @@ File: init-vendor.md
 
 ## Purpose
 
-Generate or regenerate the consuming project's `.claude/commands/*.md` shim layer with the vendor path baked in. Run this after installing codeArbiter as a submodule and after every codeArbiter upgrade.
+Wire the consuming project for codeArbiter after the framework has been added as a submodule (or subtree). This command:
 
-This command is idempotent — safe to re-run. By default it skips shims that already exist.
+1. Establishes a real `${PROJECT_ROOT}/.agents/` directory and symlinks its framework-owned subdirs (`skills/`, `agents/`, `commands/`, `hooks/`, `settings.json`) into the vendor path.
+2. Ensures `${PROJECT_ROOT}/.agents/projectContext/` exists as a **real, consumer-owned directory** at the project root — NEVER a symlink into the vendor tree. This is what keeps consumer project state in the consumer's repo and out of the framework submodule.
+3. Copies `AGENTS.md` to the project root and writes the `CLAUDE.md` shim.
+4. Generates the `.claude/commands/*.md` shim layer with the vendor path baked in.
+
+Run this after installing codeArbiter as a submodule and after every codeArbiter upgrade.
+
+This command is idempotent — safe to re-run. By default it skips files and links that already exist.
 
 ## Usage
 
@@ -32,40 +39,83 @@ This command is idempotent — safe to re-run. By default it skips shims that al
 
 ## Behavior
 
-1. Resolve `${FRAMEWORK_ROOT}` from `--vendor-path` (default: `vendor/codearbiter/`).
-2. **Copy `AGENTS.md` to project root.** Copy `${FRAMEWORK_ROOT}/AGENTS.md` → `${PROJECT_ROOT}/AGENTS.md`. Skip if `${PROJECT_ROOT}/AGENTS.md` already exists and `--force` is not set; overwrite if `--force`.
-3. **Write `CLAUDE.md` at project root.** Write `${PROJECT_ROOT}/CLAUDE.md` containing exactly:
+1. Resolve `${FRAMEWORK_ROOT}` from `--vendor-path` (default: `vendor/codearbiter/`). Verify `${FRAMEWORK_ROOT}/.agents/AGENTS-CODEARBITER-ROOT` exists — if not, stop and report that the vendor path does not point to a codeArbiter installation.
+
+2. **Establish `${PROJECT_ROOT}/.agents/` as a real directory.** If `${PROJECT_ROOT}/.agents` is a symlink (legacy whole-tree wiring from earlier versions of this command), stop and require the user to remove it explicitly — never silently replace, because that path may contain consumer projectContext writes that landed inside the vendor tree. Otherwise, `mkdir -p ${PROJECT_ROOT}/.agents`.
+
+3. **Wire framework-owned subdirs as individual symlinks** into the vendor path. For each of the following, if a real file/directory already exists at the target, stop with a clear error unless `--force` (in which case back it up to `${PROJECT_ROOT}/.agents/<name>.backup-<timestamp>`); if an existing symlink already points to the correct vendor target, skip; if missing, create:
+
+   | Target | Symlink target (relative) |
+   |---|---|
+   | `${PROJECT_ROOT}/.agents/skills` | `<vendor-path>/.agents/skills` |
+   | `${PROJECT_ROOT}/.agents/agents` | `<vendor-path>/.agents/agents` |
+   | `${PROJECT_ROOT}/.agents/commands` | `<vendor-path>/.agents/commands` |
+   | `${PROJECT_ROOT}/.agents/hooks` | `<vendor-path>/.agents/hooks` |
+   | `${PROJECT_ROOT}/.agents/settings.json` | `<vendor-path>/.agents/settings.json` |
+
+   Use relative symlink targets (relative to `${PROJECT_ROOT}/.agents/`) so the wiring survives the host repo being moved or cloned to a different absolute path.
+
+4. **Ensure consumer-owned `projectContext/` exists.** If `${PROJECT_ROOT}/.agents/projectContext` is a symlink (broken state from legacy whole-tree wiring), stop and require manual cleanup. If it does not exist, create the directory (real, not a symlink) and add a `.gitkeep` so it's tracked. Never copy framework dogfood content from `${FRAMEWORK_ROOT}/.agents/projectContext/` into it — `/create-context` or `/decompose` is responsible for populating it.
+
+5. **Wire `${PROJECT_ROOT}/.claude/settings.json`** as a symlink to `../.agents/settings.json` (which itself resolves through `.agents/` into the vendor tree). Same conflict rules as step 3.
+
+6. **Copy `AGENTS.md` to project root.** Copy `${FRAMEWORK_ROOT}/AGENTS.md` → `${PROJECT_ROOT}/AGENTS.md`. Skip if `${PROJECT_ROOT}/AGENTS.md` already exists and `--force` is not set; overwrite if `--force`.
+
+7. **Write `CLAUDE.md` at project root.** Write `${PROJECT_ROOT}/CLAUDE.md` containing exactly:
    ```
    @AGENTS.md
    ```
    Skip if `${PROJECT_ROOT}/CLAUDE.md` already exists and `--force` is not set; overwrite if `--force`.
-4. List all command bodies at `${FRAMEWORK_ROOT}/.agents/commands/*.md` — exclude `_redirect.md` (internal only).
-5. For each `<name>.md` found, generate `${PROJECT_ROOT}/.claude/commands/<name>.md` containing exactly:
+
+8. List all command bodies at `${FRAMEWORK_ROOT}/.agents/commands/*.md` — exclude `_redirect.md`, `_paths.md`, `_reference-map.md`, `_routing-table.md` (internal includes; underscore-prefixed).
+
+9. For each `<name>.md` found, generate `${PROJECT_ROOT}/.claude/commands/<name>.md` containing exactly:
    ```
    @<vendor-path>/.agents/commands/<name>.md
    ```
    Skip if the shim already exists and `--force` is not set; overwrite if `--force`.
-6. Check `${PROJECT_ROOT}/.gitignore` for entries `/.plan-tasks/` and `/revendor/`. Append missing entries (skipped if `--dry-run`).
-7. Report:
-   - Whether `AGENTS.md` was copied, skipped, or overwritten
-   - Whether `CLAUDE.md` was written, skipped, or overwritten
-   - List of shims written (or would be written, in `--dry-run`)
-   - List of shims skipped because they already exist (unless `--force`)
-   - List of `.gitignore` entries added
+
+10. Check `${PROJECT_ROOT}/.gitignore` for entries `/.plan-tasks/` and `/revendor/`. Append missing entries (skipped if `--dry-run`).
+
+11. Report:
+    - Whether `.agents/` was created or already existed
+    - Each subdir symlink: created, already correct, or backed up + replaced
+    - Whether `.agents/projectContext/` was created (real dir) or already existed
+    - Whether `AGENTS.md` was copied, skipped, or overwritten
+    - Whether `CLAUDE.md` was written, skipped, or overwritten
+    - List of `.claude/commands/` shims written (or would be written, in `--dry-run`)
+    - List of `.claude/commands/` shims skipped because they already exist (unless `--force`)
+    - List of `.gitignore` entries added
 
 ## Monolith dogfood mode
 
-With `--vendor-path=.`, the AGENTS.md copy and CLAUDE.md write are skipped (both files already exist at the project root and are the source of truth). Generated shims contain `@./.agents/commands/<name>.md`, equivalent to the existing `@.agents/commands/<name>.md` format.
+With `--vendor-path=.`, this is the framework's own repo being wired against itself. In that case:
+- Steps 2–5 (real `.agents/` + per-subdir symlinks + `.agents/projectContext/`) are skipped: the framework repo already has a real `.agents/` directory with all subdirs as real directories. Re-running `/init-vendor` in monolith mode does NOT replace those real directories with self-referential symlinks.
+- The `AGENTS.md` copy and `CLAUDE.md` write are skipped (both files already exist at the project root and are the source of truth).
+- Generated shims contain `@./.agents/commands/<name>.md`, equivalent to the existing `@.agents/commands/<name>.md` format.
 
 ## Hard Rules
 
 - MUST NOT overwrite `${PROJECT_ROOT}/AGENTS.md` unless `--force` is passed.
 - MUST NOT overwrite `${PROJECT_ROOT}/CLAUDE.md` unless `--force` is passed.
 - MUST NOT overwrite existing shims unless `--force` is passed.
+- MUST NOT replace an existing `${PROJECT_ROOT}/.agents/` symlink (legacy whole-tree wiring) silently — stop and require the user to remove it manually. Such a symlink may have absorbed consumer projectContext writes that need rescue before re-wiring.
+- MUST NOT symlink `${PROJECT_ROOT}/.agents/projectContext/` into the vendor tree under any condition. Consumer project state stays in the consumer repo.
+- MUST NOT copy framework dogfood content from `${FRAMEWORK_ROOT}/.agents/projectContext/` into `${PROJECT_ROOT}/.agents/projectContext/`. The consumer initializes their own via `/create-context` or `/decompose`.
 - MUST print the dry-run report before writing anything when `--dry-run` is passed.
-- MUST NOT modify any framework files (only writes to `${PROJECT_ROOT}/AGENTS.md`, `${PROJECT_ROOT}/CLAUDE.md`, and `${PROJECT_ROOT}/.claude/commands/`).
+- MUST NOT modify any framework files. Only writes to `${PROJECT_ROOT}/AGENTS.md`, `${PROJECT_ROOT}/CLAUDE.md`, `${PROJECT_ROOT}/.agents/` (subdir symlinks + projectContext dir), `${PROJECT_ROOT}/.claude/settings.json`, `${PROJECT_ROOT}/.claude/commands/`, and `${PROJECT_ROOT}/.gitignore`.
 - MUST NOT auto-invoke — this command is user-driven. `/onboard` does not call it automatically.
+
+## Migrating from legacy whole-tree symlink
+
+Earlier versions of the install docs instructed users to `ln -s vendor/codearbiter/.agents .agents`. That wiring caused every write to `${PROJECT_ROOT}/.agents/projectContext/...` to physically land inside the vendor submodule. To migrate:
+
+1. **Rescue consumer projectContext first.** Inspect `vendor/codearbiter/.agents/projectContext/` for files the consumer authored (CONTEXT.md with their content, their ADRs, tickets, overrides.log, etc.). Copy them somewhere safe outside the vendor tree.
+2. Remove the legacy symlink: `rm .agents`
+3. Re-run `/init-vendor --vendor-path=vendor/codearbiter/` — it creates the new per-subdir wiring.
+4. Move the rescued projectContext content into the new real `${PROJECT_ROOT}/.agents/projectContext/`.
+5. In the vendor submodule, the previously-leaked consumer projectContext files remain as uncommitted noise in `vendor/codearbiter/`. Reset the submodule (`git -C vendor/codearbiter checkout -- .` or re-checkout the pinned SHA) to clean it up.
 
 ## Not in monolith mode
 
-This command is primarily designed for consumers who have vendored codeArbiter. In monolith dogfood mode (this repo), the `.claude/commands/` shims are already correct. You may run `/init-vendor --vendor-path=. --dry-run` to verify they match the expected output.
+This command is primarily designed for consumers who have vendored codeArbiter. In monolith dogfood mode (this repo), the framework directories are already real and the `.claude/commands/` shims are already correct. You may run `/init-vendor --vendor-path=. --dry-run` to verify the shim output matches what would be generated.

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -7,19 +7,23 @@
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 CONTEXT_FILE="$PROJECT_ROOT/.agents/projectContext/CONTEXT.md"
 
-# Derive FRAMEWORK_ROOT. In vendored mode .agents is a symlink into the
-# framework submodule (e.g. vendor/codearbiter/.agents); in monolith mode
-# .agents is a real directory at PROJECT_ROOT and FRAMEWORK_ROOT collapses to
-# PROJECT_ROOT. The vendor tree is framework-owned, not consumer source, so it
-# must not satisfy the "meaningful source code" check.
-FRAMEWORK_ROOT="$PROJECT_ROOT"
-if [ -L "$PROJECT_ROOT/.agents" ]; then
-  LINK_TARGET=$(readlink "$PROJECT_ROOT/.agents")
-  case "$LINK_TARGET" in
-    /*) AGENTS_DIR="$LINK_TARGET" ;;
-    *)  AGENTS_DIR="$PROJECT_ROOT/$LINK_TARGET" ;;
-  esac
-  FRAMEWORK_ROOT=$(dirname "$AGENTS_DIR")
+# Derive FRAMEWORK_ROOT by resolving this script's physical location.
+#
+# Vendored install (per /init-vendor): ${PROJECT_ROOT}/.agents/ is a REAL
+# directory whose subdirs (skills/, agents/, commands/, hooks/, settings.json)
+# are individually symlinked into vendor/codearbiter/.agents/. projectContext/
+# is a real directory consumer-owned at PROJECT_ROOT — never in the vendor
+# tree. So ${BASH_SOURCE[0]} is e.g. ${PROJECT_ROOT}/.agents/hooks/session-start.sh
+# (the symlink path); `pwd -P` after cd resolves it to the physical path under
+# vendor/codearbiter/.agents/hooks/ and we strip two levels to get FRAMEWORK_ROOT.
+#
+# Monolith install (this repo): no symlinks; physical path == invocation path
+# and FRAMEWORK_ROOT collapses to PROJECT_ROOT.
+HOOKS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)
+if [ -n "$HOOKS_DIR" ] && [ -f "$(dirname "$(dirname "$HOOKS_DIR")")/.agents/AGENTS-CODEARBITER-ROOT" ]; then
+  FRAMEWORK_ROOT=$(dirname "$(dirname "$HOOKS_DIR")")
+else
+  FRAMEWORK_ROOT="$PROJECT_ROOT"
 fi
 
 # Phase 0 — Monolith Self-Edit Detection (per AGENTS.md §1 Phase 0).

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,17 @@ legacy/
 # resumable via /decompose if a session is interrupted. Never committed.
 .agents/projectContext/.decompose-draft/
 
+# Framework dogfood projectContext — local-only state for developers working
+# ON the framework itself. The framework's own AGENTS.md, skills, and commands
+# encode its design; projectContext here is per-developer dogfood usage state
+# and would otherwise travel with the submodule into consumer vendor trees as
+# noise. Consumer projects have their own real .agents/projectContext/ at
+# their PROJECT_ROOT (created by /init-vendor), wired via the per-subdir
+# symlink layout — so this directory in the framework repo is irrelevant to
+# them by construction. NOTE: files that were tracked before this rule was
+# added remain tracked until explicitly removed with `git rm --cached`.
+.agents/projectContext/
+
 # Ephemeral execution scaffolding written by long plan runs. Removed in
 # the plan's Phase K cleanup. Never committed.
 /.plan-tasks/

--- a/README.md
+++ b/README.md
@@ -18,11 +18,8 @@ The full specification is in [`AGENTS.md`](./AGENTS.md). The command catalog is 
 ## How it works
 
 ```
-.agents/
-├── agents/           # Reviewer subagent definitions (auth-crypto, migration, dependency, …)
-├── commands/         # Slash command bodies (/feature, /fix, /commit, /pr, /stage, …)
-├── hooks/            # Pre/post tool-use hooks + statusline + session-start
-├── projectContext/   # The single source of truth for project state
+.agents/                              (real directory, lives at ${PROJECT_ROOT})
+├── projectContext/   # Consumer-owned state — REAL directory, never symlinked into the vendor tree
 │   ├── CONTEXT.md          # Identity, scope, NOT-this-project (sentinel: <!--INITIALIZED-->)
 │   ├── stage               # Single integer: current stage
 │   ├── open-tasks.md       # In-flight, backlog, blocked
@@ -31,16 +28,19 @@ The full specification is in [`AGENTS.md`](./AGENTS.md). The command catalog is 
 │   ├── decisions/          # ADRs
 │   ├── tickets/            # Optional scope-overflow inbox
 │   └── …                   # tech-stack, security-controls, audit-spec, etc.
-├── skills/           # Orchestration skills (tdd, commit-gate, ticketing-router, …)
-└── settings.json     # Claude Code config: MCP servers, hooks, statusline
+├── agents/        → vendor/codearbiter/.agents/agents/      (symlink — framework code)
+├── commands/      → vendor/codearbiter/.agents/commands/    (symlink — framework code)
+├── hooks/         → vendor/codearbiter/.agents/hooks/       (symlink — framework code)
+├── skills/        → vendor/codearbiter/.agents/skills/      (symlink — framework code)
+└── settings.json  → vendor/codearbiter/.agents/settings.json (symlink — framework config)
 
 .claude/              # Shim layer — what Claude Code natively reads
-├── settings.json   → ../.agents/settings.json   (always a symlink)
+├── settings.json   → ../.agents/settings.json   (symlink — resolves into the vendor tree)
 ├── agents/         → ../.agents/agents/         (symlink in monolith; per-file @path shims after /init-vendor)
 └── commands/       → ../.agents/commands/       (symlink in monolith; per-file @path shims after /init-vendor)
 ```
 
-The `.claude/` directory is what Claude Code natively reads. All real content lives under `.agents/` so the framework can be lifted into another project as a single unit. **In a consuming host project**, `/init-vendor` generates per-file shim files in `.claude/commands/` and `.claude/agents/` containing a single `@vendor/codearbiter/.agents/commands/<name>.md` import line — so every `/command` resolves into the vendored framework without modifying `settings.json`.
+The `.claude/` directory is what Claude Code natively reads. The `.agents/` directory at the project root is **real** — only its framework-owned subdirs are symlinked into the vendor tree. `projectContext/` is always a real, consumer-owned directory at `${PROJECT_ROOT}/.agents/projectContext/` so consumer project state commits to the consumer repo, not the framework submodule. **In a consuming host project**, `/init-vendor` creates this entire structure: the real `.agents/` directory, the per-subdir symlinks, the empty `projectContext/`, and the per-file `.claude/commands/*.md` shims (`@vendor/codearbiter/.agents/commands/<name>.md` import lines) — so every `/command` resolves into the vendored framework without modifying `settings.json`.
 
 ---
 
@@ -81,11 +81,15 @@ Your project state (`projectContext/`, ADRs, tickets, overrides log) always live
 
 Running `/init-vendor --vendor-path=vendor/codearbiter/` inside Claude Code:
 
-1. **Copies `AGENTS.md`** from the vendor path to your repo root — Claude Code must be able to find `AGENTS.md` at `$CLAUDE_PROJECT_DIR` to load the orchestrator
-2. **Writes `CLAUDE.md`** at your repo root containing `@AGENTS.md` — the standard Claude Code project-instructions shim
-3. **Generates `.claude/commands/*.md` shims** pointing into the vendor path so every `/command` resolves correctly
+1. **Creates a real `${PROJECT_ROOT}/.agents/` directory** at your repo root (if it doesn't already exist as a real dir).
+2. **Symlinks the framework-owned subdirs** inside it — `skills/`, `agents/`, `commands/`, `hooks/`, `settings.json` — into the vendor path. Upgrades to codeArbiter are then just `git submodule update`; no re-copying.
+3. **Creates `${PROJECT_ROOT}/.agents/projectContext/` as a real directory** owned by the consumer. Your CONTEXT.md, ADRs, tickets, overrides log, etc. all live here, in your repo — never in the framework submodule.
+4. **Symlinks `${PROJECT_ROOT}/.claude/settings.json`** to `../.agents/settings.json` so Claude Code picks up the framework's hooks and MCP config.
+5. **Copies `AGENTS.md`** from the vendor path to your repo root — Claude Code must be able to find `AGENTS.md` at `$CLAUDE_PROJECT_DIR` to load the orchestrator.
+6. **Writes `CLAUDE.md`** at your repo root containing `@AGENTS.md` — the standard Claude Code project-instructions shim.
+7. **Generates `.claude/commands/*.md` shims** pointing into the vendor path so every `/command` resolves correctly.
 
-Re-run with `--force` after every codeArbiter upgrade to keep `AGENTS.md` and all shims current.
+Re-run with `--force` after every codeArbiter upgrade to keep `AGENTS.md` and all shims current. The framework subdir symlinks are stable — they don't need refreshing on upgrade since they always resolve into the current submodule SHA.
 
 ---
 
@@ -96,22 +100,18 @@ Re-run with `--force` after every codeArbiter upgrade to keep `AGENTS.md` and al
 git submodule add <repo-url> vendor/codearbiter
 git commit -m "vendor: add codeArbiter submodule"
 
-# 2. Symlink .agents/ so hook commands (bash .agents/hooks/…) resolve at repo root
-ln -s vendor/codearbiter/.agents .agents
-
-# 3. Symlink .claude/settings.json so Claude Code picks up hooks and MCP config
-mkdir -p .claude
-ln -s ../vendor/codearbiter/.agents/settings.json .claude/settings.json
-
-git add .agents .claude
-git commit -m "vendor: wire codeArbiter hooks and settings"
-
-# 4. Open Claude Code and run /init-vendor
+# 2. Open Claude Code and run /init-vendor. This creates the real .agents/
+#    directory at your repo root, symlinks the framework subdirs into the
+#    vendor path, creates the real consumer-owned .agents/projectContext/,
+#    copies AGENTS.md, writes CLAUDE.md, and generates .claude/commands/ shims.
 claude
 # → /init-vendor --vendor-path=vendor/codearbiter/
-# This writes AGENTS.md and CLAUDE.md at your repo root and generates .claude/commands/ shims.
 
-# 5. Initialize project context
+# 3. Commit the wiring (.agents/ subdir symlinks + projectContext placeholder + AGENTS.md + CLAUDE.md + .claude/)
+git add .agents .claude AGENTS.md CLAUDE.md
+git commit -m "vendor: wire codeArbiter"
+
+# 4. Initialize project context
 # → /create-context   (existing codebase)
 # → /decompose        (new project, no code yet)
 ```
@@ -152,11 +152,10 @@ After you push that host commit, teammates pick it up via `git pull --recurse-su
 
 ```sh
 git subtree add --prefix=vendor/codearbiter <repo-url> main --squash
-ln -s vendor/codearbiter/.agents .agents
-mkdir -p .claude
-ln -s ../vendor/codearbiter/.agents/settings.json .claude/settings.json
-git add .agents .claude && git commit -m "vendor: wire codeArbiter"
 # Then in Claude Code: /init-vendor --vendor-path=vendor/codearbiter/
+# (creates .agents/ with per-subdir symlinks, real .agents/projectContext/,
+#  AGENTS.md, CLAUDE.md, and .claude/ shims)
+git add .agents .claude AGENTS.md CLAUDE.md && git commit -m "vendor: wire codeArbiter"
 ```
 
 To upgrade:
@@ -178,7 +177,9 @@ Everything is already at the root so `/init-vendor` is not needed. No path to pu
 
 ---
 
-**Why the `.agents/` symlink?** Hook commands in `settings.json` reference bare paths like `bash .agents/hooks/session-start.sh`, resolved relative to your repo root. The symlink lets those resolve into the vendored tree without modifying `settings.json`. At runtime the hooks themselves walk up from their script location until they find the `${FRAMEWORK_ROOT}/.agents/AGENTS-CODEARBITER-ROOT` sentinel to discover `FRAMEWORK_ROOT` (vendored or monolith), then derive `PROJECT_ROOT` from the git toplevel. Your project state (`projectContext/`) is written into the symlinked `.agents/` and ends up in the vendored tree — if you want strict separation, copy instead of symlinking and point the hook paths at the vendor location manually.
+**Why per-subdir symlinks instead of one big `.agents/` symlink?** Earlier versions of these install instructions had you `ln -s vendor/codearbiter/.agents .agents`. That looked simpler, but every write to `${PROJECT_ROOT}/.agents/projectContext/...` then physically landed inside `vendor/codearbiter/.agents/projectContext/` — i.e. inside the framework submodule. Consumer state (CONTEXT.md, ADRs, tickets, overrides.log) would not commit to the consumer's repo and would silently pollute the submodule. The current wiring keeps `.agents/` itself a real directory at the project root and only symlinks the framework-owned subdirs (`skills/`, `agents/`, `commands/`, `hooks/`, `settings.json`), so `projectContext/` is always a real consumer-owned directory. At runtime hooks resolve their own physical path via `pwd -P` and verify they sit under a directory containing the `${FRAMEWORK_ROOT}/.agents/AGENTS-CODEARBITER-ROOT` sentinel to discover `FRAMEWORK_ROOT`; `PROJECT_ROOT` comes from `git rev-parse --show-toplevel`.
+
+**Migrating an existing install** that used the legacy whole-tree symlink: see the "Migrating from legacy whole-tree symlink" section in [`.agents/commands/init-vendor.md`](./.agents/commands/init-vendor.md). The short version: rescue any consumer projectContext that landed in the vendor tree, remove the `.agents` symlink, re-run `/init-vendor`, move the rescued content into the new real `${PROJECT_ROOT}/.agents/projectContext/`.
 
 **Note on README/LICENSE:** these root files don't travel with the framework. Your host project has its own. Authoritative docs for framework components (statusline, etc.) live under `.agents/` so they follow the code. See [`.agents/hooks/STATUSLINE.md`](./.agents/hooks/STATUSLINE.md).
 


### PR DESCRIPTION
## Summary

- The legacy install instructions (`ln -s vendor/codearbiter/.agents .agents`) made every write to `${PROJECT_ROOT}/.agents/projectContext/...` land inside the vendor submodule. Consumer state never reached the consumer's repo and silently polluted the framework submodule.
- Switch to a real `${PROJECT_ROOT}/.agents/` directory with framework subdirs (`skills/`, `agents/`, `commands/`, `hooks/`, `settings.json`) symlinked individually into the vendor path. `projectContext/` is always a real consumer-owned dir.
- Gitignore the framework's own dogfood `projectContext/` so new dogfood writes don't travel with the submodule into consumer vendor trees.

## Changes

**Commit 1 — `fix(vendor)`:**
- `/init-vendor` now wires the `.agents/` subdir layout itself instead of expecting the user to `ln -s` manually. Hard Rules forbid silent replacement of an existing top-level `.agents` symlink. Includes a "Migrating from legacy whole-tree symlink" rescue procedure.
- `session-start.sh` resolves `FRAMEWORK_ROOT` via `pwd -P` on its own script location + `AGENTS-CODEARBITER-ROOT` sentinel check, replacing the `.agents`-symlink probe that codified the broken model.
- README install steps drop the manual `ln -s .agents` for Options A (submodule) and B (subtree). The "your state ends up in the vendored tree" footnote is replaced with an explanation of the per-subdir symlink design.
- `_paths.md` install paragraph reflects the new wiring.

**Commit 2 — `chore`:**
- Adds `.agents/projectContext/` to `.gitignore`. Currently-tracked framework dogfood files remain tracked until explicitly untracked with `git rm --cached -r .agents/projectContext/` (deferred — sacrifices ~559 lines of shared dogfood policy state).

## Test plan

- [ ] Bash syntax check on `session-start.sh` — passes (`bash -n`).
- [ ] Self-edit mode hook output reproduces locally with `bash .agents/hooks/session-start.sh` after `touch .agents/SELF-EDIT-MODE`.
- [ ] Manually verify in a fresh consumer repo: `git submodule add` + `/init-vendor --vendor-path=vendor/codearbiter/` produces the documented layout (real `.agents/`, per-subdir symlinks, real `.agents/projectContext/`, copied `AGENTS.md`, `CLAUDE.md`, `.claude/commands/*.md` shims).
- [ ] Verify legacy-install detection: re-running `/init-vendor` against a clone where `.agents` is a whole-tree symlink stops with the documented error instead of silently overwriting.
- [ ] Verify monolith dogfood: `/init-vendor --vendor-path=. --dry-run` in this repo doesn't propose to replace real framework subdirs with self-referential symlinks.
- [ ] Confirm `FRAMEWORK_ROOT` walk-up works under both invocation paths: directly from the framework's own checkout, and through a per-subdir symlink in a consumer repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SsEE2JPKGQ9Sp2PEnShbU)_