### PR TITLE
docs(readme): name the ICP and pre-empt the overhead objection (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Every intent routes through a gated skill or reviewer agent. Nothing commits unt
 
 codeArbiter is a native Claude Code plugin that sits between you and your codebase. Instead of letting the model freelance, you drive through slash commands. Each one routes to the skill or agent that owns the work (TDD, the commit gate, decision-variance/SMARTS, the reviewer fleet) and clears its gates before anything ships.
 
+**Who it's for:** teams and power users who let agents write real code and need to prove what happened. The kind who'd rather a tool block than apologize.
+
 It will not:
 
 - write feature code before a failing test exists,
@@ -35,6 +37,8 @@ It will not:
 - silently reconcile a contradiction between your docs and your code.
 
 The gates are terse and non-negotiable. The thinking is not. It brainstorms a spec, works through a bug, and weighs a decision with you conversationally. When it enforces, it states the rule and holds the line.
+
+Is that a lot of ceremony? It scales to the change. The heavyweight gates are what a skimmer notices first, but a one-line docs fix takes the small lane or `/ca:chore`, not the full spec-to-PR march. The weight is there because the failure mode of an eager AI assistant is *plausible-but-wrong work that ships*, and the gates exist to make that hard.
 
 ### Why the pushback is the point
 
@@ -155,7 +159,7 @@ Every recommendation carries exactly one **strength label** — `strong` (domina
 
 **You still decide.** The arbiter recommends, it does not push, and it will not record a decision you didn't explicitly make — "use your best judgment," "I trust you," "we're short on time" are declined, because the decision log is append-only and every entry is attributed to a person. Your choice is written immediately, with the SMARTS rationale that drove it, and never edited; to change course you append a superseding entry. This runs whenever a choice surfaces — interactively through <kbd>/ca:reconcile</kbd> (the full variance pass over artifacts vs. scaffold) and on any fork inside a feature.
 
-**One deliberate exception: autonomy.** <kbd>/ca:sprint</kbd> reuses the same six-lens *scoring* to decide "as the user" on every non-hard-gate point — but only the scoring, never the "never decide alone" rule. Each auto-decision is logged to `.codearbiter/sprint-log.md` with the options weighed, the verdict, the strength, and a **confidence flag**: `high` for `strong`, `low` for anything `moderate` or `tied`. Those `low`-confidence calls are exactly what you skim in the morning — autonomy with a paper trail. Security boundaries, irreversible operations, gate bypasses, and a `[CONFIRM-NN]` the spec can't resolve still stop and wait for you.
+**Autonomy with a paper trail.** Go to bed, wake to a reviewed PR and a log of every call it made. <kbd>/ca:sprint</kbd> reuses the same six-lens *scoring* to decide "as the user" on every non-hard-gate point, but only the scoring, never the "never decide alone" rule. Each auto-decision is logged to `.codearbiter/sprint-log.md` with the options weighed, the verdict, the strength, and a **confidence flag**: `high` for `strong`, `low` for anything `moderate` or `tied`. Those `low`-confidence calls are exactly what you skim in the morning. Security boundaries, irreversible operations, gate bypasses, and a `[CONFIRM-NN]` the spec can't resolve still stop and wait for you.
 
 ## Install
 


### PR DESCRIPTION
## What this does

Three surgical positioning edits to the root `README.md` (issue #72). No behavior change, copy only.

1. **Name the ICP.** The README addressed a generic "you". A one-line "Who it's for" now states the audience up top: teams and power users who let agents write real code and need to prove what happened.
2. **Pre-empt the overhead objection.** The load-bearing answer (an eager assistant's failure mode is plausible-but-wrong work that ships) was buried in a collapsed `<details>`. It is now surfaced in "What it is", right after the "It will not" bullets, with a sentence noting that ceremony scales to change size, so a skimmer does not read every change as a heavyweight gate.
3. **Reframe sprint autonomy dream-first.** The lead-in moves from "One deliberate exception: autonomy" to "Autonomy with a paper trail. Go to bed, wake to a reviewed PR and a log of every call it made", keeping the scoring detail and the guardrails sentence after it.

Closes #72.

## Lane and verification

Routed through `/ca:chore` (docs type), then `commit-gate`:

- Anti-slop copy pass over the authored lines: §3.A em-dash separator ban and §3.B copy self-audit both clean (no separator dashes, no filler verbs, no AI cadence).
- Secrets scan over the diff: clean.
- `check-plugin-refs.py`: reference graph intact.
- coverage-auditor: PASS, no findings (no source or test files changed).
- EOL normalized to LF.

## Scope notes

- Root `README.md` only. Not under `plugins/ca/**`, so no payload version bump and no `version-bump` CI obligation.
- The legacy em-dashes elsewhere in the README are pre-existing house style and out of scope for this change; only the authored lines were held to §3.A.

## Test plan

- Docs-only: no test surface is touched. CI runs `check-plugin-refs.py` and the manifest parse, both green locally.

https://claude.ai/code/session_01DStU6Nt9KuadiP2dqAEAPT
