### PR TITLE
docs: act on #70 (strategic ADRs + README first pass)

### DIFF
--- a/.codearbiter/decisions/0005-split-persona-register.md
+++ b/.codearbiter/decisions/0005-split-persona-register.md
@@ -1,0 +1,46 @@
+---
+status: accepted
+date: 2026-06-16
+title: Split the persona register into terse gates and conversational thinking
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: plugins/ca/ORCHESTRATOR.md, plugins/ca/skills/brainstorming/SKILL.md, plugins/ca/skills/debug/SKILL.md, plugins/ca/skills/decision-variance/SKILL.md
+---
+
+# ADR-0005 — Split the persona register
+
+## Status
+Accepted — ratified 2026-06-16 by SUaDtL@users.noreply.github.com
+
+## Context
+The 2026-06 multi-agent market-readiness evaluation (issue #70) found that daily use
+"feels flat," and attributed it to the persona being terse everywhere by design. A uniformly
+mechanical voice caps the back-and-forth that makes an assistant feel alive, which suppresses
+adoption without strengthening the product. The opposing risk: softening the gates dilutes
+their authority, because a gate that chats is a gate a user argues with.
+
+## Decision
+The persona runs two registers, scoped by surface. Gates and enforcement (commit-gate, the
+reviewer fleet, hard STOPs, BLOCK findings) stay terse, mechanical, and non-negotiable. The
+thinking surfaces (`brainstorming`, `debug`, and decision-variance/SMARTS) run a
+conversational register: they explore, ask, and reason with the user. Warmth lives where it
+helps the user think; it never reaches the surfaces whose job is to refuse.
+
+## Alternatives considered
+- **A1 pure enforcement (status quo)** — terse everywhere. Reliable-strong on gate authority,
+  but it is the documented cause of flat daily feel: adoption cost with no enforcement gain.
+- **A2 pure engagement** — conversational throughout, gates included. Highest adoption-feel
+  upside, but Reliable-weak: a chatty gate dilutes the stop signal that is the product's core.
+
+## Consequences
+Easier: the exploratory surfaces can build rapport and surface intent, which is where adoption
+friction actually lives. The enforcement moat is untouched. This decision sets the direction
+for issues #82, #83, and #84 (BLOCK stakes, persona warmth at the close, the `/feature`
+receipt). Harder: two registers to maintain and keep from leaking into each other; the
+boundary between "thinking" and "gating" surfaces must stay legible to skill authors.
+
+## Risks
+Register leak: warmth creeping into gates, or terseness flattening the thinking surfaces.
+Mitigated by scoping the conversational register to named skill bodies and keeping
+`ORCHESTRATOR.md` terse. Proven wrong if conversational thinking surfaces measurably slow the
+gated lanes, or if users still report flat daily feel after the split ships.

--- a/.codearbiter/decisions/0006-broad-adoption-oss-posture.md
+++ b/.codearbiter/decisions/0006-broad-adoption-oss-posture.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+date: 2026-06-16
+title: Broad-adoption OSS posture, optimizing for adoption over a commercial vertical
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: README.md, docs/*
+---
+
+# ADR-0006 — Broad-adoption OSS posture
+
+## Status
+Accepted — ratified 2026-06-16 by SUaDtL@users.noreply.github.com
+
+## Context
+The 2026-06 market-readiness evaluation (issue #70) scored distribution 4/10 and recommended
+re-targeting the project to a regulated/audited commercial vertical, on the reasoning that the
+audit trail, attribution, and SMARTS machinery have no single-player payoff and read as
+compliance features. The maintainer rejected that framing: codeArbiter is open source, it is
+already in daily use by the maintainer's own team who rely on it, and the goal is broad public
+adoption of a tool with demonstrated value. The real and only hard problem is getting the
+public to try proven-internally software.
+
+## Decision
+codeArbiter remains broad open-source software optimized for public adoption. It does not
+re-target to a regulated or otherwise narrow commercial vertical ICP. The strategic objective
+is maximizing the number of people who adopt and benefit from the tool, grounded in the
+existing proof that a real team adopts it and depends on it daily.
+
+## Alternatives considered
+- **Re-target to a regulated/commercial vertical (the eval's #70 recommendation)** — declined.
+  It trades a frictionless OSS install for a slow enterprise sales motion the maintainer does
+  not want, and discards the broad-adoption goal that is the actual intent.
+- **Agent-fleet/team-scale ICP** — declined. It wants shared-state infrastructure that ADR-0004
+  (database-free, stdlib-only) deliberately excludes, and still narrows away from broad adoption.
+
+## Consequences
+Easier: a single, honest positioning story. The adoption bottleneck is now named as
+time-to-first-value plus visible proof, which makes the priority order concrete:
+cold-install observation (#70 move 1), a demo above the fold (#71), a zero-onboarding dry run
+(#81 `/ca:preview`), and README positioning that surfaces real adoption proof (#72). Harder:
+no revenue motion funds the work; adoption must be earned through the product and its first
+five minutes, not a sales channel. The audit-trail/SMARTS machinery stays — it is a quality
+and trust feature for the broad audience, not only a compliance one.
+
+## Risks
+Broad-adoption-without-revenue can stall on maintainer bandwidth. The eval's distribution
+critique remains valid even under this posture: choosing OSS does not by itself produce users.
+This decision is proven wrong if, after time-to-first-value and proof work ships, external
+adoption still does not move — at which point the vertical-ICP question legitimately reopens.

--- a/.codearbiter/decisions/decision-log.md
+++ b/.codearbiter/decisions/decision-log.md
@@ -140,3 +140,77 @@ section. No content was superseded — ratification is the maturation of these
 same decisions, not a new decision.
 
 ---
+
+## DECISION-0005 — ADR-0005 — Split the persona register (terse gates, conversational thinking)
+
+**Date:** 2026-06-16
+**Status:** proposed
+**Supersedes:** none
+**Decided by:** SUaDtL@users.noreply.github.com
+**Decision category:** product/persona
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** Persona is terse everywhere by design (ORCHESTRATOR.md), including the exploratory thinking surfaces.
+- **Scaffold position:** Issue #70's eval found uniform terseness is the cause of "flat" daily feel and a drag on adoption.
+- **Status type:** open-decision-closure
+
+### Decision
+Run two persona registers scoped by surface: gates and enforcement (commit-gate, reviewer fleet,
+hard STOPs, BLOCK findings) stay terse and non-negotiable; the thinking surfaces (brainstorming,
+debug, decision-variance/SMARTS) run a conversational register. Sets direction for #82/#83/#84.
+
+### SMARTS rationale
+SMARTS verdict was tied (only Reliable differentiated, favoring terse gates over a chatty gate);
+the non-SMARTS adoption factor broke the tie toward the split. Reliable holds the gate line;
+warmth is quarantined to non-gating surfaces, so enforcement authority is preserved.
+
+### Implementation implication
+ADR-0005 authored. Future work on brainstorming/debug/decision-variance bodies and ORCHESTRATOR.md
+register. Ratifies the direction of issues #82, #83, #84.
+
+---
+
+## DECISION-0006 — ADR-0006 — Broad-adoption OSS posture (decline a commercial vertical)
+
+**Date:** 2026-06-16
+**Status:** proposed
+**Supersedes:** none
+**Decided by:** SUaDtL@users.noreply.github.com
+**Decision category:** governance/strategy
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** No recorded strategic posture; the eval (#70) implicitly pushed a commercialize-to-vertical framing.
+- **Scaffold position:** Issue #70 recommended re-targeting to a regulated/audited commercial ICP for willingness-to-pay.
+- **Status type:** open-decision-closure
+
+### Decision
+codeArbiter stays broad open-source software optimized for public adoption; it declines
+re-targeting to a regulated or narrow commercial vertical. The objective is maximizing adoption
+of a tool with demonstrated value (a real team uses it daily). Explicitly overrules #70's
+vertical-ICP recommendation.
+
+### SMARTS rationale
+The user reframed the ICP question as moot for OSS. Decision rests on non-SMARTS factors (intent,
+adoption goal) over the eval's Securable-aligned commercial framing. The audit/SMARTS machinery is
+retained as a broad-audience quality/trust feature, not a compliance-only one.
+
+### Implementation implication
+ADR-0006 authored. Priority order set: cold-install observation (#70 move 1), demo above the fold
+(#71), zero-onboarding dry run (#81 /ca:preview), README adoption-proof positioning (#72).
+Re-evaluation trigger: if adoption does not move after time-to-first-value + proof work ships,
+the vertical-ICP question reopens.
+
+---
+
+## Ratification — 2026-06-16
+
+DECISION-0005 and DECISION-0006 advanced from `proposed` to **`accepted`** on
+explicit user instruction (SUaDtL@users.noreply.github.com), ratified 2026-06-16.
+The ADR files (`0005-split-persona-register.md`, `0006-broad-adoption-oss-posture.md`)
+carry the authoritative `status: accepted` frontmatter and a ratification line in their
+`## Status` section. No content was superseded — ratification is the maturation of these
+same decisions, not a new decision.
+
+---

--- a/README.md
+++ b/README.md
@@ -34,7 +34,16 @@ It will not:
 - resolve an open question by guessing, or
 - silently reconcile a contradiction between your docs and your code.
 
-It is decisive and terse by design. If you want an assistant that hedges, this is the wrong tool.
+The gates are terse and non-negotiable. The thinking is not. It brainstorms a spec, works through a bug, and weighs a decision with you conversationally. When it enforces, it states the rule and holds the line.
+
+### Why the pushback is the point
+
+The first time codeArbiter blocks you, it feels like friction. Then you see what it caught.
+
+- It wouldn't let a spec say "and then a worker handles that." The function had to be described first.
+- It blocked the agent from editing a file it had never read.
+
+The usual objection is "too many gates," right up until someone watches a gate stop a real mistake. After that the gates read as protection, not ceremony. That is the whole arc.
 
 <details>
 <summary><b>What a loop actually feels like</b></summary>


### PR DESCRIPTION
## Summary

Acts on the two strategic calls forced by the #70 market-readiness evaluation, and takes the first concrete adoption step that follows from them.

Two commits, both docs-only:

1. **`docs(decisions)`** — records two accepted ADRs (and their decision-log entries):
   - **ADR-0005** splits the persona register: enforcement gates stay terse, the thinking surfaces (`brainstorming`, `debug`, decision-variance/SMARTS) run a conversational register. Resolves the eval's "daily use feels flat" finding and sets direction for #82/#83/#84.
   - **ADR-0006** keeps codeArbiter broad OSS optimized for adoption and declines the eval's recommendation to re-target a regulated/commercial vertical. The audit-trail/SMARTS machinery stays, as a broad-audience quality feature.
2. **`docs(readme)`** — first pass at #72. Adds a "Why the pushback is the point" section that shows two real gate catches instead of arguing the overhead is worth it, and replaces the "terse by design, wrong tool if you want hedging" line that both repelled newcomers and contradicted ADR-0005.

## Why

The eval scored distribution 4/10. The two decisions stop those questions from being relitigated, and the README change applies the conversion mechanic observed in cold installs: people read the gates as ceremony until they watch one stop a real mistake, then it flips to trust. The README now leads with the catch, because showing converts where telling does not.

Issue #70 itself is amended in lockstep: move 1 (watch 5 strangers) is retired as infeasible and replaced with "get found, let the repo do the convincing"; moves 2 and 3 are marked decided against these ADRs.

## Verification

- **Suite:** PASS — `test_hook_guards.py` (79 assertions) and `test_hooks_cold_install.py` (134 assertions), both green; `check-plugin-refs.py` reports the reference graph intact.
- **Coverage audit (`coverage-auditor`):** docs-only, no source or tests, no TDD obligation. No BLOCK finding.
- **Secrets:** manual sweep of both staged diffs clean.
- **Scope:** no change under `plugins/ca/**`, so no `plugin.json` version bump required; README version badge untouched.

## Links

- ADR-0005, ADR-0006 — `.codearbiter/decisions/`
- Decisions mirrored in `.codearbiter/decisions/decision-log.md` (DECISION-0005/0006, both accepted)
- Ref: #70 (umbrella), #72 (README positioning)
