### PR TITLE
docs(forge): move --farm under Feature Forge (2.3.1)

### DIFF
--- a/.codearbiter/open-questions.md
+++ b/.codearbiter/open-questions.md
@@ -3,4 +3,13 @@
 Unresolved `[CONFIRM-NN]` items. Each blocks stage promotion until resolved.
 The SessionStart hook and statusline count `CONFIRM-NN` occurrences here.
 
-_None open. The four Phase 1 gate decisions were resolved 2026-06-04 (see `legacy/ASSESSMENT.md` §10)._
+## [CONFIRM-05] Feature Forge promotion bar for the `--farm` (OpenCode Zen) backend
+
+What evidence promotes `--farm` from `preview` to stable? Define the bar before promoting. Candidate
+signals to choose among, with thresholds to set: number of successful `/ca:sprint --farm` runs across
+how many distinct repos; per-task pass-rate and average attempts; measured cost saving vs. the premium
+backend; zero gate escapes (no farm-produced code reaching a commit without clearing the full review
+chain); no security or supply-chain incident from the third-party Zen API. The owner decides the metric
+set and thresholds; until then the farm stays `preview`.
+
+_Previously resolved: the four Phase 1 gate decisions, 2026-06-04 (see `legacy/ASSESSMENT.md` §10)._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.3.1] — 2026-06-14
+
+### Changed
+- **Moved the `--farm` (OpenCode Zen) cost-arbitrage backend under Feature Forge.** It is labeled
+  `preview` in the command catalog and the sprint body, documented in both READMEs' Feature Forge
+  section, and carries a preview banner in its setup doc. `CONFIRM-05` records the promotion bar (the
+  evidence that moves the farm from preview to stable). No behavior change to the farm itself.
+
+---
+
 ## [2.3.0] — 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ export CODEARBITER_PRUNE=dry      # collect evidence, change nothing
 
 After a few sessions, [**open a "prune data" issue**](https://github.com/arbiterForge/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune) and attach or paste your `prune-dry.jsonl`. The more real sessions come back, the sooner pruning leaves the forge. Thank you for forging. 🔨
 
+**Cost-arbitrage farm** · `/ca:sprint --farm` (needs `FARM_API_KEY`)
+
+`--farm` runs the implementation step on cheap [OpenCode Zen](https://opencode.ai) workers in isolated worktrees instead of premium subagents. Claude still writes the spec, the failing tests, and the plan, and still routes every task through the same spec-compliance, quality, and fresh-verification gates, so the cheap model can only pass the gates, never redefine them. The arbitrage is in who writes the code, not in whether it gets reviewed. It is **not yet validated on real runs**, so it ships off and stays `preview`. The promotion bar is being defined as an open question (`CONFIRM-05`); setup and the API-key/model config live in <kbd>/ca:sprint</kbd> and the farm setup doc.
+
 ## Commands
 
 Every intent flows through a command; direct off-channel instructions get redirected to the catalog. The full list is in [`plugins/ca/COMMANDS.md`](./plugins/ca/COMMANDS.md) and via <kbd>/ca:commands</kbd>.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.3.0" src="https://img.shields.io/badge/version-2.3.0-2b7489">
+<img alt="version 2.3.1" src="https://img.shields.io/badge/version-2.3.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/COMMANDS.md
+++ b/plugins/ca/COMMANDS.md
@@ -12,7 +12,7 @@ ONLY when that command is invoked — never bulk-read the directory.
 | Command | Argument | Purpose |
 |---|---|---|
 | `/ca:feature` | `"description"` | Spec-driven feature: brainstorm → plan → test-first build → commit → finish. The only path to implementation. |
-| `/ca:sprint` | `["goal"] [--farm]` | Autonomous sprint: one interactive spec gate, then plan-to-PR execution; every auto-decision SMARTS-scored and logged with a confidence flag. Hard gates still stop. |
+| `/ca:sprint` | `["goal"] [--farm]` | Autonomous sprint: one interactive spec gate, then plan-to-PR execution; every auto-decision SMARTS-scored and logged with a confidence flag. Hard gates still stop. `--farm` is a Feature Forge `preview` (off by default, needs `FARM_API_KEY`; not yet validated). |
 | `/ca:fix` | `"bug description"` | Fix a defect via `tdd`, regression-test-first. |
 | `/ca:refactor` | `"surface and motivation"` | Behavior-preserving restructure behind a parity-coverage gate. |
 | `/ca:debug` | `"symptom"` | Investigate-then-decide root-cause analysis; exits to `/ca:fix`, `/ca:adr`, or a no-action close. |

--- a/plugins/ca/README.md
+++ b/plugins/ca/README.md
@@ -32,7 +32,9 @@ transcript pruning** (`CODEARBITER_PRUNE`), which trims redundant transcript clu
 session. Run it in `dry` mode (`export CODEARBITER_PRUNE=dry`) and it logs what it *would* prune
 (sizes and verdicts only, no transcript content) to `~/.codearbiter/metrics/prune-dry.jsonl`. Sending
 that log back ([open a prune-data issue](https://github.com/arbiterForge/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune))
-is what moves it toward `on`. Full detail in the [Feature Forge section of the repo README](https://github.com/arbiterForge/codeArbiter#feature-forge).
+is what moves it toward `on`. Also in the forge: the **cost-arbitrage farm** (`/ca:sprint --farm`, needs
+`FARM_API_KEY`), which runs the implementation step on cheap OpenCode Zen workers under the same review
+gates; off by default and `preview` until validated. Full detail in the [Feature Forge section of the repo README](https://github.com/arbiterForge/codeArbiter#feature-forge).
 
 ## What's in this directory
 

--- a/plugins/ca/SPRINT.md
+++ b/plugins/ca/SPRINT.md
@@ -9,6 +9,10 @@ that is not a true hard gate. Every auto-decision is logged. Hard gates are real
 
 ## Execution backend: premium (default) vs. `--farm`
 
+> **`--farm` is a Feature Forge `preview`** — shipped off by default and not yet validated on real
+> runs. The premium subagent path is the blessed default. The promotion bar lives in
+> `${CLAUDE_PROJECT_DIR}/.codearbiter/open-questions.md` (CONFIRM-05).
+
 `/sprint` runs the normal premium-subagent path unless invoked as `/sprint --farm`. The `--farm` flag
 selects the cost-arbitrage backend: Claude still authors the spec, the failing tests, and the plan, but
 cheap Zen workers (not premium subagents) implement each task under the same hard gates. Track whether

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -1,5 +1,9 @@
 # codeArbiter farm — setup and configuration
 
+> **Feature Forge `preview`.** The `--farm` backend ships off by default and is not yet validated on
+> real runs; the premium subagent path is the blessed default. Promotion bar:
+> `${CLAUDE_PROJECT_DIR}/.codearbiter/open-questions.md` (CONFIRM-05).
+
 `farm.ts` is the zero-LLM-token dispatcher: Claude writes specs, failing tests, and a `plan.json`;
 the farm runs cheap Zen workers in isolated git worktrees to make each test pass; Claude reviews
 and merges. The cheap model cannot redefine the gates — only pass them.


### PR DESCRIPTION
## Summary

Moves the `--farm` (OpenCode Zen) cost-arbitrage backend under **Feature Forge**. It was presented as a regular `/ca:sprint` option, but it is untested on real runs and spends real money on a third-party API, so the honest home is the preview channel. No behavior change to the farm itself.

## What changed

- `--farm` labeled `preview` in `COMMANDS.md` and the `SPRINT.md` backend section.
- Feature Forge entry added in `README.md` and `plugins/ca/README.md` alongside the pruner; a preview banner added to `includes/farm.md`.
- **`CONFIRM-05`** added to `open-questions.md` to lock in the promotion bar: what evidence moves the farm from `preview` to stable (run count across repos, pass-rate, cost saving, zero gate escapes, no supply-chain incident). The owner sets the thresholds.
- Version 2.3.1 (patch: docs/governance only).

## Note

`CONFIRM-05` is intentionally open, so the statusline will show `q:1` and stage promotion is blocked until you set the promotion criteria. That is the point: the farm stays `preview` until the bar is defined and met.

Built via `/ca:chore` (docs lane). The promotion bar is a decision for you; everything else here is documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
