### PR TITLE
fix(prune): collect dry-mode decisions to a shared cross-session log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Session-hygiene sprint: two opt-in repo-hygiene features, built test-first under
   merge-to-default hard gate. A global flag `CODEARBITER_BABYSIT` (default off, mirrors
   `CODEARBITER_PRUNE`) auto-attaches a watcher when `/ca:pr` opens a PR; the flag is never set on the
   user's behalf. New `hooks/_babysitlib.py` flag reader with `unittest` coverage.
+- **Pruner dry-mode data collection** — `CODEARBITER_PRUNE=dry` now records every would-be prune to
+  a shared append-only JSONL log (`~/.codearbiter/metrics/prune-dry.jsonl`, overridable via
+  `CODEARBITER_PRUNE_METRICS`): one row per decision across all sessions, each carrying the
+  reduction, per-strategy savings, and the validation verdict. Previously the audit log was written
+  only on execute, so dry mode left no track record — the evidence base for the `dry`→`on` go/no-go
+  decision. Dry-only by design; executed prunes continue to log to `~/.codearbiter/prune.log`.
+  Covered by new `unittest` cases in `tests/test_hook.py`.
 
 ### Changed
 - **`/ca:pr`** — gains a step-6 auto-attach of the CI babysitter, gated on `CODEARBITER_BABYSIT`

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Every optional behavior is **off by default** and opt-in through an environment 
 | `CODEARBITER_PRUNE_TIER` | — | Which pruning passes run; see <kbd>/ca:prune</kbd>. |
 | `CODEARBITER_PRUNE_KEEP_RECENT` | — | Protect the K most recent turns from pruning. |
 | `CODEARBITER_PRUNE_MIN_GROWTH` / `CODEARBITER_PRUNE_MAXBYTES` | — | Growth threshold before a prune runs / cap on bytes removed. |
+| `CODEARBITER_PRUNE_METRICS` | `~/.codearbiter/metrics/prune-dry.jsonl` | Where `dry`-mode data collection lands — one shared append-only JSONL log every session writes to, the evidence base for the `dry`→`on` go/no-go. |
 
 Both feature flags mirror each other's contract: shipped off, never auto-enabled, and dormant in a repo without `arbiter: enabled`.
 

--- a/plugins/ca/commands/prune.md
+++ b/plugins/ca/commands/prune.md
@@ -17,7 +17,12 @@ the running CLI sends its in-memory history to the API, not the file.
 `$ARGUMENTS` is one of:
 
 - `status` (default) — report cumulative reduction and service state for this session from
-  `~/.codearbiter/prune-state.json`, and whether `CODEARBITER_PRUNE` is `on`/`dry`/`off`.
+  `~/.codearbiter/prune-state.json`, and whether `CODEARBITER_PRUNE` is `on`/`dry`/`off`. When
+  the service has run in `dry` mode, every would-be prune is also recorded — one JSONL row per
+  decision, across all sessions — to the shared data-collection log
+  `~/.codearbiter/metrics/prune-dry.jsonl` (override with `CODEARBITER_PRUNE_METRICS`). That log is
+  the evidence base for the `dry`→`on` decision: a clean record (every row `verdict: dry-run`,
+  `validation_errors: 0`) over a representative set of sessions is the signal that enabling is safe.
 - `dry` — copy the live transcript to a scratch path and run a dry-run analysis; present the
   per-strategy reduction table. Never writes to the live file.
 - `run <path>` — prune the target with `--execute`. Targets a **copy or an old/inactive
@@ -47,6 +52,9 @@ the running CLI sends its in-memory history to the API, not the file.
    ships **off**), `CODEARBITER_PRUNE_TIER`, `CODEARBITER_PRUNE_KEEP_RECENT` (the K most recent
    tool **turns** kept verbatim — each turn is an assistant tool_use plus its results),
    `CODEARBITER_PRUNE_MAXBYTES`. Enabling is the user's explicit choice — never set it unbidden.
+   In `dry` mode the service writes no transcript but appends each would-be prune to
+   `~/.codearbiter/metrics/prune-dry.jsonl` (path override: `CODEARBITER_PRUNE_METRICS`) for
+   data collection; in `on` mode the executed prunes are recorded in `~/.codearbiter/prune.log`.
    If a prior service-mode prune was killed mid-write, the next run self-heals the transcript
    from the newest backup in `~/.codearbiter/prune-backups/` before doing anything else.
 

--- a/plugins/ca/hooks/_prunelib.py
+++ b/plugins/ca/hooks/_prunelib.py
@@ -1022,6 +1022,31 @@ def state_path():
     return os.path.join(os.path.expanduser("~"), ".codearbiter", "prune-state.json")
 
 
+def dry_metrics_path(env=None):
+    """Dedicated dry-run data-collection log. One shared append-only JSONL file
+    every session writes to — the evidence base for the dry->on go/no-go.
+    Defaults under ~/.codearbiter/metrics; CODEARBITER_PRUNE_METRICS overrides
+    the full path (with ~ expansion)."""
+    e = env if env is not None else os.environ
+    override = e.get("CODEARBITER_PRUNE_METRICS")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(
+        os.path.expanduser("~"), ".codearbiter", "metrics", "prune-dry.jsonl")
+
+
+def append_dry_metrics(record, env=None):
+    """Append one dry-run record to the shared metrics log. Best-effort: a
+    logging failure must never break the turn (the caller always exits 0)."""
+    p = dry_metrics_path(env)
+    try:
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "a", encoding="utf-8") as f:
+            f.write(_dumps(record) + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def load_state():
     try:
         with open(state_path(), encoding="utf-8") as f:
@@ -1122,6 +1147,25 @@ def hook_run(payload, env=None):
     except Exception:  # noqa: BLE001 — never let pruning break the turn
         return 0
     b0, b1 = res["bytes_before"], res["bytes_after"]
+    if not cfg.execute:
+        # Dry mode: persist the would-be outcome to the shared data-collection
+        # log so confidence accrues across sessions before flipping to on.
+        append_dry_metrics({
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "session": session,
+            "mode": "dry",
+            "tier": cfg.tier,
+            "bytes_before": b0,
+            "bytes_after": b1,
+            "pct": round(100.0 * (b0 - b1) / b0, 1) if b0 else 0.0,
+            "freed_bytes": b0 - b1,
+            "est_tokens_before": res["est_tokens_before"],
+            "est_tokens_after": res["est_tokens_after"],
+            "verdict": res["verdict"],
+            "validation_errors": len(res["validation_errors"]),
+            "strategies": {k: v["bytes_before"] - v["bytes_after"]
+                           for k, v in res["strategies"].items()},
+        }, env=e)
     state[session] = {
         "path": path,
         "last_size": b1 if res["executed"] else b0,

--- a/plugins/ca/hooks/tests/test_hook.py
+++ b/plugins/ca/hooks/tests/test_hook.py
@@ -136,6 +136,75 @@ class TestHook(unittest.TestCase):
         self.assertLess(len(landed), len(data))
         self.assertIn("sess", P.load_state())
 
+    def _read_jsonl(self, path):
+        import json as _json
+        with open(path, encoding="utf-8") as f:
+            return [_json.loads(ln) for ln in f if ln.strip()]
+
+    def test_dry_metrics_path_default_and_override(self):
+        # Default lands in a dedicated metrics folder under ~/.codearbiter;
+        # CODEARBITER_PRUNE_METRICS overrides the full path (with ~ expansion).
+        default = P.dry_metrics_path({})
+        self.assertEqual(
+            os.path.normpath(default),
+            os.path.normpath(os.path.join(
+                os.path.expanduser("~"), ".codearbiter", "metrics", "prune-dry.jsonl")))
+        override = P.dry_metrics_path({"CODEARBITER_PRUNE_METRICS": "~/custom/d.jsonl"})
+        self.assertEqual(os.path.normpath(override),
+                         os.path.normpath(os.path.expanduser("~/custom/d.jsonl")))
+
+    def test_dry_mode_appends_metrics_and_never_writes_transcript(self):
+        before = os.path.getsize(self.path)
+        rc = P.hook_run(self.payload(), env=self.env(CODEARBITER_PRUNE="dry"))
+        self.assertEqual(rc, 0)
+        # Dry never touches the live transcript.
+        self.assertEqual(os.path.getsize(self.path), before)
+        recs = self._read_jsonl(P.dry_metrics_path(self.env()))
+        self.assertEqual(len(recs), 1)
+        r = recs[0]
+        self.assertEqual(r["mode"], "dry")
+        self.assertEqual(r["session"], "sess")
+        self.assertEqual(r["verdict"], "dry-run")
+        self.assertEqual(r["validation_errors"], 0)
+        self.assertGreater(r["bytes_before"], r["bytes_after"])
+        self.assertIn("strategies", r)
+        self.assertIn("ts", r)
+
+    def test_dry_only_on_mode_does_not_write_dry_metrics(self):
+        rc = P.hook_run(self.payload(), env=self.env(CODEARBITER_PRUNE="on"))
+        self.assertEqual(rc, 0)
+        self.assertFalse(os.path.exists(P.dry_metrics_path(self.env())))
+
+    def test_dry_metrics_accumulate_across_sessions_in_one_log(self):
+        # Every session appends to the same dedicated log — the data-collection
+        # contract: one shared file, append-only across sessions.
+        for sid in ("sessA", "sessB", "sessC"):
+            pl = self.payload()
+            pl["session_id"] = sid
+            rc = P.hook_run(pl, env=self.env(CODEARBITER_PRUNE="dry"))
+            self.assertEqual(rc, 0)
+        recs = self._read_jsonl(P.dry_metrics_path(self.env()))
+        self.assertEqual([r["session"] for r in recs], ["sessA", "sessB", "sessC"])
+
+    def test_dry_metrics_records_validation_failure_verdict(self):
+        # When the would-be prune fails validation, the dry record captures the
+        # refusal verdict and a non-zero error count — the go/no-go signal.
+        import _prunelib as _P
+
+        def boom(orig, new, lines, cfg):
+            return ["synthetic chain break"]
+        orig_validate = _P.validate
+        _P.validate = boom
+        try:
+            rc = P.hook_run(self.payload(), env=self.env(CODEARBITER_PRUNE="dry"))
+        finally:
+            _P.validate = orig_validate
+        self.assertEqual(rc, 0)
+        recs = self._read_jsonl(P.dry_metrics_path(self.env()))
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["verdict"], "refused: validation failed")
+        self.assertEqual(recs[0]["validation_errors"], 1)
+
     def test_tail_is_settled_helper(self):
         good = P.load_lines(make_transcript(n_pairs=2, result_bytes=100))
         self.assertTrue(P.tail_is_settled(good))


### PR DESCRIPTION
## Summary

Closes the dry-mode data-collection gap surfaced while deciding whether the transcript pruner is safe to turn on.

**The problem:** `CODEARBITER_PRUNE=dry` ran the full pruning engine *including validation* but left no track record — the audit log (`prune.log`) was written **only on execute**, and `prune-state.json` keeps just the latest per-session snapshot. There was no way to answer "how has dry been doing across sessions?"

**The fix:** `hook_run` now appends every would-be prune to a dedicated, append-only JSONL log — `~/.codearbiter/metrics/prune-dry.jsonl`, overridable via `CODEARBITER_PRUNE_METRICS` — **one row per decision, every session writing to the same file**. Each row carries the reduction, per-strategy savings, est-token deltas, and the validation verdict (`dry-run` vs `refused: validation failed`).

- **Dry-only by design** — executed prunes keep logging to `~/.codearbiter/prune.log`.
- **Best-effort** — a logging failure never breaks the turn (the hook always exits 0).

This is the evidence base for the `dry`→`on` go/no-go: a clean record (every row `verdict: dry-run`, `validation_errors: 0`) over a representative set of sessions is the signal that enabling is safe.

## Example row
```json
{"ts":"2026-06-13T18:50:00Z","session":"abc","mode":"dry","tier":"standard",
 "bytes_before":812340,"bytes_after":511200,"pct":37.0,"freed_bytes":301140,
 "est_tokens_before":203085,"est_tokens_after":127800,
 "verdict":"dry-run","validation_errors":0,
 "strategies":{"sidecar-collapse":210000,"oversize-clamp":91140}}
```

## Test plan
- [x] New `unittest` cases in `tests/test_hook.py` — default/override path; dry append + transcript untouched; dry-only (on-mode writes nothing here); cross-session accumulation in one log; validation-failure verdict captured
- [x] Full hooks suite green — 350 tests
- [x] `check-plugin-refs.py`, guard-logic matrix (62), cold-install matrix (131) all green
- [x] `py_compile` on `_prunelib.py`

## Versioning
Lands under the **unreleased** `2.1.0-beta.4` preview — no version bump (the `v2.1.0-beta.4` tag does not yet exist, so the version-bump guard passes). Tag beta.4 from `main` only after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)