### PR TITLE
feat(release): publish the GitHub Release in Phase 3 (2.3.0)

### DIFF
--- a/.codearbiter/triage.log
+++ b/.codearbiter/triage.log
@@ -1,0 +1,1 @@
+[2026-06-14T02:06:45Z] | BY: SUaDtL@users.noreply.github.com | LANE: small | SCOPE: /ca:release creates the GitHub Release in Phase 2 (gh release create) under the existing publish authorization | BASIS: 1 file (release SKILL.md), no new dep/command/config, no scope-touch, 3 testable criteria

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.3.0] — 2026-06-14
+
+### Added
+- **`/ca:release` now publishes the GitHub Release.** A new Phase 3 creates the GitHub Release via
+  `gh release create` under the same explicit authorization that pushes the tag, reusing the changelog
+  section composed in Phase 1 as the release notes. Closes the gap where the skill cut and pushed a tag
+  but left the Releases page empty until someone ran `gh` by hand.
+
+---
+
 ## [2.2.0] — 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.2.0" src="https://img.shields.io/badge/version-2.2.0-2b7489">
+<img alt="version 2.3.0" src="https://img.shields.io/badge/version-2.3.0-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/skills/release/SKILL.md
+++ b/plugins/ca/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: The single permitted path to a version tag. Routed to when the user invokes /release on a non-default branch with a green suite. Derives the SemVer bump from Conventional-Commits history since the last tag, rolls the commits into CHANGELOG.md, and writes an annotated tag. A release commit, if needed, routes through commit-gate; the tag itself is never pushed without explicit authorization.
+description: The single permitted path to a version tag. Routed to when the user invokes /release on a non-default branch with a green suite. Derives the SemVer bump from Conventional-Commits history since the last tag, rolls the commits into CHANGELOG.md, writes an annotated tag, and on authorization publishes it as a GitHub Release with the changelog section as its notes. A release commit, if needed, routes through commit-gate; the tag and Release are never published without explicit authorization.
 ---
 
 # release
@@ -38,15 +38,29 @@ Gate: version confirmed, strictly monotonic, and matching the commit log; `CHANG
 
 1. Compose the annotated tag from the Phase 1 section plus a `Released-at: YYYY-MM-DD` footer. Tag with `git tag -a vMAJOR.MINOR.PATCH -F <message-file>` — never `-m` for multi-line content, never an interactive editor. If the tag already exists, STOP.
 2. Report: version, bump rationale, the per-commit classification, the changelog section, and the tag SHA.
-3. MUST NOT push the tag. Publication is a separate decision the user authorizes after reading the report.
+3. MUST NOT push the tag or create the GitHub Release here. Publication is Phase 3, a separate step the user authorizes after reading the report.
 
-Gate: the annotated tag exists locally and the report is delivered. The tag is not pushed.
+Gate: the annotated tag exists locally and the report is delivered. Nothing is published.
+
+## Phase 3 — Publish · gate: STOP
+
+The tag and the GitHub Release publish together, and only after the user explicitly authorizes publication. This phase does not run until then; absent authorization, nothing leaves the local repo.
+
+On authorization:
+
+1. Push the tag: `git push origin vMAJOR.MINOR.PATCH`.
+2. Create the GitHub Release from the **same changelog section composed in Phase 1** — reuse it as the notes, never re-derive or hand-write them: `gh release create vMAJOR.MINOR.PATCH --title "<title>" --notes-file <Phase-1 section file> --latest --verify-tag`. The title follows the existing convention `codeArbiter MAJOR.MINOR.PATCH: <summary>`, with no em-dash separator.
+3. Handle edge cases explicitly, never silently: if a Release for the tag already exists, report it and skip creation (the tag push may already have landed); if `gh` is missing, unauthenticated, or the call fails, STOP and print the exact `gh release create` command so publication can be finished by hand rather than left half-done.
+4. Report the Release URL.
+
+Gate: with authorization, the tag is pushed and the GitHub Release exists (or, on failure, the exact manual command was surfaced). Without authorization, nothing is published.
 
 ## Hard rules
 
 - MUST NOT tag on a red suite — `commit-gate` enforces green on every commit reaching HEAD; do not re-run it, but do not tag if the last suite was red.
 - MUST NOT write to `main`, `master`, or the default branch, and MUST NOT force-push. Releases land through the normal branch/PR path.
-- MUST NOT push the tag without explicit user authorization, even after the local tag composes.
+- MUST NOT push the tag or create the GitHub Release without explicit user authorization; they publish together in Phase 3, even after the local tag composes.
+- MUST use the Phase-1 changelog section verbatim as the GitHub Release notes — never re-derive or hand-write them.
 - MUST NOT guess the version — derive it from the commit log. A `feat` in the window cannot ship as a `patch`.
 - MUST NOT auto-fill a missing `CHANGELOG:` footer — surface it as `[NEEDS-TRIAGE]`.
 - MUST NOT tag a non-bumping window — `test`/`docs`/`chore`/`ci`-only sets do not release.


### PR DESCRIPTION
## Summary

`/ca:release` cut and pushed an annotated tag but never created the GitHub Release, so the Releases page stayed empty until someone ran `gh` by hand. That is the dropped-step failure mode codeArbiter exists to prevent, and it bit the 2.2.0 release. This adds a Phase 3 that publishes the Release as part of the same authorized step that pushes the tag.

## What changed

- **release skill Phase 3 (new):** under the same explicit publish authorization that pushes the tag, create the GitHub Release with `gh release create --notes-file <Phase-1 changelog section> --latest --verify-tag`. The title follows the existing convention.
- Reuses the changelog section Phase 1 already composes as the notes; never re-derived.
- Edge cases reported, never silent: a Release already existing for the tag is skipped; a missing/unauthenticated/failing `gh` prints the exact manual command instead of leaving the release half-done.
- Frontmatter description and Hard rules updated; the no-publish-without-authorization rule now covers the Release too.
- Version 2.3.0 (`plugin.json` + README badge + `CHANGELOG.md`).

## Verify

- Phase structure intact (Phase 1/2 BLOCK, Phase 3 STOP), each gated.
- `gh release create`, notes-reuse, and edge-case handling all present.
- `check-plugin-refs` intact; hook-guards and cold-install pass; the three version locations in sync at 2.3.0.

## Note

Built via the `/ca:feature` small lane (logged to `triage.log`). This is a prose skill change, so tdd's red/green is a read-back against the three acceptance criteria, not a unit test (skill bodies have no test harness per `tech-stack.md`). Releasing 2.3.0 after merge will dogfood the new Phase 3, the first release to cut its own GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
