### PR TITLE
fix(audit): pre-beta.4 remediation — catalog drift, dead-code wiring, briefing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,29 @@ Session-hygiene sprint: two opt-in repo-hygiene features, built test-first under
   the user's explicit opt-in.
 - **Catalog & routing** — `COMMANDS.md`, `README.md` (catalog + counts 32→34), and the routing table
   gain `/ca:standup` and `/ca:watch` rows.
+- **Babysitter flag resolution is now executed, not eyeballed** — `_babysitlib.py` gains a fail-safe
+  CLI (`--root`, prints one JSON line, always exits 0); `/ca:pr` and `/ca:watch` invoke it to resolve
+  `enabled`/`on_red` instead of re-stating the accepted `on|true|1` spellings and the dormancy gate in
+  prose, removing a drift risk. New `unittest` coverage for the CLI path.
+- **SH-6 ff-pull gate wired into the live briefing** — `assemble_summary` now computes the
+  `ff_pull_eligible` flag via the pure `_standuplib.ff_pull_eligible` helper (clean tree AND behind
+  upstream); the SessionStart briefing surfaces it and `/ca:standup` step 1 keys off it rather than
+  re-deriving the condition. Previously the helper was tested but never invoked.
+
+### Fixed
+- **Audit remediation (pre-tag sweep).** Catalog drift: `COMMANDS.md` advertised a non-existent
+  `/ca:statusline [--check]` (actual `install | uninstall | status`) and an incomplete `/ca:init`
+  hint; both corrected, and `init.md`'s `argument-hint` gains `--check`. The §6 repeat-redirect "Full
+  list" was missing ~8 commands (incl. `/ca:standup`, `/ca:watch`) — now complete. `prune.md` gained
+  the `python3 || python` Windows interpreter fallback the other commands already carried. Bare
+  `/sprint` command references in `sprint.md`/`override.md` normalized to `/ca:sprint`; `arbiter.md`
+  `argument-hint` normalized from `""` to `(none)`.
+- **`session-start.py` briefing.** Removed a stale comment claiming the briefing summary is always
+  empty (assembly is live); the upstream line no longer prints a misleading "behind 0, ahead 0 (as of
+  last fetch)" when there is no tracking branch (now "upstream: none"); the standup default-branch
+  override moved off the wrong `FARM_BASE_BRANCH` namespace to `CODEARBITER_BASE_BRANCH`.
+- **Statusline `/dev` tell.** Dev mode now shows a textual `[DEV]` badge alongside the full-bar
+  redshift, so it reads where color is stripped or unseen.
 
 ---
 

--- a/plugins/ca/COMMANDS.md
+++ b/plugins/ca/COMMANDS.md
@@ -51,10 +51,10 @@ context docs disagree about the architecture) and you want each variance arbitra
 |---|---|---|
 | `/ca:decompose` | _(none)_ | Greenfield: layered interview to populate `.codearbiter/`. |
 | `/ca:create-context` | _(none)_ | Brownfield: back-fill `.codearbiter/` from existing source. |
-| `/ca:init` | `[--stage N]` | Scaffold the root-level `.codearbiter/` state store. |
+| `/ca:init` | `[--stage N \| --check]` | Scaffold the root-level `.codearbiter/` state store, or `--check` to report detection state without writing. |
 | `/ca:status` | _(none)_ | Show maturity, open tasks, unresolved `CONFIRM-NN`, overrides since checkpoint. |
 | `/ca:audit` | `[range]` | Assemble the governance packet for a window — commits, overrides, ADRs, sprint decisions, open items — into `.codearbiter/audits/`. Read-only. |
-| `/ca:statusline` | `[--check]` | Install/wire the codeArbiter statusline. |
+| `/ca:statusline` | `install \| uninstall \| status` | Install/wire the codeArbiter statusline, remove it, or report its state. |
 | `/ca:prune` | `status \| dry \| run <path> \| audit <path> \| on \| off` | Trim transcript clutter to extend session lifetime. Dry-run by default; gains land on resume/compaction, not the live turn. |
 | `/ca:doctor` | _(none)_ | Verify the install is enforcing: interpreter, payload, cache staleness, repo state, live-fire hook probe. |
 | `/ca:standup` | _(none)_ | Daily hygiene: review repo state, then ff-only pull / prune merged branches / remove stale worktrees / surface stashes — each under per-action confirmation. |

--- a/plugins/ca/commands/arbiter.md
+++ b/plugins/ca/commands/arbiter.md
@@ -1,6 +1,6 @@
 ---
 description: Exit maintainer dev mode — restore orchestration, remove the dev marker, log the exit.
-argument-hint: ""
+argument-hint: (none)
 ---
 
 # /ca:arbiter — restore orchestration

--- a/plugins/ca/commands/init.md
+++ b/plugins/ca/commands/init.md
@@ -1,6 +1,6 @@
 ---
 description: Opt this repo into codeArbiter — scaffold the root-level .codearbiter/ state store.
-argument-hint: (none) | --stage N
+argument-hint: (none) | --stage N | --check
 ---
 
 # /ca:init — first-run scaffold

--- a/plugins/ca/commands/override.md
+++ b/plugins/ca/commands/override.md
@@ -51,7 +51,7 @@ Heavier path (all required, in order):
    sensitive lines it approves, so hook H-09b/H-10b allows the commit — recorded **only** after
    steps 1–3, never to skip the gate proper.
 
-Under `/sprint`, a security-critical override is a hard-gate STOP: it surfaces to the user and is
+Under `/ca:sprint`, a security-critical override is a hard-gate STOP: it surfaces to the user and is
 **never** auto-decided, even in autonomous mode (`SPRINT.md` hard gates).
 
 ## Hard gate
@@ -61,7 +61,7 @@ MUST write the log line before proceeding — it is not optional. MUST capture a
 the immediate action only; it creates no standing exception. MUST NOT edit or delete an existing
 `overrides.log` entry. MUST route a security-critical / crypto-secret / irreversible stop through the
 **Security ceiling** path — never the single-confirm flow — and MUST NOT auto-decide such an override
-under `/sprint`.
+under `/ca:sprint`.
 
 ## When NOT to use
 

--- a/plugins/ca/commands/pr.md
+++ b/plugins/ca/commands/pr.md
@@ -25,9 +25,15 @@ apply, then:
 5. **Stage the PR** once all BLOCK findings clear: concise title; summary of what changed and why; a
    bulleted test plan; a conflict-hierarchy tradeoff citation for any non-obvious tradeoff; a link to
    any ADR the change implements or contradicts. Then `gh pr create`; return the URL.
-6. **Auto-attach the babysitter** — only when the global flag `CODEARBITER_BABYSIT` is on (default
-   off; mirrors `CODEARBITER_PRUNE`): attach a CI watcher to the PR just opened, equivalent to
-   `/ca:watch <new-PR>`. When the flag is off, do nothing here — the user can still run `/ca:watch`
+6. **Auto-attach the babysitter** — resolve the flag with the canonical resolver, never by eyeballing
+   the env var (so the accepted `on|true|1` spellings and the dormancy gate can't drift):
+   ```
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}"
+   ```
+   It prints one JSON line, e.g. `{"enabled": true, "on_red": "propose"}`. Only when `enabled` is
+   true (the global flag `CODEARBITER_BABYSIT` is on — default off, mirrors `CODEARBITER_PRUNE` — and
+   the repo is arbiter-active), attach a CI watcher to the PR just opened, equivalent to
+   `/ca:watch <new-PR>`. When `enabled` is false, do nothing here — the user can still run `/ca:watch`
    ad-hoc. Never enable the flag on the user's behalf.
 
 ## Routes to

--- a/plugins/ca/commands/prune.md
+++ b/plugins/ca/commands/prune.md
@@ -35,13 +35,13 @@ the running CLI sends its in-memory history to the API, not the file.
 
 1. **status / dry / audit** — run the backing tool and present its output verbatim:
    ```
-   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py" <subcommand> [<path>]
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py" <subcommand> [<path>] || python "${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py" <subcommand> [<path>]
    ```
    For `dry`, copy the live transcript to `<path>.copy.jsonl` first, then analyze the copy.
 
 2. **run** — confirm the path is a copy or an inactive session, then:
    ```
-   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py" <path> --execute [--tier T]
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py" <path> --execute [--tier T] || python "${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py" <path> --execute [--tier T]
    ```
    Present the per-strategy reduction report; follow with `audit` on the result.
 

--- a/plugins/ca/commands/sprint.md
+++ b/plugins/ca/commands/sprint.md
@@ -20,7 +20,7 @@ Load and follow `${CLAUDE_PLUGIN_ROOT}/SPRINT.md` — it is the procedure. In br
 2. **Autonomous execution (BLOCK)** — `subagent-driven-development` runs the plan; test-first via
    `tdd`, two-pass reviewed, fresh-run verified. SMARTS decides non-hard-gate points; everything logs.
 3. **Land & summarize (BLOCK)** — `commit-gate`, then `finishing-a-development-branch`, which
-   auto-selects open-PR. `/sprint` never merges and never discards; the merge decision is the user's.
+   auto-selects open-PR. `/ca:sprint` never merges and never discards; the merge decision is the user's.
 
 Hard gates — `security-controls`, crypto/secrets/auth, irreversible ops, `/override`, an
 unresolvable `[CONFIRM-NN]`, merge-to-default — are NEVER auto-decided. They halt and surface.

--- a/plugins/ca/commands/standup.md
+++ b/plugins/ca/commands/standup.md
@@ -18,10 +18,12 @@ stale worktrees) and presents it, then offers each applicable action in turn. Sk
 an action that has no candidates; never bundle confirmations.
 
 1. **Fetch + fast-forward pull** — kick `git fetch`, then offer a **`--ff-only`**
-   pull of the current branch. Offered ONLY on a clean working tree and only when
-   the branch is behind upstream. On a dirty tree the pull is withheld and the dirty
-   state is reported instead. A diverged branch (would need a merge) is refused with
-   a diverged-branch message — never a merge commit.
+   pull of the current branch. Eligibility is the briefing summary's
+   `ff_pull_eligible` flag (SH-6: clean working tree AND behind upstream) — the same
+   pure helper the SessionStart briefing computes, not a condition re-derived here.
+   On a dirty tree the pull is withheld and the dirty state is reported instead. A
+   diverged branch (would need a merge) is refused with a diverged-branch message —
+   never a merge commit.
 2. **Prune merged local branches** — list local branches already merged on remote
    (the `: gone]` upstream set), excluding the current branch and the default
    (`main`). Delete a listed branch only after an explicit per-branch confirmation;

--- a/plugins/ca/commands/watch.md
+++ b/plugins/ca/commands/watch.md
@@ -29,7 +29,13 @@ a phantom watcher.
    NOT a polling loop — there is no interval-based wake-up. Arbiter is re-invoked once
    when the watch process exits.
 3. **On red** — retrieve the failing job's logs (`gh run view --log-failed` /
-   `gh pr checks`) and act at the configured depth (`CODEARBITER_BABYSIT_ONRED`,
+   `gh pr checks`) and act at the configured depth. Resolve that depth with the
+   canonical resolver rather than reading the env var by hand (so the accepted
+   values can't drift):
+   ```
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}"
+   ```
+   It prints one JSON line; act at its `on_red` value (`CODEARBITER_BABYSIT_ONRED`,
    default `propose`):
    - **`propose`** — name the likely cause and propose a concrete fix. Do NOT edit
      any tracked file; applying the fix routes through `/ca:fix` or `/ca:feature`.

--- a/plugins/ca/hooks/_babysitlib.py
+++ b/plugins/ca/hooks/_babysitlib.py
@@ -48,3 +48,30 @@ def babysit_config(env, root, arbiter_active=None):
         on_red = _ONRED_DEFAULT  # PB-5
 
     return {"enabled": enabled, "on_red": on_red}
+
+
+def main(argv=None):
+    """CLI shim: resolve the babysitter config against the live environment and
+    print it as one JSON line, so /ca:pr and /ca:watch invoke this single
+    resolver instead of re-implementing the flag check in prose (no drift from
+    the accepted on|true|1 spellings or the PB-10 dormancy gate). Fail-safe:
+    any error degrades to the OFF default and still exits 0 — a broken resolver
+    must never become a reason to auto-attach a watcher."""
+    import argparse
+    import json
+    import os
+
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--root", default=os.getcwd())
+    args = parser.parse_args(argv)
+    try:
+        cfg = babysit_config(os.environ, args.root)
+    except Exception:  # noqa: BLE001
+        cfg = {"enabled": False, "on_red": _ONRED_DEFAULT}
+    print(json.dumps(cfg))
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import frontmatter_enabled, utf8_stdio  # noqa: E402
 from _standuplib import (  # noqa: E402
     any_actionable,
+    ff_pull_eligible,
     merged_branch_candidates,
     parse_ahead_behind,
     parse_porcelain,
@@ -263,8 +264,13 @@ def render_full_briefing(root, summary):
     print(f"  working tree: {'dirty' if summary['dirty'] else 'clean'} "
           f"(staged:{summary['staged']} unstaged:{summary['unstaged']} "
           f"untracked:{summary['untracked']})")
-    print(f"  upstream: behind {summary['behind']}, ahead {summary['ahead']} "
-          f"{STALE_REFS_NOTE}")
+    if summary.get("upstream", True):
+        print(f"  upstream: behind {summary['behind']}, ahead {summary['ahead']} "
+              f"{STALE_REFS_NOTE}")
+    else:
+        print("  upstream: none (no tracking branch)")
+    if summary.get("ff_pull_eligible"):
+        print("  ff-pull available: clean tree, behind upstream — /ca:standup to fast-forward")
     if summary["prune_candidates"]:
         print(f"  merged-branch prune candidates: "
               f"{', '.join(summary['prune_candidates'])}")
@@ -296,9 +302,12 @@ def assemble_summary(root, runner=None, current=None, default="main", path_exist
     porcelain = git_read(["status", "--porcelain=v1"], root, runner)
     p = parse_porcelain(porcelain)
 
-    behind, ahead = parse_ahead_behind(
-        git_read(["rev-list", "--left-right", "--count", "@{u}...HEAD"], root, runner)
-    )
+    revlist = git_read(["rev-list", "--left-right", "--count", "@{u}...HEAD"], root, runner)
+    behind, ahead = parse_ahead_behind(revlist)
+    # No tracking branch -> git errors -> git_read returns "". Distinguish that from
+    # an in-sync upstream (which returns "0\t0") so the briefing can suppress the
+    # misleading "behind 0, ahead 0 (as of last fetch)" line when no upstream exists.
+    has_upstream = bool(revlist.strip())
 
     branch_vv = git_read(["branch", "-vv"], root, runner)
     prune = merged_branch_candidates(branch_vv, current=current, default=default)
@@ -321,6 +330,10 @@ def assemble_summary(root, runner=None, current=None, default="main", path_exist
         "untracked": p["untracked"],
         "behind": behind,
         "ahead": ahead,
+        "upstream": has_upstream,
+        # SH-6: the canonical ff-pull gate (clean tree AND behind>0), computed by
+        # the same pure helper /ca:standup acts on — no re-derivation in prose.
+        "ff_pull_eligible": ff_pull_eligible(porcelain, behind),
         "unpushed": ahead,  # alias: ahead == commits not yet pushed upstream
         "prune_candidates": prune,
         "stale_worktrees": stale_worktrees,
@@ -420,10 +433,11 @@ def main():
     #   first session of the day (no marker)  -> full briefing + drop marker
     #   later session today, actionable       -> exactly ONE offer line
     #   later session today, nothing to do    -> emit nothing
-    # The rich briefing CONTENT and the git-derived `summary` (dirty/behind/ahead/
-    # prune candidates/worktrees/stashes) land in later tasks; until then the
-    # summary is empty, so any_actionable() is False and later sessions on a clean
-    # repo stay silent — the conservative default.
+    # The git-derived `summary` (dirty/behind/ahead/prune candidates/worktrees/
+    # stashes) is assembled below from read-only git reads; any_actionable(summary)
+    # then decides whether a later same-day session emits its single offer line. A
+    # clean repo yields an all-quiet summary, so later sessions stay silent — the
+    # conservative default.
     date_iso = local_date_iso()
     marker_present = not should_emit_briefing(root, date_iso)
 
@@ -431,7 +445,7 @@ def main():
     # (current local refs); we annotate it as possibly stale and kick a DETACHED
     # fetch to refresh for NEXT time without blocking this hook's return.
     current = head_branch(root)
-    default = os.environ.get("FARM_BASE_BRANCH") or "main"
+    default = os.environ.get("CODEARBITER_BASE_BRANCH") or "main"
     summary = assemble_summary(root, current=current, default=default)
     spawn_background_fetch(root)  # detached; never awaited
 

--- a/plugins/ca/hooks/statusline.py
+++ b/plugins/ca/hooks/statusline.py
@@ -1092,7 +1092,14 @@ def render(raw):
     arb = safe(arbiter_state, root)
     effort = (get(data, "effort", "level") or "").lower()
     sprint = bool(arb and arb.get("sprint"))
-    badge = f"{V3}{BOLD}[SPRINT]{RESET}" if sprint else ""   # effort now shows by the model pill
+    # /dev takes precedence over sprint: a textual [DEV] tell rides alongside the
+    # full-bar redshift so dev mode reads even where color is stripped or unseen.
+    if safe(dev_active, root):
+        badge = f"{BOLD}[DEV]{RESET}"
+    elif sprint:
+        badge = f"{V3}{BOLD}[SPRINT]{RESET}"   # effort now shows by the model pill
+    else:
+        badge = ""
 
     led = safe(ledger_update, data, sid)
     if not (isinstance(led, tuple) and len(led) == 3):

--- a/plugins/ca/hooks/tests/test_babysit.py
+++ b/plugins/ca/hooks/tests/test_babysit.py
@@ -1,6 +1,9 @@
+import io
+import json
 import os
 import sys
 import unittest
+from contextlib import redirect_stdout
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -78,6 +81,53 @@ class TestBabysitConfig(unittest.TestCase):
         cfg = B.babysit_config({"CODEARBITER_BABYSIT_ONRED": "propose"}, "/repo",
                                arbiter_active=active)
         self.assertEqual(cfg["on_red"], "propose")
+
+
+class TestBabysitCLI(unittest.TestCase):
+    """The CLI shim /ca:pr and /ca:watch invoke: resolves against the live env +
+    real dormancy gate and prints one JSON line. A dormant root (a temp dir with
+    no .codearbiter/) exercises the PB-10 gate end-to-end."""
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k)
+                       for k in ("CODEARBITER_BABYSIT", "CODEARBITER_BABYSIT_ONRED")}
+        for k in self._saved:
+            os.environ.pop(k, None)
+        self.root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_no_such_repo_xyz")
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _run(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = B.main(["--root", self.root])
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue().strip())
+
+    def test_prints_valid_json_with_keys(self):
+        cfg = self._run()
+        self.assertIn("enabled", cfg)
+        self.assertIn("on_red", cfg)
+
+    def test_default_is_off_and_propose(self):
+        cfg = self._run()
+        self.assertFalse(cfg["enabled"])
+        self.assertEqual(cfg["on_red"], "propose")
+
+    def test_on_but_dormant_root_stays_off(self):
+        os.environ["CODEARBITER_BABYSIT"] = "on"
+        cfg = self._run()
+        self.assertFalse(cfg["enabled"])  # PB-10 dormancy gate, end-to-end
+
+    def test_on_red_branch_surfaces(self):
+        os.environ["CODEARBITER_BABYSIT_ONRED"] = "branch"
+        cfg = self._run()
+        self.assertEqual(cfg["on_red"], "branch")
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/tests/test_standup.py
+++ b/plugins/ca/hooks/tests/test_standup.py
@@ -630,6 +630,23 @@ class TestAssembleSummary(unittest.TestCase):
         self.assertEqual(summary["stashes"], 1)
         self.assertTrue(sl.any_actionable(summary))
 
+    def test_dirty_repo_not_ff_pull_eligible(self):
+        # SH-6 wired live: a dirty tree withholds ff-pull even when behind.
+        table = {"status": "M  a.py\n", "rev-list": "2\t0",
+                 "branch": "* main aaa [origin/main]\n", "worktree": "", "stash": ""}
+        summary = _mod.assemble_summary(
+            "/root", runner=self._runner_from(table), current="main", default="main")
+        self.assertFalse(summary["ff_pull_eligible"])
+
+    def test_clean_behind_is_ff_pull_eligible(self):
+        # SH-6 wired live: clean tree AND behind>0 -> eligible.
+        table = {"status": "", "rev-list": "2\t0",
+                 "branch": "* main aaa [origin/main]\n", "worktree": "", "stash": ""}
+        summary = _mod.assemble_summary(
+            "/root", runner=self._runner_from(table), current="main", default="main")
+        self.assertTrue(summary["ff_pull_eligible"])
+        self.assertTrue(summary["upstream"])
+
     def test_clean_repo_all_zero_not_actionable(self):
         table = {
             "status": "",
@@ -643,6 +660,7 @@ class TestAssembleSummary(unittest.TestCase):
             current="main", default="main",
         )
         self.assertFalse(summary["dirty"])
+        self.assertFalse(summary["ff_pull_eligible"])   # behind 0 -> not eligible
         self.assertEqual(summary["behind"], 0)
         self.assertEqual(summary["ahead"], 0)
         self.assertEqual(summary["unpushed"], 0)
@@ -682,6 +700,8 @@ class TestAssembleSummary(unittest.TestCase):
         )
         self.assertEqual(summary["behind"], 0)
         self.assertEqual(summary["ahead"], 0)
+        self.assertFalse(summary["upstream"])   # empty rev-list -> no tracking branch
+        self.assertFalse(summary["ff_pull_eligible"])
 
 
 class TestAssembleSummaryStaleWorktrees(unittest.TestCase):

--- a/plugins/ca/includes/redirect.md
+++ b/plugins/ca/includes/redirect.md
@@ -32,9 +32,10 @@ Still need a command channel. Closest matches first:
 <up to three prefilled /ca: commands for the inferred intent>
 
 Full list:
-/ca:decompose  /ca:create-context  /ca:feature  /ca:fix  /ca:refactor  /ca:debug
-/ca:commit  /ca:pr  /ca:review  /ca:checkpoint  /ca:release  /ca:add-dep
+/ca:decompose  /ca:create-context  /ca:feature  /ca:fix  /ca:refactor  /ca:debug  /ca:chore  /ca:spike
+/ca:commit  /ca:pr  /ca:watch  /ca:review  /ca:checkpoint  /ca:release  /ca:add-dep
 /ca:threat-model  /ca:adr  /ca:adr-status  /ca:reconcile  /ca:conflict
-/ca:new-skill  /ca:btw  /ca:status  /ca:init  /ca:commands
+/ca:init  /ca:status  /ca:audit  /ca:statusline  /ca:prune  /ca:doctor  /ca:standup
+/ca:new-skill  /ca:btw  /ca:commands
 Or /ca:override "reason" to proceed anyway with an audit entry.
 ```


### PR DESCRIPTION
Pre-tag remediation of the three-subagent repo audit (UI/UX · functional · spec-conformance) run before cutting `v2.1.0-beta.4`. **No version bump** — beta.4 manifests are already set and the tag is not yet cut, so the CI version-bump guard does not fire.

## Blocker (marketplace)
- `COMMANDS.md` advertised a non-existent `/ca:statusline [--check]` → corrected to `install | uninstall | status` (matches `statusline.md` and `doctor.md`).

## Medium
- `COMMANDS.md` `/ca:init` hint completed; `init.md` `argument-hint` gains `--check`.
- §6 repeat-redirect "Full list" was missing ~8 commands (incl. `/ca:standup`, `/ca:watch`) — now complete.
- `prune.md` gained the `python3 || python` Windows interpreter fallback the sibling commands already carried.
- Bare `/sprint` references in `sprint.md`/`override.md` normalized to `/ca:sprint`.
- **Babysitter flag resolution executed, not eyeballed** — new fail-safe `_babysitlib.py` CLI (`--root`, one JSON line, always exits 0); `/ca:pr` and `/ca:watch` invoke it instead of re-stating `on|true|1` + the dormancy gate in prose. Kills the dead-code smell and the drift risk.
- **SH-6 ff-pull gate wired live** — `assemble_summary` computes `ff_pull_eligible` via the pure helper; the SessionStart briefing surfaces it and `/ca:standup` step 1 keys off it. The helper was tested but never invoked.

## Low
- `session-start.py`: dropped a stale "summary always empty" comment; the upstream line no longer prints a misleading "behind 0, ahead 0" when there is no tracking branch; standup default-branch override moved off the wrong `FARM_BASE_BRANCH` namespace to `CODEARBITER_BASE_BRANCH`.
- `statusline.py`: `/dev` now shows a textual `[DEV]` badge alongside the full-bar redshift.
- `arbiter.md` `argument-hint` normalized `""` → `(none)`.

## Verification
- `356` hook unittest cases green (+6: babysit CLI ×4, assemble ff-pull ×2).
- `check-plugin-refs.py` → reference graph intact.

After merge (squash), tag `v2.1.0-beta.4` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)