### PR TITLE
feat: migration commit-time backstop (H-14) (#77)

### DIFF
--- a/.codearbiter/specs/migration-commit-backstop.md
+++ b/.codearbiter/specs/migration-commit-backstop.md
@@ -1,0 +1,118 @@
+# Spec — Migration commit-time backstop
+
+**Source:** issue #77 (routing/firing audit). Decided **option (a)** via SMARTS
+(strength `moderate`, 2026-06-19): build the backstop rather than accept the residual
+risk. Securable + Reliable + Testable favored (a); precedent DECISION-0003 (closed an
+analogous commit/call-time bypass bound to approved content).
+
+## Problem
+
+A database migration can reach a commit with **no migration review**. When a migration
+is committed via bare `/ca:commit` or the `/feature` small lane, commit-gate Phase 6
+diff-review checks secrets and scope-creep but never classifies a migration, and **no
+hook fires** (`grep migration hooks/` = zero). The data-classification and
+destructive-schema review that the `migration-reviewer` agent performs is silently
+skipped on that path. The `/review`, `/checkpoint`, `/pr`, and sprint lanes already
+dispatch `migration-reviewer`; this is the narrow gap on the commit-only paths.
+
+## Scope
+
+**In scope**
+
+- A commit-time **backstop** that blocks committing a staged migration file unless a
+  recorded migration-review pass covers that file's exact content — mirroring the
+  H-09b/H-10b security-gate pattern (`hooks/security-pass.py` + `pre-bash.py`).
+- **Hybrid migration-path detection**: a built-in default glob set, extendable and
+  narrowable by a per-project declaration in `security-controls.md`.
+- A **self-healing** commit-gate path: commit-gate detects a staged migration,
+  dispatches `migration-reviewer`, and records the marker on PASS.
+- **Content-digest binding, no time window**: the marker holds each approved
+  migration's file-content digest; it is valid as long as content is unchanged. An
+  edit to a reviewed migration changes the digest → BLOCK (enforces immutability and
+  closes TOCTOU for free).
+
+**Out of scope (the honest boundary)**
+
+- NOT a migration runner, schema linter, or re-implementation of `migration-reviewer`'s
+  checks in the hook — the hook only enforces *that the review happened* and is bound
+  to this content.
+- NOT a test-executing commit hook — it stays cheap (marker check only), so it does
+  not trigger the "slow and invasive" concern behind deferred finding #6.
+- NOT a change to the `/pr`, `/review`, `/checkpoint`, or sprint lanes, which already
+  dispatch `migration-reviewer`.
+- NOT dogfooded in this repo: codeArbiter is database-free (DECISION-0004) and has no
+  migrations. The feature is validated entirely by hook-test fixtures with synthetic
+  migration paths.
+
+## Design (settled by brainstorming forks)
+
+- **Detection** lives in `_hooklib.py` as a shared `is_migration_path(rel, root)`,
+  consumed by both the producer and the backstop. Default globs cover the common
+  ecosystems: `**/migrations/**`, `**/migrate/**`, `**/db/migrate/**`, Alembic
+  `**/alembic/versions/*.py`, Prisma `**/prisma/migrations/**`. A
+  `security-controls.md` declaration block extends the set (additional globs) and/or
+  narrows it (exclusion globs) — the false-positive escape hatch. Declaration format
+  is stdlib-regex-parseable from the prose file (no YAML dependency).
+- **Producer** `hooks/migration-pass.py`: scans staged migration files (plus
+  worktree/untracked under `-a`, mirroring `security-pass.py`'s candidate scan),
+  writes their content digests to `.codearbiter/.markers/migration-gate-passed`.
+  Idempotent. Run by the dispatching prose on `migration-reviewer` PASS.
+- **Backstop** in `pre-bash.py`: on `git commit`, for each staged migration file whose
+  content digest is not in the marker, BLOCK with a new `H-NN` tag (next free integer,
+  assigned at implementation by scanning `pre-bash.py`). No freshness window — coverage
+  is by content digest only.
+- **Prose wiring**: commit-gate gains a migration-classification step that, on a
+  detected staged migration, dispatches `migration-reviewer` and runs
+  `migration-pass.py` on PASS — exactly how crypto-compliance/secret-handling run
+  `security-pass.py`.
+- **stdlib-only** (DECISION-0004); dormant outside an `arbiter: enabled` repo,
+  consistent with the rest of `pre-bash.py`.
+
+## Acceptance criteria
+
+Each criterion is verifiable by a single test → one `tdd` Phase 1 obligation.
+
+1. **Default-glob detection** — `is_migration_path` returns True for `db/migrate/20240101_x.rb`,
+   `migrations/0001_init.py`, `alembic/versions/abc_x.py`, and
+   `prisma/migrations/2024_x/migration.sql`; returns False for `src/app.py` and
+   `docs/migrations-guide.md`.
+2. **Override extends** — given a `security-controls.md` declaration adding
+   `schema/changesets/**`, a staged `schema/changesets/v5.sql` is detected as a migration.
+3. **Override excludes** — given a declaration excluding `migrations/seed/**`, a staged
+   `migrations/seed/data.sql` is NOT detected (false-positive escape hatch).
+4. **Producer records content digest** — running `migration-pass.py` with a staged
+   migration writes that file's content digest to
+   `.codearbiter/.markers/migration-gate-passed`.
+5. **Backstop blocks unreviewed migration** — `git commit` staging a migration with no
+   marker (or a marker missing the file's digest) exits 2 (BLOCK) and names the new H-tag.
+6. **Backstop admits reviewed migration** — after `migration-pass.py` records the digest,
+   the same `git commit` is admitted (exit 0).
+7. **Edited-after-review re-blocks** — a migration whose content changes after the marker
+   was minted (digest mismatch) is BLOCKed (TOCTOU + immutability enforcement).
+8. **Non-migration commit unaffected** — a `git commit` staging only non-migration files
+   passes with no marker required (no regression to ordinary commits).
+9. **Dormant outside an arbiter repo** — with no `.codearbiter/` present, the backstop
+   does not fire.
+10. **`-a` / untracked coverage** — a migration staged via `git commit -a`, or an
+    untracked new migration, is still detected and gated (mirrors the security check's
+    `-a`/HEAD handling).
+11. **Prose wiring present** — commit-gate's skill prose contains a migration-classification
+    step that dispatches `migration-reviewer` and runs `migration-pass.py` on PASS
+    (structural test, in the style of `test_ux_conversion.py`).
+
+## Open questions
+
+None. No new `[CONFIRM-NN]` raised — the four design forks were resolved during
+brainstorming and the default glob set is concrete (long-tail gaps handled by the
+override). Known accepted cost: a default glob may match a non-DB `migrations/`
+directory; `migration-reviewer` PASSes a file with no migration findings (friction, not
+a hard block), and the override narrows it.
+
+## Decision lineage
+
+- Issue #77; SMARTS decision (a), `moderate`, 2026-06-19.
+- Precedent: DECISION-0003 (close a bound bypass), DECISION-0002 (the rejected accept-
+  and-document alternative), DECISION-0004 (stdlib-only).
+- Consistent with deferred finding #6 (`open-questions.md`): actions one named sibling of
+  the deferred commit-time-enforcement class via the cheap marker pattern, without
+  reopening the broad deferral.

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -34,6 +34,9 @@ python .github/scripts/test_ux_conversion.py
 
 # Cold-miss nudge — nudge_decision, advisory, idle extraction, hook_run integration (O1–O11)
 python .github/scripts/test_prune_nudge.py
+
+# H-14 migration commit-time backstop — detection, producer marker, pre-bash gate (#77)
+python .github/scripts/test_migration_backstop.py
 ```
 
 Only when `plugins/ca/tools/**` changed:

--- a/.github/scripts/test_migration_backstop.py
+++ b/.github/scripts/test_migration_backstop.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""codeArbiter — H-14 migration commit-time backstop regression suite (issue #77).
+
+Proves the four moving parts of the migration backstop:
+
+  * detection   — `_hooklib.is_migration_path` over the default glob set and the
+                  `security-controls.md` extend/exclude declaration (OB-01..03).
+  * producer    — `migration-pass.py` writes a content-digest marker for every
+                  staged/worktree/untracked migration (OB-04).
+  * backstop    — `pre-bash.py` H-14 BLOCKs a `git commit` of a migration not
+                  covered by the marker, admits a covered one, re-blocks an
+                  edited one, leaves non-migration commits alone, is dormant
+                  outside an arbiter repo, and covers `-a` (OB-05..10, OB-C1).
+  * wiring      — commit-gate prose dispatches the reviewer + records the pass
+                  (OB-11), and the new hook code is byte-compilable stdlib (OB-S1).
+
+Same harness shape as test_hook_guards.py: hook JSON on stdin, throwaway
+arbiter-enabled git repos, stdlib only. Exit 0 = pass; exit 1 = failures.
+"""
+
+import json
+import os
+import py_compile
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+HOOKS = os.path.join(REPO, "plugins", "ca", "hooks")
+PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
+MIGRATION_PASS = os.path.join(HOOKS, "migration-pass.py")
+COMMIT_GATE = os.path.join(REPO, "plugins", "ca", "skills", "commit-gate", "SKILL.md")
+
+sys.path.insert(0, HOOKS)
+
+failures = []
+checks = 0
+
+
+def check(cond, label, detail=""):
+    global checks
+    checks += 1
+    if cond:
+        return
+    failures.append(f"FAIL [{label}] {detail}")
+    print(failures[-1])
+
+
+def sh(args, cwd, **kw):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=60, **kw)
+
+
+def git(args, cwd):
+    r = sh(["git"] + args, cwd)
+    if r.returncode != 0:
+        sys.exit(f"FATAL: git {' '.join(args)} failed in fixture: {r.stderr}")
+    return r
+
+
+def run_hook(fixture, command):
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+    return sh([sys.executable, PRE_BASH], fixture, input=payload)
+
+
+def run_pass(fixture):
+    return sh([sys.executable, MIGRATION_PASS], fixture)
+
+
+def make_repo(base, name, arbiter=True, controls=None):
+    """A git repo on a feature branch (so H-01 never fires), arbiter-enabled
+    unless arbiter=False. `controls` is optional security-controls.md text."""
+    root = os.path.join(base, name)
+    os.makedirs(root)
+    git(["init", "-q", "-b", "feat/work", root], base)
+    git(["config", "user.email", "h@example.com"], root)
+    git(["config", "user.name", "h"], root)
+    if arbiter:
+        ca = os.path.join(root, ".codearbiter")
+        os.makedirs(ca, exist_ok=True)
+        with open(os.path.join(ca, "CONTEXT.md"), "w", encoding="utf-8") as f:
+            f.write("---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\nfixture\n")
+        if controls is not None:
+            with open(os.path.join(ca, "security-controls.md"), "w", encoding="utf-8") as f:
+                f.write(controls)
+    return root
+
+
+def write(root, rel, text):
+    p = os.path.join(root, rel)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(text)
+    return p
+
+
+def marker_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "migration-gate-passed")
+
+
+MIG = "CREATE TABLE t (id int);\n"
+MIG2 = "CREATE TABLE t (id int, name text);\n"
+
+
+# ── A. detection (OB-01..03) ────────────────────────────────────────────────
+def section_detection(base):
+    try:
+        from _hooklib import is_migration_path  # noqa: E402
+    except Exception as e:  # noqa: BLE001
+        check(False, "OB-01..03", f"_hooklib.is_migration_path missing: {e}")
+        return
+    root = make_repo(base, "detect")
+    yes = ["db/migrate/20240101_x.rb", "migrations/0001_init.py",
+           "alembic/versions/abc_x.py", "prisma/migrations/2024_x/migration.sql"]
+    no = ["src/app.py", "docs/migrations-guide.md"]
+    for p in yes:
+        check(is_migration_path(p, root), "OB-01", f"default glob should match {p!r}")
+    for p in no:
+        check(not is_migration_path(p, root), "OB-01", f"should NOT match {p!r}")
+
+    ext = make_repo(base, "detect-ext",
+                    controls="# sc\n<!-- migration-paths -->\n+ schema/changesets/**\n<!-- /migration-paths -->\n")
+    check(is_migration_path("schema/changesets/v5.sql", ext), "OB-02",
+          "project-added glob should detect schema/changesets/v5.sql")
+
+    exc = make_repo(base, "detect-exc",
+                    controls="# sc\n<!-- migration-paths -->\n- migrations/seed/**\n<!-- /migration-paths -->\n")
+    check(not is_migration_path("migrations/seed/data.sql", exc), "OB-03",
+          "exclusion should drop migrations/seed/data.sql")
+    check(is_migration_path("migrations/0001_init.py", exc), "OB-03",
+          "exclusion must not over-suppress a normal migration")
+
+    # glob translator: bare `**` (any chars incl. /) and `?` (one non-/ char).
+    g = make_repo(base, "detect-glob",
+                  controls="# sc\n<!-- migration-paths -->\n+ legacy**\n+ rev?.sql\n<!-- /migration-paths -->\n")
+    check(is_migration_path("legacy/x/y.sql", g), "OB-02", "bare ** should span segments")
+    check(is_migration_path("rev5.sql", g), "OB-02", "? should match one char")
+    check(not is_migration_path("rev55.sql", g), "OB-02", "? must match exactly one char")
+
+
+# ── B. producer (OB-04) ─────────────────────────────────────────────────────
+def section_producer(base):
+    try:
+        from _hooklib import content_digest  # noqa: E402
+    except Exception as e:  # noqa: BLE001
+        check(False, "OB-04", f"_hooklib.content_digest missing: {e}")
+        return
+    root = make_repo(base, "producer")
+    write(root, "migrations/0001_init.sql", MIG)  # untracked, as commit-gate would stage
+    r = run_pass(root)
+    check(r.returncode == 0, "OB-04", f"migration-pass.py exit={r.returncode} stderr={r.stderr[:200]!r}")
+    mp = marker_path(root)
+    recorded = ""
+    if os.path.isfile(mp):
+        with open(mp, encoding="utf-8") as f:
+            recorded = f.read()
+    check(content_digest(MIG) in recorded.split(), "OB-04",
+          "marker must contain the migration's content digest")
+
+
+# ── C. backstop (OB-05..10, OB-C1) ──────────────────────────────────────────
+def section_backstop(base):
+    # OB-05: unreviewed migration blocks (no marker).
+    r1 = make_repo(base, "bs-block")
+    write(r1, "migrations/0001.sql", MIG)
+    git(["add", "migrations/0001.sql"], r1)
+    res = run_hook(r1, "git commit -m wip")
+    check(res.returncode == 2 and "[H-14]" in res.stderr, "OB-05",
+          f"unreviewed migration must BLOCK; exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-06: covered migration admits.
+    r2 = make_repo(base, "bs-allow")
+    write(r2, "migrations/0001.sql", MIG)
+    git(["add", "migrations/0001.sql"], r2)
+    run_pass(r2)
+    res = run_hook(r2, "git commit -m wip")
+    check(res.returncode == 0 and "BLOCKED" not in res.stderr, "OB-06",
+          f"reviewed migration must ALLOW; exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-07: edited-after-review re-blocks (digest mismatch).
+    r3 = make_repo(base, "bs-edit")
+    write(r3, "migrations/0001.sql", MIG)
+    git(["add", "migrations/0001.sql"], r3)
+    run_pass(r3)                       # marker bound to MIG
+    write(r3, "migrations/0001.sql", MIG2)  # content changes after review
+    git(["add", "migrations/0001.sql"], r3)
+    res = run_hook(r3, "git commit -m wip")
+    check(res.returncode == 2 and "[H-14]" in res.stderr, "OB-07",
+          f"edited migration must re-BLOCK; exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-08: non-migration commit unaffected (no marker required).
+    r4 = make_repo(base, "bs-nonmig")
+    write(r4, "src/app.py", "x = 1\n")
+    git(["add", "src/app.py"], r4)
+    res = run_hook(r4, "git commit -m wip")
+    check(res.returncode == 0 and "BLOCKED" not in res.stderr, "OB-08",
+          f"non-migration commit must ALLOW; exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-09: dormant outside an arbiter repo.
+    r5 = make_repo(base, "bs-dormant", arbiter=False)
+    write(r5, "migrations/0001.sql", MIG)
+    git(["add", "migrations/0001.sql"], r5)
+    res = run_hook(r5, "git commit -m wip")
+    check(res.returncode == 0 and "BLOCKED" not in res.stderr, "OB-09",
+          f"no .codearbiter -> backstop dormant; exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-10: `-a` coverage — a tracked migration modified in the worktree.
+    r6 = make_repo(base, "bs-all")
+    write(r6, "migrations/0001.sql", MIG)
+    git(["add", "migrations/0001.sql"], r6)
+    git(["commit", "-q", "-m", "seed migration"], r6)  # now tracked + committed
+    write(r6, "migrations/0001.sql", MIG2)             # worktree edit, NOT staged
+    res = run_hook(r6, "git commit -am wip")
+    check(res.returncode == 2 and "[H-14]" in res.stderr, "OB-10",
+          f"`git commit -a` of a migration must BLOCK; exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-C1: a marker present but not covering this file is no coverage -> BLOCK,
+    # and the hook does not crash (fail-closed, not fail-open).
+    r7 = make_repo(base, "bs-corrupt")
+    write(r7, "migrations/0001.sql", MIG)
+    git(["add", "migrations/0001.sql"], r7)
+    os.makedirs(os.path.dirname(marker_path(r7)), exist_ok=True)
+    with open(marker_path(r7), "w", encoding="utf-8") as f:
+        f.write("deadbeef\n")  # an unrelated digest
+    res = run_hook(r7, "git commit -m wip")
+    check(res.returncode == 2 and "[H-14]" in res.stderr, "OB-C1",
+          f"marker missing this digest must BLOCK (fail-closed); exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+    # OB-C1 (oversize): a migration too large to digest (>1MB) can never be
+    # covered by a marker, so it stays fail-closed -> BLOCK. Both producer and
+    # backstop skip the read; the backstop treats an unreadable file as
+    # uncovered. Guards against the size limit drifting between the two.
+    r8 = make_repo(base, "bs-oversize")
+    big = MIG + ("-- padding\n" * 100000)  # ~1.3 MB
+    p = write(r8, "migrations/large.sql", big)
+    check(os.path.getsize(p) > 1_000_000, "OB-C1", "oversize fixture must exceed 1MB")
+    git(["add", "migrations/large.sql"], r8)
+    run_pass(r8)  # producer skips it -> marker has no digest for it
+    res = run_hook(r8, "git commit -m wip")
+    check(res.returncode == 2 and "[H-14]" in res.stderr, "OB-C1",
+          f"oversize migration must BLOCK (too large to digest); exit={res.returncode} stderr={res.stderr[:200]!r}")
+
+
+# ── D. prose wiring (OB-11) ─────────────────────────────────────────────────
+def section_wiring():
+    try:
+        with open(COMMIT_GATE, encoding="utf-8") as f:
+            text = f.read()
+    except Exception as e:  # noqa: BLE001
+        check(False, "OB-11", f"cannot read commit-gate SKILL.md: {e}")
+        return
+    for tok in ("migration-reviewer", "migration-pass.py", "H-14", "migration-gate-passed"):
+        check(tok in text, "OB-11", f"commit-gate prose must reference {tok!r}")
+
+
+# ── E. stdlib + compile (OB-S1) ─────────────────────────────────────────────
+def section_stdlib():
+    for path in (MIGRATION_PASS, PRE_BASH, os.path.join(HOOKS, "_hooklib.py")):
+        try:
+            py_compile.compile(path, doraise=True)
+            ok = True
+        except Exception as e:  # noqa: BLE001
+            ok = False
+            check(False, "OB-S1", f"py_compile failed for {os.path.basename(path)}: {e}")
+        if ok:
+            check(True, "OB-S1", "")
+    # migration-pass.py must import only stdlib + the shared _hooklib.
+    if os.path.isfile(MIGRATION_PASS):
+        with open(MIGRATION_PASS, encoding="utf-8") as f:
+            src = f.read()
+        third_party = [ln for ln in src.splitlines()
+                       if ln.startswith(("import ", "from "))
+                       and "_hooklib" not in ln
+                       and not any(m in ln for m in (
+                           "import os", "import sys", "import subprocess",
+                           "import hashlib", "import json", "import re"))]
+        check(not third_party, "OB-S1", f"non-stdlib import in migration-pass.py: {third_party}")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        section_detection(tmp)
+        section_producer(tmp)
+        section_backstop(tmp)
+    section_wiring()
+    section_stdlib()
+    print(f"\n{checks} checks, {len(failures)} failures")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
         # hook_run integration (armed→2/stderr, resubmit→0, flag-off→today's
         # behavior), and docs gate (prune.md references CODEARBITER_PRUNE_NUDGE).
         run: python .github/scripts/test_prune_nudge.py
+      - name: Run H-14 migration backstop tests
+        # OB-01..11 + OB-C1/OB-S1 (#77): is_migration_path detection (defaults +
+        # security-controls.md extend/exclude), migration-pass.py content-digest
+        # marker, and pre-bash.py H-14 block/admit/edit-reblock/dormant/-a.
+        run: python .github/scripts/test_migration_backstop.py
 
   version-bump:
     name: plugin version bumped when payload changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.4.5] — 2026-06-19
+
+### Added
+- **Migration commit-time backstop** (`H-14`): a `git commit` that stages a database migration is
+  blocked until a migration-review pass is recorded for that file. commit-gate dispatches the
+  `migration-reviewer` agent on a staged migration and, on PASS, records a content-digest marker
+  (`.codearbiter/.markers/migration-gate-passed`) via the new `hooks/migration-pass.py`; `pre-bash.py`
+  H-14 then admits the commit only when every staged migration is covered. Binding is by file-content
+  digest with no freshness window — an edit to a reviewed migration re-blocks (closing TOCTOU and
+  enforcing migration immutability at commit time). Migration paths are detected by a default glob set,
+  extendable/narrowable via a `migration-paths` block in `security-controls.md`. Closes the bare-`/commit`
+  / `/feature` small-lane gap where no lane dispatched the reviewer and no hook fired. (#77)
+
 ## [2.4.4] — 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.4.4" src="https://img.shields.io/badge/version-2.4.4-2b7489">
+<img alt="version 2.4.5" src="https://img.shields.io/badge/version-2.4.5-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-35-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -149,6 +149,93 @@ def line_digest(line):
     return hashlib.sha256(line.rstrip().encode("utf-8", "replace")).hexdigest()
 
 
+def content_digest(text):
+    """Digest of a whole migration file's content, for the H-14 migration-gate
+    binding. Lines are rstripped and rejoined with \\n so CRLF translation
+    between worktree and index never breaks the match (same rationale as
+    line_digest). The producer (migration-pass.py) and the backstop
+    (pre-bash.py) both digest worktree content this way, so the two never
+    disagree on what a recorded pass covers."""
+    norm = "\n".join(line.rstrip() for line in text.splitlines())
+    return hashlib.sha256(norm.encode("utf-8", "replace")).hexdigest()
+
+
+# Migration-path detection (H-14). Shared by migration-pass.py (the producer)
+# and pre-bash.py (the backstop) so the two never drift on what counts as a
+# migration. Default globs cover the common ORM/migration ecosystems; a project
+# extends or narrows the set via a `migration-paths` block in
+# security-controls.md. `**` matches any run of path segments (including none);
+# `*`/`?` stay within one segment.
+MIGRATION_DEFAULT_GLOBS = (
+    "**/migrations/**",
+    "**/migrate/**",
+    "**/db/migrate/**",
+    "**/alembic/versions/*.py",
+    "**/prisma/migrations/**",
+)
+_MIG_DECL_RE = re.compile(
+    r"<!--\s*migration-paths\s*-->(.*?)<!--\s*/migration-paths\s*-->", re.S | re.I)
+
+
+def _glob_to_re(glob):
+    """Compile a forward-slash glob into a full-path regex. `**/` is an optional
+    run of leading segments, `**` is any chars, `*`/`?` stay within a segment."""
+    g = norm_path(glob)
+    out, i = ["^"], 0
+    while i < len(g):
+        if g[i:i + 3] == "**/":
+            out.append("(?:.*/)?")
+            i += 3
+        elif g[i:i + 2] == "**":
+            out.append(".*")
+            i += 2
+        elif g[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif g[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(g[i]))
+            i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def migration_globs(root):
+    """(includes, excludes) for migration detection: the built-in defaults plus
+    any `migration-paths` declaration in security-controls.md (`+ glob` extends,
+    `- glob` excludes). A missing or undeclared file yields the defaults."""
+    includes, excludes = list(MIGRATION_DEFAULT_GLOBS), []
+    try:
+        with open(os.path.join(root, ".codearbiter", "security-controls.md"),
+                  encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001 — no controls file -> defaults only
+        return includes, excludes
+    m = _MIG_DECL_RE.search(text)
+    if not m:
+        return includes, excludes
+    for ln in m.group(1).splitlines():
+        ln = ln.strip()
+        if ln.startswith("+ "):
+            includes.append(ln[2:].strip())
+        elif ln.startswith("- "):
+            excludes.append(ln[2:].strip())
+    return includes, excludes
+
+
+def is_migration_path(rel, root):
+    """True iff `rel` (a repo-relative path) is a database migration: it matches
+    an include glob and no exclude glob. Excludes win — the false-positive
+    escape hatch for a project whose `migrations/` dir holds non-DB files."""
+    rel = norm_path(rel).lstrip("/")
+    includes, excludes = migration_globs(root)
+    if any(_glob_to_re(g).match(rel) for g in excludes):
+        return False
+    return any(_glob_to_re(g).match(rel) for g in includes)
+
+
 def marker_fresh(path, minutes):
     """True if the marker file exists and was touched within `minutes`."""
     try:

--- a/plugins/ca/hooks/migration-pass.py
+++ b/plugins/ca/hooks/migration-pass.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# codeArbiter — record a migration-review pass BOUND to the migration files it
+# approved (H-14, issue #77).
+#
+# There was no commit-time migration gate before #77: a migration committed via
+# bare /commit or the /feature small lane never reached migration-reviewer (the
+# /review, /pr, /checkpoint, and sprint lanes did dispatch it). commit-gate now
+# dispatches migration-reviewer when it classifies a staged migration and runs
+# THIS script on PASS. It mirrors security-pass.py: it hashes the content of
+# every staged/worktree/untracked migration file (detected by is_migration_path)
+# and writes the digests to .codearbiter/.markers/migration-gate-passed;
+# pre-bash.py's H-14 then admits a commit only when every migration file being
+# committed is in the recorded set.
+#
+# Binding is by content digest with no freshness window: a migration is
+# immutable, so a recorded pass stays valid while the content is unchanged, and
+# any edit changes the digest -> the backstop re-blocks (closing TOCTOU and
+# enforcing immutability at commit time).
+#
+# Invoked by skill prose as:
+#   python3 "<plugin>/hooks/migration-pass.py" || python "<plugin>/hooks/migration-pass.py"
+# (same interpreter-fallback shape as hooks.json; rerun-safe — recording is a
+# deterministic overwrite.)
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _hooklib import (  # noqa: E402
+    content_digest, is_migration_path, project_root, utf8_stdio, warn,
+)
+
+MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
+
+
+def run_git(args, cwd):
+    return subprocess.run(
+        ["git"] + args, cwd=cwd, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=30,
+    )
+
+
+def candidate_paths(root):
+    """Every path the next commit could introduce a migration through: tracked
+    changes vs HEAD (staged and unstaged), plus untracked files. On an unborn
+    branch (no HEAD) every tracked file is new content."""
+    paths = set()
+    for args in (["diff", "--cached", "--name-only"], ["diff", "--name-only"]):
+        r = run_git(args, root)
+        if r.returncode == 0:
+            paths.update(p for p in r.stdout.splitlines() if p.strip())
+    if not paths:
+        r = run_git(["ls-files"], root)
+        if r.returncode == 0:
+            paths.update(p for p in r.stdout.splitlines() if p.strip())
+    u = run_git(["ls-files", "--others", "--exclude-standard"], root)
+    if u.returncode == 0:
+        paths.update(p for p in u.stdout.splitlines() if p.strip())
+    return paths
+
+
+def read_text(root, rel):
+    p = os.path.join(root, rel)
+    try:
+        if os.path.getsize(p) > MAX_FILE_BYTES:
+            return None
+        with open(p, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def main():
+    utf8_stdio()
+    root = project_root()
+    if not os.path.isdir(os.path.join(root, ".codearbiter")):
+        warn("no .codearbiter/ here — migration-pass.py records nothing outside "
+             "an initialized repo")
+        sys.exit(1)
+    migs = sorted(rel for rel in candidate_paths(root) if is_migration_path(rel, root))
+    digests = set()
+    for rel in migs:
+        text = read_text(root, rel)
+        if text is not None:
+            digests.add(content_digest(text))
+    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    os.makedirs(marker_dir, exist_ok=True)
+    marker = os.path.join(marker_dir, "migration-gate-passed")
+    digests = sorted(digests)
+    with open(marker, "w", encoding="utf-8") as f:
+        f.write("\n".join(digests) + ("\n" if digests else ""))
+    print(f"migration-gate pass recorded: {len(digests)} migration file(s) "
+          f"bound to {os.path.relpath(marker, root)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -21,8 +21,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, arbiter_active, block, line_digest, marker_fresh,
-    project_root, read_input, tool_input, utf8_stdio,
+    CRYPTO_RE, SECRET_RE, arbiter_active, block, content_digest, is_migration_path,
+    line_digest, marker_fresh, project_root, read_input, tool_input, utf8_stdio,
 )
 
 # `git` followed by any run of global options (-C <dir>, -c k=v, --git-dir=…,
@@ -158,6 +158,45 @@ def added_lines(cwd, ref):
         line[1:] for line in out.stdout.splitlines()
         if line.startswith("+") and not line.startswith("+++")
     )
+
+
+def _names(cwd, args):
+    """A set of repo-relative paths from a `git ... --name-only` style query."""
+    try:
+        out = subprocess.run(
+            ["git"] + args, cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=10,
+        )
+        if out.returncode != 0:
+            return set()
+    except Exception:  # noqa: BLE001
+        return set()
+    return {p for p in out.stdout.splitlines() if p.strip()}
+
+
+def staged_paths(cwd):
+    """Paths in the index — what a plain `git commit` would record."""
+    return _names(cwd, ["diff", "--cached", "--name-only"])
+
+
+def worktree_paths(cwd):
+    """Tracked worktree modifications (what `git commit -a` sweeps in) plus
+    untracked files."""
+    return (_names(cwd, ["diff", "--name-only"])
+            | _names(cwd, ["ls-files", "--others", "--exclude-standard"]))
+
+
+def read_worktree(cwd, rel):
+    """Worktree content of `rel`, or None if absent/oversize. The H-14 producer
+    digests worktree content too, so the backstop's view matches the marker."""
+    p = rel if os.path.isabs(rel) else os.path.join(cwd, rel)
+    try:
+        if os.path.getsize(p) > 1_000_000:
+            return None
+        with open(p, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def add_violation(args, cwd):
@@ -300,6 +339,42 @@ def main():
                            f"exact lines it reviewed, and these changed (or appeared) after "
                            f"it ran. Re-run the {skill} gate so it reviews the current diff "
                            f"and re-records the binding, then commit.")
+
+    # H-14: BLOCK a commit that stages a database migration without a recorded
+    # migration-review pass. commit-gate (and /review, /pr, /checkpoint, sprint)
+    # dispatch migration-reviewer and run hooks/migration-pass.py on PASS — a
+    # marker holding the content digest of every migration file the reviewer
+    # approved. Coverage is by content digest, no freshness window: an immutable
+    # migration stays approved while unchanged, and any edit changes the digest
+    # -> uncovered -> BLOCK (closes the TOCTOU window and enforces migration
+    # immutability at commit time). This closes the narrow #77 gap — a migration
+    # committed via bare /commit or the /feature small lane, where no lane
+    # dispatched the reviewer and no hook fired. A missing/unreadable marker is
+    # treated as no coverage (fail-closed), consistent with this layer's
+    # "ambiguity resolves CLOSED" stance.
+    if commit:
+        staged = staged_paths(cwd)
+        if COMMIT_ALL_RE.search(commit.group("args")) or add:
+            staged |= worktree_paths(cwd)
+        migs = sorted(p for p in staged if is_migration_path(p, root))
+        if migs:
+            marker = os.path.join(root, ".codearbiter", ".markers", "migration-gate-passed")
+            try:
+                with open(marker, encoding="utf-8") as f:
+                    approved = set(f.read().split())
+            except Exception:  # noqa: BLE001 — missing/unreadable marker -> no coverage
+                approved = set()
+            uncovered = []
+            for rel in migs:
+                text = read_worktree(cwd, rel)
+                if text is None or content_digest(text) not in approved:
+                    uncovered.append(rel)
+            if uncovered:
+                block("H-14", f"{len(uncovered)} staged migration file(s) lack a recorded "
+                              f"migration-review pass: {', '.join(uncovered)}. commit-gate "
+                              f"dispatches migration-reviewer and records the pass via "
+                              f"hooks/migration-pass.py; run that review, then commit. To "
+                              f"bypass a migration gate, /override logs the exception.")
 
     sys.exit(0)
 

--- a/plugins/ca/skills/commit-gate/SKILL.md
+++ b/plugins/ca/skills/commit-gate/SKILL.md
@@ -43,6 +43,8 @@ Read the staged set (`git diff --cached --name-only` and `--stat`). Classify the
 
 Derive the scope from the staged paths. If the staged set spans more than one type, split it — stage and commit each type separately.
 
+Flag any staged **database migration** (per `_hooklib.is_migration_path`) here — it carries a mandatory migration-review routing in Phase 4 (the H-14 gate), independent of the commit type.
+
 Gate: the staged set is type-homogeneous with a single type and scope.
 
 ## Phase 4 — Verification · gate: BLOCK
@@ -53,6 +55,7 @@ Read the test, lint, and secrets-scan commands from `tech-stack.md`. Then:
 - Run lint, and the type-check if the project is statically typed. Zero errors.
 - Run the secrets scan on ALL staged files, regardless of commit type. Any finding blocks.
 - **Security gates (mandatory routing):** if the staged diff touches crypto/TLS or secret patterns, route it through `crypto-compliance` and/or `secret-handling` (`${CLAUDE_PLUGIN_ROOT}/skills/`) — they scan against `security-controls.md` and, on pass, record the diff-bound marker `.codearbiter/.markers/security-gate-passed` (via `hooks/security-pass.py`). This is not optional: the PreToolUse commit hook **H-09b/H-10b blocks the commit** until that gate pass is recorded AND covers every sensitive line being committed, so a crypto/secret change cannot reach a commit without the gate having reviewed that exact change.
+- **Migration gate (mandatory routing):** if the staged set contains a database migration (Phase 3 flags it; the detection rule is `_hooklib.is_migration_path` — default migration globs, extendable/narrowable via a `migration-paths` block in `security-controls.md`), dispatch the `migration-reviewer` agent (`${CLAUDE_PLUGIN_ROOT}/agents/migration-reviewer.md`). **On a genuine PASS only**, record the content-bound marker `.codearbiter/.markers/migration-gate-passed` by running `python3 "${CLAUDE_PLUGIN_ROOT}/hooks/migration-pass.py" || python "${CLAUDE_PLUGIN_ROOT}/hooks/migration-pass.py"`. This is not optional: the PreToolUse commit hook **H-14 blocks the commit** until the pass is recorded AND covers every migration file being committed (by content digest, no freshness window — an edit to a reviewed migration re-blocks). This closes the bare-`/commit` / small-lane gap from issue #77. On a BLOCK, do not record the pass.
 
 Record each result (PASS / BLOCK) for the report.
 
@@ -123,5 +126,6 @@ Gate: the commit lands and `git status` is clean. Unexpected uncommitted changes
 - MUST NOT commit while any test is failing, any lint error stands, or any secret is present.
 - MUST NOT accept a self-reported "it works" — prove the behavior against the spec with a fresh command run (Phase 5) before committing.
 - MUST NOT skip, disable, or work around any automated gate.
+- MUST NOT commit a staged database migration without a recorded migration-review pass — the H-14 hook blocks it until `migration-reviewer` passes and `hooks/migration-pass.py` records the content-bound marker.
 - MUST NOT `--amend` after a pre-commit hook failure — create a new commit.
 - MUST NOT guess the test, lint, or secrets-scan command — read `tech-stack.md` or STOP.


### PR DESCRIPTION
## What this does

Closes #77. Adds a commit-time backstop so a database migration cannot reach a commit without a recorded migration review, on every commit path (including bare `/ca:commit` and the `/feature` small lane, which is the gap #77 identified).

Before this change the `/review`, `/pr`, `/checkpoint`, and sprint lanes dispatched `migration-reviewer`, but a migration committed straight through the commit gate was never classified and no hook fired.

## How it works

- `pre-bash.py` gains `H-14`: a `git commit` that stages a migration is blocked unless a content-digest marker records a `migration-reviewer` PASS covering that file.
- `commit-gate` dispatches `migration-reviewer` when it classifies a staged migration, and runs the new `hooks/migration-pass.py` on PASS to record the marker (`.codearbiter/.markers/migration-gate-passed`).
- Binding is by file-content digest with no freshness window. An immutable migration stays approved while unchanged; any edit changes the digest and re-blocks. This closes the TOCTOU window and enforces migration immutability at commit time.
- Detection is `_hooklib.is_migration_path`: a default glob set (`migrations/`, `db/migrate/`, Alembic `versions/`, Prisma), extendable or narrowable with a `migration-paths` block in `security-controls.md`.
- A missing or unreadable marker counts as no coverage, so the gate fails closed. It stays dormant outside an `arbiter: enabled` repo, and stays stdlib-only (DECISION-0004).

## Test plan

- New CI suite `.github/scripts/test_migration_backstop.py` (31 checks), wired into `ci.yml` and `tech-stack.md`. It covers detection (defaults, extend, exclude, glob translator), the producer marker, and the H-14 backstop (block, admit, edit-reblock, non-migration, dormant, `-a`, missing and oversize marker fail-closed), plus prose wiring and a stdlib compile check.
- Full regression green: 461 unittest, 79 guard-matrix, 134 cold-install, plus preview, ux, nudge, and reference-graph checks.
- `py_compile` clean on every touched hook.

## Review

- security-reviewer: PASS (no CRITICAL or HIGH).
- auth-crypto-reviewer: PASS. `content_digest` uses SHA-256 (approved in `security-controls.md`), integrity-binding use, no secret hashed or logged.
- coverage-auditor: PASS, with the oversize-file seam closed after its report.
- Two LOW findings accepted as informational: (1) `_glob_to_re` has a backtracking shape that is not reachable, because globs are repo-authored and match bounded paths; (2) `migration-pass.py` does not consult `arbiter_active`, which is the safe direction since the backstop does.

## Decisions

- Implements issue #77 option (a), chosen by SMARTS (strength moderate, 2026-06-19).
- Follows DECISION-0003 (close a content-bound bypass) and the `security-pass.py` precedent. The rejected alternative was #77 option (b), accept and document, which is the DECISION-0002 pattern.
- Ships as payload version 2.4.5 (`plugin.json`, README badge, `CHANGELOG`).

https://claude.ai/code/session_01G2gxzXECYEtK1jx23DyWtL