### PR TITLE
fix(statusline): self-heal stale version-pinned path on session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.1.0-beta.5] — 2026-06-13 — preview
+
+Bug fix: the statusline pin no longer goes stale across plugin updates.
+
+### Fixed
+- **Statusline now self-heals on a plugin update.** `wire-statusline.py` writes an absolute,
+  version-pinned path into `~/.claude/settings.json` (a plugin can't own a statusLine and
+  `${CLAUDE_PLUGIN_ROOT}` isn't expanded there), but nothing re-ran it after an update — so an
+  updated install kept invoking the OLD version's `statusline.py`: stale, and eventually a blank bar
+  once that version's cache dir is pruned. The SessionStart hook now refreshes a codeArbiter-owned
+  pin to the current renderer path on every session, persisting **only** on a real change (no
+  steady-state churn), leaving a third-party statusLine untouched, never wiring a fresh line where
+  the user has none, and degrading silently on any error (including a corrupt `settings.json`) so a
+  wiring refresh can never crash startup. New `refresh` action on `wire-statusline.py` and
+  `heal_statusline_wiring()` in `session-start.py`, both with `unittest` coverage.
+
+---
+
 ## [2.1.0-beta.4] — 2026-06-13 — preview
 
 Session-hygiene sprint: two opt-in repo-hygiene features, built test-first under `subagent-driven-development`. No change to existing gates; both features are dormant in a repo without `arbiter: enabled`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.1.0-beta.4" src="https://img.shields.io/badge/version-2.1.0--beta.4-2b7489">
+<img alt="version 2.1.0-beta.5" src="https://img.shields.io/badge/version-2.1.0--beta.5-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-14-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in — run /ca:init to activate.",
-  "version": "2.1.0-beta.4",
+  "version": "2.1.0-beta.5",
   "author": { "name": "suadtl" },
   "license": "MIT",
   "homepage": "https://github.com/SUaDtL/codeArbiter",

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -341,6 +341,53 @@ def assemble_summary(root, runner=None, current=None, default="main", path_exist
     }
 
 
+# --- Statusline pin self-heal (SessionStart) -------------------------------
+# A plugin cannot own a statusLine and ${CLAUDE_PLUGIN_ROOT} is NOT expanded in
+# settings.json, so wire-statusline.py writes an ABSOLUTE, version-pinned path.
+# Nothing re-ran it after a plugin update, so an updated install kept invoking the
+# OLD version's statusline.py — stale, and eventually broken when that cache dir
+# is pruned. We heal it here every SessionStart: refresh a ca-OWNED pin to the
+# current renderer path, persisting ONLY on a real change (no steady-state churn),
+# and degrade silently on ANY failure — a wiring refresh must never crash startup.
+
+
+def _load_wire_statusline(plugin):
+    """Load wire-statusline.py (hyphenated filename) from <plugin>/hooks/ as a
+    module, or None on any failure."""
+    try:
+        import importlib.util  # noqa: PLC0415 — lazy by design
+        path = os.path.join(plugin, "hooks", "wire-statusline.py")
+        spec = importlib.util.spec_from_file_location("wire_statusline", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None):
+    """Refresh a stale ca-OWNED statusLine pin to the current renderer path.
+    Returns True iff settings.json was rewritten. Fully guarded: any failure —
+    including a corrupt settings.json (which wire-statusline raises SystemExit on)
+    — degrades to False so it never crashes session startup."""
+    try:
+        ws = (loader or _load_wire_statusline)(plugin)
+        if ws is None:
+            return False
+        spath = settings_path or ws.settings_path(None)
+        script_abs = os.path.join(plugin, "hooks", "statusline.py")
+        interp = interp or ws.default_interp(None)
+        settings, exists = ws.load_settings(spath)
+        if not exists:
+            return False
+        if ws.refresh_if_stale(settings, script_abs, interp):
+            ws.save_settings(spath, settings)
+            return True
+        return False
+    except (Exception, SystemExit):  # noqa: BLE001 — heal is best-effort, never fatal
+        return False
+
+
 def has_source(root):
     """True if the repo contains any file that isn't arbiter/scaffold cruft —
     distinguishes brownfield (adopt existing code) from greenfield. Returns on the
@@ -372,6 +419,11 @@ def main():
         os.remove(os.path.join(root, ".codearbiter", ".markers", "dev-active"))
     except OSError:
         pass
+
+    # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
+    # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update
+    # must re-point it in every session, not only in arbiter-enabled repos.
+    heal_statusline_wiring(plugin)
 
     enabled, malformed = frontmatter_enabled(ctx)
     if not enabled:

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -1,8 +1,12 @@
 """Tests for session-start.py: has_source(), CONFIRM_RE, task counting."""
+import contextlib
+import io
+import json
 import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -200,6 +204,61 @@ class TestHealStatuslineWiring(unittest.TestCase):
         self.assertFalse(
             _mod.heal_statusline_wiring(
                 self.plugin, settings_path=missing, interp="python"))
+
+    def test_loader_failure_returns_false(self):
+        # The `loader=` seam exists so a wire-statusline.py that fails to load
+        # degrades to a no-op rather than crashing startup. A loader returning
+        # None must short-circuit to False without touching settings.json.
+        self._write({"statusLine": {"type": "command", "command": "x statusline.py"}})
+        self.assertFalse(
+            _mod.heal_statusline_wiring(
+                self.plugin, settings_path=self.settings, interp="python",
+                loader=lambda _p: None))
+
+
+class TestMainHealsBeforeDormantGate(unittest.TestCase):
+    """Regression (#fix): the heal must run from main() BEFORE the dormant early
+    return, so a plugin update re-points the pin in EVERY session — even a
+    non-arbiter (dormant) repo. This is the test that FAILS if the
+    `heal_statusline_wiring(plugin)` call is deleted from main(); the direct-call
+    tests above would all still pass, leaving the actual fix point unguarded."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        # A dormant repo: no .codearbiter/CONTEXT.md -> main() exits early.
+        self.repo = os.path.join(self._tmp.name, "repo")
+        os.makedirs(self.repo)
+        # A fake HOME whose ~/.claude/settings.json carries a stale ca-owned pin.
+        self.home = os.path.join(self._tmp.name, "home")
+        os.makedirs(os.path.join(self.home, ".claude"))
+        self.settings = os.path.join(self.home, ".claude", "settings.json")
+        with open(self.settings, "w", encoding="utf-8") as f:
+            json.dump({"statusLine": {"type": "command",
+                       "command": '"python" "C:\\old\\ca\\2.0.1\\hooks\\statusline.py"'}}, f)
+        self.plugin = os.path.dirname(os.path.dirname(os.path.abspath(_mod.__file__)))
+        self.real_script = os.path.join(self.plugin, "hooks", "statusline.py")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_main_heals_stale_pin_in_dormant_repo(self):
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            # expanduser("~") -> our fake HOME, so settings_path resolves into it;
+            # CLAUDE_PLUGIN_ROOT -> the real plugin so statusline.py exists.
+            with mock.patch.object(os.path, "expanduser", return_value=self.home), \
+                 mock.patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": self.plugin}), \
+                 contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit):
+                    _mod.main()
+        finally:
+            os.chdir(cwd)
+        with open(self.settings, encoding="utf-8") as f:
+            cmd = json.load(f)["statusLine"]["command"]
+        self.assertIn(self.real_script, cmd)
+        self.assertNotIn("2.0.1", cmd)
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -140,5 +140,67 @@ class TestMalformedFrontmatter(unittest.TestCase):
             self.assertTrue(malformed)
 
 
+class TestHealStatuslineWiring(unittest.TestCase):
+    """Regression (#fix): SessionStart must self-heal a stale ca-owned statusLine
+    pin so a plugin update re-points the absolute path in settings.json instead of
+    silently running the old (eventually-broken) version. Drives the real
+    wire-statusline.py from the actual plugin root, against a temp settings file."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        # Real plugin root = parent of the hooks/ dir holding session-start.py.
+        self.plugin = os.path.dirname(
+            os.path.dirname(os.path.abspath(_mod.__file__)))
+        self.real_script = os.path.join(self.plugin, "hooks", "statusline.py")
+        d = os.path.join(self._tmp.name, ".claude")
+        os.makedirs(d)
+        self.settings = os.path.join(d, "settings.json")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, obj):
+        import json
+        with open(self.settings, "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2)
+
+    def _read(self):
+        import json
+        with open(self.settings, encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_stale_ours_pin_is_healed(self):
+        self._write({"statusLine": {"type": "command",
+                     "command": '"python" "C:\\old\\ca\\2.0.1\\hooks\\statusline.py"'}})
+        changed = _mod.heal_statusline_wiring(
+            self.plugin, settings_path=self.settings, interp="python")
+        self.assertTrue(changed)
+        cmd = self._read()["statusLine"]["command"]
+        self.assertIn(self.real_script, cmd)
+        self.assertNotIn("2.0.1", cmd)
+
+    def test_third_party_pin_left_alone(self):
+        self._write({"statusLine": {"type": "command", "command": "theirs --x"}})
+        changed = _mod.heal_statusline_wiring(
+            self.plugin, settings_path=self.settings, interp="python")
+        self.assertFalse(changed)
+        self.assertEqual(self._read()["statusLine"]["command"], "theirs --x")
+
+    def test_corrupt_settings_does_not_crash(self):
+        with open(self.settings, "w", encoding="utf-8") as f:
+            f.write("{ not valid json")
+        # Must degrade silently (return False), never raise — a wiring refresh
+        # may not crash session startup.
+        self.assertFalse(
+            _mod.heal_statusline_wiring(
+                self.plugin, settings_path=self.settings, interp="python"))
+
+    def test_absent_settings_is_noop(self):
+        missing = os.path.join(self._tmp.name, "nope", "settings.json")
+        self.assertFalse(
+            _mod.heal_statusline_wiring(
+                self.plugin, settings_path=missing, interp="python"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/tests/test_wire_statusline.py
+++ b/plugins/ca/hooks/tests/test_wire_statusline.py
@@ -478,6 +478,33 @@ class TestRefreshStalePathOnSessionStart(unittest.TestCase):
         data = _read(spath)
         self.assertNotIn("statusLine", data)
 
+    def test_refresh_noop_when_renderer_missing(self):
+        # Mid-update safety: if the current renderer (hooks/statusline.py) is not
+        # present under the plugin root, refresh must NOT rewrite the pin to a path
+        # that would 404 — leave settings.json untouched (no mtime churn).
+        bare = os.path.join(self.tmp.name, "bareplugin")
+        os.makedirs(os.path.join(bare, "hooks"))  # hooks/ but NO statusline.py
+        import time
+        mtime_before = os.path.getmtime(self.settings)
+        time.sleep(0.05)
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", bare, "--interp", "python"])
+        self.assertAlmostEqual(mtime_before, os.path.getmtime(self.settings), delta=0.02)
+        self.assertEqual(_read(self.settings)["statusLine"]["command"], self.stale_cmd)
+
+    def test_refresh_heals_bare_string_statusline(self):
+        # is_ours() accepts a bare-string statusLine; the string-form branch of
+        # refresh_if_stale must heal that shape too (not only dict-form).
+        spath = _make_settings(
+            self.tmp.name,
+            {"statusLine": '"python" "C:\\old\\ca\\2.0.1\\hooks\\statusline.py"'})
+        ws.main(["refresh", "--settings", spath,
+                 "--plugin-root", self.root, "--interp", "python"])
+        sl = _read(spath).get("statusLine")
+        cmd = sl.get("command") if isinstance(sl, dict) else sl
+        self.assertIn(self.script_abs, cmd)
+        self.assertNotIn("2.0.1", cmd)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/tests/test_wire_statusline.py
+++ b/plugins/ca/hooks/tests/test_wire_statusline.py
@@ -420,5 +420,64 @@ class TestSpinnerVerbsIdempotent(unittest.TestCase):
         self.assertGreater(len(verbs), 0)
 
 
+class TestRefreshStalePathOnSessionStart(unittest.TestCase):
+    """Regression (#fix): a ca-owned statusLine whose command points at an OLD
+    plugin-version path must be REFRESHED to the current renderer path on its own
+    — without a manual re-install. Previously nothing re-wired after a plugin
+    update, so users kept running a stale (eventually-broken) statusline."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = _make_plugin_root(self.tmp.name)
+        self.script_abs = os.path.join(self.root, "hooks", "statusline.py")
+        # A ca-owned line pinned to an OLD version dir (note: still 'ours' — the
+        # MARKER 'statusline.py' is present — but a different absolute path).
+        self.stale_cmd = (
+            '"python" "C:\\old\\cache\\codearbiter\\ca\\2.0.1\\hooks\\statusline.py"')
+        self.settings = _make_settings(
+            self.tmp.name,
+            {"statusLine": {"type": "command", "command": self.stale_cmd}})
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_stale_ours_path_is_refreshed(self):
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", self.root, "--interp", "python"])
+        data = _read(self.settings)
+        cmd = (data.get("statusLine") or {}).get("command", "")
+        self.assertIn(self.script_abs, cmd)
+        self.assertNotIn("2.0.1", cmd)
+
+    def test_refresh_does_not_rewrite_when_already_current(self):
+        # First refresh brings it current; second must be a no-op (no churn): the
+        # file mtime must not change on the second call.
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", self.root, "--interp", "python"])
+        import time
+        mtime_before = os.path.getmtime(self.settings)
+        time.sleep(0.05)
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", self.root, "--interp", "python"])
+        self.assertAlmostEqual(mtime_before, os.path.getmtime(self.settings), delta=0.02)
+
+    def test_refresh_leaves_third_party_line_untouched(self):
+        third = {"statusLine": {"type": "command", "command": "their-statusline --x"}}
+        spath = _make_settings(self.tmp.name, third)
+        ws.main(["refresh", "--settings", spath,
+                 "--plugin-root", self.root, "--interp", "python"])
+        data = _read(spath)
+        self.assertEqual(data["statusLine"]["command"], "their-statusline --x")
+
+    def test_refresh_does_not_wire_when_no_statusline(self):
+        # refresh HEALS an existing ours-line; it must never wire a fresh line
+        # where the user has none (that's what `install` is for).
+        spath = _make_settings(self.tmp.name, {})
+        ws.main(["refresh", "--settings", spath,
+                 "--plugin-root", self.root, "--interp", "python"])
+        data = _read(spath)
+        self.assertNotIn("statusLine", data)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/wire-statusline.py
+++ b/plugins/ca/hooks/wire-statusline.py
@@ -11,6 +11,10 @@
 #   python wire-statusline.py install      # back up any existing line, wire ours
 #   python wire-statusline.py uninstall    # restore the backed-up line (or remove)
 #   python wire-statusline.py status       # report current wiring, change nothing
+#   python wire-statusline.py refresh      # self-heal a stale ca-owned path only
+#                                          # (no-op unless ours AND changed) — run
+#                                          # from SessionStart so a plugin update
+#                                          # re-points the pin automatically
 #
 # Options (mainly for testing):
 #   --settings PATH     target settings.json (default: ~/.claude/settings.json)
@@ -164,6 +168,41 @@ def cmd_install(settings, path, script_abs, interp):
         print("no prior statusLine existed; uninstall will simply remove ours.")
 
 
+def refresh_if_stale(settings, script_abs, interp):
+    """Self-heal a ca-owned statusLine whose command has gone stale (e.g. it points
+    at a previous plugin-version dir after an update). Mutates `settings` IN PLACE
+    and returns True iff something changed.
+
+    Scope is deliberately narrow — this is NOT install:
+      - statusLine is ours AND its command != the desired current command -> rewrite, True
+      - statusLine is ours and already current                            -> no change, False
+      - statusLine is a third-party line, or absent                       -> never touched, False
+
+    Returning a changed-flag lets the caller persist ONLY on a real change, so a
+    steady-state session start never churns settings.json."""
+    current = settings.get("statusLine")
+    if not is_ours(current):
+        return False
+    desired = build_command(interp, script_abs)
+    cur_cmd = current.get("command") if isinstance(current, dict) else current
+    if cur_cmd == desired:
+        return False
+    settings["statusLine"] = {"type": "command", "command": desired, "padding": 0}
+    return True
+
+
+def cmd_refresh(settings, path, script_abs, interp):
+    """SessionStart self-heal entry. Refresh a stale ca-owned path and persist ONLY
+    if it changed; otherwise leave settings.json untouched (no mtime churn)."""
+    if not os.path.exists(script_abs):
+        # Renderer missing (mid-update?) — do nothing rather than write a path that
+        # 404s. A later session with the file present will heal it.
+        return
+    if refresh_if_stale(settings, script_abs, interp):
+        save_settings(path, settings)
+        print(f"REFRESHED stale codeArbiter statusline path -> {settings['statusLine']['command']}")
+
+
 def _install_spinner_verbs(settings, refresh):
     current_sv = settings.get("spinnerVerbs")
     already_ours = SPINNER_BACKUP_KEY in settings
@@ -211,7 +250,7 @@ def _uninstall_spinner_verbs(settings):
 def main(argv=None):
     ap = argparse.ArgumentParser(add_help=True)
     ap.add_argument("action", nargs="?", default="status",
-                    choices=["install", "uninstall", "status"])
+                    choices=["install", "uninstall", "status", "refresh"])
     ap.add_argument("--settings")
     ap.add_argument("--plugin-root")
     ap.add_argument("--interp")
@@ -230,6 +269,8 @@ def main(argv=None):
         cmd_install(settings, spath, script_abs, interp)
     elif args.action == "uninstall":
         cmd_uninstall(settings, spath, script_abs)
+    elif args.action == "refresh":
+        cmd_refresh(settings, spath, script_abs, interp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

`wire-statusline.py` writes an **absolute, version-pinned** path into `~/.claude/settings.json` (a plugin can't own a `statusLine`, and `${CLAUDE_PLUGIN_ROOT}` isn't expanded there). Nothing ever re-ran it after a plugin update — so an updated install kept invoking the **old version's** `statusline.py`: stale code, and eventually a **blank bar** once that version's cache dir is pruned. Observed live: an install pinned at `2.0.1` survived three version bumps.

## Change

- **`wire-statusline.py`** — new `refresh` action + `refresh_if_stale()`. Narrow by design (not `install`): heals only a **ca-owned, changed** pin, persists **only on a real change** (no session-start churn), never touches a third-party `statusLine`, never wires a fresh line where the user has none, and no-ops if the renderer is missing mid-update.
- **`session-start.py`** — `heal_statusline_wiring()` called on every SessionStart, **before** the dormant gate (the statusline is wired globally, so it must heal in every repo, not just arbiter-enabled ones). Fully guarded — corrupt/absent `settings.json` degrades to a no-op; a wiring refresh can never crash startup.
- Version `2.1.0-beta.4 → 2.1.0-beta.5` (payload change on a published tag — CI `version-bump` gate).

## Test plan

- `python -m unittest discover -s tests` (from `plugins/ca/hooks`) — **368 pass**.
- `.github/scripts/test_hook_guards.py` (62/0), `test_hooks_cold_install.py` (131/0), `check-plugin-refs.py` (graph intact).
- New regression coverage: stale-pin heal, no-churn idempotency, third-party untouched, no fresh-wire, missing-renderer guard, bare-string form, loader-failure short-circuit, and a **`main()`-level test that is mutation-verified** to fail if the heal call is removed.

## Tradeoff (conflict hierarchy)

Heal runs on **every** SessionStart, including non-arbiter repos — a correctness-over-performance call (L2 over L4): the cost is one `settings.json` read per session (write only on change), in exchange for the pin self-healing everywhere the global statusline actually runs.

No ADR implemented or contradicted.