### PR TITLE
docs: rewrite demo-script as a Windows beginner walkthrough

### DIFF
--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,53 +1,186 @@
-# Demo recording script — codeArbiter in motion
+# Demo recording walkthrough — codeArbiter in motion
 
-The single highest-impact asset the README is missing is **15 seconds of a gate actually firing**.
-This file is the shot list. Record it, drop the result at `docs/demo.gif`, and uncomment the
-`<!-- DEMO -->` placeholder near the top of `README.md`.
+The single highest-impact asset the README is missing is **~15 seconds of a gate actually firing**.
+This is a complete, beginner-friendly walkthrough for recording it on **Windows** with
+[`terminalizer`](https://github.com/faressoft/terminalizer) — no prior GIF experience assumed. Follow
+it top to bottom. When you're done, the GIF lands at `docs/demo.gif` and you uncomment one line in
+`README.md`.
 
-## Why this exact sequence
+If terminalizer ever fights you (Windows can be fussy about it — see [Troubleshooting](#troubleshooting)),
+there's a zero-setup fallback at the bottom using a point-and-click app instead.
 
-It shows the one thing prose can't: a gate **blocking**, the human **resolving**, and the work going
-green. That BLOCK → resolve → green beat is the product. Don't demo a happy path with no friction —
-the friction is the feature.
+---
 
-## Setup
+## What you're filming (and why this exact sequence)
 
-- A throwaway repo already opted in (`/ca:init` done, `arbiter: enabled`), with a small, real bug
-  staged to reproduce. The statusline should be wired (`/ca:statusline`) so the arbiter row shows.
-- Terminal at ~110×30, a dark theme that matches the banner (`#0b0f14` ground, gold accents read well).
-- Tool: [`asciinema`](https://asciinema.org) + [`agg`](https://github.com/asciinema/agg) to render a
-  GIF, or [`terminalizer`](https://github.com/faressoft/terminalizer). Keep the final GIF under ~3 MB
-  so it loads fast on the README.
+Don't film a smooth happy path — **the friction is the feature.** The beat that sells codeArbiter is:
+a gate **BLOCKS**, you **resolve** it, the work goes **green**. Everything in the shot list below
+builds to that moment.
 
-## Shot list (target ~15–20s)
+You'll type three commands into a Claude Code session and let codeArbiter respond:
 
 1. `/ca:fix the statusline keeps running the old version after a plugin update`
-   - Let the routing line land: *"Routing to tdd (bug variant) — a regression test before any fix."*
-   - Show the failing test go **red for the right reason**, then the minimal fix, then green.
+   → it routes to TDD, writes a **failing** test, then the fix, then green.
 2. `/ca:commit`
-   - Let the commit-gate checklist tick across: permission, branch, tests, secrets, behavioral proof,
-     clean diff → committed. This is the satisfying beat — let it breathe.
+   → the commit-gate checklist ticks across (permission, branch, tests, secrets, behavioral proof).
 3. `/ca:pr`
-   - The reviewer fleet runs; **coverage-auditor BLOCKs** on an untested seam. Stop on the BLOCK for
-     a beat so the viewer reads it.
-   - (Optional, if it fits the time budget) resolve and re-run to green + PR opened.
+   → the reviewer fleet runs and **coverage-auditor BLOCKs** on an untested seam. ← *this is the shot.*
 
-## Capture & post
+(Use a throwaway repo that's already opted in via `/ca:init`, with a small real bug to fix. The demo
+is most honest if it's a real run, not faked.)
 
-```sh
-# record
-asciinema rec demo.cast
-# ...perform the shot list, then exit the shell to stop...
+---
 
-# render to gif
-agg --theme 0b0f14,e6edf3 demo.cast docs/demo.gif
+## Step 0 — One-time: confirm your tools (you already have Node)
+
+You already have Node and npm installed (v24 / v11 as of this writing), so you can skip installing them.
+Just confirm in a terminal:
+
+```powershell
+node --version    # expect v18 or newer
+npm --version
 ```
 
-Then in `README.md`, replace the `<!-- DEMO ... -->` comment with:
+Then install terminalizer once, globally:
 
-```md
+```powershell
+npm install -g terminalizer
+terminalizer --version    # confirms it installed
+```
+
+> If `terminalizer` isn't recognized after install, close and reopen your terminal so PATH refreshes.
+
+---
+
+## Step 1 — Start recording
+
+Pick a working folder (it doesn't matter where — the recording is just a file), then:
+
+```powershell
+terminalizer record demo
+```
+
+This drops you into a **new shell that is being recorded.** Everything you type from here is captured.
+A file called `demo.yml` will be written when you stop.
+
+> Tip: make your terminal window a comfortable size *before* recording — about **110 columns × 30 rows**.
+> A dark theme reads best (it'll match the GIF theme you set in Step 3).
+
+---
+
+## Step 2 — Perform the demo, then stop
+
+Inside that recording shell:
+
+1. Launch Claude Code (`claude`) in your throwaway opted-in repo.
+2. Run the three commands from the shot list above, **pausing a beat** after each response lands so a
+   viewer can read it. Linger an extra second on the **BLOCK** in step 3 — that's the payoff frame.
+3. When the PR step finishes, **stop the recording by exiting the shell**:
+
+```powershell
+exit
+```
+
+terminalizer prints something like `Successfully Recorded` and saves **`demo.yml`** in the current
+folder. (That `.yml` is an editable recording — not the GIF yet. You can re-render it as many times as
+you like without re-recording.)
+
+---
+
+## Step 3 — Tidy the recording (theme + pacing)
+
+Open `demo.yml` in any editor. You don't need to understand all of it — just change a few keys near the
+top so the GIF is on-brand and snappy:
+
+```yaml
+# ── make it snappy ─────────────────────────────────────────
+frameDelay: auto        # keep real typing rhythm
+maxIdleTime: 1200       # auto-compress any pause longer than 1.2s (kills dead air)
+cols: 110
+rows: 30
+
+# ── match the codeArbiter banner palette ───────────────────
+theme:
+  background: "#0b0f14"   # banner ground
+  foreground: "#e6edf3"   # banner text
+  cursor: "#e3b341"       # banner gold
+  black:   "#0b0f14"
+  red:     "#d97757"      # the "forge"/danger orange
+  green:   "#3da639"
+  yellow:  "#e3b341"      # gold
+  blue:    "#2b7489"
+  magenta: "#bc8cff"
+  cyan:    "#39c5cf"
+  white:   "#e6edf3"
+```
+
+Save the file. (`frameDelay`/`maxIdleTime` are the two that matter most — they decide how long the GIF
+runs. If your GIF comes out too long, lower `maxIdleTime`.)
+
+If a chunk at the very start or end is boring (e.g. the shell launching), you can delete those entries
+from the `records:` list at the bottom of the file — each entry is one captured frame with a `delay`
+and `content`. Optional; the `maxIdleTime` trick usually does enough.
+
+---
+
+## Step 4 — Render the GIF
+
+From the same folder:
+
+```powershell
+terminalizer render demo -o docs/demo.gif
+```
+
+The first render downloads a small headless browser and may take a minute — that's normal. When it
+finishes you'll have **`docs/demo.gif`**.
+
+**Keep it lean.** Aim for **under ~3 MB** so the README loads fast. If it's too big:
+- lower `maxIdleTime` (e.g. `800`) and re-render — shorter GIF = smaller file;
+- reduce `cols`/`rows` slightly;
+- trim boring frames from the `records:` list (Step 3).
+
+Preview it by double-clicking `docs/demo.gif` in File Explorer, or drag it into a browser tab.
+
+---
+
+## Step 5 — Put it in the README
+
+Open `README.md` and find this comment near the top:
+
+```html
+<!-- DEMO: once recorded, replace this comment with the in-motion GIF. Recording shot list in docs/demo-script.md
 <div align="center"><img src="docs/demo.gif" alt="codeArbiter in motion — a gate blocks, the human resolves, the work goes green" width="900"></div>
+-->
 ```
 
-Keep the alt text describing the BLOCK → resolve → green story; it's what someone scanning on a phone
-reads before the GIF loads.
+Delete the `<!--` line and the closing `-->` line, leaving just the `<div>…</div>` in the middle. That
+"uncomments" the GIF so it renders on GitHub. Keep the `alt` text — it's what someone on a phone reads
+before the GIF loads.
+
+Then ship it the normal way: `/ca:chore` (it's a docs change) → `/ca:commit` → `/ca:pr`. The GIF is a
+new file under `docs/` (not `plugins/ca/`), so **no version bump is required**.
+
+---
+
+## Troubleshooting
+
+- **`terminalizer: command not found` after install** — reopen the terminal (PATH refresh). Still
+  stuck? Run it via `npx terminalizer record demo`.
+- **Install fails compiling a native module** — terminalizer pulls in a PTY library. Usually retrying
+  `npm install -g terminalizer` works; if not, use the fallback below.
+- **`render` errors or hangs downloading the browser** — corporate network/proxy can block it. Try
+  again on an open network, or use the fallback below.
+- **GIF is huge (>5 MB)** — almost always too much idle time. Lower `maxIdleTime`, re-render. Length is
+  the #1 driver of file size.
+
+### Zero-setup fallback: ScreenToGif (point-and-click)
+
+If terminalizer isn't worth the fight, this needs no command line at all:
+
+1. Install **ScreenToGif** (free) from the Microsoft Store.
+2. Open it → **Recorder** → drag the frame over your Claude Code terminal window.
+3. Click **Record**, perform the shot list, click **Stop**.
+4. The editor opens → delete dead frames to trim → **File → Save as → Gif** → save to `docs/demo.gif`.
+
+It captures your real window (your font/theme) rather than a re-rendered terminal, so set a dark theme
+first. Same Step 5 afterward.


### PR DESCRIPTION
## What & why

The demo recording script (`docs/demo-script.md`) assumed `asciinema` — which **doesn't run on Windows** — and skipped tool install/operation, making it a dead end for a first-time GIF recorder. This rewrites it as a complete, hand-held walkthrough.

## Changes

- **Windows + terminalizer, step by step** — confirm Node (already installed), `npm i -g terminalizer`, record, theme the GIF to the banner palette (ready-to-paste `theme:` block), render under ~3 MB, and uncomment the README placeholder.
- **Troubleshooting** section (PATH refresh, native-module install fails, render hangs, oversized GIF).
- **Zero-setup fallback** — ScreenToGif (point-and-click) for when terminalizer isn't worth the fight.
- Keeps the original "the friction is the feature" framing and the BLOCK → resolve → green shot list.

## Test plan

- Docs-only (`docs/demo-script.md`); no code, no behavioral surface.
- Secrets scan over the diff → clean (only the literal word "secrets" in the checklist description).
- Touches only `docs/`, not `plugins/ca/**` → no version bump required and **CI skips by path filter**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
