### PR TITLE
feat(farm): pluggable execution backend (v1) — Worker seam, enrichment, scheduling, streaming

### DIFF
--- a/.codearbiter/plans/farm-pluggable-backend.md
+++ b/.codearbiter/plans/farm-pluggable-backend.md
@@ -1,0 +1,70 @@
+# Plan — farm: pluggable execution backend (v1)
+
+slug: farm-pluggable-backend
+spec: `.codearbiter/specs/farm-pluggable-backend.md` (APPROVED 2026-06-14)
+created: 2026-06-14
+mode: normal /ca:feature (premium subagents, sequential per-task; NOT a --farm sprint)
+
+> Pre-flight note: `.codearbiter/coding-standards.md` does not exist. Not blocking — all paths are
+> concrete from the spec and `tech-stack.md`. Canonical commands (from `tech-stack.md`, CI-authoritative):
+> in `plugins/ca/tools`: `npm run typecheck`, `npm test`, `npm run build`; refs: `python
+> .github/scripts/check-plugin-refs.py`.
+
+## Acceptance-criterion ledger (from the approved spec, verbatim intent)
+
+- **AC-01** — `Worker` interface extracted; HTTP-chat author becomes one impl; `runTask` depends on the interface, not `callApi`. Behavior-preserving: full existing suite passes unchanged.
+- **AC-02** — interface receives resolved model/config; optional `task.model` added to schema + `Task` type, resolved `task.model ?? meta.model`; `additionalProperties:false` honored; SAFE_TASK_ID/schema-id divergence reconciled-or-noted, not silently widened.
+- **AC-03** — outgoing worker request includes the read-only source of `task.test.path`.
+- **AC-04** — outgoing worker request includes current contents of existing in-scope files (imports best-effort); test asserts test source AND a sibling's contents in the request body.
+- **AC-05** — injected context byte-capped (configurable; default mindful of `FARM_REQUEST_TIMEOUT_MS`) and run through a NEW redaction over the `tech-stack.md` secret-pattern set; planted secret NOT transmitted (test).
+- **AC-06** — task overlapping an unfinished sibling's `filesInScope` is removed from readiness (not just merge-serialized) until that sibling is green+merged; derived ordering (no `deps` cycle), id-tiebroken; test: two overlapping tasks green, second's worktree has first's change.
+- **AC-07** — merge conflict → reset to new integration HEAD + re-run worker (one retry per D4) before escalating; post-loop merge moved into the attempt loop; test: forced conflict yields regeneration, not instant escalate.
+- **AC-08** — `farm.js` appends each settled task to `.farm/farm-results.jsonl` (plus the final `farm-report.json`); test: two-task run → both results in completion order.
+- **AC-09** — `farm-dispatch.md` + `subagent-driven-development` document completion-order consumption, Phase 3+5 per green, Phase 4 once-per-scope barrier, abort-reconcile via report (D7), temporal overlap = roadmap; `check-plugin-refs.py` passes.
+- **AC-10** — `farm.md`, ORCHESTRATOR.md `/sprint --farm` section, `SPRINT.md`, `farm-dispatch.md` reframed to "pluggable backend (cheap/premium/agentic)"; name `farm` + `preview` status preserved; refs pass.
+- **AC-11** — `farm.js` rebuilt with no stale build; typecheck + full test green; `plugin.json` version bumped and synced across `plugin.json`, README badge, dated `CHANGELOG.md` section.
+- **AC-12** *(added mid-execution at user request, 2026-06-14)* — README "Feature Forge" section restructured for parallel form/function (an index table + consistent per-feature subsections), and the farm entry rewritten from the stale "cost-arbitrage / cheap Zen" framing to this feature's pluggable-backend reality; the intro's over-broad "each feature ships a dry mode" claim corrected; `#feature-forge` anchor and all internal links still resolve.
+
+## Tasks
+
+| id | path(s) | verification | maps-to (tdd obligation) | covers | depends-on | status |
+|---|---|---|---|---|---|---|
+| T-01 | `plugins/ca/tools/farm.ts` | `cd plugins/ca/tools && npm test` green — full existing suite unchanged; `runWorker`/HTTP call now invoked via a `Worker` interface, not directly | existing farm suite stays green (refactor parity); `runTask` depends on the interface | AC-01 | — | ACCEPTED |
+| T-02 | `plugins/ca/tools/farm.ts` | `npm test` green — containment (`isInside`) + read-only-test guard relocated to a post-apply sweep in `runTask`; HTTP impl owns `extractFileBlocks`+write internally (D6); escape/test-protect/drift smoke tests still pass | apply step owned by the worker seam; containment runs post-apply for any worker type | AC-01 | T-01 | ACCEPTED |
+| T-03 | `plugins/ca/tools/farm.ts`, `plugins/ca/tools/plan.schema.json` | `npm test` green incl. new unit test: a plan with `task.model` validates (schema, `additionalProperties:false` respected) and resolution picks `task.model` over `meta.model`; SAFE_TASK_ID vs schema-id divergence reconciled or explicitly commented | optional per-task model resolves `task.model ?? meta.model`; schema accepts the field | AC-02 | T-02 | ACCEPTED |
+| T-04 | `plugins/ca/tools/farm.ts`, `plugins/ca/tools/farm.test.ts` | `npm test` green incl. new mock-server test asserting the request body contains the `test.path` source AND an existing in-scope sibling's contents; shared file-read helper reused by anti-gaming/mutation, not duplicated | `buildPrompt` injects test source + in-scope file contents via a shared reader | AC-03, AC-04 | T-01 | ACCEPTED |
+| T-05 | `plugins/ca/tools/farm.ts`, `plugins/ca/tools/farm.test.ts` | `npm test` green incl. test: planted secret-pattern string in an in-scope file is NOT in the outgoing request body; total injected context respects the configurable byte cap | enrichment byte-capped + secret-redacted over the `tech-stack.md` pattern set | AC-05 | T-04 | ACCEPTED |
+| T-06 | `plugins/ca/tools/farm.ts`, `plugins/ca/tools/farm.test.ts` | `npm test` green incl. smoke test: two scope-overlapping tasks both reach green with no merge conflict and the second's worktree contains the first's merged change | `ready()` excludes a task overlapping an unfinished sibling's `filesInScope`; id-tiebroken | AC-06 | T-02 | ACCEPTED |
+| T-07 | `plugins/ca/tools/farm.ts`, `plugins/ca/tools/farm.test.ts` | `npm test` green incl. smoke test: a forced same-file conflict produces a regeneration attempt (reset to integration HEAD + re-run worker, one retry) rather than an instant `escalate` | post-loop merge moved into the attempt loop; conflict → regenerate-then-escalate | AC-07 | T-02, T-06 | ACCEPTED |
+| T-08 | `plugins/ca/tools/farm.ts`, `plugins/ca/tools/farm.test.ts` | `npm test` green incl. test: after a two-task run `.farm/farm-results.jsonl` holds both task results in completion order; `farm-report.json` still written | each settled task appended to the JSONL stream as it settles | AC-08 | T-02 | ACCEPTED |
+| T-09 | `plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md`, `plugins/ca/skills/subagent-driven-development/SKILL.md` | `python .github/scripts/check-plugin-refs.py` passes; both docs describe completion-order consumption of the JSONL, Phase 3+5 per green, Phase 4 once-per-scope barrier, abort-reconcile via `farm-report.json` (D7), and temporal overlap as roadmap | documented dispatch contract matches the streaming rail | AC-09 | T-08 | ACCEPTED |
+| T-10 | `plugins/ca/includes/farm.md`, `plugins/ca/ORCHESTRATOR.md`, `plugins/ca/SPRINT.md`, `plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md` | `check-plugin-refs.py` passes; "pluggable backend (cheap/premium/agentic)" framing present, "cost arbitrage / cheap Zen workers" framing removed/softened; term `farm` and `preview`/Feature-Forge status intact | reframed positioning, name + preview status preserved | AC-10 | T-09 | ACCEPTED |
+| T-11 | `plugins/ca/tools/farm.js`, `plugins/ca/.claude-plugin/plugin.json`, `README.md`, `CHANGELOG.md` | `cd plugins/ca/tools && npm run typecheck && npm test` green; `npm run build` then `git diff --quiet -- farm.js` (no stale build); `plugin.json` version bumped **2.3.1 → 2.4.0** (feat → minor) and identical in `plugin.json` + README badge (NB: badge is pre-existingly stale at `2.1.0-beta.6` — correct it to `2.4.0`) + a new dated `CHANGELOG.md` section | shipped build matches source; version synced across three places | AC-11 | T-01,T-02,T-03,T-04,T-05,T-06,T-07,T-08,T-09,T-10 | ACCEPTED |
+| T-12 | `README.md` | `python .github/scripts/check-plugin-refs.py` passes; README renders; `#feature-forge` + internal anchors resolve; both forge features share a parallel structure (index table + per-feature subsections); farm entry reflects the pluggable-backend reframe, no "cost-arbitrage/cheap Zen" framing remains | README Feature Forge section has parallel form/function; farm entry accurate to shipped reality | AC-12 | T-10, T-11 | ACCEPTED |
+
+## Order & MVP slice
+
+Dependency order is linear with two short branches; no cycle. Build order:
+
+`T-01 → T-02 → { T-03, T-04→T-05, T-06→T-07, T-08 } → T-09 → T-10 → T-11`
+
+- **MVP slice (batch 1): T-01, T-02, T-03, T-04, T-05** — the Worker seam (incl. D6 apply ownership) + the per-task-model design hook + prompt enrichment. This is the escalation-rate win and the cross-model-ready spine; the highest-value, independently reviewable core.
+- **Batch 2: T-06, T-07, T-08** — scheduling, regenerate-on-conflict, streaming rail (harness robustness + the pipeline primitive).
+- **Batch 3: T-09, T-10** — dispatch-contract docs + positioning reframe (prose).
+- **Finalize: T-11** — rebuild `farm.js` + version bump; depends on every prior task. Closes the single PR.
+
+## Coverage proof (bijective)
+
+- Every AC has ≥1 task: AC-01→T-01,T-02 · AC-02→T-03 · AC-03→T-04 · AC-04→T-04 · AC-05→T-05 · AC-06→T-06 · AC-07→T-07 · AC-08→T-08 · AC-09→T-09 · AC-10→T-10 · AC-11→T-11. ✓
+- Every task advances ≥1 AC (see `covers` column). ✓
+
+## Deferred (roadmap, from spec Non-goals — not in this plan)
+
+- [NEEDS-TRIAGE] `farm.js` backgrounding for true temporal review overlap.
+- [NEEDS-TRIAGE] cross-model second provider + cheap→premium ladder + cost telemetry (item 3 build).
+- [NEEDS-TRIAGE] item-6 grab-bag: schema-validated output, adversarial second-model verify, budget-scaled depth, per-task journaling, live progress.
+
+## Security / review note for execution
+
+T-04/T-05 change what leaves the trust boundary to the third-party endpoint — `subagent-driven-development`
+Phase 4 MUST dispatch `security-reviewer` over the combined diff of this feature.

--- a/.codearbiter/specs/farm-pluggable-backend.md
+++ b/.codearbiter/specs/farm-pluggable-backend.md
@@ -1,0 +1,157 @@
+# Spec — farm: pluggable execution backend (v1)
+
+status: APPROVED — 2026-06-14, by repo owner (after blind third-party spec review)
+slug: farm-pluggable-backend
+created: 2026-06-14
+lane: full
+relates-to: [CONFIRM-05] (Feature Forge promotion bar for `--farm`) — this feature *produces evidence*
+toward that bar (lower escalation rates on real runs); it does **not** resolve it. Promotion stays a
+separate owner decision.
+
+## Problem
+
+The `/ca:sprint --farm` backend (`plugins/ca/tools/farm.ts`) is well-engineered and well-tested at the
+mechanism level, but its single worker implementation is a **blind, single-shot HTTP chat call**: the
+worker is told *where* the failing test is but never given its contents, cannot read sibling files, and
+emits whole files from a description. That maximizes avoidable escalations on anything past leaf-node
+tasks, and it hard-couples the harness to one execution style — blocking the obvious future where a
+**premium or agentic** worker does the same work behind the same gates. Secondary friction: sibling
+tasks with overlapping file scope collide at merge time and escalate; and review (Phases 3–5) only
+begins after the *entire* farm run finishes.
+
+## Goals (this slice)
+
+A coherent first slice that (a) lands the structural spine, (b) takes the biggest escalation-rate win,
+and (c) shapes — but does not build — cross-model family support.
+
+1. **Worker interface (item 1).** Extract a `Worker` seam so the safety gates wrap *any* worker
+   implementation; the current HTTP-chat path becomes one implementation. Behavior-preserving.
+2. **Prompt enrichment (item 2).** Stop sending the worker in blind — inject the read-only test source
+   and current in-scope file contents, bounded and secret-safe.
+3. **Scope-aware scheduling (item 4).** Treat overlapping-scope tasks as implicit dependencies and
+   regenerate-on-conflict instead of immediate abort+escalate.
+4. **Pipeline the review handoff — streaming rail (item 5).** Emit per-task results incrementally and
+   consume them in completion order (Phase 3 + Phase 5 per green; Phase 4 stays the once-per-scope
+   barrier by design).
+5. **Reframe positioning.** "Cost arbitrage / cheap Zen workers" → "pluggable execution backend
+   (cheap / premium / agentic)." Prose only; the name `farm` and `Feature Forge preview` status are
+   preserved (§0.1 terminology lock).
+
+## Non-goals / roadmap (captured, deliberately deferred)
+
+- **Cross-model build (item 3):** a second provider (OpenAI/GPT-5.5), the cheap→premium escalation
+  ladder, per-task cost telemetry. Designed-for here (Goal 1 + AC-02), built later — it pulls new-secret
+  handling, supply-chain vetting, and the sovereignty trade-off into hard-gate territory.
+- **Temporal review overlap:** running farm.js in the background so review executes *while* farm grinds.
+  This slice lays the streaming rail that enables it; backgrounding is the follow-up.
+- **Item 6 grab-bag:** schema-validated structured output (vs fence-scraping), adversarial second-model
+  verify on green-with-warning tasks, budget-scaled depth, per-task resume/journaling, live progress
+  streaming. Each is independently shippable on top of the Worker seam.
+
+## Decisions & trade-offs (resolve at approval; object here if wrong)
+
+- **D1 — Governed feature, not /ca:dev.** Lands via PR with version bump + CI, like PRs #55–59.
+- **D2 — Phase 4 stays a barrier.** Pipelining overlaps Phase 3 + Phase 5 only; the combined-diff
+  quality review remains once-per-scope, per `subagent-driven-development` Phase 4's stated rationale.
+- **D3 — Streaming rail this slice; backgrounding later.** farm.js stays foreground; it gains
+  incremental emission so the data model is pipeline-ready and consumption is completion-ordered. The
+  headline "review while farm runs" latency win needs backgrounding and is roadmap.
+- **D4 — Regenerate-on-conflict spends one retry from the existing `maxRetries` budget**; exhaustion
+  escalates exactly as today. No new unbounded loop.
+- **D5 — Enrichment is bounded + secret-safe by default.** More repo content now leaves the trust
+  boundary to the third-party endpoint; that is a real new exposure and must be guarded (AC-05).
+- **D6 — The `Worker` seam owns *apply*, not just the *call* (reviewer-surfaced; confirm at approval).**
+  The interface returns/produces files written **into the worktree**, with the HTTP impl doing
+  `extractFileBlocks` + write internally — so an agentic/premium worker that writes its own files fits
+  the same seam later. Consequence: containment (`isInside`) and the read-only-test guard move from
+  inside `runWorker`'s write loop to a **post-apply sweep** in `runTask` that runs regardless of worker
+  type. This is load-bearing for item-3 readiness and expensive to re-cut, so it shapes where AC-01 cuts
+  the seam. *If rejected,* AC-01 cuts a thinner call-only seam and item-3/agentic becomes a larger
+  follow-up.
+- **D7 — Two artifacts, one source of truth on settlement.** `.farm/farm-results.jsonl` is the
+  incremental, append-only record of settled tasks (drives completion-order consumption);
+  `farm-report.json` (always written in the `finally`, even on abort) remains the authoritative final
+  summary. On a circuit-breaker abort or crash, the consumer reconciles against `farm-report.json`, not
+  the partial stream.
+
+## Acceptance criteria
+
+Worker interface (item 1)
+- **AC-01** — `farm.ts` defines a `Worker` interface and refactors the existing HTTP-chat author into
+  one implementation behind it; `runTask` depends on the interface, not on `callApi` directly. Proven
+  behavior-preserving: the entire existing `farm.test.ts` + `farm.unit.test.ts` suite passes unchanged.
+- **AC-02** *(design-for cross-model)* — the interface receives the resolved model/config, and an
+  optional `task.model` is added to `plan.schema.json` + the `Task` type, resolved as
+  `task.model ?? meta.model`. Absent → identical current behavior. No second provider is implemented.
+  Note for the planner: the task object in `plan.schema.json` is `additionalProperties: false`, so the
+  new field must be declared in the task `$defs` or schema validation (`writing-plans` Phase 4-farm,
+  SKILL.md:111) will reject it. Also reconcile, or explicitly leave, the pre-existing divergence
+  between the schema's kebab-case `id` pattern and farm.ts's broader `SAFE_TASK_ID` — do not widen it
+  silently.
+
+Prompt enrichment (item 2)
+- **AC-03** — the outgoing worker request includes the read-only source of `task.test.path`.
+- **AC-04** — the outgoing worker request includes the current contents of in-scope files that already
+  exist on disk in the worktree (direct imports best-effort). A test asserts the test source AND an
+  existing sibling file's contents appear in the request body.
+- **AC-05** — injected context is byte-capped (configurable env; default chosen with
+  `FARM_REQUEST_TIMEOUT_MS` and token spend in mind) and run through a **new** redaction pass over the
+  `tech-stack.md` secret-pattern set (`api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant`,
+  case-insensitive); matches are redacted/omitted before transmission. (There is no existing in-code
+  secret sweep to reuse — the repo's sweep is the manual/hook layer; this is new code.) A test plants a
+  secret-shaped string in an in-scope file and asserts it is NOT in the outgoing request body.
+
+Scope-aware scheduling (item 4)
+- **AC-06** — a task whose `filesInScope` intersects an *unfinished* sibling's is **removed from
+  readiness** (not merely merge-serialized) until that sibling is `green` and merged — i.e. it does not
+  appear in `ready()` and is not dispatched, so when it finally cuts its worktree it cuts from the
+  post-merge integration HEAD. This is derived ordering, not a declared `deps` edge (so it cannot create
+  a plan-validation cycle); mutual overlap between two ready tasks is broken deterministically by task
+  `id`. Test: two scope-overlapping tasks both reach green with no merge conflict, and the second's
+  worktree contains the first's merged change.
+- **AC-07** — on a merge conflict against integration (the residual case where overlap wasn't caught,
+  e.g. a shared import edit outside `filesInScope`), the task resets to the new integration HEAD and
+  re-runs the worker (consuming one retry per D4) before escalating, rather than immediate
+  abort+escalate. Implementation note: this requires moving the post-loop merge step (farm.ts:727–747)
+  into the attempt loop so a merge failure can re-enter regeneration — not just adding a branch. Test: a
+  forced same-file conflict yields a regeneration attempt, not an instant escalate.
+
+Pipeline — streaming rail (item 5)
+- **AC-08** — `farm.js` emits a per-task result the moment each task settles (append to
+  `.farm/farm-results.jsonl`), in addition to the final `farm-report.json`. Test: after a two-task run
+  the stream holds both results in completion order.
+- **AC-09** — `farm-dispatch.md` + `subagent-driven-development` document the contract: consume results
+  in completion order, run Phase 3 + Phase 5 per green as it lands, Phase 4 preserved as the
+  once-per-scope combined-diff barrier (D2). Temporal overlap noted as roadmap. `check-plugin-refs.py`
+  passes.
+
+Reframe (positioning)
+- **AC-10** — `farm.md`, the `ORCHESTRATOR.md` `/sprint --farm` section, `SPRINT.md`, and
+  `farm-dispatch.md` reframe the backend as pluggable (cheap / premium / agentic); the term `farm` and
+  the `preview` status are preserved. No reference graph breaks (`check-plugin-refs.py`).
+
+Cross-cutting (release invariants, from `tech-stack.md`)
+- **AC-11** — `farm.js` is rebuilt from `farm.ts` with no stale build (`git diff --quiet -- farm.js`
+  clean after `npm run build`); `npm run typecheck` + full `npm test` green; `plugin.json` `version`
+  bumped and kept in sync across `plugin.json`, the README badge, and a dated `CHANGELOG.md` section.
+
+## Risks / security
+
+- **Trust-boundary data exposure (primary).** Enrichment increases what is sent to the third-party Zen
+  endpoint. Mitigated by AC-05 (cap + secret sweep). Phase 4 MUST dispatch `security-reviewer`; the
+  change is security-relevant.
+- **Refactor regression.** The Worker extraction is behavior-preserving and fully covered by the
+  existing suite (AC-01) — the suite is the safety net.
+- **Scheduling deadlock/starvation.** Scope-overlap ordering is *derived at schedule time* (a readiness
+  filter), never written as a `deps` edge — so it cannot create a plan-validation cycle, and mutual
+  overlap is broken deterministically by `id` (AC-06). Starvation is bounded because every overlap
+  resolves the moment the blocking sibling settles.
+- **Duplicated file reads.** `antiGamingCheck` (farm.ts:419) and `mutationCheck` (farm.ts:552) already
+  read `test.path` and in-scope files; enrichment (AC-03/04) reads the same. The planner should factor a
+  shared read helper rather than grow a parallel read path.
+
+## Out-of-scope items noticed
+
+- [NEEDS-TRIAGE] `farm.js` backgrounding for true temporal review overlap (roadmap).
+- [NEEDS-TRIAGE] cross-model second provider + cost telemetry + escalation ladder (item 3 roadmap).
+- [NEEDS-TRIAGE] item-6 grab-bag (schema output, adversarial verify, budget depth, journaling).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.4.0] — 2026-06-14
+
+### Changed
+- **Reframed `farm` as a pluggable execution backend (cheap / premium / agentic).** The dispatcher now
+  runs every task through a `Worker` interface seam rather than calling the HTTP chat endpoint directly;
+  the HTTP-chat author is one implementation. The worker owns the apply step, and a task-level
+  containment sweep runs post-apply for any worker type, so path-traversal and read-only-test guards
+  hold regardless of backend. Behavior-preserving for the existing flow. The name `farm` and its
+  `preview` (Feature Forge) status are unchanged.
+
+### Added
+- **Prompt enrichment for workers.** Outgoing requests now include the read-only source of the task's
+  failing test and the current contents of existing in-scope files, so a worker sees the contract it
+  must satisfy. The injected context is byte-capped (configurable, mindful of `FARM_REQUEST_TIMEOUT_MS`)
+  with a visible truncation marker, and is run through a redaction pass over the `security-controls.md`
+  secret-pattern set — planted secrets, including multi-line PEM keys, are never transmitted.
+- **Optional per-task `model`.** `task.model` is accepted in the plan schema (`additionalProperties:false`
+  honored) and resolves as `task.model ?? meta.model`, enabling design-for cross-model execution.
+- **Scope-aware scheduling.** A task overlapping an unfinished sibling's `filesInScope` is removed from
+  readiness (not merely merge-serialized) until that sibling is green and merged; ordering is derived
+  and id-tiebroken.
+- **Regenerate-on-conflict.** A merge conflict now resets to the new integration HEAD and re-runs the
+  worker once (the post-loop merge moved into the attempt loop) before escalating, instead of escalating
+  instantly.
+- **Streaming results rail.** Each settled task is appended to `.farm/farm-results.jsonl` in completion
+  order as it settles, alongside the final `farm-report.json`.
+
+---
+
 ## [2.3.1] — 2026-06-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.3.1" src="https://img.shields.io/badge/version-2.3.1-2b7489">
+<img alt="version 2.4.0" src="https://img.shields.io/badge/version-2.4.0-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">
@@ -169,13 +169,20 @@ Every flag is shipped off, never auto-enabled, and dormant in a repo without `ar
 
 Some features are built, tested, and shipping in the box, but not yet *blessed*. They live in the **Feature Forge**: off by default, fully dormant until you opt in, and labeled `preview` until real-world data earns them a promotion to a stable release. Nothing here touches your repo or your gates unless you turn it on.
 
-**This is also where you come in.** A preview graduates when the evidence says it's ready, and that evidence comes from people running it. Each forge feature ships a `dry` mode that does the real analysis and records what it *would* have done, changing nothing. Send that data back and you pull the promote date forward.
+**This is also where you come in.** A preview graduates when the evidence says it's ready, and that evidence comes from people running it. Each feature gives you a low-risk way to contribute that evidence — a `dry` mode, or a structured run report — see each below. Send that data back and you pull the promote date forward.
 
 ### In the forge now
 
-**Live transcript pruning** · `CODEARBITER_PRUNE`
+| Feature | Opt-in | Status | How to help it graduate |
+|---|---|---|---|
+| [Live transcript pruning](#live-transcript-pruning) | `CODEARBITER_PRUNE=dry` | `preview` | run `dry`, send the log |
+| [Pluggable execution farm](#pluggable-execution-farm) | <kbd>/ca:sprint --farm</kbd> | `preview` | run it on a real sprint, report results |
 
-Long sessions bloat the transcript until Claude Code compacts early and you lose working headroom. The pruner trims redundant clutter so a session lives longer; gains land at resume/compaction, never mid-turn. Three modes:
+#### Live transcript pruning
+
+**What it does.** Long sessions bloat the transcript until Claude Code compacts early and you lose working headroom. The pruner trims redundant clutter so a session lives longer; gains land at resume/compaction, never mid-turn.
+
+**Opt-in.** `CODEARBITER_PRUNE` — three modes:
 
 | `CODEARBITER_PRUNE` | What happens |
 |---|---|
@@ -185,7 +192,9 @@ Long sessions bloat the transcript until Claude Code compacts early and you lose
 
 Fine-tune with `CODEARBITER_PRUNE_TIER` (which passes run), `CODEARBITER_PRUNE_KEEP_RECENT` (protect the K most recent turns), and `CODEARBITER_PRUNE_MIN_GROWTH` / `CODEARBITER_PRUNE_MAXBYTES` (when a prune triggers / cap on bytes removed). Full detail in <kbd>/ca:prune</kbd>.
 
-#### Help promote it: run `dry`, send the log
+**Why it's preview.** The `dry → on` go/no-go needs real-session evidence before pruning is blessed to touch live transcripts on by default.
+
+**Help promote it: run `dry`, send the log.**
 
 ```sh
 export CODEARBITER_PRUNE=dry      # collect evidence, change nothing
@@ -195,9 +204,24 @@ export CODEARBITER_PRUNE=dry      # collect evidence, change nothing
 
 After a few sessions, [**open a "prune data" issue**](https://github.com/arbiterForge/codeArbiter/issues/new?title=Feature+Forge%3A+prune+data&labels=feature-forge,prune) and attach or paste your `prune-dry.jsonl`. The more real sessions come back, the sooner pruning leaves the forge. Thank you for forging. 🔨
 
-**Cost-arbitrage farm** · `/ca:sprint --farm` (needs `FARM_API_KEY`)
+#### Pluggable execution farm
 
-`--farm` runs the implementation step on cheap [OpenCode Zen](https://opencode.ai) workers in isolated worktrees instead of premium subagents. Claude still writes the spec, the failing tests, and the plan, and still routes every task through the same spec-compliance, quality, and fresh-verification gates, so the cheap model can only pass the gates, never redefine them. The arbitrage is in who writes the code, not in whether it gets reviewed. It is **not yet validated on real runs**, so it ships off and stays `preview`. The promotion bar is being defined as an open question (`CONFIRM-05`); setup and the API-key/model config live in <kbd>/ca:sprint</kbd> and the farm setup doc.
+**What it does.** <kbd>/ca:sprint --farm</kbd> runs the implementation step through a `Worker` seam in isolated git worktrees under the same hard gates, instead of a premium subagent. The cheap HTTP-chat worker ships today; the seam is built to admit **premium and agentic** workers behind the same gates (roadmap, not yet built). The worker prompt is enriched with the failing-test source and in-scope files — byte-capped and secret-redacted before transmission. Claude still writes the spec, failing tests, and plan, and **every green task still routes through the full spec-compliance + quality + fresh-verification chain** — a worker can pass the gates, never redefine them.
+
+**Opt-in.** <kbd>/ca:sprint --farm</kbd> (needs `FARM_API_KEY`).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `FARM_API_KEY` | _(required)_ | OpenAI-compatible provider key; never committed, never in audit files. |
+| `FARM_MODEL` | _(unset)_ | Skip selection; otherwise the model is auto-selected by measured canary at dispatch. |
+| `FARM_ENRICH_MAX_BYTES` | `131072` | Cap on test-source + in-scope context injected into the worker prompt (redacted for secrets). |
+| `FARM_CONCURRENCY` | `4` | Max concurrent task workers. |
+
+Full config (endpoint, retries, circuit breaker, mutation guard, sovereignty note) is in <kbd>/ca:sprint</kbd> and the farm setup doc.
+
+**Why it's preview / promotion bar.** Not yet validated on real runs, so it ships off and stays `preview`. The promotion bar is the open question `CONFIRM-05`.
+
+**Help promote it: run a real sprint, report results.** Run a real <kbd>/ca:sprint --farm</kbd> and report back the per-task pass-rates and any gate escapes you see. That evidence feeds `CONFIRM-05` — real-run data is exactly what moves the farm out of the forge.
 
 ## Commands
 

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/ORCHESTRATOR.md
+++ b/plugins/ca/ORCHESTRATOR.md
@@ -54,9 +54,12 @@ logging each decision (with a confidence flag) to `.codearbiter/sprint-log.md`. 
 `security-controls`, crypto/secrets/auth, irreversible ops, `/override`, an unresolvable
 `[CONFIRM-NN]`, merge-to-default — remain true stops, rare by design.
 
-The optional **`--farm`** flag selects the cost-arbitrage execution backend (cheap Zen workers
-implement under hard gates instead of premium subagents). When present, pass it through to `SPRINT.md`,
-which forwards it to `writing-plans` (to co-emit `plan.json` + failing tests) and to
+The optional **`--farm`** flag selects the pluggable execution backend: Claude authors specs, failing
+tests, and the plan; a worker implements each task under the same hard gates (containment, read-only-test
+protection, anti-gaming, the full review chain) instead of a premium subagent. The seam admits cheap,
+premium, and agentic worker implementations — only the cheap HTTP-chat worker ships today; premium and
+agentic are roadmap. Cost arbitrage is one use case, not the definition. When present, pass it through to
+`SPRINT.md`, which forwards it to `writing-plans` (to co-emit `plan.json` + failing tests) and to
 `subagent-driven-development` (farm dispatch path). See `${CLAUDE_PLUGIN_ROOT}/SPRINT.md` Phase 1–2 and
 `${CLAUDE_PLUGIN_ROOT}/includes/farm.md`. Absent the flag, the normal premium-subagent path runs
 unchanged.

--- a/plugins/ca/SPRINT.md
+++ b/plugins/ca/SPRINT.md
@@ -14,8 +14,11 @@ that is not a true hard gate. Every auto-decision is logged. Hard gates are real
 > `${CLAUDE_PROJECT_DIR}/.codearbiter/open-questions.md` (CONFIRM-05).
 
 `/sprint` runs the normal premium-subagent path unless invoked as `/sprint --farm`. The `--farm` flag
-selects the cost-arbitrage backend: Claude still authors the spec, the failing tests, and the plan, but
-cheap Zen workers (not premium subagents) implement each task under the same hard gates. Track whether
+selects the pluggable execution backend: Claude still authors the spec, the failing tests, and the plan,
+but a worker (not a premium subagent) implements each task behind the same hard gates. The backend's
+value is deterministic, gated, parallel, isolated execution; the `Worker` seam admits cheap, premium,
+and agentic implementations. Only the cheap HTTP-chat worker ships today — premium and agentic are what
+the seam is designed for, not yet built. Cost arbitrage is one worker policy, not the definition. Track whether
 `--farm` was passed and thread it into Phase 1 (`writing-plans --farm`) and Phase 2 (the farm dispatch
 path in `subagent-driven-development`). If `--farm` is set, pre-flight `FARM_API_KEY` — absent, BLOCK
 and cite `${CLAUDE_PLUGIN_ROOT}/includes/farm.md` before brainstorming begins. Everything else about `/sprint` (the one
@@ -56,8 +59,8 @@ test-first via `tdd`, two-pass reviewed, and proven on a fresh run.
 **`--farm` mode:** `subagent-driven-development` detects `plan.json` and takes its farm path —
 selecting a model (a canary probe over candidate Zen models, falling back to websearch), dispatching
 `farm.js`, then routing every green task through the SAME spec-compliance + quality + fresh-verification
-gates the premium path runs (Phases 3–5). The cost arbitrage is in who *writes* the code, never in
-whether it is *reviewed*. A farm escalation is handled per `subagent-driven-development`'s Phase 2.5
+gates the premium path runs (Phases 3–5). Swapping the worker only changes who *writes* the code, never
+whether it is *reviewed* — every farm-produced green task still routes through the full review chain. A farm escalation is handled per `subagent-driven-development`'s Phase 2.5
 (re-dispatch via premium Phase 2, or `[CONFIRM-NN]` on a genuine spec gap), and a circuit-breaker abort
 from `farm.js` (too many escalations) is itself a hard-gate surface: stop and tell the user the model
 isn't capable of the slice rather than grinding through.

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -4,11 +4,18 @@
 > real runs; the premium subagent path is the blessed default. Promotion bar:
 > `${CLAUDE_PROJECT_DIR}/.codearbiter/open-questions.md` (CONFIRM-05).
 
-`farm.ts` is the zero-LLM-token dispatcher: Claude writes specs, failing tests, and a `plan.json`;
-the farm runs cheap Zen workers in isolated git worktrees to make each test pass; Claude reviews
-and merges. The cheap model cannot redefine the gates — only pass them.
+`farm.ts` is the pluggable execution backend: Claude writes specs, failing tests, and a `plan.json`;
+the farm runs workers in isolated git worktrees to make each test pass; Claude reviews and merges. Its
+value is deterministic, gated, parallel, isolated execution — a worker cannot redefine the gates, only
+pass them. The `Worker` interface seam admits cheap, premium, and agentic worker implementations behind
+the same hard gates; **only the cheap HTTP-chat worker ships today** — premium (e.g. a top-tier hosted
+model) and agentic (a worker that reads files and iterates) are what the seam is designed for, roadmap
+not built. Cost arbitrage is one worker policy, not the definition.
 
-**The arbitrage is in who writes the code, never in whether it's reviewed.** Every task the farm
+The worker prompt is enriched with the failing-test source and current in-scope file contents, byte-capped
+(`FARM_ENRICH_MAX_BYTES`) and secret-redacted before transmission to the endpoint.
+
+**Swapping the worker changes who writes the code, never whether it's reviewed.** Every task the farm
 reports green is still routed through the normal spec-compliance, quality, and fresh-verification
 gates (`subagent-driven-development` Phases 3–5) before acceptance. The dispatcher additionally runs two
 zero-token guards (below), protects the failing test from being modified, contains all worker writes
@@ -80,6 +87,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_BASE_BRANCH` | `main` | Branch the integration branch is cut from. |
 | `FARM_REQUEST_TIMEOUT_MS` | `120000` | Per-request hard timeout (prevents worker-slot deadlock). |
 | `FARM_API_MAX_RETRIES` | `3` | Transport retries for 429/5xx (honors `Retry-After`). |
+| `FARM_ENRICH_MAX_BYTES` | `131072` | Cap on bytes of test-source + in-scope file context injected into the worker prompt (data-minimization; redacted for secrets). |
 | `FARM_ABORT_ESCALATION_RATE` | `0.5` | Circuit breaker: abort once escalations exceed this fraction… |
 | `FARM_ABORT_MIN_TASKS` | `3` | …after at least this many tasks have settled. |
 | `FARM_MUTATION` | `on` | Mutation guard on/off. |

--- a/plugins/ca/skills/subagent-driven-development/SKILL.md
+++ b/plugins/ca/skills/subagent-driven-development/SKILL.md
@@ -43,8 +43,10 @@ gates instead of premium subagents); it does **not** replace review — every ta
 is still routed through Phases 3–5 before acceptance. The cost arbitrage is in who *writes* the code,
 never in whether it is *reviewed*. In brief: select a model (canary-probe with a cache→websearch
 fallback ladder), dispatch `tools/farm.js`, honor a circuit-breaker abort as a hard-gate STOP, then for
-each result either accept-after-Phases-3–5 (green) or re-dispatch via premium Phase 2 (escalate). The
-reference has the full step-by-step.
+each result either accept-after-Phases-3–5 (green) or re-dispatch via premium Phase 2 (escalate).
+Results stream to `.farm/farm-results.jsonl` and are consumed in completion order — Phase 3 + Phase 5
+per green task as it lands, Phase 4 still the once-per-scope barrier (reconcile against `farm-report.json`
+on abort). The reference has the full step-by-step.
 
 ---
 

--- a/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
@@ -1,10 +1,13 @@
 # Farm dispatch — reference for subagent-driven-development's farm path
 
 Loaded from `subagent-driven-development` Phase 2 when `<slug>.plan.json` exists alongside the `.md`
-plan. The farm path replaces only the *authoring* step for the plan's tasks — cheap Zen workers
-implement under hard gates instead of premium subagents. It does **not** replace review: every task
-the farm reports green is still routed through Phases 3, 4, and 5 before acceptance. The cost arbitrage
-is in who *writes* the code, never in whether it is *reviewed*. See `${CLAUDE_PLUGIN_ROOT}/includes/farm.md` for setup.
+plan. The farm is a pluggable execution backend — its value is deterministic, gated, parallel, isolated
+execution. The farm path replaces only the *authoring* step for the plan's tasks — a worker implements
+under hard gates instead of a premium subagent. The `Worker` seam admits cheap, premium, and agentic
+implementations; only the cheap HTTP-chat worker ships today (premium and agentic are what the seam is
+designed for — roadmap, not built). It does **not** replace review: every task the farm reports green is
+still routed through Phases 3, 4, and 5 before acceptance. Swapping the worker only changes who *writes*
+the code, never whether it is *reviewed*. See `${CLAUDE_PLUGIN_ROOT}/includes/farm.md` for setup.
 
 ## Step 1 — Model selection
 
@@ -43,6 +46,8 @@ Run it with cwd set to `${CLAUDE_PROJECT_DIR}` (the dispatcher resolves `.farm/`
 against the current directory). It runs tasks concurrently (up to `FARM_CONCURRENCY`, default 4),
 enforces gates and a zero-token anti-gaming guard, and writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
 - `farm-report.json` / `farm-report.md` — per-task status, attempts, files, worker token spend, warnings
+- `farm-results.jsonl` — the incremental stream: one `Result` JSON object per line, appended the moment
+  each task settles (drives completion-order consumption — see Step 2.6)
 - `diffs/<task-id>.patch` — the actual change per task, for audit
 
 Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
@@ -52,11 +57,34 @@ Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run
 If `farm-report.json` has `aborted: true`, the dispatcher tripped its escalation-rate breaker — the
 chosen model is likely not capable of this slice. This is a hard-gate surface: STOP and tell the user,
 recommending the premium path or a different `FARM_MODEL`. Do not silently re-dispatch every task to
-premium Phase 2 (that erases the arbitrage and hides a bad signal).
+premium Phase 2 (that defeats the backend's purpose and hides a bad signal).
+
+## Step 2.6 — Streaming consumption contract
+
+The dispatcher writes two artifacts (D7): the incremental `farm-results.jsonl` stream and the final
+`farm-report.json` summary. The escalation/acceptance handler (Step 3) MUST consume the stream in
+**completion order** — read `farm-results.jsonl` line by line (one `Result` JSON object per line) and
+process each task the moment it settles, rather than waiting to parse only the final report. Each
+`green` task is routed through **Phase 3 (spec-compliance) + Phase 5 (verification)** as it lands.
+
+- **Per-green-task = Phase 3 + Phase 5 only.** Only the spec-compliance and fresh-verification reviews
+  run per green task as it streams in.
+- **Phase 4 stays a once-per-scope barrier.** The quality review (Phase 4) MUST NOT be pipelined per
+  task — it still runs ONCE over the combined diff of the whole scope, after every task has cleared
+  Phase 3 and Phase 5. The streaming rail moves Phase 3 + Phase 5 earlier; it does NOT move Phase 4.
+- **`farm-report.json` is authority on abort (D7).** `farm-report.json` is always written in the
+  dispatcher's `finally` — even on a circuit-breaker abort or crash — and remains the AUTHORITATIVE
+  final summary. On an abort or crash, reconcile settled-task state against `farm-report.json`, NOT the
+  partial `.jsonl` stream. The stream is an append-only progress feed; the report is the source of truth.
+- **Temporal overlap is roadmap, not today.** `farm.js` runs in the foreground, so the consumer
+  processes the stream in completion order *after* the run returns — true *temporal* overlap (running
+  review WHILE the farm is still executing) requires backgrounding `farm.js` and is explicitly a
+  future/roadmap item. The streaming rail is the enabling primitive, not the full overlap yet.
 
 ## Step 3 — Escalation handler (Phase 2.5)
 
-Read `farm-report.json`. For each result:
+Consume `farm-results.jsonl` in completion order (Step 2.6); `farm-report.json` is the authoritative
+reconciliation source on abort. For each result:
 
 - **status `green`** — the test gate + anti-gaming guard passed, but it is NOT yet accepted. Route the
   task through **Phase 3 (spec-compliance), Phase 4 (quality review), and Phase 5 (fresh verification)**

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -2,7 +2,7 @@
 
 // farm.ts
 import { spawn } from "node:child_process";
-import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readFile, writeFile, appendFile, mkdir, rm } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,7 +32,17 @@ var ENV = {
   // Default endpoint, used only when neither env nor plan.meta provides one.
   defaultApiBaseUrl: process.env.FARM_DEFAULT_API_BASE_URL ?? "https://api.opencode.ai/v1",
   // Comma-separated candidate model ids for --canary mode.
-  candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "").split(",").map((s) => s.trim()).filter(Boolean)
+  candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "").split(",").map((s) => s.trim()).filter(Boolean),
+  // AC-05 byte cap on the TOTAL injected enrichment context (test source +
+  // in-scope file bodies) that leaves the trust boundary to the third-party
+  // endpoint. Default 131072 (128 KiB): more repo content now flows outbound,
+  // so the prompt must never be unbounded. 128 KiB is ~32K tokens of context —
+  // generous enough for the real test + a handful of in-scope files, yet small
+  // enough to stay well inside the FARM_REQUEST_TIMEOUT_MS (120s) single-request
+  // budget and to bound per-task token spend. Truncation past the cap is
+  // deterministic (in-order) with a visible marker; we never silently drop the
+  // boundedness guarantee.
+  enrichMaxBytes: Number(process.env.FARM_ENRICH_MAX_BYTES ?? 131072)
 };
 var MUT = {
   enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
@@ -65,11 +75,121 @@ async function runGate(cwd, commands) {
   for (const cmd of commands) {
     const r = await run(SHELL_BIN, [SHELL_FLAG, cmd], cwd, SHELL_OPTS);
     if (r.code !== 0)
-      return { ok: false, failed: cmd, tail: r.out.slice(-3500) };
+      return { ok: false, failed: cmd, tail: redactSecrets(r.out.slice(-3500)) };
   }
   return { ok: true };
 }
-function buildPrompt(t, priorFailure, forbiddenExtra) {
+async function readWorktreeFile(wt, relPath) {
+  try {
+    return await readFile(path.resolve(wt, relPath), "utf8");
+  } catch {
+    return null;
+  }
+}
+var SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant)/i;
+var PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
+var PEM_END = /^-----END .*-----\s*$/;
+var REDACTION_MARKER = "[REDACTED \u2014 secret-pattern match removed before transmission]";
+var SECRET_FILENAME_DENYLIST = [
+  /^\.env$/i,
+  // .env
+  /^\.env\..+$/i,
+  // .env.local, .env.production, ...
+  /\.pem$/i,
+  // *.pem
+  /\.key$/i,
+  // *.key
+  /^id_rsa(\..+)?$/i,
+  // id_rsa, id_rsa.pub, id_rsa.bak
+  /^id_ed25519(\..+)?$/i,
+  // id_ed25519, id_ed25519.pub
+  /^id_ecdsa(\..+)?$/i,
+  // id_ecdsa, id_ecdsa.pub
+  /\.p12$/i,
+  // PKCS#12 keystore
+  /\.pfx$/i
+  // PKCS#12 keystore (Windows)
+];
+function isSecretBearingFilename(relPath) {
+  const base = relPath.split(/[\\/]/).pop() ?? relPath;
+  return SECRET_FILENAME_DENYLIST.some((re) => re.test(base));
+}
+function redactSecrets(contents) {
+  const lines = contents.split("\n");
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (PEM_BEGIN.test(line.trim())) {
+      out.push(REDACTION_MARKER);
+      i++;
+      while (i < lines.length && !PEM_END.test(lines[i].trim())) i++;
+      continue;
+    }
+    out.push(SECRET_LINE.test(line) ? REDACTION_MARKER : line);
+  }
+  return out.join("\n");
+}
+function renderInjectedFile(file) {
+  const label = file.readOnly ? `${file.path} (read-only \u2014 the failing test)` : file.path;
+  return [`--- ${label} ---`, redactSecrets(file.contents)].join("\n");
+}
+var TRUNCATION_MARKER = "--- [TRUNCATED \u2014 injected context exceeded FARM_ENRICH_MAX_BYTES] ---";
+function capInjected(injected, maxBytes) {
+  const out = [];
+  let used = 0;
+  for (const file of injected) {
+    const renderedBytes = Buffer.byteLength(renderInjectedFile(file), "utf8");
+    if (used + renderedBytes <= maxBytes) {
+      out.push(file);
+      used += renderedBytes;
+      continue;
+    }
+    const contentBytes = Buffer.byteLength(redactSecrets(file.contents), "utf8");
+    const overhead = renderedBytes - contentBytes;
+    const remaining = maxBytes - used - overhead - Buffer.byteLength("\n" + TRUNCATION_MARKER, "utf8");
+    if (remaining > 0) {
+      const safe = Buffer.from(redactSecrets(file.contents), "utf8").subarray(0, remaining).toString("utf8");
+      out.push({ ...file, contents: safe + "\n" + TRUNCATION_MARKER });
+    } else {
+      out.push({ ...file, contents: TRUNCATION_MARKER });
+    }
+    break;
+  }
+  return out;
+}
+async function buildEnrichment(wt, t) {
+  const injected = [];
+  const seen = /* @__PURE__ */ new Set();
+  if (!isSecretBearingFilename(t.test.path)) {
+    const testSrc = await readWorktreeFile(wt, t.test.path);
+    if (testSrc !== null) {
+      injected.push({ path: t.test.path, contents: testSrc, readOnly: true });
+      seen.add(t.test.path);
+    }
+  } else {
+    seen.add(t.test.path);
+  }
+  for (const f of t.filesInScope) {
+    if (seen.has(f)) continue;
+    if (isSecretBearingFilename(f)) {
+      seen.add(f);
+      continue;
+    }
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
+    injected.push({ path: f, contents: src, readOnly: false });
+    seen.add(f);
+  }
+  return capInjected(injected, ENV.enrichMaxBytes);
+}
+function buildPrompt(t, injected, priorFailure, forbiddenExtra) {
+  const enrichment = injected.length ? [
+    ``,
+    `Current source of the relevant files (the test is read-only; implement against it):`,
+    ``,
+    ...injected.map(renderInjectedFile),
+    ``
+  ] : [];
   return [
     `Implement exactly ONE task. Your only goal: make the failing test pass.`,
     ``,
@@ -88,7 +208,7 @@ ${t.context}
     forbiddenExtra && forbiddenExtra.length ? `
 Your previous attempt wrote these FORBIDDEN paths \u2014 do NOT touch them again:
 ${forbiddenExtra.map((f) => `  - ${f}`).join("\n")}` : ``,
-    ``,
+    ...enrichment,
     `Solve the task with REAL logic. Do not hard-code the literal values the`,
     `test asserts \u2014 an implementation that only returns the expected constant`,
     `will be rejected.`,
@@ -233,6 +353,9 @@ async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden) {
     completionTokens: api.usage?.completion_tokens
   };
 }
+var httpWorker = {
+  apply: (ctx) => runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden)
+};
 async function checkDrift(cwd, allowed) {
   const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
   const untracked = await git(
@@ -246,6 +369,19 @@ async function checkDrift(cwd, allowed) {
     changed.push(...untracked.out.split("\0").filter(Boolean));
   return [...new Set(changed)].filter((f) => !allowed.has(f));
 }
+function postApplySweep(cwd, filesWritten, forbidden) {
+  for (const f of filesWritten) {
+    const absPath = path.resolve(cwd, f);
+    if (!isInside(cwd, absPath)) {
+      return `path escapes worktree: ${f}`;
+    }
+    const rel = path.relative(cwd, absPath).split(path.sep).join("/");
+    if (forbidden.has(rel)) {
+      return `worker wrote read-only path: ${rel}`;
+    }
+  }
+  return null;
+}
 function extractLiterals(testSrc) {
   const lits = /* @__PURE__ */ new Set();
   for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
@@ -256,24 +392,16 @@ function codeLineCount(src) {
   return src.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
 }
 async function antiGamingCheck(cwd, task) {
-  let testSrc = "";
-  try {
-    testSrc = await readFile(path.resolve(cwd, task.test.path), "utf8");
-  } catch {
-    return { risk: "none" };
-  }
+  const testSrc = await readWorktreeFile(cwd, task.test.path);
+  if (testSrc === null) return { risk: "none" };
   const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
   if (literals.length === 0) return { risk: "none" };
   const hits = [];
   let anyTiny = false;
   for (const f of task.filesInScope) {
     if (f === task.test.path) continue;
-    let src = "";
-    try {
-      src = await readFile(path.resolve(cwd, f), "utf8");
-    } catch {
-      continue;
-    }
+    const src = await readWorktreeFile(cwd, f);
+    if (src === null) continue;
     const tiny = codeLineCount(src) <= 5;
     for (const lit of literals) {
       if (src.includes(lit)) {
@@ -379,12 +507,8 @@ async function mutationCheck(wt, task) {
   const originals = /* @__PURE__ */ new Map();
   let candidates = [];
   for (const f of impl) {
-    let src;
-    try {
-      src = await readFile(path.resolve(wt, f), "utf8");
-    } catch {
-      continue;
-    }
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
     if (codeLineCount(src) <= 2) continue;
     originals.set(f, src);
     candidates.push(...generateMutants(f, src));
@@ -431,16 +555,29 @@ async function prepareWorktree(branch, wt, from) {
   if (add.code !== 0) return `worktree add failed: ${add.out.slice(0, 200)}`;
   return null;
 }
-async function runTask(t, model, apiBaseUrl, apiKey) {
+var defaultRunTaskDeps = () => ({
+  worker: httpWorker,
+  prepareWorktree,
+  resetWorktree,
+  fileHash,
+  checkDrift,
+  runGate,
+  antiGamingCheck,
+  mutationCheck,
+  git,
+  withMergeLock
+});
+async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()) {
   const branch = `farm/${t.id}`;
   const wt = path.resolve(ENV.worktreeRoot, t.id);
   const limit = t.maxRetries ?? ENV.maxRetries;
+  const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
   const forbidden = /* @__PURE__ */ new Set([t.test.path]);
-  const prepErr = await prepareWorktree(branch, wt, ENV.integration);
+  const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
     return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
-  const testHashBefore = await fileHash(path.resolve(wt, t.test.path));
+  const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
   let priorFailure;
   let driftedOnce = false;
   let lastFilesWritten = [];
@@ -449,15 +586,16 @@ async function runTask(t, model, apiBaseUrl, apiKey) {
   let lastWarning;
   let mutationScore = null;
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
-    if (attempt > 1) await resetWorktree(wt);
-    const worker = await runWorker(
-      wt,
-      buildPrompt(t, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0),
-      model,
+    if (attempt > 1) await deps.resetWorktree(wt);
+    const injected = await buildEnrichment(wt, t);
+    const worker = await deps.worker.apply({
+      cwd: wt,
+      prompt: buildPrompt(t, injected, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0),
+      model: effectiveModel,
       apiBaseUrl,
       apiKey,
       forbidden
-    );
+    });
     promptTokens += worker.promptTokens ?? 0;
     completionTokens += worker.completionTokens ?? 0;
     lastFilesWritten = worker.filesWritten;
@@ -465,11 +603,15 @@ async function runTask(t, model, apiBaseUrl, apiKey) {
       priorFailure = `worker error: ${worker.error}`;
       continue;
     }
-    const testHashAfter = await fileHash(path.resolve(wt, t.test.path));
+    const sweepErr = postApplySweep(wt, worker.filesWritten, forbidden);
+    if (sweepErr) {
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
+    const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
     if (testHashBefore !== null && testHashAfter !== testHashBefore) {
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
-    const driftFiles = await checkDrift(wt, allowed);
+    const driftFiles = await deps.checkDrift(wt, allowed);
     if (driftFiles.length > 0) {
       if (!driftedOnce && attempt <= limit) {
         driftedOnce = true;
@@ -478,17 +620,17 @@ async function runTask(t, model, apiBaseUrl, apiKey) {
       }
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
-    const gate = await runGate(wt, t.gate.commands);
+    const gate = await deps.runGate(wt, t.gate.commands);
     if (!gate.ok) {
-      priorFailure = `failed: ${gate.failed}
-${gate.tail}`;
+      priorFailure = redactSecrets(`failed: ${gate.failed}
+${gate.tail}`);
       continue;
     }
-    const gaming = await antiGamingCheck(wt, t);
+    const gaming = await deps.antiGamingCheck(wt, t);
     let risk = gaming.risk;
     let riskNote = gaming.note;
     if (risk !== "high") {
-      const mut = await mutationCheck(wt, t);
+      const mut = await deps.mutationCheck(wt, t);
       if (mut) {
         mutationScore = mut.score;
         if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
@@ -508,23 +650,33 @@ ${gate.tail}`;
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore };
     }
     if (risk === "warn") lastWarning = riskNote;
-    await git(["add", "--", ...worker.filesWritten], wt);
-    const commit = await git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
+    await deps.git(["add", "--", ...worker.filesWritten], wt);
+    const commit = await deps.git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
     if (commit.code !== 0)
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
-    const diffstat = (await git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
-    const merged = await withMergeLock(async () => {
-      const m = await git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
+    const diffstat = (await deps.git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
+    const merged = await deps.withMergeLock(async () => {
+      const m = await deps.git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
       if (m.code !== 0) {
-        await git(["merge", "--abort"], integrationWorktree).catch(() => {
+        await deps.git(["merge", "--abort"], integrationWorktree).catch(() => {
         });
         return m.out;
       }
       return null;
     });
-    if (merged !== null)
+    if (merged !== null) {
+      if (attempt <= limit) {
+        await deps.git(["reset", "--hard", ENV.integration], wt).catch(() => {
+        });
+        await deps.git(["clean", "-fd"], wt).catch(() => {
+        });
+        priorFailure = redactSecrets(`merge conflict vs integration: rebuild against the updated baseline (integration HEAD moved)
+${String(merged).slice(0, 160)}`);
+        continue;
+      }
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
-    await git(["worktree", "remove", "--force", wt]).catch(() => {
+    }
+    await deps.git(["worktree", "remove", "--force", wt]).catch(() => {
     });
     return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore };
   }
@@ -648,6 +800,8 @@ async function main() {
   const { model, apiBaseUrl, apiKey } = resolveConfig(plan);
   await mkdir(ENV.worktreeRoot, { recursive: true });
   await mkdir(ENV.reportDir, { recursive: true });
+  const resultsStream = path.join(ENV.reportDir, "farm-results.jsonl");
+  await writeFile(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
   const done = /* @__PURE__ */ new Map();
   const blocked = [];
   let aborted = false;
@@ -667,10 +821,25 @@ async function main() {
     const escalated = /* @__PURE__ */ new Set();
     const pending = new Set(plan.tasks.map((t) => t.id));
     const running = /* @__PURE__ */ new Map();
+    const scopeOf = (id) => new Set(byId.get(id).filesInScope ?? []);
+    const overlaps = (a, b) => {
+      for (const f of b) if (a.has(f)) return true;
+      return false;
+    };
     const ready = () => [...pending].filter((id) => {
       const deps = byId.get(id).deps ?? [];
       if (deps.some((d) => escalated.has(d))) return false;
-      return deps.every((d) => done.get(d)?.status === "green");
+      if (!deps.every((d) => done.get(d)?.status === "green")) return false;
+      const myScope = scopeOf(id);
+      if (myScope.size === 0) return true;
+      for (const rid of running.keys()) {
+        if (overlaps(myScope, scopeOf(rid))) return false;
+      }
+      for (const pid of pending) {
+        if (pid === id) continue;
+        if (pid < id && overlaps(myScope, scopeOf(pid))) return false;
+      }
+      return true;
     });
     const tripped = () => {
       const settled = done.size;
@@ -697,6 +866,7 @@ async function main() {
       const { id, r } = await Promise.race(running.values());
       running.delete(id);
       done.set(id, r);
+      await appendFile(resultsStream, JSON.stringify(r) + "\n").catch((e) => console.error("results stream append failed:", e));
       if (r.status === "escalate") escalated.add(id);
     }
     for (const id of pending) {
@@ -777,5 +947,7 @@ export {
   codeLineCount,
   extractFileBlocks,
   extractLiterals,
+  httpWorker,
+  runTask,
   validate
 };

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -197,6 +197,43 @@ describe("farm.ts smoke tests", () => {
     expect(report.results.every((r: { status: string }) => r.status === "green")).toBe(true);
   });
 
+  it("streams each settled task to .farm/farm-results.jsonl as it settles (AC-08)", async () => {
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      const file = content.includes("src/hello.ts") ? "src/hello.ts" : "src/world.ts";
+      return ["```typescript", `// path: ${file}`, `export const x = 1;`, "```"].join("\n");
+    }));
+
+    const planPath = join(tmpDir, "plan.json");
+    const plan = JSON.parse(readFileSync(join(__dirname, "__fixtures__/simple.plan.json"), "utf8"));
+    plan.meta.apiBaseUrl = `http://127.0.0.1:${port}`;
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("green=2");
+
+    // The incremental settlement record exists and holds exactly one line per
+    // settled task (D7: JSONL is the per-task stream; report is authoritative).
+    const jsonlPath = join(tmpDir, ".farm/farm-results.jsonl");
+    const raw = readFileSync(jsonlPath, "utf8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(2);
+
+    // Each line parses to a JSON object carrying a result with an id.
+    const parsed = lines.map((l) => JSON.parse(l) as { id: string });
+    for (const entry of parsed) expect(typeof entry.id).toBe("string");
+
+    // Both tasks are present (settlement order is non-deterministic across two
+    // independent tasks — assert presence/count, not a strict order).
+    const ids = parsed.map((e) => e.id).sort();
+    expect(ids).toEqual(["task-a", "task-b"]);
+
+    // The authoritative final summary is still written.
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results).toHaveLength(2);
+  });
+
   it("escalates with 'drift:' note when worker writes outside filesInScope", async () => {
     ({ server: mockServer, port } = await startMockServer(() =>
       [
@@ -471,6 +508,457 @@ describe("farm.ts smoke tests", () => {
     expect(report.results[0].note).toMatch(/mutation score/);
   });
 
+  it("enriches the worker prompt with the test source AND an in-scope sibling's contents (AC-03/AC-04)", async () => {
+    // Capture every prompt the worker is sent. The mock returns a benign
+    // in-scope file so the task can settle; the assertion is on what reached it.
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/feature.ts", "export const feature = () => helper() + 1;", "```"].join("\n");
+    }));
+
+    // Plant the failing test AND an in-scope sibling in the worktree baseline
+    // with recognizable, distinct content, then commit so they exist on the
+    // integration HEAD the task's worktree is cut from.
+    const TEST_MARKER = "RECOGNIZABLE_TEST_SOURCE_MARKER_8675309";
+    const SIBLING_MARKER = "RECOGNIZABLE_SIBLING_CONTENTS_MARKER_24601";
+    writeFileSync(
+      join(tmpDir, "src", "feature.test.ts"),
+      `// ${TEST_MARKER}\nexpect(feature()).toBe(1);\n`,
+    );
+    writeFileSync(
+      join(tmpDir, "src", "helper.ts"),
+      `// ${SIBLING_MARKER}\nexport const helper = () => 0;\n`,
+    );
+    execSync("git add -A", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add failing test + sibling" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "enrich-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Implement feature using helper",
+          deps: [],
+          // helper.ts is in scope (existing sibling), feature.ts is the target.
+          filesInScope: ["src/feature.ts", "src/helper.ts"],
+          test: { path: "src/feature.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(prompts.length).toBeGreaterThan(0);
+    const firstPrompt = prompts[0];
+    // AC-03: the read-only test source reached the worker.
+    expect(firstPrompt).toContain(TEST_MARKER);
+    // AC-04: the existing in-scope sibling's contents reached the worker.
+    expect(firstPrompt).toContain(SIBLING_MARKER);
+  });
+
+  it("redacts secret-pattern matches from the injected context before transmission (AC-05)", async () => {
+    // Capture every outgoing prompt. The mock returns a benign in-scope file so
+    // the task can settle; the assertion is on what reached the third party.
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/feature.ts", "export const feature = () => helper() + 1;", "```"].join("\n");
+    }));
+
+    // Plant secret-shaped strings in an in-scope sibling that enrichment reads.
+    // The secret VALUES must never leave the trust boundary.
+    const SECRET_TOKEN = "sk-ant-PLANTEDSECRET123";
+    const SECRET_APIKEY = "PLANTEDSECRETVALUE";
+    writeFileSync(
+      join(tmpDir, "src", "feature.test.ts"),
+      `expect(feature()).toBe(1);\n`,
+    );
+    writeFileSync(
+      join(tmpDir, "src", "helper.ts"),
+      [
+        "export const helper = () => 0;",
+        `const token = "${SECRET_TOKEN}";`,
+        `api_key = "${SECRET_APIKEY}";`,
+        "",
+      ].join("\n"),
+    );
+    execSync("git add -A", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add test + sibling with planted secrets" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "redact-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Implement feature using helper",
+          deps: [],
+          filesInScope: ["src/feature.ts", "src/helper.ts"],
+          test: { path: "src/feature.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(prompts.length).toBeGreaterThan(0);
+    // No outgoing prompt may contain a planted secret value.
+    for (const p of prompts) {
+      expect(p).not.toContain(SECRET_TOKEN);
+      expect(p).not.toContain(SECRET_APIKEY);
+    }
+    // The redaction marker stands in for what was removed.
+    expect(prompts[0]).toContain("[REDACTED");
+  });
+
+  it("redacts a multi-line PEM private key as a span — no key-body line leaks (FINDING 1)", async () => {
+    // A PEM block: only the BEGIN header matches the per-line trigger word
+    // (PRIVATE). The base64 body lines carry no trigger word, so a per-line
+    // redactor would transmit the key body. Span-aware redaction must remove
+    // the whole BEGIN..END block.
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/feature.ts", "export const feature = () => helper() + 1;", "```"].join("\n");
+    }));
+
+    // Fake (non-real) PEM key. Body lines are distinct, recognizable markers
+    // with NO trigger word so a per-line redactor would let them through.
+    const KEY_BODY_1 = "FAKEKEYBODYLINEONE0000000000000000000000000000";
+    const KEY_BODY_2 = "FAKEKEYBODYLINETWO1111111111111111111111111111";
+    const KEY_BODY_3 = "FAKEKEYBODYLINETHREE222222222222222222222222==";
+    writeFileSync(join(tmpDir, "src", "feature.test.ts"), `expect(feature()).toBe(1);\n`);
+    writeFileSync(
+      join(tmpDir, "src", "helper.ts"),
+      [
+        "export const helper = () => 0;",
+        "const pem = `",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        KEY_BODY_1,
+        KEY_BODY_2,
+        KEY_BODY_3,
+        "-----END RSA PRIVATE KEY-----",
+        "`;",
+        "",
+      ].join("\n"),
+    );
+    execSync("git add -A", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add test + sibling with planted PEM" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "pem-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Implement feature using helper",
+          deps: [],
+          filesInScope: ["src/feature.ts", "src/helper.ts"],
+          test: { path: "src/feature.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(prompts.length).toBeGreaterThan(0);
+    // No outgoing prompt may contain ANY key-body line.
+    for (const p of prompts) {
+      expect(p).not.toContain(KEY_BODY_1);
+      expect(p).not.toContain(KEY_BODY_2);
+      expect(p).not.toContain(KEY_BODY_3);
+    }
+    // The redaction marker stands in for what was removed.
+    expect(prompts[0]).toContain("[REDACTED");
+  });
+
+  it("redacts the gate-output tail before it reaches the retry prompt (FINDING 2)", async () => {
+    // The gate prints a secret-shaped string then exits non-zero, forcing a
+    // retry. The retry prompt embeds the prior gate tail as priorFailure — it
+    // MUST be run through redaction so the secret value never reaches the worker.
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/hello.ts", "export function hello() { return 'hello'; }", "```"].join("\n");
+    }));
+
+    const GATE_SECRET = "sk-ant-GATETAILSECRET99999";
+    const plan = {
+      meta: { name: "gate-tail-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          // Print a secret-shaped string to stdout, then fail → forces a retry
+          // whose priorFailure carries the gate tail.
+          gate: { commands: [`node -e "console.log('${GATE_SECRET}'); process.exit(1)"`] },
+          maxRetries: 1,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    // More than one prompt means a retry happened (so a priorFailure was built).
+    expect(prompts.length).toBeGreaterThan(1);
+    // The planted secret must appear in NO outgoing prompt.
+    for (const p of prompts) {
+      expect(p).not.toContain(GATE_SECRET);
+    }
+  });
+
+  it("never reads a denylisted secret-bearing file into injected context (FINDING / data-minimization)", async () => {
+    // An in-scope .env file with recognizable contents must be skipped entirely
+    // by buildEnrichment — its body is never read into the prompt regardless of
+    // per-line redaction.
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/feature.ts", "export const feature = () => 1;", "```"].join("\n");
+    }));
+
+    const ENV_MARKER = "DENYLISTED_ENV_FILE_CONTENTS_MARKER_4815162342";
+    writeFileSync(join(tmpDir, "src", "feature.test.ts"), `expect(feature()).toBe(1);\n`);
+    // A denylisted filename whose body would otherwise be injected.
+    writeFileSync(join(tmpDir, "src", ".env"), `SOME_VAR=${ENV_MARKER}\n`);
+    execSync("git add -A -f", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add test + denylisted .env" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "denylist-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Implement feature",
+          deps: [],
+          filesInScope: ["src/feature.ts", "src/.env"],
+          test: { path: "src/feature.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(prompts.length).toBeGreaterThan(0);
+    // The denylisted file's contents must appear in NO outgoing prompt.
+    for (const p of prompts) {
+      expect(p).not.toContain(ENV_MARKER);
+    }
+  });
+
+  it("never injects a denylisted test.path source into injected context (STEP-A defense-in-depth)", async () => {
+    // The read-only test source (task.test.path) is injected via the same
+    // chokepoint as in-scope files, but until now it bypassed the
+    // isSecretBearingFilename denylist that guards in-scope files. A test.path
+    // pointing at a secret-bearing filename (e.g. *.pem/*.key/.env) must be
+    // skipped too — its body must never cross the trust boundary.
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/feature.ts", "export const feature = () => 1;", "```"].join("\n");
+    }));
+
+    const TESTPATH_MARKER = "DENYLISTED_TESTPATH_CONTENTS_MARKER_2718281828";
+    // A denylisted filename in the test.path slot whose body would otherwise be
+    // injected read-only. The body carries NO secret trigger word, so per-line
+    // redaction would NOT catch it — only the filename denylist can. That makes
+    // this an assertion on the denylist gap specifically, not on redactSecrets.
+    writeFileSync(join(tmpDir, "src", "creds.pem"), `harmless looking body ${TESTPATH_MARKER}\n`);
+    execSync("git add -A -f", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add denylisted test.path source" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "denylist-testpath", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Implement feature",
+          deps: [],
+          filesInScope: ["src/feature.ts"],
+          test: { path: "src/creds.pem" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    expect(prompts.length).toBeGreaterThan(0);
+    // The denylisted test.path body must appear in NO outgoing prompt.
+    for (const p of prompts) {
+      expect(p).not.toContain(TESTPATH_MARKER);
+    }
+  });
+
+  it("byte-caps the injected context with a visible truncation marker (AC-05)", async () => {
+    const prompts: string[] = [];
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      prompts.push(content);
+      return ["```typescript", "// path: src/feature.ts", "export const feature = () => helper() + 1;", "```"].join("\n");
+    }));
+
+    // An in-scope sibling far larger than the (test-lowered) cap, with a unique
+    // marker only at the very tail — past the cap it must not be transmitted.
+    const TAIL_MARKER = "TAIL_PAST_THE_CAP_MARKER_31337";
+    const big = "// filler line of in-scope source content\n".repeat(4000);
+    writeFileSync(join(tmpDir, "src", "feature.test.ts"), `expect(feature()).toBe(1);\n`);
+    writeFileSync(join(tmpDir, "src", "helper.ts"), `export const helper = () => 0;\n${big}\n// ${TAIL_MARKER}\n`);
+    execSync("git add -A", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add test + oversized sibling" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    const plan = {
+      meta: { name: "cap-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Implement feature using helper",
+          deps: [],
+          filesInScope: ["src/feature.ts", "src/helper.ts"],
+          test: { path: "src/feature.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_ENRICH_MAX_BYTES: "2048" });
+
+    expect(prompts.length).toBeGreaterThan(0);
+    // Content past the cap is not transmitted; a visible truncation marker is.
+    expect(prompts[0]).not.toContain(TAIL_MARKER);
+    expect(prompts[0]).toContain("TRUNCATED");
+  });
+
+  it("serializes scope-overlapping tasks so the second inherits the first's merged change (AC-06)", async () => {
+    // Two no-dep tasks whose filesInScope intersect on src/shared.ts.
+    //  - task-a writes X = src/shared.ts (carrying a recognizable marker).
+    //  - task-b lists src/shared.ts (overlap) in scope but writes a DIFFERENT
+    //    file Y = src/b-out.ts; its gate asserts X is present with A's marker, so
+    //    its success DEPENDS on inheriting A's merged change.
+    // Without scope-aware readiness both dispatch concurrently (default
+    // concurrency 4): task-b cuts its worktree from integration BEFORE A merges,
+    // so src/shared.ts is absent and B's gate fails → escalate. With the
+    // readiness filter B waits until A is green+merged, cuts from the post-A HEAD,
+    // sees X, and both reach green with no merge conflict.
+    const SHARED_MARKER = "SHARED_X_FROM_TASK_A_MARKER_112358";
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      // task-b's scope/target identifies it; otherwise it is task-a.
+      if (content.includes("src/b-out.ts")) {
+        return ["```typescript", "// path: src/b-out.ts", "export const b = 2;", "```"].join("\n");
+      }
+      return [
+        "```typescript",
+        "// path: src/shared.ts",
+        `export const shared = "${SHARED_MARKER}";`,
+        "```",
+      ].join("\n");
+    }));
+
+    // Both tasks' failing tests exist on the baseline so enrichment can read them.
+    writeFileSync(join(tmpDir, "src", "shared.test.ts"), `expect(shared).toBeDefined();\n`);
+    writeFileSync(join(tmpDir, "src", "b.test.ts"), `expect(b).toBe(2);\n`);
+    execSync("git add -A", { cwd: tmpDir, stdio: "pipe" });
+    execSync(`git commit -m "add failing tests for overlap tasks" --no-gpg-sign`, { cwd: tmpDir, stdio: "pipe" });
+
+    // task-b's gate proves it cut from the post-A-merge integration HEAD: it
+    // requires src/shared.ts to exist AND to carry A's marker. If B ran before
+    // A merged, shared.ts is absent → gate exits non-zero → escalate.
+    const bGate =
+      `node -e "const fs=require('fs');const s=fs.readFileSync('src/shared.ts','utf8');` +
+      `if(!s.includes('${SHARED_MARKER}'))process.exit(1)"`;
+
+    const plan = {
+      meta: { name: "overlap-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write shared X",
+          deps: [],
+          filesInScope: ["src/shared.ts"],
+          test: { path: "src/shared.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+        {
+          id: "task-b",
+          description: "Write b-out depending on shared X",
+          deps: [],
+          // Overlaps task-a on src/shared.ts; writes a different file.
+          filesInScope: ["src/shared.ts", "src/b-out.ts"],
+          test: { path: "src/b.test.ts" },
+          gate: { commands: [bGate] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+
+    if (result.code !== 0) {
+      console.error("AC-06 OUTPUT:", result.out);
+    }
+    // Both green, no escalation, no merge-conflict note anywhere.
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("green=2");
+    expect(result.out).toContain("escalate=0");
+
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    const b = report.results.find((r: { id: string }) => r.id === "task-b");
+    expect(b.status).toBe("green");
+    // No task escalated with a merge-conflict note.
+    for (const r of report.results as Array<{ note?: string }>) {
+      expect(r.note ?? "").not.toMatch(/merge failed/);
+    }
+
+    // The integration branch contains BOTH the merged X and Y — proving B cut
+    // from the post-A-merge HEAD and merged cleanly on top.
+    const integShared = execSync("git show farm/integration:src/shared.ts", {
+      cwd: tmpDir,
+      encoding: "utf8",
+    });
+    expect(integShared).toContain(SHARED_MARKER);
+    const integB = execSync("git show farm/integration:src/b-out.ts", {
+      cwd: tmpDir,
+      encoding: "utf8",
+    });
+    expect(integB).toContain("export const b = 2;");
+  });
+
   it("is safe to run twice in a row (stale branches cleaned)", async () => {
     ({ server: mockServer, port } = await startMockServer((body) => {
       const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
@@ -489,5 +977,11 @@ describe("farm.ts smoke tests", () => {
     const second = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
     expect(second.code).toBe(0);
     expect(second.out).toContain("green=2");
+
+    // The streaming rail is truncated at run start, so a re-run does not
+    // accumulate stale lines (the "safe to run twice" invariant covers it too).
+    const raw = readFileSync(join(tmpDir, ".farm/farm-results.jsonl"), "utf8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(2);
   });
 });

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -35,7 +35,7 @@
  * model selection is objective rather than web hearsay. No merge, no mutation.
  */
 import { spawn } from "node:child_process";
-import { readFile, writeFile, mkdir, rm, stat } from "node:fs/promises";
+import { readFile, writeFile, appendFile, mkdir, rm, stat } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,7 +43,7 @@ import { fileURLToPath } from "node:url";
 // --------------------------------------------------------------------------
 // Types — the handoff contract. Claude emits plan.json conforming to this.
 // --------------------------------------------------------------------------
-type Task = {
+export type Task = {
   id: string;
   description: string;
   deps?: string[];
@@ -52,6 +52,11 @@ type Task = {
   gate: { commands: string[] };
   context?: string;
   maxRetries?: number;
+  // Optional per-task model override (AC-02). The effective model for a task is
+  // `task.model ?? <run-level resolved model>`, layered where runTask invokes
+  // the worker; absent → identical current behavior. Model id only — no second
+  // provider or per-task apiBaseUrl.
+  model?: string;
 };
 type Plan = {
   meta: { name: string; repo?: string; model?: string; apiBaseUrl?: string };
@@ -89,6 +94,16 @@ const ENV = {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean),
+  // AC-05 byte cap on the TOTAL injected enrichment context (test source +
+  // in-scope file bodies) that leaves the trust boundary to the third-party
+  // endpoint. Default 131072 (128 KiB): more repo content now flows outbound,
+  // so the prompt must never be unbounded. 128 KiB is ~32K tokens of context —
+  // generous enough for the real test + a handful of in-scope files, yet small
+  // enough to stay well inside the FARM_REQUEST_TIMEOUT_MS (120s) single-request
+  // budget and to bound per-task token spend. Truncation past the cap is
+  // deterministic (in-order) with a visible marker; we never silently drop the
+  // boundedness guarantee.
+  enrichMaxBytes: Number(process.env.FARM_ENRICH_MAX_BYTES ?? 131_072),
 };
 
 // Mutation guard — a zero-token quality signal. After the gate goes green we
@@ -155,15 +170,234 @@ async function runGate(cwd: string, commands: string[]) {
   for (const cmd of commands) {
     const r = await run(SHELL_BIN, [SHELL_FLAG, cmd], cwd, SHELL_OPTS);
     if (r.code !== 0)
-      return { ok: false as const, failed: cmd, tail: r.out.slice(-3500) };
+      // FINDING 2: the raw gate stdout+stderr tail flows into priorFailure and
+      // is injected into the next worker prompt (buildPrompt), crossing the
+      // trust boundary to the third party. Run it through the SAME span-aware
+      // redaction as injected file bodies before it leaves runGate, so a
+      // secret-shaped string a test/gate happens to print is never transmitted.
+      // (redactSecrets is a hoisted function declaration — callable here.)
+      return { ok: false as const, failed: cmd, tail: redactSecrets(r.out.slice(-3500)) };
   }
   return { ok: true as const };
 }
 
 // --------------------------------------------------------------------------
+// shared file reader — single read path for every consumer that needs the
+// current contents of a worktree file. Returns the file text, or null on any
+// read failure (missing file, not yet created, permission). antiGamingCheck,
+// mutationCheck, AND the prompt enrichment (AC-03/AC-04) all go through here
+// rather than growing their own parallel try/catch read paths (spec Risks:
+// "Duplicated file reads"). `wt`-relative paths are resolved against the
+// worktree the caller passes.
+// --------------------------------------------------------------------------
+async function readWorktreeFile(wt: string, relPath: string): Promise<string | null> {
+  try {
+    return await readFile(path.resolve(wt, relPath), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// --------------------------------------------------------------------------
+// prompt enrichment (AC-03 / AC-04). Gathers the read-only source of the
+// failing test plus the current contents of in-scope files that already exist
+// in the worktree (best-effort direct context — no deep import resolution).
+// On the first attempt these in-scope files hold the dependency-inherited
+// baseline, which is exactly the context the worker needs to implement
+// against. Reads reflect the per-attempt worktree state because runTask calls
+// this AFTER any inter-attempt reset.
+//
+// ALL injected content is funneled through this ONE chokepoint and rendered by
+// `renderInjectedFile`, so T-05 can wrap the byte cap + secret redaction here
+// without touching buildPrompt or the call site. (T-04 does the injection +
+// shared reader only — cap and redaction are explicitly NOT done here.)
+// --------------------------------------------------------------------------
+export type InjectedFile = { path: string; contents: string; readOnly: boolean };
+
+// AC-05 secret redaction. NEW code — there is no existing in-code secret sweep
+// to reuse (the repo's sweep is the manual/hook layer per tech-stack.md). This
+// is the exact secret-pattern set from tech-stack.md "Secrets scan", applied
+// case-insensitively. Any single line that matches a pattern is replaced
+// WHOLESALE with a `[REDACTED]` marker rather than surgically excising the
+// matched span — over-redaction is the safe direction, and the line is the
+// smallest unit guaranteed to contain the full secret value (e.g. the trailing
+// token after `api_key =`).
+//
+// SPAN-AWARE for PEM blocks (FINDING 1). A purely per-line redactor is unsafe
+// for multi-line secrets: a PEM private key's `-----BEGIN ... PRIVATE KEY-----`
+// header matches the trigger word, but the base64 BODY lines carry no trigger
+// word, so a per-line pass would transmit the key material. When a
+// `-----BEGIN ... -----` delimiter line is seen, we redact the WHOLE block
+// through the matching `-----END ... -----` delimiter (or to end-of-content if
+// no END is present) as a single unit. Single-line trigger-word matches keep
+// the existing per-line behavior. Matching, never transmitting a matched
+// secret, is the invariant — see spec AC-05 / D5.
+const SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant)/i;
+// PEM-style armor delimiters. BEGIN opens a span; END closes it. Matched
+// independently of SECRET_LINE so even a `-----BEGIN CERTIFICATE-----` (no
+// trigger word) is span-redacted — armored material is opaque, redact it whole.
+const PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
+const PEM_END = /^-----END .*-----\s*$/;
+const REDACTION_MARKER = "[REDACTED — secret-pattern match removed before transmission]";
+
+// Data-minimization (defence in depth ahead of per-line/span redaction): some
+// filenames are secret-bearing by convention and should never be read into the
+// injected context AT ALL, regardless of whether their individual lines trip a
+// trigger word. Matched on the BASENAME so a nested `config/.env.production` or
+// `keys/id_rsa` is caught too. If a file is denylisted its contents are simply
+// never read — the strongest form of non-transmission.
+const SECRET_FILENAME_DENYLIST: RegExp[] = [
+  /^\.env$/i, // .env
+  /^\.env\..+$/i, // .env.local, .env.production, ...
+  /\.pem$/i, // *.pem
+  /\.key$/i, // *.key
+  /^id_rsa(\..+)?$/i, // id_rsa, id_rsa.pub, id_rsa.bak
+  /^id_ed25519(\..+)?$/i, // id_ed25519, id_ed25519.pub
+  /^id_ecdsa(\..+)?$/i, // id_ecdsa, id_ecdsa.pub
+  /\.p12$/i, // PKCS#12 keystore
+  /\.pfx$/i, // PKCS#12 keystore (Windows)
+];
+
+function isSecretBearingFilename(relPath: string): boolean {
+  const base = relPath.split(/[\\/]/).pop() ?? relPath;
+  return SECRET_FILENAME_DENYLIST.some((re) => re.test(base));
+}
+
+function redactSecrets(contents: string): string {
+  const lines = contents.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (PEM_BEGIN.test(line.trim())) {
+      // Span redaction: collapse BEGIN..END (inclusive) to one marker. If no
+      // END is found, redact through end-of-content — never let an unterminated
+      // armored body trickle out.
+      out.push(REDACTION_MARKER);
+      i++;
+      while (i < lines.length && !PEM_END.test(lines[i].trim())) i++;
+      // i now points at the END line (consumed by the span) or past the end.
+      continue;
+    }
+    out.push(SECRET_LINE.test(line) ? REDACTION_MARKER : line);
+  }
+  return out.join("\n");
+}
+
+// The single chokepoint for content that leaves the trust boundary. The byte
+// cap (applied over the rendered array in buildEnrichment) and the per-line
+// secret redaction (here) wrap every injected file body. Keep this the only
+// place injected file bodies are formatted so the boundary stays in one spot.
+function renderInjectedFile(file: InjectedFile): string {
+  const label = file.readOnly ? `${file.path} (read-only — the failing test)` : file.path;
+  return [`--- ${label} ---`, redactSecrets(file.contents)].join("\n");
+}
+
+// Deterministic byte cap over the TOTAL injected enrichment. Operates on the
+// InjectedFile[] (BEFORE buildPrompt renders it, so buildPrompt and the runTask
+// call site stay untouched) but budgets against each file's FULLY RENDERED size
+// — i.e. `renderInjectedFile` output, including the redaction substitutions and
+// the path label — so the cap reflects exactly what crosses the boundary.
+// Files are kept in order until the next would exceed the budget; the
+// overflowing file's contents are hard-truncated (UTF-8 safe) to fit and a
+// visible TRUNCATED marker appended; everything after is dropped. The prompt is
+// never unbounded. Measured in UTF-8 bytes — the unit the request body is
+// serialized in.
+const TRUNCATION_MARKER = "--- [TRUNCATED — injected context exceeded FARM_ENRICH_MAX_BYTES] ---";
+
+function capInjected(injected: InjectedFile[], maxBytes: number): InjectedFile[] {
+  const out: InjectedFile[] = [];
+  let used = 0;
+  for (const file of injected) {
+    const renderedBytes = Buffer.byteLength(renderInjectedFile(file), "utf8");
+    if (used + renderedBytes <= maxBytes) {
+      out.push(file);
+      used += renderedBytes;
+      continue;
+    }
+    // Fixed overhead this file's render adds around its contents (label line +
+    // joins): the difference between the rendered size and the contents size.
+    const contentBytes = Buffer.byteLength(redactSecrets(file.contents), "utf8");
+    const overhead = renderedBytes - contentBytes;
+    const remaining = maxBytes - used - overhead - Buffer.byteLength("\n" + TRUNCATION_MARKER, "utf8");
+    if (remaining > 0) {
+      // Truncate the (already redaction-safe) contents to the remaining byte
+      // budget on a UTF-8 boundary, then append the marker.
+      const safe = Buffer.from(redactSecrets(file.contents), "utf8")
+        .subarray(0, remaining)
+        .toString("utf8");
+      out.push({ ...file, contents: safe + "\n" + TRUNCATION_MARKER });
+    } else {
+      // No room even for this file's frame — emit a marker-only stub so the
+      // truncation is visible, then stop.
+      out.push({ ...file, contents: TRUNCATION_MARKER });
+    }
+    break;
+  }
+  return out;
+}
+
+async function buildEnrichment(wt: string, t: Task): Promise<InjectedFile[]> {
+  const injected: InjectedFile[] = [];
+  const seen = new Set<string>();
+
+  // AC-03: the read-only source of the failing test. Defense-in-depth: run the
+  // test path through the same secret-bearing-filename denylist as in-scope
+  // files (STEP-A) — a test.path pointing at .env/*.pem/*.key must never have its
+  // body cross the trust boundary, regardless of per-line redaction.
+  if (!isSecretBearingFilename(t.test.path)) {
+    const testSrc = await readWorktreeFile(wt, t.test.path);
+    if (testSrc !== null) {
+      injected.push({ path: t.test.path, contents: testSrc, readOnly: true });
+      seen.add(t.test.path);
+    }
+  } else {
+    seen.add(t.test.path);
+  }
+
+  // AC-04: current contents of in-scope files that already exist on disk in the
+  // worktree (best-effort). Skip the test path (already injected, read-only) and
+  // files that do not yet exist (e.g. the not-yet-written target).
+  for (const f of t.filesInScope) {
+    if (seen.has(f)) continue;
+    // Data-minimization: never even READ a secret-bearing filename
+    // (.env/.env.*/*.pem/*.key/id_rsa*, etc.) into injected context — its body
+    // must not cross the trust boundary regardless of per-line redaction.
+    if (isSecretBearingFilename(f)) {
+      seen.add(f);
+      continue;
+    }
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
+    injected.push({ path: f, contents: src, readOnly: false });
+    seen.add(f);
+  }
+
+  // AC-05: byte-cap the TOTAL injected context before it leaves the trust
+  // boundary. Redaction is applied per-file inside renderInjectedFile (the
+  // chokepoint), but the truncation stub here means contents already carry the
+  // redaction by the time they are re-rendered — redactSecrets is idempotent on
+  // the marker, so a redacted-then-truncated body stays redacted.
+  return capInjected(injected, ENV.enrichMaxBytes);
+}
+
+// --------------------------------------------------------------------------
 // worker prompt
 // --------------------------------------------------------------------------
-function buildPrompt(t: Task, priorFailure?: string, forbiddenExtra?: string[]) {
+function buildPrompt(
+  t: Task,
+  injected: InjectedFile[],
+  priorFailure?: string,
+  forbiddenExtra?: string[],
+) {
+  const enrichment = injected.length
+    ? [
+        ``,
+        `Current source of the relevant files (the test is read-only; implement against it):`,
+        ``,
+        ...injected.map(renderInjectedFile),
+        ``,
+      ]
+    : [];
   return [
     `Implement exactly ONE task. Your only goal: make the failing test pass.`,
     ``,
@@ -179,7 +413,7 @@ function buildPrompt(t: Task, priorFailure?: string, forbiddenExtra?: string[]) 
     forbiddenExtra && forbiddenExtra.length
       ? `\nYour previous attempt wrote these FORBIDDEN paths — do NOT touch them again:\n${forbiddenExtra.map((f) => `  - ${f}`).join("\n")}`
       : ``,
-    ``,
+    ...enrichment,
     `Solve the task with REAL logic. Do not hard-code the literal values the`,
     `test asserts — an implementation that only returns the expected constant`,
     `will be rejected.`,
@@ -245,7 +479,7 @@ export function extractFileBlocks(content: string): Array<{ path: string; body: 
   return blocks;
 }
 
-type WorkerResult = {
+export type WorkerResult = {
   ok: boolean;
   filesWritten: string[];
   error?: string;
@@ -370,6 +604,36 @@ async function runWorker(
 }
 
 // --------------------------------------------------------------------------
+// Worker seam (AC-01). The safety gates in runTask wrap ANY worker; the
+// HTTP-chat author is just one implementation. A worker is handed the task,
+// the resolved model/config, the worktree it must produce files into, and the
+// read-only forbidden set, and returns which files it wrote into the worktree.
+//
+// T-01 scope: this is the indirection point ONLY. httpWorker preserves the
+// existing runWorker behavior exactly (it still owns extractFileBlocks + write
+// and the inline isInside/read-only guards). Moving apply-ownership and the
+// containment sweep to a post-apply step in runTask is T-02 (D6) — not here.
+// --------------------------------------------------------------------------
+export type WorkerContext = {
+  cwd: string;
+  prompt: string;
+  model: string;
+  apiBaseUrl: string;
+  apiKey: string;
+  forbidden: Set<string>;
+};
+
+export interface Worker {
+  apply(ctx: WorkerContext): Promise<WorkerResult>;
+}
+
+// Default worker: the existing blind HTTP-chat author, unchanged.
+export const httpWorker: Worker = {
+  apply: (ctx) =>
+    runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden),
+};
+
+// --------------------------------------------------------------------------
 // drift check — path allowlist. Catches modified tracked files and new
 // untracked files individually (status --porcelain groups by directory).
 // --------------------------------------------------------------------------
@@ -385,6 +649,52 @@ async function checkDrift(cwd: string, allowed: Set<string>): Promise<string[]> 
   if (untracked.code === 0)
     changed.push(...untracked.out.split("\0").filter(Boolean));
   return [...new Set(changed)].filter((f) => !allowed.has(f));
+}
+
+// --------------------------------------------------------------------------
+// post-apply containment sweep (D6) — task-level enforcement of containment
+// (isInside) and the read-only-test guard over the worker's REPORTED writes.
+// It runs in runTask AFTER worker.apply() returns, inspecting the
+// `filesWritten` list the worker returns, so it protects against any worker
+// type whose write path differs from runWorker's inline loop — provided that
+// worker REPORTS what it wrote. The inline guards in runWorker stay as
+// defense-in-depth; this task-level sweep catches an escape or a test-path
+// write even when the inline guard was bypassed, as long as the path was
+// reported. (FINDING 3: narrowed from the prior "AUTHORITATIVE … protects
+// against ANY worker type" claim, which over-stated the guarantee.)
+//
+// [NEEDS-TRIAGE] Path-containment for a NON-REPORTING worker is NOT enforced
+// here. A future agentic/premium worker that writes a file OUTSIDE the worktree
+// without listing it in `filesWritten` is caught by neither this sweep nor
+// checkDrift (which only sees paths inside the worktree). The robust fix is a
+// process-level sandbox / cwd-jail guarantee around the worker, deferred to the
+// item-3 cross-model roadmap (no sandbox is built in this slice). The shipped
+// httpWorker reports its writes faithfully, so it is fully covered today.
+//
+// Returns a rejection reason (matching the existing /escapes worktree/ and
+// read-only/tampered note patterns), or null when every REPORTED path is
+// contained and none touches the read-only test.
+// --------------------------------------------------------------------------
+function postApplySweep(
+  cwd: string,
+  filesWritten: string[],
+  forbidden: Set<string>,
+): string | null {
+  for (const f of filesWritten) {
+    const absPath = path.resolve(cwd, f);
+    // Containment: nothing the worker produced may escape the worktree.
+    if (!isInside(cwd, absPath)) {
+      return `path escapes worktree: ${f}`;
+    }
+    // The failing test is read-only — reject a worker that wrote it, normalizing
+    // to forward slashes (plan paths are POSIX; path.relative emits backslashes
+    // on Windows and the guard would otherwise miss).
+    const rel = path.relative(cwd, absPath).split(path.sep).join("/");
+    if (forbidden.has(rel)) {
+      return `worker wrote read-only path: ${rel}`;
+    }
+  }
+  return null;
 }
 
 // --------------------------------------------------------------------------
@@ -414,12 +724,8 @@ async function antiGamingCheck(
   cwd: string,
   task: Task,
 ): Promise<{ risk: "none" | "warn" | "high"; note?: string }> {
-  let testSrc = "";
-  try {
-    testSrc = await readFile(path.resolve(cwd, task.test.path), "utf8");
-  } catch {
-    return { risk: "none" };
-  }
+  const testSrc = await readWorktreeFile(cwd, task.test.path);
+  if (testSrc === null) return { risk: "none" };
   const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
   if (literals.length === 0) return { risk: "none" };
 
@@ -427,12 +733,8 @@ async function antiGamingCheck(
   let anyTiny = false;
   for (const f of task.filesInScope) {
     if (f === task.test.path) continue;
-    let src = "";
-    try {
-      src = await readFile(path.resolve(cwd, f), "utf8");
-    } catch {
-      continue;
-    }
+    const src = await readWorktreeFile(cwd, f);
+    if (src === null) continue;
     const tiny = codeLineCount(src) <= 5;
     for (const lit of literals) {
       if (src.includes(lit)) {
@@ -547,12 +849,8 @@ async function mutationCheck(wt: string, task: Task): Promise<MutationResult | n
   const originals = new Map<string, string>();
   let candidates: Array<{ file: string; mutated: string; tag: string }> = [];
   for (const f of impl) {
-    let src: string;
-    try {
-      src = await readFile(path.resolve(wt, f), "utf8");
-    } catch {
-      continue;
-    }
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
     if (codeLineCount(src) <= 2) continue; // trivial file — nothing to constrain
     originals.set(f, src);
     candidates.push(...generateMutants(f, src));
@@ -622,23 +920,60 @@ async function prepareWorktree(branch: string, wt: string, from: string): Promis
   return null;
 }
 
-async function runTask(
+// Injectable dependencies for runTask. Every field defaults to the real
+// implementation, so callers (main/canary) get unchanged behavior. The seam
+// exists so the task-execution path can drive a stub Worker — and stub its
+// git/process/fs effects — under unit test without the network. The worker is
+// injected here (not called as runWorker directly), which is the AC-01 cut.
+export type RunTaskDeps = {
+  worker: Worker;
+  prepareWorktree: typeof prepareWorktree;
+  resetWorktree: typeof resetWorktree;
+  fileHash: typeof fileHash;
+  checkDrift: typeof checkDrift;
+  runGate: typeof runGate;
+  antiGamingCheck: typeof antiGamingCheck;
+  mutationCheck: typeof mutationCheck;
+  git: typeof git;
+  withMergeLock: typeof withMergeLock;
+};
+
+const defaultRunTaskDeps = (): RunTaskDeps => ({
+  worker: httpWorker,
+  prepareWorktree,
+  resetWorktree,
+  fileHash,
+  checkDrift,
+  runGate,
+  antiGamingCheck,
+  mutationCheck,
+  git,
+  withMergeLock,
+});
+
+export async function runTask(
   t: Task,
   model: string,
   apiBaseUrl: string,
   apiKey: string,
+  deps: RunTaskDeps = defaultRunTaskDeps(),
 ): Promise<Result> {
   const branch = `farm/${t.id}`;
   const wt = path.resolve(ENV.worktreeRoot, t.id);
   const limit = t.maxRetries ?? ENV.maxRetries;
+  // Per-task model (AC-02): layer the optional task-level override on top of the
+  // run-level resolved model (the `model` param, from resolveConfig:
+  // ENV.model ?? plan.meta.model — itself unchanged). Absent task.model →
+  // effectiveModel === model, i.e. exactly today's behavior. Model id only.
+  const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
   const forbidden = new Set([t.test.path]);
 
-  const prepErr = await prepareWorktree(branch, wt, ENV.integration);
+  const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
     return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
 
-  const testHashBefore = await fileHash(path.resolve(wt, t.test.path));
+  const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
 
   let priorFailure: string | undefined;
   let driftedOnce = false;
@@ -649,16 +984,21 @@ async function runTask(
   let mutationScore: number | null = null;
 
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
-    if (attempt > 1) await resetWorktree(wt); // never accumulate stale files
+    if (attempt > 1) await deps.resetWorktree(wt); // never accumulate stale files
 
-    const worker = await runWorker(
-      wt,
-      buildPrompt(t, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : undefined),
-      model,
+    // Enrichment (AC-03/AC-04): read the per-attempt worktree state — AFTER any
+    // reset above — so the test source and existing in-scope file contents
+    // reflect what the worker would actually see this attempt.
+    const injected = await buildEnrichment(wt, t);
+
+    const worker = await deps.worker.apply({
+      cwd: wt,
+      prompt: buildPrompt(t, injected, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : undefined),
+      model: effectiveModel,
       apiBaseUrl,
       apiKey,
       forbidden,
-    );
+    });
     promptTokens += worker.promptTokens ?? 0;
     completionTokens += worker.completionTokens ?? 0;
     lastFilesWritten = worker.filesWritten;
@@ -668,9 +1008,22 @@ async function runTask(
       continue;
     }
 
+    // Post-apply containment sweep (D6) — task-level enforcement over the
+    // worker's REPORTED writes (see postApplySweep header). Inspects the
+    // `filesWritten` the worker returned, so an escape or a read-only-test write
+    // is rejected even when the worker bypassed runWorker's inline guard —
+    // provided the path was reported. A NON-REPORTING worker that writes outside
+    // its reported set is NOT covered here ([NEEDS-TRIAGE], deferred to the
+    // item-3 sandbox). Runs alongside the checkDrift allowlist sweep below; the
+    // inline guards remain defense-in-depth.
+    const sweepErr = postApplySweep(wt, worker.filesWritten, forbidden);
+    if (sweepErr) {
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
+
     // The failing test must be untouched (defence in depth — the write path
     // already refuses test.path, this catches a sneaky in-scope edit too).
-    const testHashAfter = await fileHash(path.resolve(wt, t.test.path));
+    const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
     if (testHashBefore !== null && testHashAfter !== testHashBefore) {
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
@@ -678,7 +1031,7 @@ async function runTask(
     // Drift: on the FIRST drift, retry once with a hardened prompt naming the
     // offending paths — usually the cheap model is just being dumb, not the
     // spec being ambiguous. Only escalate as drift after that retry.
-    const driftFiles = await checkDrift(wt, allowed);
+    const driftFiles = await deps.checkDrift(wt, allowed);
     if (driftFiles.length > 0) {
       if (!driftedOnce && attempt <= limit) {
         driftedOnce = true;
@@ -688,19 +1041,25 @@ async function runTask(
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
 
-    const gate = await runGate(wt, t.gate.commands);
+    const gate = await deps.runGate(wt, t.gate.commands);
     if (!gate.ok) {
-      priorFailure = `failed: ${gate.failed}\n${gate.tail}`;
+      // FINDING 2: redact the WHOLE priorFailure that reaches the next worker
+      // prompt — not just the gate.tail (already redacted in runGate). The
+      // failing command line (gate.failed) is echoed verbatim too, so a secret
+      // embedded in a gate command would otherwise cross the trust boundary.
+      // redactSecrets is idempotent, so re-running it over the already-redacted
+      // tail is safe.
+      priorFailure = redactSecrets(`failed: ${gate.failed}\n${gate.tail}`);
       continue;
     }
 
     // Zero-token anti-gaming guard: fast literal-leak pass, then the deeper
     // mutation pass (skipped if the leak pass already says "high").
-    const gaming = await antiGamingCheck(wt, t);
+    const gaming = await deps.antiGamingCheck(wt, t);
     let risk = gaming.risk;
     let riskNote = gaming.note;
     if (risk !== "high") {
-      const mut = await mutationCheck(wt, t);
+      const mut = await deps.mutationCheck(wt, t);
       if (mut) {
         mutationScore = mut.score;
         if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
@@ -724,26 +1083,47 @@ async function runTask(
     // Commit + merge into the dedicated integration worktree.
     // B-1: stage only the files the worker actually wrote, not everything in the
     // worktree — git add -A would silently include any stale or injected files.
-    await git(["add", "--", ...worker.filesWritten], wt);
-    const commit = await git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
+    await deps.git(["add", "--", ...worker.filesWritten], wt);
+    const commit = await deps.git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
     if (commit.code !== 0)
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
 
-    const diffstat = (await git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
+    const diffstat = (await deps.git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
 
-    const merged = await withMergeLock(async () => {
-      const m = await git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
+    // Merge into the integration branch is INSIDE the attempt loop (AC-07/D4):
+    // a conflict is treated like a gate failure and re-enters regeneration,
+    // consuming ONE of the existing `maxRetries` attempts rather than escalating
+    // instantly. The merge stays serialized under withMergeLock so the
+    // integration worktree is never touched concurrently (T-06 prevents most
+    // overlaps; this is the residual defense-in-depth case).
+    const merged = await deps.withMergeLock(async () => {
+      const m = await deps.git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
       if (m.code !== 0) {
-        await git(["merge", "--abort"], integrationWorktree).catch(() => {});
+        await deps.git(["merge", "--abort"], integrationWorktree).catch(() => {});
         return m.out;
       }
       return null;
     });
-    if (merged !== null)
+    if (merged !== null) {
+      // Regenerate-on-conflict (AC-07): with retries left, rebuild against the
+      // UPDATED baseline instead of escalating. Reset the task worktree+branch
+      // onto the new integration HEAD (so the next attempt cuts from what the
+      // merge target now contains), then re-run the worker with a redacted,
+      // concise merge-conflict note seeded into priorFailure. resetWorktree at
+      // the loop top is then a no-op reset to this same HEAD. Per D4 this is NOT
+      // a new unbounded loop — it spends one of the existing attempts.
+      if (attempt <= limit) {
+        await deps.git(["reset", "--hard", ENV.integration], wt).catch(() => {});
+        await deps.git(["clean", "-fd"], wt).catch(() => {});
+        priorFailure = redactSecrets(`merge conflict vs integration: rebuild against the updated baseline (integration HEAD moved)\n${String(merged).slice(0, 160)}`);
+        continue;
+      }
+      // retries exhausted — escalate exactly as before (worktree left for inspection)
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+    }
 
     // success — drop the worktree (branch stays, merged into integration)
-    await git(["worktree", "remove", "--force", wt]).catch(() => {});
+    await deps.git(["worktree", "remove", "--force", wt]).catch(() => {});
     return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore };
   }
 
@@ -754,6 +1134,23 @@ async function runTask(
 // --------------------------------------------------------------------------
 // validation — duplicate ids, unknown deps, AND cycles
 // --------------------------------------------------------------------------
+// Intentional divergence from plan.schema.json's task `id` pattern
+// (`^[a-z0-9][a-z0-9-]*$`, strict kebab-case). The two are NOT meant to match:
+//   - The schema `id` pattern is the AUTHORING contract — what writing-plans is
+//     allowed to emit. It is deliberately narrow (kebab-case) for readable
+//     branch names.
+//   - SAFE_TASK_ID is the RUNTIME path-traversal defense. The id becomes a
+//     branch name (`farm/<id>`) and a worktree directory, so this check must
+//     hold regardless of HOW a plan was produced — including a hand-edited or
+//     non-schema-validated plan that never went through the authoring gate.
+//     It is therefore broader (`[A-Za-z0-9._-]`, capped at 64) but still admits
+//     only characters that cannot escape a path or branch ref.
+// Neither side is widened to match the other: tightening SAFE_TASK_ID to
+// kebab-case would weaken the runtime defense's independence from the authoring
+// layer, and widening the schema would loosen the authoring contract. A cleaner
+// reconciliation (a single shared, runtime-strict pattern enforced by validate()
+// AND advertised by the schema) is possible but is a behavior change to id
+// acceptance and out of scope for AC-02 — noted, not made. [NEEDS-TRIAGE]
 export const SAFE_TASK_ID = /^[A-Za-z0-9._-]{1,64}$/;
 
 // Single source of truth for the outbound base-URL scheme rule: require HTTPS,
@@ -919,6 +1316,14 @@ async function main() {
   await mkdir(ENV.worktreeRoot, { recursive: true });
   await mkdir(ENV.reportDir, { recursive: true });
 
+  // Streaming rail (AC-08 / D7): the incremental, append-only record of settled
+  // tasks, consumed in completion order. Truncate/initialize it at run start so
+  // a re-run does not accumulate stale lines (the "safe to run twice" invariant).
+  // The authoritative final summary remains farm-report.json (written in the
+  // finally, even on abort); on abort the consumer reconciles against it.
+  const resultsStream = path.join(ENV.reportDir, "farm-results.jsonl");
+  await writeFile(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
+
   const done = new Map<string, Result>();
   const blocked: { id: string; reason: string }[] = [];
   let aborted = false;
@@ -940,11 +1345,43 @@ async function main() {
     const pending = new Set(plan.tasks.map((t) => t.id));
     const running = new Map<string, Promise<{ id: string; r: Result }>>();
 
+    // AC-06: scope-aware readiness. Two tasks whose filesInScope intersect
+    // collide at merge time if dispatched concurrently, and a later-cut worktree
+    // would miss the earlier task's merge. This is enforced as a DERIVED
+    // readiness filter — never written as a `deps` edge — so it cannot create a
+    // plan-validation cycle (Risks: "Scheduling deadlock/starvation").
+    const scopeOf = (id: string) => new Set(byId.get(id)!.filesInScope ?? []);
+    const overlaps = (a: Set<string>, b: Iterable<string>) => {
+      for (const f of b) if (a.has(f)) return true;
+      return false;
+    };
+
     const ready = () =>
       [...pending].filter((id) => {
         const deps = byId.get(id)!.deps ?? [];
         if (deps.some((d) => escalated.has(d))) return false;
-        return deps.every((d) => done.get(d)?.status === "green");
+        if (!deps.every((d) => done.get(d)?.status === "green")) return false;
+
+        // A candidate is ready iff its written deps are green (above) AND no
+        // overlapping sibling is still in flight or ordered ahead of it:
+        //   - no currently-RUNNING task with intersecting filesInScope, AND
+        //   - no still-PENDING task with intersecting filesInScope and a lower
+        //     (lexicographic) id.
+        // Effect: among an overlapping group, members run sequentially in id
+        // order, each cutting its worktree from the integration HEAD that already
+        // contains the prior member's merge. A SETTLED sibling (green-merged or
+        // escalated) is neither running nor pending, so it no longer blocks —
+        // hence no deadlock and no starvation.
+        const myScope = scopeOf(id);
+        if (myScope.size === 0) return true;
+        for (const rid of running.keys()) {
+          if (overlaps(myScope, scopeOf(rid))) return false;
+        }
+        for (const pid of pending) {
+          if (pid === id) continue;
+          if (pid < id && overlaps(myScope, scopeOf(pid))) return false;
+        }
+        return true;
       });
 
     const tripped = () => {
@@ -973,6 +1410,11 @@ async function main() {
       const { id, r } = await Promise.race(running.values());
       running.delete(id);
       done.set(id, r);
+      // Streaming rail (AC-08 / D7): append this settled task as one JSONL line
+      // the moment it settles, so a pipelined consumer can act in completion
+      // order. Resilient by design — mirror the report-write .catch so a stream
+      // failure logs but never crashes the run (the report stays authoritative).
+      await appendFile(resultsStream, JSON.stringify(r) + "\n").catch((e) => console.error("results stream append failed:", e));
       if (r.status === "escalate") escalated.add(id);
     }
 

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -3,7 +3,11 @@
  * These test the exported helpers directly without spawning a subprocess.
  */
 import { describe, it, expect } from "vitest";
-import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl } from "./farm.ts";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker } from "./farm.ts";
+import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 
 // ---------------------------------------------------------------------------
 // extractFileBlocks
@@ -358,6 +362,184 @@ describe("assertSecureBaseUrl — resolved base URL guard", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Worker seam (T-01 / AC-01) — runTask must obtain and invoke its worker
+// THROUGH the Worker interface, not by calling runWorker/callApi directly.
+// This drives a task with every side-effecting dependency stubbed (no network,
+// no git, no spawned process) and asserts the injected worker is the thing that
+// produced the task's output.
+// ---------------------------------------------------------------------------
+describe("Worker seam — runTask invokes an injectable Worker (AC-01)", () => {
+  // A deps bag that makes runTask's git/process/fs effects no-ops, so the only
+  // behaviour under test is the worker indirection.
+  function stubDeps(worker: Worker): RunTaskDeps {
+    return {
+      worker,
+      prepareWorktree: async () => null, // worktree "created"
+      resetWorktree: async () => {},
+      fileHash: async () => null, // null short-circuits the tamper check
+      checkDrift: async () => [], // no files outside scope
+      runGate: async () => ({ ok: true as const }),
+      antiGamingCheck: async () => ({ risk: "none" as const }),
+      mutationCheck: async () => null,
+      git: async () => ({ code: 0, out: "" }),
+      withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+    };
+  }
+
+  const task: Task = {
+    id: "seam-task",
+    description: "make the test pass",
+    filesInScope: ["src/seam.ts"],
+    test: { path: "src/seam.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  it("calls the injected worker exactly once with the resolved config", async () => {
+    const calls: Array<{ model: string; apiBaseUrl: string; apiKey: string }> = [];
+    const worker: Worker = {
+      async apply(ctx) {
+        calls.push({ model: ctx.model, apiBaseUrl: ctx.apiBaseUrl, apiKey: ctx.apiKey });
+        return { ok: true, filesWritten: ["src/seam.ts"] } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(task, "stub-model", "https://api.example/v1", "stub-key", stubDeps(worker));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ model: "stub-model", apiBaseUrl: "https://api.example/v1", apiKey: "stub-key" });
+    expect(r.status).toBe("green");
+    // The worker's output is what flows into the result — proves the task path
+    // consumed the injected worker rather than an internal runWorker call.
+    expect(r.filesWritten).toEqual(["src/seam.ts"]);
+  });
+
+  it("escalates via the worker's error without ever hitting the network", async () => {
+    const worker: Worker = {
+      async apply() {
+        return { ok: false, filesWritten: [], error: "stub worker refused" } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(
+      { ...task, maxRetries: 0 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      stubDeps(worker),
+    );
+
+    expect(r.status).toBe("escalate");
+  });
+
+  it("exposes a default httpWorker implementation behind the interface", () => {
+    expect(httpWorker).toBeDefined();
+    expect(typeof httpWorker.apply).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-apply containment sweep (T-02 / D6) — containment (isInside) and the
+// read-only-test guard are enforced at the TASK level after worker.apply()
+// returns, inspecting what the worker actually produced — NOT only inside
+// runWorker's write loop. A worker that bypasses runWorker's inline guard
+// (e.g. a future agentic CLI that writes its own files) must still be caught.
+//
+// These stubs deliberately do NOT route through runWorker/httpWorker: they
+// report (and, for the escape case, physically write) paths the inline guard
+// would have refused. Red before the relocation, green after.
+// ---------------------------------------------------------------------------
+describe("Post-apply containment sweep — task-level enforcement for ANY worker (D6)", () => {
+  // Same no-op deps bag as the Worker-seam suite, but we keep the REAL
+  // containment behaviour under test by routing it through runTask's sweep.
+  function stubDeps(worker: Worker): RunTaskDeps {
+    return {
+      worker,
+      prepareWorktree: async () => null,
+      resetWorktree: async () => {},
+      fileHash: async () => null, // null short-circuits the hash tamper check
+      checkDrift: async () => [], // the allowlist sweep is satisfied
+      runGate: async () => ({ ok: true as const }),
+      antiGamingCheck: async () => ({ risk: "none" as const }),
+      mutationCheck: async () => null,
+      git: async () => ({ code: 0, out: "" }),
+      withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+    };
+  }
+
+  const task: Task = {
+    id: "sweep-task",
+    description: "make the test pass",
+    filesInScope: ["src/seam.ts"],
+    test: { path: "src/seam.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  it("escalates a worker that writes OUTSIDE the worktree, bypassing runWorker's inline guard", async () => {
+    // A worker that does NOT use runWorker's write loop — it reports a path that
+    // escapes the worktree. The inline isInside guard never ran; only the
+    // task-level post-apply sweep can catch this.
+    const escapeWorker: Worker = {
+      async apply(ctx) {
+        const escaped = path.resolve(ctx.cwd, "..", "escape.ts");
+        return { ok: true, filesWritten: [escaped] } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(
+      { ...task, maxRetries: 0 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      stubDeps(escapeWorker),
+    );
+
+    expect(r.status).toBe("escalate");
+    expect(r.note).toMatch(/escapes worktree/);
+  });
+
+  it("escalates a worker that writes the read-only test.path, bypassing runWorker's inline guard", async () => {
+    // A worker that overwrites task.test.path directly. fileHash is stubbed to
+    // null (no hash-based tamper signal), and the inline forbidden-set guard
+    // never ran — so only the task-level sweep can reject this.
+    const testTamperWorker: Worker = {
+      async apply() {
+        return { ok: true, filesWritten: [task.test.path] } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(
+      { ...task, maxRetries: 0 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      stubDeps(testTamperWorker),
+    );
+
+    expect(r.status).toBe("escalate");
+    expect(r.note).toMatch(/read-only|tampered/);
+  });
+
+  it("lets a compliant worker through the sweep (in-scope file, no escape)", async () => {
+    const goodWorker: Worker = {
+      async apply() {
+        return { ok: true, filesWritten: ["src/seam.ts"] } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(
+      { ...task, maxRetries: 0 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      stubDeps(goodWorker),
+    );
+
+    expect(r.status).toBe("green");
+    expect(r.filesWritten).toEqual(["src/seam.ts"]);
+  });
+});
+
 describe("validate — existing checks (cycles, duplicates, unknown deps)", () => {
   it("rejects duplicate task ids", () => {
     const plan = {
@@ -395,5 +577,266 @@ describe("validate — existing checks (cycles, duplicates, unknown deps)", () =
       ],
     };
     expect(() => validate(plan)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Optional per-task model (T-03 / AC-02) — the effective model for a task is
+// `task.model ?? <run-level resolved model>`, layered where runTask invokes the
+// worker. A task WITH `model` overrides; a task WITHOUT behaves EXACTLY as
+// today (run-level model passed straight through to the worker).
+// ---------------------------------------------------------------------------
+describe("Per-task model resolution — task.model ?? run-level model (AC-02)", () => {
+  function stubDeps(worker: Worker): RunTaskDeps {
+    return {
+      worker,
+      prepareWorktree: async () => null,
+      resetWorktree: async () => {},
+      fileHash: async () => null,
+      checkDrift: async () => [],
+      runGate: async () => ({ ok: true as const }),
+      antiGamingCheck: async () => ({ risk: "none" as const }),
+      mutationCheck: async () => null,
+      git: async () => ({ code: 0, out: "" }),
+      withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+    };
+  }
+
+  const baseModelTask: Task = {
+    id: "model-task",
+    description: "make the test pass",
+    filesInScope: ["src/seam.ts"],
+    test: { path: "src/seam.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  it("passes task.model to worker.apply when the task overrides the run-level model", async () => {
+    const seen: string[] = [];
+    const worker: Worker = {
+      async apply(ctx) {
+        seen.push(ctx.model);
+        return { ok: true, filesWritten: ["src/seam.ts"] } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(
+      { ...baseModelTask, model: "premium-x" },
+      "run-level-model",
+      "https://api.example/v1",
+      "stub-key",
+      stubDeps(worker),
+    );
+
+    expect(seen).toEqual(["premium-x"]);
+    expect(r.status).toBe("green");
+  });
+
+  it("passes the run-level model to worker.apply when the task has no model (unchanged behavior)", async () => {
+    const seen: string[] = [];
+    const worker: Worker = {
+      async apply(ctx) {
+        seen.push(ctx.model);
+        return { ok: true, filesWritten: ["src/seam.ts"] } satisfies WorkerResult;
+      },
+    };
+
+    const r = await runTask(
+      baseModelTask, // no `model`
+      "run-level-model",
+      "https://api.example/v1",
+      "stub-key",
+      stubDeps(worker),
+    );
+
+    expect(seen).toEqual(["run-level-model"]);
+    expect(r.status).toBe("green");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plan.schema.json — the optional per-task `model` field (T-03 / AC-02).
+// No JSON-schema validator is present in devDependencies, so we assert the
+// schema STRUCTURE directly via JSON.parse: `model` is declared on the task
+// `$defs` (required because the task object is additionalProperties:false, so
+// an undeclared field would be rejected) and additionalProperties:false is
+// kept intact (the strict authoring contract is not relaxed).
+// ---------------------------------------------------------------------------
+describe("plan.schema.json — optional per-task model (AC-02)", () => {
+  const schemaPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "plan.schema.json",
+  );
+  const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+  const taskDef = schema.$defs.task;
+
+  it("declares `model` as a string on the task properties", () => {
+    expect(taskDef.properties.model).toBeDefined();
+    expect(taskDef.properties.model.type).toBe("string");
+  });
+
+  it("does NOT add `model` to the task's required list (it is optional)", () => {
+    expect(taskDef.required).not.toContain("model");
+  });
+
+  it("keeps the task object additionalProperties:false (strict authoring contract intact)", () => {
+    // additionalProperties:false is what makes the declaration in (1) necessary:
+    // a plan carrying task.model would be rejected unless `model` is declared.
+    // Asserting this here documents that the field was added the correct way
+    // rather than by relaxing the contract.
+    expect(taskDef.additionalProperties).toBe(false);
+  });
+
+  it("would reject an unknown task field — no validator available, asserted structurally", () => {
+    // With additionalProperties:false and a fixed properties set, any field not
+    // in properties (e.g. `bogusField`) is rejected by a conforming validator.
+    // We have no validator in devDependencies, so we assert the structural
+    // precondition directly: the closed property set does not include it.
+    expect(taskDef.additionalProperties).toBe(false);
+    expect(Object.keys(taskDef.properties)).not.toContain("bogusField");
+    // and `model` IS in the closed set, so a plan with task.model is accepted.
+    expect(Object.keys(taskDef.properties)).toContain("model");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regenerate-on-conflict (T-07 / AC-07 / D4) — a merge conflict against the
+// integration branch is treated like a gate failure: the task resets to the new
+// integration HEAD and RE-RUNS the worker, consuming ONE of the existing
+// maxRetries attempts, rather than escalating on the first conflict. If retries
+// are exhausted with the merge still conflicting, it escalates exactly as today.
+//
+// The clean deterministic way to force a conflict is the injected deps: the git
+// stub returns a non-zero `merge` on the first merge attempt and code 0 on the
+// second, with a worker we can count. (The merge runs through deps.git inside
+// deps.withMergeLock; everything else is a no-op.)
+// ---------------------------------------------------------------------------
+describe("Regenerate-on-conflict — merge conflict re-enters regeneration (AC-07)", () => {
+  const task: Task = {
+    id: "conflict-task",
+    description: "make the test pass",
+    filesInScope: ["src/conflict.ts"],
+    test: { path: "src/conflict.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  // A deps bag where `git` is a programmable stub: every `merge --no-ff` consults
+  // `mergeOutcomes` (shift one per call); all other git calls succeed as no-ops.
+  // `worker` counts apply() invocations so we can prove regeneration happened.
+  function conflictDeps(opts: {
+    worker: Worker;
+    // one entry consumed per merge attempt: null === success, string === conflict output
+    mergeOutcomes: Array<string | null>;
+    resetCalls: Array<string[]>;
+  }): RunTaskDeps {
+    const outcomes = [...opts.mergeOutcomes];
+    return {
+      worker: opts.worker,
+      prepareWorktree: async () => null,
+      resetWorktree: async () => {},
+      fileHash: async () => null,
+      checkDrift: async () => [],
+      runGate: async () => ({ ok: true as const }),
+      antiGamingCheck: async () => ({ risk: "none" as const }),
+      mutationCheck: async () => null,
+      git: async (args: string[]) => {
+        if (args.includes("merge") && args.includes("--no-ff")) {
+          const next = outcomes.shift();
+          // unspecified beyond the provided outcomes: default to conflict so an
+          // always-conflicting test doesn't accidentally fall through to green
+          const out = next === undefined ? "CONFLICT (content): fallback" : next;
+          if (out !== null) return { code: 1, out };
+          return { code: 0, out: "" };
+        }
+        if (args[0] === "reset" || args[0] === "clean") {
+          opts.resetCalls.push(args);
+        }
+        return { code: 0, out: "" };
+      },
+      withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+    };
+  }
+
+  it("re-runs the worker after a conflict and ends green when the second merge succeeds", async () => {
+    let workerCalls = 0;
+    const worker: Worker = {
+      async apply() {
+        workerCalls++;
+        return { ok: true, filesWritten: ["src/conflict.ts"] } satisfies WorkerResult;
+      },
+    };
+    const resetCalls: Array<string[]> = [];
+
+    const r = await runTask(
+      // maxRetries:1 → 2 attempts total; first merge conflicts, second succeeds.
+      { ...task, maxRetries: 1 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      conflictDeps({ worker, mergeOutcomes: ["CONFLICT (content): src/conflict.ts", null], resetCalls }),
+    );
+
+    // Regeneration happened: the worker was invoked a SECOND time after the
+    // conflict (not an instant escalate, which would leave it at one call).
+    expect(workerCalls).toBe(2);
+    // The conflict path reset the task worktree to the new integration HEAD
+    // before re-running (rebuild against the updated baseline).
+    expect(resetCalls.some((a) => a[0] === "reset" && a.includes("--hard"))).toBe(true);
+    // Second merge succeeded → green, NOT escalate.
+    expect(r.status).toBe("green");
+    expect(r.attempts).toBe(2);
+  });
+
+  it("escalates with a merge-related note when every merge conflicts and retries are spent (no infinite loop)", async () => {
+    let workerCalls = 0;
+    const worker: Worker = {
+      async apply() {
+        workerCalls++;
+        return { ok: true, filesWritten: ["src/conflict.ts"] } satisfies WorkerResult;
+      },
+    };
+    const resetCalls: Array<string[]> = [];
+
+    const r = await runTask(
+      // maxRetries:1 → 2 attempts; BOTH merges conflict → escalate after the budget.
+      { ...task, maxRetries: 1 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      conflictDeps({
+        worker,
+        mergeOutcomes: ["CONFLICT (content): a", "CONFLICT (content): b"],
+        resetCalls,
+      }),
+    );
+
+    // The worker ran on each of the two attempts (bounded — no unbounded loop).
+    expect(workerCalls).toBe(2);
+    expect(r.status).toBe("escalate");
+    expect(r.note).toMatch(/merge/i);
+    expect(r.attempts).toBe(2);
+  });
+
+  it("escalates instantly (no regeneration) on conflict when maxRetries is 0", async () => {
+    let workerCalls = 0;
+    const worker: Worker = {
+      async apply() {
+        workerCalls++;
+        return { ok: true, filesWritten: ["src/conflict.ts"] } satisfies WorkerResult;
+      },
+    };
+    const resetCalls: Array<string[]> = [];
+
+    const r = await runTask(
+      { ...task, maxRetries: 0 },
+      "stub-model",
+      "https://api.example/v1",
+      "stub-key",
+      conflictDeps({ worker, mergeOutcomes: ["CONFLICT (content): only-attempt"], resetCalls }),
+    );
+
+    // Budget is zero retries → the single attempt's conflict escalates at once.
+    expect(workerCalls).toBe(1);
+    expect(r.status).toBe("escalate");
+    expect(r.note).toMatch(/merge failed vs integration/);
   });
 });

--- a/plugins/ca/tools/plan.schema.json
+++ b/plugins/ca/tools/plan.schema.json
@@ -83,6 +83,10 @@
           "type": "string",
           "description": "Minimal context slice — relevant types/interfaces/conventions only. NOT the whole module."
         },
+        "model": {
+          "type": "string",
+          "description": "Optional per-task model id override. When set, the effective model for this task is task.model; when absent it falls back to the run-level resolved model (FARM_MODEL / meta.model). Model id only — no per-task provider or apiBaseUrl. Must be declared here because the task object is additionalProperties:false."
+        },
         "maxRetries": {
           "type": "integer",
           "minimum": 0,


### PR DESCRIPTION
## Summary

Reframes the `--farm` backend from a single blind cheap-worker dispatcher into a **pluggable execution backend**, and hardens it. The cheap HTTP-chat worker ships today; the new `Worker` seam admits premium/agentic workers (roadmap) behind the *same* hard gates.

## What changed
- **Worker interface seam** — `runTask` invokes an injectable `Worker`; the HTTP-chat author is one implementation. The worker owns *apply*; containment (path-escape + read-only-test) moved to a **task-level post-apply sweep** that holds for any worker type.
- **Prompt enrichment** — the failing-test source + in-scope file contents now reach the worker (it was blind). Byte-capped (`FARM_ENRICH_MAX_BYTES`, 128 KiB) and **secret-redacted** (span-aware PEM, gate-output tail, `.env`/`.pem`/`.key` denylist) before leaving the trust boundary.
- **Optional per-task `model`** — resolves `task.model ?? meta.model` (design-for cross-model; no second provider built).
- **Scope-aware scheduling** — tasks overlapping an unfinished sibling's `filesInScope` serialize (derived order, id-tiebroken) instead of colliding at merge.
- **Regenerate-on-conflict** — a merge conflict resets to the new integration HEAD and re-runs the worker once before escalating.
- **Streaming rail** — each settled task appends to `.farm/farm-results.jsonl`; consumers run Phase 3+5 per green, Phase 4 stays a barrier, abort reconciles via `farm-report.json` (D7).
- **Docs** — pluggable-backend reframe across persona / `farm.md` / `SPRINT.md` / dispatch ref; README Feature Forge section restructured (index + parallel per-feature layout); version 2.3.1 → 2.4.0.

## Test plan
- `cd plugins/ca/tools && npm test` → **93 passing** (incl. AC-01…08 behavioral tests).
- `npm run typecheck` clean; `npm run build` idempotent (farm.js not stale).
- `python .github/scripts/check-plugin-refs.py` intact; hook guards (62) + cold-install (134) pass.
- `coverage-auditor`: PASS — all 8 obligations exercised with real assertions.

## Security (conflict-hierarchy §2 — security/correctness, top)
Enrichment increases what crosses the trust boundary to the third-party endpoint. Dual-lens review: `security-reviewer` BLOCK (1 CRITICAL multi-line PEM escape; 2 HIGH: gate-output egress, over-broad containment claim) → remediated (span-aware PEM redaction, gate-tail redaction, denylist, narrowed claim) → re-review **PASS**; `auth-crypto-reviewer` PASS; secret-handling gate PASS (`FARM_API_KEY` via approved `process.env`, never in prompts/logs).

## Deferred / known (`[NEEDS-TRIAGE]`, non-blocking)
- Non-reporting-worker path-containment (sandboxed cwd) — for the future agentic worker; `httpWorker` reports faithfully.
- `SAFE_TASK_ID` ↔ schema `id` pattern reconciliation.
- Pre-existing: `--canary` and circuit-breaker lack tests; coverage tooling unconfigured (v8 under-reports the subprocess suite).

## Relates to
`CONFIRM-05` — produces real-run escalation-rate evidence toward the `--farm` promotion bar; does **not** resolve it. Spec/plan: `.codearbiter/specs|plans/farm-pluggable-backend.md`.
