### PR TITLE
fix(ci): unbreak docs deploy (Astro 6 needs Node 22) + validate site build on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,12 @@ name: Deploy docs
 # Builds the Astro Starlight site in site/ and publishes it to GitHub Pages.
 # The reference section is regenerated in CI from plugins/ca/** (npm run build
 # runs `prebuild` -> the generator), so the generated output is never committed.
+#
+# On pull_request the build job runs as validation only (no deploy) so a
+# site-breaking change — e.g. a dep bump that outruns the runner's Node — is
+# caught at review time instead of going red on main after merge. Deploy stays
+# scoped to push: it needs pages:write/id-token:write, which a PR (especially
+# from a fork) can't safely hold.
 
 on:
   push:
@@ -10,6 +16,11 @@ on:
     paths:
       - "site/**"
       - "plugins/ca/**" # the reference is generated from the plugin, so rebuild when it changes
+  pull_request:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "plugins/ca/**"
   workflow_dispatch:
 
 permissions:
@@ -17,9 +28,11 @@ permissions:
   pages: write
   id-token: write
 
-# One deploy at a time; let a newer push supersede an in-flight run.
+# One run at a time per ref; let a newer push/PR-push supersede an in-flight
+# run. Per-ref grouping keeps PR validation builds from cancelling a main
+# deploy (and each other).
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -35,6 +48,8 @@ jobs:
 
   deploy:
     needs: build
+    # Push to main only — pull_request builds are validation-only.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
         uses: withastro/action@v3
         with:
           path: site # runs `npm ci` + `npm run build` (prebuild regenerates the reference)
+          node-version: 22 # Astro 6 requires Node >=22.12.0; the action defaults to 20
 
   deploy:
     needs: build


### PR DESCRIPTION
## What was red

The **"Deploy docs"** workflow has been failing on `main` since #106, even though every PR merged green. The build aborts with:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

## Root cause

- #106 bumped Astro `5.x → ^6.4.6` (resolved 6.4.8). **Astro 6 requires Node ≥22.12.0**, but `withastro/action@v3` defaults to **Node 20**.
- **Why it was green at merge:** `docs.yml` only triggered on `push` to `main`, never on `pull_request`. PR checks come entirely from `ci.yml`, which never builds the site — so the Astro/Node incompatibility was invisible until the post-merge deploy fired.

## Changes

1. **Pin Node 22 in the docs build** (`node-version: 22` on `withastro/action@v3`) — stops the bleeding; matches Astro 6's engine requirement and `site/`'s existing `@types/node: ^22`.
2. **Run the build job on `pull_request`** (same `site/**` + `plugins/ca/**` paths) so a site-breaking change is caught at review time, not post-merge.
   - **Deploy stays gated to `push`** via `if: github.event_name != 'pull_request'` — it needs `pages:write`/`id-token:write`, which a PR (especially from a fork) can't safely hold.
   - **Concurrency scoped per-ref** (`pages-${{ github.ref }}`) so PR validation builds don't cancel the main deploy or each other.

## Verification

- Failure reproduced from the run logs on `408760a` / `6d529af`.
- `docs.yml` validated as well-formed YAML locally.
- The first real exercise of the new PR-time build will be the next PR that touches `site/**` or `plugins/ca/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XW4ZjfBmDCKcTiwBNtkfFf)_