### PR TITLE
chore(changelog): document #106 security hardening under 2.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
   `§7` Override stay in-kernel, and `§3`/`§5`/`§6`/`§7` heading numbers are unchanged so hook citations
   stay accurate. Behavior-preserving — reduces the per-session SessionStart injection by ~21 lines. (#75)
 
+### Security
+- **Cleared 17 Dependabot alerts and hardened the farm test harness.** Bumped the vulnerable
+  dev-dependency pins under `plugins/ca/tools/` (`package.json` / `package-lock.json`) and tightened
+  process spawning in `farm.test.ts` so the test harness no longer shells out unsafely. Dev/test-only —
+  no change to runtime plugin behavior. (#106)
+
 ## [2.4.5] — 2026-06-19
 
 ### Added


### PR DESCRIPTION
Reconciles the CHANGELOG before cutting the **v2.4.6** release.

## Why
`main` is prepped for v2.4.6 (manifest `2.4.6`; CHANGELOG carries 2.4.4/2.4.5/2.4.6), but the v2.4.6 batch was never tagged or released. Auditing the commits since `v2.4.2`, one payload change landed after the 2.4.6 CHANGELOG entry without coverage: **#106** (Dependabot dev-dep bumps + farm test-spawn hardening under `plugins/ca/tools/`).

The other trailing commits — #104 (README), #107 (site deps), #109 (CI) — are out of plugin-CHANGELOG scope ("the plugin is the contents of `plugins/ca/`").

## Change
One `### Security` entry under `[2.4.6]` for #106. Dev/test-only; no runtime behavior change.

## Next
After merge: tag `v2.4.6` on `main` and publish the GitHub Release with the 2.4.6 section as notes (closing the unreleased 2.4.4→2.4.6 gap).

https://claude.ai/code/session_018fLGikjkdB52vyGsDDooPu