### PR TITLE
fix(docs): anti-slop copy pass on the chore docs lane (#60) + add PRIVACY.md

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,74 @@
+# Privacy Policy
+
+**Effective date:** 2026-06-14
+
+codeArbiter collects no personal data, sends no telemetry, and makes no network
+calls in its default operation. There is no account, no tracking, and no server
+operated by this project. Everything runs locally in your Claude Code session.
+
+This document explains what the plugin stores, where it stores it, and the two
+opt-in features that can transmit or record data.
+
+## What the plugin stores, and where
+
+All project state lives in a single `.codearbiter/` directory at the root of
+**your** repository: stage, specs, plans, ADRs, the decision log, and the
+append-only audit logs. These are plain files committed alongside your code.
+They stay in your repository under your control and survive uninstalling the
+plugin. This project never receives a copy of them.
+
+The optional statusline writes one entry into your global
+`~/.claude/settings.json`. It backs up whatever was there and restores it when
+you remove the statusline. Nothing in that file leaves your machine.
+
+Hooks run on your machine as part of normal operation. By design, **no hook
+makes a network call.** They read and write the local files described above and
+shell out to `git`. Nothing is transmitted off your machine.
+
+## Opt-in features that touch data
+
+Both features below are off by default. codeArbiter never enables either on your
+behalf. Each is turned on only by an explicit environment variable or command
+flag that you set.
+
+### Pluggable execution farm (`/ca:sprint --farm`)
+
+When you run a sprint with the `--farm` flag, the implementation step sends a
+worker prompt to a third-party, OpenAI-compatible provider that **you** configure
+and authenticate with `FARM_API_KEY`. What you send and to whom is your choice;
+this project operates no endpoint and receives nothing.
+
+The transmitted prompt contains the failing-test source and in-scope file context
+for the task. Before transmission it is byte-capped (`FARM_ENRICH_MAX_BYTES`,
+default 131072) and scanned to redact secrets. `FARM_API_KEY` is never committed
+to the repository, written to an audit file, or placed in a prompt.
+
+If you do not pass `--farm`, no prompt is ever sent to any provider.
+
+### Live transcript pruning, dry mode (`CODEARBITER_PRUNE=dry`)
+
+In `dry` mode the pruner writes one JSONL row per decision to a local file at
+`~/.codearbiter/metrics/prune-dry.jsonl` (relocatable with
+`CODEARBITER_PRUNE_METRICS`). Each row records only would-be reduction sizes,
+per-strategy savings, and a validation verdict. It contains **no transcript
+content.** The file is local. Nothing is uploaded.
+
+If you choose to share that file to help promote the feature, you do so manually
+by attaching it to a GitHub issue. That is your action, not the plugin's.
+
+## Third parties
+
+The only data flow to a third party is the execution farm above, and only when
+you opt in and configure the provider yourself. Your use of that provider is
+governed by that provider's own terms and privacy policy. Claude Code itself is
+governed by Anthropic's terms and privacy policy.
+
+## Changes
+
+If this policy changes, the effective date above is updated and the change is
+recorded in the repository history.
+
+## Contact
+
+Questions about this policy: open an issue at
+<https://github.com/arbiterForge/codeArbiter/issues>.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.4.0" src="https://img.shields.io/badge/version-2.4.0-2b7489">
+<img alt="version 2.4.1" src="https://img.shields.io/badge/version-2.4.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-34-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/commands/chore.md
+++ b/plugins/ca/commands/chore.md
@@ -12,7 +12,14 @@ the gates that fit it — and nothing it doesn't need. Everything still exits th
 ## Types
 
 **docs** — README, comments, CHANGELOG, `.codearbiter/` prose, typo fixes.
-- Gates: secrets scan over the diff; diff review (no behavioral code change smuggled in); `commit-gate`.
+- Gates: secrets scan over the diff; diff review (no behavioral code change smuggled in);
+  anti-slop copy pass on any user-facing doc in the change; `commit-gate`.
+- **Anti-slop copy pass** — for any user-facing doc the change touches (repo-root community docs
+  and `docs/**`; not codeArbiter's own framework bodies), load
+  `${CLAUDE_PLUGIN_ROOT}/includes/anti-slop-design/INDEX.md`, then `core.md` and the
+  `medium-documents` leaf (§7.A.1), and run the §3.A em-dash ban and the §3.B copy self-audit over
+  the authored prose before `commit-gate`. The `H-13` PostToolUse reminder surfaces §3.A separator
+  dashes as you write, so the pass is a confirmation, not a discovery.
 - No `tdd` — prose has no failing test to write.
 
 **deps** — bump an existing dependency's version (manifest + lockfile together, never one without
@@ -40,7 +47,8 @@ the other).
 
 MUST reject a change containing behavioral code (beyond the revert itself) — that is `/ca:feature`
 or `/ca:fix` territory. MUST keep manifest and lockfile changes in the same commit for `deps`.
-MUST run the full suite for `deps` and `revert`. Never skips `commit-gate`.
+MUST run the full suite for `deps` and `revert`. MUST run the anti-slop copy pass on any user-facing
+doc a `docs` change authors or edits. Never skips `commit-gate`.
 
 ## When NOT to use
 

--- a/plugins/ca/hooks/_sloplib.py
+++ b/plugins/ca/hooks/_sloplib.py
@@ -1,0 +1,90 @@
+# codeArbiter v2 — anti-slop copy-law detector (advisory).
+#
+# A lightweight guard for the single highest-signal AI tell: the em-dash / en-dash
+# used as a PROSE sentence-separator (anti-slop-design core §3.A). It backs the
+# PostToolUse reminder in post-write-edit.py and is the mechanical aid #60 asks
+# for, so the PR #59 regression class (user-facing docs shipping with separator
+# dashes) cannot recur silently.
+#
+# This is a heuristic, not a parser, and it is advisory — it nudges the producer
+# to run the §3.A/§3.B copy self-audit; it never blocks. It honors the §3.A
+# exemptions it can detect cheaply (fenced/inline code, URLs, numeric/date ranges)
+# and errs toward silence on the rest.
+
+import re
+
+EM_DASH = "—"
+EN_DASH = "–"
+_DASHES = (EM_DASH, EN_DASH)
+
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+# Strip URLs, autolinks/HTML tags and comments, and markdown link targets so a
+# dash inside any of them is never read as prose.
+_URL_RE = re.compile(r"https?://\S+|<[^>]*>|\]\([^)]*\)")
+# Numeric / date range: a dash flanked by digits (pp. 12–18, 2019–2024). Correct
+# typography per §3.A, never a finding.
+_RANGE_RE = re.compile(r"\d\s*[–—]\s*\d")
+# A letter or digit (Unicode), used to confirm a dash actually joins two text
+# spans rather than standing alone (e.g. a lone "—" N/A marker in a table cell).
+_WORD_RE = re.compile(r"[^\W_]", re.UNICODE)
+
+
+def _prose_only(line):
+    """Drop the spans §3.A exempts so only candidate prose remains."""
+    line = _INLINE_CODE_RE.sub(" ", line)
+    line = _URL_RE.sub(" ", line)
+    line = _RANGE_RE.sub(" ", line)
+    return line
+
+
+def _segment_separates(seg):
+    """True if `seg` contains an em/en dash with word characters on BOTH sides —
+    i.e. it joins two text spans (a prose separator), not a lone filler dash."""
+    for d in _DASHES:
+        idx = seg.find(d)
+        while idx != -1:
+            if _WORD_RE.search(seg[:idx]) and _WORD_RE.search(seg[idx + 1:]):
+                return True
+            idx = seg.find(d, idx + 1)
+    return False
+
+
+def find_prose_separator_dashes(text):
+    """Return a finding per line that uses an em/en dash as a prose separator.
+
+    Each finding is {"line": <1-based int>, "context": <stripped line text>}.
+    Exempt: fenced code blocks, inline code, URLs, numeric/date ranges, and a
+    lone dash that joins no text (split on `|` so a table-cell N/A marker is not
+    mistaken for a separator).
+    """
+    findings = []
+    in_fence = False
+    for i, raw in enumerate(text.splitlines(), start=1):
+        if _FENCE_RE.match(raw):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        prose = _prose_only(raw)
+        if any(_segment_separates(seg) for seg in prose.split("|")):
+            findings.append({"line": i, "context": raw.strip()})
+    return findings
+
+
+def in_antislop_doc_scope(rel_path):
+    """True for user-facing Markdown the anti-slop bundle governs: repo-root
+    community docs and docs/**. Excludes codeArbiter's own framework bodies
+    (everything under plugins/) and machine-managed .codearbiter/ state."""
+    if not rel_path:
+        return False
+    p = rel_path.replace("\\", "/")
+    if p.startswith("./"):
+        p = p[2:]
+    if not p.lower().endswith(".md"):
+        return False
+    if p.startswith("plugins/") or p.startswith(".codearbiter/"):
+        return False
+    if p.startswith("docs/"):
+        return True
+    return "/" not in p

--- a/plugins/ca/hooks/post-write-edit.py
+++ b/plugins/ca/hooks/post-write-edit.py
@@ -19,6 +19,7 @@ from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, project_root, read_input, remind,
     tool_input, utf8_stdio,
 )
+from _sloplib import find_prose_separator_dashes, in_antislop_doc_scope  # noqa: E402
 
 DEP_MANIFEST_RE = re.compile(
     r"(package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|requirements\.txt"
@@ -113,6 +114,19 @@ def main():
     if SECRET_RE.search(content):
         remind("H-10", "Possible hardcoded secret. Run the secret-handling check before "
                        "committing. The commit will block until the gate records a pass.")
+
+    # H-13: a user-facing doc was written with an em/en dash used as a prose
+    # separator (anti-slop-design core §3.A, the single highest-signal AI tell).
+    # Advisory nudge to run the copy self-audit before it ships. Scope is community
+    # docs + docs/**, never codeArbiter's own framework bodies (see _sloplib).
+    if rel and not rel.startswith("..") and in_antislop_doc_scope(rel):
+        hits = find_prose_separator_dashes(content)
+        if hits:
+            shown = ", ".join(str(h["line"]) for h in hits[:5])
+            more = "" if len(hits) <= 5 else f" (+{len(hits) - 5} more)"
+            remind("H-13", f"{rel}: em/en dash used as a prose separator on line(s) "
+                           f"{shown}{more} (anti-slop-design §3.A). Restructure the prose "
+                           f"and run the §3.A/§3.B copy self-audit before committing.")
 
     sys.exit(0)
 

--- a/plugins/ca/hooks/tests/test_post_write_edit_slop.py
+++ b/plugins/ca/hooks/tests/test_post_write_edit_slop.py
@@ -1,0 +1,59 @@
+"""Integration tests for the H-13 anti-slop reminder in post-write-edit.py.
+
+Drives the actual hook file over stdin in a git-initialized, arbiter-enabled
+temp repo, proving the scope gate (community docs in, framework bodies out) that
+is the #60 fix.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOOK = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "post-write-edit.py")
+EM = "—"
+
+
+class TestH13SlopReminder(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        os.makedirs(os.path.join(self.root, ".codearbiter"))
+        with open(os.path.join(self.root, ".codearbiter", "CONTEXT.md"),
+                  "w", encoding="utf-8") as f:
+            f.write("---\narbiter: enabled\n---\n# ctx\n")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _stderr(self, rel_path, content):
+        abspath = os.path.join(self.root, rel_path.replace("/", os.sep))
+        os.makedirs(os.path.dirname(abspath), exist_ok=True)
+        payload = {"hook_event_name": "PostToolUse", "cwd": self.root,
+                   "tool_name": "Write",
+                   "tool_input": {"file_path": abspath, "content": content}}
+        proc = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
+                              capture_output=True, text=True, cwd=self.root,
+                              encoding="utf-8")
+        return proc.stderr
+
+    def test_reminds_on_user_facing_doc_with_separator_dash(self):
+        err = self._stderr("README.md", f"The gate blocks {EM} the human resolves.\n")
+        self.assertIn("H-13", err)
+
+    def test_silent_on_clean_user_facing_doc(self):
+        err = self._stderr("README.md", "Plain prose. No separator dashes here.\n")
+        self.assertNotIn("H-13", err)
+
+    def test_silent_on_framework_body_even_with_dash(self):
+        # A command body under plugins/ is out of anti-slop scope by design.
+        err = self._stderr("plugins/ca/commands/chore.md",
+                           f"Routing {EM} the orchestrator decides.\n")
+        self.assertNotIn("H-13", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_sloplib.py
+++ b/plugins/ca/hooks/tests/test_sloplib.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _sloplib as S  # noqa: E402
+
+EM = "—"
+EN = "–"
+
+
+class TestProseSeparatorDashes(unittest.TestCase):
+    # Regression for #60: user-facing docs shipped with em-dash prose separators
+    # (the core 3.A tell) because nothing flagged them. The detector is the guard.
+
+    def test_flags_em_dash_separator_in_prose(self):
+        findings = S.find_prose_separator_dashes(f"The gate blocks {EM} the human resolves.\n")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["line"], 1)
+
+    def test_flags_en_dash_separator_in_prose(self):
+        findings = S.find_prose_separator_dashes(f"One thing {EN} then another.\n")
+        self.assertEqual(len(findings), 1)
+
+    def test_clean_prose_has_no_findings(self):
+        findings = S.find_prose_separator_dashes("Plain prose. Two sentences. No dashes.\n")
+        self.assertEqual(findings, [])
+
+    def test_fenced_code_block_is_exempt(self):
+        text = f"Intro line.\n```\nfoo {EM} bar (this is code)\n```\nOutro line.\n"
+        self.assertEqual(S.find_prose_separator_dashes(text), [])
+
+    def test_inline_code_is_exempt(self):
+        self.assertEqual(S.find_prose_separator_dashes(f"Use `a {EM} b` literally.\n"), [])
+
+    def test_numeric_and_date_range_en_dash_is_exempt(self):
+        # core 3.A: numeric/date ranges with an en-dash are correct typography.
+        text = f"Active 2019{EN}2024, pp. 12{EN}18.\n"
+        self.assertEqual(S.find_prose_separator_dashes(text), [])
+
+    def test_url_with_dash_is_exempt(self):
+        text = f"See https://example.com/a{EM}b for detail.\n"
+        self.assertEqual(S.find_prose_separator_dashes(text), [])
+
+    def test_lone_dash_table_cell_is_exempt(self):
+        # An em-dash as a standalone table-cell value (an N/A marker) is not a
+        # prose sentence separator — it joins nothing.
+        text = f"| `SessionStart` | {EM} | runs | no |\n"
+        self.assertEqual(S.find_prose_separator_dashes(text), [])
+
+    def test_real_separator_inside_table_cell_is_flagged(self):
+        text = f"| col | it blocks {EM} then resolves | end |\n"
+        self.assertEqual(len(S.find_prose_separator_dashes(text)), 1)
+
+    def test_reports_correct_line_number(self):
+        text = f"Line one is clean.\nLine two has {EM} a separator.\n"
+        findings = S.find_prose_separator_dashes(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["line"], 2)
+
+
+class TestAntiSlopDocScope(unittest.TestCase):
+    def test_root_community_docs_in_scope(self):
+        for p in ("README.md", "PRIVACY.md", "SECURITY.md", "CONTRIBUTING.md",
+                  "CODE_OF_CONDUCT.md", "CHANGELOG.md"):
+            self.assertTrue(S.in_antislop_doc_scope(p), p)
+
+    def test_docs_dir_in_scope(self):
+        self.assertTrue(S.in_antislop_doc_scope("docs/hooks.md"))
+        self.assertTrue(S.in_antislop_doc_scope("docs/guide/intro.md"))
+
+    def test_framework_bodies_out_of_scope(self):
+        # The bundle excludes codeArbiter's own framework docs — all under plugins/.
+        for p in ("plugins/ca/ORCHESTRATOR.md", "plugins/ca/commands/chore.md",
+                  "plugins/ca/agents/scout.md",
+                  "plugins/ca/includes/anti-slop-design/core.md"):
+            self.assertFalse(S.in_antislop_doc_scope(p), p)
+
+    def test_codearbiter_state_out_of_scope(self):
+        self.assertFalse(S.in_antislop_doc_scope(".codearbiter/CONTEXT.md"))
+
+    def test_non_markdown_out_of_scope(self):
+        self.assertFalse(S.in_antislop_doc_scope("README.txt"))
+        self.assertFalse(S.in_antislop_doc_scope("src/main.py"))
+
+    def test_windows_separators_normalized(self):
+        self.assertFalse(S.in_antislop_doc_scope("plugins\\ca\\ORCHESTRATOR.md"))
+        self.assertTrue(S.in_antislop_doc_scope("docs\\hooks.md"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Two related changes, two commits:

1. **`fix(docs)` — close the real part of #60.** User-facing docs authored through the `/ca:chore` docs lane got no anti-slop copy-law pass, so the core §3.A em-dash separator tell shipped unflagged (seen in PR #59). This adds:
   - an explicit anti-slop copy pass to `chore.md`'s docs lane (load `anti-slop-design` INDEX + core + `medium-documents` §7.A.1; run the §3.A em-dash ban and §3.B copy self-audit) before `commit-gate`;
   - `_sloplib.py`, a defense-in-depth detector for em/en dashes used as prose separators in user-facing markdown (root community docs + `docs/**`, never the framework's own bodies under `plugins/`), wired as the advisory `H-13` PostToolUse reminder. It exempts fenced/inline code, URLs, numeric/date ranges, and lone N/A dashes in table cells.

2. **`docs` — add `PRIVACY.md`.** Supplies the Privacy Policy URL for the Claude Community Marketplace listing and documents the no-data-by-default posture plus the two opt-in data flows (`--farm`, prune dry metrics). Authored through the anti-slop pass this PR adds.

## Findings while investigating #60

- `/ca:pr` (`pr.md`) and the `release` skill **already** apply the inline anti-slop pass; those candidate causes were stale. The genuine open gap was the `/ca:chore` docs lane.
- The "`design-quality-reviewer` not dispatchable" symptom was **a stale local plugin cache** (install pinned at 2.1.1; the agent shipped in 2.2.0), not a repo defect. Reviewers running an older install should `/plugin marketplace update codearbiter` + reinstall to pick it up. No code change was warranted.

## Test plan

- New `test_sloplib.py` (detector + scope, including exemptions and the table-cell N/A case) and `test_post_write_edit_slop.py` (end-to-end H-13 firing: community doc flagged, framework body and clean prose silent).
- Full hook suite green: **387 tests pass**.
- Dogfood: the detector reports `PRIVACY.md` clean and finds genuine pre-existing separators in `README.md`/`CHANGELOG.md` (left untouched; out of this PR's scope).

Closes #60.
