### PR TITLE
docs(redirect): route interrogative phrasing to /ca:btw (#78)

### DIFF
--- a/plugins/ca/includes/redirect.md
+++ b/plugins/ca/includes/redirect.md
@@ -2,8 +2,11 @@
 
 Canned messages for §6 when the user sends a direct instruction outside a slash command. Loaded only
 when needed. Offer the command list — the user picks. Before sending, infer the likely intent and
-pre-fill the closest command with the user's own words (e.g. "add a healthcheck endpoint" →
-`/ca:feature "add a healthcheck endpoint"`), so the user can route with one keystroke.
+pre-fill the closest command with the user's own words, so the user can route with one keystroke.
+Match the channel to the *phrasing*, not just the topic — an interrogative is a question, not a build
+request (e.g. "add a healthcheck endpoint" → `/ca:feature "add a healthcheck endpoint"`, but
+"should we add a healthcheck?" → `/ca:btw "should we add a healthcheck?"`; "do my ADRs conflict?" →
+`/ca:reconcile`). A question pulled into the heavy spec lane is a misroute.
 
 ## First redirect — first off-channel message
 


### PR DESCRIPTION
Adds an interrogative exemplar (→ `/ca:btw`) and an ADR-conflict exemplar (→ `/ca:reconcile`) to `includes/redirect.md`, and frames intent inference as match-the-phrasing not just the topic — so "should we add a healthcheck?" no longer gets pulled into the heavy `/ca:feature` spec lane.

Pure routing-prose edit; `check-plugin-refs.py` green (all command refs resolve).

Closes #78

https://claude.ai/code/session_01Sowr6A3HZLSafwoEpY8gtz