### PR TITLE
docs(add-dep): correct install-enforcement claim to match reality (#76)

### DIFF
--- a/plugins/ca/commands/add-dep.md
+++ b/plugins/ca/commands/add-dep.md
@@ -5,9 +5,10 @@ argument-hint: "<package[@version]>"
 
 # /ca:add-dep — dependency review
 
-Gate a new or changed third-party dependency through review before it lands. No install command runs
-before the `dependency-reviewer` agent clears the package. Specify the exact version if you have one;
-without one, the reviewer evaluates the latest available version.
+Gate a new or changed third-party dependency through review before it lands. When you route through
+this command, the orchestrator runs no install until the `dependency-reviewer` agent clears the
+package. Specify the exact version if you have one; without one, the reviewer evaluates the latest
+available version.
 
 ## Routes to
 
@@ -30,3 +31,9 @@ file change is committed alongside the manifest change — never one without the
 
 MUST NOT install before `dependency-reviewer` clears the package. BLOCK on a denied license or any
 unresolved supply-chain or provenance concern.
+
+This gate is **orchestrator-enforced, not hook-enforced**: unlike the crypto/secret gate
+(`pre-bash.py` H-09b/H-10b), there is no pre-bash rule that blocks a bare `npm`/`pip`/`yarn`/`pnpm
+install` typed outside this command. The discipline depends on routing installs through `/ca:add-dep`.
+A hook-level install block (parallel to the security-gate marker) would be a stronger posture, but is a
+deliberate behavior change — a possible future enhancement, not the current contract.


### PR DESCRIPTION
`add-dep.md` claimed *"No install command runs before the dependency-reviewer clears"*, but no pre-bash hook blocks a bare `npm`/`pip`/`yarn`/`pnpm install` — only crypto/secret is hook-enforced (H-09b/H-10b). The gate is **orchestrator-enforced** (depends on routing through `/ca:add-dep`), not mechanically blocked.

This is option **(b)** from the issue (honest docs). Option (a) — a hook-level install block parallel to the security-gate marker — is the stronger posture but a deliberate behavior change, so it's left as a maintainer decision rather than taken autonomously; noted in the doc as a possible future enhancement.

`check-plugin-refs.py` green.

Closes #76

https://claude.ai/code/session_01Sowr6A3HZLSafwoEpY8gtz