### PR TITLE
sprint: CI ref-checker (#28), /init ordering (#29), farm extraction + identity fallback (#30)

### DIFF
--- a/.github/scripts/check-plugin-refs.py
+++ b/.github/scripts/check-plugin-refs.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""codeArbiter plugin reference checker (issue #28).
+
+Validates the cross-reference graph of the prose surface — the bulk of the plugin
+that JSON-parse and farm-test CI cannot see. Catches exactly the drift this design
+is prone to (the kind that produced the /ca:refactor mis-route and the dangling
+legacy/ASSESSMENT.md reference). Checks:
+
+  A. Every ${CLAUDE_PLUGIN_ROOT}/<concrete path> reference resolves to a real file
+     (placeholder paths containing <...> are skipped).
+  B. Every relative markdown link [text](path.md) inside plugins/ca resolves.
+  C. agents/INDEX.md and skills/INDEX.md list exactly the agents/skills on disk.
+  D. The command catalog (COMMANDS.md) and commands/*.md agree (hidden commands —
+     sprint, dev, arbiter — are intentionally absent and excluded).
+
+Exits non-zero listing every broken reference.
+"""
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PLUGIN = os.path.join(REPO, "plugins", "ca")
+HIDDEN_COMMANDS = {"sprint", "dev", "arbiter"}
+
+errors = []
+
+
+def gitignored(abspath):
+    """A reference to a gitignored path (e.g. tools/.env, created at runtime) is
+    not drift — the file is intentionally absent from the repo."""
+    try:
+        return subprocess.run(
+            ["git", "check-ignore", "-q", abspath], cwd=REPO, timeout=5
+        ).returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def rel(p):
+    return os.path.relpath(p, REPO)
+
+
+def md_files(base):
+    for cur, dirs, files in os.walk(base):
+        dirs[:] = [d for d in dirs if d != "node_modules"]
+        for f in files:
+            if f.endswith(".md"):
+                yield os.path.join(cur, f)
+
+
+def read(p):
+    with open(p, encoding="utf-8") as f:
+        return f.read()
+
+
+# --- A. ${CLAUDE_PLUGIN_ROOT}/... references ------------------------------------
+PLUGIN_REF = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s`\"')]+)")
+for path in md_files(PLUGIN):
+    for m in PLUGIN_REF.finditer(read(path)):
+        target = m.group(1)
+        if "<" in target or ">" in target:  # placeholder, e.g. agents/<name>.md
+            continue
+        target = target.rstrip(".,;:")
+        full = os.path.join(PLUGIN, target)
+        if not os.path.exists(full) and not gitignored(full):
+            errors.append(f"{rel(path)}: dangling ${{CLAUDE_PLUGIN_ROOT}}/{target}")
+
+# --- B. relative markdown links -------------------------------------------------
+MD_LINK = re.compile(r"\]\(([^)]+)\)")
+for path in md_files(PLUGIN):
+    base = os.path.dirname(path)
+    for m in MD_LINK.finditer(read(path)):
+        link = m.group(1).strip()
+        if link.startswith(("http://", "https://", "#", "mailto:")) or "<" in link:
+            continue
+        if "${" in link:  # handled by check A
+            continue
+        target = link.split("#", 1)[0]
+        if not target.endswith(".md"):
+            continue
+        if not os.path.exists(os.path.normpath(os.path.join(base, target))):
+            errors.append(f"{rel(path)}: dangling link ({link})")
+
+# --- C. INDEX ↔ directory consistency -------------------------------------------
+def check_index(index_path, present, label):
+    if not os.path.isfile(index_path):
+        errors.append(f"{rel(index_path)}: missing")
+        return
+    text = read(index_path)
+    for name in present:
+        if name not in text:
+            errors.append(f"{rel(index_path)}: {label} '{name}' on disk but not listed")
+
+
+# agents: every agents/*.md (except INDEX) named in INDEX.md
+agents_dir = os.path.join(PLUGIN, "agents")
+agent_files = {f[:-3] for f in os.listdir(agents_dir) if f.endswith(".md") and f != "INDEX.md"}
+check_index(os.path.join(agents_dir, "INDEX.md"), agent_files, "agent")
+
+# skills: every skills/<name>/ named in INDEX.md
+skills_dir = os.path.join(PLUGIN, "skills")
+skill_names = {
+    d for d in os.listdir(skills_dir)
+    if os.path.isfile(os.path.join(skills_dir, d, "SKILL.md"))
+}
+check_index(os.path.join(skills_dir, "INDEX.md"), skill_names, "skill")
+
+# --- D. command catalog ↔ commands/*.md -----------------------------------------
+commands_dir = os.path.join(PLUGIN, "commands")
+command_stems = {f[:-3] for f in os.listdir(commands_dir) if f.endswith(".md")}
+commands_md = os.path.join(PLUGIN, "COMMANDS.md")
+catalog = read(commands_md) if os.path.isfile(commands_md) else ""
+catalog_cmds = set(re.findall(r"/ca:([a-z][a-z-]*)", catalog))
+
+for stem in command_stems:
+    if stem not in catalog_cmds:
+        errors.append(f"COMMANDS.md: command '/ca:{stem}' (commands/{stem}.md) not in the catalog")
+for cmd in catalog_cmds:
+    if cmd in HIDDEN_COMMANDS:
+        errors.append(f"COMMANDS.md: hidden command '/ca:{cmd}' must not appear in the catalog")
+    elif cmd not in command_stems:
+        errors.append(f"COMMANDS.md: '/ca:{cmd}' in catalog has no commands/{cmd}.md")
+
+# --- report ---------------------------------------------------------------------
+if errors:
+    print("Plugin reference check FAILED:\n")
+    for e in sorted(set(errors)):
+        print(f"  - {e}")
+    sys.exit(1)
+print("Plugin reference graph intact.")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,17 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "plugins/ca/tools/**"
+      - "plugins/ca/**"
       - "**/*.json"
       - ".github/workflows/ci.yml"
+      - ".github/scripts/**"
   push:
     branches: [main]
     paths:
-      - "plugins/ca/tools/**"
+      - "plugins/ca/**"
       - "**/*.json"
       - ".github/workflows/ci.yml"
+      - ".github/scripts/**"
 
 permissions:
   contents: read
@@ -53,6 +55,17 @@ jobs:
             exit 1
           fi
           echo "farm.js is in sync with farm.ts"
+
+  prose:
+    name: plugin reference graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check cross-reference graph
+        run: python3 .github/scripts/check-plugin-refs.py
 
   manifests:
     name: JSON manifests parse

--- a/plugins/ca/ORCHESTRATOR.md
+++ b/plugins/ca/ORCHESTRATOR.md
@@ -147,6 +147,8 @@ the command list — the user picks.
 ## §7 — Override
 
 `/override "reason"` is the sanctioned, **logged** bypass. Detect the operator identity from
-`git config user.email` (no platform ladder), append one line to `.codearbiter/overrides.log`
-(append-only, committed as a permanent audit artifact), then proceed and note that the override is
-logged. That log is the audit trail; the statusline surfaces overrides since the last checkpoint.
+`git config user.email` (no platform ladder); if it is unset, ask the user once to state their
+identity for the log rather than recording an empty `BY:` field — the audit trail's integrity depends
+on a real attribution. Append one line to `.codearbiter/overrides.log` (append-only, committed as a
+permanent audit artifact), then proceed and note that the override is logged. That log is the audit
+trail; the statusline surfaces overrides since the last checkpoint.

--- a/plugins/ca/commands/init.md
+++ b/plugins/ca/commands/init.md
@@ -34,6 +34,12 @@ populating before normal operation.
      read the codebase and synthesize the full context, writing the initialization sentinel).
    - **Greenfield** (no meaningful source) → route to `/ca:decompose` (layered interview).
 
+   The populator is **mandatory, not optional**: it authors `tech-stack.md`, `coding-standards.md`,
+   and `security-controls.md` (and writes the initialization sentinel). The pipeline gates BLOCK on
+   reading those files — `writing-plans` and `tdd` need `tech-stack.md`, the security gates need
+   `security-controls.md` — so `/ca:feature` run on a freshly-scaffolded stub will STOP at pre-flight
+   until the populator has run. `session-start` surfaces this as `NOT INITIALIZED` every session.
+
 4. Report what was created and which populator you are routing to.
 
 ## When NOT to use

--- a/plugins/ca/skills/subagent-driven-development/SKILL.md
+++ b/plugins/ca/skills/subagent-driven-development/SKILL.md
@@ -31,81 +31,14 @@ Gate: exactly one task selected, dependency-clean, with its spec obligation and 
 ## Phase 2 — Implementation dispatch · gate: BLOCK
 
 **Farm path (when `<slug>.plan.json` exists alongside the `.md` plan):** skip the subagent dispatch
-loop below and follow the farm path instead. The farm path replaces only the *authoring* step (Phase 2)
-for the plan's tasks — it does NOT replace review. Every task the farm reports green is still routed
-through Phases 3, 4, and 5 before acceptance. The cost arbitrage is in who *writes* the code, never in
-whether it is *reviewed*: a cheap model is more likely to game a narrow test, so its output gets the
-SAME scrutiny a premium subagent's would, not less.
-
-### Phase 2-farm — Farm dispatch and model selection
-
-**Step 1 — Model selection.** If `FARM_MODEL` env var is set, use it directly and skip selection.
-Otherwise, prefer a **measured** choice over web hearsay:
-
-1. Read `.farm/model-cache.json` if present. If it records a model chosen within the last 7 days whose
-   last canary pass-rate was acceptable, reuse it (skip to Step 2). Re-research only on a stale or
-   missing cache.
-2. Websearch `"OpenCode Zen free models <current month year>"` + the OpenCode model catalog to enumerate
-   the *candidate* free model ids (codenames included). This step is candidate **discovery**, not a
-   quality judgment.
-3. Run a canary probe to judge quality objectively: set `FARM_CANDIDATE_MODELS=<comma-separated ids>`
-   and invoke `node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" --canary "<plan.json>"`. It runs the plan's
-   smallest task against each candidate and writes `.farm/canary-report.json` ranked by measured
-   pass-rate / attempts / latency. Pick the top passing model.
-4. Surface the choice with its measured basis: "Selected `<model-id>` — canary passed in `<n>` attempts,
-   `<ms>`ms (vs. `<alternatives>`). Proceed, or set `FARM_MODEL` to override." For any opaque codename,
-   add one line of websearched identity context (e.g. "community reports GLM4-based") for the audit log.
-5. Fallback ladder if the canary can't run or none pass: (a) the cached model from Step 1; (b) a
-   websearch-selected model with a clear warning that the choice is unmeasured; (c) only if all fail,
-   BLOCK and ask the user to set `FARM_MODEL`. Halting the whole feature on a noisy websearch is wrong —
-   exhaust the ladder first.
-6. Write the chosen `meta.model` + `meta.apiBaseUrl` into `plan.json`, and update `.farm/model-cache.json`
-   (model + timestamp + canary pass-rate) before dispatching.
-
-**Step 2 — Farm dispatch.** Invoke the farm dispatcher:
-
-```
-node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" "${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json"
-```
-
-Run it with cwd set to `${CLAUDE_PROJECT_DIR}` (the dispatcher resolves `.farm/` and git worktrees
-against the current directory). It runs tasks concurrently (up to `FARM_CONCURRENCY`, default 4),
-enforces gates and a zero-token anti-gaming guard, and writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
-- `farm-report.json` / `farm-report.md` — per-task status, attempts, files, worker token spend, warnings
-- `diffs/<task-id>.patch` — the actual change per task, for audit
-
-Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
-
-**Step 2.5 — Circuit-breaker abort.** If `farm-report.json` has `aborted: true`, the dispatcher tripped
-its escalation-rate breaker — the chosen model is likely not capable of this slice. This is a hard-gate
-surface: STOP and tell the user, recommending the premium path or a different `FARM_MODEL`. Do not
-silently re-dispatch every task to premium Phase 2 (that erases the arbitrage and hides a bad signal).
-
-**Step 3 — Escalation handler (Phase 2.5).** Read `farm-report.json`. For each result:
-
-- **status `green`** — the test gate + anti-gaming guard passed, but it is NOT yet accepted. Route the
-  task through **Phase 3 (spec-compliance), Phase 4 (quality review), and Phase 5 (fresh verification)**
-  exactly as a premium subagent's output would be, measuring the merged change against the spec line the
-  task traces to. A green result carrying a `warning` (gaming-risk) gets extra attention in Phase 3.
-  Only after Phases 3–5 pass does the task reach Phase 6.
-- **status `escalate`, note starts with `"drift:"`** — the cheap model wrote outside `filesInScope`
-  even after a hardened-prompt retry. First occurrence on a task → treat as model incapacity, not a spec
-  gap: re-dispatch via premium Phase 2 (the worktree at `result.worktree` shows the attempt). Only when
-  **multiple tasks drift onto the same out-of-scope path** does it signal a genuine decomposition/spec
-  gap — then raise `[CONFIRM-NN]` and halt.
-- **status `escalate`, note starts with `"gaming:"`** — the model hard-coded the test's asserted value.
-  Re-dispatch via premium Phase 2; do not accept the farm output.
-- **status `escalate`, note starts with `"tampered test:"`** — the model altered the failing test.
-  Re-dispatch via premium Phase 2; the test is the gate's integrity anchor.
-- **status `escalate`, gate-failure note** — the model couldn't pass the test after retries. Re-dispatch
-  via premium Phase 2, seeding the brief with `result.worktree`, the gate note, and `test.path`.
-- **status `escalate`, note starts with `"merge failed"`** — re-order after the conflicting sibling and
-  re-dispatch via Phase 2.
-- **blocked** tasks (`farm-report.json` `blocked[]` array, each with a `reason`) — resolve the upstream
-  escalation first, then re-queue.
-
-Gate: every task is green AND passed Phases 3–5, or was re-dispatched via premium Phase 2 and accepted.
-No task advances to commit-gate while any sibling is unresolved.
+loop below and follow `${CLAUDE_PLUGIN_ROOT}/skills/subagent-driven-development/references/farm-dispatch.md`.
+The farm path replaces only the *authoring* step for the plan's tasks (cheap Zen workers under hard
+gates instead of premium subagents); it does **not** replace review — every task the farm reports green
+is still routed through Phases 3–5 before acceptance. The cost arbitrage is in who *writes* the code,
+never in whether it is *reviewed*. In brief: select a model (canary-probe with a cache→websearch
+fallback ladder), dispatch `tools/farm.js`, honor a circuit-breaker abort as a hard-gate STOP, then for
+each result either accept-after-Phases-3–5 (green) or re-dispatch via premium Phase 2 (escalate). The
+reference has the full step-by-step.
 
 ---
 

--- a/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
@@ -1,0 +1,83 @@
+# Farm dispatch — reference for subagent-driven-development's farm path
+
+Loaded from `subagent-driven-development` Phase 2 when `<slug>.plan.json` exists alongside the `.md`
+plan. The farm path replaces only the *authoring* step for the plan's tasks — cheap Zen workers
+implement under hard gates instead of premium subagents. It does **not** replace review: every task
+the farm reports green is still routed through Phases 3, 4, and 5 before acceptance. The cost arbitrage
+is in who *writes* the code, never in whether it is *reviewed*. See `.codearbiter/farm.md` for setup.
+
+## Step 1 — Model selection
+
+If `FARM_MODEL` env var is set, use it directly and skip selection. Otherwise, prefer a **measured**
+choice over web hearsay:
+
+1. Read `.farm/model-cache.json` if present. If it records a model chosen within the last 7 days whose
+   last canary pass-rate was acceptable, reuse it (skip to Step 2). Re-research only on a stale or
+   missing cache.
+2. Websearch `"OpenCode Zen free models <current month year>"` + the OpenCode model catalog to enumerate
+   the *candidate* free model ids (codenames included). This step is candidate **discovery**, not a
+   quality judgment.
+3. Run a canary probe to judge quality objectively: set `FARM_CANDIDATE_MODELS=<comma-separated ids>`
+   and invoke `node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" --canary "<plan.json>"`. It runs the plan's
+   smallest task against each candidate and writes `.farm/canary-report.json` ranked by measured
+   pass-rate / attempts / latency. Pick the top passing model.
+4. Surface the choice with its measured basis: "Selected `<model-id>` — canary passed in `<n>` attempts,
+   `<ms>`ms (vs. `<alternatives>`). Proceed, or set `FARM_MODEL` to override." For any opaque codename,
+   add one line of websearched identity context (e.g. "community reports GLM4-based") for the audit log.
+5. Fallback ladder if the canary can't run or none pass: (a) the cached model from Step 1; (b) a
+   websearch-selected model with a clear warning that the choice is unmeasured; (c) only if all fail,
+   BLOCK and ask the user to set `FARM_MODEL`. Halting the whole feature on a noisy websearch is wrong —
+   exhaust the ladder first.
+6. Write the chosen `meta.model` + `meta.apiBaseUrl` into `plan.json`, and update `.farm/model-cache.json`
+   (model + timestamp + canary pass-rate) before dispatching.
+
+## Step 2 — Farm dispatch
+
+Invoke the farm dispatcher:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/tools/farm.js" "${CLAUDE_PROJECT_DIR}/.codearbiter/plans/<slug>.plan.json"
+```
+
+Run it with cwd set to `${CLAUDE_PROJECT_DIR}` (the dispatcher resolves `.farm/` and git worktrees
+against the current directory). It runs tasks concurrently (up to `FARM_CONCURRENCY`, default 4),
+enforces gates and a zero-token anti-gaming guard, and writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
+- `farm-report.json` / `farm-report.md` — per-task status, attempts, files, worker token spend, warnings
+- `diffs/<task-id>.patch` — the actual change per task, for audit
+
+Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
+
+## Step 2.5 — Circuit-breaker abort
+
+If `farm-report.json` has `aborted: true`, the dispatcher tripped its escalation-rate breaker — the
+chosen model is likely not capable of this slice. This is a hard-gate surface: STOP and tell the user,
+recommending the premium path or a different `FARM_MODEL`. Do not silently re-dispatch every task to
+premium Phase 2 (that erases the arbitrage and hides a bad signal).
+
+## Step 3 — Escalation handler (Phase 2.5)
+
+Read `farm-report.json`. For each result:
+
+- **status `green`** — the test gate + anti-gaming guard passed, but it is NOT yet accepted. Route the
+  task through **Phase 3 (spec-compliance), Phase 4 (quality review), and Phase 5 (fresh verification)**
+  exactly as a premium subagent's output would be, measuring the merged change against the spec line the
+  task traces to. A green result carrying a `warning` (gaming-risk) gets extra attention in Phase 3.
+  Only after Phases 3–5 pass does the task reach Phase 6.
+- **status `escalate`, note starts with `"drift:"`** — the cheap model wrote outside `filesInScope`
+  even after a hardened-prompt retry. First occurrence on a task → treat as model incapacity, not a spec
+  gap: re-dispatch via premium Phase 2 (the worktree at `result.worktree` shows the attempt). Only when
+  **multiple tasks drift onto the same out-of-scope path** does it signal a genuine decomposition/spec
+  gap — then raise `[CONFIRM-NN]` and halt.
+- **status `escalate`, note starts with `"gaming:"`** — the model hard-coded the test's asserted value.
+  Re-dispatch via premium Phase 2; do not accept the farm output.
+- **status `escalate`, note starts with `"tampered test:"`** — the model altered the failing test.
+  Re-dispatch via premium Phase 2; the test is the gate's integrity anchor.
+- **status `escalate`, gate-failure note** — the model couldn't pass the test after retries. Re-dispatch
+  via premium Phase 2, seeding the brief with `result.worktree`, the gate note, and `test.path`.
+- **status `escalate`, note starts with `"merge failed"`** — re-order after the conflicting sibling and
+  re-dispatch via Phase 2.
+- **blocked** tasks (`farm-report.json` `blocked[]` array, each with a `reason`) — resolve the upstream
+  escalation first, then re-queue.
+
+Gate: every task is green AND passed Phases 3–5, or was re-dispatched via premium Phase 2 and accepted.
+No task advances to commit-gate while any sibling is unresolved.


### PR DESCRIPTION
Second slice of the issue-sprint, on top of the merged security epic (#31). Three focused commits.

## #28 — CI plugin reference-graph checker

A ~30-line Python checker (`.github/scripts/check-plugin-refs.py`) over the prose surface the JSON/farm jobs can't see — the reviewers' highest-leverage missing check. Validates:
- every `${CLAUDE_PLUGIN_ROOT}/<concrete path>` reference resolves (gitignored runtime paths like `tools/.env` correctly skipped);
- every relative markdown link inside `plugins/ca` resolves;
- `agents/INDEX.md` / `skills/INDEX.md` list exactly what's on disk;
- `COMMANDS.md` ↔ `commands/*.md` agree (hidden `sprint`/`dev`/`arbiter` excluded).

Would have caught the `/ca:refactor` mis-route and the dangling `legacy/` ref. New `prose` CI job, runs on `plugins/ca/**`. Verified: passes clean, catches an injected dangling ref. Closes #28.

## #29 — `/init` mandatory-ordering documentation

The policy files the gates BLOCK on (`tech-stack.md`, `coding-standards.md`, `security-controls.md`) are authored by the populators (`/create-context` | `/decompose`), which already gate on their presence — so the real gap was undocumented ordering, not missing scaffolding. `init.md` now states the populator is mandatory and that `/feature` STOPs on a fresh stub until it runs. (Chose this over scaffolding stub policy files, which would weaken the security gates.) Closes #29.

## #30 — two items (non-breaking)

- **Extract the `--farm` subsystem** out of `subagent-driven-development` into `references/farm-dispatch.md` (skill trimmed ~200→127 lines; the everyday 6-phase loop reads clean again). No behavior change.
- **`/override` identity fallback** in ORCHESTRATOR §7: ask once if `git config user.email` is unset rather than logging an empty `BY:` — aligns with `override.md`, protects audit attribution.

Remaining #30 items (shared decision-log include, secrecy-clause consolidation, minor coherence soft-spots) and the breaking command renames are intentionally **not** in this PR.

Partially addresses #30; closes #28, #29.

https://claude.ai/code/session_01CPefN4FBMGkkrKkuzvYerF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPefN4FBMGkkrKkuzvYerF)_