### PR TITLE
fix(site): Starlight 0.33+ social config array syntax (unblocks #123)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -53,9 +53,14 @@ export default defineConfig({
         "./src/styles/callouts.css",
         "./src/styles/landing.css",
       ],
-      social: {
-        github: "https://github.com/arbiterforge/codeArbiter",
-      },
+      // Starlight 0.33+ takes an array of link items, not an object.
+      social: [
+        {
+          icon: "github",
+          label: "GitHub",
+          href: "https://github.com/arbiterForge/codeArbiter",
+        },
+      ],
       sidebar: [
         {
           label: "Start here",


### PR DESCRIPTION
Unblocks the **2.5.0** release deploy. PR #123's docs validation build went red: Starlight 0.40 rejects the legacy `social: { github: ... }` object form.

## Cause

The docs polish (#122) added the GitHub social link in the pre-0.33 object syntax. It built locally and passed #122's review because the dev `node_modules` held a stale Starlight 0.32.6, which still accepts that form. CI runs a clean `npm ci`, installing the pinned `^0.40.0`, which fails at `astro:config:setup`. The clean-install gap is the same class of dev-tree masking that the PR validation build exists to catch, and it did.

## Fix

Convert `social` to the array-of-link-items form Starlight 0.33+ requires. One file, `site/astro.config.mjs`.

## Verification

Reproduced and fixed against a clean install (Starlight 0.40.0, not the stale dev tree):

- `npm run build`: exit 0, 77 pages, Pagefind indexed (this is the step that failed in CI).
- `npm run typecheck`: clean.
- `npm test`: 104 passing.

## Release path

Merge this into `release/2.5.0`, which re-triggers #123's validation green. Then #123 (`release/2.5.0` → `main`) carries the deploy.