### PR TITLE
feat(init-vendor): generate .claude/agents/ shims + tighten conflict resolution

### DIFF
--- a/.agents/commands/init-vendor.md
+++ b/.agents/commands/init-vendor.md
@@ -14,7 +14,7 @@ Wire the consuming project for codeArbiter after the framework has been added as
 1. Establishes a real `${PROJECT_ROOT}/.agents/` directory and symlinks its framework-owned subdirs (`skills/`, `agents/`, `commands/`, `hooks/`, `settings.json`) into the vendor path.
 2. Ensures `${PROJECT_ROOT}/.agents/projectContext/` exists as a **real, consumer-owned directory** at the project root — NEVER a symlink into the vendor tree. This is what keeps consumer project state in the consumer's repo and out of the framework submodule.
 3. Copies `AGENTS.md` to the project root and writes the `CLAUDE.md` shim.
-4. Generates the `.claude/commands/*.md` shim layer with the vendor path baked in.
+4. Generates the `.claude/commands/*.md` and `.claude/agents/*.md` shim layers with the vendor path baked in, so every `/command` and dispatched subagent resolves into the vendored framework.
 
 Run this after installing codeArbiter as a submodule and after every codeArbiter upgrade.
 
@@ -43,7 +43,16 @@ This command is idempotent — safe to re-run. By default it skips files and lin
 
 2. **Establish `${PROJECT_ROOT}/.agents/` as a real directory.** If `${PROJECT_ROOT}/.agents` is a symlink (legacy whole-tree wiring from earlier versions of this command), stop and require the user to remove it explicitly — never silently replace, because that path may contain consumer projectContext writes that landed inside the vendor tree. Otherwise, `mkdir -p ${PROJECT_ROOT}/.agents`.
 
-3. **Wire framework-owned subdirs as individual symlinks** into the vendor path. For each of the following, if a real file/directory already exists at the target, stop with a clear error unless `--force` (in which case back it up to `${PROJECT_ROOT}/.agents/<name>.backup-<timestamp>`); if an existing symlink already points to the correct vendor target, skip; if missing, create:
+3. **Wire framework-owned subdirs as individual symlinks** into the vendor path. For each target listed below, apply this resolution table:
+
+   | State at target | Action |
+   |---|---|
+   | Missing | Create the symlink. |
+   | Existing symlink, points to the expected `<vendor-path>/.agents/<name>` | Skip (idempotent). |
+   | Existing symlink, points elsewhere (e.g., stale path from a previous vendor location) | Error unless `--force`. With `--force`, replace the symlink. |
+   | Existing real file or real directory | Error unless `--force`. With `--force`, back it up to `${PROJECT_ROOT}/.agents/<name>.backup-<timestamp>`, then create the symlink. |
+
+   Targets:
 
    | Target | Symlink target (relative) |
    |---|---|
@@ -55,9 +64,17 @@ This command is idempotent — safe to re-run. By default it skips files and lin
 
    Use relative symlink targets (relative to `${PROJECT_ROOT}/.agents/`) so the wiring survives the host repo being moved or cloned to a different absolute path.
 
-4. **Ensure consumer-owned `projectContext/` exists.** If `${PROJECT_ROOT}/.agents/projectContext` is a symlink (broken state from legacy whole-tree wiring), stop and require manual cleanup. If it does not exist, create the directory (real, not a symlink) and add a `.gitkeep` so it's tracked. Never copy framework dogfood content from `${FRAMEWORK_ROOT}/.agents/projectContext/` into it — `/create-context` or `/decompose` is responsible for populating it.
+4. **Ensure consumer-owned `projectContext/` exists.** Apply this resolution:
 
-5. **Wire `${PROJECT_ROOT}/.claude/settings.json`** as a symlink to `../.agents/settings.json` (which itself resolves through `.agents/` into the vendor tree). Same conflict rules as step 3.
+   | State at `${PROJECT_ROOT}/.agents/projectContext` | Action |
+   |---|---|
+   | Missing | Create as a real directory and add a `.gitkeep` so the empty dir is tracked. |
+   | Existing real directory (already a consumer-owned dir) | Skip — leave contents untouched. Do NOT add a `.gitkeep` if other files are already present. |
+   | Symlink (any target) | Stop and require manual cleanup. This is a broken state from legacy whole-tree wiring; the symlink target may contain consumer projectContext writes that need rescue before re-wiring. |
+
+   Never copy framework dogfood content from `${FRAMEWORK_ROOT}/.agents/projectContext/` into `${PROJECT_ROOT}/.agents/projectContext/` — `/create-context` or `/decompose` is responsible for populating it.
+
+5. **Wire `${PROJECT_ROOT}/.claude/settings.json`** as a symlink to `../.agents/settings.json` (which itself resolves through `.agents/` into the vendor tree). Apply the same four-row resolution table as step 3 (missing / correct symlink / stale symlink / real file).
 
 6. **Copy `AGENTS.md` to project root.** Copy `${FRAMEWORK_ROOT}/AGENTS.md` → `${PROJECT_ROOT}/AGENTS.md`. Skip if `${PROJECT_ROOT}/AGENTS.md` already exists and `--force` is not set; overwrite if `--force`.
 
@@ -67,43 +84,53 @@ This command is idempotent — safe to re-run. By default it skips files and lin
    ```
    Skip if `${PROJECT_ROOT}/CLAUDE.md` already exists and `--force` is not set; overwrite if `--force`.
 
-8. List all command bodies at `${FRAMEWORK_ROOT}/.agents/commands/*.md` — exclude `_redirect.md`, `_paths.md`, `_reference-map.md`, `_routing-table.md` (internal includes; underscore-prefixed).
+8. **Generate `.claude/commands/*.md` shims.** List all command bodies at `${FRAMEWORK_ROOT}/.agents/commands/*.md` — exclude underscore-prefixed files (`_redirect.md`, `_paths.md`, `_reference-map.md`, `_routing-table.md`; internal includes that are not user commands).
 
-9. For each `<name>.md` found, generate `${PROJECT_ROOT}/.claude/commands/<name>.md` containing exactly:
+   For each `<name>.md` found, generate `${PROJECT_ROOT}/.claude/commands/<name>.md` containing exactly:
    ```
    @<vendor-path>/.agents/commands/<name>.md
    ```
    Skip if the shim already exists and `--force` is not set; overwrite if `--force`.
 
+9. **Generate `.claude/agents/*.md` shims.** List all agent bodies at `${FRAMEWORK_ROOT}/.agents/agents/*.md` — exclude `INDEX.md` (surface scan, not a dispatchable agent) and any underscore-prefixed files.
+
+   For each `<name>.md` found, generate `${PROJECT_ROOT}/.claude/agents/<name>.md` containing exactly:
+   ```
+   @<vendor-path>/.agents/agents/<name>.md
+   ```
+   Create `${PROJECT_ROOT}/.claude/agents/` if it does not exist. Skip individual shims that already exist when `--force` is not set; overwrite if `--force`.
+
 10. Check `${PROJECT_ROOT}/.gitignore` for entries `/.plan-tasks/` and `/revendor/`. Append missing entries (skipped if `--dry-run`).
 
 11. Report:
     - Whether `.agents/` was created or already existed
-    - Each subdir symlink: created, already correct, or backed up + replaced
-    - Whether `.agents/projectContext/` was created (real dir) or already existed
+    - Each subdir symlink: created, already correct, replaced (stale target), or backed up + replaced (real file/dir)
+    - Whether `.agents/projectContext/` was created (real dir), already existed as a real dir (skipped), or errored (symlink found)
+    - Whether `.claude/settings.json` symlink was created, already correct, replaced, or backed up + replaced
     - Whether `AGENTS.md` was copied, skipped, or overwritten
     - Whether `CLAUDE.md` was written, skipped, or overwritten
-    - List of `.claude/commands/` shims written (or would be written, in `--dry-run`)
-    - List of `.claude/commands/` shims skipped because they already exist (unless `--force`)
+    - List of `.claude/commands/` shims written, skipped, or overwritten (or would be, in `--dry-run`)
+    - List of `.claude/agents/` shims written, skipped, or overwritten (or would be, in `--dry-run`)
     - List of `.gitignore` entries added
 
 ## Monolith dogfood mode
 
 With `--vendor-path=.`, this is the framework's own repo being wired against itself. In that case:
-- Steps 2–5 (real `.agents/` + per-subdir symlinks + `.agents/projectContext/`) are skipped: the framework repo already has a real `.agents/` directory with all subdirs as real directories. Re-running `/init-vendor` in monolith mode does NOT replace those real directories with self-referential symlinks.
+- Steps 2–5 (real `.agents/` + per-subdir symlinks + `.agents/projectContext/` + `.claude/settings.json` symlink) are skipped: the framework repo already has a real `.agents/` directory with all subdirs as real directories. Re-running `/init-vendor` in monolith mode does NOT replace those real directories with self-referential symlinks.
 - The `AGENTS.md` copy and `CLAUDE.md` write are skipped (both files already exist at the project root and are the source of truth).
-- Generated shims contain `@./.agents/commands/<name>.md`, equivalent to the existing `@.agents/commands/<name>.md` format.
+- The shim-generation steps (8 and 9) DO run and produce `@./.agents/commands/<name>.md` / `@./.agents/agents/<name>.md`, equivalent to the existing `@.agents/...` format already present in this repo. Without `--force` they are skipped because the existing shims match.
 
 ## Hard Rules
 
 - MUST NOT overwrite `${PROJECT_ROOT}/AGENTS.md` unless `--force` is passed.
 - MUST NOT overwrite `${PROJECT_ROOT}/CLAUDE.md` unless `--force` is passed.
-- MUST NOT overwrite existing shims unless `--force` is passed.
-- MUST NOT replace an existing `${PROJECT_ROOT}/.agents/` symlink (legacy whole-tree wiring) silently — stop and require the user to remove it manually. Such a symlink may have absorbed consumer projectContext writes that need rescue before re-wiring.
+- MUST NOT overwrite existing `.claude/commands/` or `.claude/agents/` shims unless `--force` is passed.
+- MUST NOT silently replace an existing symlink pointing to an unexpected target. A stale symlink (e.g., previous vendor path before the user moved the submodule) requires `--force` and is reported in the output.
+- MUST NOT replace an existing `${PROJECT_ROOT}/.agents/` symlink (legacy whole-tree wiring) silently under any condition, even with `--force`. Such a symlink may have absorbed consumer projectContext writes that need rescue before re-wiring — the user must remove it manually after following the migration procedure below.
 - MUST NOT symlink `${PROJECT_ROOT}/.agents/projectContext/` into the vendor tree under any condition. Consumer project state stays in the consumer repo.
 - MUST NOT copy framework dogfood content from `${FRAMEWORK_ROOT}/.agents/projectContext/` into `${PROJECT_ROOT}/.agents/projectContext/`. The consumer initializes their own via `/create-context` or `/decompose`.
 - MUST print the dry-run report before writing anything when `--dry-run` is passed.
-- MUST NOT modify any framework files. Only writes to `${PROJECT_ROOT}/AGENTS.md`, `${PROJECT_ROOT}/CLAUDE.md`, `${PROJECT_ROOT}/.agents/` (subdir symlinks + projectContext dir), `${PROJECT_ROOT}/.claude/settings.json`, `${PROJECT_ROOT}/.claude/commands/`, and `${PROJECT_ROOT}/.gitignore`.
+- MUST NOT modify any framework files. Only writes to `${PROJECT_ROOT}/AGENTS.md`, `${PROJECT_ROOT}/CLAUDE.md`, `${PROJECT_ROOT}/.agents/` (subdir symlinks + projectContext dir + backups under `<name>.backup-<timestamp>`), `${PROJECT_ROOT}/.claude/settings.json`, `${PROJECT_ROOT}/.claude/commands/`, `${PROJECT_ROOT}/.claude/agents/`, and `${PROJECT_ROOT}/.gitignore`.
 - MUST NOT auto-invoke — this command is user-driven. `/onboard` does not call it automatically.
 
 ## Migrating from legacy whole-tree symlink
@@ -118,4 +145,4 @@ Earlier versions of the install docs instructed users to `ln -s vendor/codearbit
 
 ## Not in monolith mode
 
-This command is primarily designed for consumers who have vendored codeArbiter. In monolith dogfood mode (this repo), the framework directories are already real and the `.claude/commands/` shims are already correct. You may run `/init-vendor --vendor-path=. --dry-run` to verify the shim output matches what would be generated.
+This command is primarily designed for consumers who have vendored codeArbiter. In monolith dogfood mode (this repo), the framework directories are already real and the `.claude/commands/` and `.claude/agents/` shims are already correct. You may run `/init-vendor --vendor-path=. --dry-run` to verify the shim output matches what would be generated.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Running `/init-vendor --vendor-path=vendor/codearbiter/` inside Claude Code:
 5. **Copies `AGENTS.md`** from the vendor path to your repo root — Claude Code must be able to find `AGENTS.md` at `$CLAUDE_PROJECT_DIR` to load the orchestrator.
 6. **Writes `CLAUDE.md`** at your repo root containing `@AGENTS.md` — the standard Claude Code project-instructions shim.
 7. **Generates `.claude/commands/*.md` shims** pointing into the vendor path so every `/command` resolves correctly.
+8. **Generates `.claude/agents/*.md` shims** for every dispatchable agent so subagents resolve into the vendor path too.
 
-Re-run with `--force` after every codeArbiter upgrade to keep `AGENTS.md` and all shims current. The framework subdir symlinks are stable — they don't need refreshing on upgrade since they always resolve into the current submodule SHA.
+Re-run with `--force` after every codeArbiter upgrade to keep `AGENTS.md` and all shims current (the framework may add new commands or agents that need fresh shims). The framework subdir symlinks themselves are stable — they don't need refreshing on upgrade since they always resolve into the current submodule SHA.
 
 ---
 


### PR DESCRIPTION
Follow-up to #17. Closes three gaps surfaced in the post-merge verification pass.

## Summary

- `/init-vendor` now generates `${PROJECT_ROOT}/.claude/agents/*.md` shims alongside `.claude/commands/*.md`. The agents directory was previously never created by `/init-vendor` in consumer installs even though the framework ships `.claude/agents/*.md` files in monolith mode — consumers had no way to get them without manual copying.
- Step 3 (framework subdir symlinks) and step 5 (`.claude/settings.json` symlink) gain an explicit four-row resolution table covering: missing / existing-correct symlink (skip) / existing-stale symlink pointing elsewhere (error unless `--force`) / existing real file or dir (error unless `--force`, then back up to `.backup-<timestamp>`). The stale-symlink case was previously undefined.
- Step 4 (`projectContext`) spells out the "exists as a real directory" path as a no-op skip — previously implicit, easy to misread as "do nothing including the `.gitkeep`" which could create an unwanted `.gitkeep` if files are already present.

Also updates Hard Rules to forbid silent symlink replacement on stale targets, lists `.claude/agents/` as a write target, and refreshes the Monolith section + Purpose summary + the README's "What `/init-vendor` does" bullet list to reflect the new agent-shim step.

## Test plan

- [ ] Re-read updated `init-vendor.md`: step numbering 1–11 contiguous; Purpose bullets 3+4 match steps 6–9; Monolith section consistent.
- [ ] Verify `${FRAMEWORK_ROOT}/.agents/agents/INDEX.md` (and other underscore-prefixed files, if any) is excluded from generated `.claude/agents/*.md` shims.
- [ ] Fresh consumer install end-to-end: `git submodule add` + `/init-vendor --vendor-path=vendor/codearbiter/` produces both `.claude/commands/*.md` and `.claude/agents/*.md` shims with the right `@vendor/...` import targets.
- [ ] Stale-symlink scenario: rename the vendor directory (`mv vendor/codearbiter vendor/codearbiter-v2`), re-run `/init-vendor --vendor-path=vendor/codearbiter-v2/` without `--force` — should error. With `--force` — should replace.
- [ ] Existing-real-dir-in-projectContext scenario: `mkdir .agents/projectContext/x && touch .agents/projectContext/x/foo.md`, re-run `/init-vendor` — should leave the directory and its contents untouched, no spurious `.gitkeep` written.