### PR TITLE
docs(orchestrator): clarify /ca:dev is the gates-off escape hatch

### DIFF
--- a/plugins/ca/ORCHESTRATOR.md
+++ b/plugins/ca/ORCHESTRATOR.md
@@ -22,8 +22,13 @@ document means `/ca:feature`. When you tell the user what to type, use the `/ca:
 
 ## /dev — Maintainer Override (evaluated FIRST, every turn, before anything else)
 
-`/ca:dev` (optionally `/ca:dev "note"`) suspends orchestration for editing codeArbiter itself —
-skill, agent, command, and hook bodies, `ORCHESTRATOR.md`, settings. It is **env-gated and logged**:
+`/ca:dev` (optionally `/ca:dev "note"`) **suspends the gates entirely** to edit codeArbiter itself
+with no orchestration mediating — skill, agent, command, and hook bodies, `ORCHESTRATOR.md`, settings.
+It is the gates-off escape hatch, **not** the required lane for touching those files: normal
+development of codeArbiter — fixing a hook bug, adding a command, editing this persona — flows through
+the ordinary gated lanes (`/ca:feature`, `/ca:fix`, `/ca:chore`) and ships via PR + release, the same
+dogfooding path as any other change. Reach for `/ca:dev` only when orchestration itself is broken or
+genuinely in the way of editing it. It is **env-gated and logged**:
 
 - **Gate:** activates only when the `CODEARBITER_DEV` environment variable is set to `1`. Absent or
   empty → refuse in one line ("dev mode requires CODEARBITER_DEV=1") and remain in orchestration.


### PR DESCRIPTION
## What

Tightens the `/dev` section in `ORCHESTRATOR.md`. The old wording ("suspends orchestration for editing codeArbiter itself — skill, agent, command, and hook bodies") reads as *"editing these file types requires dev mode."*

It does not. `/ca:dev`'s defining property is that it **suspends the gates**. Normal development of codeArbiter — including its own command/hook/persona bodies — flows through the ordinary gated lanes (`/ca:feature`, `/ca:fix`, `/ca:chore`) and ships via PR + release, the same dogfooding path every release takes (e.g. #56 added an agent body as a normal gated PR). `/ca:dev` is the escape hatch for when orchestration itself is broken or in the way.

## Why

This exact ambiguity caused a real misroute: a bug fix to a command body was initially classed as `/ca:dev` work when it belonged in `/ca:fix`.

## Notes

- Docs-only change to a framework body (out of anti-slop scope). No behavioral change, no version bump (rides the untagged 2.4.1).