### PR TITLE
chore(repo): move to arbiterForge org and bump to 2.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "codearbiter",
-  "owner": { "name": "suadtl" },
+  "owner": { "name": "arbiterForge" },
   "metadata": {
     "description": "codeArbiter — an orchestration layer for Claude Code. Single-plugin marketplace."
   },

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Command catalog & docs
-    url: https://github.com/SUaDtL/codeArbiter#readme
+    url: https://github.com/arbiterForge/codeArbiter#readme
     about: How to install, enable, and drive codeArbiter — start here.
   - name: What's in the Feature Forge
-    url: https://github.com/SUaDtL/codeArbiter#feature-forge
+    url: https://github.com/arbiterForge/codeArbiter#feature-forge
     about: Preview features, how they're opt-in, and how your data promotes them.

--- a/.github/ISSUE_TEMPLATE/feature-forge-prune.yml
+++ b/.github/ISSUE_TEMPLATE/feature-forge-prune.yml
@@ -9,7 +9,7 @@ body:
         Thanks for forging. 🔨
 
         Live transcript pruning is a **preview** feature — it graduates from the
-        [Feature Forge](https://github.com/SUaDtL/codeArbiter#feature-forge) when real-world data
+        [Feature Forge](https://github.com/arbiterForge/codeArbiter#feature-forge) when real-world data
         says it's safe to flip `on`. Your `dry`-mode log is that data.
 
         **Privacy:** `prune-dry.jsonl` contains **sizes, strategy names, and validation verdicts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.1.1] — 2026-06-13
+
+### Changed
+- **Project moved to the `arbiterForge` GitHub organization.** Canonical home is now
+  `github.com/arbiterForge/codeArbiter`. Plugin metadata (`homepage`, `repository`, `author`),
+  the self-hosted marketplace `owner`, install instructions, and all doc links point at the new
+  org. The old `SUaDtL/codeArbiter` URLs continue to redirect. No behavior, gate, or payload logic
+  changed — metadata and documentation only.
+
+---
+
 ## [2.1.0] — 2026-06-13
 
 First stable minor since the 2.0 plugin rewrite. Consolidates the `2.1.0-beta.1`…`beta.6`
@@ -93,7 +104,7 @@ README. The per-beta history remains in the git tag log.
 
 ## [2.0.0] — 2026-06-10 — Native Claude Code plugin
 
-The big one. codeArbiter is rebuilt from a ~13,600-line `.agents/` + vendoring framework into a **native Claude Code plugin**. The soul is intact — orchestration, gates, SMARTS, the audit trail — re-grounded on Claude Code's plugin primitives and made leaner and more autonomous. Install with `/plugin marketplace add SUaDtL/codeArbiter` then `/plugin install ca@codearbiter`; commands are namespaced `/ca:<name>`. Pre-release, the whole plugin went through an eight-persona adversarial marketplace-readiness review; everything it surfaced is folded in below.
+The big one. codeArbiter is rebuilt from a ~13,600-line `.agents/` + vendoring framework into a **native Claude Code plugin**. The soul is intact — orchestration, gates, SMARTS, the audit trail — re-grounded on Claude Code's plugin primitives and made leaner and more autonomous. Install with `/plugin marketplace add arbiterForge/codeArbiter` then `/plugin install ca@codearbiter`; commands are namespaced `/ca:<name>`. Pre-release, the whole plugin went through an eight-persona adversarial marketplace-readiness review; everything it surfaced is folded in below.
 
 ### Added
 - **Native plugin packaging** — `.claude-plugin/marketplace.json` + the plugin under `plugins/ca/`. No clone-into-your-repo, no symlinks, no shims.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.1.0" src="https://img.shields.io/badge/version-2.1.0-2b7489">
+<img alt="version 2.1.1" src="https://img.shields.io/badge/version-2.1.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-14-555">
@@ -103,7 +103,7 @@ The plugin itself → `~/.claude/plugins/cache/`
 codeArbiter self-hosts a single-plugin marketplace from this repo.
 
 ```text
-/plugin marketplace add SUaDtL/codeArbiter
+/plugin marketplace add arbiterForge/codeArbiter
 /plugin install ca@codearbiter
 ```
 
@@ -120,7 +120,7 @@ global `~/.claude/settings.json` (it backs up what was there and restores it on 
 <br>
 
 ```sh
-git clone https://github.com/SUaDtL/codeArbiter
+git clone https://github.com/arbiterForge/codeArbiter
 ```
 ```text
 /plugin marketplace add ./codeArbiter
@@ -193,7 +193,7 @@ export CODEARBITER_PRUNE=dry      # collect evidence, change nothing
 
 `dry` mode appends one JSONL row per decision to `~/.codearbiter/metrics/prune-dry.jsonl` (relocate it with `CODEARBITER_PRUNE_METRICS`). Each row carries only the **would-be reduction, per-strategy savings, and a validation verdict** — sizes and strategy names, **no transcript content**. That file is the entire evidence base for the `dry → on` go/no-go.
 
-After a few sessions, [**open a "prune data" issue**](https://github.com/SUaDtL/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune) and attach or paste your `prune-dry.jsonl`. The more real sessions come back, the sooner pruning leaves the forge. Thank you for forging. 🔨
+After a few sessions, [**open a "prune data" issue**](https://github.com/arbiterForge/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune) and attach or paste your `prune-dry.jsonl`. The more real sessions come back, the sooner pruning leaves the forge. Thank you for forging. 🔨
 
 ## Commands
 

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,10 +2,10 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in — run /ca:init to activate.",
-  "version": "2.1.0",
-  "author": { "name": "suadtl" },
+  "version": "2.1.1",
+  "author": { "name": "arbiterForge" },
   "license": "MIT",
-  "homepage": "https://github.com/SUaDtL/codeArbiter",
-  "repository": "https://github.com/SUaDtL/codeArbiter",
+  "homepage": "https://github.com/arbiterForge/codeArbiter",
+  "repository": "https://github.com/arbiterForge/codeArbiter",
   "keywords": ["orchestration", "tdd", "commit-gate", "code-review", "adr", "audit-trail", "governance"]
 }

--- a/plugins/ca/README.md
+++ b/plugins/ca/README.md
@@ -6,12 +6,12 @@ decisions go through SMARTS; the audit trail (`overrides.log`, `triage.log`, ADR
 append-only and mechanically guarded.
 
 Full documentation, install instructions, and the command catalog live in the
-[repository README](https://github.com/SUaDtL/codeArbiter) and in [`COMMANDS.md`](./COMMANDS.md)
+[repository README](https://github.com/arbiterForge/codeArbiter) and in [`COMMANDS.md`](./COMMANDS.md)
 (`/ca:commands` in-session).
 
 ## The short version
 
-- **Install** — `/plugin marketplace add SUaDtL/codeArbiter` → `/plugin install ca@codearbiter`.
+- **Install** — `/plugin marketplace add arbiterForge/codeArbiter` → `/plugin install ca@codearbiter`.
 - **Prerequisites** — Python 3 on `PATH` (all hooks are Python); `git config user.email` set
   (audit attribution). Optional `/ca:statusline` writes to your global `~/.claude/settings.json`
   (backed up; restored on removal).
@@ -31,8 +31,8 @@ in, labeled `preview` until real-world data earns them a stable promotion. In th
 transcript pruning** (`CODEARBITER_PRUNE`), which trims redundant transcript clutter to extend a
 session. Run it in `dry` mode (`export CODEARBITER_PRUNE=dry`) and it logs what it *would* prune —
 sizes and verdicts only, no transcript content — to `~/.codearbiter/metrics/prune-dry.jsonl`. Sending
-that log back ([open a prune-data issue](https://github.com/SUaDtL/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune))
-is what moves it toward `on`. Full detail in the [Feature Forge section of the repo README](https://github.com/SUaDtL/codeArbiter#feature-forge).
+that log back ([open a prune-data issue](https://github.com/arbiterForge/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune))
+is what moves it toward `on`. Full detail in the [Feature Forge section of the repo README](https://github.com/arbiterForge/codeArbiter#feature-forge).
 
 ## What's in this directory
 

--- a/tools/statusline-screenshot.py
+++ b/tools/statusline-screenshot.py
@@ -67,7 +67,7 @@ payload = {
     "context_window": {"used_percentage": 41, "context_window_size": 1000000},
     "cost": {"total_cost_usd": 4.20, "total_lines_added": 312, "total_lines_removed": 47},
     "workspace": {"current_dir": ROOT.replace("\\", "/"),
-                  "repo": {"owner": "SUaDtL", "name": "codeArbiter"}},
+                  "repo": {"owner": "arbiterForge", "name": "codeArbiter"}},
     "rate_limits": {"five_hour": {"used_percentage": 22, "resets_at": int((now + 1.8 * 3600) * 1000)},
                     "seven_day": {"used_percentage": 31, "resets_at": int((now + 3.2 * 86400) * 1000)}},
 }


### PR DESCRIPTION
## What

Moves the project's canonical home from `SUaDtL/codeArbiter` (personal account) to the **`arbiterForge`** GitHub org, ahead of marketplace submission. Repo transfer is already done; this PR updates every in-repo reference to match.

- **Plugin metadata** (`plugins/ca/.claude-plugin/plugin.json`) — `homepage`, `repository`, `author`
- **Marketplace manifest** (`.claude-plugin/marketplace.json`) — `owner.name`
- **Docs** — root `README.md` (install cmd, clone URL, issue link), `plugins/ca/README.md`, both `.github/ISSUE_TEMPLATE/*` files
- **Fixture** — `tools/statusline-screenshot.py` sample-payload owner string
- **Version bump 2.1.0 → 2.1.1** in lockstep across `plugin.json`, README badge, and a dated `CHANGELOG.md` section

## Why

The org move is a prerequisite for submitting to the community marketplace. Touching `plugins/ca/**` at an already-tagged version trips the CI `version-bump` gate, so the patch bump rides along — this is metadata/documentation only, no behavior, gate, or payload logic changed.

## Test plan

- [x] `claude plugin validate .` — passes (marketplace + plugin manifests schema-clean)
- [x] `python .github/scripts/test_hook_guards.py` — 62 assertions, 0 failed
- [x] `python .github/scripts/test_hooks_cold_install.py` — 134 assertions, 0 failed
- [x] `python .github/scripts/check-plugin-refs.py` — reference graph intact
- [x] Both JSON manifests parse; `tools/statusline-screenshot.py` compiles
- [x] Secrets sweep of staged diff — no credential patterns
- [x] `coverage-auditor` — PASS, no findings (no behavioral source change, no TDD obligation)
- [x] Zero live `SUaDtL` references remain (audit trail under `.codearbiter/` intentionally preserved — append-only)

## Tradeoffs

No non-obvious tradeoff. The one judgment call — keeping this as a single `chore` commit rather than splitting metadata from docs — favors **maintainability/reviewability** (conflict-hierarchy level 3): the rename is atomic and the version bump must travel with the manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)