### PR TITLE
refactor(orchestrator): trim the always-on ORCHESTRATOR kernel (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.4.6] — 2026-06-19
+
+### Changed
+- **Trimmed the always-on `ORCHESTRATOR.md` kernel.** The verbose `/dev` maintainer-override body
+  moved to a new on-demand `includes/dev-mode.md` (loaded only on `/ca:dev` or `/ca:arbiter`), and the
+  `--farm` summary compressed to a one-line pointer at `SPRINT.md` / `includes/farm.md`. The kernel
+  retains the `/dev` security invariant (env-gated on `CODEARBITER_DEV=1`, entry/exit logged
+  append-only, load the detail before suspending any gate) as a stub; the `§0.1` terminology lock and
+  `§7` Override stay in-kernel, and `§3`/`§5`/`§6`/`§7` heading numbers are unchanged so hook citations
+  stay accurate. Behavior-preserving — reduces the per-session SessionStart injection by ~21 lines. (#75)
+
 ## [2.4.5] — 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.4.5" src="https://img.shields.io/badge/version-2.4.5-2b7489">
+<img alt="version 2.4.6" src="https://img.shields.io/badge/version-2.4.6-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-35-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/ORCHESTRATOR.md
+++ b/plugins/ca/ORCHESTRATOR.md
@@ -29,30 +29,13 @@ document means `/ca:feature`. When you tell the user what to type, use the `/ca:
 
 ## /dev — Maintainer Override (evaluated FIRST, every turn, before anything else)
 
-`/ca:dev` (optionally `/ca:dev "note"`) **suspends the gates entirely** to edit codeArbiter itself
-with no orchestration mediating — skill, agent, command, and hook bodies, `ORCHESTRATOR.md`, settings.
-It is the gates-off escape hatch, **not** the required lane for touching those files: normal
-development of codeArbiter — fixing a hook bug, adding a command, editing this persona — flows through
-the ordinary gated lanes (`/ca:feature`, `/ca:fix`, `/ca:chore`) and ships via PR + release, the same
-dogfooding path as any other change. Reach for `/ca:dev` only when orchestration itself is broken or
-genuinely in the way of editing it. It is **env-gated and logged**:
-
-- **Gate:** activates only when the `CODEARBITER_DEV` environment variable is set to `1`. Absent or
-  empty → refuse in one line ("dev mode requires CODEARBITER_DEV=1") and remain in orchestration.
-- **Log:** on entry, append `[ISO-8601] | BY: <git user.email> | DEV: enter | NOTE: <note or —>` to
-  `.codearbiter/overrides.log` (append with `>>`, per §7's append-only rule). On exit, append the
-  matching `DEV: exit` line. Dev mode is on the audit trail like any other bypass.
-- **Mode:** while active — no routing, no skills, no gates, no `[CONFIRM-NN]` surfacing, no redirect,
-  no startup presentation; a plain, direct coding assistant. Drop the transient marker
-  `${CLAUDE_PROJECT_DIR}/.codearbiter/.markers/dev-active` (gitignored local UI flag); it flips the
-  statusline alarm-red so dev mode is unmistakable. The marker is NOT the log — the overrides.log
-  lines are.
-- **Exit:** `/ca:arbiter` restores orchestration (removes the marker, writes the exit line). A new
-  session also restores it (SessionStart clears the marker); write the exit line at the next
-  opportunity if the session ended mid-dev.
-
-Even in dev mode, `overrides.log` itself is never rewritten — the append-only rule has no dev
-exception.
+`/ca:dev` (optionally `/ca:dev "note"`) **suspends the gates entirely** to edit codeArbiter itself.
+It is **env-gated and logged** — activates only when `CODEARBITER_DEV=1` (else refuse in one line and
+stay in orchestration), and entry/exit are appended to `.codearbiter/overrides.log` (append-only, per
+§7). On `/ca:dev` or `/ca:arbiter`, load `${CLAUDE_PLUGIN_ROOT}/includes/dev-mode.md` and honor it in
+full **before** suspending any gate. It is the gates-off escape hatch, **not** the required lane for
+editing codeArbiter — normal changes flow through `/ca:feature` / `/ca:fix` / `/ca:chore` and ship via
+PR.
 
 ---
 
@@ -66,15 +49,11 @@ logging each decision (with a confidence flag) to `.codearbiter/sprint-log.md`. 
 `security-controls`, crypto/secrets/auth, irreversible ops, `/override`, an unresolvable
 `[CONFIRM-NN]`, merge-to-default — remain true stops, rare by design.
 
-The optional **`--farm`** flag selects the pluggable execution backend: Claude authors specs, failing
-tests, and the plan; a worker implements each task under the same hard gates (containment, read-only-test
-protection, anti-gaming, the full review chain) instead of a premium subagent. The seam admits cheap,
-premium, and agentic worker implementations — only the cheap HTTP-chat worker ships today; premium and
-agentic are roadmap. Cost arbitrage is one use case, not the definition. When present, pass it through to
-`SPRINT.md`, which forwards it to `writing-plans` (to co-emit `plan.json` + failing tests) and to
-`subagent-driven-development` (farm dispatch path). See `${CLAUDE_PLUGIN_ROOT}/SPRINT.md` Phase 1–2 and
-`${CLAUDE_PLUGIN_ROOT}/includes/farm.md`. Absent the flag, the normal premium-subagent path runs
-unchanged.
+The optional **`--farm`** flag selects a pluggable execution backend — a worker implements each task
+under the same hard gates, in place of a premium subagent. When present, pass it through to
+`${CLAUDE_PLUGIN_ROOT}/SPRINT.md`, which forwards it to `writing-plans` and `subagent-driven-development`;
+full detail in `${CLAUDE_PLUGIN_ROOT}/SPRINT.md` Phase 1–2 and `${CLAUDE_PLUGIN_ROOT}/includes/farm.md`.
+Absent the flag, the normal premium-subagent path runs unchanged.
 
 ---
 

--- a/plugins/ca/includes/dev-mode.md
+++ b/plugins/ca/includes/dev-mode.md
@@ -1,0 +1,31 @@
+<!-- codeArbiter — maintainer dev-mode detail. Loaded on demand by the orchestrator
+when the user invokes /ca:dev or /ca:arbiter. The always-on kernel (ORCHESTRATOR.md)
+keeps only the env-gate + logged + load-before-gates-off invariant as a stub; the full
+mode description lives here. -->
+
+# /dev — Maintainer Override (evaluated FIRST, every turn, before anything else)
+
+`/ca:dev` (optionally `/ca:dev "note"`) **suspends the gates entirely** to edit codeArbiter itself
+with no orchestration mediating — skill, agent, command, and hook bodies, `ORCHESTRATOR.md`, settings.
+It is the gates-off escape hatch, **not** the required lane for touching those files: normal
+development of codeArbiter — fixing a hook bug, adding a command, editing this persona — flows through
+the ordinary gated lanes (`/ca:feature`, `/ca:fix`, `/ca:chore`) and ships via PR + release, the same
+dogfooding path as any other change. Reach for `/ca:dev` only when orchestration itself is broken or
+genuinely in the way of editing it. It is **env-gated and logged**:
+
+- **Gate:** activates only when the `CODEARBITER_DEV` environment variable is set to `1`. Absent or
+  empty → refuse in one line ("dev mode requires CODEARBITER_DEV=1") and remain in orchestration.
+- **Log:** on entry, append `[ISO-8601] | BY: <git user.email> | DEV: enter | NOTE: <note or —>` to
+  `.codearbiter/overrides.log` (append with `>>`, per ORCHESTRATOR §7's append-only rule). On exit,
+  append the matching `DEV: exit` line. Dev mode is on the audit trail like any other bypass.
+- **Mode:** while active — no routing, no skills, no gates, no `[CONFIRM-NN]` surfacing, no redirect,
+  no startup presentation; a plain, direct coding assistant. Drop the transient marker
+  `${CLAUDE_PROJECT_DIR}/.codearbiter/.markers/dev-active` (gitignored local UI flag); it flips the
+  statusline alarm-red so dev mode is unmistakable. The marker is NOT the log — the overrides.log
+  lines are.
+- **Exit:** `/ca:arbiter` restores orchestration (removes the marker, writes the exit line). A new
+  session also restores it (SessionStart clears the marker); write the exit line at the next
+  opportunity if the session ended mid-dev.
+
+Even in dev mode, `overrides.log` itself is never rewritten — the append-only rule has no dev
+exception.


### PR DESCRIPTION
## What this does

Trims the always-on `ORCHESTRATOR.md` kernel, which the SessionStart hook injects verbatim into context on every session in an arbiter-enabled repo. Every line is a recurring per-session token cost, and a chunk of the kernel routed on only a fraction of turns.

Two regions move off the always-on payload:

- The verbose `/dev` maintainer-override body moves to a new on-demand `plugins/ca/includes/dev-mode.md`, loaded only when the user invokes `/ca:dev` or `/ca:arbiter`. The kernel keeps a short stub.
- The `--farm` summary compresses to a one-line pointer at the existing `SPRINT.md` and `includes/farm.md`, which already hold the authoritative detail.

Closes #75.

## Why it is safe (behavior-preserving)

- The `/dev` security invariant stays in the kernel stub, never deferred: env-gated on `CODEARBITER_DEV=1`, entry and exit logged append-only to `overrides.log`, and the detail file is loaded before any gate is suspended.
- The `§0.1` terminology lock and `§7` Override stay in-kernel by design, since no command triggers their load and they cannot be deferred safely.
- The `§3`, `§5`, `§6`, and `§7` heading numbers are unchanged, because several hooks cite them as literal strings (`pre-bash.py`, `pre-edit.py`, `pre-write.py`, `post-write-edit.py`).

Net effect: about 21 fewer lines in the per-session injection.

## Lane and verification

Routed through `/ca:refactor` (six parity phases), then `commit-gate`:

- Full hook suite green: `test_hook_guards`, `test_hooks_cold_install`, `test_preview_lib`, `test_ux_conversion`, `test_prune_nudge`, `test_migration_backstop`.
- `check-plugin-refs.py` green: the new `includes/dev-mode.md` reference resolves and no references dangle.
- Zero pre-existing test files edited. The one content-asserting test (`test_ux_conversion`) targets the Register section, which is untouched.
- EOL normalized back to LF after an Edit flipped the file to CRLF.
- coverage-auditor: PASS, no coverage obligation (no source or test files changed).

## Commits

- `refactor(orchestrator)`: the kernel trim and the new include.
- `chore(release)`: payload bump 2.4.5 to 2.4.6 across `plugin.json`, the README badge, and `CHANGELOG.md`, satisfying the version-bump CI invariant.

## Test plan

- CI runs the hook suite, the cold-install matrix, and `check-plugin-refs.py`.
- The `version-bump` job is satisfied by the 2.4.6 bump carried on this branch.

https://claude.ai/code/session_01DStU6Nt9KuadiP2dqAEAPT
