### PR TITLE
feat(farm): cost-arbitrage execution backend for /sprint --farm

### DIFF
--- a/.codearbiter/farm.md
+++ b/.codearbiter/farm.md
@@ -4,6 +4,13 @@
 the farm runs cheap Zen workers in isolated git worktrees to make each test pass; Claude reviews
 and merges. The cheap model cannot redefine the gates — only pass them.
 
+**The arbitrage is in who writes the code, never in whether it's reviewed.** Every task the farm
+reports green is still routed through the normal spec-compliance, quality, and fresh-verification
+gates (`subagent-driven-development` Phases 3–5) before acceptance. The dispatcher additionally runs a
+zero-token anti-gaming guard (rejects an impl that hard-codes the test's asserted value), protects the
+failing test from being modified, contains all worker writes inside the worktree, and trips a circuit
+breaker if too many tasks escalate (a sign the model isn't capable of the slice).
+
 ## Required
 
 ### `FARM_API_KEY`
@@ -18,29 +25,40 @@ Never commit this key. It must not appear in `.codearbiter/` audit files.
 
 ### `FARM_API_BASE_URL`
 
-The OpenAI-compatible endpoint base URL. Defaults to `https://api.opencode.ai/v1` if set in `.env`.
-Override for DeepSeek direct (`https://api.deepseek.com/v1`), Ollama (`http://localhost:11434/v1`), etc.
+The OpenAI-compatible endpoint base URL. Resolution order: `FARM_API_BASE_URL` env → `plan.meta.apiBaseUrl`
+→ a built-in default of `https://api.opencode.ai/v1`. Override for DeepSeek direct
+(`https://api.deepseek.com/v1`), Ollama (`http://localhost:11434/v1`), etc.
 
-## Model selection — automatic at dispatch time
+## Model selection — measured at dispatch time
 
-`FARM_MODEL` is normally **not set**. Before each `/ca:sprint --farm` run, `subagent-driven-development`
-performs a fresh websearch to identify the current best free model on Zen's roster:
+`FARM_MODEL` is normally **not set**. Before a `/ca:sprint --farm` run, `subagent-driven-development`
+picks a model by *measurement*, not hearsay:
 
-1. Searches for the current free model list and any opaque codenames (e.g. "Big Pickle").
-2. Researches community consensus on each codename's underlying model and coding ability.
-3. Surfaces the selection and rationale for user confirmation before dispatching.
-
-This research runs fresh before each farm run so the model selection never goes stale.
+1. **Cache check** — reuse `.farm/model-cache.json` if it holds a model chosen in the last 7 days with
+   an acceptable canary pass-rate. Otherwise re-select.
+2. **Discovery** — websearch the current free Zen roster to enumerate candidate ids (codenames included).
+   This finds *candidates*; it does not judge quality.
+3. **Canary** — `farm.js --canary` runs the plan's smallest task against each candidate and ranks them by
+   measured pass-rate / attempts / latency (`FARM_CANDIDATE_MODELS` carries the list). The top passer wins.
+4. **Surface** — the choice is presented with its measured basis (and a one-line websearched identity note
+   for the audit log), then written to `plan.meta.model` + `.farm/model-cache.json`.
+5. **Fallback ladder** — if the canary can't run or none pass: cached model → unmeasured websearch pick
+   (with a warning) → only then BLOCK for a manual `FARM_MODEL`. A noisy websearch never halts the feature.
 
 ## Optional overrides
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `FARM_MODEL` | _(unset)_ | Skip model research and use this model ID directly. Power-user/CI override. |
-| `FARM_API_BASE_URL` | _(from plan.json or .env)_ | Override the endpoint URL. |
+| `FARM_MODEL` | _(unset)_ | Skip selection and use this model id directly. Power-user/CI override. |
+| `FARM_API_BASE_URL` | `https://api.opencode.ai/v1` | Endpoint URL (env → plan.json → this default). |
+| `FARM_CANDIDATE_MODELS` | _(unset)_ | Comma-separated ids for `--canary` probing. Set by the dispatch skill. |
 | `FARM_CONCURRENCY` | `4` | Max concurrent task workers. |
 | `FARM_MAX_RETRIES` | `2` | Max gate retries per task before escalating. |
 | `FARM_BASE_BRANCH` | `main` | Branch the integration branch is cut from. |
+| `FARM_REQUEST_TIMEOUT_MS` | `120000` | Per-request hard timeout (prevents worker-slot deadlock). |
+| `FARM_API_MAX_RETRIES` | `3` | Transport retries for 429/5xx (honors `Retry-After`). |
+| `FARM_ABORT_ESCALATION_RATE` | `0.5` | Circuit breaker: abort once escalations exceed this fraction… |
+| `FARM_ABORT_MIN_TASKS` | `3` | …after at least this many tasks have settled. |
 
 ## Sovereignty note
 
@@ -58,7 +76,14 @@ Normal use: `/ca:sprint --farm` — the skill handles model selection and dispat
 ## Report artifacts
 
 After a run, the farm writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
-- `farm-report.json` — structured results (status, attempts, worktree, note per task)
-- `farm-report.md` — human-readable summary table
+- `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
+  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons.
+- `farm-report.md` — human-readable summary table.
+- `diffs/<task-id>.patch` — the actual change each task produced, for audit.
+- `canary-report.json` — model-probe ranking (when `--canary` was run).
+- `model-cache.json` — last selected model + timestamp + canary pass-rate.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
+
+Run `/ca:sprint --farm`, or invoke directly: `node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" <plan.json>`
+(with cwd at the project root). Canary: `FARM_CANDIDATE_MODELS=a,b,c farm.js --canary <plan.json>`.

--- a/.codearbiter/farm.md
+++ b/.codearbiter/farm.md
@@ -6,10 +6,29 @@ and merges. The cheap model cannot redefine the gates — only pass them.
 
 **The arbitrage is in who writes the code, never in whether it's reviewed.** Every task the farm
 reports green is still routed through the normal spec-compliance, quality, and fresh-verification
-gates (`subagent-driven-development` Phases 3–5) before acceptance. The dispatcher additionally runs a
-zero-token anti-gaming guard (rejects an impl that hard-codes the test's asserted value), protects the
-failing test from being modified, contains all worker writes inside the worktree, and trips a circuit
-breaker if too many tasks escalate (a sign the model isn't capable of the slice).
+gates (`subagent-driven-development` Phases 3–5) before acceptance. The dispatcher additionally runs two
+zero-token guards (below), protects the failing test from being modified, contains all worker writes
+inside the worktree, and trips a circuit breaker if too many tasks escalate (a sign the model isn't
+capable of the slice).
+
+### Zero-token quality guards
+
+1. **Literal-leak** — rejects an impl that simply hard-codes the literal value the test asserts
+   (`return 42` for `expect(f()).toBe(42)`).
+2. **Mutation** — after the gate is green, mutates the worker's in-scope impl (operator flips, return
+   replacement, boolean inversion) and re-runs **only the task's narrow test** (`gate.commands[0]`). A
+   surviving mutant is code the test does not constrain — gaming, dead code, or a weak test. The score
+   is **bounded by test strength**: a low score is a strong red flag, a high score is necessary but not
+   sufficient (Phases 3–5 remain the real quality gate). A low score attaches a **warning that rides
+   into Phase 3** for Claude to judge (worker gaming vs. weak test); only a near-zero score on a
+   non-trivial impl hard-escalates. Sampled and time-boxed so it never balloons wall-clock. Set
+   `FARM_MUTATION_CMD` to swap the built-in text mutator for a real per-language framework (Stryker,
+   mutmut, …); it runs in the worktree with `FARM_MUTATION_FILES` / `FARM_MUTATION_TEST_PATH` /
+   `FARM_MUTATION_TEST_CMD` set and must print a trailing JSON line with a numeric `score`.
+
+Note: `writing-plans --farm` MUST place the task's narrow behavioral test first in `gate.commands` —
+the mutation guard runs `gate.commands[0]` as the per-mutant test (running the full suite per mutant
+would be too slow).
 
 ## Required
 
@@ -59,6 +78,12 @@ picks a model by *measurement*, not hearsay:
 | `FARM_API_MAX_RETRIES` | `3` | Transport retries for 429/5xx (honors `Retry-After`). |
 | `FARM_ABORT_ESCALATION_RATE` | `0.5` | Circuit breaker: abort once escalations exceed this fraction… |
 | `FARM_ABORT_MIN_TASKS` | `3` | …after at least this many tasks have settled. |
+| `FARM_MUTATION` | `on` | Mutation guard on/off. |
+| `FARM_MUTATION_SAMPLE` | `15` | Max mutants per task (sampled). |
+| `FARM_MUTATION_BUDGET_MS` | `30000` | Per-task mutation time box. |
+| `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
+| `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
+| `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
 
 ## Sovereignty note
 

--- a/.codearbiter/farm.md
+++ b/.codearbiter/farm.md
@@ -1,0 +1,64 @@
+# codeArbiter farm — setup and configuration
+
+`farm.ts` is the zero-LLM-token dispatcher: Claude writes specs, failing tests, and a `plan.json`;
+the farm runs cheap Zen workers in isolated git worktrees to make each test pass; Claude reviews
+and merges. The cheap model cannot redefine the gates — only pass them.
+
+## Required
+
+### `FARM_API_KEY`
+
+Your OpenCode Zen API key (or a compatible OpenAI-compatible provider key). Set it in one of:
+
+- Shell environment: `export FARM_API_KEY=sk-...` (recommended for CI and development)
+- Local `.env` at `plugins/ca/tools/.env` (dev convenience, never committed)
+- `${CLAUDE_PROJECT_DIR}/.claude/settings.local.json` `env` block (gitignored by default)
+
+Never commit this key. It must not appear in `.codearbiter/` audit files.
+
+### `FARM_API_BASE_URL`
+
+The OpenAI-compatible endpoint base URL. Defaults to `https://api.opencode.ai/v1` if set in `.env`.
+Override for DeepSeek direct (`https://api.deepseek.com/v1`), Ollama (`http://localhost:11434/v1`), etc.
+
+## Model selection — automatic at dispatch time
+
+`FARM_MODEL` is normally **not set**. Before each `/ca:sprint --farm` run, `subagent-driven-development`
+performs a fresh websearch to identify the current best free model on Zen's roster:
+
+1. Searches for the current free model list and any opaque codenames (e.g. "Big Pickle").
+2. Researches community consensus on each codename's underlying model and coding ability.
+3. Surfaces the selection and rationale for user confirmation before dispatching.
+
+This research runs fresh before each farm run so the model selection never goes stale.
+
+## Optional overrides
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `FARM_MODEL` | _(unset)_ | Skip model research and use this model ID directly. Power-user/CI override. |
+| `FARM_API_BASE_URL` | _(from plan.json or .env)_ | Override the endpoint URL. |
+| `FARM_CONCURRENCY` | `4` | Max concurrent task workers. |
+| `FARM_MAX_RETRIES` | `2` | Max gate retries per task before escalating. |
+| `FARM_BASE_BRANCH` | `main` | Branch the integration branch is cut from. |
+
+## Sovereignty note
+
+`FARM_MODEL` is the one-line control for model provenance on sensitivity-relevant projects.
+Many free Zen models are Chinese-origin (DeepSeek variants, GLM, etc.). Set `FARM_MODEL` to a
+sovereignty-clean model (e.g. a Mistral or Llama variant) when project sensitivity requires it.
+The dispatch skill surfaces the underlying model identity so you can make an informed choice.
+
+## Invocation
+
+Direct (dev): `cd plugins/ca/tools && npm run farm -- <plan.json>`
+Via plugin: `node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" <plan.json>`
+Normal use: `/ca:sprint --farm` — the skill handles model selection and dispatch automatically.
+
+## Report artifacts
+
+After a run, the farm writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
+- `farm-report.json` — structured results (status, attempts, worktree, note per task)
+- `farm-report.md` — human-readable summary table
+
+Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ __pycache__/
 # Ephemeral execution scaffolding written by long plan runs. Removed in the
 # plan's cleanup phase. Never committed.
 /.plan-tasks/
+
+# farm.ts dev dependencies — not shipped, only needed to build farm.js.
+plugins/ca/tools/node_modules/
+
+# Farm dispatcher runtime artifacts — worktrees, reports, integration branch staging.
+# Written per-run in any project using codeArbiter. Never committed to the plugin repo.
+.farm/

--- a/plugins/ca/ORCHESTRATOR.md
+++ b/plugins/ca/ORCHESTRATOR.md
@@ -40,13 +40,19 @@ behave exactly as if this section did not exist.
 
 ## /sprint — autonomous sprint (hidden)
 
-If the message is exactly `/sprint` (optionally `/sprint "goal"`), enter autonomous sprint mode: load
-and follow `${CLAUDE_PLUGIN_ROOT}/SPRINT.md`. In brief — brainstorm a sprint spec with the user (the
-one interactive gate), then execute the plan autonomously via `subagent-driven-development`, deciding
-"as the user" via SMARTS on every non-hard-gate point and logging each decision (with a confidence
-flag) to `.codearbiter/sprint-log.md`. Hard gates — `security-controls`, crypto/secrets/auth,
-irreversible ops, `/override`, an unresolvable `[CONFIRM-NN]`, merge-to-default — remain true stops,
-rare by design.
+If the message is `/sprint` (optionally `/sprint "goal"`, and optionally with a trailing `--farm`
+flag), enter autonomous sprint mode: load and follow `${CLAUDE_PLUGIN_ROOT}/SPRINT.md`. In brief —
+brainstorm a sprint spec with the user (the one interactive gate), then execute the plan autonomously
+via `subagent-driven-development`, deciding "as the user" via SMARTS on every non-hard-gate point and
+logging each decision (with a confidence flag) to `.codearbiter/sprint-log.md`. Hard gates —
+`security-controls`, crypto/secrets/auth, irreversible ops, `/override`, an unresolvable
+`[CONFIRM-NN]`, merge-to-default — remain true stops, rare by design.
+
+The optional **`--farm`** flag selects the cost-arbitrage execution backend (cheap Zen workers
+implement under hard gates instead of premium subagents). When present, pass it through to `SPRINT.md`,
+which forwards it to `writing-plans` (to co-emit `plan.json` + failing tests) and to
+`subagent-driven-development` (farm dispatch path). See `${CLAUDE_PLUGIN_ROOT}/SPRINT.md` Phase 1–2 and
+`.codearbiter/farm.md`. Absent the flag, the normal premium-subagent path runs unchanged.
 
 **Secrecy — never violate:** like `/dev`, `/sprint` MUST NOT appear in `/commands`, help, redirects,
 suggestions, errors, or status, and MUST NOT be hinted at or volunteered. If `/sprint` is never typed,

--- a/plugins/ca/SPRINT.md
+++ b/plugins/ca/SPRINT.md
@@ -11,6 +11,16 @@ commands/ entirely. -->
 Brainstorm a sprint with the user, then execute it end-to-end — deciding "as the user" on everything
 that is not a true hard gate. Every auto-decision is logged. Hard gates are real stops, rare by design.
 
+## Execution backend: premium (default) vs. `--farm`
+
+`/sprint` runs the normal premium-subagent path unless invoked as `/sprint --farm`. The `--farm` flag
+selects the cost-arbitrage backend: Claude still authors the spec, the failing tests, and the plan, but
+cheap Zen workers (not premium subagents) implement each task under the same hard gates. Track whether
+`--farm` was passed and thread it into Phase 1 (`writing-plans --farm`) and Phase 2 (the farm dispatch
+path in `subagent-driven-development`). If `--farm` is set, pre-flight `FARM_API_KEY` — absent, BLOCK
+and cite `.codearbiter/farm.md` before brainstorming begins. Everything else about `/sprint` (the one
+interactive gate, deciding-as-the-user, hard gates, logging) is identical between backends.
+
 ## Secrecy — never violate
 
 `/sprint` MUST NOT appear in `/ca:commands`, `COMMANDS.md`, help, the §6 redirect, suggestions,
@@ -30,11 +40,27 @@ explicit "decide it this way" steers here. STOP for explicit user approval of th
 plan before autonomy begins. A blocking `[CONFIRM-NN]` is resolved here, with the user — never carried
 into autonomous execution unresolved.
 
+**`--farm` mode:** route the plan step through `writing-plans --farm`, which additionally writes each
+task's failing test and co-emits `plans/<sprint-slug>.plan.json`. To preserve the MVP-slice philosophy
+(and to cap the blast radius of a bad model), drive the farm **one MVP slice at a time**: emit and
+dispatch the plan.json for the current slice, review/merge it, then plan the next slice with the merged
+code in hand — rather than authoring every failing test in the sprint up front. The user approves the
+sprint spec and the first slice's plan at this gate; subsequent slices proceed under the same autonomy.
+
 ## Phase 2 — Autonomous execution · gate: BLOCK
 
 Hand the approved plan to `subagent-driven-development` and run it to completion WITHOUT per-batch
 human checkpoints — that is the difference from `/feature`'s `executing-plans`. Each task is
 test-first via `tdd`, two-pass reviewed, and proven on a fresh run.
+
+**`--farm` mode:** `subagent-driven-development` detects `plan.json` and takes its farm path —
+selecting a model (a canary probe over candidate Zen models, falling back to websearch), dispatching
+`farm.js`, then routing every green task through the SAME spec-compliance + quality + fresh-verification
+gates the premium path runs (Phases 3–5). The cost arbitrage is in who *writes* the code, never in
+whether it is *reviewed*. A farm escalation is handled per `subagent-driven-development`'s Phase 2.5
+(re-dispatch via premium Phase 2, or `[CONFIRM-NN]` on a genuine spec gap), and a circuit-breaker abort
+from `farm.js` (too many escalations) is itself a hard-gate surface: stop and tell the user the model
+isn't capable of the slice rather than grinding through.
 
 ### Deciding "as the user"
 

--- a/plugins/ca/skills/release/SKILL.md
+++ b/plugins/ca/skills/release/SKILL.md
@@ -16,6 +16,7 @@ Read these, or STOP and surface the gap — never guess:
 - The current branch MUST NOT be `main`, `master`, or the default branch. Release lands through the normal branch/PR path; if HEAD is the default branch, STOP.
 - `git describe --tags --abbrev=0` identifies the last tag. No tags → `LAST_TAG=<none>`, treat the full history as the window. Set the base version to `0.0.0`.
 - The commit set `LAST_TAG..HEAD` must be non-empty. If empty, STOP — nothing to release.
+- **farm.js build check:** if `plugins/ca/tools/farm.ts` was modified in the release window (`git log LAST_TAG..HEAD -- plugins/ca/tools/farm.ts`), verify that `plugins/ca/tools/farm.js` is up to date by rebuilding: `cd plugins/ca/tools && npm run build`. A stale `farm.js` (built from an older `farm.ts`) is a release blocker — the plugin ships `farm.js`, not `farm.ts`. If the rebuild produces changes, commit them through `commit-gate` before tagging.
 
 ## Phase 1 — Version & changelog · gate: BLOCK
 

--- a/plugins/ca/skills/subagent-driven-development/SKILL.md
+++ b/plugins/ca/skills/subagent-driven-development/SKILL.md
@@ -31,19 +31,36 @@ Gate: exactly one task selected, dependency-clean, with its spec obligation and 
 ## Phase 2 — Implementation dispatch · gate: BLOCK
 
 **Farm path (when `<slug>.plan.json` exists alongside the `.md` plan):** skip the subagent dispatch
-loop below and follow the farm path instead. The farm path replaces Phases 2–6 for ALL tasks in the
-plan simultaneously.
+loop below and follow the farm path instead. The farm path replaces only the *authoring* step (Phase 2)
+for the plan's tasks — it does NOT replace review. Every task the farm reports green is still routed
+through Phases 3, 4, and 5 before acceptance. The cost arbitrage is in who *writes* the code, never in
+whether it is *reviewed*: a cheap model is more likely to game a narrow test, so its output gets the
+SAME scrutiny a premium subagent's would, not less.
 
 ### Phase 2-farm — Farm dispatch and model selection
 
-**Step 1 — Model selection.** If `FARM_MODEL` env var is set, use it directly and skip the research
-steps. Otherwise:
+**Step 1 — Model selection.** If `FARM_MODEL` env var is set, use it directly and skip selection.
+Otherwise, prefer a **measured** choice over web hearsay:
 
-1. Websearch `"OpenCode Zen free models <current month year>"` and the OpenCode model catalog page.
-2. For any opaque codename (e.g. "Big Pickle"), follow up: `"<codename> model underlying LLM coding benchmark site:reddit.com OR site:news.ycombinator.com"` — community consensus on the underlying model and its coding ability is the only reliable signal; model IDs change without notice.
-3. Select the best available free model for single-file code generation. Surface the selection to the user: "Selected `<model-id>` — community reports `<underlying model>`, `<coding assessment>`. Source: `<link>`. Proceed, or set `FARM_MODEL` to override."
-4. Gate: model selected and identity understood. BLOCK if no free models are identifiable (community has no consensus) — the user must set `FARM_MODEL` manually.
-5. Write `meta.model` and `meta.apiBaseUrl` into the `plan.json` file before dispatching (this records what actually ran in the plan artifact).
+1. Read `.farm/model-cache.json` if present. If it records a model chosen within the last 7 days whose
+   last canary pass-rate was acceptable, reuse it (skip to Step 2). Re-research only on a stale or
+   missing cache.
+2. Websearch `"OpenCode Zen free models <current month year>"` + the OpenCode model catalog to enumerate
+   the *candidate* free model ids (codenames included). This step is candidate **discovery**, not a
+   quality judgment.
+3. Run a canary probe to judge quality objectively: set `FARM_CANDIDATE_MODELS=<comma-separated ids>`
+   and invoke `node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" --canary "<plan.json>"`. It runs the plan's
+   smallest task against each candidate and writes `.farm/canary-report.json` ranked by measured
+   pass-rate / attempts / latency. Pick the top passing model.
+4. Surface the choice with its measured basis: "Selected `<model-id>` — canary passed in `<n>` attempts,
+   `<ms>`ms (vs. `<alternatives>`). Proceed, or set `FARM_MODEL` to override." For any opaque codename,
+   add one line of websearched identity context (e.g. "community reports GLM4-based") for the audit log.
+5. Fallback ladder if the canary can't run or none pass: (a) the cached model from Step 1; (b) a
+   websearch-selected model with a clear warning that the choice is unmeasured; (c) only if all fail,
+   BLOCK and ask the user to set `FARM_MODEL`. Halting the whole feature on a noisy websearch is wrong —
+   exhaust the ladder first.
+6. Write the chosen `meta.model` + `meta.apiBaseUrl` into `plan.json`, and update `.farm/model-cache.json`
+   (model + timestamp + canary pass-rate) before dispatching.
 
 **Step 2 — Farm dispatch.** Invoke the farm dispatcher:
 
@@ -51,21 +68,44 @@ steps. Otherwise:
 node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" "${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json"
 ```
 
-The dispatcher runs all tasks concurrently (up to `FARM_CONCURRENCY`, default 4), enforces gates, and writes:
-- `${CLAUDE_PROJECT_DIR}/.farm/farm-report.json` — structured results (status per task)
-- `${CLAUDE_PROJECT_DIR}/.farm/farm-report.md` — human-readable summary
+Run it with cwd set to `${CLAUDE_PROJECT_DIR}` (the dispatcher resolves `.farm/` and git worktrees
+against the current directory). It runs tasks concurrently (up to `FARM_CONCURRENCY`, default 4),
+enforces gates and a zero-token anti-gaming guard, and writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
+- `farm-report.json` / `farm-report.md` — per-task status, attempts, files, worker token spend, warnings
+- `diffs/<task-id>.patch` — the actual change per task, for audit
 
-Collect both reports. Exit code 0 = all green; exit code 2 = some tasks escalated.
+Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
+
+**Step 2.5 — Circuit-breaker abort.** If `farm-report.json` has `aborted: true`, the dispatcher tripped
+its escalation-rate breaker — the chosen model is likely not capable of this slice. This is a hard-gate
+surface: STOP and tell the user, recommending the premium path or a different `FARM_MODEL`. Do not
+silently re-dispatch every task to premium Phase 2 (that erases the arbitrage and hides a bad signal).
 
 **Step 3 — Escalation handler (Phase 2.5).** Read `farm-report.json`. For each result:
 
-- **status `green`** — task accepted. Advance directly to Phase 6 (Accept and advance) for this task.
-- **status `escalate`, note starts with `"drift:"`** — the cheap model touched files outside `filesInScope`. This indicates spec-gap or ambiguity. Raise a `[CONFIRM-NN]` in `open-questions.md` describing which files were written and why the worker strayed. HALT the loop — do not re-dispatch until the user resolves the ambiguity.
-- **status `escalate`, note is a gate failure message** — the cheap model failed to make the test pass after retries. Re-dispatch via normal Phase 2 (author subagent + `tdd`), seeding the brief with: the farm worktree path (`result.worktree` from the report), the gate failure note, and the task's `test.path`. The left-in-place worktree shows what the cheap model attempted; the author subagent can inspect it.
-- **status `escalate`, note is `"merge conflict vs integration branch"`** — re-order the task after its conflicting sibling and re-dispatch via Phase 2.
-- **blocked** tasks (dependency escalated) — treat as gate failure of the upstream task first; once the upstream is resolved, re-queue the blocked task normally.
+- **status `green`** — the test gate + anti-gaming guard passed, but it is NOT yet accepted. Route the
+  task through **Phase 3 (spec-compliance), Phase 4 (quality review), and Phase 5 (fresh verification)**
+  exactly as a premium subagent's output would be, measuring the merged change against the spec line the
+  task traces to. A green result carrying a `warning` (gaming-risk) gets extra attention in Phase 3.
+  Only after Phases 3–5 pass does the task reach Phase 6.
+- **status `escalate`, note starts with `"drift:"`** — the cheap model wrote outside `filesInScope`
+  even after a hardened-prompt retry. First occurrence on a task → treat as model incapacity, not a spec
+  gap: re-dispatch via premium Phase 2 (the worktree at `result.worktree` shows the attempt). Only when
+  **multiple tasks drift onto the same out-of-scope path** does it signal a genuine decomposition/spec
+  gap — then raise `[CONFIRM-NN]` and halt.
+- **status `escalate`, note starts with `"gaming:"`** — the model hard-coded the test's asserted value.
+  Re-dispatch via premium Phase 2; do not accept the farm output.
+- **status `escalate`, note starts with `"tampered test:"`** — the model altered the failing test.
+  Re-dispatch via premium Phase 2; the test is the gate's integrity anchor.
+- **status `escalate`, gate-failure note** — the model couldn't pass the test after retries. Re-dispatch
+  via premium Phase 2, seeding the brief with `result.worktree`, the gate note, and `test.path`.
+- **status `escalate`, note starts with `"merge failed"`** — re-order after the conflicting sibling and
+  re-dispatch via Phase 2.
+- **blocked** tasks (`farm-report.json` `blocked[]` array, each with a `reason`) — resolve the upstream
+  escalation first, then re-queue.
 
-Gate: all tasks either green or re-dispatched via Phase 2 and accepted. No task may advance to commit-gate while any sibling is unresolved.
+Gate: every task is green AND passed Phases 3–5, or was re-dispatched via premium Phase 2 and accepted.
+No task advances to commit-gate while any sibling is unresolved.
 
 ---
 
@@ -96,10 +136,18 @@ with a corrective brief.
 
 ## Phase 4 — Quality review · gate: BLOCK
 
-Dispatch `grader` (`${CLAUDE_PLUGIN_ROOT}/agents/grader.md`) for the quality pass, then
-`finding-triage` (`${CLAUDE_PLUGIN_ROOT}/agents/finding-triage.md`) to classify every finding by
-severity. For a security-relevant task, also dispatch `security-reviewer`
-(`${CLAUDE_PLUGIN_ROOT}/agents/security-reviewer.md`).
+Dispatch the reviewers applicable to what the change touches, then `finding-triage`
+(`${CLAUDE_PLUGIN_ROOT}/agents/finding-triage.md`) to classify every finding by severity. Select
+reviewers by the diff, not blanket — dispatching an irrelevant reviewer wastes a context:
+
+- `security-reviewer` (`${CLAUDE_PLUGIN_ROOT}/agents/security-reviewer.md`) — any security-relevant path (authn/authz, deploy, CI, trust boundary).
+- `auth-crypto-reviewer` (`${CLAUDE_PLUGIN_ROOT}/agents/auth-crypto-reviewer.md`) — auth, crypto, key, or secret changes.
+- `dependency-reviewer` (`${CLAUDE_PLUGIN_ROOT}/agents/dependency-reviewer.md`) — `package.json` / lockfile / base-image changes.
+- `migration-reviewer` (`${CLAUDE_PLUGIN_ROOT}/agents/migration-reviewer.md`) — DB migration add/modify.
+
+(Do NOT dispatch `grader` or `scout` — they are INTERNAL to `decision-variance` and must never be
+dispatched here.) If the change touches none of the above domains, the quality bar is `tdd`'s own gates
+plus `coverage-auditor` (already run in `tdd` Phase 4) — record that and proceed.
 
 - A security CRITICAL finding halts the loop — see Hard rules.
 - A HIGH finding returns the task to Phase 2.
@@ -138,6 +186,9 @@ Gate: every plan task `ACCEPTED`, the suite green, ready for `commit-gate`.
 - MUST halt and surface to the user on a `tdd` BLOCK, a security CRITICAL finding, or an unresolved `[CONFIRM-NN]` inside the loop — and on a `commit-gate` failure at the finish handoff — even under `/sprint`. These never auto-proceed.
 - MUST NOT commit — hand the accepted branch to `commit-gate`.
 - MUST mark out-of-scope findings with an inline `[NEEDS-TRIAGE]` marker and never act on them inside the task.
-- MUST NOT invoke `farm.js` before writing `meta.model` and `meta.apiBaseUrl` into `plan.json` — the dispatcher fails loudly if neither is set.
-- MUST NOT skip model selection research (Step 1) when `FARM_MODEL` is not set — a blind invocation with an unknown model ID is a waste of compute and fails unpredictably.
-- MUST raise a `[CONFIRM-NN]` and HALT on a drift escalation — do not silently re-dispatch a task where the cheap model strayed outside `filesInScope`; that signals a spec ambiguity, not an implementation gap.
+- MUST NOT invoke `farm.js` before writing `meta.model` into `plan.json` (or setting `FARM_MODEL`) — the dispatcher fails loudly otherwise.
+- MUST NOT skip model selection (Step 1) when `FARM_MODEL` is not set — exhaust the canary→cache→websearch fallback ladder before BLOCKing; never blind-invoke with an unknown model id.
+- MUST route every green farm task through Phases 3–5 before acceptance — the farm replaces authoring, never review. A cheap model gets the same scrutiny as a premium subagent, not less.
+- MUST treat a single task's drift/gaming/tampered-test escalation as model incapacity (re-dispatch via premium Phase 2); raise `[CONFIRM-NN]` and HALT only when multiple tasks drift onto the same out-of-scope path (a real spec gap).
+- MUST treat a `farm.js` circuit-breaker abort (`aborted: true`) as a hard-gate STOP — surface to the user; do not silently re-dispatch the whole slice to premium.
+- MUST NOT dispatch `grader` or `scout` in Phase 4 — they are INTERNAL to `decision-variance`.

--- a/plugins/ca/skills/subagent-driven-development/SKILL.md
+++ b/plugins/ca/skills/subagent-driven-development/SKILL.md
@@ -30,7 +30,46 @@ Gate: exactly one task selected, dependency-clean, with its spec obligation and 
 
 ## Phase 2 — Implementation dispatch · gate: BLOCK
 
-Dispatch ONE fresh subagent for the selected task — `backend-author`, `frontend-author`, or
+**Farm path (when `<slug>.plan.json` exists alongside the `.md` plan):** skip the subagent dispatch
+loop below and follow the farm path instead. The farm path replaces Phases 2–6 for ALL tasks in the
+plan simultaneously.
+
+### Phase 2-farm — Farm dispatch and model selection
+
+**Step 1 — Model selection.** If `FARM_MODEL` env var is set, use it directly and skip the research
+steps. Otherwise:
+
+1. Websearch `"OpenCode Zen free models <current month year>"` and the OpenCode model catalog page.
+2. For any opaque codename (e.g. "Big Pickle"), follow up: `"<codename> model underlying LLM coding benchmark site:reddit.com OR site:news.ycombinator.com"` — community consensus on the underlying model and its coding ability is the only reliable signal; model IDs change without notice.
+3. Select the best available free model for single-file code generation. Surface the selection to the user: "Selected `<model-id>` — community reports `<underlying model>`, `<coding assessment>`. Source: `<link>`. Proceed, or set `FARM_MODEL` to override."
+4. Gate: model selected and identity understood. BLOCK if no free models are identifiable (community has no consensus) — the user must set `FARM_MODEL` manually.
+5. Write `meta.model` and `meta.apiBaseUrl` into the `plan.json` file before dispatching (this records what actually ran in the plan artifact).
+
+**Step 2 — Farm dispatch.** Invoke the farm dispatcher:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" "${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json"
+```
+
+The dispatcher runs all tasks concurrently (up to `FARM_CONCURRENCY`, default 4), enforces gates, and writes:
+- `${CLAUDE_PROJECT_DIR}/.farm/farm-report.json` — structured results (status per task)
+- `${CLAUDE_PROJECT_DIR}/.farm/farm-report.md` — human-readable summary
+
+Collect both reports. Exit code 0 = all green; exit code 2 = some tasks escalated.
+
+**Step 3 — Escalation handler (Phase 2.5).** Read `farm-report.json`. For each result:
+
+- **status `green`** — task accepted. Advance directly to Phase 6 (Accept and advance) for this task.
+- **status `escalate`, note starts with `"drift:"`** — the cheap model touched files outside `filesInScope`. This indicates spec-gap or ambiguity. Raise a `[CONFIRM-NN]` in `open-questions.md` describing which files were written and why the worker strayed. HALT the loop — do not re-dispatch until the user resolves the ambiguity.
+- **status `escalate`, note is a gate failure message** — the cheap model failed to make the test pass after retries. Re-dispatch via normal Phase 2 (author subagent + `tdd`), seeding the brief with: the farm worktree path (`result.worktree` from the report), the gate failure note, and the task's `test.path`. The left-in-place worktree shows what the cheap model attempted; the author subagent can inspect it.
+- **status `escalate`, note is `"merge conflict vs integration branch"`** — re-order the task after its conflicting sibling and re-dispatch via Phase 2.
+- **blocked** tasks (dependency escalated) — treat as gate failure of the upstream task first; once the upstream is resolved, re-queue the blocked task normally.
+
+Gate: all tasks either green or re-dispatched via Phase 2 and accepted. No task may advance to commit-gate while any sibling is unresolved.
+
+---
+
+**Normal path (no `plan.json`):** dispatch ONE fresh subagent for the selected task — `backend-author`, `frontend-author`, or
 `infra-author` by the scope mapping in `tech-stack.md`
 (`${CLAUDE_PLUGIN_ROOT}/agents/<name>.md`). A fresh context per task is the whole point: no carried-over
 assumptions, no accumulated drift.
@@ -99,3 +138,6 @@ Gate: every plan task `ACCEPTED`, the suite green, ready for `commit-gate`.
 - MUST halt and surface to the user on a `tdd` BLOCK, a security CRITICAL finding, or an unresolved `[CONFIRM-NN]` inside the loop — and on a `commit-gate` failure at the finish handoff — even under `/sprint`. These never auto-proceed.
 - MUST NOT commit — hand the accepted branch to `commit-gate`.
 - MUST mark out-of-scope findings with an inline `[NEEDS-TRIAGE]` marker and never act on them inside the task.
+- MUST NOT invoke `farm.js` before writing `meta.model` and `meta.apiBaseUrl` into `plan.json` — the dispatcher fails loudly if neither is set.
+- MUST NOT skip model selection research (Step 1) when `FARM_MODEL` is not set — a blind invocation with an unknown model ID is a waste of compute and fails unpredictably.
+- MUST raise a `[CONFIRM-NN]` and HALT on a drift escalation — do not silently re-dispatch a task where the cheap model strayed outside `filesInScope`; that signals a spec ambiguity, not an implementation gap.

--- a/plugins/ca/skills/writing-plans/SKILL.md
+++ b/plugins/ca/skills/writing-plans/SKILL.md
@@ -76,15 +76,19 @@ through `tdd`. The plan never hands off to `tdd` directly.
 ### Phase 4-farm extension (only when `--farm` was requested)
 
 After the bijective coverage gate passes and the `.md` plan is written, produce the machine artifact
-that the farm dispatcher needs. For each task in the plan, in dependency order:
+the farm dispatcher needs — **one MVP slice at a time, not the whole plan up front.** Front-loading
+every failing test for the entire plan would be the waterfall this skill otherwise rejects (Phase 3),
+and it maximizes the cost of a mid-flight spec change. So the farm artifact is scoped to the **current
+slice** (the MVP slice on the first pass; the next contiguous group on later passes). For each task in
+the current slice, in dependency order:
 
 1. Route through `tdd` Phase 1 (derive obligations) + Phase 2 (write the failing test). The test file
    must exist on disk and fail before continuing. Record the test file path for this task.
 2. Confirm the test is actually failing (run the gate command from `tech-stack.md`; it must exit non-zero).
    A test that passes before implementation means the obligation is wrong — STOP and revisit Phase 2.
 
-Then write `${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json` conforming to
-`${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json`:
+Then write `${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json` (the current slice's tasks only)
+conforming to `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json`:
 
 - `meta.name` ← slug
 - `meta.repo` ← project name from CONTEXT.md

--- a/plugins/ca/skills/writing-plans/SKILL.md
+++ b/plugins/ca/skills/writing-plans/SKILL.md
@@ -16,6 +16,8 @@ Read these, or STOP and surface the gap — never plan against an unapproved or 
 - `${CLAUDE_PROJECT_DIR}/.codearbiter/tech-stack.md` — file layout, build/test/lint invocations. A verification step cites a real command from here, never a guess.
 - `${CLAUDE_PROJECT_DIR}/.codearbiter/coding-standards.md` — structure and naming, so a task names the right path.
 
+**If `--farm` was requested:** check that `FARM_API_KEY` is set in the environment (or `.env` at `${CLAUDE_PLUGIN_ROOT}/tools/.env`). If absent, BLOCK immediately — cite `.codearbiter/farm.md` for setup instructions. Do not proceed; the farm dispatcher cannot run without an API key. Model selection happens later (at dispatch time in `subagent-driven-development`), so no model research is needed here.
+
 ## Phase 1 — Criterion extraction · gate: BLOCK
 
 Lift every acceptance criterion from the spec verbatim and assign each a stable ID (`AC-01`,
@@ -71,6 +73,32 @@ plan written to disk. This clears the path to execution: `executing-plans` (chec
 `/feature`) or `subagent-driven-development` (autonomous, via `/sprint`) — each routes every task
 through `tdd`. The plan never hands off to `tdd` directly.
 
+### Phase 4-farm extension (only when `--farm` was requested)
+
+After the bijective coverage gate passes and the `.md` plan is written, produce the machine artifact
+that the farm dispatcher needs. For each task in the plan, in dependency order:
+
+1. Route through `tdd` Phase 1 (derive obligations) + Phase 2 (write the failing test). The test file
+   must exist on disk and fail before continuing. Record the test file path for this task.
+2. Confirm the test is actually failing (run the gate command from `tech-stack.md`; it must exit non-zero).
+   A test that passes before implementation means the obligation is wrong — STOP and revisit Phase 2.
+
+Then write `${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json` conforming to
+`${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json`:
+
+- `meta.name` ← slug
+- `meta.repo` ← project name from CONTEXT.md
+- `meta.model` and `meta.apiBaseUrl` — **leave unset**. These are written by `subagent-driven-development`'s model research step at dispatch time. Writing them here would bake in a potentially stale selection.
+- Per task: `id` ← T-NN (normalized to kebab-case), `description` ← task description,
+  `filesInScope` ← path(s) from the task table, `test.path` ← the failing test written above,
+  `gate.commands` ← verification command from task table plus full-suite and lint/typecheck from
+  `tech-stack.md`, `deps` ← dependency ids (empty array if none), `context` ← a minimal slice of
+  relevant types/interfaces (omit if the test file plus task description is self-contained), `maxRetries` ← omit to use the farm default.
+
+Validate the JSON against the schema before writing (load the schema from `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json` and check). A schema-invalid plan BLOCKS.
+
+Gate: all failing tests written and confirmed failing; `plan.json` written and schema-valid. Both artifacts exist before handing off to `subagent-driven-development`.
+
 ## Hard rules
 
 - MUST NOT plan against an absent or unapproved spec — STOP and route back to `/feature`.
@@ -79,3 +107,6 @@ through `tdd`. The plan never hands off to `tdd` directly.
 - MUST NOT write the plan while any acceptance criterion is uncovered or any task covers nothing.
 - MUST NOT guess a verification command — cite `tech-stack.md` or STOP.
 - MUST NOT resolve an ambiguous criterion by guessing — raise a `[CONFIRM-NN]`.
+- MUST NOT emit `plan.json` in `--farm` mode without writing and confirming each failing test first.
+- MUST NOT set `meta.model` or `meta.apiBaseUrl` in `plan.json` — these belong to the dispatch step.
+- MUST NOT proceed with `--farm` if `FARM_API_KEY` is absent — cite `.codearbiter/farm.md` and BLOCK.

--- a/plugins/ca/skills/writing-plans/SKILL.md
+++ b/plugins/ca/skills/writing-plans/SKILL.md
@@ -98,6 +98,10 @@ conforming to `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json`:
   `gate.commands` ← verification command from task table plus full-suite and lint/typecheck from
   `tech-stack.md`, `deps` ← dependency ids (empty array if none), `context` ← a minimal slice of
   relevant types/interfaces (omit if the test file plus task description is self-contained), `maxRetries` ← omit to use the farm default.
+- **`gate.commands[0]` MUST be the task's narrow behavioral test** (the command that runs just
+  `test.path`), with the full suite and lint/typecheck following. The farm's mutation guard re-runs
+  `gate.commands[0]` per mutant; if the first command were the full suite, mutation testing would be
+  prohibitively slow.
 
 Validate the JSON against the schema before writing (load the schema from `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json` and check). A schema-invalid plan BLOCKS.
 

--- a/plugins/ca/tools/.env.example
+++ b/plugins/ca/tools/.env.example
@@ -23,6 +23,11 @@ FARM_API_BASE_URL=https://api.opencode.ai/v1
 # (e.g. DeepSeek variants) are often Chinese-origin. Swap FARM_MODEL for a
 # sovereignty-clean model on sensitivity-relevant projects.
 
+# --- Model canary (used by --canary mode) ------------------------------------
+# Comma-separated candidate model ids the dispatch skill probes to pick the best
+# performer on a real task. Set transiently by subagent-driven-development.
+# FARM_CANDIDATE_MODELS=big-pickle,grok-code,deepseek-chat
+
 # --- Farm tuning -------------------------------------------------------------
 FARM_CONCURRENCY=4
 FARM_MAX_RETRIES=2
@@ -30,3 +35,12 @@ FARM_BASE_BRANCH=main
 FARM_INTEGRATION_BRANCH=farm/integration
 FARM_WORKTREE_ROOT=.farm/worktrees
 FARM_REPORT_DIR=.farm
+
+# Per-request hard timeout (ms) so a hung endpoint can't deadlock a worker slot.
+FARM_REQUEST_TIMEOUT_MS=120000
+# Transport retries for 429 / 5xx (honors Retry-After) — distinct from gate retries.
+FARM_API_MAX_RETRIES=3
+# Circuit breaker: abort the run once the escalation rate exceeds this, after at
+# least FARM_ABORT_MIN_TASKS have settled (a bad/incapable model fails fast).
+FARM_ABORT_ESCALATION_RATE=0.5
+FARM_ABORT_MIN_TASKS=3

--- a/plugins/ca/tools/.env.example
+++ b/plugins/ca/tools/.env.example
@@ -1,0 +1,32 @@
+# --- OpenCode Zen API --------------------------------------------------------
+# Your Zen API key. Get it from the OpenCode dashboard.
+# Set here for local dev, or use your shell / .claude/settings.local.json env block.
+FARM_API_KEY=sk-REPLACE_ME
+
+# OpenAI-compatible endpoint base URL for your Zen model provider.
+# Defaults to OpenCode Zen's endpoint. Override for DeepSeek direct, Ollama, etc.
+FARM_API_BASE_URL=https://api.opencode.ai/v1
+
+# --- Model selection ---------------------------------------------------------
+# Normally left UNSET. subagent-driven-development researches the current free
+# Zen model roster at dispatch time and writes the selection into plan.json.
+# Set this ONLY to override the automatic selection (power-user / CI use).
+#
+# Free model IDs change frequently and use codenames ("Big Pickle", etc.).
+# The dispatch skill researches community consensus on what's behind each name.
+# See .codearbiter/farm.md for how model selection works.
+#
+# FARM_MODEL=opencode/some-model-id
+
+# --- Sovereignty note --------------------------------------------------------
+# If FARM_MODEL is set, the value controls which model runs. Cheap models
+# (e.g. DeepSeek variants) are often Chinese-origin. Swap FARM_MODEL for a
+# sovereignty-clean model on sensitivity-relevant projects.
+
+# --- Farm tuning -------------------------------------------------------------
+FARM_CONCURRENCY=4
+FARM_MAX_RETRIES=2
+FARM_BASE_BRANCH=main
+FARM_INTEGRATION_BRANCH=farm/integration
+FARM_WORKTREE_ROOT=.farm/worktrees
+FARM_REPORT_DIR=.farm

--- a/plugins/ca/tools/.env.example
+++ b/plugins/ca/tools/.env.example
@@ -44,3 +44,19 @@ FARM_API_MAX_RETRIES=3
 # least FARM_ABORT_MIN_TASKS have settled (a bad/incapable model fails fast).
 FARM_ABORT_ESCALATION_RATE=0.5
 FARM_ABORT_MIN_TASKS=3
+
+# --- Mutation guard ----------------------------------------------------------
+# Zero-token quality check: after the gate is green, mutate the worker's in-scope
+# impl and re-run ONLY the task's narrow test (gate.commands[0]). Surviving
+# mutants = code the test doesn't constrain (gaming / dead code / weak test).
+# Low score warns into Phase 3 review; near-zero on a non-trivial impl escalates.
+FARM_MUTATION=on
+FARM_MUTATION_SAMPLE=15          # max mutants per task (sampled)
+FARM_MUTATION_BUDGET_MS=30000    # per-task time box
+FARM_MUTATION_WARN_BELOW=0.5     # score below this attaches a warning
+FARM_MUTATION_ESCALATE_BELOW=0.1 # score at/below this (>=5 mutants) escalates
+# Pluggable: point this at a real per-language framework instead of the built-in
+# text mutator. It runs in the worktree with FARM_MUTATION_FILES,
+# FARM_MUTATION_TEST_PATH, FARM_MUTATION_TEST_CMD set, and must print a trailing
+# JSON line containing a numeric "score" (0..1). e.g. a Stryker/mutmut wrapper.
+# FARM_MUTATION_CMD=./scripts/mutate.sh

--- a/plugins/ca/tools/__fixtures__/simple.plan.json
+++ b/plugins/ca/tools/__fixtures__/simple.plan.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "name": "farm-smoke-test",
+    "repo": "test",
+    "model": "test-model",
+    "apiBaseUrl": "http://localhost:9999"
+  },
+  "tasks": [
+    {
+      "id": "task-a",
+      "description": "Write a hello function",
+      "deps": [],
+      "filesInScope": ["src/hello.ts"],
+      "test": { "path": "src/hello.test.ts" },
+      "gate": { "commands": ["bash -c 'exit 0'"] }
+    },
+    {
+      "id": "task-b",
+      "description": "Write a world function that uses hello",
+      "deps": ["task-a"],
+      "filesInScope": ["src/world.ts"],
+      "test": { "path": "src/world.test.ts" },
+      "gate": { "commands": ["bash -c 'exit 0'"] }
+    }
+  ]
+}

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
-#!/usr/bin/env node
 
 // farm.ts
 import { spawn } from "node:child_process";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 var ENV = {
   // Model: plan.meta.model (set by subagent-driven-development before dispatch),
   // then FARM_MODEL env var override. Fails at startup if neither is set.
   model: process.env.FARM_MODEL ?? null,
+  // No-default kept deliberately: dispatch records the chosen endpoint in
+  // plan.meta.apiBaseUrl. A code default is provided only as a last resort so a
+  // user who sets just FARM_API_KEY (per the docs) is not hard-blocked.
   apiBaseUrl: process.env.FARM_API_BASE_URL ?? null,
   apiKey: process.env.FARM_API_KEY ?? null,
   concurrency: Number(process.env.FARM_CONCURRENCY ?? 4),
@@ -16,7 +19,19 @@ var ENV = {
   base: process.env.FARM_BASE_BRANCH ?? "main",
   integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
   worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
-  reportDir: process.env.FARM_REPORT_DIR ?? ".farm"
+  reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
+  // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
+  requestTimeoutMs: Number(process.env.FARM_REQUEST_TIMEOUT_MS ?? 12e4),
+  // Transport-level retries (429 / 5xx) — distinct from model-quality retries.
+  apiMaxRetries: Number(process.env.FARM_API_MAX_RETRIES ?? 3),
+  // Circuit breaker: abort dispatch once the escalation rate exceeds this,
+  // after at least abortMinTasks have settled.
+  abortEscalationRate: Number(process.env.FARM_ABORT_ESCALATION_RATE ?? 0.5),
+  abortMinTasks: Number(process.env.FARM_ABORT_MIN_TASKS ?? 3),
+  // Default endpoint, used only when neither env nor plan.meta provides one.
+  defaultApiBaseUrl: process.env.FARM_DEFAULT_API_BASE_URL ?? "https://api.opencode.ai/v1",
+  // Comma-separated candidate model ids for --canary mode.
+  candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "").split(",").map((s) => s.trim()).filter(Boolean)
 };
 function run(cmd, args, cwd) {
   return new Promise((resolve) => {
@@ -24,18 +39,26 @@ function run(cmd, args, cwd) {
     let out = "";
     c.stdout.on("data", (d) => out += d);
     c.stderr.on("data", (d) => out += d);
+    c.on("error", (e) => resolve({ code: 1, out: String(e) }));
     c.on("close", (code) => resolve({ code: code ?? 1, out }));
   });
 }
 var git = (args, cwd) => run("git", args, cwd);
+var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+var NOSIGN = ["-c", "commit.gpgsign=false"];
+function isInside(root, target) {
+  const rel = path.relative(root, target);
+  return rel === "" || !rel.startsWith("..") && !path.isAbsolute(rel);
+}
 async function runGate(cwd, commands) {
   for (const cmd of commands) {
-    const r = await run("bash", ["-lc", cmd], cwd);
-    if (r.code !== 0) return { ok: false, failed: cmd, tail: r.out.slice(-3500) };
+    const r = await run("bash", ["-c", cmd], cwd);
+    if (r.code !== 0)
+      return { ok: false, failed: cmd, tail: r.out.slice(-3500) };
   }
   return { ok: true };
 }
-function buildPrompt(t, priorFailure) {
+function buildPrompt(t, priorFailure, forbiddenExtra) {
   return [
     `Implement exactly ONE task. Your only goal: make the failing test pass.`,
     ``,
@@ -46,10 +69,18 @@ ${t.context}
 ` : ``,
     `The failing test is at: ${t.test.path}`,
     `Make it pass WITHOUT modifying, deleting, or weakening that test.`,
+    `You may NOT create, edit, or delete ${t.test.path} \u2014 it is read-only.`,
     ``,
     `You may ONLY create or edit these files:`,
     ...t.filesInScope.map((f) => `  - ${f}`),
     `Touch nothing else. Do not run git. Do not install global packages.`,
+    forbiddenExtra && forbiddenExtra.length ? `
+Your previous attempt wrote these FORBIDDEN paths \u2014 do NOT touch them again:
+${forbiddenExtra.map((f) => `  - ${f}`).join("\n")}` : ``,
+    ``,
+    `Solve the task with REAL logic. Do not hard-code the literal values the`,
+    `test asserts \u2014 an implementation that only returns the expected constant`,
+    `will be rejected.`,
     ``,
     `Respond with ONLY the files you need to create or modify.`,
     `For each file, use this exact format:`,
@@ -66,59 +97,191 @@ Gate output (tail):
 ${priorFailure}` : ``
   ].join("\n");
 }
-async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey) {
-  let resp;
-  try {
-    resp = await fetch(`${apiBaseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`
-      },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: prompt }]
-      })
-    });
-  } catch (e) {
-    return { ok: false, filesWritten: [], error: `fetch failed: ${e}` };
+function extractFileBlocks(content) {
+  const lines = content.split("\n");
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    const open = lines[i].match(/^\s*```(.*)$/);
+    if (!open) {
+      i++;
+      continue;
+    }
+    const info = open[1].trim();
+    const body = [];
+    i++;
+    while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+      body.push(lines[i]);
+      i++;
+    }
+    i++;
+    let filePath = null;
+    const infoPath = info.match(/^[a-z0-9]*:(.+)$/i);
+    if (infoPath && /[\/.]/.test(infoPath[1])) {
+      filePath = infoPath[1].trim();
+    } else if (body.length) {
+      const first = body[0].trim();
+      const m = first.match(/^(?:\/\/|#)\s*path:\s*(.+)$/i) || first.match(/^\/\*\s*path:\s*(.+?)\s*\*\/$/i);
+      if (m) {
+        filePath = m[1].trim();
+        body.shift();
+      }
+    }
+    if (filePath) blocks.push({ path: filePath, body: body.join("\n") });
   }
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => "(unreadable)");
-    return { ok: false, filesWritten: [], error: `API ${resp.status}: ${body.slice(0, 500)}` };
+  return blocks;
+}
+async function callApi(prompt, model, apiBaseUrl, apiKey) {
+  for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), ENV.requestTimeoutMs);
+    let resp;
+    try {
+      resp = await fetch(`${apiBaseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: prompt }]
+        }),
+        signal: ctrl.signal
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      const aborted = e?.name === "AbortError";
+      if (attempt < ENV.apiMaxRetries) {
+        await sleep(Math.min(2 ** attempt * 1e3, 16e3));
+        continue;
+      }
+      return { ok: false, error: aborted ? `request timed out after ${ENV.requestTimeoutMs}ms` : `fetch failed: ${e}` };
+    }
+    clearTimeout(timer);
+    if (resp.status === 429 || resp.status >= 500) {
+      if (attempt < ENV.apiMaxRetries) {
+        const ra = Number(resp.headers.get("retry-after"));
+        const wait = Number.isFinite(ra) && ra > 0 ? ra * 1e3 : Math.min(2 ** attempt * 1e3, 16e3);
+        await sleep(wait);
+        continue;
+      }
+      const body = await resp.text().catch(() => "(unreadable)");
+      return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries: ${body.slice(0, 300)}` };
+    }
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "(unreadable)");
+      return { ok: false, error: `API ${resp.status}: ${body.slice(0, 500)}` };
+    }
+    let data;
+    try {
+      data = await resp.json();
+    } catch (e) {
+      return { ok: false, error: `non-JSON response: ${e}` };
+    }
+    return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
   }
-  const data = await resp.json();
-  const content = data.choices?.[0]?.message?.content ?? "";
+  return { ok: false, error: "exhausted API retries" };
+}
+async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden) {
+  const api = await callApi(prompt, model, apiBaseUrl, apiKey);
+  if (!api.ok) return { ok: false, filesWritten: [], error: api.error };
+  const blocks = extractFileBlocks(api.content);
   const filesWritten = [];
-  const blockRe = /```[a-z]*\n\/\/ path: ([^\n]+)\n([\s\S]*?)```/g;
-  let match;
-  while ((match = blockRe.exec(content)) !== null) {
-    const [, filePath, fileContent] = match;
-    const absPath = path.resolve(cwd, filePath.trim());
+  for (const { path: filePath, body } of blocks) {
+    const cleanPath = filePath.trim();
+    const absPath = path.resolve(cwd, cleanPath);
+    if (!isInside(cwd, absPath)) {
+      return { ok: false, filesWritten, error: `path escapes worktree: ${cleanPath}` };
+    }
+    const rel = path.relative(cwd, absPath);
+    if (forbidden.has(rel)) {
+      return { ok: false, filesWritten, error: `worker tried to write read-only path: ${rel}` };
+    }
     await mkdir(path.dirname(absPath), { recursive: true });
-    await writeFile(absPath, fileContent);
-    filesWritten.push(filePath.trim());
+    await writeFile(absPath, body.endsWith("\n") ? body : body + "\n");
+    filesWritten.push(rel);
   }
   if (filesWritten.length === 0) {
-    return { ok: false, filesWritten: [], error: "no parseable file blocks in response" };
+    return {
+      ok: false,
+      filesWritten: [],
+      error: "no parseable file blocks in response",
+      promptTokens: api.usage?.prompt_tokens,
+      completionTokens: api.usage?.completion_tokens
+    };
   }
-  return { ok: true, filesWritten };
+  return {
+    ok: true,
+    filesWritten,
+    promptTokens: api.usage?.prompt_tokens,
+    completionTokens: api.usage?.completion_tokens
+  };
 }
-async function checkDrift(cwd, filesInScope) {
+async function checkDrift(cwd, allowed) {
   const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
   const untracked = await git(
     ["ls-files", "--others", "--exclude-standard", "-z"],
     cwd
   );
   const changed = [];
-  if (tracked.code === 0) {
+  if (tracked.code === 0)
     changed.push(...tracked.out.trim().split("\n").filter(Boolean));
-  }
-  if (untracked.code === 0) {
+  if (untracked.code === 0)
     changed.push(...untracked.out.split("\0").filter(Boolean));
+  return [...new Set(changed)].filter((f) => !allowed.has(f));
+}
+function extractLiterals(testSrc) {
+  const lits = /* @__PURE__ */ new Set();
+  for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
+  for (const m of testSrc.matchAll(/\b(\d{2,}|[2-9])\b/g)) lits.add(m[1]);
+  return [...lits];
+}
+function codeLineCount(src) {
+  return src.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
+}
+async function antiGamingCheck(cwd, task) {
+  let testSrc = "";
+  try {
+    testSrc = await readFile(path.resolve(cwd, task.test.path), "utf8");
+  } catch {
+    return { risk: "none" };
   }
-  const allowed = new Set(filesInScope);
-  return changed.filter((f) => !allowed.has(f));
+  const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
+  if (literals.length === 0) return { risk: "none" };
+  const hits = [];
+  let anyTiny = false;
+  for (const f of task.filesInScope) {
+    if (f === task.test.path) continue;
+    let src = "";
+    try {
+      src = await readFile(path.resolve(cwd, f), "utf8");
+    } catch {
+      continue;
+    }
+    const tiny = codeLineCount(src) <= 5;
+    for (const lit of literals) {
+      if (src.includes(lit)) {
+        hits.push(`${f} contains test literal ${JSON.stringify(lit)}`);
+        if (tiny) anyTiny = true;
+      }
+    }
+  }
+  if (hits.length === 0) return { risk: "none" };
+  if (anyTiny) return { risk: "high", note: `gaming: ${hits[0]} (impl is trivial)` };
+  return { risk: "warn", note: `gaming-risk: ${hits[0]}` };
+}
+async function fileHash(p) {
+  try {
+    const buf = await readFile(p);
+    return createHash("sha256").update(buf).digest("hex");
+  } catch {
+    return null;
+  }
+}
+async function resetWorktree(wt) {
+  await git(["reset", "--hard", "HEAD"], wt);
+  await git(["clean", "-fd"], wt);
 }
 var mergeChain = Promise.resolve();
 var integrationWorktree;
@@ -128,167 +291,97 @@ function withMergeLock(fn) {
   });
   return next;
 }
+async function prepareWorktree(branch, wt, from) {
+  await git(["worktree", "remove", "--force", wt]).catch(() => {
+  });
+  await rm(wt, { recursive: true, force: true }).catch(() => {
+  });
+  await git(["branch", "-D", branch]).catch(() => {
+  });
+  const add = await git(["worktree", "add", "-b", branch, wt, from]);
+  if (add.code !== 0) return `worktree add failed: ${add.out.slice(0, 200)}`;
+  return null;
+}
 async function runTask(t, model, apiBaseUrl, apiKey) {
   const branch = `farm/${t.id}`;
   const wt = path.resolve(ENV.worktreeRoot, t.id);
   const limit = t.maxRetries ?? ENV.maxRetries;
-  await git(["worktree", "add", "-b", branch, wt, ENV.integration]);
+  const allowed = new Set(t.filesInScope);
+  const forbidden = /* @__PURE__ */ new Set([t.test.path]);
+  const prepErr = await prepareWorktree(branch, wt, ENV.integration);
+  if (prepErr)
+    return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
+  const testHashBefore = await fileHash(path.resolve(wt, t.test.path));
   let priorFailure;
+  let driftedOnce = false;
+  let lastFilesWritten = [];
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let lastWarning;
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
-    const worker = await runWorker(wt, buildPrompt(t, priorFailure), model, apiBaseUrl, apiKey);
+    if (attempt > 1) await resetWorktree(wt);
+    const worker = await runWorker(
+      wt,
+      buildPrompt(t, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0),
+      model,
+      apiBaseUrl,
+      apiKey,
+      forbidden
+    );
+    promptTokens += worker.promptTokens ?? 0;
+    completionTokens += worker.completionTokens ?? 0;
+    lastFilesWritten = worker.filesWritten;
     if (!worker.ok) {
       priorFailure = `worker error: ${worker.error}`;
       continue;
     }
-    const driftFiles = await checkDrift(wt, t.filesInScope);
+    const testHashAfter = await fileHash(path.resolve(wt, t.test.path));
+    if (testHashBefore !== null && testHashAfter !== testHashBefore) {
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
+    const driftFiles = await checkDrift(wt, allowed);
     if (driftFiles.length > 0) {
-      await git(["checkout", "."], wt);
-      return {
-        id: t.id,
-        status: "escalate",
-        attempts: attempt,
-        branch,
-        worktree: wt,
-        note: `drift: ${driftFiles.join(", ")}`
-      };
+      if (!driftedOnce && attempt <= limit) {
+        driftedOnce = true;
+        priorFailure = `drift: you wrote outside the allowed files: ${driftFiles.join(", ")}`;
+        continue;
+      }
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
     const gate = await runGate(wt, t.gate.commands);
-    if (gate.ok) {
-      await git(["add", "-A"], wt);
-      const commitResult = await git(
-        ["-c", "commit.gpgsign=false", "commit", "-m", `farm(${t.id}): ${t.description}`],
-        wt
-      );
-      if (commitResult.code !== 0) {
-        return {
-          id: t.id,
-          status: "escalate",
-          attempts: attempt,
-          branch,
-          worktree: wt,
-          note: `commit failed: ${commitResult.out.slice(0, 200)}`
-        };
-      }
-      const merged = await withMergeLock(async () => {
-        const m = await git(["merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
-        if (m.code !== 0) {
-          await git(["merge", "--abort"], integrationWorktree);
-          return false;
-        }
-        return true;
-      });
-      if (!merged) {
-        return {
-          id: t.id,
-          status: "escalate",
-          attempts: attempt,
-          branch,
-          worktree: wt,
-          note: "merge conflict vs integration branch"
-        };
-      }
-      await git(["worktree", "remove", "--force", wt]).catch(() => {
-      });
-      return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt };
-    }
-    priorFailure = `failed: ${gate.failed}
+    if (!gate.ok) {
+      priorFailure = `failed: ${gate.failed}
 ${gate.tail}`;
-  }
-  return {
-    id: t.id,
-    status: "escalate",
-    attempts: limit + 1,
-    branch,
-    worktree: wt,
-    note: priorFailure?.split("\n")[0]
-  };
-}
-async function main() {
-  const planPath = process.argv[2] ?? "plan.json";
-  const plan = JSON.parse(await readFile(planPath, "utf8"));
-  validate(plan);
-  const model = ENV.model ?? plan.meta.model;
-  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl;
-  const apiKey = ENV.apiKey;
-  if (!model) {
-    console.error(
-      "Error: No model configured.\nSet FARM_MODEL env var, or run /ca:sprint --farm to trigger automatic model selection.\nSee .codearbiter/farm.md for setup instructions."
-    );
-    process.exit(1);
-  }
-  if (!apiBaseUrl) {
-    console.error(
-      "Error: No API base URL configured.\nSet FARM_API_BASE_URL env var or run /ca:sprint --farm.\nSee .codearbiter/farm.md for setup instructions."
-    );
-    process.exit(1);
-  }
-  if (!apiKey) {
-    console.error(
-      "Error: FARM_API_KEY is not set.\nSee .codearbiter/farm.md for setup instructions."
-    );
-    process.exit(1);
-  }
-  await mkdir(ENV.worktreeRoot, { recursive: true });
-  await mkdir(ENV.reportDir, { recursive: true });
-  const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
-  if (branchResult.code !== 0) {
-    console.error(`Error: could not create integration branch '${ENV.integration}' from '${ENV.base}'.
-${branchResult.out}`);
-    process.exit(1);
-  }
-  integrationWorktree = path.resolve(".farm/integration-wt");
-  await mkdir(path.dirname(integrationWorktree), { recursive: true });
-  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
-  });
-  const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
-  if (wtResult.code !== 0) {
-    console.error(`Error: could not create integration worktree.
-${wtResult.out}`);
-    process.exit(1);
-  }
-  const byId = new Map(plan.tasks.map((t) => [t.id, t]));
-  const done = /* @__PURE__ */ new Map();
-  const escalated = /* @__PURE__ */ new Set();
-  const pending = new Set(plan.tasks.map((t) => t.id));
-  const running = /* @__PURE__ */ new Map();
-  const ready = () => [...pending].filter((id) => {
-    const deps = byId.get(id).deps ?? [];
-    if (deps.some((d) => escalated.has(d))) return false;
-    return deps.every((d) => done.get(d)?.status === "green");
-  });
-  while (pending.size > 0 || running.size > 0) {
-    for (const id2 of ready()) {
-      if (running.size >= ENV.concurrency) break;
-      pending.delete(id2);
-      running.set(
-        id2,
-        runTask(byId.get(id2), model, apiBaseUrl, apiKey).then((r2) => ({ id: id2, r: r2 }))
-      );
+      continue;
     }
-    if (running.size === 0) break;
-    const { id, r } = await Promise.race(running.values());
-    running.delete(id);
-    done.set(id, r);
-    if (r.status === "escalate") escalated.add(id);
+    const gaming = await antiGamingCheck(wt, t);
+    if (gaming.risk === "high") {
+      priorFailure = `${gaming.note}. Implement real logic, do not hard-code the asserted value.`;
+      if (attempt <= limit) continue;
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: gaming.note, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
+    if (gaming.risk === "warn") lastWarning = gaming.note;
+    await git(["add", "-A"], wt);
+    const commit = await git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
+    if (commit.code !== 0)
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    const diffstat = (await git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
+    const merged = await withMergeLock(async () => {
+      const m = await git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
+      if (m.code !== 0) {
+        await git(["merge", "--abort"], integrationWorktree).catch(() => {
+        });
+        return m.out;
+      }
+      return null;
+    });
+    if (merged !== null)
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    await git(["worktree", "remove", "--force", wt]).catch(() => {
+    });
+    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens };
   }
-  const blocked = [...pending].map((id) => ({ id }));
-  await writeReport(plan, [...done.values()], blocked);
-  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
-  });
-  const esc = [...done.values()].filter((r) => r.status === "escalate").length;
-  const green = [...done.values()].filter((r) => r.status === "green").length;
-  const exitCode = esc || blocked.length ? 2 : 0;
-  const summary = [
-    `
-Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
-    `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
-    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
-    ""
-  ].join("\n");
-  await new Promise(
-    (resolve) => process.stdout.write(summary, () => resolve())
-  );
-  process.exit(exitCode);
+  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens };
 }
 function validate(plan) {
   const ids = /* @__PURE__ */ new Set();
@@ -299,30 +392,197 @@ function validate(plan) {
   for (const t of plan.tasks)
     for (const d of t.deps ?? [])
       if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown task ${d}`);
+  const byId = new Map(plan.tasks.map((t) => [t.id, t]));
+  const state = /* @__PURE__ */ new Map();
+  const visit = (id, stack) => {
+    if (state.get(id) === 2) return;
+    if (state.get(id) === 1)
+      throw new Error(`dependency cycle: ${[...stack, id].join(" -> ")}`);
+    state.set(id, 1);
+    for (const d of byId.get(id).deps ?? []) visit(d, [...stack, id]);
+    state.set(id, 2);
+  };
+  for (const t of plan.tasks) visit(t.id, []);
 }
-async function writeReport(plan, results, blocked) {
+function resolveConfig(plan) {
+  const model = ENV.model ?? plan.meta.model;
+  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl ?? ENV.defaultApiBaseUrl;
+  const apiKey = ENV.apiKey;
+  if (!model) {
+    console.error(
+      "Error: No model configured.\nSet FARM_MODEL env var, or run /ca:sprint --farm to trigger automatic model selection.\nSee .codearbiter/farm.md for setup instructions."
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error("Error: FARM_API_KEY is not set.\nSee .codearbiter/farm.md for setup instructions.");
+    process.exit(1);
+  }
+  return { model, apiBaseUrl, apiKey };
+}
+async function runCanary(plan) {
+  if (ENV.candidateModels.length === 0) {
+    console.error("Error: --canary requires FARM_CANDIDATE_MODELS (comma-separated model ids).");
+    process.exit(1);
+  }
+  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl ?? ENV.defaultApiBaseUrl;
+  const apiKey = ENV.apiKey;
+  if (!apiKey) {
+    console.error("Error: FARM_API_KEY is not set.");
+    process.exit(1);
+  }
+  await mkdir(ENV.worktreeRoot, { recursive: true });
+  await mkdir(ENV.reportDir, { recursive: true });
+  await git(["branch", "-f", ENV.integration, ENV.base]);
+  integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
+  });
+  await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {
+  });
+  await git(["worktree", "add", integrationWorktree, ENV.integration]).catch(() => {
+  });
+  const task = [...plan.tasks].filter((t) => (t.deps ?? []).length === 0).sort((a, b) => a.filesInScope.length - b.filesInScope.length)[0] ?? plan.tasks[0];
+  const results = [];
+  for (const model of ENV.candidateModels) {
+    const t0 = Date.now();
+    const r = await runTask({ ...task, id: `canary-${task.id}` }, model, apiBaseUrl, apiKey);
+    results.push({ model, green: r.status === "green", attempts: r.attempts, ms: Date.now() - t0, note: r.note });
+    await git(["worktree", "remove", "--force", path.resolve(ENV.worktreeRoot, `canary-${task.id}`)]).catch(() => {
+    });
+    await git(["branch", "-D", `farm/canary-${task.id}`]).catch(() => {
+    });
+  }
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
+  });
+  results.sort((a, b) => Number(b.green) - Number(a.green) || a.attempts - b.attempts || a.ms - b.ms);
+  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
+  const summary = ["\nCanary results (best first):", ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`), `
+Recommended: ${results[0]?.green ? results[0].model : "NONE PASSED \u2014 set FARM_MODEL manually or revise the plan"}`, ""].join("\n");
+  await new Promise((resolve) => process.stdout.write(summary, () => resolve()));
+  process.exit(results[0]?.green ? 0 : 2);
+}
+async function main() {
+  const args = process.argv.slice(2);
+  const canary = args.includes("--canary");
+  const planPath = args.find((a) => !a.startsWith("--")) ?? "plan.json";
+  const plan = JSON.parse(await readFile(planPath, "utf8"));
+  validate(plan);
+  if (canary) return runCanary(plan);
+  const { model, apiBaseUrl, apiKey } = resolveConfig(plan);
+  await mkdir(ENV.worktreeRoot, { recursive: true });
+  await mkdir(ENV.reportDir, { recursive: true });
+  const done = /* @__PURE__ */ new Map();
+  const blocked = [];
+  let aborted = false;
+  try {
+    const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
+    if (branchResult.code !== 0)
+      throw new Error(`could not create integration branch '${ENV.integration}' from '${ENV.base}': ${branchResult.out}`);
+    integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+    await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
+    });
+    await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {
+    });
+    const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
+    if (wtResult.code !== 0)
+      throw new Error(`could not create integration worktree: ${wtResult.out}`);
+    const byId = new Map(plan.tasks.map((t) => [t.id, t]));
+    const escalated = /* @__PURE__ */ new Set();
+    const pending = new Set(plan.tasks.map((t) => t.id));
+    const running = /* @__PURE__ */ new Map();
+    const ready = () => [...pending].filter((id) => {
+      const deps = byId.get(id).deps ?? [];
+      if (deps.some((d) => escalated.has(d))) return false;
+      return deps.every((d) => done.get(d)?.status === "green");
+    });
+    const tripped = () => {
+      const settled = done.size;
+      if (settled < ENV.abortMinTasks) return false;
+      return escalated.size / settled > ENV.abortEscalationRate;
+    };
+    while (pending.size > 0 || running.size > 0) {
+      if (tripped()) {
+        aborted = true;
+        break;
+      }
+      for (const id2 of ready()) {
+        if (running.size >= ENV.concurrency) break;
+        pending.delete(id2);
+        running.set(
+          id2,
+          runTask(byId.get(id2), model, apiBaseUrl, apiKey).then(
+            (r2) => ({ id: id2, r: r2 }),
+            (e) => ({ id: id2, r: { id: id2, status: "escalate", attempts: 0, branch: `farm/${id2}`, worktree: path.resolve(ENV.worktreeRoot, id2), note: `crashed: ${e?.message ?? e}` } })
+          )
+        );
+      }
+      if (running.size === 0) break;
+      const { id, r } = await Promise.race(running.values());
+      running.delete(id);
+      done.set(id, r);
+      if (r.status === "escalate") escalated.add(id);
+    }
+    for (const id of pending) {
+      const deps = byId.get(id).deps ?? [];
+      const culprit = deps.find((d) => escalated.has(d));
+      blocked.push({ id, reason: aborted ? "run aborted (circuit breaker)" : culprit ? `dependency ${culprit} escalated` : "not scheduled" });
+    }
+  } finally {
+    await writeReport(plan, [...done.values()], blocked, aborted).catch((e) => console.error("report write failed:", e));
+    await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
+    });
+  }
+  const results = [...done.values()];
+  const esc = results.filter((r) => r.status === "escalate").length;
+  const green = results.filter((r) => r.status === "green").length;
+  const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
+  const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
+  const exitCode = esc || blocked.length || aborted ? 2 : 0;
+  const summary = [
+    aborted ? `
+ABORTED by circuit breaker \u2014 escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
+    `
+Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
+    `Worker tokens: prompt=${pTok} completion=${cTok}`,
+    `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
+    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
+    ""
+  ].join("\n");
+  await new Promise((resolve) => process.stdout.write(summary, () => resolve()));
+  process.exit(exitCode);
+}
+async function writeReport(plan, results, blocked, aborted) {
+  await mkdir(path.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {
+  });
+  for (const r of results) {
+    const d = await git(["diff", `${ENV.base}...${r.branch}`]);
+    if (d.code === 0 && d.out.trim())
+      await writeFile(path.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {
+      });
+  }
+  const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
+  const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
   await writeFile(
     path.join(ENV.reportDir, "farm-report.json"),
-    JSON.stringify(
-      { plan: plan.meta, results, blocked, ts: (/* @__PURE__ */ new Date()).toISOString() },
-      null,
-      2
-    )
+    JSON.stringify({ plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)
   );
   const md = [
     `# Farm report \u2014 ${plan.meta.name}`,
     ``,
-    `| task | status | attempts | branch | note |`,
-    `| --- | --- | --- | --- | --- |`,
-    ...results.map(
-      (r) => `| ${r.id} | ${r.status} | ${r.attempts} | ${r.branch} | ${r.note ?? ""} |`
-    ),
-    ...blocked.map((b) => `| ${b.id} | blocked | 0 | \u2014 | dependency escalated |`),
+    aborted ? `> **ABORTED by circuit breaker** \u2014 escalation rate exceeded threshold.
+` : ``,
+    `Worker tokens: prompt=${pTok} completion=${cTok}`,
+    ``,
+    `| task | status | attempts | files | branch | note |`,
+    `| --- | --- | --- | --- | --- | --- |`,
+    ...results.map((r) => `| ${r.id} | ${r.status}${r.warning ? " \u26A0" : ""} | ${r.attempts} | ${(r.filesWritten ?? []).length} | ${r.branch} | ${r.note ?? r.warning ?? ""} |`),
+    ...blocked.map((b) => `| ${b.id} | blocked | 0 | 0 | \u2014 | ${b.reason} |`),
     ``,
     `## Escalations \u2014 handle only these`,
-    ...results.filter((r) => r.status === "escalate").map(
-      (r) => `- **${r.id}** \u2014 worktree at \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`
-    )
+    ...results.filter((r) => r.status === "escalate").map((r) => `- **${r.id}** \u2014 worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
+    ``,
+    `## Warnings \u2014 review during spec-compliance`,
+    ...results.filter((r) => r.warning).map((r) => `- **${r.id}** \u2014 ${r.warning} (diff: \`${path.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`)
   ].join("\n");
   await writeFile(path.join(ENV.reportDir, "farm-report.md"), md);
 }

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+#!/usr/bin/env node
+
+// farm.ts
+import { spawn } from "node:child_process";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+var ENV = {
+  // Model: plan.meta.model (set by subagent-driven-development before dispatch),
+  // then FARM_MODEL env var override. Fails at startup if neither is set.
+  model: process.env.FARM_MODEL ?? null,
+  apiBaseUrl: process.env.FARM_API_BASE_URL ?? null,
+  apiKey: process.env.FARM_API_KEY ?? null,
+  concurrency: Number(process.env.FARM_CONCURRENCY ?? 4),
+  maxRetries: Number(process.env.FARM_MAX_RETRIES ?? 2),
+  base: process.env.FARM_BASE_BRANCH ?? "main",
+  integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
+  worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
+  reportDir: process.env.FARM_REPORT_DIR ?? ".farm"
+};
+function run(cmd, args, cwd) {
+  return new Promise((resolve) => {
+    const c = spawn(cmd, args, { cwd, env: process.env });
+    let out = "";
+    c.stdout.on("data", (d) => out += d);
+    c.stderr.on("data", (d) => out += d);
+    c.on("close", (code) => resolve({ code: code ?? 1, out }));
+  });
+}
+var git = (args, cwd) => run("git", args, cwd);
+async function runGate(cwd, commands) {
+  for (const cmd of commands) {
+    const r = await run("bash", ["-lc", cmd], cwd);
+    if (r.code !== 0) return { ok: false, failed: cmd, tail: r.out.slice(-3500) };
+  }
+  return { ok: true };
+}
+function buildPrompt(t, priorFailure) {
+  return [
+    `Implement exactly ONE task. Your only goal: make the failing test pass.`,
+    ``,
+    `TASK: ${t.description}`,
+    t.context ? `
+CONTEXT:
+${t.context}
+` : ``,
+    `The failing test is at: ${t.test.path}`,
+    `Make it pass WITHOUT modifying, deleting, or weakening that test.`,
+    ``,
+    `You may ONLY create or edit these files:`,
+    ...t.filesInScope.map((f) => `  - ${f}`),
+    `Touch nothing else. Do not run git. Do not install global packages.`,
+    ``,
+    `Respond with ONLY the files you need to create or modify.`,
+    `For each file, use this exact format:`,
+    ``,
+    `\`\`\`typescript`,
+    `// path: src/example.ts`,
+    `<complete file content here>`,
+    `\`\`\``,
+    ``,
+    `Do not include any explanation outside the code blocks.`,
+    priorFailure ? `
+Your previous attempt FAILED the gate. Fix it.
+Gate output (tail):
+${priorFailure}` : ``
+  ].join("\n");
+}
+async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey) {
+  let resp;
+  try {
+    resp = await fetch(`${apiBaseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }]
+      })
+    });
+  } catch (e) {
+    return { ok: false, filesWritten: [], error: `fetch failed: ${e}` };
+  }
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "(unreadable)");
+    return { ok: false, filesWritten: [], error: `API ${resp.status}: ${body.slice(0, 500)}` };
+  }
+  const data = await resp.json();
+  const content = data.choices?.[0]?.message?.content ?? "";
+  const filesWritten = [];
+  const blockRe = /```[a-z]*\n\/\/ path: ([^\n]+)\n([\s\S]*?)```/g;
+  let match;
+  while ((match = blockRe.exec(content)) !== null) {
+    const [, filePath, fileContent] = match;
+    const absPath = path.resolve(cwd, filePath.trim());
+    await mkdir(path.dirname(absPath), { recursive: true });
+    await writeFile(absPath, fileContent);
+    filesWritten.push(filePath.trim());
+  }
+  if (filesWritten.length === 0) {
+    return { ok: false, filesWritten: [], error: "no parseable file blocks in response" };
+  }
+  return { ok: true, filesWritten };
+}
+async function checkDrift(cwd, filesInScope) {
+  const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
+  const untracked = await git(
+    ["ls-files", "--others", "--exclude-standard", "-z"],
+    cwd
+  );
+  const changed = [];
+  if (tracked.code === 0) {
+    changed.push(...tracked.out.trim().split("\n").filter(Boolean));
+  }
+  if (untracked.code === 0) {
+    changed.push(...untracked.out.split("\0").filter(Boolean));
+  }
+  const allowed = new Set(filesInScope);
+  return changed.filter((f) => !allowed.has(f));
+}
+var mergeChain = Promise.resolve();
+var integrationWorktree;
+function withMergeLock(fn) {
+  const next = mergeChain.then(fn, fn);
+  mergeChain = next.catch(() => {
+  });
+  return next;
+}
+async function runTask(t, model, apiBaseUrl, apiKey) {
+  const branch = `farm/${t.id}`;
+  const wt = path.resolve(ENV.worktreeRoot, t.id);
+  const limit = t.maxRetries ?? ENV.maxRetries;
+  await git(["worktree", "add", "-b", branch, wt, ENV.integration]);
+  let priorFailure;
+  for (let attempt = 1; attempt <= limit + 1; attempt++) {
+    const worker = await runWorker(wt, buildPrompt(t, priorFailure), model, apiBaseUrl, apiKey);
+    if (!worker.ok) {
+      priorFailure = `worker error: ${worker.error}`;
+      continue;
+    }
+    const driftFiles = await checkDrift(wt, t.filesInScope);
+    if (driftFiles.length > 0) {
+      await git(["checkout", "."], wt);
+      return {
+        id: t.id,
+        status: "escalate",
+        attempts: attempt,
+        branch,
+        worktree: wt,
+        note: `drift: ${driftFiles.join(", ")}`
+      };
+    }
+    const gate = await runGate(wt, t.gate.commands);
+    if (gate.ok) {
+      await git(["add", "-A"], wt);
+      const commitResult = await git(
+        ["-c", "commit.gpgsign=false", "commit", "-m", `farm(${t.id}): ${t.description}`],
+        wt
+      );
+      if (commitResult.code !== 0) {
+        return {
+          id: t.id,
+          status: "escalate",
+          attempts: attempt,
+          branch,
+          worktree: wt,
+          note: `commit failed: ${commitResult.out.slice(0, 200)}`
+        };
+      }
+      const merged = await withMergeLock(async () => {
+        const m = await git(["merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
+        if (m.code !== 0) {
+          await git(["merge", "--abort"], integrationWorktree);
+          return false;
+        }
+        return true;
+      });
+      if (!merged) {
+        return {
+          id: t.id,
+          status: "escalate",
+          attempts: attempt,
+          branch,
+          worktree: wt,
+          note: "merge conflict vs integration branch"
+        };
+      }
+      await git(["worktree", "remove", "--force", wt]).catch(() => {
+      });
+      return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt };
+    }
+    priorFailure = `failed: ${gate.failed}
+${gate.tail}`;
+  }
+  return {
+    id: t.id,
+    status: "escalate",
+    attempts: limit + 1,
+    branch,
+    worktree: wt,
+    note: priorFailure?.split("\n")[0]
+  };
+}
+async function main() {
+  const planPath = process.argv[2] ?? "plan.json";
+  const plan = JSON.parse(await readFile(planPath, "utf8"));
+  validate(plan);
+  const model = ENV.model ?? plan.meta.model;
+  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl;
+  const apiKey = ENV.apiKey;
+  if (!model) {
+    console.error(
+      "Error: No model configured.\nSet FARM_MODEL env var, or run /ca:sprint --farm to trigger automatic model selection.\nSee .codearbiter/farm.md for setup instructions."
+    );
+    process.exit(1);
+  }
+  if (!apiBaseUrl) {
+    console.error(
+      "Error: No API base URL configured.\nSet FARM_API_BASE_URL env var or run /ca:sprint --farm.\nSee .codearbiter/farm.md for setup instructions."
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error(
+      "Error: FARM_API_KEY is not set.\nSee .codearbiter/farm.md for setup instructions."
+    );
+    process.exit(1);
+  }
+  await mkdir(ENV.worktreeRoot, { recursive: true });
+  await mkdir(ENV.reportDir, { recursive: true });
+  const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
+  if (branchResult.code !== 0) {
+    console.error(`Error: could not create integration branch '${ENV.integration}' from '${ENV.base}'.
+${branchResult.out}`);
+    process.exit(1);
+  }
+  integrationWorktree = path.resolve(".farm/integration-wt");
+  await mkdir(path.dirname(integrationWorktree), { recursive: true });
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
+  });
+  const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
+  if (wtResult.code !== 0) {
+    console.error(`Error: could not create integration worktree.
+${wtResult.out}`);
+    process.exit(1);
+  }
+  const byId = new Map(plan.tasks.map((t) => [t.id, t]));
+  const done = /* @__PURE__ */ new Map();
+  const escalated = /* @__PURE__ */ new Set();
+  const pending = new Set(plan.tasks.map((t) => t.id));
+  const running = /* @__PURE__ */ new Map();
+  const ready = () => [...pending].filter((id) => {
+    const deps = byId.get(id).deps ?? [];
+    if (deps.some((d) => escalated.has(d))) return false;
+    return deps.every((d) => done.get(d)?.status === "green");
+  });
+  while (pending.size > 0 || running.size > 0) {
+    for (const id2 of ready()) {
+      if (running.size >= ENV.concurrency) break;
+      pending.delete(id2);
+      running.set(
+        id2,
+        runTask(byId.get(id2), model, apiBaseUrl, apiKey).then((r2) => ({ id: id2, r: r2 }))
+      );
+    }
+    if (running.size === 0) break;
+    const { id, r } = await Promise.race(running.values());
+    running.delete(id);
+    done.set(id, r);
+    if (r.status === "escalate") escalated.add(id);
+  }
+  const blocked = [...pending].map((id) => ({ id }));
+  await writeReport(plan, [...done.values()], blocked);
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
+  });
+  const esc = [...done.values()].filter((r) => r.status === "escalate").length;
+  const green = [...done.values()].filter((r) => r.status === "green").length;
+  const exitCode = esc || blocked.length ? 2 : 0;
+  const summary = [
+    `
+Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
+    `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
+    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
+    ""
+  ].join("\n");
+  await new Promise(
+    (resolve) => process.stdout.write(summary, () => resolve())
+  );
+  process.exit(exitCode);
+}
+function validate(plan) {
+  const ids = /* @__PURE__ */ new Set();
+  for (const t of plan.tasks) {
+    if (ids.has(t.id)) throw new Error(`duplicate task id: ${t.id}`);
+    ids.add(t.id);
+  }
+  for (const t of plan.tasks)
+    for (const d of t.deps ?? [])
+      if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown task ${d}`);
+}
+async function writeReport(plan, results, blocked) {
+  await writeFile(
+    path.join(ENV.reportDir, "farm-report.json"),
+    JSON.stringify(
+      { plan: plan.meta, results, blocked, ts: (/* @__PURE__ */ new Date()).toISOString() },
+      null,
+      2
+    )
+  );
+  const md = [
+    `# Farm report \u2014 ${plan.meta.name}`,
+    ``,
+    `| task | status | attempts | branch | note |`,
+    `| --- | --- | --- | --- | --- |`,
+    ...results.map(
+      (r) => `| ${r.id} | ${r.status} | ${r.attempts} | ${r.branch} | ${r.note ?? ""} |`
+    ),
+    ...blocked.map((b) => `| ${b.id} | blocked | 0 | \u2014 | dependency escalated |`),
+    ``,
+    `## Escalations \u2014 handle only these`,
+    ...results.filter((r) => r.status === "escalate").map(
+      (r) => `- **${r.id}** \u2014 worktree at \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`
+    )
+  ].join("\n");
+  await writeFile(path.join(ENV.reportDir, "farm-report.md"), md);
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -33,6 +33,14 @@ var ENV = {
   // Comma-separated candidate model ids for --canary mode.
   candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "").split(",").map((s) => s.trim()).filter(Boolean)
 };
+var MUT = {
+  enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
+  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
+  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 3e4),
+  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
+  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
+  cmd: process.env.FARM_MUTATION_CMD ?? null
+};
 function run(cmd, args, cwd) {
   return new Promise((resolve) => {
     const c = spawn(cmd, args, { cwd, env: process.env });
@@ -283,6 +291,119 @@ async function resetWorktree(wt) {
   await git(["reset", "--hard", "HEAD"], wt);
   await git(["clean", "-fd"], wt);
 }
+function shuffle(a) {
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+function generateMutants(file, src) {
+  const lines = src.split("\n");
+  const rules = [
+    [/ >= /, " > ", ">=>"],
+    [/ <= /, " < ", "<=<"],
+    [/ === /, " !== ", "===>!=="],
+    [/ !== /, " === ", "!==>==="],
+    [/ == /, " != ", "==>!="],
+    [/ != /, " == ", "!=>=="],
+    [/ > /, " >= ", ">>="],
+    [/ < /, " <= ", "<<="],
+    [/ \+ /, " - ", "+>-"],
+    [/ - /, " + ", "->+"],
+    [/ \* /, " / ", "*>/"],
+    [/ && /, " || ", "&&>||"],
+    [/ \|\| /, " && ", "||>&&"],
+    [/\btrue\b/, "false", "true>false"],
+    [/\bfalse\b/, "true", "false>true"]
+  ];
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    const t = ln.trim();
+    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("*") || t.startsWith("/*")) continue;
+    for (const [re, rep, name] of rules) {
+      if (re.test(ln)) {
+        const mline = ln.replace(re, rep);
+        if (mline !== ln) {
+          const m = [...lines];
+          m[i] = mline;
+          out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} ${name}` });
+        }
+      }
+    }
+    const rm2 = ln.match(/\breturn\s+(.+?);/);
+    if (rm2 && rm2[1].trim() !== "null" && rm2[1].trim() !== "") {
+      const m = [...lines];
+      m[i] = ln.replace(/\breturn\s+.+?;/, "return null;");
+      out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} return>null` });
+    }
+  }
+  return out;
+}
+async function mutationCheck(wt, task) {
+  if (!MUT.enabled) return null;
+  const testCmd = task.gate.commands[0];
+  if (!testCmd) return null;
+  const impl = task.filesInScope.filter((f) => f !== task.test.path);
+  if (MUT.cmd) {
+    const r = await new Promise((resolve) => {
+      const c = spawn("bash", ["-c", MUT.cmd], {
+        cwd: wt,
+        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd }
+      });
+      let out = "";
+      c.stdout.on("data", (d) => out += d);
+      c.stderr.on("data", (d) => out += d);
+      c.on("error", (e) => resolve({ code: 1, out: String(e) }));
+      c.on("close", (code) => resolve({ code: code ?? 1, out }));
+    });
+    const j = [...r.out.matchAll(/\{[^\n]*"score"[^\n]*\}/g)].pop();
+    if (!j) return null;
+    try {
+      const parsed = JSON.parse(j[0]);
+      if (typeof parsed.score === "number")
+        return { score: parsed.score, evaluated: parsed.total ?? parsed.evaluated ?? 99, survivors: parsed.survived ?? [] };
+    } catch {
+    }
+    return null;
+  }
+  const originals = /* @__PURE__ */ new Map();
+  let candidates = [];
+  for (const f of impl) {
+    let src;
+    try {
+      src = await readFile(path.resolve(wt, f), "utf8");
+    } catch {
+      continue;
+    }
+    if (codeLineCount(src) <= 2) continue;
+    originals.set(f, src);
+    candidates.push(...generateMutants(f, src));
+  }
+  if (candidates.length === 0) return null;
+  candidates = shuffle(candidates).slice(0, MUT.sample);
+  const start = Date.now();
+  let killed = 0;
+  let evaluated = 0;
+  const survivors = [];
+  try {
+    for (const c of candidates) {
+      if (Date.now() - start > MUT.budgetMs) break;
+      await writeFile(path.resolve(wt, c.file), c.mutated);
+      const r = await run("bash", ["-c", testCmd], wt);
+      await writeFile(path.resolve(wt, c.file), originals.get(c.file));
+      evaluated++;
+      if (r.code !== 0) killed++;
+      else survivors.push(c.tag);
+    }
+  } finally {
+    for (const [f, src] of originals) await writeFile(path.resolve(wt, f), src).catch(() => {
+    });
+  }
+  if (evaluated < 3) return null;
+  return { score: killed / evaluated, evaluated, survivors };
+}
 var mergeChain = Promise.resolve();
 var integrationWorktree;
 function withMergeLock(fn) {
@@ -318,6 +439,7 @@ async function runTask(t, model, apiBaseUrl, apiKey) {
   let promptTokens = 0;
   let completionTokens = 0;
   let lastWarning;
+  let mutationScore = null;
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
     if (attempt > 1) await resetWorktree(wt);
     const worker = await runWorker(
@@ -355,12 +477,29 @@ ${gate.tail}`;
       continue;
     }
     const gaming = await antiGamingCheck(wt, t);
-    if (gaming.risk === "high") {
-      priorFailure = `${gaming.note}. Implement real logic, do not hard-code the asserted value.`;
-      if (attempt <= limit) continue;
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: gaming.note, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    let risk = gaming.risk;
+    let riskNote = gaming.note;
+    if (risk !== "high") {
+      const mut = await mutationCheck(wt, t);
+      if (mut) {
+        mutationScore = mut.score;
+        if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
+          risk = "high";
+          riskNote = `gaming: mutation score ${mut.score.toFixed(2)} (${mut.evaluated} mutants survived \u2014 the test does not constrain the implementation)`;
+        } else if (mut.score < MUT.warnBelow) {
+          if (risk !== "warn") {
+            risk = "warn";
+            riskNote = `mutation-risk: score ${mut.score.toFixed(2)} (${mut.survivors.length}/${mut.evaluated} survived) \u2014 weak test or under-implemented logic`;
+          }
+        }
+      }
     }
-    if (gaming.risk === "warn") lastWarning = gaming.note;
+    if (risk === "high") {
+      priorFailure = `${riskNote}. Implement real logic; do not hard-code or special-case the asserted value.`;
+      if (attempt <= limit) continue;
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore };
+    }
+    if (risk === "warn") lastWarning = riskNote;
     await git(["add", "-A"], wt);
     const commit = await git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
     if (commit.code !== 0)
@@ -379,9 +518,9 @@ ${gate.tail}`;
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     await git(["worktree", "remove", "--force", wt]).catch(() => {
     });
-    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens };
+    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore };
   }
-  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens };
+  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore };
 }
 function validate(plan) {
   const ids = /* @__PURE__ */ new Set();
@@ -573,10 +712,10 @@ async function writeReport(plan, results, blocked, aborted) {
 ` : ``,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     ``,
-    `| task | status | attempts | files | branch | note |`,
-    `| --- | --- | --- | --- | --- | --- |`,
-    ...results.map((r) => `| ${r.id} | ${r.status}${r.warning ? " \u26A0" : ""} | ${r.attempts} | ${(r.filesWritten ?? []).length} | ${r.branch} | ${r.note ?? r.warning ?? ""} |`),
-    ...blocked.map((b) => `| ${b.id} | blocked | 0 | 0 | \u2014 | ${b.reason} |`),
+    `| task | status | attempts | files | mut | branch | note |`,
+    `| --- | --- | --- | --- | --- | --- | --- |`,
+    ...results.map((r) => `| ${r.id} | ${r.status}${r.warning ? " \u26A0" : ""} | ${r.attempts} | ${(r.filesWritten ?? []).length} | ${r.mutationScore == null ? "\u2014" : r.mutationScore.toFixed(2)} | ${r.branch} | ${r.note ?? r.warning ?? ""} |`),
+    ...blocked.map((b) => `| ${b.id} | blocked | 0 | 0 | \u2014 | \u2014 | ${b.reason} |`),
     ``,
     `## Escalations \u2014 handle only these`,
     ...results.filter((r) => r.status === "escalate").map((r) => `- **${r.id}** \u2014 worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync, exec } from "node:child_process";
-import { readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -260,5 +260,133 @@ describe("farm.ts smoke tests", () => {
       readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"),
     );
     expect(report.results[0].status).toBe("escalate");
+  });
+
+  it("blocks path traversal — worker cannot write outside the worktree", async () => {
+    const sentinel = join(tmpDir, "..", `farm-escape-${Date.now()}.txt`);
+    ({ server: mockServer, port } = await startMockServer(() =>
+      [
+        "```typescript",
+        `// path: ../${sentinel.split("/").pop()}`,
+        "export const pwned = true;",
+        "```",
+      ].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "traversal-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          gate: { commands: ["bash -c 'exit 0'"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(result.code).toBe(2);
+    // The escape file must NOT have been written anywhere outside the worktree.
+    expect(existsSync(sentinel)).toBe(false);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results[0].status).toBe("escalate");
+    expect(report.results[0].note).toMatch(/escapes worktree/);
+  });
+
+  it("protects the failing test — worker cannot overwrite test.path", async () => {
+    ({ server: mockServer, port } = await startMockServer(() =>
+      [
+        "```typescript",
+        "// path: src/hello.test.ts",
+        "// neutered test that always passes",
+        "```",
+      ].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "test-protect", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          gate: { commands: ["bash -c 'exit 0'"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(result.code).toBe(2);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results[0].status).toBe("escalate");
+    expect(report.results[0].note).toMatch(/read-only|tampered/);
+  });
+
+  it("flags anti-gaming — tiny impl that hard-codes the asserted literal escalates", async () => {
+    ({ server: mockServer, port } = await startMockServer(() =>
+      ["```typescript", "// path: src/answer.ts", "export const answer = 42;", "```"].join("\n"),
+    ));
+
+    // Commit a test that asserts a specific literal, so it exists in the worktree.
+    writeFileSync(join(tmpDir, "src", "answer.test.ts"), "expect(answer).toBe(42);\n");
+    execSync("git add -A", { cwd: tmpDir, stdio: "pipe" });
+    execSync("git commit -m 'add failing test' --no-gpg-sign", { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "gaming-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Compute the answer",
+          deps: [],
+          filesInScope: ["src/answer.ts"],
+          test: { path: "src/answer.test.ts" },
+          gate: { commands: ["bash -c 'exit 0'"] }, // gate passes; guard must still catch gaming
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(result.code).toBe(2);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results[0].status).toBe("escalate");
+    expect(report.results[0].note).toMatch(/^gaming:/);
+  });
+
+  it("is safe to run twice in a row (stale branches cleaned)", async () => {
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      const file = content.includes("src/hello.ts") ? "src/hello.ts" : "src/world.ts";
+      return ["```typescript", `// path: ${file}`, `export const x = 1;`, "```"].join("\n");
+    }));
+
+    const planPath = join(tmpDir, "plan.json");
+    const plan = JSON.parse(readFileSync(join(__dirname, "__fixtures__/simple.plan.json"), "utf8"));
+    plan.meta.apiBaseUrl = `http://127.0.0.1:${port}`;
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const first = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+    expect(first.code).toBe(0);
+    // Second run against the same repo must not fail on stale farm/* branches.
+    const second = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+    expect(second.code).toBe(0);
+    expect(second.out).toContain("green=2");
   });
 });

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Smoke tests for farm.ts. Uses a mock HTTP server so no real API key needed.
+ * Tests run against a temp git repo to avoid touching the main worktree.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync, exec } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const TSX_BIN = resolve(__dirname, "node_modules/.bin/tsx");
+const farmTs = resolve(__dirname, "farm.ts");
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import type { Server } from "node:http";
+
+// --------------------------------------------------------------------------
+// Mini mock HTTP server that returns canned file-block responses
+// --------------------------------------------------------------------------
+type MockHandler = (body: unknown) => string;
+
+function startMockServer(handler: MockHandler): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        const body = JSON.parse(data || "{}");
+        const content = handler(body);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { content } }],
+          }),
+        );
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ server, port: addr.port });
+    });
+  });
+}
+
+// --------------------------------------------------------------------------
+// Temp git repo setup
+// --------------------------------------------------------------------------
+function createTempRepo(dir: string) {
+  mkdirSync(dir, { recursive: true });
+  execSync("git init -b main", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.email test@test.com", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.name Test", { cwd: dir, stdio: "pipe" });
+  execSync("git config commit.gpgsign false", { cwd: dir, stdio: "pipe" });
+  // Initial commit so we have a HEAD on main
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  execSync("git add -A", { cwd: dir, stdio: "pipe" });
+  execSync("git commit -m init --no-gpg-sign", { cwd: dir, stdio: "pipe" });
+  mkdirSync(join(dir, "src"), { recursive: true });
+}
+
+// --------------------------------------------------------------------------
+// Run farm.ts via tsx (dev path) against the temp repo
+// --------------------------------------------------------------------------
+function runFarm(
+  repoDir: string,
+  planPath: string,
+  env: Record<string, string>,
+): Promise<{ code: number; out: string }> {
+  return new Promise((resolve) => {
+    exec(
+      `"${TSX_BIN}" "${farmTs}" "${planPath}"`,
+      {
+        cwd: repoDir,
+        env: {
+          ...process.env,
+          // Disable commit signing in temp repos
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: "commit.gpgsign",
+          GIT_CONFIG_VALUE_0: "false",
+          ...env,
+        },
+      },
+      (err, stdout, stderr) => {
+        resolve({ code: err?.code ?? 0, out: stdout + stderr });
+      },
+    );
+  });
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+describe("farm.ts smoke tests", () => {
+  let tmpDir: string;
+  let mockServer: Server;
+  let port: number;
+
+  beforeEach(async () => {
+    tmpDir = join("/tmp", `farm-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    createTempRepo(tmpDir);
+  });
+
+  afterEach(() => {
+    mockServer?.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+    // Clean up any leftover farm worktrees
+    rmSync(join(tmpDir, "../.codearbiter-farm"), { recursive: true, force: true });
+  });
+
+  it("fails immediately when FARM_MODEL is not set", async () => {
+    const plan = {
+      meta: { name: "test" },
+      tasks: [
+        {
+          id: "t1",
+          description: "test",
+          filesInScope: ["src/a.ts"],
+          test: { path: "src/a.test.ts" },
+          gate: { commands: ["bash -c 'exit 0'"] },
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_API_BASE_URL: "http://localhost:9",
+      // No FARM_MODEL, no meta.model
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("No model configured");
+  });
+
+  it("completes two tasks green when API returns valid file blocks", async () => {
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      // Return a file block appropriate to the task described in the prompt
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      if (content.includes("src/hello.ts")) {
+        return [
+          "```typescript",
+          "// path: src/hello.ts",
+          "export function hello() { return 'hello'; }",
+          "```",
+        ].join("\n");
+      }
+      return [
+        "```typescript",
+        "// path: src/world.ts",
+        "export function world() { return 'world'; }",
+        "```",
+      ].join("\n");
+    }));
+
+    const planPath = join(tmpDir, "plan.json");
+    const plan = JSON.parse(
+      readFileSync(join(__dirname, "__fixtures__/simple.plan.json"), "utf8"),
+    );
+    plan.meta.apiBaseUrl = `http://127.0.0.1:${port}`;
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_BASE_BRANCH: "main",
+    });
+
+    if (result.code !== 0) {
+      console.error("FARM OUTPUT:", result.out);
+      try {
+        const r = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+        console.error("REPORT:", JSON.stringify(r.results, null, 2));
+      } catch {}
+    }
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("green=2");
+    expect(result.out).toContain("escalate=0");
+
+    // Report written
+    const report = JSON.parse(
+      readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"),
+    );
+    expect(report.results).toHaveLength(2);
+    expect(report.results.every((r: { status: string }) => r.status === "green")).toBe(true);
+  });
+
+  it("escalates with 'drift:' note when worker writes outside filesInScope", async () => {
+    ({ server: mockServer, port } = await startMockServer(() =>
+      [
+        "```typescript",
+        "// path: src/hello.ts",
+        "export function hello() { return 'hello'; }",
+        "```",
+        "```typescript",
+        "// path: src/UNAUTHORIZED.ts",
+        "// this file should not be here",
+        "```",
+      ].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "drift-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          gate: { commands: ["bash -c 'exit 0'"] },
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    console.error("DRIFT TEST OUTPUT:", result.out);
+    expect(result.code).toBe(2);
+    const report = JSON.parse(
+      readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"),
+    );
+    const escalated = report.results.find((r: { id: string }) => r.id === "task-a");
+    expect(escalated.status).toBe("escalate");
+    expect(escalated.note).toMatch(/^drift:/);
+  });
+
+  it("escalates with gate failure note after maxRetries exceeded", async () => {
+    ({ server: mockServer, port } = await startMockServer(() =>
+      [
+        "```typescript",
+        "// path: src/hello.ts",
+        "export function hello() { return 'hello'; }",
+        "```",
+      ].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "gate-fail-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          gate: { commands: ["false"] }, // always fails (exit 1)
+          maxRetries: 1,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(result.code).toBe(2);
+    const report = JSON.parse(
+      readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"),
+    );
+    expect(report.results[0].status).toBe("escalate");
+  });
+});

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -370,6 +370,94 @@ describe("farm.ts smoke tests", () => {
     expect(report.results[0].note).toMatch(/^gaming:/);
   });
 
+  it("mutation guard — flags an impl whose branches the narrow test does not constrain", async () => {
+    // Worker returns a multi-branch impl; the narrow test only exercises one path,
+    // so mutating the unexercised branch/operator survives → low mutation score.
+    ({ server: mockServer, port } = await startMockServer(() =>
+      [
+        "```javascript",
+        "// path: src/classify.js",
+        "module.exports.classify = function (n) {",
+        '  if (n > 10) return "big";',
+        '  return "small";',
+        "};",
+        "```",
+      ].join("\n"),
+    ));
+
+    const narrowTest =
+      `node -e "const {classify}=require('./src/classify.js'); process.exit(classify(5)==='small'?0:1)"`;
+    const plan = {
+      meta: { name: "mutation-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Classify a number",
+          deps: [],
+          filesInScope: ["src/classify.js"],
+          test: { path: "src/classify.test.js" },
+          gate: { commands: [narrowTest] }, // gate.commands[0] = the narrow behavioral test
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    // Score is low but not near-zero (the "small" return IS killed), so it warns
+    // into Phase 3 rather than hard-escalating: task stays green with a warning.
+    expect(result.code).toBe(0);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    const r = report.results[0];
+    expect(r.status).toBe("green");
+    expect(r.mutationScore).toBeLessThan(0.5);
+    expect(r.warning).toMatch(/mutation-risk/);
+  });
+
+  it("mutation guard — near-zero score on a non-trivial impl hard-escalates", async () => {
+    // A multi-branch impl behind a no-op gate: nothing is constrained, so every
+    // mutant survives (score ~0) and the guard escalates.
+    ({ server: mockServer, port } = await startMockServer(() =>
+      [
+        "```javascript",
+        "// path: src/m.js",
+        "module.exports.f = function (a, b) {",
+        "  if (a > b) return 1;",
+        "  if (a < b) return 2;",
+        "  if (a === b) return 3;",
+        "  return 4;",
+        "};",
+        "```",
+      ].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "mutation-escalate", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Compare",
+          deps: [],
+          filesInScope: ["src/m.js"],
+          test: { path: "src/m.test.js" },
+          gate: { commands: ["bash -c 'exit 0'"] }, // no-op gate constrains nothing
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(result.code).toBe(2);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results[0].status).toBe("escalate");
+    expect(report.results[0].note).toMatch(/mutation score/);
+  });
+
   it("is safe to run twice in a row (stale branches cleaned)", async () => {
     ({ server: mockServer, port } = await startMockServer((body) => {
       const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -1,11 +1,10 @@
-#!/usr/bin/env node
 /**
  * farm.ts — codeArbiter's zero-LLM-token dispatcher.
  *
  * Papa Claude (your interactive Claude Code session) does the judgment work:
  * brainstorm -> spec -> write the FAILING tests into the repo -> emit plan.json.
- * Then he runs THIS script and walks away. No model calls happen in here — the
- * only model cost is the cheap Zen worker invoked per task.
+ * Then he runs THIS script and walks away. No premium model calls happen in
+ * here — the only model cost is the cheap Zen worker invoked per task.
  *
  * For each task the dispatcher:
  *   1. cuts an isolated git worktree off the *current integration HEAD*
@@ -13,18 +12,31 @@
  *   2. calls the Zen/DeepSeek API directly whose only job is to make the
  *      failing test pass,
  *   3. enforces filesInScope — any file outside the allowed set fails the task,
+ *      and protects the failing test from being modified or deleted,
  *   4. enforces the gate deterministically (the test must go green, suite stays
  *      green, lint/types pass — whatever you put in gate.commands),
- *   5. retries with the gate failure fed back in, up to maxRetries,
- *   6. on success commits + merges into the integration branch via a dedicated
+ *   5. runs a zero-token anti-gaming check (does the impl hard-code the test's
+ *      expected values?) so obviously-gamed output is caught before review,
+ *   6. retries with the gate failure fed back in, up to maxRetries, resetting
+ *      the worktree between attempts so stale files never accumulate,
+ *   7. on success commits + merges into the integration branch via a dedicated
  *      integration worktree (never touches the main repo checkout),
- *   7. on exhaustion leaves the worktree in place and ESCALATES the task.
+ *   8. on exhaustion leaves the worktree in place and ESCALATES the task.
+ *
+ * A circuit breaker aborts the run if too many tasks escalate (a bad/incapable
+ * model), so you don't burn quota cutting 50 worktrees for nothing.
  *
  * It never merges to main — codeArbiter's PR-only rule is preserved. You review
- * the integration branch and open the PR yourself.
+ * the integration branch (each green task still routes through the normal
+ * spec-compliance + quality + fresh-verification gates) and open the PR yourself.
+ *
+ * Canary mode (`--canary <plan.json>`): runs the smallest task against each
+ * model in FARM_CANDIDATE_MODELS and reports a measured pass-rate ranking, so
+ * model selection is objective rather than web hearsay. No merge, no mutation.
  */
 import { spawn } from "node:child_process";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rm, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 
 // --------------------------------------------------------------------------
@@ -49,6 +61,9 @@ const ENV = {
   // Model: plan.meta.model (set by subagent-driven-development before dispatch),
   // then FARM_MODEL env var override. Fails at startup if neither is set.
   model: process.env.FARM_MODEL ?? null,
+  // No-default kept deliberately: dispatch records the chosen endpoint in
+  // plan.meta.apiBaseUrl. A code default is provided only as a last resort so a
+  // user who sets just FARM_API_KEY (per the docs) is not hard-blocked.
   apiBaseUrl: process.env.FARM_API_BASE_URL ?? null,
   apiKey: process.env.FARM_API_KEY ?? null,
   concurrency: Number(process.env.FARM_CONCURRENCY ?? 4),
@@ -57,6 +72,22 @@ const ENV = {
   integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
   worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
+  // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
+  requestTimeoutMs: Number(process.env.FARM_REQUEST_TIMEOUT_MS ?? 120_000),
+  // Transport-level retries (429 / 5xx) — distinct from model-quality retries.
+  apiMaxRetries: Number(process.env.FARM_API_MAX_RETRIES ?? 3),
+  // Circuit breaker: abort dispatch once the escalation rate exceeds this,
+  // after at least abortMinTasks have settled.
+  abortEscalationRate: Number(process.env.FARM_ABORT_ESCALATION_RATE ?? 0.5),
+  abortMinTasks: Number(process.env.FARM_ABORT_MIN_TASKS ?? 3),
+  // Default endpoint, used only when neither env nor plan.meta provides one.
+  defaultApiBaseUrl:
+    process.env.FARM_DEFAULT_API_BASE_URL ?? "https://api.opencode.ai/v1",
+  // Comma-separated candidate model ids for --canary mode.
+  candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
 };
 
 // --------------------------------------------------------------------------
@@ -68,29 +99,43 @@ function run(cmd: string, args: string[], cwd?: string) {
     let out = "";
     c.stdout.on("data", (d) => (out += d));
     c.stderr.on("data", (d) => (out += d));
+    c.on("error", (e) => resolve({ code: 1, out: String(e) }));
     c.on("close", (code) => resolve({ code: code ?? 1, out }));
   });
 }
 const git = (args: string[], cwd?: string) => run("git", args, cwd);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Commit without signing — the farm makes mechanical commits; signing servers
+// in CI environments reject unattended commits and would be misreported as
+// merge conflicts. The integration PR the human opens is the signed artifact.
+const NOSIGN = ["-c", "commit.gpgsign=false"];
 
 // --------------------------------------------------------------------------
-// gate — pure determinism, no model
+// path containment — untrusted worker output must never escape the worktree
+// --------------------------------------------------------------------------
+function isInside(root: string, target: string): boolean {
+  const rel = path.relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+// --------------------------------------------------------------------------
+// gate — pure determinism, no model. `bash -c` (NOT -lc): a login shell would
+// source the invoking user's dotfiles and make the gate non-deterministic.
 // --------------------------------------------------------------------------
 async function runGate(cwd: string, commands: string[]) {
   for (const cmd of commands) {
-    const r = await run("bash", ["-lc", cmd], cwd);
-    if (r.code !== 0) return { ok: false as const, failed: cmd, tail: r.out.slice(-3500) };
+    const r = await run("bash", ["-c", cmd], cwd);
+    if (r.code !== 0)
+      return { ok: false as const, failed: cmd, tail: r.out.slice(-3500) };
   }
   return { ok: true as const };
 }
 
 // --------------------------------------------------------------------------
-// worker — direct OpenAI-compatible API call (Bug #3 fix)
-// Note: at implementation time, also check github.com/sst/opencode for any
-// TypeScript SDK or MCP server — if a typed run_task() interface exists with
-// structured file-change output, it's worth comparing against this approach.
+// worker prompt
 // --------------------------------------------------------------------------
-function buildPrompt(t: Task, priorFailure?: string) {
+function buildPrompt(t: Task, priorFailure?: string, forbiddenExtra?: string[]) {
   return [
     `Implement exactly ONE task. Your only goal: make the failing test pass.`,
     ``,
@@ -98,10 +143,18 @@ function buildPrompt(t: Task, priorFailure?: string) {
     t.context ? `\nCONTEXT:\n${t.context}\n` : ``,
     `The failing test is at: ${t.test.path}`,
     `Make it pass WITHOUT modifying, deleting, or weakening that test.`,
+    `You may NOT create, edit, or delete ${t.test.path} — it is read-only.`,
     ``,
     `You may ONLY create or edit these files:`,
     ...t.filesInScope.map((f) => `  - ${f}`),
     `Touch nothing else. Do not run git. Do not install global packages.`,
+    forbiddenExtra && forbiddenExtra.length
+      ? `\nYour previous attempt wrote these FORBIDDEN paths — do NOT touch them again:\n${forbiddenExtra.map((f) => `  - ${f}`).join("\n")}`
+      : ``,
+    ``,
+    `Solve the task with REAL logic. Do not hard-code the literal values the`,
+    `test asserts — an implementation that only returns the expected constant`,
+    `will be rejected.`,
     ``,
     `Respond with ONLY the files you need to create or modify.`,
     `For each file, use this exact format:`,
@@ -118,84 +171,259 @@ function buildPrompt(t: Task, priorFailure?: string) {
   ].join("\n");
 }
 
+// --------------------------------------------------------------------------
+// response parsing — line-based fence scanner. Robust to language tags,
+// `// path:` / `# path:` comments, and the ```lang:path fence convention.
+// Returns the path + body for each file block.
+// --------------------------------------------------------------------------
+function extractFileBlocks(content: string): Array<{ path: string; body: string }> {
+  const lines = content.split("\n");
+  const blocks: Array<{ path: string; body: string }> = [];
+  let i = 0;
+  while (i < lines.length) {
+    const open = lines[i].match(/^\s*```(.*)$/);
+    if (!open) {
+      i++;
+      continue;
+    }
+    const info = open[1].trim();
+    // collect body until the next fence line
+    const body: string[] = [];
+    i++;
+    while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+      body.push(lines[i]);
+      i++;
+    }
+    i++; // consume closing fence (or fall off the end)
+
+    // Determine the path: prefer `lang:path` info string, else a leading
+    // `// path:` / `# path:` / `/* path: ... */` comment in the body.
+    let filePath: string | null = null;
+    const infoPath = info.match(/^[a-z0-9]*:(.+)$/i);
+    if (infoPath && /[\/.]/.test(infoPath[1])) {
+      filePath = infoPath[1].trim();
+    } else if (body.length) {
+      const first = body[0].trim();
+      const m =
+        first.match(/^(?:\/\/|#)\s*path:\s*(.+)$/i) ||
+        first.match(/^\/\*\s*path:\s*(.+?)\s*\*\/$/i);
+      if (m) {
+        filePath = m[1].trim();
+        body.shift(); // drop the path-marker line from the written content
+      }
+    }
+    if (filePath) blocks.push({ path: filePath, body: body.join("\n") });
+  }
+  return blocks;
+}
+
+type WorkerResult = {
+  ok: boolean;
+  filesWritten: string[];
+  error?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+};
+
+async function callApi(
+  prompt: string,
+  model: string,
+  apiBaseUrl: string,
+  apiKey: string,
+): Promise<{ ok: true; content: string; usage?: { prompt_tokens?: number; completion_tokens?: number } } | { ok: false; error: string }> {
+  for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), ENV.requestTimeoutMs);
+    let resp: Response;
+    try {
+      resp = await fetch(`${apiBaseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: prompt }],
+        }),
+        signal: ctrl.signal,
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      const aborted = (e as Error)?.name === "AbortError";
+      // network / timeout: retry with backoff
+      if (attempt < ENV.apiMaxRetries) {
+        await sleep(Math.min(2 ** attempt * 1000, 16_000));
+        continue;
+      }
+      return { ok: false, error: aborted ? `request timed out after ${ENV.requestTimeoutMs}ms` : `fetch failed: ${e}` };
+    }
+    clearTimeout(timer);
+
+    // Transport-level failure (rate limit / server) — back off and retry the
+    // REQUEST, not the task. A 429 is not a failed implementation attempt.
+    if (resp.status === 429 || resp.status >= 500) {
+      if (attempt < ENV.apiMaxRetries) {
+        const ra = Number(resp.headers.get("retry-after"));
+        const wait = Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(2 ** attempt * 1000, 16_000);
+        await sleep(wait);
+        continue;
+      }
+      const body = await resp.text().catch(() => "(unreadable)");
+      return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries: ${body.slice(0, 300)}` };
+    }
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "(unreadable)");
+      return { ok: false, error: `API ${resp.status}: ${body.slice(0, 500)}` };
+    }
+
+    let data: { choices?: Array<{ message?: { content?: string } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } };
+    try {
+      data = (await resp.json()) as typeof data;
+    } catch (e) {
+      return { ok: false, error: `non-JSON response: ${e}` };
+    }
+    return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
+  }
+  return { ok: false, error: "exhausted API retries" };
+}
+
 async function runWorker(
   cwd: string,
   prompt: string,
   model: string,
   apiBaseUrl: string,
   apiKey: string,
-): Promise<{ ok: boolean; filesWritten: string[]; error?: string }> {
-  let resp: Response;
-  try {
-    resp = await fetch(`${apiBaseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: prompt }],
-      }),
-    });
-  } catch (e) {
-    return { ok: false, filesWritten: [], error: `fetch failed: ${e}` };
-  }
+  forbidden: Set<string>,
+): Promise<WorkerResult> {
+  const api = await callApi(prompt, model, apiBaseUrl, apiKey);
+  if (!api.ok) return { ok: false, filesWritten: [], error: api.error };
 
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => "(unreadable)");
-    return { ok: false, filesWritten: [], error: `API ${resp.status}: ${body.slice(0, 500)}` };
-  }
-
-  const data = await resp.json() as {
-    choices?: Array<{ message?: { content?: string } }>;
-  };
-  const content = data.choices?.[0]?.message?.content ?? "";
-
-  // Parse fenced code blocks with `// path: <file>` as first line
+  const blocks = extractFileBlocks(api.content);
   const filesWritten: string[] = [];
-  const blockRe = /```[a-z]*\n\/\/ path: ([^\n]+)\n([\s\S]*?)```/g;
-  let match: RegExpExecArray | null;
-  while ((match = blockRe.exec(content)) !== null) {
-    const [, filePath, fileContent] = match;
-    const absPath = path.resolve(cwd, filePath.trim());
+  for (const { path: filePath, body } of blocks) {
+    const cleanPath = filePath.trim();
+    const absPath = path.resolve(cwd, cleanPath);
+    // Containment: untrusted output may not escape the worktree.
+    if (!isInside(cwd, absPath)) {
+      return { ok: false, filesWritten, error: `path escapes worktree: ${cleanPath}` };
+    }
+    // The failing test is read-only — refuse to let the worker touch it.
+    const rel = path.relative(cwd, absPath);
+    if (forbidden.has(rel)) {
+      return { ok: false, filesWritten, error: `worker tried to write read-only path: ${rel}` };
+    }
     await mkdir(path.dirname(absPath), { recursive: true });
-    await writeFile(absPath, fileContent);
-    filesWritten.push(filePath.trim());
+    await writeFile(absPath, body.endsWith("\n") ? body : body + "\n");
+    filesWritten.push(rel);
   }
 
   if (filesWritten.length === 0) {
-    return { ok: false, filesWritten: [], error: "no parseable file blocks in response" };
+    return {
+      ok: false,
+      filesWritten: [],
+      error: "no parseable file blocks in response",
+      promptTokens: api.usage?.prompt_tokens,
+      completionTokens: api.usage?.completion_tokens,
+    };
   }
-
-  return { ok: true, filesWritten };
+  return {
+    ok: true,
+    filesWritten,
+    promptTokens: api.usage?.prompt_tokens,
+    completionTokens: api.usage?.completion_tokens,
+  };
 }
 
 // --------------------------------------------------------------------------
-// drift check — Bug #1 fix
-// Catches both modified tracked files and new untracked files.
-// git status --porcelain groups untracked files by directory; use ls-files
-// for new files to get individual paths.
+// drift check — path allowlist. Catches modified tracked files and new
+// untracked files individually (status --porcelain groups by directory).
 // --------------------------------------------------------------------------
-async function checkDrift(cwd: string, filesInScope: string[]): Promise<string[]> {
-  // Modified/deleted tracked files
+async function checkDrift(cwd: string, allowed: Set<string>): Promise<string[]> {
   const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
-  // New untracked files (individual paths, not directories)
   const untracked = await git(
     ["ls-files", "--others", "--exclude-standard", "-z"],
     cwd,
   );
-
   const changed: string[] = [];
-  if (tracked.code === 0) {
+  if (tracked.code === 0)
     changed.push(...tracked.out.trim().split("\n").filter(Boolean));
-  }
-  if (untracked.code === 0) {
+  if (untracked.code === 0)
     changed.push(...untracked.out.split("\0").filter(Boolean));
-  }
+  return [...new Set(changed)].filter((f) => !allowed.has(f));
+}
 
-  const allowed = new Set(filesInScope);
-  return changed.filter((f) => !allowed.has(f));
+// --------------------------------------------------------------------------
+// anti-gaming guard — zero-token heuristic. A cheap model can satisfy a narrow
+// test by hard-coding the asserted value. We extract the literals the test
+// asserts and flag an impl file that (a) is tiny and (b) reproduces a
+// non-trivial test literal verbatim. Egregious cases escalate; borderline
+// cases attach a warning that rides into the report for the human reviewer.
+// --------------------------------------------------------------------------
+function extractLiterals(testSrc: string): string[] {
+  const lits = new Set<string>();
+  // quoted strings
+  for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
+  // multi-digit / non-0-1 numbers
+  for (const m of testSrc.matchAll(/\b(\d{2,}|[2-9])\b/g)) lits.add(m[1]);
+  return [...lits];
+}
+
+function codeLineCount(src: string): number {
+  return src
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
+}
+
+async function antiGamingCheck(
+  cwd: string,
+  task: Task,
+): Promise<{ risk: "none" | "warn" | "high"; note?: string }> {
+  let testSrc = "";
+  try {
+    testSrc = await readFile(path.resolve(cwd, task.test.path), "utf8");
+  } catch {
+    return { risk: "none" };
+  }
+  const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
+  if (literals.length === 0) return { risk: "none" };
+
+  const hits: string[] = [];
+  let anyTiny = false;
+  for (const f of task.filesInScope) {
+    if (f === task.test.path) continue;
+    let src = "";
+    try {
+      src = await readFile(path.resolve(cwd, f), "utf8");
+    } catch {
+      continue;
+    }
+    const tiny = codeLineCount(src) <= 5;
+    for (const lit of literals) {
+      if (src.includes(lit)) {
+        hits.push(`${f} contains test literal ${JSON.stringify(lit)}`);
+        if (tiny) anyTiny = true;
+      }
+    }
+  }
+  if (hits.length === 0) return { risk: "none" };
+  if (anyTiny) return { risk: "high", note: `gaming: ${hits[0]} (impl is trivial)` };
+  return { risk: "warn", note: `gaming-risk: ${hits[0]}` };
+}
+
+async function fileHash(p: string): Promise<string | null> {
+  try {
+    const buf = await readFile(p);
+    return createHash("sha256").update(buf).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+async function resetWorktree(wt: string) {
+  await git(["reset", "--hard", "HEAD"], wt);
+  await git(["clean", "-fd"], wt);
 }
 
 // --------------------------------------------------------------------------
@@ -208,10 +436,15 @@ type Result = {
   branch: string;
   worktree: string;
   note?: string;
+  warning?: string;
+  filesWritten?: string[];
+  diffstat?: string;
+  promptTokens?: number;
+  completionTokens?: number;
 };
 
-// Integration merges happen inside a dedicated worktree — Bug #2 fix.
-// mergeChain serializes access to that worktree.
+// Integration merges happen inside a dedicated worktree — never the main
+// checkout. mergeChain serializes access to that worktree.
 let mergeChain: Promise<unknown> = Promise.resolve();
 let integrationWorktree: string;
 
@@ -221,198 +454,128 @@ function withMergeLock<T>(fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
-async function runTask(t: Task, model: string, apiBaseUrl: string, apiKey: string): Promise<Result> {
+async function prepareWorktree(branch: string, wt: string, from: string): Promise<string | null> {
+  // Clean any stale worktree dir and branch so a re-run doesn't trip over the
+  // leftovers of a prior run (git worktree add -b fails if the branch exists).
+  await git(["worktree", "remove", "--force", wt]).catch(() => {});
+  await rm(wt, { recursive: true, force: true }).catch(() => {});
+  await git(["branch", "-D", branch]).catch(() => {});
+  const add = await git(["worktree", "add", "-b", branch, wt, from]);
+  if (add.code !== 0) return `worktree add failed: ${add.out.slice(0, 200)}`;
+  return null;
+}
+
+async function runTask(
+  t: Task,
+  model: string,
+  apiBaseUrl: string,
+  apiKey: string,
+): Promise<Result> {
   const branch = `farm/${t.id}`;
   const wt = path.resolve(ENV.worktreeRoot, t.id);
   const limit = t.maxRetries ?? ENV.maxRetries;
+  const allowed = new Set(t.filesInScope);
+  const forbidden = new Set([t.test.path]);
 
-  await git(["worktree", "add", "-b", branch, wt, ENV.integration]);
+  const prepErr = await prepareWorktree(branch, wt, ENV.integration);
+  if (prepErr)
+    return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
+
+  const testHashBefore = await fileHash(path.resolve(wt, t.test.path));
 
   let priorFailure: string | undefined;
+  let driftedOnce = false;
+  let lastFilesWritten: string[] = [];
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let lastWarning: string | undefined;
+
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
-    const worker = await runWorker(wt, buildPrompt(t, priorFailure), model, apiBaseUrl, apiKey);
+    if (attempt > 1) await resetWorktree(wt); // never accumulate stale files
+
+    const worker = await runWorker(
+      wt,
+      buildPrompt(t, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : undefined),
+      model,
+      apiBaseUrl,
+      apiKey,
+      forbidden,
+    );
+    promptTokens += worker.promptTokens ?? 0;
+    completionTokens += worker.completionTokens ?? 0;
+    lastFilesWritten = worker.filesWritten;
 
     if (!worker.ok) {
       priorFailure = `worker error: ${worker.error}`;
       continue;
     }
 
-    // Bug #1 fix: enforce filesInScope
-    const driftFiles = await checkDrift(wt, t.filesInScope);
+    // The failing test must be untouched (defence in depth — the write path
+    // already refuses test.path, this catches a sneaky in-scope edit too).
+    const testHashAfter = await fileHash(path.resolve(wt, t.test.path));
+    if (testHashBefore !== null && testHashAfter !== testHashBefore) {
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
+
+    // Drift: on the FIRST drift, retry once with a hardened prompt naming the
+    // offending paths — usually the cheap model is just being dumb, not the
+    // spec being ambiguous. Only escalate as drift after that retry.
+    const driftFiles = await checkDrift(wt, allowed);
     if (driftFiles.length > 0) {
-      await git(["checkout", "."], wt);
-      return {
-        id: t.id,
-        status: "escalate",
-        attempts: attempt,
-        branch,
-        worktree: wt,
-        note: `drift: ${driftFiles.join(", ")}`,
-      };
+      if (!driftedOnce && attempt <= limit) {
+        driftedOnce = true;
+        priorFailure = `drift: you wrote outside the allowed files: ${driftFiles.join(", ")}`;
+        continue;
+      }
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
 
     const gate = await runGate(wt, t.gate.commands);
-
-    if (gate.ok) {
-      await git(["add", "-A"], wt);
-      const commitResult = await git(
-        ["-c", "commit.gpgsign=false", "commit", "-m", `farm(${t.id}): ${t.description}`],
-        wt,
-      );
-      if (commitResult.code !== 0) {
-        return {
-          id: t.id,
-          status: "escalate" as const,
-          attempts: attempt,
-          branch,
-          worktree: wt,
-          note: `commit failed: ${commitResult.out.slice(0, 200)}`,
-        };
-      }
-      // Bug #2 fix: merge into dedicated integration worktree, not main checkout
-      const merged = await withMergeLock(async () => {
-        const m = await git(["merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
-        if (m.code !== 0) {
-          await git(["merge", "--abort"], integrationWorktree);
-          return false;
-        }
-        return true;
-      });
-      if (!merged) {
-        return {
-          id: t.id,
-          status: "escalate",
-          attempts: attempt,
-          branch,
-          worktree: wt,
-          note: "merge conflict vs integration branch",
-        };
-      }
-      await git(["worktree", "remove", "--force", wt]).catch(() => {});
-      return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt };
+    if (!gate.ok) {
+      priorFailure = `failed: ${gate.failed}\n${gate.tail}`;
+      continue;
     }
-    priorFailure = `failed: ${gate.failed}\n${gate.tail}`;
-  }
-  // worktree intentionally left in place for Claude to inspect
-  return {
-    id: t.id,
-    status: "escalate",
-    attempts: limit + 1,
-    branch,
-    worktree: wt,
-    note: priorFailure?.split("\n")[0],
-  };
-}
 
-// --------------------------------------------------------------------------
-// DAG scheduler with a concurrency cap
-// --------------------------------------------------------------------------
-async function main() {
-  const planPath = process.argv[2] ?? "plan.json";
-  const plan = JSON.parse(await readFile(planPath, "utf8")) as Plan;
-  validate(plan);
+    // Zero-token anti-gaming guard.
+    const gaming = await antiGamingCheck(wt, t);
+    if (gaming.risk === "high") {
+      priorFailure = `${gaming.note}. Implement real logic, do not hard-code the asserted value.`;
+      if (attempt <= limit) continue; // give it a chance to fix
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: gaming.note, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
+    if (gaming.risk === "warn") lastWarning = gaming.note;
 
-  // Resolve model — no hardcoded default (Bug #3 design)
-  const model = ENV.model ?? plan.meta.model;
-  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl;
-  const apiKey = ENV.apiKey;
+    // Commit + merge into the dedicated integration worktree.
+    await git(["add", "-A"], wt);
+    const commit = await git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
+    if (commit.code !== 0)
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
 
-  if (!model) {
-    console.error(
-      "Error: No model configured.\n" +
-      "Set FARM_MODEL env var, or run /ca:sprint --farm to trigger automatic model selection.\n" +
-      "See .codearbiter/farm.md for setup instructions.",
-    );
-    process.exit(1);
-  }
-  if (!apiBaseUrl) {
-    console.error(
-      "Error: No API base URL configured.\n" +
-      "Set FARM_API_BASE_URL env var or run /ca:sprint --farm.\n" +
-      "See .codearbiter/farm.md for setup instructions.",
-    );
-    process.exit(1);
-  }
-  if (!apiKey) {
-    console.error(
-      "Error: FARM_API_KEY is not set.\n" +
-      "See .codearbiter/farm.md for setup instructions.",
-    );
-    process.exit(1);
-  }
+    const diffstat = (await git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
 
-  await mkdir(ENV.worktreeRoot, { recursive: true });
-  await mkdir(ENV.reportDir, { recursive: true });
-
-  // Reset integration branch to base
-  const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
-  if (branchResult.code !== 0) {
-    console.error(`Error: could not create integration branch '${ENV.integration}' from '${ENV.base}'.\n${branchResult.out}`);
-    process.exit(1);
-  }
-
-  // Bug #2 fix: dedicated integration worktree — merges never touch main checkout
-  integrationWorktree = path.resolve(".farm/integration-wt");
-  await mkdir(path.dirname(integrationWorktree), { recursive: true });
-  // Remove stale worktree if it exists
-  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
-  const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
-  if (wtResult.code !== 0) {
-    console.error(`Error: could not create integration worktree.\n${wtResult.out}`);
-    process.exit(1);
-  }
-
-  const byId = new Map(plan.tasks.map((t) => [t.id, t]));
-  const done = new Map<string, Result>();
-  const escalated = new Set<string>();
-  const pending = new Set(plan.tasks.map((t) => t.id));
-  const running = new Map<string, Promise<{ id: string; r: Result }>>();
-
-  const ready = () =>
-    [...pending].filter((id) => {
-      const deps = byId.get(id)!.deps ?? [];
-      if (deps.some((d) => escalated.has(d))) return false;
-      return deps.every((d) => done.get(d)?.status === "green");
+    const merged = await withMergeLock(async () => {
+      const m = await git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
+      if (m.code !== 0) {
+        await git(["merge", "--abort"], integrationWorktree).catch(() => {});
+        return m.out;
+      }
+      return null;
     });
+    if (merged !== null)
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
 
-  while (pending.size > 0 || running.size > 0) {
-    for (const id of ready()) {
-      if (running.size >= ENV.concurrency) break;
-      pending.delete(id);
-      running.set(
-        id,
-        runTask(byId.get(id)!, model, apiBaseUrl, apiKey).then((r) => ({ id, r })),
-      );
-    }
-    if (running.size === 0) break;
-    const { id, r } = await Promise.race(running.values());
-    running.delete(id);
-    done.set(id, r);
-    if (r.status === "escalate") escalated.add(id);
+    // success — drop the worktree (branch stays, merged into integration)
+    await git(["worktree", "remove", "--force", wt]).catch(() => {});
+    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens };
   }
 
-  const blocked = [...pending].map((id) => ({ id }));
-  await writeReport(plan, [...done.values()], blocked);
-
-  // Teardown integration worktree
-  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
-
-  const esc = [...done.values()].filter((r) => r.status === "escalate").length;
-  const green = [...done.values()].filter((r) => r.status === "green").length;
-  const exitCode = esc || blocked.length ? 2 : 0;
-  const summary = [
-    `\nDone. green=${green} escalate=${esc} blocked=${blocked.length}`,
-    `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
-    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
-    "",
-  ].join("\n");
-  // Flush stdout before exiting so piped consumers see the output
-  await new Promise<void>((resolve) =>
-    process.stdout.write(summary, () => resolve()),
-  );
-  process.exit(exitCode);
+  // worktree intentionally left in place for inspection
+  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens };
 }
 
+// --------------------------------------------------------------------------
+// validation — duplicate ids, unknown deps, AND cycles
+// --------------------------------------------------------------------------
 function validate(plan: Plan) {
   const ids = new Set<string>();
   for (const t of plan.tasks) {
@@ -422,35 +585,223 @@ function validate(plan: Plan) {
   for (const t of plan.tasks)
     for (const d of t.deps ?? [])
       if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown task ${d}`);
+
+  // cycle detection (DFS)
+  const byId = new Map(plan.tasks.map((t) => [t.id, t]));
+  const state = new Map<string, 0 | 1 | 2>(); // 0=unseen 1=onstack 2=done
+  const visit = (id: string, stack: string[]) => {
+    if (state.get(id) === 2) return;
+    if (state.get(id) === 1)
+      throw new Error(`dependency cycle: ${[...stack, id].join(" -> ")}`);
+    state.set(id, 1);
+    for (const d of byId.get(id)!.deps ?? []) visit(d, [...stack, id]);
+    state.set(id, 2);
+  };
+  for (const t of plan.tasks) visit(t.id, []);
 }
 
-async function writeReport(plan: Plan, results: Result[], blocked: { id: string }[]) {
+function resolveConfig(plan: Plan): { model: string; apiBaseUrl: string; apiKey: string } {
+  const model = ENV.model ?? plan.meta.model;
+  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl ?? ENV.defaultApiBaseUrl;
+  const apiKey = ENV.apiKey;
+  if (!model) {
+    console.error(
+      "Error: No model configured.\n" +
+        "Set FARM_MODEL env var, or run /ca:sprint --farm to trigger automatic model selection.\n" +
+        "See .codearbiter/farm.md for setup instructions.",
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error("Error: FARM_API_KEY is not set.\nSee .codearbiter/farm.md for setup instructions.");
+    process.exit(1);
+  }
+  return { model, apiBaseUrl, apiKey };
+}
+
+// --------------------------------------------------------------------------
+// canary — measure candidate models on the smallest task. No merge.
+// --------------------------------------------------------------------------
+async function runCanary(plan: Plan) {
+  if (ENV.candidateModels.length === 0) {
+    console.error("Error: --canary requires FARM_CANDIDATE_MODELS (comma-separated model ids).");
+    process.exit(1);
+  }
+  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl ?? ENV.defaultApiBaseUrl;
+  const apiKey = ENV.apiKey;
+  if (!apiKey) {
+    console.error("Error: FARM_API_KEY is not set.");
+    process.exit(1);
+  }
+  await mkdir(ENV.worktreeRoot, { recursive: true });
+  await mkdir(ENV.reportDir, { recursive: true });
+  // Reset integration to base so canary worktrees branch from a clean point.
+  await git(["branch", "-f", ENV.integration, ENV.base]);
+  integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
+  await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {});
+  await git(["worktree", "add", integrationWorktree, ENV.integration]).catch(() => {});
+
+  // smallest task = fewest filesInScope, no deps
+  const task = [...plan.tasks]
+    .filter((t) => (t.deps ?? []).length === 0)
+    .sort((a, b) => a.filesInScope.length - b.filesInScope.length)[0] ?? plan.tasks[0];
+
+  const results: Array<{ model: string; green: boolean; attempts: number; ms: number; note?: string }> = [];
+  for (const model of ENV.candidateModels) {
+    const t0 = Date.now();
+    const r = await runTask({ ...task, id: `canary-${task.id}` }, model, apiBaseUrl, apiKey);
+    results.push({ model, green: r.status === "green", attempts: r.attempts, ms: Date.now() - t0, note: r.note });
+    await git(["worktree", "remove", "--force", path.resolve(ENV.worktreeRoot, `canary-${task.id}`)]).catch(() => {});
+    await git(["branch", "-D", `farm/canary-${task.id}`]).catch(() => {});
+  }
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
+
+  results.sort((a, b) => Number(b.green) - Number(a.green) || a.attempts - b.attempts || a.ms - b.ms);
+  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, ts: new Date().toISOString() }, null, 2));
+  const summary = ["\nCanary results (best first):", ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`), `\nRecommended: ${results[0]?.green ? results[0].model : "NONE PASSED — set FARM_MODEL manually or revise the plan"}`, ""].join("\n");
+  await new Promise<void>((resolve) => process.stdout.write(summary, () => resolve()));
+  process.exit(results[0]?.green ? 0 : 2);
+}
+
+// --------------------------------------------------------------------------
+// main — DAG scheduler with a concurrency cap and a circuit breaker
+// --------------------------------------------------------------------------
+async function main() {
+  const args = process.argv.slice(2);
+  const canary = args.includes("--canary");
+  const planPath = args.find((a) => !a.startsWith("--")) ?? "plan.json";
+  const plan = JSON.parse(await readFile(planPath, "utf8")) as Plan;
+  validate(plan);
+
+  if (canary) return runCanary(plan);
+
+  const { model, apiBaseUrl, apiKey } = resolveConfig(plan);
+
+  await mkdir(ENV.worktreeRoot, { recursive: true });
+  await mkdir(ENV.reportDir, { recursive: true });
+
+  const done = new Map<string, Result>();
+  const blocked: { id: string; reason: string }[] = [];
+  let aborted = false;
+
+  try {
+    const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
+    if (branchResult.code !== 0)
+      throw new Error(`could not create integration branch '${ENV.integration}' from '${ENV.base}': ${branchResult.out}`);
+
+    integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+    await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
+    await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {});
+    const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
+    if (wtResult.code !== 0)
+      throw new Error(`could not create integration worktree: ${wtResult.out}`);
+
+    const byId = new Map(plan.tasks.map((t) => [t.id, t]));
+    const escalated = new Set<string>();
+    const pending = new Set(plan.tasks.map((t) => t.id));
+    const running = new Map<string, Promise<{ id: string; r: Result }>>();
+
+    const ready = () =>
+      [...pending].filter((id) => {
+        const deps = byId.get(id)!.deps ?? [];
+        if (deps.some((d) => escalated.has(d))) return false;
+        return deps.every((d) => done.get(d)?.status === "green");
+      });
+
+    const tripped = () => {
+      const settled = done.size;
+      if (settled < ENV.abortMinTasks) return false;
+      return escalated.size / settled > ENV.abortEscalationRate;
+    };
+
+    while (pending.size > 0 || running.size > 0) {
+      if (tripped()) {
+        aborted = true;
+        break;
+      }
+      for (const id of ready()) {
+        if (running.size >= ENV.concurrency) break;
+        pending.delete(id);
+        running.set(
+          id,
+          runTask(byId.get(id)!, model, apiBaseUrl, apiKey).then(
+            (r) => ({ id, r }),
+            (e) => ({ id, r: { id, status: "escalate" as const, attempts: 0, branch: `farm/${id}`, worktree: path.resolve(ENV.worktreeRoot, id), note: `crashed: ${e?.message ?? e}` } }),
+          ),
+        );
+      }
+      if (running.size === 0) break;
+      const { id, r } = await Promise.race(running.values());
+      running.delete(id);
+      done.set(id, r);
+      if (r.status === "escalate") escalated.add(id);
+    }
+
+    // anything still pending is blocked (dependency escalated, cycle-free by validate, or aborted)
+    for (const id of pending) {
+      const deps = byId.get(id)!.deps ?? [];
+      const culprit = deps.find((d) => escalated.has(d));
+      blocked.push({ id, reason: aborted ? "run aborted (circuit breaker)" : culprit ? `dependency ${culprit} escalated` : "not scheduled" });
+    }
+  } finally {
+    await writeReport(plan, [...done.values()], blocked, aborted).catch((e) => console.error("report write failed:", e));
+    await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
+  }
+
+  const results = [...done.values()];
+  const esc = results.filter((r) => r.status === "escalate").length;
+  const green = results.filter((r) => r.status === "green").length;
+  const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
+  const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
+  const exitCode = esc || blocked.length || aborted ? 2 : 0;
+  const summary = [
+    aborted ? `\nABORTED by circuit breaker — escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
+    `\nDone. green=${green} escalate=${esc} blocked=${blocked.length}`,
+    `Worker tokens: prompt=${pTok} completion=${cTok}`,
+    `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
+    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
+    "",
+  ].join("\n");
+  await new Promise<void>((resolve) => process.stdout.write(summary, () => resolve()));
+  process.exit(exitCode);
+}
+
+async function writeReport(plan: Plan, results: Result[], blocked: { id: string; reason: string }[], aborted: boolean) {
+  // per-task diff artifacts for audit
+  await mkdir(path.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {});
+  for (const r of results) {
+    const d = await git(["diff", `${ENV.base}...${r.branch}`]);
+    if (d.code === 0 && d.out.trim())
+      await writeFile(path.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {});
+  }
+
+  const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
+  const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
+
   await writeFile(
     path.join(ENV.reportDir, "farm-report.json"),
-    JSON.stringify(
-      { plan: plan.meta, results, blocked, ts: new Date().toISOString() },
-      null,
-      2,
-    ),
+    JSON.stringify({ plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, ts: new Date().toISOString() }, null, 2),
   );
+
   const md = [
     `# Farm report — ${plan.meta.name}`,
     ``,
-    `| task | status | attempts | branch | note |`,
-    `| --- | --- | --- | --- | --- |`,
-    ...results.map(
-      (r) =>
-        `| ${r.id} | ${r.status} | ${r.attempts} | ${r.branch} | ${r.note ?? ""} |`,
-    ),
-    ...blocked.map((b) => `| ${b.id} | blocked | 0 | — | dependency escalated |`),
+    aborted ? `> **ABORTED by circuit breaker** — escalation rate exceeded threshold.\n` : ``,
+    `Worker tokens: prompt=${pTok} completion=${cTok}`,
+    ``,
+    `| task | status | attempts | files | branch | note |`,
+    `| --- | --- | --- | --- | --- | --- |`,
+    ...results.map((r) => `| ${r.id} | ${r.status}${r.warning ? " ⚠" : ""} | ${r.attempts} | ${(r.filesWritten ?? []).length} | ${r.branch} | ${r.note ?? r.warning ?? ""} |`),
+    ...blocked.map((b) => `| ${b.id} | blocked | 0 | 0 | — | ${b.reason} |`),
     ``,
     `## Escalations — handle only these`,
     ...results
       .filter((r) => r.status === "escalate")
-      .map(
-        (r) =>
-          `- **${r.id}** — worktree at \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`,
-      ),
+      .map((r) => `- **${r.id}** — worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
+    ``,
+    `## Warnings — review during spec-compliance`,
+    ...results.filter((r) => r.warning).map((r) => `- **${r.id}** — ${r.warning} (diff: \`${path.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`),
   ].join("\n");
   await writeFile(path.join(ENV.reportDir, "farm-report.md"), md);
 }

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+/**
+ * farm.ts — codeArbiter's zero-LLM-token dispatcher.
+ *
+ * Papa Claude (your interactive Claude Code session) does the judgment work:
+ * brainstorm -> spec -> write the FAILING tests into the repo -> emit plan.json.
+ * Then he runs THIS script and walks away. No model calls happen in here — the
+ * only model cost is the cheap Zen worker invoked per task.
+ *
+ * For each task the dispatcher:
+ *   1. cuts an isolated git worktree off the *current integration HEAD*
+ *      (so a task inherits the merged output of its dependencies),
+ *   2. calls the Zen/DeepSeek API directly whose only job is to make the
+ *      failing test pass,
+ *   3. enforces filesInScope — any file outside the allowed set fails the task,
+ *   4. enforces the gate deterministically (the test must go green, suite stays
+ *      green, lint/types pass — whatever you put in gate.commands),
+ *   5. retries with the gate failure fed back in, up to maxRetries,
+ *   6. on success commits + merges into the integration branch via a dedicated
+ *      integration worktree (never touches the main repo checkout),
+ *   7. on exhaustion leaves the worktree in place and ESCALATES the task.
+ *
+ * It never merges to main — codeArbiter's PR-only rule is preserved. You review
+ * the integration branch and open the PR yourself.
+ */
+import { spawn } from "node:child_process";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+// --------------------------------------------------------------------------
+// Types — the handoff contract. Claude emits plan.json conforming to this.
+// --------------------------------------------------------------------------
+type Task = {
+  id: string;
+  description: string;
+  deps?: string[];
+  filesInScope: string[];
+  test: { path: string };
+  gate: { commands: string[] };
+  context?: string;
+  maxRetries?: number;
+};
+type Plan = {
+  meta: { name: string; repo?: string; model?: string; apiBaseUrl?: string };
+  tasks: Task[];
+};
+
+const ENV = {
+  // Model: plan.meta.model (set by subagent-driven-development before dispatch),
+  // then FARM_MODEL env var override. Fails at startup if neither is set.
+  model: process.env.FARM_MODEL ?? null,
+  apiBaseUrl: process.env.FARM_API_BASE_URL ?? null,
+  apiKey: process.env.FARM_API_KEY ?? null,
+  concurrency: Number(process.env.FARM_CONCURRENCY ?? 4),
+  maxRetries: Number(process.env.FARM_MAX_RETRIES ?? 2),
+  base: process.env.FARM_BASE_BRANCH ?? "main",
+  integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
+  worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
+  reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
+};
+
+// --------------------------------------------------------------------------
+// process helpers
+// --------------------------------------------------------------------------
+function run(cmd: string, args: string[], cwd?: string) {
+  return new Promise<{ code: number; out: string }>((resolve) => {
+    const c = spawn(cmd, args, { cwd, env: process.env });
+    let out = "";
+    c.stdout.on("data", (d) => (out += d));
+    c.stderr.on("data", (d) => (out += d));
+    c.on("close", (code) => resolve({ code: code ?? 1, out }));
+  });
+}
+const git = (args: string[], cwd?: string) => run("git", args, cwd);
+
+// --------------------------------------------------------------------------
+// gate — pure determinism, no model
+// --------------------------------------------------------------------------
+async function runGate(cwd: string, commands: string[]) {
+  for (const cmd of commands) {
+    const r = await run("bash", ["-lc", cmd], cwd);
+    if (r.code !== 0) return { ok: false as const, failed: cmd, tail: r.out.slice(-3500) };
+  }
+  return { ok: true as const };
+}
+
+// --------------------------------------------------------------------------
+// worker — direct OpenAI-compatible API call (Bug #3 fix)
+// Note: at implementation time, also check github.com/sst/opencode for any
+// TypeScript SDK or MCP server — if a typed run_task() interface exists with
+// structured file-change output, it's worth comparing against this approach.
+// --------------------------------------------------------------------------
+function buildPrompt(t: Task, priorFailure?: string) {
+  return [
+    `Implement exactly ONE task. Your only goal: make the failing test pass.`,
+    ``,
+    `TASK: ${t.description}`,
+    t.context ? `\nCONTEXT:\n${t.context}\n` : ``,
+    `The failing test is at: ${t.test.path}`,
+    `Make it pass WITHOUT modifying, deleting, or weakening that test.`,
+    ``,
+    `You may ONLY create or edit these files:`,
+    ...t.filesInScope.map((f) => `  - ${f}`),
+    `Touch nothing else. Do not run git. Do not install global packages.`,
+    ``,
+    `Respond with ONLY the files you need to create or modify.`,
+    `For each file, use this exact format:`,
+    ``,
+    `\`\`\`typescript`,
+    `// path: src/example.ts`,
+    `<complete file content here>`,
+    `\`\`\``,
+    ``,
+    `Do not include any explanation outside the code blocks.`,
+    priorFailure
+      ? `\nYour previous attempt FAILED the gate. Fix it.\nGate output (tail):\n${priorFailure}`
+      : ``,
+  ].join("\n");
+}
+
+async function runWorker(
+  cwd: string,
+  prompt: string,
+  model: string,
+  apiBaseUrl: string,
+  apiKey: string,
+): Promise<{ ok: boolean; filesWritten: string[]; error?: string }> {
+  let resp: Response;
+  try {
+    resp = await fetch(`${apiBaseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+  } catch (e) {
+    return { ok: false, filesWritten: [], error: `fetch failed: ${e}` };
+  }
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "(unreadable)");
+    return { ok: false, filesWritten: [], error: `API ${resp.status}: ${body.slice(0, 500)}` };
+  }
+
+  const data = await resp.json() as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content ?? "";
+
+  // Parse fenced code blocks with `// path: <file>` as first line
+  const filesWritten: string[] = [];
+  const blockRe = /```[a-z]*\n\/\/ path: ([^\n]+)\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+  while ((match = blockRe.exec(content)) !== null) {
+    const [, filePath, fileContent] = match;
+    const absPath = path.resolve(cwd, filePath.trim());
+    await mkdir(path.dirname(absPath), { recursive: true });
+    await writeFile(absPath, fileContent);
+    filesWritten.push(filePath.trim());
+  }
+
+  if (filesWritten.length === 0) {
+    return { ok: false, filesWritten: [], error: "no parseable file blocks in response" };
+  }
+
+  return { ok: true, filesWritten };
+}
+
+// --------------------------------------------------------------------------
+// drift check — Bug #1 fix
+// Catches both modified tracked files and new untracked files.
+// git status --porcelain groups untracked files by directory; use ls-files
+// for new files to get individual paths.
+// --------------------------------------------------------------------------
+async function checkDrift(cwd: string, filesInScope: string[]): Promise<string[]> {
+  // Modified/deleted tracked files
+  const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
+  // New untracked files (individual paths, not directories)
+  const untracked = await git(
+    ["ls-files", "--others", "--exclude-standard", "-z"],
+    cwd,
+  );
+
+  const changed: string[] = [];
+  if (tracked.code === 0) {
+    changed.push(...tracked.out.trim().split("\n").filter(Boolean));
+  }
+  if (untracked.code === 0) {
+    changed.push(...untracked.out.split("\0").filter(Boolean));
+  }
+
+  const allowed = new Set(filesInScope);
+  return changed.filter((f) => !allowed.has(f));
+}
+
+// --------------------------------------------------------------------------
+// per-task lifecycle
+// --------------------------------------------------------------------------
+type Result = {
+  id: string;
+  status: "green" | "escalate";
+  attempts: number;
+  branch: string;
+  worktree: string;
+  note?: string;
+};
+
+// Integration merges happen inside a dedicated worktree — Bug #2 fix.
+// mergeChain serializes access to that worktree.
+let mergeChain: Promise<unknown> = Promise.resolve();
+let integrationWorktree: string;
+
+function withMergeLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = mergeChain.then(fn, fn);
+  mergeChain = next.catch(() => {});
+  return next;
+}
+
+async function runTask(t: Task, model: string, apiBaseUrl: string, apiKey: string): Promise<Result> {
+  const branch = `farm/${t.id}`;
+  const wt = path.resolve(ENV.worktreeRoot, t.id);
+  const limit = t.maxRetries ?? ENV.maxRetries;
+
+  await git(["worktree", "add", "-b", branch, wt, ENV.integration]);
+
+  let priorFailure: string | undefined;
+  for (let attempt = 1; attempt <= limit + 1; attempt++) {
+    const worker = await runWorker(wt, buildPrompt(t, priorFailure), model, apiBaseUrl, apiKey);
+
+    if (!worker.ok) {
+      priorFailure = `worker error: ${worker.error}`;
+      continue;
+    }
+
+    // Bug #1 fix: enforce filesInScope
+    const driftFiles = await checkDrift(wt, t.filesInScope);
+    if (driftFiles.length > 0) {
+      await git(["checkout", "."], wt);
+      return {
+        id: t.id,
+        status: "escalate",
+        attempts: attempt,
+        branch,
+        worktree: wt,
+        note: `drift: ${driftFiles.join(", ")}`,
+      };
+    }
+
+    const gate = await runGate(wt, t.gate.commands);
+
+    if (gate.ok) {
+      await git(["add", "-A"], wt);
+      const commitResult = await git(
+        ["-c", "commit.gpgsign=false", "commit", "-m", `farm(${t.id}): ${t.description}`],
+        wt,
+      );
+      if (commitResult.code !== 0) {
+        return {
+          id: t.id,
+          status: "escalate" as const,
+          attempts: attempt,
+          branch,
+          worktree: wt,
+          note: `commit failed: ${commitResult.out.slice(0, 200)}`,
+        };
+      }
+      // Bug #2 fix: merge into dedicated integration worktree, not main checkout
+      const merged = await withMergeLock(async () => {
+        const m = await git(["merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
+        if (m.code !== 0) {
+          await git(["merge", "--abort"], integrationWorktree);
+          return false;
+        }
+        return true;
+      });
+      if (!merged) {
+        return {
+          id: t.id,
+          status: "escalate",
+          attempts: attempt,
+          branch,
+          worktree: wt,
+          note: "merge conflict vs integration branch",
+        };
+      }
+      await git(["worktree", "remove", "--force", wt]).catch(() => {});
+      return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt };
+    }
+    priorFailure = `failed: ${gate.failed}\n${gate.tail}`;
+  }
+  // worktree intentionally left in place for Claude to inspect
+  return {
+    id: t.id,
+    status: "escalate",
+    attempts: limit + 1,
+    branch,
+    worktree: wt,
+    note: priorFailure?.split("\n")[0],
+  };
+}
+
+// --------------------------------------------------------------------------
+// DAG scheduler with a concurrency cap
+// --------------------------------------------------------------------------
+async function main() {
+  const planPath = process.argv[2] ?? "plan.json";
+  const plan = JSON.parse(await readFile(planPath, "utf8")) as Plan;
+  validate(plan);
+
+  // Resolve model — no hardcoded default (Bug #3 design)
+  const model = ENV.model ?? plan.meta.model;
+  const apiBaseUrl = ENV.apiBaseUrl ?? plan.meta.apiBaseUrl;
+  const apiKey = ENV.apiKey;
+
+  if (!model) {
+    console.error(
+      "Error: No model configured.\n" +
+      "Set FARM_MODEL env var, or run /ca:sprint --farm to trigger automatic model selection.\n" +
+      "See .codearbiter/farm.md for setup instructions.",
+    );
+    process.exit(1);
+  }
+  if (!apiBaseUrl) {
+    console.error(
+      "Error: No API base URL configured.\n" +
+      "Set FARM_API_BASE_URL env var or run /ca:sprint --farm.\n" +
+      "See .codearbiter/farm.md for setup instructions.",
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error(
+      "Error: FARM_API_KEY is not set.\n" +
+      "See .codearbiter/farm.md for setup instructions.",
+    );
+    process.exit(1);
+  }
+
+  await mkdir(ENV.worktreeRoot, { recursive: true });
+  await mkdir(ENV.reportDir, { recursive: true });
+
+  // Reset integration branch to base
+  const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
+  if (branchResult.code !== 0) {
+    console.error(`Error: could not create integration branch '${ENV.integration}' from '${ENV.base}'.\n${branchResult.out}`);
+    process.exit(1);
+  }
+
+  // Bug #2 fix: dedicated integration worktree — merges never touch main checkout
+  integrationWorktree = path.resolve(".farm/integration-wt");
+  await mkdir(path.dirname(integrationWorktree), { recursive: true });
+  // Remove stale worktree if it exists
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
+  const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
+  if (wtResult.code !== 0) {
+    console.error(`Error: could not create integration worktree.\n${wtResult.out}`);
+    process.exit(1);
+  }
+
+  const byId = new Map(plan.tasks.map((t) => [t.id, t]));
+  const done = new Map<string, Result>();
+  const escalated = new Set<string>();
+  const pending = new Set(plan.tasks.map((t) => t.id));
+  const running = new Map<string, Promise<{ id: string; r: Result }>>();
+
+  const ready = () =>
+    [...pending].filter((id) => {
+      const deps = byId.get(id)!.deps ?? [];
+      if (deps.some((d) => escalated.has(d))) return false;
+      return deps.every((d) => done.get(d)?.status === "green");
+    });
+
+  while (pending.size > 0 || running.size > 0) {
+    for (const id of ready()) {
+      if (running.size >= ENV.concurrency) break;
+      pending.delete(id);
+      running.set(
+        id,
+        runTask(byId.get(id)!, model, apiBaseUrl, apiKey).then((r) => ({ id, r })),
+      );
+    }
+    if (running.size === 0) break;
+    const { id, r } = await Promise.race(running.values());
+    running.delete(id);
+    done.set(id, r);
+    if (r.status === "escalate") escalated.add(id);
+  }
+
+  const blocked = [...pending].map((id) => ({ id }));
+  await writeReport(plan, [...done.values()], blocked);
+
+  // Teardown integration worktree
+  await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
+
+  const esc = [...done.values()].filter((r) => r.status === "escalate").length;
+  const green = [...done.values()].filter((r) => r.status === "green").length;
+  const exitCode = esc || blocked.length ? 2 : 0;
+  const summary = [
+    `\nDone. green=${green} escalate=${esc} blocked=${blocked.length}`,
+    `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
+    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
+    "",
+  ].join("\n");
+  // Flush stdout before exiting so piped consumers see the output
+  await new Promise<void>((resolve) =>
+    process.stdout.write(summary, () => resolve()),
+  );
+  process.exit(exitCode);
+}
+
+function validate(plan: Plan) {
+  const ids = new Set<string>();
+  for (const t of plan.tasks) {
+    if (ids.has(t.id)) throw new Error(`duplicate task id: ${t.id}`);
+    ids.add(t.id);
+  }
+  for (const t of plan.tasks)
+    for (const d of t.deps ?? [])
+      if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown task ${d}`);
+}
+
+async function writeReport(plan: Plan, results: Result[], blocked: { id: string }[]) {
+  await writeFile(
+    path.join(ENV.reportDir, "farm-report.json"),
+    JSON.stringify(
+      { plan: plan.meta, results, blocked, ts: new Date().toISOString() },
+      null,
+      2,
+    ),
+  );
+  const md = [
+    `# Farm report — ${plan.meta.name}`,
+    ``,
+    `| task | status | attempts | branch | note |`,
+    `| --- | --- | --- | --- | --- |`,
+    ...results.map(
+      (r) =>
+        `| ${r.id} | ${r.status} | ${r.attempts} | ${r.branch} | ${r.note ?? ""} |`,
+    ),
+    ...blocked.map((b) => `| ${b.id} | blocked | 0 | — | dependency escalated |`),
+    ``,
+    `## Escalations — handle only these`,
+    ...results
+      .filter((r) => r.status === "escalate")
+      .map(
+        (r) =>
+          `- **${r.id}** — worktree at \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`,
+      ),
+  ].join("\n");
+  await writeFile(path.join(ENV.reportDir, "farm-report.md"), md);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -90,6 +90,25 @@ const ENV = {
     .filter(Boolean),
 };
 
+// Mutation guard — a zero-token quality signal. After the gate goes green we
+// mutate the worker's in-scope impl and re-run ONLY the task's narrow test
+// (gate.commands[0]); a mutant the test fails to catch ("survivor") is code the
+// test does not constrain — gaming, dead code, or a weak test. Bounded by test
+// strength, so a LOW score is a strong red flag but a high one is only
+// necessary-not-sufficient. Low score → warning into Phase 3; only a near-zero
+// score on a non-trivial impl hard-escalates. Pluggable: set FARM_MUTATION_CMD
+// to a real per-language framework (it runs in the worktree with
+// FARM_MUTATION_FILES / FARM_MUTATION_TEST_PATH / FARM_MUTATION_TEST_CMD set,
+// and must print a trailing JSON line containing a numeric "score").
+const MUT = {
+  enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
+  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
+  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 30_000),
+  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
+  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
+  cmd: process.env.FARM_MUTATION_CMD ?? null,
+};
+
 // --------------------------------------------------------------------------
 // process helpers
 // --------------------------------------------------------------------------
@@ -427,6 +446,127 @@ async function resetWorktree(wt: string) {
 }
 
 // --------------------------------------------------------------------------
+// mutation guard
+// --------------------------------------------------------------------------
+function shuffle<T>(a: T[]): T[] {
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// Single-point text mutants. Space-padded operators bias toward real code (not
+// string/generic content); invalid mutants that break compilation just fail the
+// test and count as "killed" — the lenient direction (no false escalation).
+function generateMutants(file: string, src: string): Array<{ file: string; mutated: string; tag: string }> {
+  const lines = src.split("\n");
+  const rules: Array<[RegExp, string, string]> = [
+    [/ >= /, " > ", ">=>"], [/ <= /, " < ", "<=<"],
+    [/ === /, " !== ", "===>!=="], [/ !== /, " === ", "!==>==="],
+    [/ == /, " != ", "==>!="], [/ != /, " == ", "!=>=="],
+    [/ > /, " >= ", ">>="], [/ < /, " <= ", "<<="],
+    [/ \+ /, " - ", "+>-"], [/ - /, " + ", "->+"], [/ \* /, " \/ ", "*>/"],
+    [/ && /, " || ", "&&>||"], [/ \|\| /, " && ", "||>&&"],
+    [/\btrue\b/, "false", "true>false"], [/\bfalse\b/, "true", "false>true"],
+  ];
+  const out: Array<{ file: string; mutated: string; tag: string }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    const t = ln.trim();
+    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("*") || t.startsWith("/*")) continue;
+    for (const [re, rep, name] of rules) {
+      if (re.test(ln)) {
+        const mline = ln.replace(re, rep);
+        if (mline !== ln) {
+          const m = [...lines]; m[i] = mline;
+          out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} ${name}` });
+        }
+      }
+    }
+    const rm = ln.match(/\breturn\s+(.+?);/);
+    if (rm && rm[1].trim() !== "null" && rm[1].trim() !== "") {
+      const m = [...lines];
+      m[i] = ln.replace(/\breturn\s+.+?;/, "return null;");
+      out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} return>null` });
+    }
+  }
+  return out;
+}
+
+type MutationResult = { score: number; evaluated: number; survivors: string[] };
+
+async function mutationCheck(wt: string, task: Task): Promise<MutationResult | null> {
+  if (!MUT.enabled) return null;
+  const testCmd = task.gate.commands[0];
+  if (!testCmd) return null;
+  const impl = task.filesInScope.filter((f) => f !== task.test.path);
+
+  // Pluggable hook — hand off to a real per-language framework if configured.
+  if (MUT.cmd) {
+    const r = await new Promise<{ code: number; out: string }>((resolve) => {
+      const c = spawn("bash", ["-c", MUT.cmd!], {
+        cwd: wt,
+        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
+      });
+      let out = "";
+      c.stdout.on("data", (d) => (out += d));
+      c.stderr.on("data", (d) => (out += d));
+      c.on("error", (e) => resolve({ code: 1, out: String(e) }));
+      c.on("close", (code) => resolve({ code: code ?? 1, out }));
+    });
+    const j = [...r.out.matchAll(/\{[^\n]*"score"[^\n]*\}/g)].pop();
+    if (!j) return null;
+    try {
+      const parsed = JSON.parse(j[0]) as { score?: number; total?: number; evaluated?: number; survived?: string[] };
+      if (typeof parsed.score === "number")
+        return { score: parsed.score, evaluated: parsed.total ?? parsed.evaluated ?? 99, survivors: parsed.survived ?? [] };
+    } catch {
+      /* unparseable — skip leniently */
+    }
+    return null;
+  }
+
+  // Built-in text mutation.
+  const originals = new Map<string, string>();
+  let candidates: Array<{ file: string; mutated: string; tag: string }> = [];
+  for (const f of impl) {
+    let src: string;
+    try {
+      src = await readFile(path.resolve(wt, f), "utf8");
+    } catch {
+      continue;
+    }
+    if (codeLineCount(src) <= 2) continue; // trivial file — nothing to constrain
+    originals.set(f, src);
+    candidates.push(...generateMutants(f, src));
+  }
+  if (candidates.length === 0) return null;
+  candidates = shuffle(candidates).slice(0, MUT.sample);
+
+  const start = Date.now();
+  let killed = 0;
+  let evaluated = 0;
+  const survivors: string[] = [];
+  try {
+    for (const c of candidates) {
+      if (Date.now() - start > MUT.budgetMs) break;
+      await writeFile(path.resolve(wt, c.file), c.mutated);
+      const r = await run("bash", ["-c", testCmd], wt);
+      await writeFile(path.resolve(wt, c.file), originals.get(c.file)!); // restore
+      evaluated++;
+      if (r.code !== 0) killed++;
+      else survivors.push(c.tag);
+    }
+  } finally {
+    // defensive: guarantee every impl file is back to the worker's output
+    for (const [f, src] of originals) await writeFile(path.resolve(wt, f), src).catch(() => {});
+  }
+  if (evaluated < 3) return null; // too few mutants to judge fairly
+  return { score: killed / evaluated, evaluated, survivors };
+}
+
+// --------------------------------------------------------------------------
 // per-task lifecycle
 // --------------------------------------------------------------------------
 type Result = {
@@ -441,6 +581,7 @@ type Result = {
   diffstat?: string;
   promptTokens?: number;
   completionTokens?: number;
+  mutationScore?: number | null;
 };
 
 // Integration merges happen inside a dedicated worktree — never the main
@@ -489,6 +630,7 @@ async function runTask(
   let promptTokens = 0;
   let completionTokens = 0;
   let lastWarning: string | undefined;
+  let mutationScore: number | null = null;
 
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
     if (attempt > 1) await resetWorktree(wt); // never accumulate stale files
@@ -536,14 +678,32 @@ async function runTask(
       continue;
     }
 
-    // Zero-token anti-gaming guard.
+    // Zero-token anti-gaming guard: fast literal-leak pass, then the deeper
+    // mutation pass (skipped if the leak pass already says "high").
     const gaming = await antiGamingCheck(wt, t);
-    if (gaming.risk === "high") {
-      priorFailure = `${gaming.note}. Implement real logic, do not hard-code the asserted value.`;
-      if (attempt <= limit) continue; // give it a chance to fix
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: gaming.note, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    let risk = gaming.risk;
+    let riskNote = gaming.note;
+    if (risk !== "high") {
+      const mut = await mutationCheck(wt, t);
+      if (mut) {
+        mutationScore = mut.score;
+        if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
+          risk = "high";
+          riskNote = `gaming: mutation score ${mut.score.toFixed(2)} (${mut.evaluated} mutants survived — the test does not constrain the implementation)`;
+        } else if (mut.score < MUT.warnBelow) {
+          if (risk !== "warn") {
+            risk = "warn";
+            riskNote = `mutation-risk: score ${mut.score.toFixed(2)} (${mut.survivors.length}/${mut.evaluated} survived) — weak test or under-implemented logic`;
+          }
+        }
+      }
     }
-    if (gaming.risk === "warn") lastWarning = gaming.note;
+    if (risk === "high") {
+      priorFailure = `${riskNote}. Implement real logic; do not hard-code or special-case the asserted value.`;
+      if (attempt <= limit) continue; // give it a chance to fix
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore };
+    }
+    if (risk === "warn") lastWarning = riskNote;
 
     // Commit + merge into the dedicated integration worktree.
     await git(["add", "-A"], wt);
@@ -566,11 +726,11 @@ async function runTask(
 
     // success — drop the worktree (branch stays, merged into integration)
     await git(["worktree", "remove", "--force", wt]).catch(() => {});
-    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens };
+    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore };
   }
 
   // worktree intentionally left in place for inspection
-  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens };
+  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore };
 }
 
 // --------------------------------------------------------------------------
@@ -790,10 +950,10 @@ async function writeReport(plan: Plan, results: Result[], blocked: { id: string;
     aborted ? `> **ABORTED by circuit breaker** — escalation rate exceeded threshold.\n` : ``,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     ``,
-    `| task | status | attempts | files | branch | note |`,
-    `| --- | --- | --- | --- | --- | --- |`,
-    ...results.map((r) => `| ${r.id} | ${r.status}${r.warning ? " ⚠" : ""} | ${r.attempts} | ${(r.filesWritten ?? []).length} | ${r.branch} | ${r.note ?? r.warning ?? ""} |`),
-    ...blocked.map((b) => `| ${b.id} | blocked | 0 | 0 | — | ${b.reason} |`),
+    `| task | status | attempts | files | mut | branch | note |`,
+    `| --- | --- | --- | --- | --- | --- | --- |`,
+    ...results.map((r) => `| ${r.id} | ${r.status}${r.warning ? " ⚠" : ""} | ${r.attempts} | ${(r.filesWritten ?? []).length} | ${r.mutationScore == null ? "—" : r.mutationScore.toFixed(2)} | ${r.branch} | ${r.note ?? r.warning ?? ""} |`),
+    ...blocked.map((b) => `| ${b.id} | blocked | 0 | 0 | — | — | ${b.reason} |`),
     ``,
     `## Escalations — handle only these`,
     ...results

--- a/plugins/ca/tools/package-lock.json
+++ b/plugins/ca/tools/package-lock.json
@@ -1,0 +1,2428 @@
+{
+  "name": "ca-farm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ca-farm",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.9.2",
+        "esbuild": "^0.24.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.6"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/plugins/ca/tools/package.json
+++ b/plugins/ca/tools/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "description": "codeArbiter dispatcher: writing-plans emits plan.json + failing tests, cheap Zen workers implement under hard gates.",
   "scripts": {
-    "farm": "node --env-file=.env --import tsx farm.ts",
-    "farm:dist": "node --env-file=.env farm.js",
-    "farm:example": "node --env-file=.env --import tsx farm.ts __fixtures__/simple.plan.json",
+    "farm": "node --env-file-if-exists=.env --import tsx farm.ts",
+    "farm:dist": "node --env-file-if-exists=.env farm.js",
+    "farm:example": "node --env-file-if-exists=.env --import tsx farm.ts __fixtures__/simple.plan.json",
     "build": "npx esbuild farm.ts --bundle --platform=node --format=esm --outfile=farm.js --banner:js='#!/usr/bin/env node'",
     "test": "npx vitest run",
     "typecheck": "npx tsc --noEmit"

--- a/plugins/ca/tools/package.json
+++ b/plugins/ca/tools/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ca-farm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "codeArbiter dispatcher: writing-plans emits plan.json + failing tests, cheap Zen workers implement under hard gates.",
+  "scripts": {
+    "farm": "node --env-file=.env --import tsx farm.ts",
+    "farm:dist": "node --env-file=.env farm.js",
+    "farm:example": "node --env-file=.env --import tsx farm.ts __fixtures__/simple.plan.json",
+    "build": "npx esbuild farm.ts --bundle --platform=node --format=esm --outfile=farm.js --banner:js='#!/usr/bin/env node'",
+    "test": "npx vitest run",
+    "typecheck": "npx tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "esbuild": "^0.24.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/plugins/ca/tools/plan.schema.json
+++ b/plugins/ca/tools/plan.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codearbiter/farm/plan.schema.json",
+  "title": "codeArbiter farm plan",
+  "description": "The handoff artifact writing-plans emits in --farm mode. Each task is a self-contained work packet a cheap Zen worker can complete. meta.model and meta.apiBaseUrl are written by subagent-driven-development at dispatch time (not at plan-authoring time).",
+  "type": "object",
+  "required": ["meta", "tasks"],
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "repo": { "type": "string" },
+        "model": {
+          "type": "string",
+          "description": "Zen model selected at dispatch time by subagent-driven-development's model research step. Not set at plan-authoring time."
+        },
+        "apiBaseUrl": {
+          "type": "string",
+          "description": "OpenAI-compatible endpoint base URL. Set at dispatch time alongside model."
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/task" }
+    }
+  },
+  "$defs": {
+    "task": {
+      "type": "object",
+      "required": ["id", "description", "filesInScope", "test", "gate"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Unique, kebab-case. Becomes the branch name farm/<id>."
+        },
+        "description": {
+          "type": "string",
+          "description": "One concrete unit of work, scoped tightly enough that a cheap model can do it."
+        },
+        "deps": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Task ids that must be GREEN before this one runs."
+        },
+        "filesInScope": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "The ONLY paths the worker may create or edit. Enforced by drift detection after each worker run."
+        },
+        "test": {
+          "type": "object",
+          "required": ["path"],
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Path to the failing test writing-plans already wrote. Workers must NOT touch it."
+            }
+          }
+        },
+        "gate": {
+          "type": "object",
+          "required": ["commands"],
+          "additionalProperties": false,
+          "properties": {
+            "commands": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" },
+              "description": "Shell commands; ALL must exit 0. Typically: run this test, run full suite, lint, typecheck."
+            }
+          }
+        },
+        "context": {
+          "type": "string",
+          "description": "Minimal context slice — relevant types/interfaces/conventions only. NOT the whole module."
+        },
+        "maxRetries": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Overrides FARM_MAX_RETRIES for this task."
+        }
+      }
+    }
+  }
+}

--- a/plugins/ca/tools/tsconfig.json
+++ b/plugins/ca/tools/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts", "__fixtures__/**/*.ts"],
+  "exclude": ["node_modules", "farm.js"]
+}


### PR DESCRIPTION
## Summary

Adds an optional cost-arbitrage execution backend for `/sprint`: Claude authors the spec, failing tests, and a machine-readable `plan.json`; cheap Zen workers implement each task in an isolated git worktree under hard gates; **every green task still routes through the normal spec-compliance + quality + fresh-verification review** before acceptance. The arbitrage is in *who writes the code, never in whether it's reviewed.*

Reachable only via `/sprint --farm` (by design — farm's autonomous batch model matches `/sprint`, not `/feature`'s checkpointed flow). See #21 for a follow-up on the orchestrator-vs-doer entry-point question.

## What's included

**Dispatcher (`plugins/ca/tools/farm.ts` + committed bundled `farm.js`):**
- Zero-LLM-token DAG scheduler with a concurrency cap; one git worktree per task, a dedicated integration worktree (merges never touch the main checkout).
- Direct OpenAI-compatible `fetch()` to the worker model (no CLI dependency), with timeout + 429/5xx backoff.
- **Security/correctness guards:** path-traversal containment, read-only failing-test protection, `filesInScope` drift detection, worktree reset between retries, stale-branch cleanup (safe re-runs), `try/finally` report+teardown, cycle detection.
- **Quality guards (zero-token):** literal-leak check + a sampled/time-boxed **mutation guard** (built-in text mutator, pluggable `FARM_MUTATION_CMD` for Stryker/mutmut). Low score warns into Phase 3; near-zero on a non-trivial impl escalates.
- **Model selection:** `--canary` mode measures candidate models on the smallest task (objective, not web-hearsay), with a cache → websearch fallback ladder.
- **Circuit breaker:** aborts the run past an escalation-rate threshold (incapable model fails fast). Cost/diff reporting (tokens + per-task `.patch`).

**Pipeline integration:**
- `ORCHESTRATOR.md` / `SPRINT.md` — recognize and thread `--farm` end-to-end; slice-at-a-time planning preserves the MVP-slice philosophy.
- `writing-plans` — `--farm` mode writes failing tests + emits schema-valid `plan.json`.
- `subagent-driven-development` — farm path: model selection, dispatch, circuit-breaker handling, and Phase 2.5 escalation handler routing green tasks through Phases 3–5.
- `release` — rebuilds `farm.js` from `farm.ts` before tagging.
- `.codearbiter/farm.md` — setup + configuration docs.

**Also fixes a pre-existing bug** surfaced during review: `subagent-driven-development` Phase 4 dispatched `grader`, an INTERNAL `decision-variance` agent marked "never dispatch directly." Now dispatches the applicable domain reviewers + `finding-triage`.

## Provenance

Three adversarial reviewers (integration, correctness, design) examined the initial cut; their findings were triaged and the blocking/correctness/design fixes implemented in this branch.

## Tests

`plugins/ca/tools/farm.test.ts` — 10 passing: no-model fail-fast, two-task green, drift escalation, gate-failure escalation, path-traversal block, test-file protection, literal-leak anti-gaming, mutation warn-into-Phase-3, mutation hard-escalate, re-run safety. Build + typecheck clean; `--canary` smoke-tested.

https://claude.ai/code/session_01CPefN4FBMGkkrKkuzvYerF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPefN4FBMGkkrKkuzvYerF)_