### PR TITLE
fix(standup): clarify once-per-day briefing + add gating regression tests (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ One plugin, named `ca`. Claude Code namespaces every plugin command, so you invo
 
 Activation is **per-repo and explicit**. A `SessionStart` hook checks the repo for `.codearbiter/CONTEXT.md` carrying the frontmatter flag `arbiter: enabled`. Present → it injects the orchestrator persona and live startup state. Absent → it exits silently. Install the plugin globally and it stays out of the way everywhere you haven't opted in.
 
-The first session of each day also opens with a read-only repo-hygiene briefing: branch drift against the remote, merged-but-unpruned branches, stale worktrees, and uncommitted or stashed work, all surfaced, never acted on. <kbd>/ca:standup</kbd> then performs the cleanups under per-action confirmation (ff-only pull on a clean tree, branch and worktree pruning, never the default branch). Later sessions that day collapse to a single-line offer.
+The first session of each local day also opens with a read-only repo-hygiene briefing: branch drift against the remote, merged-but-unpruned branches, stale worktrees, and uncommitted or stashed work, all surfaced, never acted on. The full briefing fires **once per day** — later sessions that day stay quiet: a single-line offer (`run /ca:standup`) only if something is actionable, and **nothing at all when the repo is clean**. The briefing only *reports*; <kbd>/ca:standup</kbd> is the separate command that performs the cleanups under per-action confirmation (ff-only pull on a clean tree, branch and worktree pruning, never the default branch).
 
 ```mermaid
 flowchart LR

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -23,6 +23,11 @@ _spec.loader.exec_module(_mod)
 
 has_source = _mod.has_source
 CONFIRM_RE = _mod.CONFIRM_RE
+should_emit_briefing = _mod.should_emit_briefing
+briefing_mode = _mod.briefing_mode
+standup_marker_path = _mod.standup_marker_path
+local_date_iso = _mod.local_date_iso
+write_standup_marker = _mod.write_standup_marker
 
 
 class TestHasSource(unittest.TestCase):
@@ -259,6 +264,65 @@ class TestMainHealsBeforeDormantGate(unittest.TestCase):
             cmd = json.load(f)["statusLine"]["command"]
         self.assertIn(self.real_script, cmd)
         self.assertNotIn("2.0.1", cmd)
+
+
+class TestStandupBriefingGating(unittest.TestCase):
+    """#61 regression: pin the once-per-LOCAL-day briefing contract so the
+    documented behavior (and the absence of a marker/timezone misfire) cannot
+    silently regress.
+
+    Conclusion of the #61 investigation: the briefing is correct-but-surprising,
+    NOT a bug. The full briefing shows once per local day (first session); later
+    same-day sessions emit an offer line ONLY when something is actionable, and
+    nothing otherwise. A prior-day marker never suppresses today (rules out the
+    marker-staleness hypothesis)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_first_session_of_day_emits(self):
+        # No marker for today -> emit the full briefing.
+        self.assertTrue(should_emit_briefing(self.root, "2026-06-18"))
+
+    def test_marker_present_suppresses_same_day(self):
+        write_standup_marker(self.root, "2026-06-18")
+        self.assertFalse(should_emit_briefing(self.root, "2026-06-18"))
+
+    def test_prior_day_marker_does_NOT_suppress_today(self):
+        # The marker is date-keyed: yesterday's marker is irrelevant to today.
+        # This is the guard against the "stale marker persists" hypothesis.
+        write_standup_marker(self.root, "2026-06-17")
+        self.assertTrue(should_emit_briefing(self.root, "2026-06-18"))
+
+    def test_write_marker_is_idempotent(self):
+        write_standup_marker(self.root, "2026-06-18")
+        write_standup_marker(self.root, "2026-06-18")  # must not raise
+        self.assertTrue(os.path.isfile(standup_marker_path(self.root, "2026-06-18")))
+
+    def test_marker_path_is_date_keyed_under_markers_dir(self):
+        p = standup_marker_path(self.root, "2026-06-18")
+        self.assertEqual(
+            p,
+            os.path.join(self.root, ".codearbiter", ".markers", "standup-2026-06-18"),
+        )
+
+    def test_local_date_iso_accepts_injected_date(self):
+        import datetime
+        self.assertEqual(local_date_iso(datetime.date(2026, 6, 18)), "2026-06-18")
+
+    def test_briefing_mode_first_session_is_full_regardless_of_actionable(self):
+        # marker absent -> "full" whether or not the repo is actionable.
+        self.assertEqual(briefing_mode(marker_present=False, actionable=False), "full")
+        self.assertEqual(briefing_mode(marker_present=False, actionable=True), "full")
+
+    def test_briefing_mode_later_session_offers_only_when_actionable(self):
+        # marker present -> "offer" iff actionable, else "none" (silent).
+        self.assertEqual(briefing_mode(marker_present=True, actionable=True), "offer")
+        self.assertEqual(briefing_mode(marker_present=True, actionable=False), "none")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Investigation conclusion

The SessionStart standup briefing is **correct-but-surprising, not a bug** (issue hypothesis 1).

- The full briefing fires **once per local day** — first session writes a **date-keyed** marker (`standup-<YYYY-MM-DD>`); later same-day sessions emit a one-line offer **only if actionable**, and **nothing when the repo is clean**.
- The marker is date-keyed, so a **prior-day marker never suppresses today** — the marker-staleness/timezone hypothesis (2) does not hold.
- The repro note confirmed the hook itself fires (rules out 3/4).

So the gap was expectation vs documentation. No code change to the hook.

## Changes
- **README** — make the once-per-day model explicit: later sessions stay quiet (offer only if actionable, nothing when clean), and the briefing *reports* while `/ca:standup` *acts*.
- **Tests** — the gating functions (`should_emit_briefing`, `briefing_mode`, `standup_marker_path`, `local_date_iso`, `write_standup_marker`) had **no dedicated coverage**. Adds 8 regression tests pinning the contract — including `prior_day_marker_does_NOT_suppress_today`, which locks the staleness hypothesis out permanently. **29/29 green.**

Closes #61

https://claude.ai/code/session_01Sowr6A3HZLSafwoEpY8gtz