### PR TITLE
feat(metrics): /ca:metrics governance trend glance (#79)

### DIFF
--- a/.codearbiter/plans/metrics.md
+++ b/.codearbiter/plans/metrics.md
@@ -1,0 +1,65 @@
+# Plan — /ca:metrics (issue #79)
+
+**Slug:** `metrics` · **Spec:** `.codearbiter/specs/metrics.md` (approved) · **Lane:** full
+
+Pre-flight note: `.codearbiter/coding-standards.md` is absent in this project; paths below are resolved
+against the live repo layout and `tech-stack.md` (authoritative for build/test commands).
+
+## AC ledger (verbatim from spec)
+
+- **AC-01 — Window tiling.** Given M commits and window size N, the tiler produces windows over the
+  correct commit boundaries; an ISO-8601 timestamp maps to the window whose commit-date span
+  `[commit[i].date, commit[i+N].date)` contains it; an edge timestamp maps to the higher-index window.
+- **AC-02 — Override rate.** `overrides.log` with C current / P prior entries → `override_rate.current==C`,
+  `.prior==P`, arrow ↑/↓/→ by sign of C−P; `#` comment lines excluded.
+- **AC-03 — Small-lane rate.** `triage.log` → `small_lane.current`/`.prior` count `LANE: small` entries
+  in each window with correct arrow; comment lines excluded.
+- **AC-04 — Sprint low-confidence ratio.** `sprint-log.md` with H `**high**`, L `**low**` in window →
+  `ratio.current == round(L/(L+H), 2)`; `"n/a"` when `L+H==0`; arrow vs prior; sentinel window → `→`.
+- **AC-05 — Empty / missing source.** Absent file or empty window → defined sentinel (`0` for counts,
+  `"n/a"` for ratio); never raises, never divides by zero.
+- **AC-06 — Read-only.** Compute over a fixture project dir leaves every `.codearbiter/` file
+  byte-for-byte unchanged.
+- **AC-07 — Fixed output surface.** Result holds exactly `override_rate`, `small_lane_rate`,
+  `sprint_low_conf_ratio`; no verbatim source-log line in any value.
+
+## Tasks
+
+| id | path(s) | verification | maps-to (tdd obligation) | covers | depends-on | status |
+|----|---------|--------------|--------------------------|--------|------------|--------|
+| T-01 | `plugins/ca/hooks/_metricslib.py`, `.github/scripts/test_metrics_lib.py` | `python .github/scripts/test_metrics_lib.py WindowTest` passes (boundaries for M commits/size N; edge timestamp → higher-index window) | window-tiling | AC-01 | — | ACCEPTED |
+| T-02 | `plugins/ca/hooks/_metricslib.py`, `.github/scripts/test_metrics_lib.py` | `… OverrideRateTest` passes (current==C, prior==P, arrow by sign, `#` excluded) | override-rate | AC-02 | T-01 | ACCEPTED |
+| T-03 | `plugins/ca/hooks/_metricslib.py`, `.github/scripts/test_metrics_lib.py` | `… SmallLaneTest` passes (`LANE: small` counts current/prior, arrow, comments excluded) | small-lane-rate | AC-03 | T-01 | ACCEPTED |
+| T-04 | `plugins/ca/hooks/_metricslib.py`, `.github/scripts/test_metrics_lib.py` | `… SprintRatioTest` passes (`round(L/(L+H),2)`; `"n/a"` at 0; arrow; sentinel→`→`) | sprint-low-conf-ratio | AC-04 | T-01 | ACCEPTED |
+| T-05 | `plugins/ca/hooks/_metricslib.py`, `.github/scripts/test_metrics_lib.py` | `… EmptySourceTest` passes (missing file & empty window → sentinels; no raise; no div-by-zero) | empty/missing-safety | AC-05 | T-02, T-03, T-04 | ACCEPTED |
+| T-06 | `plugins/ca/hooks/_metricslib.py`, `.github/scripts/test_metrics_lib.py` | `… ComputeApiTest` passes (`compute(dir, window=20)` returns exactly the 3 keys; no verbatim source line in any value) | fixed-output-surface | AC-07 | T-02, T-03, T-04 | ACCEPTED |
+| T-07 | `.github/scripts/test_metrics_lib.py` | `… ReadOnlyTest` passes (fixture `.codearbiter/` byte-identical before/after compute) | read-only-invariant | AC-06 | T-06 | ACCEPTED |
+| T-08 | `plugins/ca/commands/metrics.md` | Command file present; documents the `python3 … _metricslib … || python …` fallback call (per `preview.md`); running it on this repo renders the 3-metric block (value + arrow), writes nothing | _(prose — authoring gate, no tdd obligation)_ | AC-07 | T-06 | ACCEPTED |
+| T-09 | `plugins/ca/COMMANDS.md` | `python3 .github/scripts/check-plugin-refs.py ca` passes (rule D: `/ca:metrics` cataloged, file↔catalog agree) | _(static CI check — no tdd obligation)_ | AC-07 | T-08 | ACCEPTED |
+| T-10 | `.github/workflows/ci.yml`, `.codearbiter/tech-stack.md` | `ci.yml` runs `python .github/scripts/test_metrics_lib.py` in the hooks-test job (green); `tech-stack.md` test list mirrors it | _(CI registration — enforces AC-01–07; no new tdd obligation)_ | AC-01, AC-02, AC-03, AC-04, AC-05, AC-06, AC-07 | T-07 | ACCEPTED |
+| T-11 | `README.md`, `CHANGELOG.md` | README shows a `/ca:metrics` command-table row and the commands-count badge reads `36`; `CHANGELOG.md` `[2.5.0]` **Added** lists `/ca:metrics` | _(docs hygiene — authoring gate)_ | AC-07 | T-08 | ACCEPTED |
+
+## Order & MVP slice
+
+Dependency order: **T-01 → {T-02, T-03, T-04} → {T-05, T-06} → {T-07, T-08} → {T-09, T-10, T-11}**.
+No cycle.
+
+- **MVP slice — T-01 … T-10:** the helper computing all three trends (AC-01–05, AC-07), proven
+  read-only (AC-06), surfaced through an invocable `/ca:metrics` command that passes
+  `check-plugin-refs` (T-09) and is CI-enforced (T-10). Shippable on its own: a working, reachable,
+  test-gated command.
+- **Incremental — T-11:** README/CHANGELOG discoverability hygiene. Not CI-enforced; lands in the
+  same PR but after the MVP slice.
+
+## Notes
+
+- **Version:** `2.5.0` is the current **untagged** version (latest tag `v2.4.6`); per the release
+  invariant a bump is required only on an *already-tagged* version, so `plugin.json` stays `2.5.0`
+  and the CHANGELOG entry appends to the existing unreleased `[2.5.0]` section. No `version-bump` task.
+- **No new skill/agent** — `/ca:metrics` is self-contained command prose calling `_metricslib.py`
+  directly (the `/ca:preview` → `_previewlib.py` pattern), so `skills/INDEX.md` and `agents/INDEX.md`
+  are untouched.
+- **EOL:** new `.py`/`.md` files are LF.
+- `[NEEDS-TRIAGE]` (future features, out of scope — carried from the spec): true small-lane *share*
+  (needs `/ca:feature` to log full-lane classifications); a caught-by-gate "where arbiter stops bad
+  things" trend (needs a new gate-catch event log — un-instrumented today).

--- a/.codearbiter/specs/metrics.md
+++ b/.codearbiter/specs/metrics.md
@@ -1,0 +1,93 @@
+# Spec — /ca:metrics (issue #79)
+
+**Slug:** `metrics` · **Lane:** full · **Source:** GitHub issue #79 (market-eval, enhancement)
+
+## Problem
+
+codeArbiter captures rich, append-only audit data and never analyzes it. `/ca:audit`,
+`/ca:status`, and `/ca:adr-status` only **list or snapshot** — none computes a trend. A
+maintainer/lead cannot tell at a glance whether governance discipline is **holding or
+eroding**.
+
+## Scope
+
+**In:** a new read-only command `/ca:metrics` that computes a small fixed set of
+single-number governance trends from the existing append-only sources, each shown as a
+current-window value plus a direction arrow (↑ / ↓ / →) versus the immediately prior
+window. The arithmetic lives in a Python stdlib helper `_metricslib.py` (sibling of
+`_previewlib.py`), unit-tested by `test_metrics_lib.py` against fixture logs — the
+`/ca:preview` precedent. The command is prose that calls the helper and renders its
+result. Writes nothing.
+
+**Window model:** history is tiled into **commit-count windows of N=20 commits** (default;
+overridable via `--window N`). Each append-only log entry is mapped into a window by its
+ISO-8601 timestamp falling in that window's commit-date span. A metric compares the current
+(most recent) window against the immediately prior window. Requires `git log` (already a
+sanctioned read in `/ca:audit`); no network, no writes.
+
+**The fixed metric set (3):**
+
+1. **Override rate** — count of `overrides.log` entries in the window. ↑ = worse.
+2. **Small-lane rate** — count of `LANE: small` entries in `triage.log` per window.
+3. **Sprint low-confidence ratio** — `low / (low + high)` over the SMARTS confidence markers
+   (`**low**` / `**high**`) in `sprint-log.md` entries in the window. ↑ = worse.
+
+Each metric renders value + arrow (↑ / ↓ / →) vs. the immediately prior window.
+
+**Out of scope (the guardrail, issue #79):** NOT a second `/ca:audit` packet. Emits bare
+numbers/arrows only — no verbatim override lines, no commit list, no compliance dump, no
+file write. Captures no new data. No network. Does not modify any log, decision, or
+checkpoint. The `decisions/` source is **not** mined for a trend in this version (ADR
+cadence is too sparse to trend; it stays an `/ca:audit` / `/ca:adr-status` concern).
+
+**Deferred (`[NEEDS-TRIAGE]`, future features, not this one):**
+- A true small-lane *share* (small ÷ total triaged) would require `/ca:feature` to also log
+  full-lane classifications to `triage.log` — a producer change in another command's routing.
+- A **"where does arbiter stop bad things" / caught-by-gate trend** (issue #79's original
+  metric #2) is **not buildable on existing data**: nothing logs a gate catching-and-holding
+  (a failed `tdd` Phase 1, a `commit-gate` block, a reviewer `BLOCK`). It needs a new
+  append-only gate-catch event log — new instrumentation deliberately absent today. Dropped
+  from this read-only feature and recorded for a future instrumentation feature.
+
+## Acceptance criteria
+
+Each criterion is verifiable by a single fixture-driven test against `_metricslib.py`
+(one `tdd` Phase 1 obligation per criterion).
+
+1. **Window tiling.** Given a git history of M commits and window size N, the tiler produces
+   windows over the correct commit boundaries, and an ISO-8601 timestamp maps to the window
+   whose commit-date span `[commit[i].date, commit[i+N].date)` contains it. Boundary case:
+   a timestamp on a window edge maps to the higher-index (more recent) window.
+2. **Override rate.** Given a fixture `overrides.log` with C entries timestamped inside the
+   current window and P inside the prior window, the result reports `override_rate.current == C`,
+   `.prior == P`, and `arrow` = ↑ if C>P, ↓ if C<P, → if C==P. Comment lines (`#`) are excluded.
+3. **Small-lane rate.** Given a fixture `triage.log`, `small_lane.current` equals the count of
+   `LANE: small` entries in the current window and `.prior` the count in the prior window, with
+   the correct arrow; comment lines excluded.
+4. **Sprint low-confidence ratio.** Given a fixture `sprint-log.md` with H `**high**` and L
+   `**low**` confidence markers in the current window, `ratio.current == round(L/(L+H), 2)`;
+   when `L+H == 0` the value is the sentinel `"n/a"`; the arrow compares current vs. prior, and
+   any window with a sentinel value yields a `→` (no spurious arrow).
+5. **Empty / missing source.** When a source file is absent or a window contains no relevant
+   entries, the corresponding metric returns its defined sentinel (`0` for counts, `"n/a"` for
+   the ratio) and the helper never raises and never divides by zero.
+6. **Read-only.** Invoking the helper's public compute API over a fixture project directory
+   leaves every file in `.codearbiter/` byte-for-byte unchanged (no writes, no log appends).
+7. **Fixed output surface.** The helper's structured result contains exactly the three metric
+   keys (`override_rate`, `small_lane_rate`, `sprint_low_conf_ratio`) and no verbatim
+   source-log line is present in any value — enforcing the "not a second audit packet" guardrail.
+
+## Open questions
+
+None blocking. No `[CONFIRM-NN]` raised — the four delegated decisions were resolved by SMARTS
+recommendation and user choice during brainstorming (window = commit-count N=20; small-lane =
+rate not share; most-overridden/caught-by-gate metric dropped as un-instrumented; surface =
+new `/ca:metrics` command). The default
+N=20 and the prior-window-only comparison are deliberate simplicity calls, overridable later.
+
+## Implementation notes (for writing-plans, not gating criteria)
+
+- New helper `plugins/ca/hooks/_metricslib.py` (Python 3, stdlib only) + `.github/scripts/test_metrics_lib.py`; register the test in `tech-stack.md` and CI parity.
+- New command `plugins/ca/commands/metrics.md`; add to the `/ca:commands` catalog and the README/docs command list; ensure `check-plugin-refs.py` resolves.
+- This is a `plugins/ca/**` change on a tagged version → `plugin.json` version bump required (CI `version-bump` job), plus README badge + dated `CHANGELOG.md` section.
+- Canonical EOL is LF for the new `.py`/`.md` files.

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -37,6 +37,9 @@ python .github/scripts/test_prune_nudge.py
 
 # H-14 migration commit-time backstop — detection, producer marker, pre-bash gate (#77)
 python .github/scripts/test_migration_backstop.py
+
+# /ca:metrics trends helper — window tiling, 3 metrics, empty-source safety, read-only
+python .github/scripts/test_metrics_lib.py
 ```
 
 Only when `plugins/ca/tools/**` changed:

--- a/.github/scripts/test_metrics_lib.py
+++ b/.github/scripts/test_metrics_lib.py
@@ -1,0 +1,1854 @@
+#!/usr/bin/env python3
+"""codeArbiter — unit tests for the window-tiling foundation (_metricslib, T-01).
+
+Proves the pure window-tiling logic (AC-01): correct commit-count windows,
+timestamp-to-window mapping, boundary semantics, and edge values. The git
+wrapper (commit_timeline) is NOT tested here — only the pure functions are
+exercised with synthetic commit lists, keeping git out of the test suite.
+
+Test class: WindowTest (select with: python .github/scripts/test_metrics_lib.py WindowTest)
+Stdlib only. Exit 0 = all tests pass; non-zero = failure.
+"""
+
+import sys
+import os
+import unittest
+from datetime import datetime, timezone, timedelta
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+HOOKS = os.path.join(REPO, "plugins", "ca", "hooks")
+sys.path.insert(0, HOOKS)
+
+import _metricslib  # noqa: E402 — needs sys.path mutation above
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _utc(year, month, day, hour=0, minute=0, second=0):
+    """Produce a timezone-aware UTC datetime for test fixtures."""
+    return datetime(year, month, day, hour, minute, second, tzinfo=timezone.utc)
+
+
+def _make_timeline(n, start=None, step_days=1):
+    """Return a list of n timezone-aware UTC datetimes, oldest first,
+    spaced `step_days` days apart from `start` (default 2020-01-01)."""
+    if start is None:
+        start = _utc(2020, 1, 1)
+    return [start + timedelta(days=i * step_days) for i in range(n)]
+
+
+class WindowTest(unittest.TestCase):
+    """AC-01: window-tiling pure functions."""
+
+    # ------------------------------------------------------------------
+    # tile_windows: basic window production
+    # ------------------------------------------------------------------
+
+    def test_60_commits_n20_yields_3_windows(self):
+        """60 commits / N=20 produces exactly 3 windows indexed 0, 1, 2."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        self.assertEqual(len(windows), 3)
+
+    def test_60_commits_window_indices_are_0_1_2(self):
+        """Windows are indexed 0 (oldest) through 2 (most recent / current)."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        indices = [w.index for w in windows]
+        self.assertEqual(indices, [0, 1, 2])
+
+    def test_most_recent_window_is_highest_index(self):
+        """The highest-index window covers the newest commits."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        newest_window = windows[-1]
+        self.assertEqual(newest_window.index, 2)
+        # Its last commit must be the very last commit in the timeline.
+        self.assertEqual(newest_window.end_dt, timeline[-1])
+
+    def test_window_boundaries_cover_all_commits(self):
+        """Each commit falls into exactly one window's [start_dt, end_dt] span."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        # Window i covers commits [i*20, (i+1)*20 - 1].
+        self.assertEqual(windows[0].start_dt, timeline[0])
+        self.assertEqual(windows[0].end_dt, timeline[19])
+        self.assertEqual(windows[1].start_dt, timeline[20])
+        self.assertEqual(windows[1].end_dt, timeline[39])
+        self.assertEqual(windows[2].start_dt, timeline[40])
+        self.assertEqual(windows[2].end_dt, timeline[59])
+
+    def test_default_window_size_is_20(self):
+        """tile_windows defaults to window_size=20 when not supplied."""
+        timeline = _make_timeline(40)
+        windows = _metricslib.tile_windows(timeline)
+        self.assertEqual(len(windows), 2)
+
+    # ------------------------------------------------------------------
+    # tile_windows: partial window (non-divisible M)
+    # ------------------------------------------------------------------
+
+    def test_partial_window_is_oldest_when_not_divisible(self):
+        """With 45 commits and N=20, the oldest window (index 0) is partial
+        (5 commits); windows 1 and 2 are full (20 commits each).
+        The newest two windows are always full; the partial group is oldest."""
+        timeline = _make_timeline(45)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        # 45 = 5 (partial oldest) + 20 + 20 => 3 windows
+        self.assertEqual(len(windows), 3)
+        # oldest window has 5 commits (the partial group)
+        w0 = windows[0]
+        self.assertEqual(w0.start_dt, timeline[0])
+        self.assertEqual(w0.end_dt, timeline[4])
+        # middle window is full
+        w1 = windows[1]
+        self.assertEqual(w1.start_dt, timeline[5])
+        self.assertEqual(w1.end_dt, timeline[24])
+        # newest window is full
+        w2 = windows[2]
+        self.assertEqual(w2.start_dt, timeline[25])
+        self.assertEqual(w2.end_dt, timeline[44])
+
+    def test_fewer_than_window_size_commits_is_one_window(self):
+        """With M < N, there is exactly one window (index 0) that is partial."""
+        timeline = _make_timeline(7)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0].index, 0)
+        self.assertEqual(windows[0].start_dt, timeline[0])
+        self.assertEqual(windows[0].end_dt, timeline[6])
+
+    def test_empty_timeline_yields_no_windows(self):
+        """An empty commit list produces an empty window list, not a crash."""
+        windows = _metricslib.tile_windows([], window_size=20)
+        self.assertEqual(windows, [])
+
+    def test_exactly_one_commit_is_one_window(self):
+        """A single-commit timeline produces one window covering that commit."""
+        timeline = _make_timeline(1)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0].start_dt, timeline[0])
+        self.assertEqual(windows[0].end_dt, timeline[0])
+
+    # ------------------------------------------------------------------
+    # map_to_window: timestamp → window index
+    # ------------------------------------------------------------------
+
+    def test_timestamp_inside_window_maps_correctly(self):
+        """A timestamp in the middle of window 1's date span maps to index 1."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        # Middle of window 1 (commits 20–39): pick commit 29's date
+        ts = timeline[29]
+        idx = _metricslib.map_to_window(ts, windows)
+        self.assertEqual(idx, 1)
+
+    def test_timestamp_at_window_start_maps_to_that_window(self):
+        """A timestamp equal to a window's start_dt maps to that window's index."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        # timeline[20] is the start of window 1
+        ts = timeline[20]
+        idx = _metricslib.map_to_window(ts, windows)
+        self.assertEqual(idx, 1)
+
+    def test_timestamp_at_boundary_maps_to_higher_index_window(self):
+        """A timestamp exactly equal to a window-boundary commit date maps to the
+        higher-index (more recent) window, not the lower-index one that ends there.
+
+        With windows [0: t0..t19], [1: t20..t39], [2: t40..t59]:
+        timeline[39] is end_dt of window 1 AND start_dt of window 2 in
+        the half-open [start, end) sense — it must map to window 2 (index 2).
+        """
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        # timeline[40] is start of window 2; timeline[39] is end of window 1.
+        # The boundary in question is timeline[40]: it should map to window 2.
+        boundary_ts = windows[2].start_dt
+        idx = _metricslib.map_to_window(boundary_ts, windows)
+        self.assertEqual(idx, 2, "boundary commit date must map to the more-recent window")
+
+    def test_timestamp_newer_than_newest_commit_maps_to_last_window(self):
+        """A timestamp newer than the last commit maps to the most-recent window."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        future_ts = timeline[-1] + timedelta(days=365)
+        idx = _metricslib.map_to_window(future_ts, windows)
+        self.assertEqual(idx, 2)
+
+    def test_timestamp_older_than_oldest_commit_maps_to_sentinel(self):
+        """A timestamp older than the oldest commit returns BEFORE_HISTORY sentinel
+        (a defined value, not a crash)."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        ancient_ts = timeline[0] - timedelta(days=365)
+        idx = _metricslib.map_to_window(ancient_ts, windows)
+        self.assertEqual(idx, _metricslib.BEFORE_HISTORY)
+
+    def test_map_to_window_accepts_iso8601_z_string(self):
+        """map_to_window accepts an ISO-8601 string with trailing Z (log format)."""
+        timeline = _make_timeline(60)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        # Pick a timestamp inside window 0 and encode it as a Z-string.
+        ts_dt = timeline[5]
+        ts_str = ts_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        idx = _metricslib.map_to_window(ts_str, windows)
+        self.assertEqual(idx, 0)
+
+    def test_map_to_window_empty_windows_returns_sentinel(self):
+        """map_to_window with an empty window list returns BEFORE_HISTORY, not crash."""
+        idx = _metricslib.map_to_window(_utc(2024, 1, 1), [])
+        self.assertEqual(idx, _metricslib.BEFORE_HISTORY)
+
+    # ------------------------------------------------------------------
+    # tile_windows: ISO-8601 string input
+    # ------------------------------------------------------------------
+
+    def test_tile_windows_accepts_iso8601_z_strings(self):
+        """tile_windows accepts a list of ISO-8601 Z strings (as the log emits)."""
+        base = _utc(2026, 1, 1)
+        strs = [(base + timedelta(days=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+                for i in range(40)]
+        windows = _metricslib.tile_windows(strs, window_size=20)
+        self.assertEqual(len(windows), 2)
+
+    # ------------------------------------------------------------------
+    # sentinel constant
+    # ------------------------------------------------------------------
+
+    def test_before_history_sentinel_is_negative(self):
+        """BEFORE_HISTORY sentinel is a negative integer (clearly not a valid index)."""
+        self.assertIsInstance(_metricslib.BEFORE_HISTORY, int)
+        self.assertLess(_metricslib.BEFORE_HISTORY, 0)
+
+
+# ---------------------------------------------------------------------------
+# OverrideRateTest — T-02: override-rate metric (AC-02)
+# ---------------------------------------------------------------------------
+
+class OverrideRateTest(unittest.TestCase):
+    """AC-02: override-rate pure function — counts overrides.log entries per window."""
+
+    # Shared window setup: 60 synthetic commits producing 3 windows (N=20).
+    # window 0: commits 0–19   (oldest)
+    # window 1: commits 20–39  (prior)
+    # window 2: commits 40–59  (current)
+    _TIMELINE_START = _utc(2026, 1, 1)
+
+    def _make_windows(self):
+        """Return a 3-window list using a 60-commit timeline, N=20."""
+        timeline = _make_timeline(60, start=self._TIMELINE_START, step_days=1)
+        return _metricslib.tile_windows(timeline, window_size=20)
+
+    def _ts_in_window(self, windows, window_index, offset_hours=1):
+        """Return an ISO-8601 Z string for a timestamp strictly inside `window_index`."""
+        band = windows[window_index]
+        # Use start_dt + offset to land well inside the band.
+        dt = band.start_dt + timedelta(hours=offset_hours)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _make_log_line(self, ts_str, hook="H-02", actor="user@example.com"):
+        """Return a synthetic overrides.log non-comment line."""
+        return (
+            f"[{ts_str}] | BY: {actor} | "
+            f"OVERRIDE: {hook} force-push | REASON: test"
+        )
+
+    # ------------------------------------------------------------------
+    # Happy path: current > prior  (arrow "↑")
+    # ------------------------------------------------------------------
+
+    def test_current_greater_than_prior_arrow_up(self):
+        """C=3 in current window, P=1 in prior window -> current==3, prior==1, arrow='↑'."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        prior_idx = current_idx - 1
+
+        lines = []
+        # 3 entries in the current window
+        for _ in range(3):
+            lines.append(self._make_log_line(self._ts_in_window(windows, current_idx)))
+        # 1 entry in the prior window
+        lines.append(self._make_log_line(self._ts_in_window(windows, prior_idx)))
+
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 3)
+        self.assertEqual(result["prior"], 1)
+        self.assertEqual(result["arrow"], "↑")
+
+    # ------------------------------------------------------------------
+    # Happy path: current < prior  (arrow "↓")
+    # ------------------------------------------------------------------
+
+    def test_current_less_than_prior_arrow_down(self):
+        """C=1 in current window, P=4 in prior window -> arrow='↓'."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        prior_idx = current_idx - 1
+
+        lines = []
+        lines.append(self._make_log_line(self._ts_in_window(windows, current_idx)))
+        for _ in range(4):
+            lines.append(self._make_log_line(self._ts_in_window(windows, prior_idx)))
+
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 1)
+        self.assertEqual(result["prior"], 4)
+        self.assertEqual(result["arrow"], "↓")
+
+    # ------------------------------------------------------------------
+    # Happy path: current == prior  (arrow "→")
+    # ------------------------------------------------------------------
+
+    def test_current_equal_prior_arrow_flat(self):
+        """C=2 in current window, P=2 in prior window -> arrow='→'."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        prior_idx = current_idx - 1
+
+        lines = []
+        for _ in range(2):
+            lines.append(self._make_log_line(self._ts_in_window(windows, current_idx)))
+        for _ in range(2):
+            lines.append(self._make_log_line(self._ts_in_window(windows, prior_idx)))
+
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 2)
+        self.assertEqual(result["prior"], 2)
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Comment lines and blank lines are excluded
+    # ------------------------------------------------------------------
+
+    def test_comment_lines_excluded(self):
+        """Lines starting with '#' must not be counted, even if they contain a timestamp."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        ts_str = self._ts_in_window(windows, current_idx)
+        # One real entry and two comment lines that look like entries.
+        lines = [
+            self._make_log_line(ts_str),
+            f"# [{ts_str}] | BY: actor | OVERRIDE: H-02 | REASON: comment",
+            "# another comment",
+        ]
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 1, "comment lines must not be counted")
+
+    def test_blank_lines_excluded(self):
+        """Blank lines (and whitespace-only lines) must not cause errors or counts."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        ts_str = self._ts_in_window(windows, current_idx)
+        lines = [
+            "",
+            "   ",
+            self._make_log_line(ts_str),
+            "",
+        ]
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 1)
+
+    # ------------------------------------------------------------------
+    # Entries that map to BEFORE_HISTORY are not counted
+    # ------------------------------------------------------------------
+
+    def test_before_history_entries_not_counted(self):
+        """An entry timestamped before the first window must not appear in any count."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        # A timestamp 1 year before the oldest window start
+        ancient_dt = windows[0].start_dt - timedelta(days=365)
+        ancient_str = ancient_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        lines = [
+            self._make_log_line(ancient_str),
+            self._make_log_line(self._ts_in_window(windows, current_idx)),
+        ]
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 1, "ancient entry must not be counted")
+        self.assertEqual(result["prior"], 0)
+
+    # ------------------------------------------------------------------
+    # Fewer than 2 windows: prior == 0, arrow compares against 0
+    # ------------------------------------------------------------------
+
+    def test_single_window_prior_is_zero(self):
+        """With only 1 window, prior==0 and arrow reflects current vs 0."""
+        # 7 commits => 1 window (N=20)
+        timeline = _make_timeline(7, start=self._TIMELINE_START, step_days=1)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        self.assertEqual(len(windows), 1)
+
+        ts_str = self._ts_in_window(windows, 0)
+        lines = [self._make_log_line(ts_str), self._make_log_line(ts_str)]
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["current"], 2)
+        self.assertEqual(result["arrow"], "↑")  # 2 > 0
+
+    def test_single_window_zero_entries_arrow_flat(self):
+        """With 1 window and zero entries in it, current==0, prior==0, arrow='→'."""
+        timeline = _make_timeline(7, start=self._TIMELINE_START, step_days=1)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+
+        result = _metricslib.override_rate([], windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_empty_windows_returns_zeros(self):
+        """With an empty windows list, both counts are 0 and arrow is '→'."""
+        result = _metricslib.override_rate([], [])
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Text-block input (accepts str with newlines, not just list)
+    # ------------------------------------------------------------------
+
+    def test_accepts_text_block(self):
+        """override_rate may accept a single multi-line string as well as a list."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        ts_str = self._ts_in_window(windows, current_idx)
+
+        text = "\n".join([
+            "# header comment",
+            self._make_log_line(ts_str),
+            "",
+            self._make_log_line(ts_str),
+        ])
+        result = _metricslib.override_rate(text, windows)
+        self.assertEqual(result["current"], 2)
+
+
+# ---------------------------------------------------------------------------
+# SmallLaneTest — T-03: small-lane-rate metric (AC-03)
+# ---------------------------------------------------------------------------
+
+class SmallLaneTest(unittest.TestCase):
+    """AC-03: small_lane_rate pure function — counts LANE: small entries in
+    triage.log per window.
+
+    Line format (non-comment):
+        [<ISO-8601 Z timestamp>] | BY: <actor> | LANE: small | SCOPE: ... | BASIS: ...
+
+    Only lines containing 'LANE: small' are counted.  'LANE: full' and any other
+    lane value must NOT be counted.  Comment (#) and blank lines are excluded.
+    Entries mapping to BEFORE_HISTORY are excluded.
+    """
+
+    _TIMELINE_START = _utc(2026, 1, 1)
+
+    def _make_windows(self):
+        """Return a 3-window list using a 60-commit timeline, N=20.
+        window 0: oldest  (prior's prior)
+        window 1: prior
+        window 2: current
+        """
+        timeline = _make_timeline(60, start=self._TIMELINE_START, step_days=1)
+        return _metricslib.tile_windows(timeline, window_size=20)
+
+    def _ts_in_window(self, windows, window_index, offset_hours=1):
+        """Return an ISO-8601 Z string for a timestamp strictly inside `window_index`."""
+        band = windows[window_index]
+        dt = band.start_dt + timedelta(hours=offset_hours)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _make_small_lane_line(self, ts_str, actor="tester@example.com"):
+        """Return a synthetic triage.log line with LANE: small."""
+        return (
+            f"[{ts_str}] | BY: {actor} | LANE: small | "
+            f"SCOPE: commit-quality | BASIS: short fix"
+        )
+
+    def _make_full_lane_line(self, ts_str, actor="tester@example.com"):
+        """Return a synthetic triage.log line with LANE: full (must NOT be counted)."""
+        return (
+            f"[{ts_str}] | BY: {actor} | LANE: full | "
+            f"SCOPE: broad-refactor | BASIS: large change"
+        )
+
+    # ------------------------------------------------------------------
+    # Happy path: current > prior  (arrow "↑")
+    # ------------------------------------------------------------------
+
+    def test_current_greater_than_prior_arrow_up(self):
+        """3 LANE: small in current, 1 in prior -> current==3, prior==1, arrow='↑'."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        prior_idx = current_idx - 1
+
+        lines = []
+        for _ in range(3):
+            lines.append(self._make_small_lane_line(self._ts_in_window(windows, current_idx)))
+        lines.append(self._make_small_lane_line(self._ts_in_window(windows, prior_idx)))
+
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 3)
+        self.assertEqual(result["prior"], 1)
+        self.assertEqual(result["arrow"], "↑")
+
+    # ------------------------------------------------------------------
+    # Happy path: current < prior  (arrow "↓")
+    # ------------------------------------------------------------------
+
+    def test_current_less_than_prior_arrow_down(self):
+        """1 LANE: small in current, 4 in prior -> arrow='↓'."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        prior_idx = current_idx - 1
+
+        lines = []
+        lines.append(self._make_small_lane_line(self._ts_in_window(windows, current_idx)))
+        for _ in range(4):
+            lines.append(self._make_small_lane_line(self._ts_in_window(windows, prior_idx)))
+
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 1)
+        self.assertEqual(result["prior"], 4)
+        self.assertEqual(result["arrow"], "↓")
+
+    # ------------------------------------------------------------------
+    # Happy path: current == prior  (arrow "→")
+    # ------------------------------------------------------------------
+
+    def test_current_equal_prior_arrow_flat(self):
+        """2 LANE: small in current, 2 in prior -> arrow='→'."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        prior_idx = current_idx - 1
+
+        lines = []
+        for _ in range(2):
+            lines.append(self._make_small_lane_line(self._ts_in_window(windows, current_idx)))
+        for _ in range(2):
+            lines.append(self._make_small_lane_line(self._ts_in_window(windows, prior_idx)))
+
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 2)
+        self.assertEqual(result["prior"], 2)
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Comment lines are excluded
+    # ------------------------------------------------------------------
+
+    def test_comment_lines_excluded(self):
+        """Lines starting with '#' must not be counted."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        ts_str = self._ts_in_window(windows, current_idx)
+        lines = [
+            self._make_small_lane_line(ts_str),
+            f"# [{ts_str}] | BY: actor | LANE: small | SCOPE: x | BASIS: y",
+            "# just a comment",
+        ]
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 1, "comment lines must not be counted")
+
+    # ------------------------------------------------------------------
+    # LANE: full must NOT be counted
+    # ------------------------------------------------------------------
+
+    def test_full_lane_not_counted(self):
+        """A LANE: full line must not contribute to the small-lane count."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        ts_str = self._ts_in_window(windows, current_idx)
+        lines = [
+            self._make_small_lane_line(ts_str),   # counted
+            self._make_full_lane_line(ts_str),     # NOT counted
+        ]
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 1, "LANE: full must not be counted")
+
+    # ------------------------------------------------------------------
+    # Blank lines are excluded
+    # ------------------------------------------------------------------
+
+    def test_blank_lines_excluded(self):
+        """Blank and whitespace-only lines must not cause errors or counts."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        ts_str = self._ts_in_window(windows, current_idx)
+        lines = [
+            "",
+            "   ",
+            self._make_small_lane_line(ts_str),
+            "",
+        ]
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 1)
+
+    # ------------------------------------------------------------------
+    # Entries mapping to BEFORE_HISTORY are excluded
+    # ------------------------------------------------------------------
+
+    def test_before_history_entries_not_counted(self):
+        """An entry timestamped before the first window must not appear in any count."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+
+        ancient_dt = windows[0].start_dt - timedelta(days=365)
+        ancient_str = ancient_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        lines = [
+            self._make_small_lane_line(ancient_str),
+            self._make_small_lane_line(self._ts_in_window(windows, current_idx)),
+        ]
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 1, "ancient entry must not be counted")
+        self.assertEqual(result["prior"], 0)
+
+    # ------------------------------------------------------------------
+    # Fewer than 2 windows: prior == 0
+    # ------------------------------------------------------------------
+
+    def test_single_window_prior_is_zero(self):
+        """With only 1 window, prior==0 and arrow reflects current vs 0."""
+        timeline = _make_timeline(7, start=self._TIMELINE_START, step_days=1)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        self.assertEqual(len(windows), 1)
+
+        ts_str = self._ts_in_window(windows, 0)
+        lines = [self._make_small_lane_line(ts_str), self._make_small_lane_line(ts_str)]
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["current"], 2)
+        self.assertEqual(result["arrow"], "↑")  # 2 > 0
+
+    def test_single_window_zero_entries_arrow_flat(self):
+        """With 1 window and no entries, current==0, prior==0, arrow='→'."""
+        timeline = _make_timeline(7, start=self._TIMELINE_START, step_days=1)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+
+        result = _metricslib.small_lane_rate([], windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_empty_windows_returns_zeros(self):
+        """With an empty windows list, both counts are 0 and arrow is '→'."""
+        result = _metricslib.small_lane_rate([], [])
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Text-block input accepted
+    # ------------------------------------------------------------------
+
+    def test_accepts_text_block(self):
+        """small_lane_rate may accept a single multi-line string as well as a list."""
+        windows = self._make_windows()
+        current_idx = len(windows) - 1
+        ts_str = self._ts_in_window(windows, current_idx)
+
+        text = "\n".join([
+            "# header comment",
+            self._make_small_lane_line(ts_str),
+            "",
+            self._make_small_lane_line(ts_str),
+        ])
+        result = _metricslib.small_lane_rate(text, windows)
+        self.assertEqual(result["current"], 2)
+
+
+# ---------------------------------------------------------------------------
+# SprintRatioTest — T-04: sprint low-confidence ratio (AC-04)
+# ---------------------------------------------------------------------------
+
+class SprintRatioTest(unittest.TestCase):
+    """AC-04: sprint_low_confidence_ratio pure function.
+
+    Counts the literal bold tokens **high** and **low** (case-sensitive) in
+    sprint-log.md text, per window (by sprint-header date), and returns:
+        current = round(L/(L+H), 2)  for the current (highest-index) window,
+                  or "n/a" when L+H == 0
+        prior   = same for the prior window (current - 1),
+                  or "n/a" when no prior window or L+H == 0
+        arrow   = "↑"/"↓"/"→" comparing current to prior;
+                  "→" when EITHER value is the "n/a" sentinel
+
+    Parsing rules:
+        - Bold tokens **high** and **low** are counted; all other bold tokens
+          (including **strong**, **moderate**, **weak**) are excluded.
+        - Each sprint section is introduced by a header matching:
+              # Sprint[^\\n]* · <YYYY-MM-DD>
+          The date is parsed as midnight UTC and mapped to a window via
+          map_to_window.
+        - Markers without a parseable sprint date are excluded (not counted).
+        - A **medium** token, if present, is neither high nor low and is
+          excluded from the ratio denominator.
+    """
+
+    _TIMELINE_START = _utc(2026, 1, 1)
+
+    def _make_windows(self):
+        """Return a 3-window list using a 60-commit timeline, N=20.
+
+        window 0: commits 0-19   (oldest, ~2026-01-01 to 2026-01-20)
+        window 1: commits 20-39  (prior,  ~2026-01-21 to 2026-02-09)
+        window 2: commits 40-59  (current,~2026-02-10 to 2026-03-01)
+        """
+        timeline = _make_timeline(60, start=self._TIMELINE_START, step_days=1)
+        return _metricslib.tile_windows(timeline, window_size=20)
+
+    def _date_in_window(self, windows, window_index):
+        """Return a YYYY-MM-DD string for a date inside the given window."""
+        band = windows[window_index]
+        dt = band.start_dt + timedelta(hours=12)  # noon on start day
+        return dt.strftime("%Y-%m-%d")
+
+    # ------------------------------------------------------------------
+    # Happy path: ratio computed correctly (H and L in current window)
+    # ------------------------------------------------------------------
+
+    def test_ratio_computed_from_high_and_low_counts(self):
+        """With 1 high and 3 low in current window, ratio = round(3/4, 2) = 0.75."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        text = (
+            f"# Sprint — alpha · {date_cur}\n"
+            "- Decision. **high**.\n"
+            "- Decision. **low**.\n"
+            "- Decision. **low**.\n"
+            "- Decision. **low**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], round(3 / 4, 2))
+
+    def test_ratio_all_high_is_zero(self):
+        """All-high window yields current == 0.0 (zero low markers)."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        text = (
+            f"# Sprint — beta · {date_cur}\n"
+            "- Decision. **high**.\n"
+            "- Decision. **high**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], 0.0)
+
+    def test_ratio_all_low_is_one(self):
+        """All-low window yields current == 1.0."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        text = (
+            f"# Sprint — gamma · {date_cur}\n"
+            "- Decision. **low**.\n"
+            "- Decision. **low**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], 1.0)
+
+    # ------------------------------------------------------------------
+    # n/a sentinel: L+H == 0 in a window
+    # ------------------------------------------------------------------
+
+    def test_empty_current_window_is_na(self):
+        """A current window with zero **high**/**low** markers returns "n/a"."""
+        windows = self._make_windows()
+        # No sprint sections with dates in the current window.
+        text = "# Some other header\nNo confidence markers here.\n"
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], "n/a")
+
+    def test_empty_prior_window_is_na(self):
+        """A prior window with zero markers returns "n/a" for prior."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+        # Only put content in the current window; prior window stays empty.
+        text = (
+            f"# Sprint — delta · {date_cur}\n"
+            "- Decision. **high**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["prior"], "n/a")
+
+    # ------------------------------------------------------------------
+    # Arrow comparisons
+    # ------------------------------------------------------------------
+
+    def test_arrow_up_when_current_greater_than_prior(self):
+        """current ratio > prior ratio -> arrow == '↑'."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+        date_pri = self._date_in_window(windows, 1)
+
+        # current: 3 low / 1 high = 0.75
+        # prior:   1 low / 3 high = 0.25
+        text = (
+            f"# Sprint — epsilon · {date_pri}\n"
+            "- **high**. **high**. **high**. **low**.\n"
+            f"# Sprint — zeta · {date_cur}\n"
+            "- **low**. **low**. **low**. **high**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertGreater(result["current"], result["prior"])
+        self.assertEqual(result["arrow"], "↑")
+
+    def test_arrow_down_when_current_less_than_prior(self):
+        """current ratio < prior ratio -> arrow == '↓'."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+        date_pri = self._date_in_window(windows, 1)
+
+        # current: 0 low / 2 high = 0.0
+        # prior:   2 low / 0 high = 1.0
+        text = (
+            f"# Sprint — eta · {date_pri}\n"
+            "- **low**. **low**.\n"
+            f"# Sprint — theta · {date_cur}\n"
+            "- **high**. **high**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertLess(result["current"], result["prior"])
+        self.assertEqual(result["arrow"], "↓")
+
+    def test_arrow_flat_when_current_equals_prior(self):
+        """current ratio == prior ratio -> arrow == '→'."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+        date_pri = self._date_in_window(windows, 1)
+
+        # both: 1 low / 1 high = 0.5
+        text = (
+            f"# Sprint — iota · {date_pri}\n"
+            "- **low**. **high**.\n"
+            f"# Sprint — kappa · {date_cur}\n"
+            "- **low**. **high**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], result["prior"])
+        self.assertEqual(result["arrow"], "→")
+
+    def test_arrow_flat_when_current_is_na(self):
+        """When current is "n/a", arrow must be "→" (no spurious comparison)."""
+        windows = self._make_windows()
+        date_pri = self._date_in_window(windows, 1)
+
+        text = (
+            f"# Sprint — lambda · {date_pri}\n"
+            "- **low**. **high**.\n"
+            # No section in current window.
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    def test_arrow_flat_when_prior_is_na(self):
+        """When prior is "n/a", arrow must be "→" (no spurious comparison)."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        text = (
+            f"# Sprint — mu · {date_cur}\n"
+            "- **low**. **high**.\n"
+            # No section in prior window.
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Disambiguation: strength words must NOT be counted
+    # ------------------------------------------------------------------
+
+    def test_strength_words_not_counted(self):
+        """**strong**, **moderate**, **weak** must NOT be counted as high or low."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        # Only strength words bolded — no **high** or **low** present.
+        text = (
+            f"# Sprint — nu · {date_cur}\n"
+            "- Decision. **strong**.\n"
+            "- Decision. **moderate**.\n"
+            "- Decision. **weak**.\n"
+            "- Other bold: **D-01**, **Point:**, **Chosen:**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], "n/a",
+                         "strength words must not be counted as high/low")
+
+    def test_medium_not_counted_in_denominator(self):
+        """**medium**, if present, is excluded from the L+H denominator."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        # 1 high + 1 medium; medium excluded, so denominator = 1 (just the high)
+        text = (
+            f"# Sprint — xi · {date_cur}\n"
+            "- Decision A. **high**.\n"
+            "- Decision B. **medium**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        # L=0, H=1 → ratio = 0/(0+1) = 0.0
+        self.assertEqual(result["current"], 0.0,
+                         "**medium** must not inflate the denominator")
+
+    # ------------------------------------------------------------------
+    # Markers without a parseable sprint header date are excluded
+    # ------------------------------------------------------------------
+
+    def test_markers_without_date_excluded(self):
+        """A sprint section with no parseable date — its markers are excluded."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        text = (
+            # Section with no date in the header — markers should be dropped.
+            "# Sprint log — general notes\n"
+            "- **low**. **low**. **low**.\n"
+            # Section with a proper date — only these markers count.
+            f"# Sprint — omicron · {date_cur}\n"
+            "- **high**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        # Only the 1 high from the dated section counts; the 3 low from the
+        # undated section are excluded.  L=0, H=1 → 0.0
+        self.assertEqual(result["current"], 0.0,
+                         "markers in undated sections must be excluded")
+
+    # ------------------------------------------------------------------
+    # Single window: prior == "n/a"
+    # ------------------------------------------------------------------
+
+    def test_single_window_prior_is_na(self):
+        """With only one window, prior == "n/a" and arrow == "→"."""
+        # 7 commits → 1 window (N=20)
+        timeline = _make_timeline(7, start=self._TIMELINE_START, step_days=1)
+        windows = _metricslib.tile_windows(timeline, window_size=20)
+        self.assertEqual(len(windows), 1)
+
+        date_cur = windows[0].start_dt.strftime("%Y-%m-%d")
+        text = (
+            f"# Sprint — pi · {date_cur}\n"
+            "- **high**. **low**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Empty windows list
+    # ------------------------------------------------------------------
+
+    def test_empty_windows_returns_na(self):
+        """With an empty windows list, both current and prior are "n/a"."""
+        text = "# Sprint — rho · 2026-01-05\n- **high**. **low**.\n"
+        result = _metricslib.sprint_low_confidence_ratio(text, [])
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    # ------------------------------------------------------------------
+    # Multiple sprint sections with the same window accumulate markers
+    # ------------------------------------------------------------------
+
+    def test_multiple_sections_same_window_accumulate(self):
+        """Multiple sprint sections whose dates fall in the same window
+        accumulate their **high**/**low** markers together."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+        # Second date also in window 2 (one day later)
+        band = windows[2]
+        date_cur2 = (band.start_dt + timedelta(days=2)).strftime("%Y-%m-%d")
+
+        text = (
+            f"# Sprint — sigma · {date_cur}\n"
+            "- **low**. **high**.\n"
+            f"# Sprint — tau · {date_cur2}\n"
+            "- **low**. **low**.\n"
+        )
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        # L=3, H=1 → 0.75
+        self.assertEqual(result["current"], round(3 / 4, 2))
+
+    # ------------------------------------------------------------------
+    # Accepts both string and list-of-strings input
+    # ------------------------------------------------------------------
+
+    def test_accepts_list_of_strings(self):
+        """sprint_low_confidence_ratio accepts a list of lines as well as a str."""
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, 2)
+
+        lines = [
+            f"# Sprint — upsilon · {date_cur}",
+            "- **low**. **high**.",
+        ]
+        result = _metricslib.sprint_low_confidence_ratio(lines, windows)
+        self.assertEqual(result["current"], 0.5)
+
+
+# ---------------------------------------------------------------------------
+# EmptySourceTest — T-05: empty / missing-source safety (AC-05)
+# ---------------------------------------------------------------------------
+
+class EmptySourceTest(unittest.TestCase):
+    """AC-05: every metric degrades safely when the source file is absent or
+    a window contains no relevant entries.
+
+    Proves (and hardens where needed) that:
+      - The thin readers return [] / "" on a non-existent path, never raise.
+      - Feeding that empty content to each metric yields the defined sentinel
+        (counts 0/0 with arrow "→"; ratio "n/a" with arrow "→").
+      - Calling each metric with windows=[] returns the sentinel result.
+      - Non-empty windows but zero matching log entries → sentinel.
+      - sprint ratio with low+high == 0 returns "n/a", never ZeroDivisionError.
+    """
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    _NONEXISTENT = "/tmp/__ca_metrics_no_such_file_t05__.log"
+
+    _TIMELINE_START = _utc(2026, 1, 1)
+
+    def _make_windows(self):
+        """Return a 3-window list (60 commits, N=20)."""
+        timeline = _make_timeline(60, start=self._TIMELINE_START, step_days=1)
+        return _metricslib.tile_windows(timeline, window_size=20)
+
+    def _date_in_window(self, windows, window_index):
+        """Return a YYYY-MM-DD date string inside the given window."""
+        band = windows[window_index]
+        return (band.start_dt + timedelta(hours=12)).strftime("%Y-%m-%d")
+
+    def _ts_in_window(self, windows, window_index):
+        """Return an ISO-8601 Z timestamp string inside the given window."""
+        band = windows[window_index]
+        return (band.start_dt + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # ==================================================================
+    # PART 1 — Thin readers: missing file returns empty, never raises
+    # ==================================================================
+
+    def test_read_override_log_missing_file_returns_empty_list(self):
+        """read_override_log on a non-existent path returns [], does not raise."""
+        result = _metricslib.read_override_log(self._NONEXISTENT)
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, [])
+
+    def test_read_triage_log_missing_file_returns_empty_list(self):
+        """read_triage_log on a non-existent path returns [], does not raise."""
+        result = _metricslib.read_triage_log(self._NONEXISTENT)
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, [])
+
+    def test_read_sprint_log_missing_file_returns_empty_string(self):
+        """read_sprint_log on a non-existent path returns "", does not raise."""
+        result = _metricslib.read_sprint_log(self._NONEXISTENT)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, "")
+
+    # ==================================================================
+    # PART 2 — Missing file → reader result fed directly to metric
+    #           Expected: sentinel values, no raise
+    # ==================================================================
+
+    def test_override_rate_from_missing_file_yields_sentinel(self):
+        """read_override_log (missing) → override_rate → 0/0/"→" sentinel."""
+        windows = self._make_windows()
+        lines = _metricslib.read_override_log(self._NONEXISTENT)
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_small_lane_rate_from_missing_file_yields_sentinel(self):
+        """read_triage_log (missing) → small_lane_rate → 0/0/"→" sentinel."""
+        windows = self._make_windows()
+        lines = _metricslib.read_triage_log(self._NONEXISTENT)
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_from_missing_file_yields_sentinel(self):
+        """read_sprint_log (missing) → sprint_low_confidence_ratio → "n/a"/"n/a"/"→"."""
+        windows = self._make_windows()
+        text = _metricslib.read_sprint_log(self._NONEXISTENT)
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    # ==================================================================
+    # PART 3 — Empty window set: windows=[]
+    # ==================================================================
+
+    def test_override_rate_empty_windows_sentinel(self):
+        """override_rate with windows=[] returns 0/0/"→", does not raise."""
+        result = _metricslib.override_rate([], [])
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_override_rate_content_with_empty_windows_sentinel(self):
+        """override_rate with real log lines but windows=[] returns sentinel (no crash)."""
+        # Provide a plausible log line; with no windows, nothing should be counted.
+        lines = [
+            "[2026-02-01T10:00:00Z] | BY: user@example.com | OVERRIDE: H-02 | REASON: test"
+        ]
+        result = _metricslib.override_rate(lines, [])
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_small_lane_rate_empty_windows_sentinel(self):
+        """small_lane_rate with windows=[] returns 0/0/"→", does not raise."""
+        result = _metricslib.small_lane_rate([], [])
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_small_lane_rate_content_with_empty_windows_sentinel(self):
+        """small_lane_rate with LANE: small lines but windows=[] returns sentinel."""
+        lines = [
+            "[2026-02-01T10:00:00Z] | BY: user@example.com | LANE: small | SCOPE: x | BASIS: y"
+        ]
+        result = _metricslib.small_lane_rate(lines, [])
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_empty_windows_sentinel(self):
+        """sprint_low_confidence_ratio with windows=[] returns "n/a"/"n/a"/"→"."""
+        text = "# Sprint — alpha · 2026-02-01\n- **high**. **low**.\n"
+        result = _metricslib.sprint_low_confidence_ratio(text, [])
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_empty_content_empty_windows_sentinel(self):
+        """sprint_low_confidence_ratio with "" and windows=[] returns sentinel."""
+        result = _metricslib.sprint_low_confidence_ratio("", [])
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    # ==================================================================
+    # PART 4 — Non-empty windows, zero matching log entries
+    # ==================================================================
+
+    def test_override_rate_no_matching_entries_yields_zeros(self):
+        """override_rate with non-empty windows but zero log entries → 0/0/"→"."""
+        windows = self._make_windows()
+        result = _metricslib.override_rate([], windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_override_rate_only_comment_lines_yields_zeros(self):
+        """override_rate where all lines are comments → 0/0/"→" (no counts)."""
+        windows = self._make_windows()
+        lines = [
+            "# This is a comment",
+            "# [2026-02-01T10:00:00Z] | BY: x | OVERRIDE: H-02 | REASON: commented",
+            "",
+            "   ",
+        ]
+        result = _metricslib.override_rate(lines, windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_small_lane_rate_no_matching_entries_yields_zeros(self):
+        """small_lane_rate with non-empty windows but empty lines → 0/0/"→"."""
+        windows = self._make_windows()
+        result = _metricslib.small_lane_rate([], windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_small_lane_rate_only_full_lane_entries_yields_zeros(self):
+        """small_lane_rate where all entries are LANE: full → 0/0/"→".
+
+        Verifies that LANE: full never bleeds into the LANE: small count.
+        """
+        windows = self._make_windows()
+        ts = self._ts_in_window(windows, len(windows) - 1)
+        lines = [
+            f"[{ts}] | BY: tester@example.com | LANE: full | SCOPE: x | BASIS: y",
+            f"[{ts}] | BY: tester@example.com | LANE: full | SCOPE: x | BASIS: y",
+        ]
+        result = _metricslib.small_lane_rate(lines, windows)
+        self.assertEqual(result["current"], 0)
+        self.assertEqual(result["prior"], 0)
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_no_matching_sections_yields_na(self):
+        """sprint_low_confidence_ratio with windows but no dated sections → "n/a"."""
+        windows = self._make_windows()
+        # Text has bold tokens but inside an undated section.
+        text = "# Sprint log — general\n- **high**. **low**.\n"
+        result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_empty_text_with_windows_yields_na(self):
+        """sprint_low_confidence_ratio with empty string and non-empty windows → "n/a"."""
+        windows = self._make_windows()
+        result = _metricslib.sprint_low_confidence_ratio("", windows)
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    # ==================================================================
+    # PART 5 — No division by zero: low+high == 0 inside a dated section
+    # ==================================================================
+
+    def test_sprint_ratio_zero_markers_in_dated_section_no_divzero(self):
+        """A dated sprint section with zero **high**/**low** markers returns "n/a",
+        never raises ZeroDivisionError.
+
+        The section header is parseable and maps to the current window, but
+        the section body contains only strength words (**strong**, **moderate**,
+        **weak**) and other bold tokens — none of which are **high** or **low**.
+        """
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, len(windows) - 1)
+        text = (
+            f"# Sprint — noscore · {date_cur}\n"
+            "- Decision A. **strong**.\n"
+            "- Decision B. **moderate**.\n"
+            "- Decision C. **weak**.\n"
+            "- Other: **D-01**, **Chosen:**.\n"
+        )
+        try:
+            result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        except ZeroDivisionError as exc:
+            self.fail(f"ZeroDivisionError raised when low+high==0: {exc}")
+        self.assertEqual(result["current"], "n/a",
+                         "zero confidence markers must yield sentinel 'n/a', not divide by zero")
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_both_windows_zero_markers_no_divzero(self):
+        """Both current and prior sections have zero **high**/**low** markers.
+        Must return "n/a"/"n/a"/"→", never raise ZeroDivisionError.
+        """
+        windows = self._make_windows()
+        date_cur = self._date_in_window(windows, len(windows) - 1)
+        date_pri = self._date_in_window(windows, len(windows) - 2)
+        text = (
+            f"# Sprint — prior-noscore · {date_pri}\n"
+            "- Only **strong** here.\n"
+            f"# Sprint — cur-noscore · {date_cur}\n"
+            "- Only **moderate** here.\n"
+        )
+        try:
+            result = _metricslib.sprint_low_confidence_ratio(text, windows)
+        except ZeroDivisionError as exc:
+            self.fail(f"ZeroDivisionError raised when both windows have low+high==0: {exc}")
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+        self.assertEqual(result["arrow"], "→")
+
+    def test_sprint_ratio_empty_list_input_no_divzero(self):
+        """Empty list input must not raise ZeroDivisionError under any window set."""
+        windows = self._make_windows()
+        try:
+            result = _metricslib.sprint_low_confidence_ratio([], windows)
+        except ZeroDivisionError as exc:
+            self.fail(f"ZeroDivisionError raised on empty list input: {exc}")
+        self.assertEqual(result["current"], "n/a")
+        self.assertEqual(result["prior"], "n/a")
+
+
+# ---------------------------------------------------------------------------
+# ComputeApiTest — T-06: public compute() API + fixed output surface (AC-07)
+# ---------------------------------------------------------------------------
+
+class ComputeApiTest(unittest.TestCase):
+    """AC-07: compute() public entry point.
+
+    Tests the single callable the /ca:metrics command will invoke.  The function
+    signature is:
+
+        compute(project_dir, window_size=20, *, _timeline=None) -> dict
+
+    Testability seam: the optional keyword-only ``_timeline`` parameter accepts
+    an injected list[datetime] that replaces the ``commit_timeline(project_dir)``
+    git call.  When ``_timeline`` is None (the default), the real git wrapper is
+    called.  This keeps the test suite hermetic while the production code path
+    reads real git — the seam is documented in the function docstring.
+
+    Fixture layout:
+        <tmpdir>/.codearbiter/overrides.log   — two data lines
+        <tmpdir>/.codearbiter/triage.log      — two data lines (LANE: small)
+        <tmpdir>/.codearbiter/sprint-log.md   — one sprint section with markers
+
+    The injected timeline is 40 datetimes starting 2024-01-01 (two full windows
+    of N=20 so both current and prior window indices exist).  All fixture log
+    lines are timestamped inside window 1 (prior) so the current window counts
+    are predictably 0 — but the exact counts don't matter for AC-07; only the
+    key-set and shape assertions matter.
+    """
+
+    # Distinctive raw strings that MUST NOT appear in the json.dumps(result).
+    # These are substrings unique to the fixture log lines that would betray
+    # that a raw log line had leaked into the output dict.
+    _OVERRIDE_RAW_MARKER = "BY: override-actor@example.com"
+    _TRIAGE_RAW_MARKER   = "SCOPE: commit-quality-fixture"
+    _SPRINT_RAW_MARKER   = "Sprint — fixture-sprint"
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the fixture project directory once for the whole class."""
+        import tempfile
+        cls._tmpdir = tempfile.mkdtemp(prefix="ca_metrics_t06_")
+        ca_dir = os.path.join(cls._tmpdir, ".codearbiter")
+        os.makedirs(ca_dir, exist_ok=True)
+
+        # --- Build a timeline: 40 commits starting 2024-01-01, daily.
+        # window 0 (index 0): commits  0-19  ~ 2024-01-01 to 2024-01-20  (prior)
+        # window 1 (index 1): commits 20-39  ~ 2024-01-21 to 2024-02-09  (current)
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        cls._injected_timeline = [
+            start + timedelta(days=i) for i in range(40)
+        ]
+        # window 1 = index 1 = current; window 0 = index 0 = prior
+        # Place fixture log entries inside window 0 (prior) so current==0,
+        # ensuring the assertions are independent of window count.
+        prior_ts = (start + timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        prior_date = (start + timedelta(days=5)).strftime("%Y-%m-%d")
+
+        # overrides.log — two entries in the prior window
+        override_lines = (
+            "# codeArbiter overrides log\n"
+            f"[{prior_ts}] | BY: {cls._OVERRIDE_RAW_MARKER} | "
+            "OVERRIDE: H-02 force-push | REASON: fixture test\n"
+            f"[{prior_ts}] | BY: {cls._OVERRIDE_RAW_MARKER} | "
+            "OVERRIDE: H-02 force-push | REASON: fixture test 2\n"
+        )
+        with open(os.path.join(ca_dir, "overrides.log"), "w", newline="\n",
+                  encoding="utf-8") as fh:
+            fh.write(override_lines)
+
+        # triage.log — two LANE: small entries in the prior window
+        triage_lines = (
+            "# codeArbiter triage log\n"
+            f"[{prior_ts}] | BY: triage-actor@example.com | LANE: small | "
+            f"SCOPE: {cls._TRIAGE_RAW_MARKER} | BASIS: fixture\n"
+            f"[{prior_ts}] | BY: triage-actor@example.com | LANE: small | "
+            f"SCOPE: {cls._TRIAGE_RAW_MARKER} | BASIS: fixture 2\n"
+        )
+        with open(os.path.join(ca_dir, "triage.log"), "w", newline="\n",
+                  encoding="utf-8") as fh:
+            fh.write(triage_lines)
+
+        # sprint-log.md — one section in the prior window with 1 high + 1 low
+        sprint_text = (
+            f"# {cls._SPRINT_RAW_MARKER} · {prior_date}\n"
+            "- Decision A. **high**.\n"
+            "- Decision B. **low**.\n"
+        )
+        with open(os.path.join(ca_dir, "sprint-log.md"), "w", newline="\n",
+                  encoding="utf-8") as fh:
+            fh.write(sprint_text)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the fixture temp directory after all tests in this class."""
+        import shutil
+        shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def _compute(self, **kwargs):
+        """Call compute() with the injected timeline to keep tests hermetic."""
+        return _metricslib.compute(
+            self._tmpdir,
+            _timeline=self._injected_timeline,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # AC-07-1: exact key set — no extras, none missing
+    # ------------------------------------------------------------------
+
+    def test_key_set_is_exactly_three_keys(self):
+        """compute() returns a dict with EXACTLY the three contracted keys."""
+        result = self._compute()
+        self.assertIsInstance(result, dict)
+        self.assertEqual(
+            set(result.keys()),
+            {"override_rate", "small_lane_rate", "sprint_low_conf_ratio"},
+            "compute() must return exactly the three contracted keys",
+        )
+
+    def test_no_extra_keys_in_result(self):
+        """compute() must not return any key beyond the three contracted ones."""
+        result = self._compute()
+        extra = set(result.keys()) - {"override_rate", "small_lane_rate",
+                                       "sprint_low_conf_ratio"}
+        self.assertEqual(extra, set(), f"unexpected extra keys: {extra!r}")
+
+    def test_all_three_contracted_keys_present(self):
+        """compute() must include all three contracted keys — none may be absent."""
+        result = self._compute()
+        for key in ("override_rate", "small_lane_rate", "sprint_low_conf_ratio"):
+            self.assertIn(key, result, f"contracted key {key!r} is missing")
+
+    # ------------------------------------------------------------------
+    # AC-07-3: each sub-result has the current/prior/arrow shape
+    # ------------------------------------------------------------------
+
+    def test_override_rate_has_current_prior_arrow(self):
+        """The override_rate sub-result must have current, prior, and arrow keys."""
+        result = self._compute()
+        sub = result["override_rate"]
+        self.assertIsInstance(sub, dict)
+        for key in ("current", "prior", "arrow"):
+            self.assertIn(key, sub,
+                          f"override_rate sub-result missing key {key!r}")
+
+    def test_small_lane_rate_has_current_prior_arrow(self):
+        """The small_lane_rate sub-result must have current, prior, and arrow keys."""
+        result = self._compute()
+        sub = result["small_lane_rate"]
+        self.assertIsInstance(sub, dict)
+        for key in ("current", "prior", "arrow"):
+            self.assertIn(key, sub,
+                          f"small_lane_rate sub-result missing key {key!r}")
+
+    def test_sprint_low_conf_ratio_has_current_prior_arrow(self):
+        """The sprint_low_conf_ratio sub-result must have current, prior, and arrow keys."""
+        result = self._compute()
+        sub = result["sprint_low_conf_ratio"]
+        self.assertIsInstance(sub, dict)
+        for key in ("current", "prior", "arrow"):
+            self.assertIn(key, sub,
+                          f"sprint_low_conf_ratio sub-result missing key {key!r}")
+
+    def test_arrow_values_are_valid_arrows(self):
+        """Each sub-result arrow must be one of the three defined arrow strings."""
+        result = self._compute()
+        valid = {"↑", "↓", "→"}
+        for metric_key in ("override_rate", "small_lane_rate", "sprint_low_conf_ratio"):
+            arrow = result[metric_key]["arrow"]
+            self.assertIn(arrow, valid,
+                          f"{metric_key}['arrow'] = {arrow!r} is not a valid arrow")
+
+    # ------------------------------------------------------------------
+    # AC-07-2: no raw log line appears in any value (no-raw-line guardrail)
+    # ------------------------------------------------------------------
+
+    def test_no_raw_override_log_line_in_result(self):
+        """The distinctive override log marker must not appear in json.dumps(result).
+
+        This guards against compute() accidentally passing raw log text through
+        instead of only the derived metric dict.
+        """
+        import json
+        result = self._compute()
+        serialised = json.dumps(result, ensure_ascii=False)
+        self.assertNotIn(
+            self._OVERRIDE_RAW_MARKER,
+            serialised,
+            "raw override log line leaked into the compute() result",
+        )
+
+    def test_no_raw_triage_log_line_in_result(self):
+        """The distinctive triage log marker must not appear in json.dumps(result)."""
+        import json
+        result = self._compute()
+        serialised = json.dumps(result, ensure_ascii=False)
+        self.assertNotIn(
+            self._TRIAGE_RAW_MARKER,
+            serialised,
+            "raw triage log line leaked into the compute() result",
+        )
+
+    def test_no_raw_sprint_log_line_in_result(self):
+        """The distinctive sprint-log marker must not appear in json.dumps(result)."""
+        import json
+        result = self._compute()
+        serialised = json.dumps(result, ensure_ascii=False)
+        self.assertNotIn(
+            self._SPRINT_RAW_MARKER,
+            serialised,
+            "raw sprint-log line leaked into the compute() result",
+        )
+
+    def test_no_iso_timestamp_bracket_in_result(self):
+        """No value in the result may contain a raw '[' ISO-8601 timestamp prefix.
+
+        Log lines begin with '[YYYY-' so the substring '[2024-' is unique to
+        raw log lines and must not appear in the serialised metric output.
+        """
+        import json
+        result = self._compute()
+        serialised = json.dumps(result, ensure_ascii=False)
+        self.assertNotIn(
+            "[2024-",
+            serialised,
+            "a raw '[<ISO-timestamp>' log-line prefix leaked into the result",
+        )
+
+    # ------------------------------------------------------------------
+    # Degrade safely: missing .codearbiter dir — never raise
+    # ------------------------------------------------------------------
+
+    def test_missing_codearbiter_dir_does_not_raise(self):
+        """compute() on a dir with no .codearbiter sub-dir must return the sentinel
+        dict with zero counts / 'n/a' — it must never raise."""
+        import tempfile
+        with tempfile.TemporaryDirectory(prefix="ca_metrics_t06_nodotca_") as empty_dir:
+            try:
+                result = _metricslib.compute(
+                    empty_dir,
+                    _timeline=self._injected_timeline,
+                )
+            except Exception as exc:
+                self.fail(
+                    f"compute() raised {type(exc).__name__} on missing "
+                    f".codearbiter dir: {exc}"
+                )
+            # Key-set must still be correct.
+            self.assertEqual(
+                set(result.keys()),
+                {"override_rate", "small_lane_rate", "sprint_low_conf_ratio"},
+            )
+
+    def test_missing_codearbiter_dir_returns_sentinels(self):
+        """compute() with a missing .codearbiter dir returns zero-count / n/a
+        sentinels for all three metrics."""
+        import tempfile
+        with tempfile.TemporaryDirectory(prefix="ca_metrics_t06_sentinels_") as empty_dir:
+            result = _metricslib.compute(
+                empty_dir,
+                _timeline=self._injected_timeline,
+            )
+        self.assertEqual(result["override_rate"]["current"], 0)
+        self.assertEqual(result["override_rate"]["prior"], 0)
+        self.assertEqual(result["small_lane_rate"]["current"], 0)
+        self.assertEqual(result["small_lane_rate"]["prior"], 0)
+        self.assertEqual(result["sprint_low_conf_ratio"]["current"], "n/a")
+        self.assertEqual(result["sprint_low_conf_ratio"]["prior"], "n/a")
+
+    # ------------------------------------------------------------------
+    # Degrade safely: empty injected timeline (no git history)
+    # ------------------------------------------------------------------
+
+    def test_empty_timeline_does_not_raise(self):
+        """compute() with an empty timeline (no git history) must not raise."""
+        try:
+            result = _metricslib.compute(self._tmpdir, _timeline=[])
+        except Exception as exc:
+            self.fail(
+                f"compute() raised {type(exc).__name__} on empty timeline: {exc}"
+            )
+        self.assertEqual(
+            set(result.keys()),
+            {"override_rate", "small_lane_rate", "sprint_low_conf_ratio"},
+        )
+
+    def test_empty_timeline_returns_sentinels(self):
+        """compute() with an empty timeline returns sentinel values for all metrics."""
+        result = _metricslib.compute(self._tmpdir, _timeline=[])
+        self.assertEqual(result["override_rate"]["current"], 0)
+        self.assertEqual(result["override_rate"]["prior"], 0)
+        self.assertEqual(result["small_lane_rate"]["current"], 0)
+        self.assertEqual(result["small_lane_rate"]["prior"], 0)
+        self.assertEqual(result["sprint_low_conf_ratio"]["current"], "n/a")
+        self.assertEqual(result["sprint_low_conf_ratio"]["prior"], "n/a")
+
+    # ------------------------------------------------------------------
+    # window_size parameter is forwarded
+    # ------------------------------------------------------------------
+
+    def test_window_size_parameter_is_accepted(self):
+        """compute() accepts window_size kwarg without raising."""
+        try:
+            result = _metricslib.compute(
+                self._tmpdir,
+                window_size=10,
+                _timeline=self._injected_timeline,
+            )
+        except Exception as exc:
+            self.fail(
+                f"compute() raised {type(exc).__name__} with window_size=10: {exc}"
+            )
+        self.assertEqual(
+            set(result.keys()),
+            {"override_rate", "small_lane_rate", "sprint_low_conf_ratio"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# ReadOnlyTest — T-07: read-only invariant (AC-06)
+# ---------------------------------------------------------------------------
+
+class ReadOnlyTest(unittest.TestCase):
+    """AC-06: compute() leaves every file in .codearbiter/ byte-for-byte unchanged.
+
+    Strategy:
+        1. Build a fixture .codearbiter/ subtree with known byte content in a
+           temporary directory.  Include a nested sub-directory to catch any write
+           that might land in an unexpected location.
+        2. Take a byte-level snapshot BEFORE calling compute(): for every regular
+           file, record its SHA-256 digest (binary read) keyed by its path relative
+           to .codearbiter/.  Also record the set of all paths so that file
+           creation or deletion is also caught.
+        3. Call compute() with an injected _timeline to avoid any git subprocess.
+        4. Take an identical snapshot AFTER the call.
+        5. Assert both snapshots are identical.
+
+    Why the assertion is non-trivial:
+        If compute() (or any function it calls) opened any file for writing —
+        even writing the same bytes back — the open-for-write call on a POSIX or
+        Windows filesystem may truncate and rewrite the file.  On Windows, the
+        file's modification time and other metadata change as well; but more
+        critically: if any byte were added, removed, or changed (e.g. a trailing
+        newline appended to a log), the SHA-256 digest would differ.  If a new
+        file were created (e.g. a cache or lock file), the path set would differ.
+        If an existing file were deleted, the path set would also differ.
+        Either failure mode causes the test to fail — asserting both path-set
+        equality AND per-file hash equality ensures there is no loophole.
+    """
+
+    # Injected timeline: 40 commits starting 2024-01-01 (two full N=20 windows).
+    _TIMELINE_START = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    @classmethod
+    def _injected_timeline(cls):
+        return [cls._TIMELINE_START + timedelta(days=i) for i in range(40)]
+
+    @classmethod
+    def setUpClass(cls):
+        """Build the fixture .codearbiter/ subtree once for the whole class."""
+        import tempfile
+        cls._tmpdir = tempfile.mkdtemp(prefix="ca_metrics_t07_")
+        ca_dir = os.path.join(cls._tmpdir, ".codearbiter")
+        os.makedirs(ca_dir, exist_ok=True)
+
+        # Nested sub-directory — catches any write that might land one level deeper.
+        nested_dir = os.path.join(ca_dir, "nested")
+        os.makedirs(nested_dir, exist_ok=True)
+
+        # Timestamps in the prior window (window index 0: days 0-19 from start).
+        prior_ts = (cls._TIMELINE_START + timedelta(days=5)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        prior_date = (cls._TIMELINE_START + timedelta(days=5)).strftime("%Y-%m-%d")
+
+        # overrides.log — fixed byte content (LF line endings).
+        override_content = (
+            "# codeArbiter overrides log — T-07 fixture\n"
+            f"[{prior_ts}] | BY: readonly-actor@example.com | "
+            "OVERRIDE: H-02 force-push | REASON: readonly fixture test\n"
+        )
+        with open(
+            os.path.join(ca_dir, "overrides.log"), "w", newline="\n", encoding="utf-8"
+        ) as fh:
+            fh.write(override_content)
+
+        # triage.log — fixed byte content (LF line endings).
+        triage_content = (
+            "# codeArbiter triage log — T-07 fixture\n"
+            f"[{prior_ts}] | BY: readonly-actor@example.com | LANE: small | "
+            "SCOPE: readonly-test | BASIS: fixture\n"
+        )
+        with open(
+            os.path.join(ca_dir, "triage.log"), "w", newline="\n", encoding="utf-8"
+        ) as fh:
+            fh.write(triage_content)
+
+        # sprint-log.md — fixed byte content (LF line endings).
+        sprint_content = (
+            f"# Sprint — readonly-fixture · {prior_date}\n"
+            "- Decision A. **high**.\n"
+            "- Decision B. **low**.\n"
+        )
+        with open(
+            os.path.join(ca_dir, "sprint-log.md"), "w", newline="\n", encoding="utf-8"
+        ) as fh:
+            fh.write(sprint_content)
+
+        # nested/notes.txt — a sentinel file one directory deeper.
+        # Its presence extends the path set so a write to the wrong place is caught.
+        nested_content = "nested sentinel file — must not be touched\n"
+        with open(
+            os.path.join(nested_dir, "notes.txt"), "w", newline="\n", encoding="utf-8"
+        ) as fh:
+            fh.write(nested_content)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the fixture temp directory after all tests in the class."""
+        import shutil
+        shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Snapshot helpers
+    # ------------------------------------------------------------------
+
+    def _snapshot(self):
+        """Return a dict mapping relative-path -> sha256 hex digest for every
+        regular file found recursively under <tmpdir>/.codearbiter/.
+
+        Files are read in binary mode so that any byte-level change — including
+        a CRLF/LF difference or a trailing newline append — is captured by the
+        digest.
+
+        The path set is also captured implicitly by the dict's key set.
+        """
+        import hashlib
+
+        ca_dir = os.path.join(self._tmpdir, ".codearbiter")
+        snapshot = {}
+        for dirpath, _dirnames, filenames in os.walk(ca_dir):
+            for fname in filenames:
+                abs_path = os.path.join(dirpath, fname)
+                rel_path = os.path.relpath(abs_path, ca_dir)
+                # Normalise path separators so the dict is OS-agnostic.
+                rel_path = rel_path.replace(os.sep, "/")
+                with open(abs_path, "rb") as fh:
+                    digest = hashlib.sha256(fh.read()).hexdigest()
+                snapshot[rel_path] = digest
+        return snapshot
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_no_file_created_or_deleted(self):
+        """compute() must not create or delete any file under .codearbiter/."""
+        before = self._snapshot()
+        _metricslib.compute(self._tmpdir, _timeline=self._injected_timeline())
+        after = self._snapshot()
+
+        before_paths = set(before.keys())
+        after_paths = set(after.keys())
+
+        created = after_paths - before_paths
+        deleted = before_paths - after_paths
+
+        self.assertEqual(
+            created,
+            set(),
+            f"compute() created unexpected files under .codearbiter/: {sorted(created)}",
+        )
+        self.assertEqual(
+            deleted,
+            set(),
+            f"compute() deleted files from .codearbiter/: {sorted(deleted)}",
+        )
+
+    def test_no_file_bytes_changed(self):
+        """compute() must not modify the byte content of any file under .codearbiter/.
+
+        The SHA-256 digest is compared per file so that even a single-byte change
+        (e.g. an appended newline or CRLF conversion) causes a failure.
+        """
+        before = self._snapshot()
+        _metricslib.compute(self._tmpdir, _timeline=self._injected_timeline())
+        after = self._snapshot()
+
+        # Only compare files present in both snapshots (creation/deletion is
+        # covered by test_no_file_created_or_deleted above).
+        common_paths = set(before.keys()) & set(after.keys())
+        changed = {
+            p for p in common_paths if before[p] != after[p]
+        }
+        self.assertEqual(
+            changed,
+            set(),
+            f"compute() modified byte content of file(s) under .codearbiter/: "
+            f"{sorted(changed)}",
+        )
+
+    def test_full_snapshot_identical(self):
+        """Composite assertion: both path set and all per-file digests must be
+        identical before and after compute() — single-call proof of the invariant.
+
+        This is the primary AC-06 assertion.  The two helper tests above decompose
+        the failure mode for easier diagnosis; this test asserts the combined
+        invariant as the spec states it.
+        """
+        before = self._snapshot()
+        _metricslib.compute(self._tmpdir, _timeline=self._injected_timeline())
+        after = self._snapshot()
+
+        self.assertEqual(
+            before,
+            after,
+            "compute() altered the .codearbiter/ subtree — snapshot mismatch.\n"
+            "Expected: no file created, deleted, or modified.\n"
+            f"Before keys: {sorted(before.keys())}\n"
+            f"After  keys: {sorted(after.keys())}\n"
+            "Changed digests: "
+            + str({p: (before.get(p), after.get(p))
+                   for p in set(before) | set(after)
+                   if before.get(p) != after.get(p)}),
+        )
+
+    def test_nested_file_unchanged(self):
+        """The sentinel file in .codearbiter/nested/ must also be byte-identical
+        after compute(), proving the snapshot covers the full subtree recursively.
+        """
+        import hashlib
+
+        nested_path = os.path.join(
+            self._tmpdir, ".codearbiter", "nested", "notes.txt"
+        )
+        with open(nested_path, "rb") as fh:
+            before_digest = hashlib.sha256(fh.read()).hexdigest()
+
+        _metricslib.compute(self._tmpdir, _timeline=self._injected_timeline())
+
+        with open(nested_path, "rb") as fh:
+            after_digest = hashlib.sha256(fh.read()).hexdigest()
+
+        self.assertEqual(
+            before_digest,
+            after_digest,
+            "compute() modified .codearbiter/nested/notes.txt — "
+            "the nested sentinel file must not be touched.",
+        )
+
+    def test_compute_still_returns_correct_shape_after_snapshot(self):
+        """Sanity check: compute() still returns the three-key dict with the
+        correct shape during the read-only test run (no silent no-op regression).
+        """
+        result = _metricslib.compute(
+            self._tmpdir, _timeline=self._injected_timeline()
+        )
+        self.assertIsInstance(result, dict)
+        self.assertEqual(
+            set(result.keys()),
+            {"override_rate", "small_lane_rate", "sprint_low_conf_ratio"},
+            "compute() must still return all three contracted keys during T-07 run",
+        )
+        for metric_key in ("override_rate", "small_lane_rate", "sprint_low_conf_ratio"):
+            sub = result[metric_key]
+            self.assertIsInstance(sub, dict)
+            for field in ("current", "prior", "arrow"):
+                self.assertIn(
+                    field, sub,
+                    f"{metric_key} sub-dict is missing key {field!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
         # security-controls.md extend/exclude), migration-pass.py content-digest
         # marker, and pre-bash.py H-14 block/admit/edit-reblock/dormant/-a.
         run: python .github/scripts/test_migration_backstop.py
+      - name: Run /ca:metrics helper unit tests
+        # AC-01..AC-07: window tiling, 3-metric collection, empty-source safety,
+        # and read-only enforcement (_metricslib).
+        run: python .github/scripts/test_metrics_lib.py
 
   version-bump:
     name: ca version bumped when payload changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
   `deploy-paths` blocks in `security-controls.md` (same grammar as `migration-paths`); the migration,
   CI, and deploy detectors now share one `path_in_globs` matcher in `_hooklib.py`. Resolves the
   scope-touch half of #73. (#73)
+- **`/ca:metrics` — governance trend glance** (issue #79). Read-only command computing override rate,
+  small-lane rate, and sprint low-confidence ratio over 20-commit windows, each with a direction arrow
+  (↑/↓/→) vs. the prior window. Optional `--window N` to adjust the window size. Bare numbers only —
+  not a second `/ca:audit` packet; writes nothing.
 
 ## [2.4.6] — 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Every intent routes through a gated skill or reviewer agent. Nothing commits unt
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="version 2.4.6" src="https://img.shields.io/badge/version-2.4.6-2b7489">
-<img alt="commands" src="https://img.shields.io/badge/commands-35-555">
+<img alt="commands" src="https://img.shields.io/badge/commands-36-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">
 <img alt="license MIT" src="https://img.shields.io/badge/license-MIT-3da639">
@@ -240,9 +240,10 @@ Every intent flows through a command; direct off-channel instructions get redire
 | <kbd>/ca:adr "title"</kbd> | Author a numbered, user-attributed Architecture Decision Record. |
 | <kbd>/ca:status</kbd> | Stage, open tasks, unresolved `CONFIRM-NN`, overrides since checkpoint. |
 | <kbd>/ca:audit</kbd> | One command, one packet: every commit, override, ADR, and autonomous decision in a window, with attribution: the document an auditor actually asks for. |
+| <kbd>/ca:metrics</kbd> | Read-only trend glance: override rate, small-lane rate, and sprint low-confidence ratio, each with a direction arrow vs. the prior 20-commit window. |
 
 <details>
-<summary><b>The full catalog</b>: 35 commands</summary>
+<summary><b>The full catalog</b>: 36 commands</summary>
 
 <br>
 
@@ -296,6 +297,7 @@ Every intent flows through a command; direct off-channel instructions get redire
 | `/ca:btw "question"` | Lightweight Q&amp;A; no state change |
 | `/ca:override "reason"` | Sanctioned, logged single-identity gate bypass |
 | `/ca:audit [range]` | Assemble the governance packet for a window into `.codearbiter/audits/`; read-only |
+| `/ca:metrics [--window N]` | Read-only trend glance: override rate, small-lane rate, sprint low-confidence ratio, each with a direction arrow vs. the prior 20-commit window |
 | `/ca:prune [status\|dry\|run\|audit\|on\|off]` | Trim transcript clutter to extend session lifetime; dry-run by default, gains land at resume/compaction |
 | `/ca:commands` | Show the catalog |
 
@@ -318,7 +320,7 @@ plugins/ca/                         the plugin (CLAUDE_PLUGIN_ROOT)
 ├── ORCHESTRATOR.md                 always-on persona, injected by the SessionStart hook
 ├── COMMANDS.md                     command catalog (+ user-facing glossary)
 ├── SPRINT.md                       /ca:sprint mode body — the autonomous-sprint procedure
-├── commands/   (35)   skills/   (20)   agents/   (15)
+├── commands/   (36)   skills/   (20)   agents/   (15)
 ├── includes/                       routing-table · reference-map · redirect · farm setup (loaded on demand)
 ├── hooks/                          session-start (activation linchpin) · pre/post gates · statusline → docs/hooks.md
 └── tools/                          farm dispatcher (farm.js + TypeScript source and tests)

--- a/plugins/ca/COMMANDS.md
+++ b/plugins/ca/COMMANDS.md
@@ -54,6 +54,7 @@ context docs disagree about the architecture) and you want each variance arbitra
 | `/ca:init` | `[--stage N \| --check]` | Scaffold the root-level `.codearbiter/` state store, or `--check` to report detection state without writing. |
 | `/ca:status` | _(none)_ | Show maturity, open tasks, unresolved `CONFIRM-NN`, overrides since checkpoint. |
 | `/ca:audit` | `[range]` | Assemble the governance packet for a window — commits, overrides, ADRs, sprint decisions, open items — into `.codearbiter/audits/`. Read-only. |
+| `/ca:metrics` | `[--window N]` | Read-only governance trend glance: override rate, small-lane rate, sprint low-confidence ratio, each with a direction arrow vs. the prior 20-commit window. Not a second `/ca:audit` packet. |
 | `/ca:statusline` | `install \| uninstall \| status` | Install/wire the codeArbiter statusline, remove it, or report its state. |
 | `/ca:prune` | `status \| dry \| run <path> \| audit <path> \| on \| off` | Trim transcript clutter to extend session lifetime. Dry-run by default; gains land on resume/compaction, not the live turn. |
 | `/ca:doctor` | _(none)_ | Verify the install is enforcing: interpreter, payload, cache staleness, repo state, live-fire hook probe. |

--- a/plugins/ca/commands/metrics.md
+++ b/plugins/ca/commands/metrics.md
@@ -1,0 +1,75 @@
+---
+description: Read-only 3-metric governance glance — override rate, small-lane rate, sprint low-confidence ratio — each with a trend arrow vs. the prior 20-commit window.
+argument-hint: "[--window N]"
+---
+
+# /ca:metrics — governance trend glance
+
+A bare-numbers summary of the three governance-health metrics that `_metricslib.py`
+tracks across commit windows. Each metric shows its value for the **current** 20-commit
+window and a direction arrow (↑/↓/→) relative to the immediately preceding window.
+
+This is NOT a second `/ca:audit` packet. It prints numbers and arrows only — no
+verbatim override lines, no commit list, no file write. Use it to spot a trend at a
+glance; reach for `/ca:audit` when you need the full evidentiary packet.
+
+## Flow
+
+1. **Invoke the helper.** Call `compute` from `_metricslib.py` via a Windows-safe
+   `python3 … || python …` fallback one-liner. Pass `${CLAUDE_PROJECT_DIR}` as the
+   project root. If `--window N` was supplied, pass `N` as `window_size`; otherwise
+   use the default (20).
+
+   ```
+   python3 -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}')))" || python -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}')))"
+   ```
+
+   > **`ensure_ascii` note — do not remove this.** The one-liner uses `json.dumps`
+   > with its default `ensure_ascii=True`. This ASCII-escapes the arrow glyphs
+   > (↑↓→) in the subprocess stdout, which avoids a `UnicodeEncodeError` on Windows
+   > `cp1252` consoles that cannot encode those code-points raw. The rendered output
+   > you present to the user (step 2 below) uses the real glyphs — they are written
+   > by the assistant, not piped through the subprocess stdout. Do NOT add
+   > `ensure_ascii=False` here.
+
+   With a custom window size:
+   ```
+   python3 -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}', window_size=N)))" || python -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}', window_size=N)))"
+   ```
+   Replace `N` with the integer the user supplied.
+
+2. **Render the glance.** Parse the returned JSON dict. Present exactly three lines,
+   one per metric, in this order:
+
+   ```
+   override rate:          <current>  <arrow>  (prior: <prior>)
+   small-lane rate:        <current>  <arrow>  (prior: <prior>)
+   sprint low-conf ratio:  <current>  <arrow>  (prior: <prior>)
+   ```
+
+   - Use the real glyphs ↑, ↓, → in your message (not the JSON-escaped forms).
+   - For `sprint_low_conf_ratio`, the `current` or `prior` value may be the string
+     `"n/a"` — render it literally (e.g. `n/a ↑`).
+   - ↑ on `override_rate` and `sprint_low_conf_ratio` is a worsening signal; state
+     this briefly below the table so the reader does not have to guess.
+
+3. **State the window.** Append one line naming the window size used, e.g.
+   `Window: 20 commits (default)` or `Window: N commits (--window N)`.
+
+## Hard gate
+
+- Read-only. MUST NOT write, create, or modify any file. MUST NOT stage or commit.
+  `git status` MUST be unchanged after a run.
+- Emits ONLY the fixed 3-metric glance: `override_rate`, `small_lane_rate`,
+  `sprint_low_conf_ratio`. MUST NOT emit verbatim override log lines, verbatim
+  triage entries, commit lists, or any other content from the governance logs.
+- MUST NOT require `/ca:init` to have been run. The helper degrades gracefully on
+  absent logs (counts return 0 / ratio returns `"n/a"`); surface the degraded
+  values as-is rather than blocking.
+- If the helper subprocess fails entirely (import error, Python not found), report
+  the error and stop — do not fabricate metric values.
+
+## When NOT to use
+
+- Full governance packet with verbatim overrides and audit trail → `/ca:audit`.
+- Live project state (active sprint, open confirms, hook health) → `/ca:status`.

--- a/plugins/ca/hooks/_metricslib.py
+++ b/plugins/ca/hooks/_metricslib.py
@@ -1,0 +1,707 @@
+#!/usr/bin/env python3
+# codeArbiter — metrics helper foundation (T-01 + T-02, /ca:metrics).
+#
+# Builds the window-tiling layer for governance-log trend computation. Governance
+# history is tiled into commit-count windows of N=20 commits (default, parameterized).
+# Each log entry will later be mapped into a window by its ISO-8601 timestamp.
+#
+# Design principles (mirroring _previewlib.py / _prunelib.py):
+#   - Stdlib only; no third-party imports ever — runs on stock Python.
+#   - Zero side effects at import time: no git calls, no file I/O.
+#   - Pure functions are fully testable with synthetic data (no real git needed).
+#   - The thin git wrapper (commit_timeline) is the ONLY function that shells out.
+#
+# Public API (T-01 scope — window tiling):
+#   tile_windows(timestamps, window_size=20) -> list[WindowBand]
+#   map_to_window(timestamp, windows) -> int   (window index or BEFORE_HISTORY)
+#   commit_timeline(root) -> list[datetime]     (git wrapper, not unit-tested)
+#   BEFORE_HISTORY: int = -1                   (sentinel for pre-history timestamps)
+#
+# Public API (T-02 scope — override-rate metric):
+#   override_rate(lines_or_text, windows) -> dict with keys: current, prior, arrow
+#   read_override_log(path) -> list[str]        (thin file reader, not unit-tested)
+#
+# Public API (T-03 scope — small-lane-rate metric):
+#   small_lane_rate(lines_or_text, windows) -> dict with keys: current, prior, arrow
+#   read_triage_log(path) -> list[str]          (thin file reader, not unit-tested)
+#
+# Public API (T-04 scope — sprint low-confidence ratio):
+#   sprint_low_confidence_ratio(lines_or_text, windows) -> dict: current, prior, arrow
+#   read_sprint_log(path) -> str                (thin file reader, not unit-tested)
+#
+# [NEEDS-TRIAGE] Later tasks will add the public compute() API, the /ca:metrics
+# command file, and command registration in plugin.json — none of that is
+# implemented here.
+
+import subprocess
+from collections import namedtuple
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Default commit-count window size (parameterized on every call).
+DEFAULT_WINDOW_SIZE = 20
+
+# Sentinel returned by map_to_window when the timestamp precedes the entire
+# known history. Negative so it can never be confused with a valid window index.
+BEFORE_HISTORY = -1
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+# One window band as produced by tile_windows.
+#
+# Fields:
+#   index    — 0-based integer; 0 = oldest, highest = most recent ("current").
+#   start_dt — timezone-aware UTC datetime of the first (oldest) commit in the band.
+#   end_dt   — timezone-aware UTC datetime of the last  (newest) commit in the band.
+#
+# Window semantics: consecutive commit-count groups of `window_size` commits.
+# When M commits are not evenly divisible by N, the OLDEST group is partial
+# (smaller than N). All subsequent groups are full-size. This keeps the most
+# recent window always "full" — the current window is never artificially short.
+WindowBand = namedtuple("WindowBand", ["index", "start_dt", "end_dt"])
+
+# ---------------------------------------------------------------------------
+# ISO-8601 parsing
+# ---------------------------------------------------------------------------
+
+def _parse_ts(ts):
+    """Accept either a timezone-aware datetime or an ISO-8601 string with
+    trailing Z (e.g. '2026-06-14T02:06:45Z') and always return a
+    timezone-aware UTC datetime.
+
+    Raises ValueError on unrecognised string format.
+    Raises TypeError on values that are neither str nor datetime.
+    """
+    if isinstance(ts, datetime):
+        if ts.tzinfo is None:
+            # Treat naive datetimes as UTC for robustness; caller should pass
+            # aware datetimes.  [NEEDS-TRIAGE] — consider rejecting naive
+            # datetimes once the call-sites are fully settled.
+            return ts.replace(tzinfo=timezone.utc)
+        return ts
+    if isinstance(ts, str):
+        # The governance logs emit '2026-06-14T02:06:45Z'. Python 3.11+
+        # fromisoformat handles the Z suffix, but earlier 3.x versions do not,
+        # so we normalise the Z to +00:00 for broad compatibility.
+        normalised = ts.rstrip()
+        if normalised.endswith("Z"):
+            normalised = normalised[:-1] + "+00:00"
+        return datetime.fromisoformat(normalised)
+    raise TypeError(f"timestamp must be a datetime or ISO-8601 str, got {type(ts)!r}")
+
+# ---------------------------------------------------------------------------
+# Pure function: tile_windows
+# ---------------------------------------------------------------------------
+
+def tile_windows(timestamps, window_size=DEFAULT_WINDOW_SIZE):
+    """Tile a commit timeline into consecutive commit-count windows.
+
+    Args:
+        timestamps: ordered (oldest → newest) list of timezone-aware datetimes
+                    OR ISO-8601 strings ending in Z.  Empty list is accepted.
+        window_size: number of commits per full window (default 20, must be >= 1).
+
+    Returns:
+        list of WindowBand in ascending index order (index 0 = oldest).
+        Empty list when `timestamps` is empty.
+
+    Partial-window rule:
+        When len(timestamps) % window_size != 0, the OLDEST window is the
+        partial (smaller) group.  All windows from index 1 onward are full-size.
+        Example: 45 commits, N=20 → window 0 has 5 commits (partial/oldest),
+        window 1 has 20, window 2 has 20.
+    """
+    if window_size < 1:
+        raise ValueError(f"window_size must be >= 1, got {window_size!r}")
+
+    parsed = [_parse_ts(t) for t in timestamps]
+    m = len(parsed)
+    if m == 0:
+        return []
+
+    # Compute the size of the (possibly partial) oldest group.
+    remainder = m % window_size
+    oldest_size = remainder if remainder != 0 else window_size
+
+    # Build slices: [oldest_group] + [full groups...]
+    # The oldest group starts at index 0 in the parsed list.
+    groups = []
+    pos = 0
+    # First group (partial when remainder != 0, full when m % window_size == 0)
+    groups.append(parsed[pos: pos + oldest_size])
+    pos += oldest_size
+    # Remaining full-size groups
+    while pos < m:
+        groups.append(parsed[pos: pos + window_size])
+        pos += window_size
+
+    return [
+        WindowBand(index=i, start_dt=grp[0], end_dt=grp[-1])
+        for i, grp in enumerate(groups)
+    ]
+
+# ---------------------------------------------------------------------------
+# Pure function: map_to_window
+# ---------------------------------------------------------------------------
+
+def map_to_window(timestamp, windows):
+    """Map a single timestamp to a window index.
+
+    Boundary semantics (half-open intervals, higher-index wins at boundaries):
+        A timestamp T maps to the highest-index window whose start_dt <= T.
+        Concretely: if T >= windows[i].start_dt for multiple i, the largest
+        such i is returned.  This ensures a timestamp exactly equal to a
+        window-boundary commit date maps to the more-recent (higher-index) window.
+
+    Args:
+        timestamp: timezone-aware datetime OR ISO-8601 Z string.
+        windows:   list of WindowBand from tile_windows (may be empty).
+
+    Returns:
+        int — the matching window index (0-based), or BEFORE_HISTORY (-1)
+        when `timestamp` precedes all windows or `windows` is empty.
+
+    Never raises on valid input.
+    """
+    if not windows:
+        return BEFORE_HISTORY
+
+    ts = _parse_ts(timestamp)
+
+    # Walk from the most-recent window downward; return the first whose
+    # start_dt <= ts.  This implements "highest-index wins at a boundary".
+    for band in reversed(windows):
+        if ts >= band.start_dt:
+            return band.index
+
+    # ts is older than every window's start_dt
+    return BEFORE_HISTORY
+
+# ---------------------------------------------------------------------------
+# Git wrapper: commit_timeline (thin shell; NOT unit-tested with real git)
+# ---------------------------------------------------------------------------
+
+def commit_timeline(root):
+    """Return a list of timezone-aware UTC datetimes for every commit in the
+    repository at `root`, ordered oldest → newest.
+
+    Shells out to `git log --format=%cI --reverse` (ISO-8601 strict format,
+    with timezone offset).  Returns an empty list if git is unavailable, if
+    `root` is not a git repository, or if any other error occurs — callers
+    must not assume a non-empty return.
+
+    This wrapper is intentionally thin: it exists only to bridge the git
+    boundary and feed the pure tile_windows / map_to_window functions with
+    real commit data.  It is NOT unit-tested with real git; the pure functions
+    carry all the testable contract.
+
+    Args:
+        root: absolute path to a git repository root (or any worktree path).
+
+    Returns:
+        list[datetime] — timezone-aware UTC datetimes, oldest first.
+        Empty list on any error.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "--format=%cI", "--reverse"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+    except Exception:  # noqa: BLE001 — missing git binary, timeout, etc.
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    datetimes = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            datetimes.append(_parse_ts(line))
+        except (ValueError, TypeError):
+            # Malformed git output line — skip rather than crash.
+            continue
+    return datetimes
+
+# ---------------------------------------------------------------------------
+# Pure function: override_rate  (T-02)
+# ---------------------------------------------------------------------------
+
+# Regex to extract the leading timestamp from an overrides.log data line.
+# Format: [<ISO-8601-Z>] | BY: ...
+# Only the timestamp portion inside the first [...] is captured.
+import re as _re
+_OVERRIDE_TS_RE = _re.compile(r"^\[([^\]]+)\]")
+
+
+def override_rate(lines_or_text, windows):
+    """Compute the override rate for the current and prior windows.
+
+    Parses overrides.log content, maps each entry to a window, and returns
+    counts for the most-recent (current) window and the preceding (prior) window,
+    together with a trend arrow.
+
+    Args:
+        lines_or_text: either a list of strings (one per log line) or a single
+                       multi-line string.  Both forms are accepted so that callers
+                       can pass raw file text or pre-split lines with equal ease.
+        windows:       list of WindowBand from tile_windows (may be empty).
+
+    Returns:
+        dict with keys:
+            "current" (int)  — count of override entries mapped to the current
+                               window (highest index in `windows`).
+            "prior"   (int)  — count mapped to the prior window (current − 1),
+                               or 0 when fewer than 2 windows exist.
+            "arrow"   (str)  — "↑" if current > prior, "↓" if current < prior,
+                               "→" if equal.
+
+    Filtering rules:
+        - Lines that start with "#" (after stripping leading whitespace) are
+          comment lines and are excluded.
+        - Blank and whitespace-only lines are excluded.
+        - Entries whose parsed timestamp maps to BEFORE_HISTORY are excluded
+          from all window counts.
+    """
+    # Normalise input: accept either a str block or an iterable of strings.
+    if isinstance(lines_or_text, str):
+        raw_lines = lines_or_text.splitlines()
+    else:
+        raw_lines = list(lines_or_text)
+
+    # Determine current and prior window indices.
+    if windows:
+        current_idx = windows[-1].index
+        prior_idx = current_idx - 1 if len(windows) >= 2 else None
+    else:
+        current_idx = None
+        prior_idx = None
+
+    current_count = 0
+    prior_count = 0
+
+    for raw in raw_lines:
+        line = raw.strip()
+        # Skip blank lines and comment lines.
+        if not line or line.startswith("#"):
+            continue
+
+        # Extract the leading timestamp token "[<ts>]".
+        m = _OVERRIDE_TS_RE.match(line)
+        if not m:
+            # No recognisable timestamp; skip rather than crash.
+            continue
+
+        ts_str = m.group(1).strip()
+        try:
+            window_idx = map_to_window(ts_str, windows)
+        except (ValueError, TypeError):
+            # Malformed timestamp in log line; skip.
+            continue
+
+        if window_idx == BEFORE_HISTORY:
+            continue
+        if window_idx == current_idx:
+            current_count += 1
+        elif prior_idx is not None and window_idx == prior_idx:
+            prior_count += 1
+        # Entries in older windows (index < prior_idx) are intentionally ignored;
+        # they contribute to neither current nor prior.
+
+    if current_count > prior_count:
+        arrow = "↑"  # ↑
+    elif current_count < prior_count:
+        arrow = "↓"  # ↓
+    else:
+        arrow = "→"  # →
+
+    return {"current": current_count, "prior": prior_count, "arrow": arrow}
+
+
+# ---------------------------------------------------------------------------
+# Pure function: small_lane_rate  (T-03)
+# ---------------------------------------------------------------------------
+
+# Match "LANE: small" as a field value — the pipe-delimited field must read
+# exactly "LANE: small" (not "LANE: smallX" or "LANE: full").
+# We look for the literal token after optional surrounding whitespace.
+_SMALL_LANE_RE = _re.compile(r"\|\s*LANE:\s*small\s*(?:\||$)")
+
+
+def small_lane_rate(lines_or_text, windows):
+    """Compute the small-lane rate for the current and prior windows.
+
+    Parses triage.log content, counts only entries containing 'LANE: small',
+    maps each to a window, and returns counts for the most-recent (current)
+    window and the preceding (prior) window, together with a trend arrow.
+
+    triage.log line format (non-comment):
+        [<ISO-8601 Z timestamp>] | BY: <actor> | LANE: small | SCOPE: ... | BASIS: ...
+
+    Args:
+        lines_or_text: either a list of strings (one per log line) or a single
+                       multi-line string.
+        windows:       list of WindowBand from tile_windows (may be empty).
+
+    Returns:
+        dict with keys:
+            "current" (int)  — count of LANE: small entries mapped to the
+                               current window (highest index in `windows`).
+            "prior"   (int)  — count mapped to the prior window (current - 1),
+                               or 0 when fewer than 2 windows exist.
+            "arrow"   (str)  — "↑" if current > prior, "↓" if current < prior,
+                               "→" if equal.
+
+    Filtering rules:
+        - Lines that start with "#" (after stripping leading whitespace) are
+          comment lines and are excluded.
+        - Blank and whitespace-only lines are excluded.
+        - Lines that do NOT contain 'LANE: small' are excluded (e.g. LANE: full).
+        - Entries whose parsed timestamp maps to BEFORE_HISTORY are excluded
+          from all window counts.
+    """
+    # Normalise input: accept either a str block or an iterable of strings.
+    if isinstance(lines_or_text, str):
+        raw_lines = lines_or_text.splitlines()
+    else:
+        raw_lines = list(lines_or_text)
+
+    # Determine current and prior window indices.
+    if windows:
+        current_idx = windows[-1].index
+        prior_idx = current_idx - 1 if len(windows) >= 2 else None
+    else:
+        current_idx = None
+        prior_idx = None
+
+    current_count = 0
+    prior_count = 0
+
+    for raw in raw_lines:
+        line = raw.strip()
+        # Skip blank lines and comment lines.
+        if not line or line.startswith("#"):
+            continue
+
+        # Only count lines that contain the exact field 'LANE: small'.
+        if not _SMALL_LANE_RE.search(line):
+            continue
+
+        # Extract the leading timestamp token "[<ts>]".
+        m = _OVERRIDE_TS_RE.match(line)
+        if not m:
+            # No recognisable timestamp; skip rather than crash.
+            continue
+
+        ts_str = m.group(1).strip()
+        try:
+            window_idx = map_to_window(ts_str, windows)
+        except (ValueError, TypeError):
+            # Malformed timestamp in log line; skip.
+            continue
+
+        if window_idx == BEFORE_HISTORY:
+            continue
+        if window_idx == current_idx:
+            current_count += 1
+        elif prior_idx is not None and window_idx == prior_idx:
+            prior_count += 1
+        # Entries in older windows (index < prior_idx) are intentionally
+        # ignored; they contribute to neither current nor prior.
+
+    if current_count > prior_count:
+        arrow = "↑"  # ↑
+    elif current_count < prior_count:
+        arrow = "↓"  # ↓
+    else:
+        arrow = "→"  # →
+
+    return {"current": current_count, "prior": prior_count, "arrow": arrow}
+
+
+# ---------------------------------------------------------------------------
+# Thin file reader: read_triage_log  (T-03, not unit-tested)
+# ---------------------------------------------------------------------------
+
+def read_triage_log(path):
+    """Read triage.log from `path` and return its lines as a list of strings.
+
+    This is the only function in T-03 that performs file I/O.  It is kept
+    intentionally thin — callers pass the result to the pure small_lane_rate()
+    function for all business logic.
+
+    Returns an empty list if the file does not exist or cannot be read.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return fh.readlines()
+    except OSError:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Thin file reader: read_override_log  (T-02, not unit-tested)
+# ---------------------------------------------------------------------------
+
+def read_override_log(path):
+    """Read overrides.log from `path` and return its lines as a list of strings.
+
+    This is the only function in T-02 that performs file I/O.  It is kept
+    intentionally thin — callers pass the result to the pure override_rate()
+    function for all business logic.
+
+    Returns an empty list if the file does not exist or cannot be read.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return fh.readlines()
+    except OSError:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Pure function: sprint_low_confidence_ratio  (T-04)
+# ---------------------------------------------------------------------------
+
+# Match a sprint-section header and capture the YYYY-MM-DD date.
+# Handles both "# Sprint — name · YYYY-MM-DD" and "# Sprint: name · YYYY-MM-DD".
+# The date must follow a " · " (space-middot-space) separator anywhere in the
+# header line.  Other "# Sprint …" headers without this pattern produce no match
+# and their markers are excluded (documented below).
+_SPRINT_HEADER_RE = _re.compile(r"^#\s+Sprint[^\n]*·\s*(\d{4}-\d{2}-\d{2})")
+
+# Match exactly the bold tokens **high** and **low** (case-sensitive).
+# The pattern anchors on the literal ** delimiters, so **strong**, **moderate**,
+# **weak**, **medium**, **D-01**, etc. cannot match.
+_CONFIDENCE_MARKER_RE = _re.compile(r"\*\*(high|low)\*\*")
+
+
+def sprint_low_confidence_ratio(lines_or_text, windows):
+    """Compute the sprint low-confidence ratio for the current and prior windows.
+
+    Scans sprint-log.md content for SMARTS confidence markers.  Only the literal
+    bold tokens ``**high**`` and ``**low**`` are counted — confidence markers only.
+    All other bold tokens, including the SMARTS strength words (``**strong**``,
+    ``**moderate**``, ``**weak**``) and ``**medium**``, are explicitly excluded.
+
+    Each marker is attributed to the sprint section it appears in.  A section
+    begins at a header matching::
+
+        # Sprint[...] · YYYY-MM-DD
+
+    and extends until the next such header (or end-of-text).  The header date is
+    parsed as midnight UTC and mapped to a window via ``map_to_window``.  Markers
+    in sections whose header contains no parseable date are excluded entirely
+    (never mapped, never counted).
+
+    Args:
+        lines_or_text: either a list of strings (one per line) or a single
+                       multi-line string.  Both forms are accepted.
+        windows:       list of WindowBand from tile_windows (may be empty).
+
+    Returns:
+        dict with keys:
+            "current" — ``round(L/(L+H), 2)`` for the current (highest-index)
+                        window, or the sentinel string ``"n/a"`` when ``L+H == 0``
+                        in that window.
+            "prior"   — same for the prior window (current − 1); ``"n/a"`` when
+                        no prior window exists or its ``L+H == 0``.
+            "arrow"   — ``"↑"`` if current > prior, ``"↓"`` if current < prior,
+                        ``"→"`` if equal.  When EITHER ``current`` or ``prior``
+                        is the ``"n/a"`` sentinel, ``arrow`` is always ``"→"``.
+
+    Exclusion rules (documented):
+        - Sections with no parseable date in their header: markers excluded.
+        - ``**medium**`` tokens: excluded (neither high nor low).
+        - ``**strong**``, ``**moderate**``, ``**weak**`` and all other bold
+          tokens: excluded (different SMARTS axis).
+        - Markers mapping to BEFORE_HISTORY: excluded (older than all windows).
+    """
+    # Normalise input.
+    if isinstance(lines_or_text, str):
+        raw_lines = lines_or_text.splitlines()
+    else:
+        raw_lines = list(lines_or_text)
+
+    # Determine the current and prior window indices.
+    if windows:
+        current_idx = windows[-1].index
+        prior_idx = current_idx - 1 if len(windows) >= 2 else None
+    else:
+        current_idx = None
+        prior_idx = None
+
+    # Accumulate high/low counts per window index.
+    # Keys: window index (int).  Values: [low_count, high_count].
+    counts = {}  # {window_idx: [low, high]}
+
+    # Walk lines, tracking which window the current sprint section belongs to.
+    # section_window_idx: the window index for the active sprint section,
+    # or None when no section is active (or the last header had no parseable date).
+    section_window_idx = None
+
+    for raw in raw_lines:
+        line = raw.rstrip("\n").rstrip("\r")
+
+        # Check whether this line starts a new sprint-section header.
+        m_header = _SPRINT_HEADER_RE.match(line)
+        if m_header:
+            date_str = m_header.group(1)
+            try:
+                # Treat the sprint date as midnight UTC.
+                dt = datetime.strptime(date_str, "%Y-%m-%d").replace(
+                    tzinfo=timezone.utc
+                )
+                window_idx = map_to_window(dt, windows)
+            except (ValueError, TypeError):
+                # Malformed date — exclude this section's markers.
+                section_window_idx = None
+                continue
+
+            if window_idx == BEFORE_HISTORY:
+                # Predates all windows; exclude this section.
+                section_window_idx = None
+            else:
+                section_window_idx = window_idx
+            continue
+
+        # Not a sprint header: scan for confidence markers if inside a dated section.
+        if section_window_idx is None:
+            continue
+
+        for m_marker in _CONFIDENCE_MARKER_RE.finditer(line):
+            token = m_marker.group(1)  # "high" or "low"
+            bucket = counts.setdefault(section_window_idx, [0, 0])
+            if token == "low":
+                bucket[0] += 1
+            else:  # "high"
+                bucket[1] += 1
+
+    # Compute ratio for a given window index.
+    def _ratio(idx):
+        if idx is None or idx not in counts:
+            return "n/a"
+        low_c, high_c = counts[idx]
+        total = low_c + high_c
+        if total == 0:
+            return "n/a"
+        return round(low_c / total, 2)
+
+    current_val = _ratio(current_idx)
+    prior_val = _ratio(prior_idx)
+
+    # Arrow: "→" when either value is the sentinel string (no numeric comparison).
+    if current_val == "n/a" or prior_val == "n/a":
+        arrow = "→"  # →
+    elif current_val > prior_val:
+        arrow = "↑"  # ↑
+    elif current_val < prior_val:
+        arrow = "↓"  # ↓
+    else:
+        arrow = "→"  # →
+
+    return {"current": current_val, "prior": prior_val, "arrow": arrow}
+
+
+# ---------------------------------------------------------------------------
+# Thin file reader: read_sprint_log  (T-04, not unit-tested)
+# ---------------------------------------------------------------------------
+
+def read_sprint_log(path):
+    """Read sprint-log.md from `path` and return its text as a single string.
+
+    This is the only function in T-04 that performs file I/O.  It is kept
+    intentionally thin — callers pass the result to the pure
+    sprint_low_confidence_ratio() function for all business logic.
+
+    Returns an empty string if the file does not exist or cannot be read.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point: compute()  (T-06 — AC-07)
+# ---------------------------------------------------------------------------
+
+import os as _os
+
+
+def compute(project_dir, window_size=DEFAULT_WINDOW_SIZE, *, _timeline=None):
+    """Compute all three governance metrics for `project_dir` and return them.
+
+    This is the single public entry point the ``/ca:metrics`` command calls.
+    It ties the window-tiling, log-reading, and metric-computation layers
+    together and returns a fixed-surface dict.
+
+    Args:
+        project_dir: absolute path to the project root (the directory that
+                     contains ``.codearbiter/``).  The git repository at this
+                     path (or any of its parents) is used for the commit
+                     timeline when ``_timeline`` is not supplied.
+        window_size: number of commits per window (default 20).
+        _timeline:   [testability seam] optional list[datetime] injected in
+                     place of ``commit_timeline(project_dir)``.  When None
+                     (the default), the real git wrapper is called.  Tests
+                     pass a synthetic timeline to keep the suite hermetic.
+                     This parameter is keyword-only and intentionally not part
+                     of the public /ca:metrics API surface — callers should
+                     omit it.
+
+    Returns:
+        dict with EXACTLY these three keys and no others:
+            "override_rate"       — result of override_rate(...)
+            "small_lane_rate"     — result of small_lane_rate(...)
+            "sprint_low_conf_ratio" — result of sprint_low_confidence_ratio(...)
+
+        Each sub-value is a dict with keys "current", "prior", "arrow".
+
+    Degradation contract:
+        The function is READ-ONLY.  It never writes, creates, or modifies any
+        file.  On any missing resource (logs absent, .codearbiter/ not found,
+        git unavailable, etc.) the affected sub-metric returns its sentinel
+        (counts 0 / ratio "n/a") and the function never raises.
+    """
+    # -- Step 1: build the commit timeline and tile it into windows.
+    # The injected _timeline seam replaces the git call when testing.
+    try:
+        if _timeline is not None:
+            timeline = list(_timeline)
+        else:
+            timeline = commit_timeline(project_dir)
+        windows = tile_windows(timeline, window_size=window_size)
+    except Exception:  # noqa: BLE001 — never crash regardless of git state
+        windows = []
+
+    # -- Step 2: resolve log paths under <project_dir>/.codearbiter/
+    ca_dir = _os.path.join(project_dir, ".codearbiter")
+    override_path = _os.path.join(ca_dir, "overrides.log")
+    triage_path   = _os.path.join(ca_dir, "triage.log")
+    sprint_path   = _os.path.join(ca_dir, "sprint-log.md")
+
+    # -- Step 3: read each log (thin readers degrade to empty on missing files).
+    override_lines = read_override_log(override_path)
+    triage_lines   = read_triage_log(triage_path)
+    sprint_text    = read_sprint_log(sprint_path)
+
+    # -- Step 4: compute the three metrics and assemble the fixed output dict.
+    return {
+        "override_rate":        override_rate(override_lines, windows),
+        "small_lane_rate":      small_lane_rate(triage_lines, windows),
+        "sprint_low_conf_ratio": sprint_low_confidence_ratio(sprint_text, windows),
+    }


### PR DESCRIPTION
## What & why

The append-only audit trail (`overrides.log`, `triage.log`, `sprint-log.md`) was only ever **listed or snapshotted** — never trended. A lead couldn't tell at a glance whether governance discipline was holding or eroding. This adds a read-only `/ca:metrics` command that answers exactly that in <10s.

## What it does

A stdlib helper `plugins/ca/hooks/_metricslib.py` tiles git history into **20-commit windows** (overridable `--window N`) and computes three single-number trends, each with a direction arrow (↑/↓/→) vs. the immediately prior window:

| Metric | Source | ↑ means |
|--------|--------|---------|
| Override rate | `overrides.log` | worse |
| Small-lane rate | `triage.log` | — |
| Sprint low-confidence ratio | `sprint-log.md` | worse |

Bare numbers + arrows only — **not a second `/ca:audit` packet**; writes nothing, no network. Live on this branch: `override 0 →`, `small-lane 0 ↓ (prior 1)`, `sprint 0.0 → (prior n/a)`.

## Deliberately scoped out (recorded as future work)

Two metrics from issue #79 were dropped as **un-instrumented**, not implemented blindly:
- A true small-lane **share** (small ÷ total triaged) needs `/ca:feature` to also log full-lane classifications — a producer change in another command.
- A "where does arbiter stop bad things" **caught-by-gate** trend needs a gate-catch event log that doesn't exist today (nothing records a gate blocking-and-holding).

Both are `[NEEDS-TRIAGE]` notes in the spec, not silently swallowed.

## Notes

- **No version bump**: `2.5.0` is untagged (latest tag `v2.4.6`), so the CHANGELOG entry rides the existing unreleased section; `plugin.json` unchanged.
- **CI**: `test_metrics_lib.py` (98 tests) wired into the unconditional hooks job; `check-plugin-refs` rule D satisfied (cataloged in `COMMANDS.md`); README badge 35→36.
- All Windows-console-safe: the command emits ascii-escaped JSON from the subprocess (arrow glyphs render in the reply, not piped through `cp1252` stdout).

## Gates

Spec-driven `/ca:feature`: brainstormed spec → plan (11 tasks, bijective AC coverage) → executed in 4 batches (fresh author per task, test-first via `tdd`, spec + quality review, fresh verification) → commit-gate (9 gates: tests/lint/secrets, behavioral proof, clean diff). 7 acceptance criteria, each a single fixture test.

Closes #79

https://claude.ai/code/session_016NVNTNAPKXzWD8bmmjVHP7