### PR TITLE
docs(forge): center seal text so it clears the FORGE label

### DIFF
--- a/docs/feature-forge.svg
+++ b/docs/feature-forge.svg
@@ -70,7 +70,7 @@
         font-size="10" letter-spacing="2.5" fill="#c08a6a">FORGE</text>
 
   <!-- the seal: how a preview graduates -->
-  <text x="1166" y="220" text-anchor="end"
+  <text x="600" y="224" text-anchor="middle"
         font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
         font-size="9" letter-spacing="1.5" fill="#6e7b8b">preview channel · opt-in · your data promotes it</text>
 </svg>


### PR DESCRIPTION
## What

Re-centers the seal line in the Feature Forge hero SVG (`docs/feature-forge.svg`).

The `preview channel · opt-in · your data promotes it` text was right-anchored at `x=1166` and sat at the same baseline as the `FORGE` gate label — it stretched left through the label and rendered overlapping/behind it. Re-anchored to horizontal center (`x=600`, `text-anchor="middle"`, `y=224`) so it sits cleanly under the wordmark, clear of the gate and FORGE label.

## Change

One `<text>` element, three presentation attributes:

```diff
- <text x="1166" y="220" text-anchor="end"
+ <text x="600" y="224" text-anchor="middle"
```

## Verification

- Rendered via headless Edge at 2× — seal now centers, no overlap with FORGE.
- `docs` chore lane: secrets sweep clean; hook test suite green (62 + 131 assertions, 0 failed).
- Non-behavioral, single-file SVG asset edit. No code, manifest, or version-bump surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)