### PR TITLE
fix(statusline): Fable pricing + gold model pill (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.0.1] — 2026-06-10
+
+### Added
+- **Fable pricing in the statusline** — `API_PRICES` gains the Fable family ($10/$50 per MTok, standard 1.25×/2×/0.1× cache multipliers) so the `api≈` cost estimate prices Fable-model tokens correctly instead of falling back to Sonnet rates.
+- **Fable model pill** — the statusline model pill recognizes the Fable family and renders it gold, the tier above Opus violet; previously an unrecognized Fable model fell through to the grey unknown-model pill.
+
+---
+
 ## [2.0.0] — 2026-06-10 — Native Claude Code plugin
 
 The big one. codeArbiter is rebuilt from a ~13,600-line `.agents/` + vendoring framework into a **native Claude Code plugin**. The soul is intact — orchestration, gates, SMARTS, the audit trail — re-grounded on Claude Code's plugin primitives and made leaner and more autonomous. Install with `/plugin marketplace add SUaDtL/codeArbiter` then `/plugin install ca@codearbiter`; commands are namespaced `/ca:<name>`. Pre-release, the whole plugin went through an eight-persona adversarial marketplace-readiness review; everything it surfaced is folded in below.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.0.0" src="https://img.shields.io/badge/version-2.0.0-2b7489">
+<img alt="version 2.0.1" src="https://img.shields.io/badge/version-2.0.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-31-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-14-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in — run /ca:init to activate.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": { "name": "suadtl" },
   "license": "MIT",
   "homepage": "https://github.com/SUaDtL/codeArbiter",

--- a/plugins/ca/hooks/statusline.py
+++ b/plugins/ca/hooks/statusline.py
@@ -395,11 +395,13 @@ SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
 
-# API list prices, USD per 1M tokens (captured 2026-06-06 from Anthropic's
+# API list prices, USD per 1M tokens (captured 2026-06-10 from Anthropic's
 # pricing pages). Used ONLY to estimate the pay-as-you-go API-equivalent cost of
 # this session's REAL tokens — the bar labels it "api≈"; it is not a bill.
 # Per model family: (input, output, cache_write_5m, cache_write_1h, cache_read).
+# Cache multipliers are the standard ones: write 1.25x/2x input, read 0.1x.
 API_PRICES = {
+    "fable":  (10.0, 50.0, 12.50, 20.0, 1.00),
     "opus":   (5.0, 25.0, 6.25, 10.0, 0.50),
     "sonnet": (3.0, 15.0, 3.75,  6.0, 0.30),
     "haiku":  (1.0,  5.0, 1.25,  2.0, 0.10),
@@ -933,12 +935,15 @@ EFF_DISP = {"low": "Low", "medium": "Medium", "high": "High",
 
 def model_pill(model, effort=""):
     """A gradient-filled pill carrying the model AND its effort level, e.g.
-    " Opus 4.8 │ Ultracode ", keyed by family — Opus violet, Sonnet blue, Haiku
-    green. The background ramps dark->bright across the pill (a sheen matching the
-    box). Plain block ends (half-circle caps don't align in a monospace cell)."""
+    " Opus 4.8 │ Ultracode ", keyed by family — Fable gold, Opus violet, Sonnet
+    blue, Haiku green. The background ramps dark->bright across the pill (a sheen
+    matching the box). Plain block ends (half-circle caps don't align in a
+    monospace cell)."""
     m = str(model)
     ml = m.lower()
-    if "opus" in ml:
+    if "fable" in ml:
+        c = (235, 184, 90)        # gold — the tier above Opus
+    elif "opus" in ml:
         c = (188, 120, 255)       # violet
     elif "sonnet" in ml:
         c = (96, 174, 235)        # blue


### PR DESCRIPTION
## What

- Adds the **Fable family** to `API_PRICES` in `plugins/ca/hooks/statusline.py`: $10/$50 per MTok with the standard cache multipliers (5m write 1.25x = $12.50, 1h write 2x = $20.00, read 0.1x = $1.00).
- Keys the **model pill gold** `(235, 184, 90)` for Fable, checked before the Opus branch.
- Bumps the plugin to **2.0.1** (plugin.json + CHANGELOG section + README badge) so `claude plugin update` actually delivers the payload — v2.0.0 is published and the version-bump CI guard enforces this.

## Why

Fable sessions were priced at the Sonnet fallback ($3/$15 — a ~3x underestimate of the `api≈` readout) and rendered the grey unknown-model pill (the reported "silver pill" symptom).

## Verification (commit gate)

- Guard-logic matrix: 62/62 PASS
- Cold-install interpreter matrix: 110/110 PASS
- Plugin reference graph: intact
- JSON manifests: parse
- Behavioral proof: `price_for("claude-fable-5[1m]")` returns the Fable tuple; `api_cost` of 1M tokens in every bucket = $93.50; pill renders gold with body ` Fable 5 │ Ultracode `; grey fallback and Opus violet unaffected.

Tradeoff note: none beyond list-price data entry; conflict-hierarchy level 2 (correctness of the cost estimate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
