### PR TITLE
Token-efficiency: subagent model tiering (Step 2a verified) + tooling

### DIFF
--- a/docs/investigations/token-efficiency.md
+++ b/docs/investigations/token-efficiency.md
@@ -1,0 +1,217 @@
+# Investigation Plan — Stretching the Max Subscription Across arbiter Use
+
+## Context
+
+**Goal:** get more out of the Max subscription across **all** arbiter use — the everyday interactive
+turns (`/ca:fix`, `/ca:feature`, `/ca:refactor`, `/ca:debug`, `/ca:review`, …) *and* the nightly
+`/ca:sprint` ritual (start a long sprint, go to bed; it grinds low-risk turns autonomously and
+exercises the plan allowance). The currency is usage-limit headroom and context quality, not dollars.
+The levers below are deliberately cross-cutting: model tiering, pruning, reviewer yield, and `/clear`
+discipline each pay off on every fan-out command during the day, not only inside a sprint. `/sprint`
+matters here only as the single longest, highest-burn *session class* — the place a regression shows
+up first — not as the sole target.
+
+**Why this plan exists, and why it differs from the input brief.** The input brief was written by
+Claude-for-desktop with only a *general* idea of what arbiter is, so several of its mechanics are
+wrong. This plan re-grounds every line against the actual plugin at
+`/home/user/codeArbiter/plugins/ca/`. Two corrections drive everything below:
+
+1. **Model tier is the dominant lever, and it applies to the premium path you use most.** Confirmed
+   from lived experience: Opus ≫ Sonnet ≫ Haiku in burn (Fable could drain a 5-hour window in ~17
+   minutes). The ca agents currently set **no `model:`** in frontmatter, so they all *inherit the
+   session model* — when you're on Opus, your reviewers, your finding-triage, your checkpoint-doc
+   writer are **all Opus**, including mechanical work that doesn't need it. Pinning cheap/mechanical
+   subagents to a lower tier is a **config lever, not a code rewrite** — and it's independent of farm.
+2. **`--farm` is a supplement, not the savior** — "a little extra juice." Its shape is: Claude spends
+   its (subscription) tokens on **thinking** — specs, failing tests, review judgment — while cheap
+   external models do the **labor** of making tests pass. It moves only the *authoring grunt-work* off
+   the Anthropic pool, behind the same gates. It stays a *tracked secondary experiment*; you'll be in
+   normal premium mode a lot even once farm works, which is exactly why lever #1 is primary.
+
+**Deliverable:** a representative measurement of where sprint burn concentrates, then a small set of
+*user-gated* changes — subagent model tiering, statusline on, pruner `dry`→`on`, context discipline —
+each justified by measurement, plus a go/no-go read on `--farm`.
+
+---
+
+## Ground-truth corrections to the brief (read this first)
+
+| Brief claim | Reality in the code / verified | Consequence for the plan |
+|---|---|---|
+| §3 Downgrade `backend-author` via a per-agent `model:` field that's already there | **No `model:` field is set on any of the 16 agents** (`plugins/ca/agents/*.md`) — they inherit the session model. But Claude Code **does support** `model:` in agent frontmatter (`sonnet`/`opus`/`haiku`/`fable`/full-id/`inherit`, default `inherit`). | The field isn't *set*, but the lever is real and supported. Becomes **Step 2 (primary)** — not a dead end. |
+| (implicit) downgrading subagents saves subscription | Confirmed by user experience: lower tier = materially less burn. Docs don't detail Max's all-model vs Sonnet-only weekly-cap accounting, but raw 5-hour-window + active-compute burn drops regardless. | Tiering directly buys session/weekly headroom. Sonnet possibly *also* draws a separate weekly bucket (unconfirmed bonus). |
+| §3 "cheaper tier for authors" is the only/main saver | **`--farm` is a *supplement*:** it offloads authoring *grunt-work* to an external OpenAI-compatible endpoint (`FARM_API_KEY`, OpenCode Zen) — a billing source separate from the Max pool — while Claude still spends its tokens on specs/tests/review (`includes/farm.md`, `SPRINT.md`). | Not the savior; "extra juice." `preview`/off/"not validated on real runs" (`CONFIRM-05`). **Secondary, tracked.** |
+| §4 Pruner may do "gate-aware retention" | Pruner **exists** (`hooks/_prunelib.py`, `commands/prune.md`) but is **recency-only**: protects the K most recent tool turns + latest assistant msg, trims older bulk. **Not** gate-aware. Ships **off**. | §4 "is it gate-aware?" is answered (no). Its value is *session lifetime at resume/compaction*, provable via its `dry` metrics log. |
+| §4 Pruner trims the *live* context mid-sprint | Gains land at `--resume`/restart/next compaction, **not the current turn** (`commands/prune.md:12`). | Pruner lets a sprint *resume* further; it doesn't lower live burn mid-turn. |
+| §2 MCP residency / resident overhead is a primary line | **No MCP infra or `ENABLE_TOOL_SEARCH` in the plugin.** Standing context is **exactly one file** — `ORCHESTRATOR.md` on `arbiter: enabled`; all skills/agents/routing load **on demand per reached node** (`docs/architecture.md` "Context minimization"; `docs/patterns/lazy-load-bundles.md`). | No resident footprint to trim. Cost is per-*session* accumulation (interactive or sprint) + authoring, not residency. |
+| §5 Sprint fans out the full reviewer set on every change | Quality review runs **once per scope** over the combined diff, **reviewers selected by what the diff touches** "by path matrix" (`subagent-driven-development/SKILL.md` Phase 4; `docs/architecture.md`). | Fan-out already engineered down. Re-frame §5 as a *yield* measurement that also feeds tiering. |
+| §6 "instrument visibility / first-pass rate" needs building | `/ca:statusline` already renders rate limits, context, tokens, API-equiv cost, per-call burn. Farm writes per-task attempts/escalations to `.farm/farm-report.json`. | Instrumentation exists; turn it on and sample. |
+
+---
+
+## The investigation, in priority order
+
+### Step 0 — Confirm the billing source (gate; invalidates everything if wrong)
+- Verify subscription auth, not a shadowing `ANTHROPIC_API_KEY`: `env | grep -i ANTHROPIC` + `/status`.
+
+### Step 1 — Turn on visibility, then sample (zero risk, prerequisite for all measurement)
+- `/ca:statusline install` (it surfaces the resolved command and asks before editing
+  `~/.claude/settings.json` — backing script `hooks/wire-statusline.py`).
+- **Sample across several sessions of both kinds** — ordinary daytime interactive sessions *and* the
+  nightly sprint — not one day (the brief's basis was a single day the tool flagged as "not a
+  breakdown"). Record per session: context-bar peak, cumulative tokens, per-call burn, which
+  5-hour/weekly cap bites first (`/status`, `/usage`). Note which command classes fan out subagents
+  most — that's where Step 2 pays off.
+- Proceed to the cost-concentration steps only if "subagent fan-out + long-context" reproduces.
+
+### Step 2 — Subagent model tiering (PRIMARY — biggest premium-path lever)
+The premium path runs every subagent at the session model. Tier the cheap/mechanical ones down, keep
+the high-judgment ones strong, and measure that quality holds. **This is the all-day lever:** every
+fan-out command pays for it — `/ca:fix`, `/ca:feature`, `/ca:refactor`, `/ca:checkpoint`, `/ca:pr`,
+the nightly sprint — anywhere arbiter dispatches an author, a reviewer, or an aggregator.
+
+**2a — First, settle how to apply tiers to *plugin* agents (one quick empirical test).** Claude Code's
+`model:` frontmatter is documented for user/project agents, but **whether it's honored for
+plugin-bundled agents is undocumented.** Test it: add `model: haiku` to one low-risk agent (e.g.
+`checkpoint-aggregator`), dispatch it, and confirm via the statusline's per-call model which model
+actually ran. Resolution order is **`CLAUDE_CODE_SUBAGENT_MODEL` env → per-invocation → frontmatter →
+session model**, which gives three ways to apply tiers, in increasing surgical precision:
+  - **Blunt/global:** `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` puts *all* subagents on Sonnet in one line —
+    easiest experiment, but also downgrades security reviewers (see governance caveat).
+  - **Surgical via frontmatter** (if the test shows plugin agents honor it): set `model:` per agent.
+  - **Surgical guaranteed:** shadow the specific agents into `.claude/agents/` with a `model:` line
+    (overrides the plugin copy) — works for sure, but carries drift-from-plugin maintenance cost.
+
+**2b — Proposed tier map** (validate each downgrade against its kill criterion before keeping it):
+  - **Keep strong (inherit/Opus) — high-judgment or governance-critical:** `security-reviewer`,
+    `auth-crypto-reviewer`, `migration-reviewer`, `decision-challenger`, `grader` (SMARTS scoring).
+  - **Sonnet candidates — real work, bounded by a gate:** the authors (`backend/frontend/infra-author`)
+    implement against a spec + a failing test, so a cheaper author is checked by the gate; the
+    user-facing `design-quality-reviewer`.
+  - **Haiku candidates — mechanical/low-judgment:** `checkpoint-aggregator` (writes a dated doc),
+    `finding-triage` (severity classification), `architecture-drift-reviewer` (informational, never
+    blocks), `coverage-auditor` (counts untested files / threshold checks), `scout` (evidence
+    gathering). This is the "don't burn Opus to write a line in `open-tasks.md`" class.
+
+**2c — Kill criteria (downgrade only survives if quality holds):**
+  - *Authors:* metric is **first-pass-through-gate rate**. A cheaper author that needs extra TDD
+    cycles to go green — and extra premium re-reviews — can net *more* burn. Baseline the current
+    author first-pass rate (Step 1 data) before changing anything; revert any author whose rate drops.
+  - *Reviewers/aggregators:* **replay equivalence** — re-run a past scope (from any command, sprint or
+    interactive) with the reviewer downgraded; it must produce the *same* findings/severities. Any miss
+    on a governance reviewer reverts immediately. (This is why security/auth/migration stay strong
+    until proven, not before.)
+  - Step 4's yield data tells you which reviewers are safest to try first.
+
+**2d — Possible repo deliverable:** if the 2a test shows plugin frontmatter is honored, the cleanest
+durable outcome is to add `model:` lines to the ca agents in `plugins/ca/agents/*.md` (a small,
+reviewable change to this repo) rather than per-user shadow copies. Gate that on the test result.
+*(Pre-staged on this branch as a separate, droppable commit — keep only if 2a passes.)*
+
+### Step 3 — Decide pruner `dry`→`on` from the ledger you ALREADY have (session-lifetime lever)
+The collection phase is done: `CODEARBITER_PRUNE=dry` has already run across several `standard`
+sessions and a couple of `aggressive` ones, so `~/.codearbiter/metrics/prune-dry.jsonl` exists
+**on the local machine** (not the fresh remote container — the analysis runs where the data lives).
+- **Analyze, don't re-collect:** `/ca:prune status` reports cumulative reduction + service state and
+  reads the ledger. The go/no-go signal is the framework's own bar: **every row `verdict: dry-run`,
+  `validation_errors: 0`** across the accumulated sessions. Also read the per-strategy reduction to see
+  where the bytes actually come from on real sessions (it helps any long session, daytime or sprint).
+- **Expected caveat (you flagged it):** the `aggressive`-only strategies (`stale-read`, `reminder
+  dedup`, `image evict`) only fire when those conditions occur, so the couple of aggressive sessions
+  may show little aggressive-specific data — that's an inconclusive aggressive-vs-standard comparison,
+  not a failure. `standard` is the tier with real coverage; decide on that, treat aggressive as TBD.
+- **Then, user's explicit choice only** (the framework refuses to enable it unbidden):
+  `CODEARBITER_PRUNE=on` at the tier the ledger validates (likely `standard`). Measure how much further
+  a *resumed* long session (sprint or a deep interactive thread) gets before the context bar forces a stop.
+- Files: `commands/prune.md`, `hooks/_prunelib.py`, `hooks/prune-transcript.py`, `hooks/hooks.json`.
+
+### Step 4 — Reviewer dispatch *yield* (the narrowed §5 — find unnecessary review)
+- Dispatch is already once-per-scope and diff-conditional, so the only waste is a reviewer that
+  **fires when nothing in its purview meaningfully changed** (e.g. a comment-only touch to a security
+  file still trips `security-reviewer`).
+- **Metric: dispatch-to-finding yield per reviewer** — from `sprint-log.md` (sprints) and the
+  per-command `finding-triage` output (interactive commands like `/ca:fix`, `/ca:pr`, `/ca:checkpoint`),
+  how often each reviewer is dispatched vs. returns any finding. Near-zero yield on trivial touches →
+  candidate for a tighter trigger (semantic change in domain, not mere path-touch) **and** a safer
+  model downgrade in Step 2.
+- **Tooling:** `python3 tools/reviewer-yield.py` computes this from `.codearbiter/checkpoints/*.md`.
+- **Governance constraint:** output is at most a *more precise trigger*, never a removed reviewer.
+- Files: `subagent-driven-development/SKILL.md` (Phase 4 triggers), `docs/architecture.md` (path-matrix
+  map, kept in lockstep with `includes/routing-table.md`), `agents/*-reviewer.md`, `agents/finding-triage.md`.
+
+### Step 5 — Context discipline (free, safe — and most relevant to *daytime* use)
+- `/clear` between *unrelated* tasks and `/compact` mid-task. This bites hardest in interactive use,
+  where a day's worth of unrelated `/ca:fix` / `/ca:feature` / `/ca:debug` turns pile up in one session
+  that a `/clear` would reset; a single coherent sprint accumulates less *unrelated* context. Investigate
+  where context actually goes stale, and measure the >150k-context usage share before/after the habit.
+
+### Step 6 — `--farm` as a tracked experiment (secondary supplement — "Claude thinks, cheap models labor")
+- The right mental model, not "the savior": Claude keeps spending its tokens on the high-judgment work
+  (specs, failing tests, the review chain) and hands the *labor* of making tests pass to cheap external
+  models. The win is marginal extra monthly juice, not a wholesale offload. It's `preview`/off/
+  unvalidated and uses external (often Chinese-origin) free models, gated by mutation + full review.
+- **The one real test (agreed to run):** `--farm` on a *low-sensitivity* sprint after setting
+  `FARM_API_KEY`; framework auto-selects a model by canary probe (`includes/farm.md` §"Model selection").
+- **Kill criterion:** **first-pass / escalation rate** from `.farm/farm-report.json`. High escalation
+  or a circuit-breaker trip (`FARM_ABORT_ESCALATION_RATE`) means re-dispatches land back on the Max
+  pool → the "labor" quietly becomes Claude's again, erasing the juice. **Sovereignty:** pin
+  `FARM_MODEL` to a clean model on anything sensitive.
+- **Tooling:** `python3 tools/farm-first-pass.py` computes first-pass/escalation from the report.
+- Files: `includes/farm.md`, `tools/farm.ts`, `skills/subagent-driven-development/references/farm-dispatch.md`,
+  `SPRINT.md` (§"Execution backend").
+
+---
+
+## Explicitly out of scope (debunked or non-arbiter)
+- **Blanket "cheapest model for *all* subagents"** — would silently downgrade the governance reviewers.
+  Tiering is *selective* (Step 2), gated by replay equivalence; security/auth/migration stay strong.
+- **MCP residency / `ENABLE_TOOL_SEARCH`** — no MCP infra in the plugin; a harness concern.
+- **Resident-overhead reduction** — standing context is one file; the rest is lazy-loaded. Nothing to trim.
+- **Peak-hour timing** — conflicting public reports; verify via `/usage` only if it ever bites.
+
+---
+
+## Verification / how we'll know each step worked
+- **Step 1:** statusline renders; `/ca:statusline status` confirms it's arbiter's with a backup. Multi-session sample captured.
+- **Step 2:** the 2a test shows which application mechanism actually changes a subagent's model (read it off the statusline's per-call model). Each downgrade passes its kill criterion — authors hold first-pass rate; downgraded reviewers/aggregators produce identical findings on a replayed scope. Net burn drops vs. the all-Opus baseline across both interactive commands and the sprint.
+- **Step 3:** `/ca:prune status` over the *already-accumulated* ledger shows every row `verdict: dry-run`, `validation_errors: 0` (clean across the `standard` sessions); after flipping `on`, a resumed long session reaches further before the context bar forces a stop.
+- **Step 4:** a per-reviewer dispatch-vs-finding table (across sprint + interactive scopes); any trigger change replays an old scope to the *same* findings set (no governance regression).
+- **Step 5:** measured drop in the >150k-context usage share across sampled sessions (esp. daytime interactive).
+- **Step 6:** `farm-report.json` first-pass/escalation rate on a real slice; net Max-pool burn (incl. premium re-dispatches) vs. a premium-only run of a comparable slice.
+
+## Note on this plan's own method
+This is an *investigation* plan: most steps are measurements and user-gated config toggles (`model:`
+frontmatter / `CLAUDE_CODE_SUBAGENT_MODEL`, `/ca:statusline install`, `CODEARBITER_PRUNE`), with one
+optional repo change (Step 2d) gated on the plugin-frontmatter test. The framework refuses to enable
+the pruner or statusline on the user's behalf — every "turn it on" step is the user's explicit call.
+
+---
+
+## Findings — local execution (2026-06-18)
+- **Step 0:** no `ANTHROPIC_API_KEY` in env → burn draws on the Max subscription. Gate passes.
+- **Step 1:** statusline already installed and wired to codeArbiter (backup recorded).
+- **Step 2a — RESOLVED: plugin frontmatter `model:` IS honored, at session start.** Proven by
+  self-report dispatch after `/exit` + `--resume`: `coverage-auditor` (haiku) ran as Haiku,
+  `backend-author` (sonnet) ran as Sonnet, both with no override. A mid-session cache patch did
+  *not* take (ran Opus) — defs load once at session start and are held in memory. Per-invocation
+  override also works and *beats* frontmatter (verified: haiku frontmatter + `sonnet` override → Sonnet).
+  - **Verdict:** keep commit 2 as the durable automatic baseline tier map; reserve per-invocation
+    override for dynamic exceptions. `.claude/agents/` shadow copies rejected — they inflate the
+    resident agent roster (a real cost off the ~27k floor); frontmatter does not.
+  - **Precedence gotcha:** `CLAUDE_CODE_SUBAGENT_MODEL` (env) beats per-invocation, so it can't be a
+    "Sonnet floor" without dragging governance reviewers down. No env var; rely on per-agent frontmatter.
+  - Kill criteria (2c) still apply before each downgrade is trusted: authors hold first-pass rate;
+    downgraded reviewers/aggregators must replay to identical findings.
+- **Step 3:** local `prune-dry.jsonl` = 9 sessions, every row `verdict: dry-run`, `validation_errors: 0`.
+  standard ~33% avg (4 sessions), aggressive ~32% (5) with its extra strategies barely firing
+  (`repeat-reminder-fold`/`inline-image-evict` never triggered) → aggressive inconclusive. Wins come
+  from `sidecar-collapse` + `aged-result-condense` (both standard). Justified to flip `on@standard`
+  (user toggle). Aggressive: TBD.
+
+## Branch artifacts (for resuming locally)
+This branch (`claude/investigate-token-efficiency-bbf17t`) carries:
+- `tools/reviewer-yield.py`, `tools/farm-first-pass.py`, `tools/README.md` — the analysis aids (Steps 4 & 6).
+- `plugins/ca/agents/*.md` `model:` lines — the **gated** Step 2d tiering (separate commit; keep only if the 2a test confirms plugin frontmatter is honored).
+- this plan doc.
+
+Local resume: `git pull`, then run the runbook from Step 0 in your terminal Claude Code (statusline, prune ledger, the 2a test, sampling, and — when ready — the `--farm` test all need the live local session).

--- a/docs/investigations/token-efficiency.md
+++ b/docs/investigations/token-efficiency.md
@@ -207,6 +207,22 @@ the pruner or statusline on the user's behalf — every "turn it on" step is the
   (`repeat-reminder-fold`/`inline-image-evict` never triggered) → aggressive inconclusive. Wins come
   from `sidecar-collapse` + `aged-result-condense` (both standard). Justified to flip `on@standard`
   (user toggle). Aggressive: TBD.
+- **Step 4 — reviewer yield (n=2 checkpoints, thin):** no actionable trigger change at this sample.
+  Found and fixed a data-quality bug first: the auth-crypto sub-reviewer was logged under two names
+  (`auth-crypto-reviewer` / `auth-reviewer`), splitting its row and mis-reading as 0% — actually ~50%
+  (4 findings). `tools/reviewer-yield.py` now canonicalizes that alias. After the merge, the only
+  genuine 0%-yield reviewer is `migration-reviewer` (2 disp / 0 found) — but it's governance (held
+  `inherit`) and n=2, so per the governance constraint the most it could ever justify is a *tighter
+  trigger*, never a downgrade/removal, and not on this sample. **Action: accumulate checkpoints; watch
+  `migration-reviewer`.** Deeper fix: canonical reviewer names at checkpoint-authoring time.
+- **Step 5 — context discipline (advisory; longitudinal):** habit = `/clear` between *unrelated* tasks,
+  `/compact` mid-task. The before/after >150k-context usage share needs `/usage` sampling across days;
+  not measurable in one session. Ledger corroborates large transcripts (9 sessions est. 270k–585k
+  tokens) but those are transcript sizes, not live-window peaks.
+- **Step 6 — `--farm` (user-gated; not run):** no `FARM_API_KEY`, no `.farm/` (never run). Instrument
+  `tools/farm-first-pass.py` confirmed working (clean no-data path). Protocol: set `FARM_API_KEY`, run
+  one low-sensitivity `/ca:sprint --farm`, judge on first-pass/escalation from `.farm/farm-report.json`;
+  pin `FARM_MODEL` on anything sensitive.
 
 ## Branch artifacts (for resuming locally)
 This branch (`claude/investigate-token-efficiency-bbf17t`) carries:

--- a/plugins/ca/agents/architecture-drift-reviewer.md
+++ b/plugins/ca/agents/architecture-drift-reviewer.md
@@ -2,6 +2,7 @@
 name: architecture-drift-reviewer
 description: Read-only checkpoint reviewer. Surfaces drift between the codebase and accepted ADRs in .codearbiter/decisions/. Informational — never blocks.
 tools: Read, Grep, Glob, Bash
+model: haiku
 ---
 
 # Architecture Drift Reviewer Agent

--- a/plugins/ca/agents/auth-crypto-reviewer.md
+++ b/plugins/ca/agents/auth-crypto-reviewer.md
@@ -2,6 +2,7 @@
 name: auth-crypto-reviewer
 description: Reviews authentication, cryptography, key handling, and secrets against ${CLAUDE_PROJECT_DIR}/.codearbiter/security-controls.md. Hard blocks on banned primitives, exposed secrets, disabled TLS verification, and shell injection. Read-only checkpoint reviewer.
 tools: Read, Grep, Glob, Bash
+model: inherit
 ---
 
 # Auth/Crypto Reviewer Agent

--- a/plugins/ca/agents/backend-author.md
+++ b/plugins/ca/agents/backend-author.md
@@ -2,6 +2,7 @@
 name: backend-author
 description: Use when writing or modifying backend/server-side code. Owns the TDD workflow, input validation, framework conventions, and ORM usage. MUST write failing tests before implementation code. Reads tech stack from ${CLAUDE_PROJECT_DIR}/.codearbiter/tech-stack.md.
 tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
 ---
 
 # Backend Author Agent

--- a/plugins/ca/agents/checkpoint-aggregator.md
+++ b/plugins/ca/agents/checkpoint-aggregator.md
@@ -2,6 +2,7 @@
 name: checkpoint-aggregator
 description: Composes the finding-triage report and decision-challenger output into a dated checkpoint document under .codearbiter/checkpoints/YYYY-MM-DD.md. Aggregator, not a blocker.
 tools: Read, Glob, Bash, Write
+model: haiku
 ---
 
 # Checkpoint Aggregator Agent

--- a/plugins/ca/agents/coverage-auditor.md
+++ b/plugins/ca/agents/coverage-auditor.md
@@ -2,6 +2,7 @@
 name: coverage-auditor
 description: Dispatched by the tdd skill (Phase 4) to audit test coverage against TDD obligations. Identifies untested source files, coverage below the maturity threshold, and logical test gaps.
 tools: Read, Grep, Glob, Bash
+model: haiku
 ---
 
 # Coverage Auditor Agent

--- a/plugins/ca/agents/decision-challenger.md
+++ b/plugins/ca/agents/decision-challenger.md
@@ -2,6 +2,7 @@
 name: decision-challenger
 description: Adversarial red-team reviewer of ADRs. Builds the strongest case against each decision, names load-bearing assumptions, assigns confidence 1–5, and surfaces evidence that would prove a decision wrong. Read-only. Dispatched optionally by decision-variance. Reads ADRs from .codearbiter/decisions/.
 tools: Read, Grep, Glob, Bash
+model: inherit
 ---
 
 # Decision Challenger Agent

--- a/plugins/ca/agents/dependency-reviewer.md
+++ b/plugins/ca/agents/dependency-reviewer.md
@@ -2,6 +2,7 @@
 name: dependency-reviewer
 description: Dispatched when package.json, lock files, or container base images change. Verifies license, provenance, maintenance signal, and supply-chain posture against .codearbiter/security-controls.md and .codearbiter/tech-stack.md before merge.
 tools: Read, Bash, Grep, WebFetch
+model: sonnet
 ---
 
 # Dependency Reviewer Agent

--- a/plugins/ca/agents/design-quality-reviewer.md
+++ b/plugins/ca/agents/design-quality-reviewer.md
@@ -2,6 +2,7 @@
 name: design-quality-reviewer
 description: Reviews generated, user-facing visual or formatted output (UI, reports, slides, charts, diagrams, CLI output) against the anti-slop-design reference. Read-only; surfaces design-slop findings. Dispatched by frontend-author on UI changes. Tier 2 document producers (/pr, release) apply the reference inline and do not dispatch this agent. Loads only the medium leaf the artifact needs.
 tools: Read, Grep, Glob
+model: sonnet
 ---
 
 # Design Quality Reviewer Agent

--- a/plugins/ca/agents/finding-triage.md
+++ b/plugins/ca/agents/finding-triage.md
@@ -2,6 +2,7 @@
 name: finding-triage
 description: Post-processes all checkpoint reviewer reports — consolidates findings, classifies each by severity and whether it blocks the current change. Sequential. Produces a unified triage report for the checkpoint-aggregator. Reads project state from .codearbiter/.
 tools: Read, Grep, Glob
+model: haiku
 ---
 
 # Finding Triage Agent

--- a/plugins/ca/agents/frontend-author.md
+++ b/plugins/ca/agents/frontend-author.md
@@ -2,6 +2,7 @@
 name: frontend-author
 description: Use when writing or modifying frontend/UI code. Owns the TDD workflow, component conventions, state management, and UI security. MUST write failing tests before implementation code. Reads tech stack from ${CLAUDE_PROJECT_DIR}/.codearbiter/tech-stack.md.
 tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
 ---
 
 # Frontend Author Agent

--- a/plugins/ca/agents/grader.md
+++ b/plugins/ca/agents/grader.md
@@ -2,6 +2,7 @@
 name: grader
 description: INTERNAL SMARTS analyst dispatched by the decision-variance skill. Produces a SMARTS analysis and recommendation for one (artifact-position, scaffold-evidence) pair. Never decides — the user decides. Never dispatch directly.
 tools: Read, Grep, Glob, Bash
+model: inherit
 ---
 
 # Grader Subagent

--- a/plugins/ca/agents/infra-author.md
+++ b/plugins/ca/agents/infra-author.md
@@ -2,6 +2,7 @@
 name: infra-author
 description: Use when writing or modifying IaC, containers, CI/CD manifests, or deployment configuration. Reads tech stack and security boundaries from ${CLAUDE_PROJECT_DIR}/.codearbiter/.
 tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
 ---
 
 # Infrastructure Author Agent

--- a/plugins/ca/agents/migration-reviewer.md
+++ b/plugins/ca/agents/migration-reviewer.md
@@ -2,6 +2,7 @@
 name: migration-reviewer
 description: Dispatched when a database migration file is added or modified. Reviews migrations for safety, data-classification tagging, and immutability against .codearbiter/security-controls.md.
 tools: Read, Bash, Grep
+model: inherit
 ---
 
 # Migration Reviewer Agent

--- a/plugins/ca/agents/scout.md
+++ b/plugins/ca/agents/scout.md
@@ -2,6 +2,7 @@
 name: scout
 description: INTERNAL evidence-gatherer dispatched by the decision-variance and context-creation skills. Scans an assigned code scope and reports evidence of architectural decisions — file paths and line numbers only. Never dispatch directly.
 tools: Read, Grep, Glob, Bash
+model: haiku
 ---
 
 # Scout Subagent

--- a/plugins/ca/agents/security-reviewer.md
+++ b/plugins/ca/agents/security-reviewer.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: Dispatch PROACTIVELY when a change touches authentication, authorization, cryptography, secrets, deployment manifests, network policies, or CI workflows. Reviews diffs against ${CLAUDE_PROJECT_DIR}/.codearbiter/security-controls.md. Read-only; produces findings.
 tools: Read, Grep, Glob, Bash
+model: inherit
 ---
 
 # Security Reviewer Agent

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,36 @@
+# tools/ — repo-level utilities
+
+Standalone helper scripts (not part of the shipped `ca` plugin runtime). Read-only
+unless noted.
+
+## Token-efficiency investigation aids
+
+Two analysis scripts that turn arbiter's own persisted artifacts into the metrics the
+subscription-efficiency investigation needs. Both are stdlib-only Python 3, read-only,
+and print a human table by default or `--json` for machine use.
+
+### `reviewer-yield.py` — per-reviewer dispatch-to-finding yield
+```
+python3 tools/reviewer-yield.py [CHECKPOINT_DIR ...]      # default ./.codearbiter/checkpoints
+python3 tools/reviewer-yield.py --json
+```
+Parses the `## Finding summary` table in each `.codearbiter/checkpoints/*.md` and reports,
+per reviewer, how often it was dispatched vs. actually returned a finding. Lowest-yield
+reviewers (dispatched a lot, find little) are the candidates for a tighter dispatch
+trigger and/or a cheaper model tier. Coverage is persisted checkpoint docs only — sprint
+Phase-4 reviews that don't write a checkpoint are undercounted, so treat it as a pointer.
+
+### `farm-first-pass.py` — first-pass / escalation rate for `--farm` runs
+```
+python3 tools/farm-first-pass.py [PATH]                   # default .farm/farm-report.json
+python3 tools/farm-first-pass.py --json
+```
+Parses `.farm/farm-report.json` (written by `tools/farm.ts`) and reports the
+first-pass-through-gate rate, escalation rate, average attempts, gaming warnings, and
+off-pool worker token spend. A low first-pass rate plus a nonzero escalation rate means
+the cheap worker is offloading less than it appears — escalated tasks revert to the
+premium (Max-pool) path. That is the revert signal for the farm experiment.
+
+## Other
+
+- `statusline-screenshot.py` — renders a sample of the codeArbiter statusline.

--- a/tools/farm-first-pass.py
+++ b/tools/farm-first-pass.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""farm-first-pass.py — first-pass-through-gate & escalation rate from a farm report.
+
+Part of the token-efficiency investigation. Serves two plan steps at once:
+  - Step 6 kill-criterion: is `--farm` actually buying juice, or are escalations
+    sending the work back to the premium (Max-pool) path?
+  - Step 2c baseline (farm path): the first-pass-through-gate rate for worker-authored
+    tasks. A cheap author that needs multiple attempts to go green can cost MORE than a
+    stronger model passing first try; this measures it instead of guessing.
+
+Source of truth: `.farm/farm-report.json`, written by tools/farm.ts:
+  { plan, aborted, tokens:{prompt,completion},
+    results:[ {id, status:"green"|"escalate", attempts, promptTokens?, completionTokens?,
+               mutationScore?, warning?, note?, filesWritten?} ],
+    blocked:[ {id, reason} ], ts }
+
+Definitions:
+  - settled task         = appears in results[] (green or escalate)
+  - first-pass green      = status=="green" AND attempts==1
+  - first-pass rate       = first-pass green / settled
+  - escalation rate       = escalate / settled   (compare to FARM_ABORT_ESCALATION_RATE)
+  - A high escalation rate (or aborted=true) means re-dispatches land back on the Max
+    pool — the farm's "extra juice" erodes. That is the revert signal.
+
+Usage:
+  farm-first-pass.py [PATH]      Default: .farm/farm-report.json
+  farm-first-pass.py --json [PATH]
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def load(path):
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def analyze(report):
+    results = report.get("results", []) or []
+    blocked = report.get("blocked", []) or []
+    settled = len(results)
+    green = [r for r in results if r.get("status") == "green"]
+    escalated = [r for r in results if r.get("status") == "escalate"]
+    first_pass = [r for r in green if int(r.get("attempts", 0)) == 1]
+    multi_pass = [r for r in green if int(r.get("attempts", 0)) > 1]
+
+    def rate(n):
+        return (n / settled * 100) if settled else 0.0
+
+    total_attempts = sum(int(r.get("attempts", 0)) for r in results)
+    warned = [r for r in results if r.get("warning")]
+
+    return {
+        "aborted": bool(report.get("aborted")),
+        "settled": settled,
+        "blocked": len(blocked),
+        "green": len(green),
+        "escalated": len(escalated),
+        "first_pass_green": len(first_pass),
+        "multi_pass_green": len(multi_pass),
+        "first_pass_rate_pct": round(rate(len(first_pass)), 1),
+        "escalation_rate_pct": round(rate(len(escalated)), 1),
+        "avg_attempts_per_settled": round(total_attempts / settled, 2) if settled else 0.0,
+        "gaming_warnings": len(warned),
+        "tokens": report.get("tokens", {}),
+        "model": (report.get("plan") or {}).get("model"),
+        "ts": report.get("ts"),
+        "_results": results,
+        "_blocked": blocked,
+    }
+
+
+def main(argv):
+    json_out = "--json" in argv
+    pos = [a for a in argv if not a.startswith("--")]
+    path = pos[0] if pos else os.path.join(".farm", "farm-report.json")
+    if not os.path.exists(path):
+        print(f"No farm report at {path}. Run `/ca:sprint --farm` first, or pass a path.",
+              file=sys.stderr)
+        return 1
+
+    a = analyze(load(path))
+
+    if json_out:
+        out = {k: v for k, v in a.items() if not k.startswith("_")}
+        print(json.dumps(out, indent=2))
+        return 0
+
+    print(f"Farm first-pass / escalation report  ({path})")
+    if a["model"]:
+        print(f"Model: {a['model']}    written: {a['ts']}")
+    if a["aborted"]:
+        print("\n  ** ABORTED by circuit breaker — escalation exceeded threshold. **")
+        print("  ** Re-dispatches go to the premium Max pool: net-negative this run. **")
+    print()
+    print(f"  settled tasks      : {a['settled']}  (blocked: {a['blocked']})")
+    print(f"  green              : {a['green']}  (first-pass: {a['first_pass_green']}, "
+          f"multi-pass: {a['multi_pass_green']})")
+    print(f"  escalated          : {a['escalated']}")
+    print(f"  FIRST-PASS RATE    : {a['first_pass_rate_pct']}%   <- Step 2c baseline / kill-criterion")
+    print(f"  escalation rate    : {a['escalation_rate_pct']}%   (compare to FARM_ABORT_ESCALATION_RATE, default 50%)")
+    print(f"  avg attempts/task  : {a['avg_attempts_per_settled']}")
+    print(f"  gaming warnings    : {a['gaming_warnings']}")
+    tok = a["tokens"] or {}
+    if tok:
+        print(f"  worker tokens      : prompt={tok.get('prompt','?')} completion={tok.get('completion','?')} "
+              f"(off-pool; the point of the farm)")
+
+    if a["escalated"]:
+        print("\n  Escalated tasks (each one's labor reverts to the premium path):")
+        for r in a["_results"]:
+            if r.get("status") == "escalate":
+                note = (r.get("note") or "").split("\n")[0]
+                print(f"    - {r.get('id')}: attempts={r.get('attempts')}  {note}")
+    print("\nVerdict heuristic: low first-pass rate + nonzero escalation = the cheap worker")
+    print("is offloading less than it looks; weigh against a premium-only run of the same slice.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/reviewer-yield.py
+++ b/tools/reviewer-yield.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""reviewer-yield.py — per-reviewer dispatch-to-finding yield from checkpoint docs.
+
+Part of the token-efficiency investigation (Step 4 of the plan). Answers: when a
+reviewer IS dispatched, how often does it actually return a finding? A reviewer that
+is dispatched a lot but almost never finds anything on the changes it sees is the
+candidate for (a) a tighter dispatch trigger and (b) a safer model downgrade (Step 2).
+
+Source of truth: the "## Finding summary" table inside each
+`.codearbiter/checkpoints/YYYY-MM-DD*.md` document (written by checkpoint-aggregator).
+Each row is a reviewer that ran in that checkpoint, with its CRITICAL/HIGH/MEDIUM/LOW
+counts. A row whose cells say "Not run" is excluded from the dispatch denominator;
+a row that PASSed with zero findings counts as a dispatch that produced nothing.
+
+LIMITATIONS (read before trusting):
+- Coverage is whatever checkpoint docs exist on disk. The `/sprint` Phase-4 quality
+  review does not always persist a checkpoint document, so sprint-only review activity
+  may be undercounted. This measures the persisted record, not every dispatch ever.
+- "Finding produced" means an enforced C/H/M/L severity. Bare [NEEDS-TRIAGE] notes are
+  not counted as findings.
+
+Usage:
+  reviewer-yield.py [CHECKPOINT_DIR ...]
+      Default dir: ./.codearbiter/checkpoints
+  reviewer-yield.py --json        Emit machine-readable JSON instead of a table.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import sys
+
+SEVERITIES = ("critical", "high", "medium", "low")
+_LEADING_INT = re.compile(r"-?\d+")
+
+
+def _cell_count(raw: str) -> int:
+    """Leading integer of a summary cell; 0 for '—', 'PASS', 'Not run', prose, etc."""
+    m = _LEADING_INT.search(raw.strip())
+    return int(m.group()) if m and raw.strip()[:1].isdigit() else 0
+
+
+def _norm(name: str) -> str:
+    return name.strip().strip("*` ").strip()
+
+
+def parse_finding_summary(text: str):
+    """Yield (reviewer, [c,h,m,l], not_run) for each data row of the first
+    '## Finding summary' table in a checkpoint document."""
+    lines = text.splitlines()
+    in_section = False
+    seen_table = False
+    for line in lines:
+        if line.lstrip().lower().startswith("## finding summary"):
+            in_section = True
+            continue
+        if in_section:
+            stripped = line.strip()
+            if stripped.startswith("## ") or stripped.startswith("---"):
+                break  # left the section
+            if not stripped.startswith("|"):
+                continue
+            cells = [c.strip() for c in stripped.strip("|").split("|")]
+            if len(cells) < 2:
+                continue
+            reviewer = _norm(cells[0])
+            low = reviewer.lower()
+            if not seen_table:
+                # First table row is the header (| Reviewer | CRITICAL | ... |)
+                seen_table = True
+                continue
+            if set(reviewer) <= {"-", " "} or low.startswith(":--") or "--" in reviewer:
+                continue  # separator row
+            if not reviewer or low.startswith("total") or low.startswith("**total"):
+                continue
+            sev_cells = cells[1:5]
+            not_run = any("not run" in c.lower() for c in sev_cells)
+            counts = [_cell_count(c) for c in sev_cells] + [0, 0, 0, 0]
+            yield reviewer, counts[:4], not_run
+
+
+def collect(dirs):
+    files = []
+    for d in dirs:
+        files.extend(sorted(glob.glob(os.path.join(d, "*.md"))))
+    stats = {}  # reviewer -> dict
+    for fp in files:
+        try:
+            text = open(fp, encoding="utf-8").read()
+        except OSError as e:
+            print(f"warn: cannot read {fp}: {e}", file=sys.stderr)
+            continue
+        for reviewer, counts, not_run in parse_finding_summary(text):
+            s = stats.setdefault(
+                reviewer,
+                {"dispatched": 0, "with_findings": 0, "not_run": 0,
+                 "total_findings": 0, "by_sev": [0, 0, 0, 0], "checkpoints": []},
+            )
+            if not_run:
+                s["not_run"] += 1
+                continue
+            s["dispatched"] += 1
+            total = sum(counts)
+            if total > 0:
+                s["with_findings"] += 1
+            s["total_findings"] += total
+            for i in range(4):
+                s["by_sev"][i] += counts[i]
+            s["checkpoints"].append(os.path.basename(fp))
+    return files, stats
+
+
+def main(argv):
+    json_out = "--json" in argv
+    dirs = [a for a in argv if not a.startswith("--")] or [
+        os.path.join(".codearbiter", "checkpoints")
+    ]
+    files, stats = collect(dirs)
+
+    if not files:
+        print(f"No checkpoint documents found under: {', '.join(dirs)}", file=sys.stderr)
+        return 1
+
+    rows = []
+    for reviewer, s in stats.items():
+        disp = s["dispatched"]
+        yield_pct = (s["with_findings"] / disp * 100) if disp else 0.0
+        rows.append((reviewer, s, yield_pct))
+    # Lowest yield first — best downgrade/tighten candidates at the top.
+    rows.sort(key=lambda r: (r[2], r[1]["total_findings"]))
+
+    if json_out:
+        out = {
+            "checkpoints_scanned": [os.path.basename(f) for f in files],
+            "reviewers": [
+                {
+                    "reviewer": rv,
+                    "dispatched": s["dispatched"],
+                    "with_findings": s["with_findings"],
+                    "not_run": s["not_run"],
+                    "yield_pct": round(yp, 1),
+                    "total_findings": s["total_findings"],
+                    "by_severity": dict(zip([x.upper() for x in SEVERITIES], s["by_sev"])),
+                }
+                for rv, s, yp in rows
+            ],
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    print(f"Reviewer dispatch-to-finding yield  ({len(files)} checkpoint(s) scanned)")
+    print("Lowest yield first = best candidate for a tighter trigger (Step 4) / model downgrade (Step 2).\n")
+    hdr = f"{'reviewer':<30} {'disp':>4} {'found':>5} {'yield':>6} {'tot':>4}  {'C/H/M/L'}"
+    print(hdr)
+    print("-" * len(hdr))
+    for rv, s, yp in rows:
+        chml = "/".join(str(x) for x in s["by_sev"])
+        nr = f"  (not-run x{s['not_run']})" if s["not_run"] else ""
+        print(f"{rv:<30} {s['dispatched']:>4} {s['with_findings']:>5} {yp:>5.0f}% {s['total_findings']:>4}  {chml}{nr}")
+    print("\nNote: coverage is persisted checkpoint docs only; sprint Phase-4 reviews may")
+    print("not write a checkpoint and can be undercounted. Treat as a pointer, not a census.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/reviewer-yield.py
+++ b/tools/reviewer-yield.py
@@ -42,8 +42,20 @@ def _cell_count(raw: str) -> int:
     return int(m.group()) if m and raw.strip()[:1].isdigit() else 0
 
 
+# Checkpoint docs are authored free-hand, so the same reviewer can appear under more
+# than one label across documents (e.g. the auth-crypto sub-reviewer logged as both
+# "auth-crypto-reviewer" and the shorthand "auth-reviewer"). Left unmerged, that splits
+# one reviewer's dispatches across two rows and corrupts the yield metric. Canonicalize
+# known aliases to the agent's real name (plugins/ca/agents/<name>.md). Extend as new
+# label drift is observed; the deeper fix is canonical names at checkpoint authoring time.
+_CANON = {
+    "auth-reviewer": "auth-crypto-reviewer",
+}
+
+
 def _norm(name: str) -> str:
-    return name.strip().strip("*` ").strip()
+    cleaned = name.strip().strip("*` ").strip()
+    return _CANON.get(cleaned.lower(), cleaned)
 
 
 def parse_finding_summary(text: str):


### PR DESCRIPTION
## What

Token-efficiency investigation to stretch the Max subscription across arbiter use. Ships
three things, plus the investigation record:

1. **Subagent model tiering** (the primary lever) — adds an explicit `model:` line to each
   of the 15 ca agents so cheap/mechanical work stops inheriting the expensive session model.
2. **reviewer-yield tool fix** — canonicalizes a reviewer-name alias so the yield metric is
   trustworthy.
3. **Analysis tools** — `tools/reviewer-yield.py`, `tools/farm-first-pass.py`, `tools/README.md`.
4. **Plan + findings doc** — `docs/investigations/token-efficiency.md`.

## The tier map (15 agents)

- **sonnet** — backend / frontend / infra-author, design-quality-reviewer, dependency-reviewer
- **inherit** (kept strong) — security-reviewer, auth-crypto-reviewer, migration-reviewer,
  decision-challenger, grader (governance / high-judgment)
- **haiku** — checkpoint-aggregator, finding-triage, architecture-drift-reviewer,
  coverage-auditor, scout (mechanical / low-judgment)

## Why this is safe to ship (Step 2a verified)

Plugin-bundled agent frontmatter `model:` IS honored, but only when loaded at session start.
Proven empirically: with the tier map staged into the plugin cache and the session restarted
(/exit + --resume), coverage-auditor (haiku) ran as Haiku and backend-author (sonnet) ran as
Sonnet, both with no per-invocation override. A mid-session cache edit did NOT take (agent defs
are read once at startup, held in memory). Per-invocation override also works and beats
frontmatter, so it remains available for dynamic exceptions; frontmatter is the durable
automatic baseline, with zero added always-resident context (shadow copies in .claude/agents/
were rejected for inflating the resident roster). No CLAUDE_CODE_SUBAGENT_MODEL floor: env beats
per-invocation and would drag the governance reviewers down.

## Reviewer-yield fix (Step 4)

The auth-crypto sub-reviewer was logged under two names across checkpoint docs
(auth-crypto-reviewer / the shorthand auth-reviewer), splitting its row and mis-reading as 0%
yield when it actually produced 4 findings (~50%). Added an alias map in _norm so the metric is
correct as checkpoint data accumulates. Deeper fix (canonical names at checkpoint-authoring
time) noted but out of scope here.

## Kill-criteria before each downgrade is trusted (2c)

Each downgrade is a starting recommendation, not yet validated against real runs:

- Authors hold their first-pass-through-gate rate. A Sonnet author burning extra TDD cycles is
  net-negative; revert that agent to `model: inherit`.
- Downgraded reviewers/aggregators must reproduce the same findings on a replayed scope. Any
  miss on a governance-adjacent reviewer reverts immediately.

Governance reviewers stay `inherit` precisely so they never enter this gamble.

## Not in this PR (user-gated / longitudinal)

- Step 5 context discipline (/clear + /compact) — needs longitudinal /usage sampling.
- Step 6 --farm — needs FARM_API_KEY and one low-sensitivity sprint; instrument confirmed working.
- The pruner flip to on@standard is a local settings.json change, not a repo change.

https://claude.ai/code/session_01B69UKoeYjCzM7hEJtwBdjx
