### PR TITLE
feat(ux): make enforcement land as value — Receipt close, stakes, register split (#82 #83 #84)

### DIFF
--- a/.codearbiter/plans/ux-conversion-trio.md
+++ b/.codearbiter/plans/ux-conversion-trio.md
@@ -1,0 +1,63 @@
+# Plan — UX conversion trio (#82 + #84 + #83)
+
+Spec: `.codearbiter/specs/ux-conversion-trio.md` (pending approval). Stage 2. Effort M.
+
+**Architecture (resolved this session):**
+- **Executable obligations via one structural test.** `.github/scripts/test_ux_conversion.py`
+  (stdlib-only per ADR-0004) reads each touched framework file and asserts durable marker phrases are
+  present (Receipt fields, register-split clause, stakes lines) and forbidden tokens are absent
+  (saves-ledger / statusline segment / per-gate counter; stakes phrasing on mechanical-gate blocks).
+  Each prose task pairs its own assertion (red) with its edit (green), mirroring how
+  `test_preview_lib.py` was grown task-by-task. Coarse markers, not exact wording — avoids brittleness.
+- **Two surfaces, six files.** The *close* surface = `finishing-a-development-branch/SKILL.md` +
+  `SPRINT.md` + the register permission in `ORCHESTRATOR.md`. The *caught-finding* surface =
+  `tdd/SKILL.md` + `secret-handling/SKILL.md` + `commit-gate/SKILL.md` + the same register permission.
+- **Copy only.** No gate logic, no `security-controls.md`, no crypto/secret/auth enforcement changes.
+
+## AC ledger (verbatim from spec)
+
+| ID | Acceptance criterion |
+|---|---|
+| AC-01 | Receipt close lists all five fields (obligations, gates+catches, SMARTS decisions, secrets/regressions prevented, suite time). |
+| AC-02 | Receipt draws only from Phase-1 state + `last-checkpoint`; skill forbids a fresh audit crawl. |
+| AC-03 | `SPRINT.md` Phase 3 summary aligned to the Receipt field shape. |
+| AC-04 | No saves-ledger / per-gate counter / new statusline segment in any touched file. |
+| AC-05 | Stakes line on each finding block: tdd coverage/MISSING (Phase 4 & 5), secret caught, commit-gate Phase 5 + Phase 6. |
+| AC-06 | Mechanical gates stay terse — no stakes line on protected-branch / missing tech-stack / wildcard-stage / subject>72. |
+| AC-07 | `ORCHESTRATOR.md` register split: terse default + exactly one warm sentence at closes and genuine caught findings. |
+| AC-08 | Register forbids warmth on routine green commits; no emojis/flattery. |
+| AC-09 | Warm-sentence permission wired at real close points (Receipt, /sprint summary) + caught-finding points (tdd/secret/commit-gate). |
+| AC-10 | `check-plugin-refs.py` passes; no broken refs. |
+| AC-11 | `test_ux_conversion.py` runs in CI, listed in `tech-stack.md`, encodes AC 1–9 as assertions. |
+
+## Tasks
+
+| ID | Path(s) | Verification | maps-to (tdd obligation) | covers | depends-on | status |
+|---|---|---|---|---|---|---|
+| T-01 | `plugins/ca/ORCHESTRATOR.md`; `.github/scripts/test_ux_conversion.py` (new) | `python .github/scripts/test_ux_conversion.py` passes: asserts register-split clause present (terse-for-gating + one-warm-sentence-at-close/catch) and "routine green"/no-emoji prohibition present | "register split exists; warmth bounded; test harness created" | AC-07, AC-08 | — | ACCEPTED |
+| T-02 | `plugins/ca/skills/finishing-a-development-branch/SKILL.md`; `test_ux_conversion.py` | test passes: Receipt section present with all 5 field markers + "no fresh audit-trail crawl" clause + one-warm-sentence reference | "Receipt close from Phase-1 state only; warm sentence wired" | AC-01, AC-02, AC-09 | T-01 | ACCEPTED |
+| T-03 | `plugins/ca/SPRINT.md`; `test_ux_conversion.py` | test passes: Phase 3 summary carries the Receipt field markers + one warm closing sentence | "sprint summary aligned to Receipt shape" | AC-03, AC-09 | T-01 | ACCEPTED |
+| T-04 | `plugins/ca/skills/tdd/SKILL.md`; `test_ux_conversion.py` | test passes: stakes marker on Phase 4 & Phase 5 coverage/MISSING blocks; assert mechanical obligation-scan/threshold blocks carry NO stakes phrasing | "stakes on coverage finding blocks; mechanical terse" | AC-05, AC-06 | T-01 | ACCEPTED |
+| T-05 | `plugins/ca/skills/secret-handling/SKILL.md`; `test_ux_conversion.py` | test passes: stakes marker on the caught-secret block + one-warm-sentence reference on a genuine catch | "stakes on caught-secret; warm sentence wired" | AC-05, AC-09 | T-01 | ACCEPTED |
+| T-06 | `plugins/ca/skills/commit-gate/SKILL.md`; `test_ux_conversion.py` | test passes: stakes marker on Phase 5 behavioral-proof + Phase 6 diff-review finding blocks; assert branch/wildcard-stage/subject>72 blocks carry NO stakes phrasing | "stakes on commit-gate findings; mechanical terse" | AC-05, AC-06 | T-01 | ACCEPTED |
+| T-07 | `.github/scripts/test_ux_conversion.py`; `.github/workflows/ci.yml`; `.codearbiter/tech-stack.md` | test passes incl. global negative assertions (no `saves-ledger`/`statusline` segment/per-gate counter added across the six files); `test_ux_conversion.py` invoked in CI; tech-stack Test section lists it | "negative constraints enforced; test wired into CI + tech-stack" | AC-04, AC-11 | T-01..T-06 | ACCEPTED |
+| T-08 | (no edit — verification) `python .github/scripts/check-plugin-refs.py` | reference graph passes; `git diff` confirms `security-controls.md` + all crypto/secret/auth enforcement logic untouched (copy-only) | "reference graph green; no logic/security drift" | AC-10 | T-01..T-07 | ACCEPTED |
+
+## Order & MVP slice
+
+Dependency order: T-01 (root: register split + test harness) → T-02, T-03, T-04, T-05, T-06 (independent, each appends one assertion to the shared test) → T-07 (negatives + CI wiring, after all edits) → T-08 (final graph/security verification). No cycle.
+
+**MVP slice (the close experience — the demo):** `T-01, T-02, T-03`. Register split + Receipt close +
+aligned `/sprint` summary. On its own this delivers the "end every loop on its most rewarding beat"
+payoff and the warm close. The stakes layer (T-04..T-06) and the negatives/CI wiring (T-07) are the
+incremental past the slice; T-08 is the final guard.
+
+## Coverage proof
+
+Every AC has ≥1 task: AC-01→T-02 · AC-02→T-02 · AC-03→T-03 · AC-04→T-07 · AC-05→T-04,T-05,T-06 ·
+AC-06→T-04,T-06 · AC-07→T-01 · AC-08→T-01 · AC-09→T-02,T-03,T-05 · AC-10→T-08 · AC-11→T-07. Every task
+covers ≥1 AC (table column). ✓
+
+`[NEEDS-TRIAGE]` Structural prose-marker assertions are coarse by design; they prove the required copy
+is present, not that it reads well. Copy quality is carried by the two-pass review (spec-compliance +
+quality) in `subagent-driven-development`, not by the test.

--- a/.codearbiter/specs/ux-conversion-trio.md
+++ b/.codearbiter/specs/ux-conversion-trio.md
@@ -1,0 +1,79 @@
+# Spec — UX conversion trio: "Make enforcement land as value"
+
+**Issues:** #82 + #84 + #83 · **Effort:** M (M+S+S) · **Posture:** cashes the promise PR 86 wrote into
+the README — "the gates read as protection, not ceremony." Conversion mechanic under ADR-0006: SHOW a
+gate catching a real mistake, then reflect the prevention back.
+
+## Problem
+
+The product enforces well but never reflects its value back. Shipping a feature ends in silence
+(`skills/finishing-a-development-branch/SKILL.md` ends at "the merge is not yours to take"). Gate
+blocks state the *rule*, not the *stakes* ("coverage below threshold"), so friction reads as "blocked
+again" with no felt payoff. And `ORCHESTRATOR.md` mandates "decisive and terse" *globally*, which is
+right for routing/gating but turns the close into a vending-machine interaction. Three small,
+coherent changes fix the two moments where value is earned: **the close** and **the caught finding**.
+
+## Scope
+
+**In:** prose/skill-body edits to six framework files that reflect prevention back at the close and at
+substantive finding-blocks. No new command, no new runtime code path, no statusline change.
+
+- **#82 Receipt close.** `finishing-a-development-branch` gains a **Receipt**: obligations covered,
+  gates that fired and what they caught, the SMARTS decisions the user made, secrets/regressions
+  prevented, suite time. Drawn ONLY from the Phase-1 state the skill already assembles plus
+  `last-checkpoint` — never a fresh audit-trail crawl (avoids a slow terminal step). `SPRINT.md`'s
+  existing Phase-3 summary (`:104`) is aligned to the same Receipt field shape.
+- **#84 Stakes on substantive blocks.** A one-line **consequence-avoided** statement (state the
+  consequence avoided, not the rule violated) is required on exactly the *finding* blocks: tdd
+  coverage/`MISSING` (Phases 4 & 5), secret-handling caught secret, commit-gate Phase 5
+  behavioral-proof mismatch, commit-gate Phase 6 diff-review scope/credential finding.
+- **#83 Register split.** `ORCHESTRATOR.md:9-11` keeps the terse default for routing/gating but
+  permits **exactly one** warm synthesizing sentence at each close and at each genuine *caught* finding
+  the user then fixed. The permission is wired at the real close/finding points, not only stated.
+
+**Verification model:** a new structural test `.github/scripts/test_ux_conversion.py` (stdlib-only per
+ADR-0004) asserts the required content markers are present and the forbidden ones are absent. This
+turns the otherwise-inspectable prose obligations into executable red→green tests wired into CI —
+enforcement-not-trust applied to this sprint's own output. Assertions are coarse (durable marker
+phrases / section anchors), not exact-wording, to avoid brittleness.
+
+**Out of scope (explicit — rejected under challenge):** a global rolling "saves ledger", a per-gate
+counter, or a new statusline segment (gameable junk-signal; statusline is column-rationed). A fresh
+audit-trail crawl at the close. Stakes lines on *mechanical* gates — protected branch, missing
+`tech-stack.md`, wildcard staging, subject >72 chars (a "this would have bitten you" line there is
+noise). Warmth on routine green commits; emojis; flattery. No change to gate *logic*, to
+`security-controls.md`, or to any crypto/secret/auth enforcement — copy only.
+
+## Acceptance criteria
+
+1. **Receipt exists.** `finishing-a-development-branch` prints a Receipt close listing all five fields:
+   obligations covered, gates fired + what each caught, SMARTS decisions the user made,
+   secrets/regressions prevented, suite time.
+2. **Receipt sourcing.** The Receipt text draws only from Phase-1 state + `last-checkpoint`; the skill
+   explicitly forbids a fresh audit-trail crawl.
+3. **Sprint summary aligned.** `SPRINT.md` Phase 3 summary uses the same Receipt field shape.
+4. **No ledger/counter/statusline.** No saves-ledger, per-gate counter, or new statusline segment is
+   introduced in any touched file.
+5. **Stakes on finding blocks.** A one-line consequence-avoided statement is present on each of: tdd
+   coverage/`MISSING` (Phase 4 & 5), secret-handling caught secret, commit-gate Phase 5
+   behavioral-proof mismatch, commit-gate Phase 6 diff-review finding.
+6. **Mechanical gates stay terse.** No stakes line is added to the protected-branch, missing
+   `tech-stack.md`, wildcard-staging, or subject-over-72 blocks.
+7. **Register split.** `ORCHESTRATOR.md` retains the terse default for routing/gating and permits
+   exactly one warm synthesizing sentence at each close and each genuine caught finding the user fixed.
+8. **Warmth bounded.** The register text forbids warmth on routine green commits and forbids
+   emojis/flattery.
+9. **Warmth wired, not abstract.** The one-warm-sentence permission is referenced at the actual close
+   points (Receipt, `/sprint` summary) and at the caught-finding points (tdd/secret/commit-gate), not
+   only declared in `ORCHESTRATOR.md`.
+10. **Reference graph green.** `python .github/scripts/check-plugin-refs.py` passes; no broken refs.
+11. **Test wired.** `test_ux_conversion.py` runs in CI and is listed in `tech-stack.md`; it encodes
+    ACs 1–9 as executable assertions (positive markers present, negatives absent).
+
+## Notes
+
+- **No version bump:** `plugin.json` is `2.4.3`, unpublished (no `v2.4.3` tag), so further `plugins/ca/**`
+  payload changes pass the version-bump gate as-is.
+- **No hard-gate surface:** every edit is user-facing copy on existing gates; gate logic,
+  `security-controls.md`, and crypto/secret/auth enforcement are untouched. Editing the
+  `secret-handling`/`commit-gate` skill *prose* is not a secrets/crypto operation.

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -226,3 +226,17 @@ Spec + plan approved by the user at the Phase-1 gate. Branch `sprint/ux-conversi
 ## D-02 — AC-5 Phase 5 stakes gap (SMARTS, confidence: high)
 - **Decision point:** spec/plan say tdd "Phase 4 & 5" stakes; implementation + test covered only Phase 4. Resolve toward the approved spec or narrow scope?
 - **Chosen:** honor the approved contract — added a Stakes line to tdd Phase 5 (Coverage) and a Phase-5 test assertion. Below-threshold coverage is the same "untested code ships" finding class; narrowing would weaken a user-approved AC. Strength: strong.
+
+---
+
+# Sprint complete — ux-conversion-trio · 2026-06-17
+
+8 of 8 tasks ACCEPTED. Landed as 3 type-homogeneous commits on `sprint/ux-conversion-trio`, **PR #88** opened against `main` (https://github.com/arbiterForge/codeArbiter/pull/88) — **NOT merged**; the merge is the user's call (the `/sprint` hard gate).
+
+- `4a32a31` feat(ux): reflect prevention back at the close and caught findings (7 files)
+- `4255727` ci(ux): run test_ux_conversion.py in CI; list it in tech-stack (2 files)
+- `f28603f` chore(sprint): ux-conversion-trio spec, plan, decision log (3 files)
+
+**Verification at land:** full Python suite green (hook-guards · cold-install · preview · ux-conversion) · ref graph intact · PR CI 7/7 green incl. version-bump gate. Two-pass review: spec-compliance 11/11 (after the AC-5 fix), copy-quality clean (5 NITs applied).
+
+**Auto-decisions flagged for review:** D-01 (execution model — coordinate-author + independent review, moderate) is the one low-confidence call. D-02 (AC-5 Phase-5 stakes) resolved high toward the approved spec.

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -202,3 +202,27 @@ Spec `.codearbiter/specs/review-remediation.md`, plan `plans/review-remediation.
 **Auto-decisions flagged for review (per /sprint contract):** two moderate-confidence SMARTS calls — C-19 (lifecycle↔variance boundary-clarified, not merged) and the task-9 MultiEdit block-outright posture. Both logged above with rationale. **Two corrections to the original review** were recorded: pre-bash guards live in `.github/scripts/test_hook_guards.py` (not the hooks tests dir), and the `/spike` routing-table row was not actually missing.
 
 **Deferred (own decision):** review finding #6 (mechanical red-suite / commit-gate enforcement) — non-blocking note in `open-questions.md`. **Carried:** SH-TRIAGE-2 (missing coding-standards.md) and SD-02 (farm host-normalization re-review) folded into `open-tasks.md`.
+
+---
+
+# Sprint — ux-conversion-trio (#82 + #84 + #83) · 2026-06-17
+
+Spec + plan approved by the user at the Phase-1 gate. Branch `sprint/ux-conversion-trio` off `main`.
+
+## D-01 — execution model (SMARTS, confidence: moderate → flag for review)
+- **Decision point:** subagent-driven-development prescribes one fresh author subagent per task. The 8 tasks are tightly-coupled prose edits sharing one marker scheme and one test file (`test_ux_conversion.py`).
+- **Options weighed:** (a) fresh author per task — max anti-drift isolation, but fragments voice across coordinated copy and risks marker-scheme divergence on a shared test; (b) coordinate authoring in the orchestrator context, then enforce the load-bearing guarantee via independent fresh reviewers (spec-compliance + quality) + mechanical fresh-run verification (the structural test + check-plugin-refs).
+- **SMARTS verdict:** Maintainable/Testable favor (b) for coherence of a shared marker scheme; the anti-drift guarantee is preserved by independent review + a mechanical test, so nothing is accepted on the author's own word. Scalable/Available/Reliable/Securable neutral (copy-only, no logic change).
+- **Chosen:** (b). Strength: moderate. Flagged for morning review.
+
+## Execution — tasks T-01..T-08 (confidence: high)
+- All six framework files edited test-first; structural test `test_ux_conversion.py` drove 22-red → green. One brittle assertion corrected (markdown bold `**exactly one**` split the literal phrase) — assertion fixed to component-presence, semantics unchanged (not a relaxed implementation pass).
+- Wired into CI (`ci.yml`) + `tech-stack.md`. Ref graph intact. `security-controls.md` untouched; secret-handling/commit-gate edits confirmed purely additive copy (no gate-logic/MUST change).
+
+## Two-pass independent review (per D-01)
+- **Spec-compliance:** 10/11 ACs COVERED; one real GAP — AC-5 ("tdd Phase 4 & 5") had a Stakes line on Phase 4 only, and the test did not guard Phase 5.
+- **Copy-quality:** no BLOCK; 5 NITs — duplicated warm example, 4×-restated no-crawl gloss, "no-op" wording drift, a purple "under cover of" clause, a secret-handling run-on. All 5 applied.
+
+## D-02 — AC-5 Phase 5 stakes gap (SMARTS, confidence: high)
+- **Decision point:** spec/plan say tdd "Phase 4 & 5" stakes; implementation + test covered only Phase 4. Resolve toward the approved spec or narrow scope?
+- **Chosen:** honor the approved contract — added a Stakes line to tdd Phase 5 (Coverage) and a Phase-5 test assertion. Below-threshold coverage is the same "untested code ships" finding class; narrowing would weaken a user-approved AC. Strength: strong.

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -28,6 +28,9 @@ python .github/scripts/test_hooks_cold_install.py
 
 # /ca:preview helpers — diff-collection + redacting secret-scan (_previewlib)
 python .github/scripts/test_preview_lib.py
+
+# UX-conversion-trio copy — Receipt close, stakes lines, register split (structural)
+python .github/scripts/test_ux_conversion.py
 ```
 
 Only when `plugins/ca/tools/**` changed:

--- a/.github/scripts/test_ux_conversion.py
+++ b/.github/scripts/test_ux_conversion.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Structural test for the UX-conversion-trio sprint (#82 + #84 + #83).
+
+These are prose/skill-body changes, so the obligations are content-presence and
+content-absence assertions rather than behavioral unit tests. The test makes the
+otherwise-inspectable obligations executable and CI-enforced.
+
+Assertions are deliberately COARSE — durable marker phrases and a bold
+`**Stakes:**` lead-in — not exact wording, so ordinary copy edits do not break
+the test. Copy *quality* is carried by the two-pass review, not by this test.
+
+Run: python .github/scripts/test_ux_conversion.py
+"""
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CA = ROOT / "plugins" / "ca"
+
+ORCH = CA / "ORCHESTRATOR.md"
+SPRINT = CA / "SPRINT.md"
+FINISH = CA / "skills" / "finishing-a-development-branch" / "SKILL.md"
+TDD = CA / "skills" / "tdd" / "SKILL.md"
+SECRET = CA / "skills" / "secret-handling" / "SKILL.md"
+COMMIT = CA / "skills" / "commit-gate" / "SKILL.md"
+
+ALL_FILES = [ORCH, SPRINT, FINISH, TDD, SECRET, COMMIT]
+
+_failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+
+
+def read(p):
+    return p.read_text(encoding="utf-8")
+
+
+def section(text, heading_substr):
+    """Return the body of the `## ...heading_substr...` block up to the next `## `.
+
+    Heading match is case-insensitive on the substring. Returns "" if absent.
+    """
+    lines = text.splitlines()
+    out, capturing = [], False
+    for ln in lines:
+        if ln.startswith("## "):
+            if capturing:
+                break
+            capturing = heading_substr.lower() in ln.lower()
+            continue
+        if capturing:
+            out.append(ln)
+    return "\n".join(out)
+
+
+# ---- #83 register split (T-01) -------------------------------------------------
+def test_register_split():
+    t = read(ORCH).lower()
+    check("terse" in t, "ORCHESTRATOR: terse default must be retained")
+    # 'exactly one' and 'warm' may be split by markdown emphasis (**exactly one** warm),
+    # so assert the components rather than a brittle contiguous substring.
+    check("exactly one" in t and "warm" in t,
+          "ORCHESTRATOR: must permit exactly one warm synthesizing sentence")
+    check("synthesi" in t, "ORCHESTRATOR: warm sentence must be 'synthesizing'")
+    check("close" in t, "ORCHESTRATOR: warmth permitted 'at the close'")
+    check("caught" in t, "ORCHESTRATOR: warmth permitted at a genuine 'caught' finding")
+    check("routine green" in t,
+          "ORCHESTRATOR: must forbid warmth on 'routine green' commits")
+    check("no emojis" in t or "no emoji" in t, "ORCHESTRATOR: must forbid emojis")
+    check("flattery" in t, "ORCHESTRATOR: must forbid flattery")
+
+
+# ---- #82 Receipt close (T-02) --------------------------------------------------
+def test_receipt_close():
+    t = read(FINISH)
+    low = t.lower()
+    check("receipt" in low, "finishing: must add a Receipt close")
+    check("obligations" in low, "Receipt: must list obligations covered")
+    check("caught" in low, "Receipt: must list gates fired + what each caught")
+    check("smarts" in low, "Receipt: must list the SMARTS decisions the user made")
+    check("secret" in low and "prevented" in low,
+          "Receipt: must list secrets/regressions prevented")
+    check("suite time" in low, "Receipt: must list suite time")
+    # sourcing: Phase-1 state + last-checkpoint only, no fresh crawl
+    check("last-checkpoint" in low, "Receipt: must source from last-checkpoint")
+    check("phase 1" in low, "Receipt: must source from Phase 1 state")
+    check("no fresh audit" in low or "not a fresh audit" in low,
+          "Receipt: must forbid a fresh audit-trail crawl")
+    check("warm" in low, "finishing: must wire the one warm closing sentence")
+
+
+# ---- #82 + #83 sprint summary aligned (T-03) -----------------------------------
+def test_sprint_summary_aligned():
+    body = section(read(SPRINT), "Land & summarize")
+    low = body.lower()
+    check("receipt" in low, "SPRINT Phase 3: summary must align to the Receipt shape")
+    check("suite time" in low or "obligations" in low,
+          "SPRINT Phase 3: summary must carry Receipt fields")
+    check("warm" in low, "SPRINT Phase 3: must wire the one warm closing sentence")
+
+
+# ---- #84 stakes on tdd finding blocks (T-04) -----------------------------------
+def test_tdd_stakes():
+    t = read(TDD)
+    verify = section(t, "Obligation verify")  # Phase 4 — MISSING
+    check("**stakes:**" in verify.lower(),
+          "tdd Phase 4: a **Stakes:** line must state the consequence of a MISSING obligation")
+    coverage = section(t, "Coverage")  # Phase 5 — below threshold
+    check("**stakes:**" in coverage.lower(),
+          "tdd Phase 5: a **Stakes:** line must state the consequence of coverage below threshold")
+    # mechanical surfaces stay terse
+    scan = section(t, "Obligation scan")  # Phase 1
+    check("**stakes:**" not in scan.lower(),
+          "tdd Phase 1 (obligation scan) must stay terse — no Stakes line")
+    pre = t.split("## Phase 1")[0]  # pre-flight
+    check("**stakes:**" not in pre.lower(),
+          "tdd pre-flight must stay terse — no Stakes line")
+
+
+# ---- #84 stakes on caught-secret (T-05) ----------------------------------------
+def test_secret_stakes():
+    t = read(SECRET)
+    src = section(t, "Source")  # Phase 2 — hardcoded literal = the classic caught secret
+    check("**stakes:**" in src.lower(),
+          "secret-handling Phase 2: a **Stakes:** line must state the consequence of a caught secret")
+    check("warm" in t.lower(),
+          "secret-handling: must wire the one warm sentence on a genuine catch")
+
+
+# ---- #84 stakes on commit-gate findings + mechanical terse (T-06) --------------
+def test_commit_gate_stakes():
+    t = read(COMMIT)
+    proof = section(t, "Behavioral proof")  # Phase 5
+    diff = section(t, "Diff review")        # Phase 6
+    check("**stakes:**" in proof.lower(),
+          "commit-gate Phase 5: a **Stakes:** line must state the consequence of a behavioral-proof mismatch")
+    check("**stakes:**" in diff.lower(),
+          "commit-gate Phase 6: a **Stakes:** line must state the consequence of a scope/credential finding")
+    # mechanical gates stay terse
+    for h in ("Branch", "Selective stage", "Message"):
+        check("**stakes:**" not in section(t, h).lower(),
+              f"commit-gate {h} must stay terse — no Stakes line")
+
+
+# ---- global negatives: no ledger/counter/statusline (T-07) ---------------------
+def test_no_ledger_or_statusline():
+    banned = ("saves ledger", "saves-ledger", "per-gate counter",
+              "statusline segment", "saves counter")
+    for p in ALL_FILES:
+        low = read(p).lower()
+        for b in banned:
+            check(b not in low,
+                  f"{p.name}: must not introduce a '{b}' (rejected under challenge)")
+
+
+TESTS = [
+    test_register_split,
+    test_receipt_close,
+    test_sprint_summary_aligned,
+    test_tdd_stakes,
+    test_secret_stakes,
+    test_commit_gate_stakes,
+    test_no_ledger_or_statusline,
+]
+
+
+def main():
+    for p in ALL_FILES:
+        if not p.exists():
+            print(f"FATAL: missing file {p}")
+            return 2
+    for fn in TESTS:
+        try:
+            fn()
+        except Exception as e:  # noqa: BLE001
+            _failures.append(f"{fn.__name__} raised {type(e).__name__}: {e}")
+    if _failures:
+        print(f"FAIL: {len(_failures)} assertion(s)")
+        for m in _failures:
+            print(f"  - {m}")
+        return 1
+    print(f"OK: {len(TESTS)} obligation groups green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
         # (_previewlib): collect_diff over the three change kinds it unions and
         # the redacting secret scan, including the no-raise edges.
         run: python .github/scripts/test_preview_lib.py
+      - name: Run UX-conversion-trio structural copy tests
+        # Content-presence/absence assertions for the #82/#84/#83 prose changes:
+        # the Receipt close, stakes lines on substantive finding-blocks, the
+        # register split, and the negatives (no saves-ledger/statusline segment).
+        run: python .github/scripts/test_ux_conversion.py
 
   version-bump:
     name: plugin version bumped when payload changes

--- a/plugins/ca/ORCHESTRATOR.md
+++ b/plugins/ca/ORCHESTRATOR.md
@@ -10,6 +10,13 @@ slash command, routes to the skill or agent that owns it, and clears its gates b
 You are decisive and terse. You state, you do not hedge. You hold the gates; the user holds the
 decisions.
 
+**Register.** Terse is the default — for routing, for gating, and for every routine green result:
+state the rule, hold the line, move on. Terse is not affectless, and it is not the whole range. At a
+*close* (a shipped branch, a sprint wrap) and at a *genuine caught finding the user then fixed*, you
+may add **exactly one** warm, synthesizing sentence that reflects the work back — e.g. "Real catch: an
+untested error path, now covered; clean run otherwise." Earned acknowledgment, never filler. Never on
+routine green commits, never more than one sentence, no emojis, no flattery.
+
 **Paths.** Framework files: `${CLAUDE_PLUGIN_ROOT}/` (`ORCHESTRATOR.md`, `skills/`, `commands/`,
 `agents/`, `hooks/`). Project state: `${CLAUDE_PROJECT_DIR}/.codearbiter/`. There is no `.agents/`,
 no vendoring, no dual root.

--- a/plugins/ca/SPRINT.md
+++ b/plugins/ca/SPRINT.md
@@ -101,9 +101,13 @@ On plan completion, route the branch through `commit-gate`, then `finishing-a-de
 which under `/sprint` AUTO-SELECTS open-PR and surfaces the merge decision to the user. `/sprint`
 never merges and never discards.
 
-Emit a sprint summary: what shipped; the auto-decision count with every `low`-confidence call listed
-for review (cite `sprint-log.md`); any hard gates that tripped, each with the planning/confidence
-signal; and any open `[NEEDS-TRIAGE]` items.
+Emit the sprint **Receipt** — the same win-summary shape `finishing-a-development-branch` Phase 4 uses,
+widened to the whole sprint: what shipped; obligations covered and the gates that fired with what each
+caught; secrets/regressions prevented; suite time; the auto-decision count with every `low`-confidence
+call listed for review (cite `sprint-log.md`); any hard gates that tripped, each with the
+planning/confidence signal; and any open `[NEEDS-TRIAGE]` items. Drawn from in-hand state, not a fresh
+crawl. Close with exactly one warm, synthesizing sentence (per the orchestrator register) — earned,
+never on a no-op run.
 
 ## Hard rules
 

--- a/plugins/ca/skills/commit-gate/SKILL.md
+++ b/plugins/ca/skills/commit-gate/SKILL.md
@@ -67,6 +67,8 @@ self-report.
 - Identify the proving command or observable: the acceptance criterion from `${CLAUDE_PROJECT_DIR}/.codearbiter/specs/<slug>.md` (or the task's verification in the plan). If none exists, derive the smallest command that exercises the claimed behavior.
 - Run it fresh in this phase, read its output and exit code, and confirm the observed behavior matches the spec's acceptance criteria. A mismatch, or an unverifiable claim, blocks.
 
+**Stakes:** a behavioral-proof mismatch means the change does not do what the spec claims — state what would ship broken if this passed ("the retry path never fires; a transient error would hang the caller"), not just "proof mismatch." That gap is exactly what a green-looking suite hides.
+
 Gate: the change is proven to do what it claimed by fresh evidence — command output and exit code read in this phase. A self-reported "it works" does not pass.
 
 ## Phase 6 — Diff review · gate: BLOCK
@@ -80,6 +82,8 @@ Read the complete staged diff (`git diff --cached`). Flag as blocking:
 - Scope creep — changes outside the agreed feature or fix boundary.
 
 On any blocking finding, unstage the affected files, surface the finding, and STOP. An out-of-scope change that should not be lost gets an inline `[NEEDS-TRIAGE]` marker before it is set aside.
+
+**Stakes:** name what the finding would have cost if committed — a leaked credential is live the moment it lands and must be rotated; a scope-creep file ships untested behavior the review waved through. State that consequence on a credential or scope finding, not just "out of scope."
 
 Gate: the diff is clean — zero blocking findings.
 

--- a/plugins/ca/skills/finishing-a-development-branch/SKILL.md
+++ b/plugins/ca/skills/finishing-a-development-branch/SKILL.md
@@ -54,6 +54,31 @@ Carry out the chosen option, and only that one:
 
 Gate: the chosen option completed — for open-PR a PR exists against the default branch; for merge the work landed through that PR; for discard the user confirmed against a stated loss summary.
 
+## Phase 4 — Receipt · gate: BLOCK
+
+The loop has been a chain of gates the user watched clear. End it on its most rewarding beat, not in
+silence. Emit a tight **Receipt** — a win summary that reflects the prevention back, drawn ONLY from
+the state Phase 1 already assembled plus `${CLAUDE_PROJECT_DIR}/.codearbiter/last-checkpoint`. This is
+**not a fresh audit-trail crawl** — no new log scan, no `git` archaeology. If a field has no data in
+hand, omit the line rather than go digging.
+
+Report only what the assembled state supports:
+
+- **Obligations covered** — the count of `tdd` obligations that reached `COVERED` on this branch.
+- **Gates that fired and what each caught** — the gates that BLOCKed and then cleared, named with the
+  specific thing caught (an untested seam, a scope-creep file set aside), not a bare gate name.
+- **SMARTS decisions the user made** — the architectural forks the user resolved, one line each.
+- **Secrets / regressions prevented** — credential findings and behavioral-proof mismatches the gates
+  stopped before they shipped.
+- **Suite time** — the wall-clock of the verifying run, from the gate results in hand.
+
+Close with **exactly one** warm, synthesizing sentence (per the orchestrator register) that reflects
+the run back — synthesized for this branch, not the register's canned example. One sentence, earned,
+never on a no-op close.
+
+Gate: the Receipt is emitted from in-hand state (no fresh crawl), and the close carries at most one
+warm sentence.
+
 ## Hard rules
 
 - MUST NOT merge directly to the default branch or force-push — every change lands through a PR.
@@ -62,3 +87,5 @@ Gate: the chosen option completed — for open-PR a PR exists against the defaul
 - MUST NOT delete un-pushed commits silently — STOP and report the loss before any discard.
 - MUST NOT run before `commit-gate` has cleared on the current HEAD.
 - MUST NOT guess the branch or default-branch name — read `CONTEXT.md` or STOP.
+- MUST draw the Receipt only from Phase 1 state + `last-checkpoint` — never a fresh audit-trail crawl — and never build a rolling cross-branch "saves" tally.
+- MUST keep the close to at most one warm sentence; never on a no-op close.

--- a/plugins/ca/skills/secret-handling/SKILL.md
+++ b/plugins/ca/skills/secret-handling/SKILL.md
@@ -28,6 +28,12 @@ Each secret MUST originate from the approved store in `security-controls.md`, ac
 - A database column holding the raw value (a stored *reference* is allowed — see Phase 3).
 - Any store endpoint not named in `security-controls.md`.
 
+**Stakes:** a hardcoded or unapproved-source secret does not merely fail policy — it ships to every
+clone, every CI log, and anyone who reads the history. Rotation is the only fix once it lands. State
+that consequence when you block, not just "unapproved source." A genuine catch the user then rotates
+earns **exactly one** warm sentence at the close (per the orchestrator register) — never on a clean
+pass.
+
 Gate: every secret is sourced from the approved store via the approved access method.
 
 ## Phase 3 — Sinks and persistence · gate: BLOCK

--- a/plugins/ca/skills/tdd/SKILL.md
+++ b/plugins/ca/skills/tdd/SKILL.md
@@ -71,6 +71,10 @@ contract-critical logic, dispatch the `coverage-auditor` agent
 A `MISSING` obligation returns the workflow to Phase 2 — author a correct failing test, then re-run
 Phase 3 — and loops until it is `COVERED`.
 
+**Stakes:** when you block on a `MISSING` obligation, state what the untested seam leaves exposed, not
+just that it is `MISSING` — one line naming the consequence: "this error path is untested; a 500 here
+would reach users silently." The block is the rule; the stakes are why it is worth the friction.
+
 Gate: every obligation `COVERED`, each backed by a passing test. Any `MISSING` blocks Phase 5.
 
 ## Phase 5 — Coverage · gate: BLOCK
@@ -80,6 +84,10 @@ gate. The threshold table is the shared `${CLAUDE_PLUGIN_ROOT}/includes/maturity
 single source of truth, also used by `refactor` Phase 2).
 
 Run the coverage command from `tech-stack.md`. Below the maturity threshold → add tests until it is met.
+
+**Stakes:** when coverage blocks below threshold, name the class of code left dark — the paths a later
+regression could rot unnoticed — not just "below threshold." The number is the rule; the untested paths
+are why it matters.
 
 Gate: threshold met for the current maturity value.
 


### PR DESCRIPTION
## What & why

Cashes the promise PR #86 wrote into the README — "the gates read as protection, not ceremony." The product enforced well but never reflected its value back: shipping ended in silence, blocks stated the rule not the stakes, and a global "terse" register turned the close into a vending-machine interaction. This sprint reflects prevention back at the two moments it's earned — **the close** and **the caught finding**.

Autonomous `/ca:sprint`. Spec + plan: `.codearbiter/specs/ux-conversion-trio.md`, `.codearbiter/plans/ux-conversion-trio.md`.

## Changes (plan items satisfied — all 8 tasks ACCEPTED)

- **#82 Receipt close** — `finishing-a-development-branch` gains a Receipt (obligations covered, gates fired + what each caught, SMARTS decisions, secrets/regressions prevented, suite time), sourced **only** from Phase-1 state + `last-checkpoint` (no fresh audit crawl). `SPRINT.md` summary aligned to the same shape.
- **#84 Stakes on substantive blocks** — tdd Phase 4/5, secret-handling, commit-gate Phase 5/6 finding blocks now state the consequence avoided. Mechanical gates (protected branch, missing tech-stack, wildcard staging, subject >72) stay terse.
- **#83 Register split** — `ORCHESTRATOR.md` keeps the terse default but permits exactly one warm synthesizing sentence at a close or a genuine caught finding; never on routine greens, no emojis/flattery.

## Verification

- New `test_ux_conversion.py` makes the prose obligations executable (22 red → green), wired into CI + `tech-stack.md`.
- Full suite green: `test_hook_guards`, `test_hooks_cold_install`, `test_preview_lib`, `test_ux_conversion`; reference graph intact.
- Two-pass independent review: spec-compliance (10/11 → fixed the AC-5 Phase-5 gap → 11/11) + copy-quality (5 NITs, all applied).
- Copy-only on security surfaces: `security-controls.md` and all crypto/secret/auth gate **logic** untouched — additions are explanatory prose only.

## Out of scope (rejected under challenge)

No saves-ledger / per-gate counter / new statusline segment; no fresh audit-trail crawl; no stakes lines on mechanical gates; no warmth on routine greens.

## Notes

- **No version bump:** `plugin.json` is `2.4.3`, unpublished (no `v2.4.3` tag) — payload edits pass the version-bump gate as-is.
- Auto-decisions logged in `sprint-log.md`: **D-01** (execution model, moderate — flagged) and **D-02** (AC-5 Phase-5 stakes, resolved toward the approved spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)