### PR TITLE
feat(prune): opt-in cold-miss nudge (Feature Forge preview)

### DIFF
--- a/.codearbiter/specs/prune-cold-miss-nudge.md
+++ b/.codearbiter/specs/prune-cold-miss-nudge.md
@@ -1,0 +1,132 @@
+# Spec: prune cold-miss nudge
+
+**Source:** GitHub issue #69 (`enhancement,prune`). Brainstormed 2026-06-18; all six
+issue open-questions resolved (see Decisions). Feature Forge: ships under the
+`preview` gate, same as live pruning.
+
+## Problem
+
+When the prompt cache TTL (~5 min, refreshed on each cached read) lapses, the next
+submit pays an unavoidable full re-cache **write** (~1.25×) on the entire **in-memory**
+context. A running session streams in-memory history to the API, not the on-disk
+transcript — so prune savings banked in the file only materialize when context is
+rebuilt from disk (`--resume` or compaction). Today the user gets no signal at the one
+moment where acting changes the bill: they can let the re-cache land on **bloated**
+context, or `/compact` / exit+`--resume` to land that same write on **pruned** context.
+
+**Caller:** a user running `CODEARBITER_PRUNE=on` who has opted into the nudge, returning
+mid-session after an idle stretch with a large banked prune delta. "Done" = they are told,
+**once**, before the cold submit, and can act or override by resubmitting.
+
+## Scope
+
+**In:**
+- A new arming check in `plugins/ca/hooks/_prunelib.py`'s `hook_run` (the `UserPromptSubmit`
+  path) that, when all conditions hold, **blocks the submit once** with an advisory.
+- A pure, injectable decision helper (`nudge_decision(...)`) that hook_run calls — the
+  unit-testable surface, stdlib-only, consistent with the existing pure-function + thin-hook
+  structure.
+- The block is the **first non-zero exit path** in a hook that otherwise always returns 0.
+  It MUST be the rare, well-gated exception: any error or uncertainty fails open (returns 0).
+- New env gate + thresholds (all default-safe, see Decisions).
+- Docs: `/ca:prune` doc + the preview / Feature-Forge note describe the nudge and its env gate.
+
+**Out of scope (NOT this feature):**
+- Auto-restarting the CLI / re-attaching the TTY — a hook cannot relaunch the host. The
+  action stays the user's (`/compact`, exit + `--resume`).
+- Predicting cache hit/miss exactly — no API cache-state query exists; we approximate from
+  local signals (banked delta + idle time).
+- Touching the live transcript beyond the existing prune; intercepting a warm cache *hit*
+  (a warm read is the cheap state — never interrupt it).
+- Any nudge in `dry`/`off` mode or on a non-aggressive/non-armed submit.
+- `[NEEDS-TRIAGE]` **dry-mode "you'd save X if on" informational nudge** — deferred. In dry
+  mode nothing is banked (disk isn't pruned), so a resume reloads the same size; that message
+  is a different (marketing) nudge, not this one.
+- `[NEEDS-TRIAGE]` **statusline tie-in** — a passive delta+staleness statusline hint is
+  independently shippable from the submit-time block; deferred to a follow-up.
+
+## Decisions (issue open-questions, resolved)
+
+1. **Gate = dedicated flag, default off.** `CODEARBITER_PRUNE_NUDGE=on`, independent of
+   `CODEARBITER_PRUNE_TIER`. The block is a distinct UX behavior from pruning depth; a
+   separate opt-in keeps it rare, well-gated, and off by default (preview).
+2. **Hard block once, override on resubmit.** Armed → `hook_run` returns `2` with the advisory
+   on **stderr**; a per-session `cold_nudged` marker in `prune-state.json` makes the immediate
+   resubmit proceed (returns 0). Chosen over a non-blocking injected advisory because it owns
+   the one decision moment; safety is preserved by the strict arming gate + fail-open.
+3. **Cadence = once per cold window.** The `cold_nudged` marker is set when the nudge fires
+   and **cleared on any warm submit** (idle < idle-floor), so the next genuine cold window
+   re-arms. No arbitrary turn counter.
+4. **Banked-delta proxy = last run's `freed_bytes`** from `prune-state.json` (the issue's
+   "projected freed_bytes/pct from the last run"). Approximate by design.
+5. **Idle signal = now − last assistant-turn `timestamp`** from the transcript tail. Optional
+   corroboration from the last turn's `message.usage.cache_*` fields is a non-required nicety.
+6. **Thresholds (env-overridable defaults):**
+   - `CODEARBITER_PRUNE_NUDGE_MIN_TOKENS` = `80000` — floor on est-tokens freed
+     (`est_tokens(freed_bytes)`), below which the nudge is noise.
+   - `CODEARBITER_PRUNE_NUDGE_IDLE_SECS` = `240` — idle floor (~approaching the ~5 min TTL);
+     a submit after this gap is treated as probably-cold. Heuristic; TTL is not queryable.
+
+## Behavior
+
+Advisory (sizes/tokens/percent/time only — never transcript content):
+
+> Cold cache miss imminent on ~140k tokens. `/compact` or exit + `--resume` lands that
+> re-cache on pruned context (~40% smaller). Submit again to proceed.
+
+Arming (ALL must hold): mode is `on` · `CODEARBITER_PRUNE_NUDGE=on` · est-tokens(freed_bytes)
+≥ MIN_TOKENS · idle ≥ IDLE_SECS · `cold_nudged` not already set for this cold window. The
+nudge is evaluated even when this turn's prune would short-circuit on insufficient growth
+(an idle user adds no bytes but is exactly who should be nudged); the `cold_nudged` flag
+change is persisted regardless. When armed, hook_run blocks **before** pruning this turn —
+the bank is already on disk from a prior run; the override resubmit proceeds to the normal path.
+
+## Acceptance criteria
+
+Each is verifiable by a single test (one `tdd` Phase 1 obligation each). Idle/state-driven
+tests use synthetic transcript tails (timestamps) + synthetic `prune-state` records, with an
+injectable `now`. New fixtures carry top-level `timestamp` (the live synthetic fixture omits it).
+
+1. **Flag off → silent.** `nudge_decision` returns not-armed when `CODEARBITER_PRUNE_NUDGE`
+   is unset or ≠ `on`, even if every other condition holds.
+2. **Wrong mode → silent.** `hook_run` reaches the nudge only in `on` mode; in `off`/`dry`
+   it returns 0 and never blocks.
+3. **Small delta → silent.** Not-armed when `est_tokens(freed_bytes)` < `MIN_TOKENS`
+   (default 80000).
+4. **Warm session → silent.** Not-armed when idle (now − last-assistant `timestamp`) <
+   `IDLE_SECS` (default 240).
+5. **All conditions hold → armed.** Returns a block decision carrying the advisory string.
+6. **Blocked exactly once.** A second evaluation with `cold_nudged` already set returns
+   not-armed — the override resubmit proceeds.
+7. **Once per cold window.** A warm evaluation (idle < floor) clears `cold_nudged`, so a
+   subsequent cold window arms again.
+8. **Fail-open always.** Any internal error (malformed transcript, missing timestamp, bad
+   state) yields not-armed; `hook_run` returns 0 — never 2 on a pruner fault.
+9. **Privacy.** The advisory contains only sizes / est-tokens / percent / time — asserted to
+   be derived from state numbers, with no transcript text (consistent with the dry-metrics
+   privacy stance).
+10. **hook_run integration.** Armed → `hook_run` returns `2` with the advisory on stderr and
+    skips this turn's prune; non-armed → returns 0 and the existing prune behavior is
+    unchanged (verified: flag-off run is byte-identical to today).
+11. **Docs updated.** The `/ca:prune` doc and the preview / Feature-Forge note describe the
+    nudge and name its env gate (`CODEARBITER_PRUNE_NUDGE` + the two threshold vars) —
+    verifiable by asserting the doc text references `CODEARBITER_PRUNE_NUDGE`.
+
+## Open questions
+
+None blocking. The two deferred items (dry-mode marketing nudge, statusline tie-in) are marked
+`[NEEDS-TRIAGE]` in Scope above — future scope, not routed to a ticket.
+
+## Implementation notes
+
+- Entry: `plugins/ca/hooks/_prunelib.py` → `hook_run` (already wired to `UserPromptSubmit`
+  via `prune-transcript.py:123`, which `sys.exit()`s the return). Block = return `2` +
+  advisory on stderr; allow = return `0`.
+- New state fields in `prune-state.json` per session: `cold_nudged` (bool). Reuses existing
+  `freed_bytes`, `pct`, `last_pruned_size`, `last_run_ts`.
+- New env: `CODEARBITER_PRUNE_NUDGE`, `CODEARBITER_PRUNE_NUDGE_MIN_TOKENS`,
+  `CODEARBITER_PRUNE_NUDGE_IDLE_SECS` (wire through `Config.from_env` or read in the helper).
+- Tests under `plugins/ca/hooks/tests/` (mirror `test_prune_cli.py` / `test_hook.py` style);
+  register any new test entry in `tech-stack.md`'s test list if it must run in the commit gate.
+- Release: any `plugins/ca/**` change on a tagged version bumps `plugin.json` version (CI
+  `version-bump`), and the version rides in plugin.json + README badge + CHANGELOG.

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -31,6 +31,9 @@ python .github/scripts/test_preview_lib.py
 
 # UX-conversion-trio copy — Receipt close, stakes lines, register split (structural)
 python .github/scripts/test_ux_conversion.py
+
+# Cold-miss nudge — nudge_decision, advisory, idle extraction, hook_run integration (O1–O11)
+python .github/scripts/test_prune_nudge.py
 ```
 
 Only when `plugins/ca/tools/**` changed:

--- a/.github/scripts/test_prune_nudge.py
+++ b/.github/scripts/test_prune_nudge.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""CI runner for the cold-miss nudge unit tests.
+
+Mirrors .github/scripts/test_preview_lib.py's sys.path pattern:
+adds plugins/ca/hooks/tests to sys.path so test_prune_nudge can import
+_prunelib and _helpers without a package install.
+
+Exit 0 = all tests pass; exit 1 = any failure.
+
+Run as: python .github/scripts/test_prune_nudge.py
+"""
+
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+HOOKS = os.path.join(REPO, "plugins", "ca", "hooks")
+HOOKS_TESTS = os.path.join(HOOKS, "tests")
+
+sys.path.insert(0, HOOKS)
+sys.path.insert(0, HOOKS_TESTS)
+
+import test_prune_nudge  # noqa: E402 — needs sys.path mutation above
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(test_prune_nudge)
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,11 @@ jobs:
         # the Receipt close, stakes lines on substantive finding-blocks, the
         # register split, and the negatives (no saves-ledger/statusline segment).
         run: python .github/scripts/test_ux_conversion.py
+      - name: Run cold-miss nudge unit tests
+        # O1–O11: nudge_decision pure helper, advisory builder, idle extraction,
+        # hook_run integration (armed→2/stderr, resubmit→0, flag-off→today's
+        # behavior), and docs gate (prune.md references CODEARBITER_PRUNE_NUDGE).
+        run: python .github/scripts/test_prune_nudge.py
 
   version-bump:
     name: plugin version bumped when payload changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.4.4] — 2026-06-18
+
+### Added
+- **Cold-miss nudge** [Feature Forge — `preview`]: an opt-in `UserPromptSubmit` speed bump that
+  blocks once, with an advisory on stderr, when a large banked prune delta is about to re-cache on
+  bloated in-memory context (idle ≥ 240 s, freed tokens ≥ 80k, `CODEARBITER_PRUNE_NUDGE=on`).
+  Returns exit code 2 once; a resubmit proceeds. The once-per-cold-window `cold_nudged` marker is
+  persisted in `prune-state.json` and reset on any warm submit. Strictly fail-open: any internal
+  error returns 0 and never blocks the session. This is the first non-zero exit path in `hook_run`.
+  Advisory content is derived from state numbers only (no transcript text). (#69)
+
 ## [2.4.2] — 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.4.3" src="https://img.shields.io/badge/version-2.4.3-2b7489">
+<img alt="version 2.4.4" src="https://img.shields.io/badge/version-2.4.4-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-35-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/commands/prune.md
+++ b/plugins/ca/commands/prune.md
@@ -58,6 +58,18 @@ the running CLI sends its in-memory history to the API, not the file.
    If a prior service-mode prune was killed mid-write, the next run self-heals the transcript
    from the newest backup in `~/.codearbiter/prune-backups/` before doing anything else.
 
+   **Cold-miss nudge** [Feature Forge — `preview`]: when `CODEARBITER_PRUNE` is `on`, an
+   optional submit-time speed bump warns once before a cold cache re-cache lands on bloated
+   context. Enable with `CODEARBITER_PRUNE_NUDGE=on` (default `off`). When all arming conditions
+   hold (idle ≥ `CODEARBITER_PRUNE_NUDGE_IDLE_SECS`, default 240 s; estimated freed tokens ≥
+   `CODEARBITER_PRUNE_NUDGE_MIN_TOKENS`, default 80 000), the hook blocks the submit once with
+   an advisory on stderr and returns exit code 2. The advisory names the approximate token count,
+   saving percentage, and the two actions that move the re-cache to pruned context:
+   `/compact` or exit + `--resume`. Resubmitting immediately proceeds. The block fires at most
+   once per cold window; a subsequent warm submit (idle < floor) resets the window so the next
+   genuine cold stretch re-arms. The gate is strictly opt-in, never fires in `dry`/`off` mode,
+   and fails open on any error — a pruner fault will never block the session.
+
 ## When NOT to use
 
 - Context bar nowhere near compaction — the most recent turns are protected anyway.

--- a/plugins/ca/hooks/_prunelib.py
+++ b/plugins/ca/hooks/_prunelib.py
@@ -1093,14 +1093,17 @@ def tail_is_settled(lines):
 # --------------------------------------------------------------------------- #
 
 def _parse_iso8601(s):
-    """Parse an ISO 8601 datetime string to a UTC epoch int.
-    Robust Z/+offset/fractional-second handling; stdlib-only; never raises."""
+    """Parse a UTC (`Z`-suffixed) ISO 8601 datetime to an epoch int.
+
+    Claude Code transcript timestamps are always UTC `Z`. We deliberately
+    handle only that form plus fractional seconds; a non-`Z` numeric offset
+    (`+HH:MM` / `-HH:MM`) is treated as unknown and returns None rather than
+    being silently misread as UTC. Stdlib-only; never raises (fail open)."""
     try:
         s = str(s).strip()
-        if s.endswith("Z"):
-            s = s[:-1]
-        # Drop fractional seconds and any UTC-offset suffix.
-        s = s.split(".")[0].split("+")[0]
+        if not s.endswith("Z"):
+            return None  # offset-bearing or naive timestamp: don't guess → no nudge
+        s = s[:-1].split(".")[0]  # drop the Z and any fractional seconds
         return calendar.timegm(time.strptime(s, "%Y-%m-%dT%H:%M:%S"))
     except Exception:  # noqa: BLE001 — fail open
         return None

--- a/plugins/ca/hooks/_prunelib.py
+++ b/plugins/ca/hooks/_prunelib.py
@@ -19,11 +19,13 @@
 #
 # Stdlib only (hooks must run on a stock interpreter — see _hooklib.py).
 
+import calendar
 import hashlib
 import json
 import os
 import re
 import shutil
+import sys
 import time
 
 BOM = b"\xef\xbb\xbf"
@@ -1086,10 +1088,99 @@ def tail_is_settled(lines):
     return True
 
 
+# --------------------------------------------------------------------------- #
+# Cold-miss nudge helpers (opt-in; `CODEARBITER_PRUNE_NUDGE=on` required)
+# --------------------------------------------------------------------------- #
+
+def _parse_iso8601(s):
+    """Parse an ISO 8601 datetime string to a UTC epoch int.
+    Robust Z/+offset/fractional-second handling; stdlib-only; never raises."""
+    try:
+        s = str(s).strip()
+        if s.endswith("Z"):
+            s = s[:-1]
+        # Drop fractional seconds and any UTC-offset suffix.
+        s = s.split(".")[0].split("+")[0]
+        return calendar.timegm(time.strptime(s, "%Y-%m-%dT%H:%M:%S"))
+    except Exception:  # noqa: BLE001 — fail open
+        return None
+
+
+def _last_assistant_ts(data):
+    """Return epoch secs of the most recent assistant turn's top-level
+    `timestamp`, or None when absent/unparseable."""
+    ts = None
+    for ln in load_lines(data):
+        o = ln.obj
+        if isinstance(o, dict) and o.get("type") == "assistant" and o.get("timestamp"):
+            ts = o.get("timestamp")
+    return _parse_iso8601(ts) if ts is not None else None
+
+
+def _idle_seconds(data, now):
+    """Seconds since the last assistant turn, or None when unknown."""
+    t = _last_assistant_ts(data)
+    return None if t is None else now - t
+
+
+def _nudge_advisory(rec):
+    """Build the advisory string from state-record numbers only.
+    Never includes transcript content — only sizes / est-tokens / percent."""
+    freed = int(rec.get("freed_bytes", 0) or 0)
+    pruned = int(rec.get("last_pruned_size", 0) or 0)
+    approx_tokens = est_tokens(pruned + freed)   # ~ in-memory (bloated) size
+    pct = rec.get("pct", 0)
+    return (f"Cold cache miss imminent on ~{approx_tokens // 1000}k tokens. "
+            f"/compact or exit + --resume lands that re-cache on pruned context "
+            f"(~{pct}% smaller). Submit again to proceed.")
+
+
+def nudge_decision(rec, idle_secs, e):
+    """Decide whether to fire the cold-miss nudge. Pure + fail-open.
+
+    Returns (armed: bool, advisory: str, new_rec: dict). new_rec is `rec`
+    unchanged unless the cold_nudged marker must flip (arm) or clear (warm
+    reset).  `rec` is a prune-state session record; `idle_secs` is seconds
+    since the last assistant turn (None if unknown); `e` is the env mapping.
+    """
+    rec = rec if isinstance(rec, dict) else {}
+    if (e.get("CODEARBITER_PRUNE_NUDGE", "off") or "off").lower() != "on":
+        return (False, "", rec)
+
+    def _num(key, default):
+        try:
+            return int(e[key])
+        except Exception:  # noqa: BLE001
+            return default
+
+    idle_floor = _num("CODEARBITER_PRUNE_NUDGE_IDLE_SECS", 240)
+    min_tokens = _num("CODEARBITER_PRUNE_NUDGE_MIN_TOKENS", 80000)
+    cold = isinstance(idle_secs, (int, float)) and idle_secs >= idle_floor
+
+    if not cold:
+        if rec.get("cold_nudged"):          # warm submit resets the window
+            nr = dict(rec)
+            nr["cold_nudged"] = False
+            return (False, "", nr)
+        return (False, "", rec)
+
+    freed = rec.get("freed_bytes", 0)
+    if not isinstance(freed, (int, float)) or est_tokens(int(freed)) < min_tokens:
+        return (False, "", rec)
+
+    if rec.get("cold_nudged"):              # already fired this cold window
+        return (False, "", rec)
+
+    nr = dict(rec)
+    nr["cold_nudged"] = True
+    return (True, _nudge_advisory(rec), nr)
+
+
 def hook_run(payload, env=None):
     """Service-mode entry: gate, short-circuit cheaply, prune at a safe point,
-    and record state for the statusline. ALWAYS returns 0 — a pruner failure
-    must never block the user's prompt or break the session."""
+    and record state for the statusline. Normally returns 0; returns 2 only
+    when the cold-miss nudge is armed (opt-in, see nudge_decision). A pruner
+    fault must never block the user's prompt or break the session."""
     e = env if env is not None else os.environ
     mode = (e.get("CODEARBITER_PRUNE", "off") or "off").lower()
     if mode not in ("dry", "on"):
@@ -1131,8 +1222,27 @@ def hook_run(payload, env=None):
         return 0
     if st.st_size < cfg.min_size or st.st_size > (50 << 20):
         return 0
-    state = load_state()
+    try:
+        state = load_state()
+    except Exception:  # noqa: BLE001 — fail open on any state-read fault
+        return 0
     rec = state.get(session, {})
+    # Cold-miss nudge (opt-in): the ONLY non-zero return in this hook. Evaluated
+    # before the growth short-circuit so an idle user (no new bytes) still nudges.
+    if cfg.execute and (e.get("CODEARBITER_PRUNE_NUDGE", "off") or "off").lower() == "on":
+        try:
+            with open(path, "rb") as f:
+                ndata = f.read()
+            armed, advisory, new_rec = nudge_decision(
+                rec, _idle_seconds(ndata, time.time()), e)
+            if new_rec != rec:
+                state[session] = new_rec
+                save_state(state)
+            if armed:
+                sys.stderr.write(advisory + "\n")
+                return 2
+        except Exception:  # noqa: BLE001 — fail open; pruner fault must never block
+            pass
     if rec and (st.st_size - rec.get("last_pruned_size", 0)) < cfg.min_growth:
         return 0  # cheap stat short-circuit: not enough new bytes
     try:
@@ -1166,7 +1276,11 @@ def hook_run(payload, env=None):
             "strategies": {k: v["bytes_before"] - v["bytes_after"]
                            for k, v in res["strategies"].items()},
         }, env=e)
-    state[session] = {
+    # Carry cold_nudged forward so the once-per-cold-window marker survives a
+    # normal (non-armed) prune run. Re-read from state in case the nudge block
+    # above already flushed an updated rec (e.g. a warm-submit clear).
+    _cold_nudged = state.get(session, {}).get("cold_nudged")
+    new_state = {
         "path": path,
         "last_size": b1 if res["executed"] else b0,
         "last_pruned_size": (b1 if res["executed"] else st.st_size),
@@ -1175,6 +1289,9 @@ def hook_run(payload, env=None):
         "freed_bytes": b0 - b1,
         "verdict": res["verdict"],
     }
+    if _cold_nudged:
+        new_state["cold_nudged"] = _cold_nudged
+    state[session] = new_state
     save_state(state)
     return 0
 

--- a/plugins/ca/hooks/tests/test_prune_nudge.py
+++ b/plugins/ca/hooks/tests/test_prune_nudge.py
@@ -463,5 +463,165 @@ class TestO11Docs(unittest.TestCase):
                       "prune.md must document the CODEARBITER_PRUNE_NUDGE env var")
 
 
+def _warm_ts():
+    """A `Z` timestamp at 'now' (UTC) → idle ~ 0 → warm."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+# ---------------------------------------------------------------------------
+# Parser + idle extraction edge cases (MEDIUM coverage gaps + the offset bug)
+# ---------------------------------------------------------------------------
+
+class TestParseAndIdleEdges(unittest.TestCase):
+    def test_parse_plain_z(self):
+        # Returns an int epoch, and the arithmetic is sane: +90s parses 90 higher.
+        t0 = P._parse_iso8601("2026-06-18T10:00:00Z")
+        t1 = P._parse_iso8601("2026-06-18T10:01:30Z")
+        self.assertIsInstance(t0, int)
+        self.assertEqual(t1 - t0, 90)
+
+    def test_parse_fractional_seconds_z(self):
+        # Fractional seconds are dropped; same epoch as the whole-second form.
+        self.assertEqual(P._parse_iso8601("2026-06-18T10:00:00.123456Z"),
+                         P._parse_iso8601("2026-06-18T10:00:00Z"))
+
+    def test_parse_positive_offset_returns_none(self):
+        # Offset-bearing timestamps are treated as unknown — never silently UTC.
+        self.assertIsNone(P._parse_iso8601("2026-06-18T10:00:00+05:00"))
+
+    def test_parse_negative_offset_returns_none(self):
+        # The bug the audit caught: -offset must behave the same as +offset.
+        self.assertIsNone(P._parse_iso8601("2026-06-18T10:00:00-05:00"))
+
+    def test_parse_garbage_returns_none(self):
+        self.assertIsNone(P._parse_iso8601("not a date"))
+        self.assertIsNone(P._parse_iso8601(None))
+
+    def test_last_assistant_ts_no_assistant_turn(self):
+        # A transcript with no assistant line → None (fail open, no nudge).
+        data = (b'{"type":"user","uuid":"u0","parentUuid":null,'
+                b'"message":{"role":"user","content":"hi"}}\n')
+        self.assertIsNone(P._last_assistant_ts(data))
+
+    def test_last_assistant_ts_assistant_without_timestamp(self):
+        # make_transcript emits assistant turns but NO top-level timestamp → None.
+        data = make_transcript(n_pairs=2, result_bytes=100, final_assistant=True)
+        self.assertIsNone(P._last_assistant_ts(data))
+
+    def test_idle_seconds_none_when_ts_absent(self):
+        data = make_transcript(n_pairs=1, result_bytes=100)
+        self.assertIsNone(P._idle_seconds(data, now=1.0e9))
+
+
+# ---------------------------------------------------------------------------
+# Shared armed-eligible integration harness (cold transcript + big delta)
+# ---------------------------------------------------------------------------
+
+class _ArmedHarness(unittest.TestCase):
+    """setUp builds an arbiter repo + a cold transcript whose state record has a
+    large freed_bytes and a SMALL last_pruned_size (so a later warm submit's
+    grown transcript actually prunes, exercising the carry-forward path)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._home = redirect_home(self.tmp.name)
+        self.repo = os.path.join(self.tmp.name, "repo")
+        os.makedirs(os.path.join(self.repo, ".codearbiter"))
+        with open(os.path.join(self.repo, ".codearbiter", "CONTEXT.md"), "w") as f:
+            f.write("---\narbiter: enabled\n---\n# ctx\n")
+        self.claude_dir = os.path.join(self.tmp.name, ".claude", "projects", "test")
+        os.makedirs(self.claude_dir, exist_ok=True)
+        self.path = os.path.join(self.claude_dir, "sess.jsonl")
+        self._write_transcript("2026-06-17T00:00:00Z")  # cold
+        P.save_state({"sess": {"freed_bytes": 400_000,
+                               "last_pruned_size": 1000, "pct": 33.0}})
+
+    def tearDown(self):
+        restore_home(self._home)
+        self.tmp.cleanup()
+
+    def _write_transcript(self, ts, result_bytes=20000):
+        with open(self.path, "wb") as f:
+            f.write(_make_transcript_with_ts(n_pairs=6, result_bytes=result_bytes,
+                                             final_ts=ts))
+
+    def _env(self, **kw):
+        e = {"CODEARBITER_PRUNE": "on", "CODEARBITER_PRUNE_NUDGE": "on",
+             "CODEARBITER_PRUNE_KEEP_RECENT": "2",
+             "CODEARBITER_PRUNE_MIN_SIZE": "1000",
+             "CODEARBITER_PRUNE_MIN_GROWTH": "1000",
+             "CODEARBITER_PRUNE_NUDGE_MIN_TOKENS": "1",
+             "CODEARBITER_PRUNE_NUDGE_IDLE_SECS": "1"}
+        e.update(kw)
+        return e
+
+    def _payload(self):
+        return {"hook_event_name": "UserPromptSubmit", "transcript_path": self.path,
+                "session_id": "sess", "cwd": self.repo}
+
+
+# ---------------------------------------------------------------------------
+# O8 (hook_run level) — a fault INSIDE the nudge block fails open, never 2
+# ---------------------------------------------------------------------------
+
+class TestO8bNudgeBlockFailOpen(_ArmedHarness):
+    def test_exception_in_nudge_block_returns_0(self):
+        # The armed conditions hold (this env returns 2 normally — see O10). Force
+        # nudge_decision (called only inside the nudge block's try/except) to raise
+        # and prove the block fails open to 0 rather than escaping or returning 2.
+        orig = P.nudge_decision
+        P.nudge_decision = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+        try:
+            rc = P.hook_run(self._payload(), env=self._env())
+        finally:
+            P.nudge_decision = orig
+        self.assertEqual(rc, 0,
+                         "a fault inside the nudge block must fail open to 0, never 2")
+
+    def test_armed_baseline_returns_2(self):
+        # Guard: prove the harness IS armed, so the fail-open test above is meaningful.
+        rc = P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(rc, 2)
+
+
+# ---------------------------------------------------------------------------
+# O10 — warm submit clears cold_nudged AND that clear persists through a prune
+# ---------------------------------------------------------------------------
+
+class TestO10bWarmResetPersistence(_ArmedHarness):
+    def test_cold_arm_then_warm_clears_and_persists_through_prune(self):
+        # 1) Cold submit arms: returns 2, persists cold_nudged=True, skips prune.
+        rc1 = P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(rc1, 2)
+        self.assertTrue(P.load_state()["sess"].get("cold_nudged"))
+
+        # 2) A warm, GROWN transcript arrives (recent timestamp, larger body so it
+        #    exceeds min_growth and actually prunes — exercising the carry-forward).
+        self._write_transcript(_warm_ts(), result_bytes=40000)
+        before = os.path.getsize(self.path)
+        rc2 = P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(rc2, 0, "warm submit must not block")
+
+        # 3) The clear is persisted to disk (not just decided in memory)...
+        self.assertFalse(P.load_state()["sess"].get("cold_nudged"),
+                         "warm submit must persist the cold_nudged clear")
+        # ...and the prune actually ran (carry-forward path, not a short-circuit).
+        self.assertLess(os.path.getsize(self.path), before,
+                        "warm grown transcript should have pruned")
+
+
+# ---------------------------------------------------------------------------
+# O2 (LOW) — dry mode never ENTERS the nudge block (no state mutation)
+# ---------------------------------------------------------------------------
+
+class TestO2bDryModeSkipsNudgeBlock(_ArmedHarness):
+    def test_dry_mode_does_not_touch_cold_nudged(self):
+        # Armed-eligible state, but PRUNE=dry → cfg.execute False → nudge block
+        # is gated out entirely; the cold_nudged marker is never written.
+        P.hook_run(self._payload(), env=self._env(CODEARBITER_PRUNE="dry"))
+        self.assertIsNone(P.load_state().get("sess", {}).get("cold_nudged"),
+                          "dry mode must not enter the nudge block")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/plugins/ca/hooks/tests/test_prune_nudge.py
+++ b/plugins/ca/hooks/tests/test_prune_nudge.py
@@ -1,0 +1,467 @@
+"""Unit tests for the cold-miss nudge — O1–O11.
+
+Mirror test_hook.py style: redirect_home/restore_home from _helpers, tempdir,
+import _prunelib as P. Tests are isolated from the real ~ via home redirect.
+
+Run via: python .github/scripts/test_prune_nudge.py
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+# Ensure hooks/ and hooks/tests/ are importable.
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOKS_DIR = os.path.dirname(_TESTS_DIR)
+sys.path.insert(0, _HOOKS_DIR)
+sys.path.insert(0, _TESTS_DIR)
+
+import _prunelib as P  # noqa: E402
+from _helpers import make_transcript, redirect_home, restore_home  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_transcript_with_ts(n_pairs=4, result_bytes=5000,
+                              final_ts="2026-06-18T10:00:00Z"):
+    """Build a transcript whose final assistant turn carries a top-level
+    `timestamp` field.  The shared make_transcript() omits it — we need it for
+    idle-time detection.
+    """
+    data = make_transcript(n_pairs=n_pairs, result_bytes=result_bytes,
+                           final_assistant=True)
+    # Re-parse the last non-blank line, inject the timestamp, re-serialize.
+    lines = data.rstrip(b"\n").split(b"\n")
+    last = json.loads(lines[-1])
+    last["timestamp"] = final_ts
+    lines[-1] = json.dumps(last, ensure_ascii=False, separators=(",", ":")).encode()
+    return b"\n".join(lines) + b"\n"
+
+
+def _big_rec(cold_nudged=False):
+    """A session state record with a large freed_bytes (> 80 000 tokens @ 4 B)."""
+    # 80 000 tokens * 4 bytes/token = 320 000 bytes freed — well above the floor.
+    return {
+        "freed_bytes": 400_000,
+        "last_pruned_size": 1_200_000,
+        "pct": 33.0,
+        "cold_nudged": cold_nudged,
+    }
+
+
+# ---------------------------------------------------------------------------
+# O1 — flag off → nudge_decision not-armed
+# ---------------------------------------------------------------------------
+
+class TestO1FlagOff(unittest.TestCase):
+    def test_flag_unset(self):
+        rec = _big_rec()
+        armed, advisory, new_rec = P.nudge_decision(rec, idle_secs=300, e={})
+        self.assertFalse(armed)
+        self.assertEqual(advisory, "")
+
+    def test_flag_off_explicit(self):
+        rec = _big_rec()
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=300, e={"CODEARBITER_PRUNE_NUDGE": "off"})
+        self.assertFalse(armed)
+
+    def test_flag_wrong_value(self):
+        rec = _big_rec()
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=300, e={"CODEARBITER_PRUNE_NUDGE": "yes"})
+        self.assertFalse(armed)
+
+
+# ---------------------------------------------------------------------------
+# O2 — hook_run with PRUNE=dry or PRUNE=off + NUDGE=on → returns 0
+# ---------------------------------------------------------------------------
+
+class TestO2WrongMode(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._home = redirect_home(self.tmp.name)
+        self.repo = os.path.join(self.tmp.name, "repo")
+        os.makedirs(os.path.join(self.repo, ".codearbiter"))
+        with open(os.path.join(self.repo, ".codearbiter", "CONTEXT.md"), "w") as f:
+            f.write("---\narbiter: enabled\n---\n# ctx\n")
+        claude_dir = os.path.join(self.tmp.name, ".claude", "projects", "test")
+        os.makedirs(claude_dir, exist_ok=True)
+        self.path = os.path.join(claude_dir, "sess.jsonl")
+        ts = "2026-06-18T00:00:00Z"  # old enough to be "cold"
+        with open(self.path, "wb") as f:
+            f.write(_make_transcript_with_ts(n_pairs=6, result_bytes=20000,
+                                              final_ts=ts))
+        # Pre-seed state with a big freed_bytes record.
+        P.save_state({"sess": _big_rec()})
+
+    def tearDown(self):
+        restore_home(self._home)
+        self.tmp.cleanup()
+
+    def _env(self, **kw):
+        e = {"CODEARBITER_PRUNE_KEEP_RECENT": "2",
+             "CODEARBITER_PRUNE_MIN_SIZE": "1000",
+             "CODEARBITER_PRUNE_MIN_GROWTH": "1000",
+             "CODEARBITER_PRUNE_NUDGE": "on",
+             "CODEARBITER_PRUNE_NUDGE_IDLE_SECS": "1",   # very low floor
+             "CODEARBITER_PRUNE_NUDGE_MIN_TOKENS": "1"}  # very low floor
+        e.update(kw)
+        return e
+
+    def payload(self):
+        return {"hook_event_name": "UserPromptSubmit",
+                "transcript_path": self.path,
+                "session_id": "sess",
+                "cwd": self.repo}
+
+    def test_dry_mode_returns_0(self):
+        rc = P.hook_run(self.payload(),
+                        env=self._env(CODEARBITER_PRUNE="dry"))
+        self.assertEqual(rc, 0)
+
+    def test_off_mode_returns_0(self):
+        rc = P.hook_run(self.payload(),
+                        env=self._env(CODEARBITER_PRUNE="off"))
+        self.assertEqual(rc, 0)
+
+    def test_transcript_untouched_in_dry_mode(self):
+        before = os.path.getsize(self.path)
+        P.hook_run(self.payload(), env=self._env(CODEARBITER_PRUNE="dry"))
+        self.assertEqual(os.path.getsize(self.path), before)
+
+
+# ---------------------------------------------------------------------------
+# O3 — cold + freed_bytes below floor → not-armed
+# ---------------------------------------------------------------------------
+
+class TestO3SmallDelta(unittest.TestCase):
+    def test_below_floor_freed_bytes(self):
+        # est_tokens(freed_bytes) < 80 000 when freed_bytes < 320 000
+        rec = {"freed_bytes": 100_000, "last_pruned_size": 500_000, "pct": 20.0}
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=300,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertFalse(armed)
+
+    def test_exactly_at_floor_tokens_passes(self):
+        # 80 000 tokens * 4 = 320 000 bytes — on the threshold; should arm
+        rec = {"freed_bytes": 320_000, "last_pruned_size": 1_000_000, "pct": 32.0}
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=300,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertTrue(armed)
+
+    def test_custom_min_tokens_env(self):
+        # With MIN_TOKENS=50 000 tokens, freed_bytes=210_000 (52 500 tokens) arms.
+        rec = {"freed_bytes": 210_000, "last_pruned_size": 600_000, "pct": 35.0}
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=300,
+            e={"CODEARBITER_PRUNE_NUDGE": "on",
+               "CODEARBITER_PRUNE_NUDGE_MIN_TOKENS": "50000"})
+        self.assertTrue(armed)
+
+
+# ---------------------------------------------------------------------------
+# O4 — warm (idle < 240) → not-armed; no spurious cold_nudged set
+# ---------------------------------------------------------------------------
+
+class TestO4WarmSession(unittest.TestCase):
+    def test_warm_not_armed(self):
+        rec = _big_rec()
+        armed, _, new_rec = P.nudge_decision(
+            rec, idle_secs=100,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertFalse(armed)
+        self.assertFalse(new_rec.get("cold_nudged"),
+                         "warm submit must not set cold_nudged")
+
+    def test_warm_at_boundary_not_armed(self):
+        rec = _big_rec()
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=239,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertFalse(armed)
+
+    def test_idle_none_not_armed(self):
+        rec = _big_rec()
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=None,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertFalse(armed)
+
+
+# ---------------------------------------------------------------------------
+# O5 — all conditions hold → armed, advisory non-empty
+# ---------------------------------------------------------------------------
+
+class TestO5Armed(unittest.TestCase):
+    def test_arms_when_all_hold(self):
+        rec = _big_rec()
+        armed, advisory, new_rec = P.nudge_decision(
+            rec, idle_secs=300,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertTrue(armed)
+        self.assertTrue(advisory, "advisory must be non-empty when armed")
+        self.assertTrue(new_rec.get("cold_nudged"),
+                        "cold_nudged must be set on arm")
+
+    def test_custom_idle_floor(self):
+        rec = _big_rec()
+        # Default floor 240; custom floor 60 → armed at idle=70
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=70,
+            e={"CODEARBITER_PRUNE_NUDGE": "on",
+               "CODEARBITER_PRUNE_NUDGE_IDLE_SECS": "60"})
+        self.assertTrue(armed)
+
+
+# ---------------------------------------------------------------------------
+# O6 — already cold_nudged=True → not-armed on second call
+# ---------------------------------------------------------------------------
+
+class TestO6AlreadyNudged(unittest.TestCase):
+    def test_second_call_not_armed(self):
+        rec = _big_rec(cold_nudged=True)
+        armed, _, _ = P.nudge_decision(
+            rec, idle_secs=300,
+            e={"CODEARBITER_PRUNE_NUDGE": "on"})
+        self.assertFalse(armed)
+
+
+# ---------------------------------------------------------------------------
+# O7 — two-step: cold_nudged + warm → clears → re-arms on next cold
+# ---------------------------------------------------------------------------
+
+class TestO7OncePerColdWindow(unittest.TestCase):
+    def test_warm_clears_marker_then_cold_rearms(self):
+        # Step 1: start with cold_nudged=True, submit while warm → clears
+        rec = _big_rec(cold_nudged=True)
+        e = {"CODEARBITER_PRUNE_NUDGE": "on"}
+        armed1, _, rec2 = P.nudge_decision(rec, idle_secs=100, e=e)
+        self.assertFalse(armed1)
+        self.assertFalse(rec2.get("cold_nudged"),
+                         "warm submit must clear cold_nudged")
+
+        # Step 2: feed that cleared rec back; cold submit → arms again
+        armed2, advisory2, rec3 = P.nudge_decision(rec2, idle_secs=300, e=e)
+        self.assertTrue(armed2)
+        self.assertTrue(advisory2)
+        self.assertTrue(rec3.get("cold_nudged"))
+
+
+# ---------------------------------------------------------------------------
+# O8 — fail-open: bad inputs never raise, hook_run never returns 2 on error
+# ---------------------------------------------------------------------------
+
+class TestO8FailOpen(unittest.TestCase):
+    def test_nudge_decision_none_rec(self):
+        try:
+            armed, _, _ = P.nudge_decision(None, idle_secs=300,
+                                           e={"CODEARBITER_PRUNE_NUDGE": "on"})
+            self.assertFalse(armed)
+        except Exception as ex:
+            self.fail(f"nudge_decision(None, ...) raised {ex!r}")
+
+    def test_nudge_decision_freed_bytes_non_int(self):
+        rec = {"freed_bytes": "not-a-number", "pct": 10.0}
+        try:
+            armed, _, _ = P.nudge_decision(rec, idle_secs=300,
+                                           e={"CODEARBITER_PRUNE_NUDGE": "on"})
+            self.assertFalse(armed)
+        except Exception as ex:
+            self.fail(f"nudge_decision with bad freed_bytes raised {ex!r}")
+
+    def test_last_assistant_ts_bad_json(self):
+        result = P._last_assistant_ts(b"{bad json\n")
+        self.assertIsNone(result)
+
+    def test_hook_run_never_returns_2_when_state_throws(self):
+        """If load_state raises (monkeypatched), hook_run must still return 0."""
+        import _prunelib as _P
+        orig = _P.load_state
+
+        def _boom():
+            raise RuntimeError("injected")
+
+        _P.load_state = _boom
+        try:
+            # We need a minimal valid environment; the hook will fail open at the
+            # load_state call and return 0.
+            tmp = tempfile.mkdtemp()
+            hm = redirect_home(tmp)
+            try:
+                repo = os.path.join(tmp, "repo")
+                os.makedirs(os.path.join(repo, ".codearbiter"))
+                with open(os.path.join(repo, ".codearbiter", "CONTEXT.md"), "w") as f:
+                    f.write("---\narbiter: enabled\n---\n# ctx\n")
+                cd = os.path.join(tmp, ".claude", "projects", "t")
+                os.makedirs(cd)
+                tp = os.path.join(cd, "s.jsonl")
+                with open(tp, "wb") as f:
+                    f.write(make_transcript(n_pairs=8, result_bytes=20000))
+                pl = {"hook_event_name": "UserPromptSubmit",
+                      "transcript_path": tp,
+                      "session_id": "s",
+                      "cwd": repo}
+                env = {"CODEARBITER_PRUNE": "on",
+                       "CODEARBITER_PRUNE_NUDGE": "on",
+                       "CODEARBITER_PRUNE_MIN_SIZE": "1000",
+                       "CODEARBITER_PRUNE_MIN_GROWTH": "1000",
+                       "CODEARBITER_PRUNE_KEEP_RECENT": "2"}
+                rc = _P.hook_run(pl, env=env)
+                self.assertEqual(rc, 0)
+            finally:
+                restore_home(hm)
+                import shutil
+                shutil.rmtree(tmp, ignore_errors=True)
+        finally:
+            _P.load_state = orig
+
+
+# ---------------------------------------------------------------------------
+# O9 — advisory is a pure function of rec numbers; no transcript content
+# ---------------------------------------------------------------------------
+
+class TestO9Advisory(unittest.TestCase):
+    def test_advisory_contains_token_count_and_pct(self):
+        rec = {"freed_bytes": 400_000, "last_pruned_size": 800_000,
+               "pct": 33.0}
+        advisory = P._nudge_advisory(rec)
+        # ~(400_000 + 800_000) / 4 = 300_000 tokens → 300k
+        self.assertIn("300k", advisory)
+        self.assertIn("33", advisory)
+
+    def test_advisory_contains_action_words(self):
+        rec = {"freed_bytes": 400_000, "last_pruned_size": 800_000, "pct": 33.0}
+        advisory = P._nudge_advisory(rec)
+        self.assertIn("/compact", advisory)
+        self.assertIn("--resume", advisory)
+        self.assertIn("Submit again", advisory)
+
+    def test_advisory_no_transcript_filler(self):
+        rec = {"freed_bytes": 400_000, "last_pruned_size": 800_000, "pct": 33.0}
+        advisory = P._nudge_advisory(rec)
+        # The filler used in make_transcript is "X" * result_bytes
+        self.assertNotIn("X" * 20, advisory,
+                         "advisory must not contain transcript filler content")
+
+    def test_advisory_pure_function_of_numbers(self):
+        # Same rec → same advisory regardless of call order
+        rec = {"freed_bytes": 500_000, "last_pruned_size": 1_000_000, "pct": 50.0}
+        a1 = P._nudge_advisory(rec)
+        a2 = P._nudge_advisory(rec)
+        self.assertEqual(a1, a2)
+
+
+# ---------------------------------------------------------------------------
+# O10 — hook_run integration (full pipeline)
+# ---------------------------------------------------------------------------
+
+class TestO10Integration(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._home = redirect_home(self.tmp.name)
+        self.repo = os.path.join(self.tmp.name, "repo")
+        os.makedirs(os.path.join(self.repo, ".codearbiter"))
+        with open(os.path.join(self.repo, ".codearbiter", "CONTEXT.md"), "w") as f:
+            f.write("---\narbiter: enabled\n---\n# ctx\n")
+        claude_dir = os.path.join(self.tmp.name, ".claude", "projects", "test")
+        os.makedirs(claude_dir, exist_ok=True)
+        self.path = os.path.join(claude_dir, "sess.jsonl")
+        # Old assistant timestamp → guaranteed idle
+        old_ts = "2026-06-17T00:00:00Z"   # 24 hours ago relative to any "now"
+        data = _make_transcript_with_ts(n_pairs=6, result_bytes=20000,
+                                         final_ts=old_ts)
+        with open(self.path, "wb") as f:
+            f.write(data)
+        self._original_size = len(data)
+        # Pre-seed state: big freed_bytes, no marker.
+        P.save_state({"sess": _big_rec(cold_nudged=False)})
+
+    def tearDown(self):
+        restore_home(self._home)
+        self.tmp.cleanup()
+
+    def _env(self, **kw):
+        e = {"CODEARBITER_PRUNE": "on",
+             "CODEARBITER_PRUNE_NUDGE": "on",
+             "CODEARBITER_PRUNE_KEEP_RECENT": "2",
+             "CODEARBITER_PRUNE_MIN_SIZE": "1000",
+             "CODEARBITER_PRUNE_MIN_GROWTH": "1000",
+             # Very low thresholds so the nudge conditions are reliably met.
+             "CODEARBITER_PRUNE_NUDGE_MIN_TOKENS": "1",
+             "CODEARBITER_PRUNE_NUDGE_IDLE_SECS": "1"}
+        e.update(kw)
+        return e
+
+    def _payload(self):
+        return {"hook_event_name": "UserPromptSubmit",
+                "transcript_path": self.path,
+                "session_id": "sess",
+                "cwd": self.repo}
+
+    def test_armed_returns_2_and_advisory_on_stderr(self):
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            rc = P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(rc, 2, "armed nudge must return 2")
+        self.assertIn("Submit again", stderr_buf.getvalue())
+
+    def test_armed_transcript_size_unchanged(self):
+        """When the nudge fires (return 2), prune is skipped — transcript stays."""
+        P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(os.path.getsize(self.path), self._original_size)
+
+    def test_armed_sets_cold_nudged_in_state(self):
+        P.hook_run(self._payload(), env=self._env())
+        st = P.load_state()
+        self.assertTrue(st.get("sess", {}).get("cold_nudged"),
+                        "hook_run must persist cold_nudged=True after arming")
+
+    def test_resubmit_returns_0(self):
+        """Second call (marker already set) must return 0 — the override path."""
+        P.hook_run(self._payload(), env=self._env())
+        rc2 = P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(rc2, 0)
+
+    def test_nudge_off_is_identical_to_today(self):
+        """With NUDGE unset, hook_run prunes normally and returns 0."""
+        before = os.path.getsize(self.path)
+        env_no_nudge = self._env()
+        del env_no_nudge["CODEARBITER_PRUNE_NUDGE"]
+        del env_no_nudge["CODEARBITER_PRUNE_NUDGE_MIN_TOKENS"]
+        del env_no_nudge["CODEARBITER_PRUNE_NUDGE_IDLE_SECS"]
+        # Reset state so the short-circuit doesn't fire.
+        P.save_state({})
+        rc = P.hook_run(self._payload(), env=env_no_nudge)
+        self.assertEqual(rc, 0)
+        self.assertLess(os.path.getsize(self.path), before,
+                        "without nudge, hook_run should prune normally")
+
+
+# ---------------------------------------------------------------------------
+# O11 — prune.md mentions CODEARBITER_PRUNE_NUDGE
+# ---------------------------------------------------------------------------
+
+class TestO11Docs(unittest.TestCase):
+    def test_prune_md_references_nudge_env(self):
+        # _TESTS_DIR = plugins/ca/hooks/tests → go up 4 levels to repo root
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.dirname(_TESTS_DIR))))
+        doc = os.path.join(repo_root, "plugins", "ca", "commands", "prune.md")
+        with open(doc, encoding="utf-8") as f:
+            text = f.read()
+        self.assertIn("CODEARBITER_PRUNE_NUDGE", text,
+                      "prune.md must document the CODEARBITER_PRUNE_NUDGE env var")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds an opt-in `UserPromptSubmit` speed bump for the transcript pruner. When `CODEARBITER_PRUNE=on`
and `CODEARBITER_PRUNE_NUDGE=on`, the hook blocks the submit once, with a one-line advisory on
stderr, when a large banked prune delta is about to re-cache on bloated in-memory context. Submitting
again proceeds. This is the actionable half of "prune gains only land at resume/compaction": it owns
the single moment where acting changes the bill.

Closes #69.

## Why

A running session streams its in-memory history to the API, not the on-disk transcript. Prune savings
are banked in the file and only materialize when context is rebuilt from disk (`--resume` or
compaction). The expensive event is the cold cache miss: once the prompt-cache TTL lapses, the next
submit pays a full re-cache write on the whole in-memory context. That write is unavoidable. The only
lever is which context it lands on, bloated or pruned, and the nudge surfaces that choice at the right
moment.

## Arming (all required)

Mode `on`, the flag `on`, estimated freed tokens at or above `CODEARBITER_PRUNE_NUDGE_MIN_TOKENS`
(default 80000), idle since the last assistant turn at or above `CODEARBITER_PRUNE_NUDGE_IDLE_SECS`
(default 240), and no prior nudge in the current cold window. The `cold_nudged` marker lives in
`prune-state.json` and resets on any warm submit, so it fires at most once per cold window.

## Safety

This is the first non-zero exit path in a hook that otherwise always returns 0. It is strictly
fail-open: any internal fault returns 0, never a spurious block. With the flag off, the hook is
byte-identical to today's behavior. The advisory is built from state numbers only (sizes, tokens,
percent); no transcript content is read into it.

## Tests

- 42 nudge tests in `plugins/ca/hooks/tests/test_prune_nudge.py`, gated in CI through a new
  `.github/scripts/test_prune_nudge.py` runner listed in `tech-stack.md`.
- Full pruner suite green at 453 tests, no regression.
- Coverage review flagged two fail-open gaps (the in-hook exception seam and warm-reset persistence)
  plus an ISO-offset parse inconsistency. The second commit (`a211f35`) closes all three with passing
  tests.
- Security review returned 0 critical and 0 high. Fail-open contract, transcript-path containment,
  advisory privacy, and timestamp-parse safety all hold.

## Test plan

- [ ] `python .github/scripts/test_prune_nudge.py`
- [ ] `python -m unittest discover -s plugins/ca/hooks/tests -t plugins/ca/hooks`
- [ ] CI hooks job green (cold-install matrix, guards, preview-lib, ux-conversion, nudge)

## Feature Forge

Ships under the `preview` gate, same as live pruning. Version 2.4.3 to 2.4.4 (`plugin.json`, README
badge, `CHANGELOG.md`).

https://claude.ai/code/session_01Sowr6A3HZLSafwoEpY8gtz
