### PR TITLE
feat(farm): entitlement pre-check + fix stale endpoint default and CRLF drift (#90 #91 #93)

### DIFF
--- a/.codearbiter/plans/farm-feature-forge-fixes.md
+++ b/.codearbiter/plans/farm-feature-forge-fixes.md
@@ -1,0 +1,51 @@
+# Plan — farm feature-forge fixes (#90, #91, #93)
+
+Spec: `.codearbiter/specs/farm-feature-forge-fixes.md`. Each task is test-first via `tdd`.
+Status ledger: `PENDING` → `RED` (failing test in) → `GREEN` → `ACCEPTED` (reviewed + verified).
+All paths relative to repo root. Tools cwd = `plugins/ca/tools/`.
+
+## Landing structure
+
+**One combined PR** (user decision at the gate, 2026-06-18): single branch
+`fix/farm-feature-forge-90-91-93` off `main`, closing #90, #91, and #93. Zero `farm.js` merge friction,
+one review, one rebuild of the bundle at the end. The per-branch headings below are kept as logical
+task groups; all land in the one branch/PR.
+
+---
+
+## Branch 1 — #90 stale base URL  (`fix/farm-stale-base-url`)
+
+- **T90-1** `[PENDING]` — RED: unit test in `farm.unit.test.ts` asserting the resolved default base URL is `https://opencode.ai/zen/v1`. Files: `plugins/ca/tools/farm.unit.test.ts`. Verify: test fails (still old URL). Maps: AC-90.1.
+- **T90-2** `[PENDING]` — GREEN: change `ENV.defaultApiBaseUrl` default to `https://opencode.ai/zen/v1`. Files: `plugins/ca/tools/farm.ts`. Verify: T90-1 green. Maps: AC-90.1.
+- **T90-3** `[PENDING]` — RED: unit test driving a 2xx-with-non-JSON-body response through `callApi` (export `callApi` or extract `parseApiResponse`), asserting an actionable error naming `FARM_API_BASE_URL`. Files: `farm.unit.test.ts`. Verify: fails. Maps: AC-90.2.
+- **T90-4** `[PENDING]` — GREEN: in `callApi`, detect a non-JSON 2xx body and return the actionable message; keep diagnostics-to-stderr behavior. Files: `farm.ts`. Verify: T90-3 green, suite green. Maps: AC-90.2.
+- **T90-5** `[PENDING]` — docs: update `plugins/ca/includes/farm.md` default URL; no `api.opencode.ai/v1` left. Files: `plugins/ca/includes/farm.md`. Verify: grep clean. Maps: AC-90.3.
+- **T90-6** `[PENDING]` — build + land: `npm run typecheck && npm test && npm run build`; assert `git diff --quiet -- farm.js`; commit-gate; open PR closing #90. Maps: AC-90.4.
+
+## Branch 2 — #91 CRLF drift  (`fix/farm-crlf-drift`)
+
+- **T91-1** `[PENDING]` — RED: unit test for an exported `checkDrift(cwd, allowed, gitRunner)` — stub git returns an out-of-scope path on `stdout` and a `warning: ... LF will be replaced by CRLF ...` on `stderr` (also in merged `out`); assert only the real out-of-scope path returns and the warning never does; second case asserts in-scope-only + warning → `[]`. Files: `farm.unit.test.ts`. Verify: fails (checkDrift not exported / parses merged out). Maps: AC-91.1–91.3.
+- **T91-2** `[PENDING]` — GREEN: `run()` returns `{ code, out, stdout, stderr }` (`out` stays merged for back-compat); export `checkDrift` with an injectable git runner defaulting to real `git`, parsing `stdout` only. Files: `farm.ts`. Verify: T91-1 green, full suite green (back-compat consumers unaffected). Maps: AC-91.1–91.3.
+- **T91-3** `[PENDING]` — build + land: typecheck/test/build, `git diff --quiet -- farm.js`; commit-gate; open PR closing #91. Maps: AC-91.4.
+
+## Branch 3 — #93 entitlement pre-check  (`feat/farm-entitlement-precheck`)
+
+- **T93-1** `[PENDING]` — RED: unit test for exported `screenEntitlements(models, probeFn, opts)` — stub probe returns 401 for one model, 200 for another; assert 401 → skipped set with entitlement note, 200 → survivor; assert a probe exceeding the cap is handled as a drop, not a hang. Files: `farm.unit.test.ts`. Verify: fails (function absent). Maps: AC-93.1–93.4.
+- **T93-2** `[PENDING]` — GREEN: implement `screenEntitlements` (one minimal `/chat/completions` probe per candidate, per-candidate wall-clock cap via new env knob defaulting ≤ `FARM_REQUEST_TIMEOUT_MS`, 401 → skip with distinct note). Files: `farm.ts`. Verify: T93-1 green. Maps: AC-93.1, 93.3, 93.4.
+- **T93-3** `[PENDING]` — GREEN: wire `screenEntitlements` into `runCanary` before the candidate loop; include skipped entries distinctly in `canary-report.json` and the printed summary. Files: `farm.ts`. Verify: suite green; report-shape assertion. Maps: AC-93.2.
+- **T93-4** `[PENDING]` — build + land: typecheck/test/build, `git diff --quiet -- farm.js`; commit-gate; open PR closing #93. Maps: AC-93.5.
+
+---
+
+## Execution order
+
+One branch off `main`. Execute groups 1 → 2 → 3 sequentially (shared file `farm.ts`), each task
+test-first (RED → GREEN). The build/land steps (T90-6, T91-3, T93-4) collapse into a SINGLE final
+land: one `npm run typecheck && npm test && npm run build` + `git diff --quiet -- farm.js`, one
+commit-gate (or grouped commits per issue), one PR closing #90/#91/#93. Morning summary lists the one
+PR + its merge decision.
+
+## Coverage check
+
+Every AC maps to ≥1 task: 90.1→T90-1/2, 90.2→T90-3/4, 90.3→T90-5, 90.4→T90-6; 91.1-3→T91-1/2,
+91.4→T91-3; 93.1-4→T93-1/2/3, 93.5→T93-4. ✔

--- a/.codearbiter/specs/farm-feature-forge-fixes.md
+++ b/.codearbiter/specs/farm-feature-forge-fixes.md
@@ -1,0 +1,88 @@
+# Sprint spec — farm feature-forge fixes (#90, #91, #93)
+
+**Status:** awaiting approval (Phase 1 gate)
+**Mode:** `/ca:sprint` (premium subagent path — NOT `--farm`; we are fixing the farm tool itself)
+**Author attribution:** user (brennonhuff@gmail.com), 2026-06-18
+**Surface:** `plugins/ca/tools/farm.ts` (+ rebuilt `farm.js`), `plugins/ca/tools/farm.unit.test.ts`, `plugins/ca/includes/farm.md`
+**Landing:** one PR per issue (see plan; final structure confirmed at the gate).
+
+All three were filed during the `docs-site-mvp` `/ca:sprint --farm` run (2026-06-18, Windows) and
+carry author-verified root causes and fix candidates. This sprint turns those candidates into gated,
+test-first fixes. Premium path is mandatory here: `--farm` is broken until #90 lands, and dogfooding
+the broken tool to fix itself is circular.
+
+---
+
+## Issue #90 — stale built-in default API base URL (bug)
+
+**Root cause.** `ENV.defaultApiBaseUrl` (farm.ts ~L90) is `https://api.opencode.ai/v1`. That host now
+returns HTTP 200 with body `Not Found` for `/models` and `/chat/completions`, so every worker dies with
+the opaque `non-JSON response: SyntaxError ...`. Live endpoint is `https://opencode.ai/zen/v1`.
+
+**Acceptance criteria.**
+- **AC-90.1** — `ENV.defaultApiBaseUrl` default is `https://opencode.ai/zen/v1` (the `FARM_DEFAULT_API_BASE_URL` env override is preserved).
+- **AC-90.2** — When `/chat/completions` returns a 2xx whose body is not valid JSON, `callApi` returns an actionable error that names the endpoint and points at `FARM_API_BASE_URL` (e.g. `endpoint returned a non-JSON body ("Not Found") — check FARM_API_BASE_URL / the endpoint path`), not the bare `non-JSON response: <SyntaxError>`.
+- **AC-90.3** — `plugins/ca/includes/farm.md` documents `https://opencode.ai/zen/v1` as the default; no stale `api.opencode.ai/v1` reference remains.
+- **AC-90.4** — `farm.js` rebuilt; `git diff --quiet -- farm.js` clean after build.
+
+**Verification.** Unit test asserts the default constant resolves to the new URL. Unit test drives the
+non-JSON-body path through an injectable fetch (export `callApi` or a small `parseApiResponse` helper)
+and asserts the actionable message. `npm test` + `npm run typecheck` + rebuilt bundle.
+
+---
+
+## Issue #91 — git CRLF stderr pollutes drift detection (bug)
+
+**Root cause.** The shared `run()` helper merges stdout+stderr into one `out` string. `checkDrift()`
+parses `git diff --name-only HEAD` from `out`; on Windows with `core.safecrlf` warnings on, git prints
+`warning: in the working copy of '<file>', LF will be replaced by CRLF ...` to **stderr**, which is then
+parsed as a changed file path → false `drift:` escalation of a fully-correct worker.
+
+**Acceptance criteria.**
+- **AC-91.1** — `run()` captures stdout and stderr **separately** (e.g. returns `{ code, out, stdout, stderr }`, where `out` stays the merged string for back-compat consumers like `runGate`).
+- **AC-91.2** — `checkDrift()` parses **stdout only** (`git diff --name-only`, `git ls-files`), so no stderr line — CRLF warning or otherwise — is ever treated as a changed path.
+- **AC-91.3** — `checkDrift` is exported and accepts an injectable git runner (default = real `git`) so the behavior is unit-testable without a real repo.
+- **AC-91.4** — `farm.js` rebuilt; `git diff --quiet -- farm.js` clean.
+
+**Verification.** Unit test: stub git so `diff --name-only` returns a real in-scope-violating path on
+`stdout` and a `warning: ... LF will be replaced by CRLF ...` line on `stderr` (merged into `out`).
+Assert `checkDrift` returns only the real out-of-scope path and never the warning line. A second case:
+worker touched only its in-scope file + a CRLF warning on stderr → `checkDrift` returns `[]` (no drift).
+
+---
+
+## Issue #93 — model discovery surfaces expired 'free promotion' models (enhancement)
+
+**Root cause.** OpenCode Zen's `/models` lists models the key is not entitled to (`*-free` promos);
+`/chat/completions` then returns HTTP 401 `"Free promotion has ended for ..."`. The canary cannot
+distinguish entitlement-denial from a capability failure, so it burns full attempts/timeouts on dead
+candidates (one 7-model canary ran for minutes before being killed).
+
+**Acceptance criteria.**
+- **AC-93.1** — Before the real canary loop, a cheap entitlement screen runs one minimal `/chat/completions` probe (≤ a few tokens) per candidate; any candidate whose probe returns **401** is dropped from the canary.
+- **AC-93.2** — A dropped candidate is surfaced **distinctly** in `canary-report.json` — an entry marked as skipped-for-entitlement (e.g. `{ model, skipped: "entitlement", note: "401 — not entitled / promotion ended" }`) — never silently removed and never conflated with a capability `FAIL`.
+- **AC-93.3** — The entitlement screen is bounded by a per-candidate wall-clock cap (own timeout, default ≤ `FARM_REQUEST_TIMEOUT_MS`, overridable via a new env knob) so one slow/dead model cannot dominate the probe.
+- **AC-93.4** — Screening is a pure, exported function (`screenEntitlements(models, probeFn, ...)`) taking an injectable probe so it is unit-testable without the network; the real `runCanary` wires it in.
+- **AC-93.5** — `farm.js` rebuilt; `git diff --quiet -- farm.js` clean.
+
+**Verification.** Unit test: `screenEntitlements` with a stub probe returning 401 for one model and 200
+for another → the 401 model is in the skipped set with an entitlement note, the 200 model survives.
+Unit test: a probe that exceeds the cap is treated as a drop/handled (not a hang). `runCanary`'s report
+shape includes the skipped entries.
+
+---
+
+## Cross-cutting hard rules (apply to all three)
+
+- **No security-controls / auth / crypto / secrets surface is touched** by design. `assertSecureBaseUrl` and the secret-redaction path are NOT modified. If any task drifts into that surface, it is a hard-gate stop.
+- The new default URL (#90) must still pass `assertSecureBaseUrl` (it is HTTPS — verified).
+- Every task is test-first via `tdd`; the failing test is written and shown red before impl.
+- Every PR's gate includes the full `tech-stack.md` tools sequence: `npm ci && npm run typecheck && npm test && npm run build` then `git diff --quiet -- farm.js`.
+- `/ca:sprint` never merges and never discards — each PR's merge decision is surfaced to the user in the morning summary.
+- Every non-hard-gate auto-decision is logged to `.codearbiter/sprint-log.md`.
+
+## Out of scope (noted, not done)
+
+- Reconciling `SAFE_TASK_ID` vs `plan.schema.json` id pattern (existing `[NEEDS-TRIAGE]`).
+- The non-reporting-worker path-containment sandbox (existing `[NEEDS-TRIAGE]`).
+- #92 (per-worktree dependency setup hook) and #61 (standup-at-session-start — needs `/ca:debug` first).

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -267,3 +267,24 @@ Spec + plan approved by the user at the Phase-1 gate. Branch `sprint/ux-conversi
 
 ## Security gate (H-09b) — cleared by review
 The commit hook flagged 3 lines in `site/package-lock.json` as crypto-sensitive: the transitive dependency `iron-webcrypto@1.2.1`. Dispatched `auth-crypto-reviewer` — verdict **PASS** (0 findings): it is a reputable MIT WebCrypto wrapper arriving via the owner-approved Astro/Starlight stack (`astro → unstorage → h3 → iron-webcrypto`), not a banned/home-rolled primitive; no secret, key material, or disabled-TLS introduced; the real API key is absent from all tracked files. Recorded the diff-bound security-pass marker (no `/override` needed — the gate genuinely passed).
+
+# Sprint — farm-feature-forge-fixes · 2026-06-18 (#90, #91, #93)
+
+`/ca:sprint` (premium path, NOT --farm — the farm tool is itself the subject, and #90 leaves --farm broken; dogfooding a broken tool to fix itself is circular). Spec + plan approved at the one interactive gate. Closes the three known-cause feature-forge bugs filed during the docs-site-mvp farm run.
+
+## User decisions (at the one interactive gate — NOT auto-decided)
+- **U-01 PR structure → single combined PR.** User chose one branch/PR closing #90/#91/#93 over three separate or stacked PRs, to avoid farm.js bundle-merge friction. User-attributed.
+- **U-02 scope = #90, #91, #93.** #92 (enhancement) and #61 (needs /ca:debug — unknown cause) deferred. User-attributed.
+
+## Auto-decisions (SMARTS, deciding-as-the-user)
+- **D-01 #90 testability seam → extract+export `parseChatCompletion(text, apiBaseUrl)`** rather than export `callApi` + inject `fetch`. Lets the non-JSON-body path be unit-tested with no network; callApi now reads `resp.text()` then delegates. SMARTS: strong (minimal surface, single chokepoint). Confidence: **high**.
+- **D-02 #90 default URL via exported `DEFAULT_API_BASE_URL` const** (single source of truth, referenced by ENV). Strong. **high**.
+- **D-03 #90 scope widened to `.env.example`** (operator-facing default also carried the stale URL) beyond the 3 spec-named files. Obvious correctness. **high**.
+- **D-04 #91 fix = separate stdout/stderr in `run()`** (return `{code,out,stdout,stderr}`; `out` stays merged for back-compat consumers like runGate) + export `checkDrift` with an injectable git runner, parsing stdout only. Chosen over line-filtering `^warning:` (fragile, CRLF-only). Strong (principled, handles all stderr noise). **high**.
+- **D-05 #91 updated 5 pre-existing git-stub return shapes** in farm.unit.test.ts to the new RunResult contract. These are test DOUBLES (return values), not assertions — mechanical type-conformance, not evidence tampering. **high**.
+- **D-06 #93 screen owns the wall-clock cap via Promise.race + null sentinel**; new env knob `FARM_ENTITLEMENT_PROBE_TIMEOUT_MS` (default 35_000, ≤ request timeout). Only HTTP 401 drops a candidate (entitlement); a race timeout drops as `timeout`; any other status (incl. 5xx/network=0) stays a survivor so the real canary judges capability. SMARTS: strong (matches issue's 401-is-the-signal framing). **high**.
+- **D-07 #93 skipped candidates surfaced in their own `skipped[]` array** in canary-report.json + summary, never folded into capability `results` as FAIL (AC-93.2). **high**.
+
+## Verification
+- `plugins/ca/tools`: typecheck clean, **104/104 vitest** (was 93; +11 new across #90/#91/#93), `npm run build` regenerated farm.js. No security/auth/crypto surface touched (hard-gate-clear by design).
+- Note (manual): `runCanary`'s report-shape wiring (D-07) is typecheck-verified but not unit-covered — runCanary does real git+network+process.exit and has no existing harness; consistent with current coverage.

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -56,7 +56,7 @@ Never commit this key. It must not appear in `.codearbiter/` audit files.
 ### `FARM_API_BASE_URL`
 
 The OpenAI-compatible endpoint base URL. Resolution order: `FARM_API_BASE_URL` env → `plan.meta.apiBaseUrl`
-→ a built-in default of `https://api.opencode.ai/v1`. Override for DeepSeek direct
+→ a built-in default of `https://opencode.ai/zen/v1` (the live OpenCode Zen host). Override for DeepSeek direct
 (`https://api.deepseek.com/v1`), Ollama (`http://localhost:11434/v1`), etc.
 
 ## Model selection — measured at dispatch time
@@ -80,7 +80,7 @@ picks a model by *measurement*, not hearsay:
 | Variable | Default | Purpose |
 |---|---|---|
 | `FARM_MODEL` | _(unset)_ | Skip selection and use this model id directly. Power-user/CI override. |
-| `FARM_API_BASE_URL` | `https://api.opencode.ai/v1` | Endpoint URL (env → plan.json → this default). |
+| `FARM_API_BASE_URL` | `https://opencode.ai/zen/v1` | Endpoint URL (env → plan.json → this default). |
 | `FARM_CANDIDATE_MODELS` | _(unset)_ | Comma-separated ids for `--canary` probing. Set by the dispatch skill. |
 | `FARM_CONCURRENCY` | `4` | Max concurrent task workers. |
 | `FARM_MAX_RETRIES` | `2` | Max gate retries per task before escalating. |

--- a/plugins/ca/tools/.env.example
+++ b/plugins/ca/tools/.env.example
@@ -5,7 +5,7 @@ FARM_API_KEY=sk-REPLACE_ME
 
 # OpenAI-compatible endpoint base URL for your Zen model provider.
 # Defaults to OpenCode Zen's endpoint. Override for DeepSeek direct, Ollama, etc.
-FARM_API_BASE_URL=https://api.opencode.ai/v1
+FARM_API_BASE_URL=https://opencode.ai/zen/v1
 
 # --- Model selection ---------------------------------------------------------
 # Normally left UNSET. subagent-driven-development researches the current free

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -6,6 +6,7 @@ import { readFile, writeFile, appendFile, mkdir, rm } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+var DEFAULT_API_BASE_URL = "https://opencode.ai/zen/v1";
 var ENV = {
   // Model: plan.meta.model (set by subagent-driven-development before dispatch),
   // then FARM_MODEL env var override. Fails at startup if neither is set.
@@ -23,6 +24,10 @@ var ENV = {
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
   // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
   requestTimeoutMs: Number(process.env.FARM_REQUEST_TIMEOUT_MS ?? 12e4),
+  // Per-candidate wall-clock cap for the #93 entitlement pre-screen, so one
+  // slow/dead model can't dominate the probe. Kept short (35s) — a screen, not a
+  // capability run — and ≤ the per-request timeout.
+  entitlementProbeTimeoutMs: Number(process.env.FARM_ENTITLEMENT_PROBE_TIMEOUT_MS ?? 35e3),
   // Transport-level retries (429 / 5xx) — distinct from model-quality retries.
   apiMaxRetries: Number(process.env.FARM_API_MAX_RETRIES ?? 3),
   // Circuit breaker: abort dispatch once the escalation rate exceeds this,
@@ -30,7 +35,7 @@ var ENV = {
   abortEscalationRate: Number(process.env.FARM_ABORT_ESCALATION_RATE ?? 0.5),
   abortMinTasks: Number(process.env.FARM_ABORT_MIN_TASKS ?? 3),
   // Default endpoint, used only when neither env nor plan.meta provides one.
-  defaultApiBaseUrl: process.env.FARM_DEFAULT_API_BASE_URL ?? "https://api.opencode.ai/v1",
+  defaultApiBaseUrl: process.env.FARM_DEFAULT_API_BASE_URL ?? DEFAULT_API_BASE_URL,
   // Comma-separated candidate model ids for --canary mode.
   candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "").split(",").map((s) => s.trim()).filter(Boolean),
   // AC-05 byte cap on the TOTAL injected enrichment context (test source +
@@ -55,11 +60,12 @@ var MUT = {
 function run(cmd, args, cwd, opts = {}) {
   return new Promise((resolve) => {
     const c = spawn(cmd, args, { cwd, env: process.env, ...opts });
-    let out = "";
-    c.stdout.on("data", (d) => out += d);
-    c.stderr.on("data", (d) => out += d);
-    c.on("error", (e) => resolve({ code: 1, out: String(e) }));
-    c.on("close", (code) => resolve({ code: code ?? 1, out }));
+    let stdout = "";
+    let stderr = "";
+    c.stdout.on("data", (d) => stdout += d);
+    c.stderr.on("data", (d) => stderr += d);
+    c.on("error", (e) => resolve({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
+    c.on("close", (code) => resolve({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
   });
 }
 var git = (args, cwd) => run("git", args, cwd);
@@ -262,6 +268,19 @@ function extractFileBlocks(content) {
   }
   return blocks;
 }
+function parseChatCompletion(text, apiBaseUrl) {
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    const snippet = text.trim().slice(0, 120).replace(/\s+/g, " ");
+    return {
+      ok: false,
+      error: `endpoint ${apiBaseUrl} returned a non-JSON body (${JSON.stringify(snippet)}) \u2014 check FARM_API_BASE_URL and that the endpoint path is correct (expected an OpenAI-compatible /chat/completions)`
+    };
+  }
+  return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
+}
 async function callApi(prompt, model, apiBaseUrl, apiKey) {
   for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
     const ctrl = new AbortController();
@@ -308,13 +327,8 @@ async function callApi(prompt, model, apiBaseUrl, apiKey) {
 `);
       return { ok: false, error: `API ${resp.status}` };
     }
-    let data;
-    try {
-      data = await resp.json();
-    } catch (e) {
-      return { ok: false, error: `non-JSON response: ${e}` };
-    }
-    return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
+    const text = await resp.text().catch(() => "");
+    return parseChatCompletion(text, apiBaseUrl);
   }
   return { ok: false, error: "exhausted API retries" };
 }
@@ -356,17 +370,17 @@ async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden) {
 var httpWorker = {
   apply: (ctx) => runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden)
 };
-async function checkDrift(cwd, allowed) {
-  const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
-  const untracked = await git(
+async function checkDrift(cwd, allowed, gitRunner = git) {
+  const tracked = await gitRunner(["diff", "--name-only", "HEAD"], cwd);
+  const untracked = await gitRunner(
     ["ls-files", "--others", "--exclude-standard", "-z"],
     cwd
   );
   const changed = [];
   if (tracked.code === 0)
-    changed.push(...tracked.out.trim().split("\n").filter(Boolean));
+    changed.push(...tracked.stdout.trim().split("\n").filter(Boolean));
   if (untracked.code === 0)
-    changed.push(...untracked.out.split("\0").filter(Boolean));
+    changed.push(...untracked.stdout.split("\0").filter(Boolean));
   return [...new Set(changed)].filter((f) => !allowed.has(f));
 }
 function postApplySweep(cwd, filesWritten, forbidden) {
@@ -748,6 +762,53 @@ function resolveConfig(plan) {
   }
   return { model, apiBaseUrl, apiKey };
 }
+async function screenEntitlements(models, probe, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? ENV.entitlementProbeTimeoutMs;
+  const sleepFn = opts.sleepFn ?? sleep;
+  const survivors = [];
+  const skipped = [];
+  for (const model of models) {
+    let res;
+    try {
+      res = await Promise.race([
+        probe(model),
+        sleepFn(timeoutMs).then(() => null)
+      ]);
+    } catch (e) {
+      skipped.push({ model, reason: "error", note: `entitlement probe error: ${e}` });
+      continue;
+    }
+    if (res === null) {
+      skipped.push({ model, reason: "timeout", note: `entitlement probe exceeded ${timeoutMs}ms \u2014 model is slow or dead` });
+      continue;
+    }
+    if (res.status === 401) {
+      skipped.push({ model, reason: "entitlement", note: "401 \u2014 not entitled / free promotion ended" });
+      continue;
+    }
+    survivors.push(model);
+  }
+  return { survivors, skipped };
+}
+function makeEntitlementProbe(apiBaseUrl, apiKey, timeoutMs) {
+  return async (model) => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const resp = await fetch(`${apiBaseUrl}/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify({ model, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),
+        signal: ctrl.signal
+      });
+      return { status: resp.status };
+    } catch {
+      return { status: 0 };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
 async function runCanary(plan) {
   if (ENV.candidateModels.length === 0) {
     console.error("Error: --canary requires FARM_CANDIDATE_MODELS (comma-separated model ids).");
@@ -771,8 +832,15 @@ async function runCanary(plan) {
   await git(["worktree", "add", integrationWorktree, ENV.integration]).catch(() => {
   });
   const task = [...plan.tasks].filter((t) => (t.deps ?? []).length === 0).sort((a, b) => a.filesInScope.length - b.filesInScope.length)[0] ?? plan.tasks[0];
+  const { survivors, skipped } = await screenEntitlements(
+    ENV.candidateModels,
+    makeEntitlementProbe(apiBaseUrl, apiKey, ENV.entitlementProbeTimeoutMs)
+  );
+  if (skipped.length)
+    process.stderr.write(`Entitlement screen dropped ${skipped.length}/${ENV.candidateModels.length}: ${skipped.map((s) => `${s.model} (${s.reason})`).join(", ")}
+`);
   const results = [];
-  for (const model of ENV.candidateModels) {
+  for (const model of survivors) {
     const t0 = Date.now();
     const r = await runTask({ ...task, id: `canary-${task.id}` }, model, apiBaseUrl, apiKey);
     results.push({ model, green: r.status === "green", attempts: r.attempts, ms: Date.now() - t0, note: r.note });
@@ -784,9 +852,15 @@ async function runCanary(plan) {
   await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
   });
   results.sort((a, b) => Number(b.green) - Number(a.green) || a.attempts - b.attempts || a.ms - b.ms);
-  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
-  const summary = ["\nCanary results (best first):", ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`), `
-Recommended: ${results[0]?.green ? results[0].model : "NONE PASSED \u2014 set FARM_MODEL manually or revise the plan"}`, ""].join("\n");
+  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, skipped, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
+  const summary = [
+    "\nCanary results (best first):",
+    ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`),
+    ...skipped.map((s) => `  SKIP  ${s.model}  (${s.reason}: ${s.note})`),
+    `
+Recommended: ${results[0]?.green ? results[0].model : "NONE PASSED \u2014 set FARM_MODEL manually or revise the plan"}`,
+    ""
+  ].join("\n");
   await new Promise((resolve) => process.stdout.write(summary, () => resolve()));
   process.exit(results[0]?.green ? 0 : 2);
 }
@@ -942,12 +1016,16 @@ if (_thisFile === _entryFile) {
   });
 }
 export {
+  DEFAULT_API_BASE_URL,
   SAFE_TASK_ID,
   assertSecureBaseUrl,
+  checkDrift,
   codeLineCount,
   extractFileBlocks,
   extractLiterals,
   httpWorker,
+  parseChatCompletion,
   runTask,
+  screenEntitlements,
   validate
 };

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -63,6 +63,13 @@ type Plan = {
   tasks: Task[];
 };
 
+// Built-in default endpoint, used only when neither FARM_API_BASE_URL nor
+// plan.meta.apiBaseUrl provides one. The live OpenCode Zen OpenAI-compatible
+// host: `/models` and `/chat/completions` both 200 here. The former default
+// `https://api.opencode.ai/v1` now answers 200 with body "Not Found" (#90), so
+// every worker died with an opaque non-JSON parse error.
+export const DEFAULT_API_BASE_URL = "https://opencode.ai/zen/v1";
+
 const ENV = {
   // Model: plan.meta.model (set by subagent-driven-development before dispatch),
   // then FARM_MODEL env var override. Fails at startup if neither is set.
@@ -80,6 +87,10 @@ const ENV = {
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
   // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
   requestTimeoutMs: Number(process.env.FARM_REQUEST_TIMEOUT_MS ?? 120_000),
+  // Per-candidate wall-clock cap for the #93 entitlement pre-screen, so one
+  // slow/dead model can't dominate the probe. Kept short (35s) — a screen, not a
+  // capability run — and ≤ the per-request timeout.
+  entitlementProbeTimeoutMs: Number(process.env.FARM_ENTITLEMENT_PROBE_TIMEOUT_MS ?? 35_000),
   // Transport-level retries (429 / 5xx) — distinct from model-quality retries.
   apiMaxRetries: Number(process.env.FARM_API_MAX_RETRIES ?? 3),
   // Circuit breaker: abort dispatch once the escalation rate exceeds this,
@@ -88,7 +99,7 @@ const ENV = {
   abortMinTasks: Number(process.env.FARM_ABORT_MIN_TASKS ?? 3),
   // Default endpoint, used only when neither env nor plan.meta provides one.
   defaultApiBaseUrl:
-    process.env.FARM_DEFAULT_API_BASE_URL ?? "https://api.opencode.ai/v1",
+    process.env.FARM_DEFAULT_API_BASE_URL ?? DEFAULT_API_BASE_URL,
   // Comma-separated candidate model ids for --canary mode.
   candidateModels: (process.env.FARM_CANDIDATE_MODELS ?? "")
     .split(",")
@@ -128,17 +139,27 @@ const MUT = {
 // --------------------------------------------------------------------------
 // process helpers
 // --------------------------------------------------------------------------
-function run(cmd: string, args: string[], cwd?: string, opts: object = {}) {
-  return new Promise<{ code: number; out: string }>((resolve) => {
+// Result of a spawned process. `out` stays the merged stdout+stderr string that
+// existing consumers (runGate, diagnostics) read. `stdout`/`stderr` are kept
+// SEPARATE so parsing contexts (checkDrift — #91) read only stdout: on Windows
+// with core.safecrlf, git writes a `warning: ... LF will be replaced by CRLF`
+// line to stderr that, when merged, was parsed as a changed file path and tripped
+// a false `drift:` escalation.
+type RunResult = { code: number; out: string; stdout: string; stderr: string };
+type GitRunner = (args: string[], cwd?: string) => Promise<RunResult>;
+
+function run(cmd: string, args: string[], cwd?: string, opts: object = {}): Promise<RunResult> {
+  return new Promise<RunResult>((resolve) => {
     const c = spawn(cmd, args, { cwd, env: process.env, ...opts });
-    let out = "";
-    c.stdout.on("data", (d) => (out += d));
-    c.stderr.on("data", (d) => (out += d));
-    c.on("error", (e) => resolve({ code: 1, out: String(e) }));
-    c.on("close", (code) => resolve({ code: code ?? 1, out }));
+    let stdout = "";
+    let stderr = "";
+    c.stdout.on("data", (d) => (stdout += d));
+    c.stderr.on("data", (d) => (stderr += d));
+    c.on("error", (e) => resolve({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
+    c.on("close", (code) => resolve({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
   });
 }
-const git = (args: string[], cwd?: string) => run("git", args, cwd);
+const git: GitRunner = (args, cwd) => run("git", args, cwd);
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 // Commit without signing — the farm makes mechanical commits; signing servers
@@ -487,6 +508,33 @@ export type WorkerResult = {
   completionTokens?: number;
 };
 
+// Interpret a `/chat/completions` response BODY (already read as text). Split
+// out from callApi (#90) so the non-JSON-body path is unit-testable without a
+// network round-trip, and so the error it produces is actionable rather than an
+// opaque `non-JSON response: SyntaxError`. A stale/misconfigured endpoint (the
+// #90 failure: a 200 whose body is the literal "Not Found") is the common cause,
+// so the error names the endpoint and the FARM_API_BASE_URL knob the operator
+// must fix. The body snippet is bounded so a large HTML error page can't flood
+// the message.
+export function parseChatCompletion(
+  text: string,
+  apiBaseUrl: string,
+):
+  | { ok: true; content: string; usage?: { prompt_tokens?: number; completion_tokens?: number } }
+  | { ok: false; error: string } {
+  let data: { choices?: Array<{ message?: { content?: string } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } };
+  try {
+    data = JSON.parse(text) as typeof data;
+  } catch {
+    const snippet = text.trim().slice(0, 120).replace(/\s+/g, " ");
+    return {
+      ok: false,
+      error: `endpoint ${apiBaseUrl} returned a non-JSON body (${JSON.stringify(snippet)}) — check FARM_API_BASE_URL and that the endpoint path is correct (expected an OpenAI-compatible /chat/completions)`,
+    };
+  }
+  return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
+}
+
 async function callApi(
   prompt: string,
   model: string,
@@ -543,13 +591,13 @@ async function callApi(
       return { ok: false, error: `API ${resp.status}` };
     }
 
-    let data: { choices?: Array<{ message?: { content?: string } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } };
-    try {
-      data = (await resp.json()) as typeof data;
-    } catch (e) {
-      return { ok: false, error: `non-JSON response: ${e}` };
-    }
-    return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
+    // Read the body as text first, then parse — so a 2xx-with-non-JSON-body (the
+    // #90 stale-endpoint failure: a 200 whose body is "Not Found") yields an
+    // actionable, endpoint-naming error instead of an opaque SyntaxError. The
+    // body is consumed once, so a re-read on parse failure is not possible —
+    // parseChatCompletion works off the text we already hold.
+    const text = await resp.text().catch(() => "");
+    return parseChatCompletion(text, apiBaseUrl);
   }
   return { ok: false, error: "exhausted API retries" };
 }
@@ -637,17 +685,25 @@ export const httpWorker: Worker = {
 // drift check — path allowlist. Catches modified tracked files and new
 // untracked files individually (status --porcelain groups by directory).
 // --------------------------------------------------------------------------
-async function checkDrift(cwd: string, allowed: Set<string>): Promise<string[]> {
-  const tracked = await git(["diff", "--name-only", "HEAD"], cwd);
-  const untracked = await git(
+// gitRunner is injectable (default = real git) so the stdout-only parsing is
+// unit-testable without a repo. Parse STDOUT only (#91): a git stderr line —
+// the Windows core.safecrlf `warning: ... LF will be replaced by CRLF` notably —
+// must never be mistaken for a changed file path.
+export async function checkDrift(
+  cwd: string,
+  allowed: Set<string>,
+  gitRunner: GitRunner = git,
+): Promise<string[]> {
+  const tracked = await gitRunner(["diff", "--name-only", "HEAD"], cwd);
+  const untracked = await gitRunner(
     ["ls-files", "--others", "--exclude-standard", "-z"],
     cwd,
   );
   const changed: string[] = [];
   if (tracked.code === 0)
-    changed.push(...tracked.out.trim().split("\n").filter(Boolean));
+    changed.push(...tracked.stdout.trim().split("\n").filter(Boolean));
   if (untracked.code === 0)
-    changed.push(...untracked.out.split("\0").filter(Boolean));
+    changed.push(...untracked.stdout.split("\0").filter(Boolean));
   return [...new Set(changed)].filter((f) => !allowed.has(f));
 }
 
@@ -1253,6 +1309,82 @@ function resolveConfig(plan: Plan): { model: string; apiBaseUrl: string; apiKey:
 }
 
 // --------------------------------------------------------------------------
+// entitlement pre-screen (#93). OpenCode Zen's /models catalog lists models the
+// API key is NOT entitled to (expired `*-free` promos); /chat/completions then
+// returns 401 "Free promotion has ended for ...". The canary cannot tell that
+// from a capability failure and burns full attempts/timeouts on dead candidates.
+// This cheap screen runs one minimal probe per candidate and drops the 401s
+// BEFORE the real canary, surfacing them distinctly (never conflated with a
+// capability FAIL). Pure + injectable (probe, sleepFn) so it is unit-testable
+// without the network; the per-candidate wall-clock cap is enforced here via a
+// race, so a hung/dead endpoint cannot dominate the screen.
+// --------------------------------------------------------------------------
+export type EntitlementSkip = { model: string; reason: "entitlement" | "timeout" | "error"; note: string };
+export type EntitlementScreen = { survivors: string[]; skipped: EntitlementSkip[] };
+export type EntitlementProbe = (model: string) => Promise<{ status: number }>;
+
+export async function screenEntitlements(
+  models: string[],
+  probe: EntitlementProbe,
+  opts: { timeoutMs?: number; sleepFn?: (ms: number) => Promise<void> } = {},
+): Promise<EntitlementScreen> {
+  const timeoutMs = opts.timeoutMs ?? ENV.entitlementProbeTimeoutMs;
+  const sleepFn = opts.sleepFn ?? sleep;
+  const survivors: string[] = [];
+  const skipped: EntitlementSkip[] = [];
+  for (const model of models) {
+    // null is the timeout sentinel — the probe itself never resolves to null,
+    // so `res === null` cleanly means the wall-clock race fired.
+    let res: { status: number } | null;
+    try {
+      res = await Promise.race<{ status: number } | null>([
+        probe(model),
+        sleepFn(timeoutMs).then(() => null),
+      ]);
+    } catch (e) {
+      skipped.push({ model, reason: "error", note: `entitlement probe error: ${e}` });
+      continue;
+    }
+    if (res === null) {
+      skipped.push({ model, reason: "timeout", note: `entitlement probe exceeded ${timeoutMs}ms — model is slow or dead` });
+      continue;
+    }
+    if (res.status === 401) {
+      skipped.push({ model, reason: "entitlement", note: "401 — not entitled / free promotion ended" });
+      continue;
+    }
+    // Any other status (200, 4xx≠401, 5xx) → let the real canary judge capability.
+    survivors.push(model);
+  }
+  return { survivors, skipped };
+}
+
+// Real entitlement probe: one minimal /chat/completions call (max_tokens: 1),
+// returning only the HTTP status. Its own AbortController bounds the underlying
+// fetch so a hung socket is actually torn down (the screen's race is the
+// higher-level cap). A network/abort failure maps to status 0 → screened as a
+// survivor, not an entitlement drop (only a real 401 drops a candidate).
+function makeEntitlementProbe(apiBaseUrl: string, apiKey: string, timeoutMs: number): EntitlementProbe {
+  return async (model) => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const resp = await fetch(`${apiBaseUrl}/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify({ model, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),
+        signal: ctrl.signal,
+      });
+      return { status: resp.status };
+    } catch {
+      return { status: 0 };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+// --------------------------------------------------------------------------
 // canary — measure candidate models on the smallest task. No merge.
 // --------------------------------------------------------------------------
 async function runCanary(plan: Plan) {
@@ -1282,8 +1414,18 @@ async function runCanary(plan: Plan) {
     .filter((t) => (t.deps ?? []).length === 0)
     .sort((a, b) => a.filesInScope.length - b.filesInScope.length)[0] ?? plan.tasks[0];
 
+  // #93: entitlement pre-screen. Drop candidates the key isn't entitled to (401
+  // "free promotion ended") BEFORE the expensive per-candidate canary, so a dead
+  // promo model can't burn full attempts/timeouts. Bounded per candidate.
+  const { survivors, skipped } = await screenEntitlements(
+    ENV.candidateModels,
+    makeEntitlementProbe(apiBaseUrl, apiKey, ENV.entitlementProbeTimeoutMs),
+  );
+  if (skipped.length)
+    process.stderr.write(`Entitlement screen dropped ${skipped.length}/${ENV.candidateModels.length}: ${skipped.map((s) => `${s.model} (${s.reason})`).join(", ")}\n`);
+
   const results: Array<{ model: string; green: boolean; attempts: number; ms: number; note?: string }> = [];
-  for (const model of ENV.candidateModels) {
+  for (const model of survivors) {
     const t0 = Date.now();
     const r = await runTask({ ...task, id: `canary-${task.id}` }, model, apiBaseUrl, apiKey);
     results.push({ model, green: r.status === "green", attempts: r.attempts, ms: Date.now() - t0, note: r.note });
@@ -1293,8 +1435,16 @@ async function runCanary(plan: Plan) {
   await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
 
   results.sort((a, b) => Number(b.green) - Number(a.green) || a.attempts - b.attempts || a.ms - b.ms);
-  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, ts: new Date().toISOString() }, null, 2));
-  const summary = ["\nCanary results (best first):", ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`), `\nRecommended: ${results[0]?.green ? results[0].model : "NONE PASSED — set FARM_MODEL manually or revise the plan"}`, ""].join("\n");
+  // Skipped candidates are surfaced DISTINCTLY (their own array), never folded
+  // into the capability `results` as a FAIL.
+  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, skipped, ts: new Date().toISOString() }, null, 2));
+  const summary = [
+    "\nCanary results (best first):",
+    ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`),
+    ...skipped.map((s) => `  SKIP  ${s.model}  (${s.reason}: ${s.note})`),
+    `\nRecommended: ${results[0]?.green ? results[0].model : "NONE PASSED — set FARM_MODEL manually or revise the plan"}`,
+    "",
+  ].join("\n");
   await new Promise<void>((resolve) => process.stdout.write(summary, () => resolve()));
   process.exit(results[0]?.green ? 0 : 2);
 }

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker } from "./farm.ts";
+import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 
 // ---------------------------------------------------------------------------
@@ -382,7 +382,7 @@ describe("Worker seam — runTask invokes an injectable Worker (AC-01)", () => {
       runGate: async () => ({ ok: true as const }),
       antiGamingCheck: async () => ({ risk: "none" as const }),
       mutationCheck: async () => null,
-      git: async () => ({ code: 0, out: "" }),
+      git: async () => ({ code: 0, out: "", stdout: "", stderr: "" }),
       withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
     };
   }
@@ -462,7 +462,7 @@ describe("Post-apply containment sweep — task-level enforcement for ANY worker
       runGate: async () => ({ ok: true as const }),
       antiGamingCheck: async () => ({ risk: "none" as const }),
       mutationCheck: async () => null,
-      git: async () => ({ code: 0, out: "" }),
+      git: async () => ({ code: 0, out: "", stdout: "", stderr: "" }),
       withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
     };
   }
@@ -597,7 +597,7 @@ describe("Per-task model resolution — task.model ?? run-level model (AC-02)", 
       runGate: async () => ({ ok: true as const }),
       antiGamingCheck: async () => ({ risk: "none" as const }),
       mutationCheck: async () => null,
-      git: async () => ({ code: 0, out: "" }),
+      git: async () => ({ code: 0, out: "", stdout: "", stderr: "" }),
       withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
     };
   }
@@ -744,13 +744,13 @@ describe("Regenerate-on-conflict — merge conflict re-enters regeneration (AC-0
           // unspecified beyond the provided outcomes: default to conflict so an
           // always-conflicting test doesn't accidentally fall through to green
           const out = next === undefined ? "CONFLICT (content): fallback" : next;
-          if (out !== null) return { code: 1, out };
-          return { code: 0, out: "" };
+          if (out !== null) return { code: 1, out, stdout: "", stderr: out };
+          return { code: 0, out: "", stdout: "", stderr: "" };
         }
         if (args[0] === "reset" || args[0] === "clean") {
           opts.resetCalls.push(args);
         }
-        return { code: 0, out: "" };
+        return { code: 0, out: "", stdout: "", stderr: "" };
       },
       withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
     };
@@ -838,5 +838,142 @@ describe("Regenerate-on-conflict — merge conflict re-enters regeneration (AC-0
     expect(workerCalls).toBe(1);
     expect(r.status).toBe("escalate");
     expect(r.note).toMatch(/merge failed vs integration/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #90 — stale default base URL + opaque non-JSON-body error
+// ---------------------------------------------------------------------------
+describe("#90 default base URL + non-JSON body", () => {
+  it("default base URL points at the live OpenCode Zen endpoint", () => {
+    expect(DEFAULT_API_BASE_URL).toBe("https://opencode.ai/zen/v1");
+  });
+
+  it("parseChatCompletion returns content + usage for a valid JSON body", () => {
+    const body = JSON.stringify({
+      choices: [{ message: { content: "hello" } }],
+      usage: { prompt_tokens: 3, completion_tokens: 4 },
+    });
+    const r = parseChatCompletion(body, "https://opencode.ai/zen/v1");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.content).toBe("hello");
+      expect(r.usage?.prompt_tokens).toBe(3);
+      expect(r.usage?.completion_tokens).toBe(4);
+    }
+  });
+
+  it("parseChatCompletion returns an actionable, endpoint-naming error for a non-JSON body", () => {
+    // The exact failure mode of the stale endpoint: 200 with body "Not Found".
+    const r = parseChatCompletion("Not Found", "https://api.opencode.ai/v1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // Names the knob the operator must fix...
+      expect(r.error).toMatch(/FARM_API_BASE_URL/);
+      // ...echoes the offending endpoint...
+      expect(r.error).toMatch(/api\.opencode\.ai\/v1/);
+      // ...and is NOT the opaque raw-SyntaxError message it used to be.
+      expect(r.error).not.toMatch(/^non-JSON response: SyntaxError/);
+    }
+  });
+
+  it("parseChatCompletion echoes a (bounded) snippet of the offending body", () => {
+    const r = parseChatCompletion("Not Found", "https://opencode.ai/zen/v1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/Not Found/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #91 — git CRLF stderr warning must not pollute drift detection (Windows)
+// ---------------------------------------------------------------------------
+describe("#91 checkDrift parses stdout only (CRLF stderr immune)", () => {
+  // The exact line git prints to STDERR under core.safecrlf on Windows.
+  const crlfWarning =
+    "warning: in the working copy of 'site/scripts/generator/split-frontmatter.ts', LF will be replaced by CRLF the next time Git touches it";
+
+  // Stub git runner: returns the given stdout per subcommand, with the CRLF
+  // warning ALWAYS on stderr (and folded into the merged `out`, as the real
+  // run() helper does) — so a stdout-only parser is immune and a merged-string
+  // parser is poisoned.
+  function stubGit(stdoutFor: { diff?: string; lsfiles?: string }) {
+    return async (args: string[]) => {
+      const stdout = args[0] === "diff" ? (stdoutFor.diff ?? "") : (stdoutFor.lsfiles ?? "");
+      const stderr = crlfWarning + "\n";
+      return { code: 0, stdout, stderr, out: stdout + stderr };
+    };
+  }
+
+  it("never treats a git CRLF stderr warning as a changed path", async () => {
+    const allowed = new Set(["src/a.ts"]);
+    // worker edited an OUT-of-scope file (src/b.ts) — that is real drift; the
+    // CRLF warning on stderr is noise that must be ignored.
+    const drift = await checkDrift("/wt", allowed, stubGit({ diff: "src/b.ts\n" }));
+    expect(drift).toEqual(["src/b.ts"]);
+    expect(drift.join(" ")).not.toMatch(/LF will be replaced by CRLF/);
+    expect(drift.some((f) => f.startsWith("warning:"))).toBe(false);
+  });
+
+  it("reports NO drift when only in-scope files changed, despite a CRLF warning on stderr", async () => {
+    const allowed = new Set(["src/a.ts"]);
+    const drift = await checkDrift("/wt", allowed, stubGit({ diff: "src/a.ts\n" }));
+    expect(drift).toEqual([]);
+  });
+
+  it("still catches an out-of-scope untracked file from ls-files stdout", async () => {
+    const allowed = new Set(["src/a.ts"]);
+    const drift = await checkDrift("/wt", allowed, stubGit({ diff: "", lsfiles: "src/new.ts\0" }));
+    expect(drift).toEqual(["src/new.ts"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #93 — entitlement pre-check drops 401 ("free promotion ended") candidates
+// ---------------------------------------------------------------------------
+describe("#93 screenEntitlements", () => {
+  // sleepFn that never resolves → the wall-clock race never fires, so the
+  // probe's verdict is what's tested (used by the non-timeout cases).
+  const neverSleep = () => new Promise<void>(() => {});
+
+  it("drops a 401 candidate with a distinct entitlement note and keeps an entitled one", async () => {
+    const probe = async (m: string) => ({ status: m.endsWith("-free") ? 401 : 200 });
+    const { survivors, skipped } = await screenEntitlements(
+      ["big-pickle", "minimax-m3-free"],
+      probe,
+      { sleepFn: neverSleep },
+    );
+    expect(survivors).toEqual(["big-pickle"]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].model).toBe("minimax-m3-free");
+    expect(skipped[0].reason).toBe("entitlement");
+    expect(skipped[0].note).toMatch(/401/);
+    expect(skipped[0].note).toMatch(/promotion|entitle/i);
+  });
+
+  it("keeps every candidate when none returns 401", async () => {
+    const probe = async () => ({ status: 200 });
+    const { survivors, skipped } = await screenEntitlements(["a", "b"], probe, { sleepFn: neverSleep });
+    expect(survivors).toEqual(["a", "b"]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("drops a candidate whose probe exceeds the per-candidate wall-clock cap (no hang)", async () => {
+    const hangingProbe = () => new Promise<{ status: number }>(() => {}); // never resolves
+    const { survivors, skipped } = await screenEntitlements(
+      ["slow-model"],
+      hangingProbe,
+      { timeoutMs: 5, sleepFn: async () => {} }, // instant timeout wins the race
+    );
+    expect(survivors).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].model).toBe("slow-model");
+    expect(skipped[0].reason).toBe("timeout");
+  });
+
+  it("treats a non-401 error status as a survivor (let the canary judge capability)", async () => {
+    const probe = async () => ({ status: 500 });
+    const { survivors, skipped } = await screenEntitlements(["flaky"], probe, { sleepFn: neverSleep });
+    expect(survivors).toEqual(["flaky"]);
+    expect(skipped).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Autonomous `/ca:sprint` (premium path) fixing the three known-cause **feature-forge** bugs filed during the `docs-site-mvp --farm` run. One combined PR per the spec-gate decision. All three are in `plugins/ca/tools/farm.ts`; test-first, **104/104 vitest**, typecheck clean, `farm.js` rebuilt and idempotent.

### #90 — stale default API base URL → 404 (fix)
`api.opencode.ai/v1` now answers `200` with body `Not Found`, so every worker died with an opaque `non-JSON response: SyntaxError`.
- Default → `https://opencode.ai/zen/v1` (exported `DEFAULT_API_BASE_URL`, single source of truth).
- `callApi` reads the body as text; new exported `parseChatCompletion()` returns an **actionable** error naming `FARM_API_BASE_URL` on a non-JSON body.
- `farm.md` + `.env.example` updated.

### #91 — git CRLF stderr pollutes drift detection (fix, Windows)
`run()` merged stdout+stderr, so git's `core.safecrlf` `warning: … LF will be replaced by CRLF …` line was parsed by `checkDrift` as a changed path → false `drift:` escalation of correct workers.
- `run()` now returns `stdout`/`stderr` separately (`out` stays merged for back-compat consumers like `runGate`).
- `checkDrift` exported with an injectable git runner; parses **stdout only**.

### #93 — expired `*-free` promo models burn the canary (feat)
The `/models` catalog lists models the key isn't entitled to; `/chat/completions` returns `401 "Free promotion has ended"`. The canary couldn't tell that from a capability failure and burned full attempts/timeouts.
- New exported `screenEntitlements()` runs a cheap 1-token probe per candidate, drops 401s **before** the canary.
- Dropped candidates surface **distinctly** in `canary-report.json` (`skipped[]`), never folded into capability `results` as a FAIL.
- Bounded by a per-candidate wall-clock cap: `FARM_ENTITLEMENT_PROBE_TIMEOUT_MS` (default 35s).

## Tests
- `plugins/ca/tools`: 104/104 vitest (was 93; +11 across #90/#91/#93), `npm run typecheck` clean, `npm run build` regenerates `farm.js` with no further diff.
- New unit coverage: default-URL constant, `parseChatCompletion` (valid + non-JSON body), `checkDrift` stdout-only / CRLF-immune, `screenEntitlements` (401 drop, timeout cap, all-survive, non-401 passthrough).

## Security
No new secret source/sink. The #93 probe reuses the existing `FARM_API_KEY` Bearer header against the already-`assertSecureBaseUrl`-guarded HTTPS endpoint and returns only the HTTP status. `auth-crypto-reviewer` — **PASS, 0 findings** at every severity.

## Notes
- `runCanary`'s report-shape wiring is typecheck-verified but not unit-covered (it does real git + network + `process.exit`; consistent with existing coverage).
- Spec/plan/auto-decision log: `.codearbiter/{specs,plans}/farm-feature-forge-fixes.md`, `.codearbiter/sprint-log.md`. All auto-decisions were `high` confidence.

Closes #90
Closes #91
Closes #93

https://claude.ai/code/session_01Sowr6A3HZLSafwoEpY8gtz
