### PR TITLE
docs: Feature Forge + white-glove README pass (2.1.0-beta.6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Command catalog & docs
+    url: https://github.com/SUaDtL/codeArbiter#readme
+    about: How to install, enable, and drive codeArbiter — start here.
+  - name: What's in the Feature Forge
+    url: https://github.com/SUaDtL/codeArbiter#feature-forge
+    about: Preview features, how they're opt-in, and how your data promotes them.

--- a/.github/ISSUE_TEMPLATE/feature-forge-prune.yml
+++ b/.github/ISSUE_TEMPLATE/feature-forge-prune.yml
@@ -1,0 +1,61 @@
+name: "Feature Forge: prune data"
+description: "Send back your CODEARBITER_PRUNE=dry log to help promote live pruning out of preview."
+title: "Feature Forge: prune data — "
+labels: ["feature-forge", "prune"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for forging. 🔨
+
+        Live transcript pruning is a **preview** feature — it graduates from the
+        [Feature Forge](https://github.com/SUaDtL/codeArbiter#feature-forge) when real-world data
+        says it's safe to flip `on`. Your `dry`-mode log is that data.
+
+        **Privacy:** `prune-dry.jsonl` contains **sizes, strategy names, and validation verdicts
+        only — no transcript content**. Skim it first if you like; it's plain JSONL.
+
+        Generate it by running a few sessions with:
+        ```sh
+        export CODEARBITER_PRUNE=dry
+        ```
+        then attach or paste `~/.codearbiter/metrics/prune-dry.jsonl` below.
+  - type: textarea
+    id: jsonl
+    attributes:
+      label: Your prune-dry.jsonl
+      description: "Drag the file into this box to attach it, or paste its contents. Sizes/verdicts only — no transcript content."
+      render: json
+    validations:
+      required: true
+  - type: input
+    id: sessions
+    attributes:
+      label: Roughly how many sessions does this cover?
+      placeholder: "e.g. 12 sessions over a week"
+    validations:
+      required: false
+  - type: dropdown
+    id: would-flip
+    attributes:
+      label: Based on what you saw in dry mode, would you flip it to `on`?
+      options:
+        - "Yes — the reductions look worth it and nothing important was cut"
+        - "Not sure — need to look closer"
+        - "No — it would have cut something I'd want to keep"
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything surprising? (optional)
+      description: "A verdict that looked wrong, a strategy that over- or under-pruned, anything that stood out."
+    validations:
+      required: false
+  - type: input
+    id: env
+    attributes:
+      label: Environment (optional)
+      placeholder: "OS · Python version · any CODEARBITER_PRUNE_* overrides you set"
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.1.0-beta.6] — 2026-06-13 — preview
+
+Docs-only release: distribution-readiness pass ahead of a marketplace submission. No code, no gate
+change, no behavioral surface.
+
+### Added
+- **"Feature Forge" section** (repo README) with its own hero (`docs/feature-forge.svg`, in the
+  banner's visual family — a commit at a gate that still glows hot, embers rising). Frames preview
+  features as opt-in, dormant, and promoted by real-world data rather than a calendar. Houses live
+  transcript pruning with its `off`/`dry`/`on` contract and a concrete feedback loop: run
+  `CODEARBITER_PRUNE=dry`, then send `~/.codearbiter/metrics/prune-dry.jsonl` back via a pre-filled
+  GitHub issue. The log carries sizes, per-strategy savings, and verdicts only — **no transcript
+  content** — and is the evidence base for the `dry → on` go/no-go.
+- **Issue form `Feature Forge: prune data`** (`.github/ISSUE_TEMPLATE/`) so returning a `dry` log is
+  drag-attach-submit, plus an issue-chooser config linking the docs and the Forge.
+- **Demo recording shot list** (`docs/demo-script.md`) and a commented placeholder in the README for
+  an in-motion GIF (the BLOCK → resolve → green beat).
+
+### Changed
+- **Plugin storefront** (`plugins/ca/README.md`) gains a compact Feature Forge blurb with the
+  prune-data ask — it's what the marketplace directory renders, so it can't be silent on previews.
+- **Configuration table** (repo README) split: the prune flags moved out of the stable table into
+  Feature Forge, so preview opt-ins no longer sit beside blessed ones.
+- A collapsible worked-example added to the README so it *shows* a real `/ca:fix → commit → pr` flow,
+  not only describes the gates.
+
+---
+
 ## [2.1.0-beta.5] — 2026-06-13 — preview
 
 Bug fix: the statusline pin no longer goes stale across plugin updates.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.1.0-beta.5" src="https://img.shields.io/badge/version-2.1.0--beta.5-2b7489">
+<img alt="version 2.1.0-beta.6" src="https://img.shields.io/badge/version-2.1.0--beta.6-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-14-555">
 <img alt="license MIT" src="https://img.shields.io/badge/license-MIT-3da639">
 
 <sub>Install it globally; it stays dormant until you opt a repo in.</sub>
+
+<!-- DEMO: once recorded, replace this comment with the in-motion GIF. Recording shot list in docs/demo-script.md
+<div align="center"><img src="docs/demo.gif" alt="codeArbiter in motion — a gate blocks, the human resolves, the work goes green" width="900"></div>
+-->
 
 </div>
 
@@ -161,18 +165,7 @@ Every flag is shipped off, never auto-enabled, and dormant in a repo without `ar
 
 ## Feature Forge
 
-<div align="center">
-
-### 🔨 &nbsp; The Feature Forge &nbsp; 🔨
-
-**Built, tested, and shipping — but not yet blessed.**<br/>
-Run them. Send the data. Decide what graduates.
-
-<img alt="channel preview" src="https://img.shields.io/badge/channel-preview-d97757">
-<img alt="opt-in only" src="https://img.shields.io/badge/opt--in-only-555">
-<img alt="your data promotes it" src="https://img.shields.io/badge/your_data-promotes_it-3da639">
-
-</div>
+<div align="center"><img src="docs/feature-forge.svg" alt="The Feature Forge — preview features: built, tested, shipping, not yet blessed" width="100%"></div>
 
 Some features are built, tested, and shipping in the box — but not yet *blessed*. They live in the **Feature Forge**: off by default, fully dormant until you opt in, and labeled `preview` until real-world data earns them a promotion to a stable release. Nothing here touches your repo or your gates unless you turn it on.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ It will not:
 
 It is decisive and terse by design. If you want an assistant that hedges, this is the wrong tool.
 
+<details>
+<summary><b>What a loop actually feels like</b></summary>
+
+<br>
+
+```text
+you      /ca:fix the statusline keeps running the old version after an update
+
+arbiter  Routing to tdd (bug variant) — a regression test before any fix.
+         → writes a failing test, confirms it's red for the right reason
+         → minimal fix → suite green → coverage + lint gates clear
+
+you      /ca:commit
+arbiter  commit-gate: ✓ permission ✓ branch ✓ tests ✓ secrets
+         ✓ behavioral proof ✓ clean diff → committed.
+
+you      /ca:pr
+arbiter  reviewer fleet over the diff — coverage-auditor flags an untested seam.
+         BLOCK. Here's the gap. → (you resolve, re-run) → PR opened.
+```
+
+Every step is a gate you watch clear. You stay in the driver's seat; the gates keep the work honest — that exchange is a real one from this project's own history.
+
+</details>
+
 ## How it works
 
 One plugin, named `ca`. Claude Code namespaces every plugin command, so you invoke it as <kbd>/ca:feature</kbd>, <kbd>/ca:commit</kbd>, <kbd>/ca:commands</kbd>, and so on.
@@ -131,13 +156,51 @@ Every optional behavior is **off by default** and opt-in through an environment 
 |---|---|---|
 | `CODEARBITER_BABYSIT` | `off` | When `on`, <kbd>/ca:pr</kbd> auto-attaches a CI watcher to the PR it opens (same as running <kbd>/ca:watch</kbd> by hand). Ad-hoc <kbd>/ca:watch</kbd> works regardless. |
 | `CODEARBITER_BABYSIT_ONRED` | `propose` | The watcher's depth on a red check: `propose` (name the cause, suggest a fix, touch nothing) or `branch` (additionally stage the fix on an unmergeable `spike/fix-*`). |
-| `CODEARBITER_PRUNE` | `off` | Transcript-pruner mode: `off`, `dry` (report only), or `on` (trim on resume/compaction). |
-| `CODEARBITER_PRUNE_TIER` | — | Which pruning passes run; see <kbd>/ca:prune</kbd>. |
-| `CODEARBITER_PRUNE_KEEP_RECENT` | — | Protect the K most recent turns from pruning. |
-| `CODEARBITER_PRUNE_MIN_GROWTH` / `CODEARBITER_PRUNE_MAXBYTES` | — | Growth threshold before a prune runs / cap on bytes removed. |
-| `CODEARBITER_PRUNE_METRICS` | `~/.codearbiter/metrics/prune-dry.jsonl` | Where `dry`-mode data collection lands — one shared append-only JSONL log every session writes to, the evidence base for the `dry`→`on` go/no-go. |
 
-Both feature flags mirror each other's contract: shipped off, never auto-enabled, and dormant in a repo without `arbiter: enabled`.
+Every flag is shipped off, never auto-enabled, and dormant in a repo without `arbiter: enabled`. Preview features carry their own opt-ins — see [**Feature Forge**](#feature-forge) below.
+
+## Feature Forge
+
+<div align="center">
+
+### 🔨 &nbsp; The Feature Forge &nbsp; 🔨
+
+**Built, tested, and shipping — but not yet blessed.**<br/>
+Run them. Send the data. Decide what graduates.
+
+<img alt="channel preview" src="https://img.shields.io/badge/channel-preview-d97757">
+<img alt="opt-in only" src="https://img.shields.io/badge/opt--in-only-555">
+<img alt="your data promotes it" src="https://img.shields.io/badge/your_data-promotes_it-3da639">
+
+</div>
+
+Some features are built, tested, and shipping in the box — but not yet *blessed*. They live in the **Feature Forge**: off by default, fully dormant until you opt in, and labeled `preview` until real-world data earns them a promotion to a stable release. Nothing here touches your repo or your gates unless you turn it on.
+
+**This is also where you come in.** A preview graduates when the evidence says it's ready — and that evidence comes from people running it. Each forge feature ships a `dry` mode that does the real analysis and records what it *would* have done, changing nothing. Send that data back and you pull the promote date forward.
+
+### In the forge now
+
+**Live transcript pruning** · `CODEARBITER_PRUNE`
+
+Long sessions bloat the transcript until Claude Code compacts early and you lose working headroom. The pruner trims redundant clutter so a session lives longer — gains land at resume/compaction, never mid-turn. Three modes:
+
+| `CODEARBITER_PRUNE` | What happens |
+|---|---|
+| `off` *(default)* | nothing — fully dormant |
+| `dry` | **report only** — computes every prune it *would* make and logs the evidence; your transcript is untouched |
+| `on` | actually trims, at resume/compaction |
+
+Fine-tune with `CODEARBITER_PRUNE_TIER` (which passes run), `CODEARBITER_PRUNE_KEEP_RECENT` (protect the K most recent turns), and `CODEARBITER_PRUNE_MIN_GROWTH` / `CODEARBITER_PRUNE_MAXBYTES` (when a prune triggers / cap on bytes removed). Full detail in <kbd>/ca:prune</kbd>.
+
+#### Help promote it — run `dry`, send the log
+
+```sh
+export CODEARBITER_PRUNE=dry      # collect evidence, change nothing
+```
+
+`dry` mode appends one JSONL row per decision to `~/.codearbiter/metrics/prune-dry.jsonl` (relocate it with `CODEARBITER_PRUNE_METRICS`). Each row carries only the **would-be reduction, per-strategy savings, and a validation verdict** — sizes and strategy names, **no transcript content**. That file is the entire evidence base for the `dry → on` go/no-go.
+
+After a few sessions, [**open a "prune data" issue**](https://github.com/SUaDtL/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune) and attach or paste your `prune-dry.jsonl`. The more real sessions come back, the sooner pruning leaves the forge. Thank you for forging. 🔨
 
 ## Commands
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,0 +1,53 @@
+# Demo recording script — codeArbiter in motion
+
+The single highest-impact asset the README is missing is **15 seconds of a gate actually firing**.
+This file is the shot list. Record it, drop the result at `docs/demo.gif`, and uncomment the
+`<!-- DEMO -->` placeholder near the top of `README.md`.
+
+## Why this exact sequence
+
+It shows the one thing prose can't: a gate **blocking**, the human **resolving**, and the work going
+green. That BLOCK → resolve → green beat is the product. Don't demo a happy path with no friction —
+the friction is the feature.
+
+## Setup
+
+- A throwaway repo already opted in (`/ca:init` done, `arbiter: enabled`), with a small, real bug
+  staged to reproduce. The statusline should be wired (`/ca:statusline`) so the arbiter row shows.
+- Terminal at ~110×30, a dark theme that matches the banner (`#0b0f14` ground, gold accents read well).
+- Tool: [`asciinema`](https://asciinema.org) + [`agg`](https://github.com/asciinema/agg) to render a
+  GIF, or [`terminalizer`](https://github.com/faressoft/terminalizer). Keep the final GIF under ~3 MB
+  so it loads fast on the README.
+
+## Shot list (target ~15–20s)
+
+1. `/ca:fix the statusline keeps running the old version after a plugin update`
+   - Let the routing line land: *"Routing to tdd (bug variant) — a regression test before any fix."*
+   - Show the failing test go **red for the right reason**, then the minimal fix, then green.
+2. `/ca:commit`
+   - Let the commit-gate checklist tick across: permission, branch, tests, secrets, behavioral proof,
+     clean diff → committed. This is the satisfying beat — let it breathe.
+3. `/ca:pr`
+   - The reviewer fleet runs; **coverage-auditor BLOCKs** on an untested seam. Stop on the BLOCK for
+     a beat so the viewer reads it.
+   - (Optional, if it fits the time budget) resolve and re-run to green + PR opened.
+
+## Capture & post
+
+```sh
+# record
+asciinema rec demo.cast
+# ...perform the shot list, then exit the shell to stop...
+
+# render to gif
+agg --theme 0b0f14,e6edf3 demo.cast docs/demo.gif
+```
+
+Then in `README.md`, replace the `<!-- DEMO ... -->` comment with:
+
+```md
+<div align="center"><img src="docs/demo.gif" alt="codeArbiter in motion — a gate blocks, the human resolves, the work goes green" width="900"></div>
+```
+
+Keep the alt text describing the BLOCK → resolve → green story; it's what someone scanning on a phone
+reads before the GIF loads.

--- a/docs/feature-forge.svg
+++ b/docs/feature-forge.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 240" width="1200" height="240" role="img" aria-label="The Feature Forge — preview features: built, tested, shipping, not yet blessed. A commit travels toward a gate that still glows hot, embers rising.">
+  <title>The Feature Forge</title>
+  <defs>
+    <linearGradient id="ffbg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#16110d"/>
+    </linearGradient>
+    <radialGradient id="ffheat" cx="0.82" cy="0.82" r="0.55">
+      <stop offset="0" stop-color="#d97757" stop-opacity="0.22"/>
+      <stop offset="0.55" stop-color="#d97757" stop-opacity="0.06"/>
+      <stop offset="1" stop-color="#d97757" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="ffgrid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#e6edf3" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <linearGradient id="ffword" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f0b35a"/>
+      <stop offset="1" stop-color="#d97757"/>
+    </linearGradient>
+    <filter id="ffglow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="3" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- ground -->
+  <rect width="1200" height="240" fill="url(#ffbg)"/>
+  <rect width="1200" height="240" fill="url(#ffgrid)"/>
+  <rect width="1200" height="240" fill="url(#ffheat)"/>
+
+  <!-- certificate frame — same family as the top banner -->
+  <rect x="10" y="10" width="1180" height="220" fill="none" stroke="#e3b341" stroke-opacity="0.16" stroke-width="1"/>
+  <rect x="14" y="14" width="1172" height="212" fill="none" stroke="#e3b341" stroke-opacity="0.07" stroke-width="1"/>
+
+  <!-- wordmark -->
+  <text x="600" y="92" text-anchor="middle"
+        font-family="'Segoe UI', -apple-system, 'Helvetica Neue', Arial, sans-serif"
+        font-size="52" letter-spacing="0.5">
+    <tspan fill="#e6edf3" font-weight="300">the feature </tspan><tspan fill="url(#ffword)" font-weight="700">forge</tspan>
+  </text>
+  <text x="600" y="126" text-anchor="middle"
+        font-family="ui-monospace, 'Cascadia Code', Consolas, 'Courier New', monospace"
+        font-size="12.5" letter-spacing="3.5" fill="#9a8b7a">BUILT · TESTED · SHIPPING — NOT YET BLESSED</text>
+
+  <!-- the forge line: commits travel toward a gate that still glows hot -->
+  <line x1="120" y1="190" x2="1012" y2="190" stroke="#46505a" stroke-width="2"/>
+
+  <!-- unproven commits: hollow -->
+  <circle cx="160" cy="190" r="4.5" fill="#0b0f14" stroke="#6e7b8b" stroke-width="1.5"/>
+  <circle cx="212" cy="190" r="4.5" fill="#0b0f14" stroke="#6e7b8b" stroke-width="1.5"/>
+  <circle cx="264" cy="190" r="4.5" fill="#0b0f14" stroke="#6e7b8b" stroke-width="1.5"/>
+
+  <!-- the work on the anvil: a commit, still hot -->
+  <circle cx="900" cy="190" r="5.5" fill="#d97757" filter="url(#ffglow)"/>
+
+  <!-- embers rising off the hot work -->
+  <circle cx="906" cy="168" r="2.2" fill="#f0b35a" filter="url(#ffglow)"/>
+  <circle cx="890" cy="154" r="1.6" fill="#e8954a" filter="url(#ffglow)"/>
+  <circle cx="913" cy="146" r="1.3" fill="#f0b35a" filter="url(#ffglow)"/>
+  <circle cx="884" cy="137" r="1.1" fill="#d97757" filter="url(#ffglow)"/>
+
+  <!-- the forge gate — glowing hot, still being worked -->
+  <g filter="url(#ffglow)">
+    <line x1="980" y1="150" x2="980" y2="206" stroke="#d97757" stroke-width="3"/>
+    <line x1="996" y1="150" x2="996" y2="206" stroke="#d97757" stroke-width="3"/>
+    <rect x="974" y="143" width="28" height="6" fill="#f0b35a"/>
+  </g>
+  <text x="988" y="224" text-anchor="middle"
+        font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="10" letter-spacing="2.5" fill="#c08a6a">FORGE</text>
+
+  <!-- the seal: how a preview graduates -->
+  <text x="1166" y="220" text-anchor="end"
+        font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="9" letter-spacing="1.5" fill="#6e7b8b">preview channel · opt-in · your data promotes it</text>
+</svg>

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in — run /ca:init to activate.",
-  "version": "2.1.0-beta.5",
+  "version": "2.1.0-beta.6",
   "author": { "name": "suadtl" },
   "license": "MIT",
   "homepage": "https://github.com/SUaDtL/codeArbiter",

--- a/plugins/ca/README.md
+++ b/plugins/ca/README.md
@@ -24,6 +24,16 @@ Full documentation, install instructions, and the command catalog live in the
 - **What it writes to your repo** — `.codearbiter/` only. Uninstalling the plugin leaves your
   project state intact and yours.
 
+## Feature Forge (preview)
+
+Some features ship in the box but aren't yet *blessed* — off by default, fully dormant until you opt
+in, labeled `preview` until real-world data earns them a stable promotion. In the forge now: **live
+transcript pruning** (`CODEARBITER_PRUNE`), which trims redundant transcript clutter to extend a
+session. Run it in `dry` mode (`export CODEARBITER_PRUNE=dry`) and it logs what it *would* prune —
+sizes and verdicts only, no transcript content — to `~/.codearbiter/metrics/prune-dry.jsonl`. Sending
+that log back ([open a prune-data issue](https://github.com/SUaDtL/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune))
+is what moves it toward `on`. Full detail in the [Feature Forge section of the repo README](https://github.com/SUaDtL/codeArbiter#feature-forge).
+
 ## What's in this directory
 
 `ORCHESTRATOR.md` (the persona injected in enabled repos) · `commands/` · `skills/` · `agents/` ·


### PR DESCRIPTION
## What & why

Distribution-readiness pass on the docs ahead of a marketplace submission. Pure docs/assets — no code, no gate change, no behavioral surface.

The headline is the **Feature Forge**: a home for features that ship in the box but aren't yet *blessed* (off by default, dormant, promoted by real-world data, not a calendar). It gives live transcript pruning an honest "preview" home and a concrete way for users to help promote it.

## Changes

- **Feature Forge section** (repo README) with its own hero (`docs/feature-forge.svg`, in the top banner's visual family — a commit at a gate that still glows hot, embers rising). Frames the `off`/`dry`/`on` contract and a feedback loop: run `CODEARBITER_PRUNE=dry`, send `prune-dry.jsonl` back via a pre-filled issue. The log is sizes + verdicts only — **no transcript content**.
- **Storefront** (`plugins/ca/README.md`) gains a compact Feature Forge blurb with the prune-data ask — it's what the marketplace directory renders, so it can't be silent on previews.
- **Issue form** `Feature Forge: prune data` (+ chooser config) so returning a dry log is drag-attach-submit; `feature-forge`/`prune` labels created to match the pre-filled link.
- **Demo scaffold** (`docs/demo-script.md` + a commented README placeholder) — the shot list for an in-motion GIF of the BLOCK → resolve → green beat.
- **Configuration table split** — prune flags moved out of the stable table into Feature Forge.
- **Worked example** added to the README so it *shows* a real `/ca:fix → commit → pr` flow.
- **Version bump → `2.1.0-beta.6`** (plugin.json + README badge + CHANGELOG): required by the version-bump CI gate because the change touches `plugins/ca/**` (the storefront) on the already-tagged beta.5.

## Test plan

- `python -m unittest discover -s tests` → 368/368 OK (no code touched; run as a guard).
- `check-plugin-refs.py` → reference graph intact.
- JSON (`plugin.json`, `marketplace.json`), YAML (both issue templates), and SVG (`feature-forge.svg`) all parse.
- Secrets scan over the diff → clean (only the literal word "secrets" in the demo checklist).
- Version-bump gate satisfied: beta.5 → beta.6.

## Tradeoff note

Classified `docs` (conflict hierarchy: maintainability/reviewability). The `plugin.json` bump is bundled in rather than split out — it's the mechanical CI requirement for shipping doc changes under `plugins/ca/`, not an independent change, consistent with prior beta releases.

## Follow-up (not in this PR)

Record the demo GIF per `docs/demo-script.md` and uncomment the README placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
