### PR TITLE
fix(release): correct ca over-bump 2.6.0 → 2.5.1 + 2.5.1 changelog

### DIFF
--- a/.codearbiter/overrides.log
+++ b/.codearbiter/overrides.log
@@ -3,3 +3,4 @@
 # Written only by /override. The statusline counts non-comment lines after the
 # last-checkpoint marker as "overrides since last checkpoint."
 [2026-06-13T14:25:05Z] | BY: SUaDtL@users.noreply.github.com | OVERRIDE: H-02 force-push | REASON: rebase onto origin/main to resolve add/add conflicts on feature branch checkpoint-remediation-2026-06-12; no commits lost, all 4 sprint SHAs rebased cleanly, 225+56 tests green
+[2026-06-23T18:48:12Z] | BY: SUaDtL@users.noreply.github.com | OVERRIDE: release Phase-1 CHANGELOG-footer BLOCK | REASON: #125 squash-merged with no CHANGELOG: footers on its fix(release)/fix(hooks) commits; changelog 2.5.1 section composed verbatim from those commit bodies (no user-visible change dropped) and shown for review before commit. Also corrects the over-bump: ca-scoped derivation is patch 2.5.1, plugin.json was over-bumped to 2.6.0 (feat(site) is not a ca-payload change).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.5.1] — 2026-06-23
+
+### Fixed
+- **Scope-touch reminders now fire on macOS and Windows** (`H-12`/`H-15`/`H-16`/`H-13`).
+  `post-write-edit.py` derived its repo-relative path with a lexical `os.path.relpath`. When
+  the hook payload's `file_path` and `git rev-parse --show-toplevel` named the same repo via
+  divergent forms (a symlinked `/var` vs `/private/var` on macOS, an 8.3 short name on
+  Windows), the path came out `..`-prefixed and every path-scoped reminder was silently
+  dropped. A new `_hooklib.repo_rel()` canonicalizes both sides with `realpath` first. (#125)
+- **`/ca:release` is now scoped to the `ca` plugin** (ADR-0007). The skill assumed a
+  single-plugin repo: `LAST_TAG` resolved via bare `git describe` (returning a `ca-sandbox`
+  tag), the bump and commit window spanned the whole repo, the derived version was never
+  asserted against `plugin.json`, and the README/catalog surfaces had no sync step. All are
+  now scoped to `plugins/ca/` and enforced, including a read-back of the published Release. (#125)
+
 ## [2.5.0] — 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.6.0" src="https://img.shields.io/badge/version-2.6.0-2b7489">
+<img alt="version 2.5.1" src="https://img.shields.io/badge/version-2.5.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-37-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.6.0",
+  "version": "2.5.1",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",


### PR DESCRIPTION
## What

Corrects the #125 payload version over-bump and adds the `[2.5.1]` changelog section, in preparation for tagging `v2.5.1`.

## Why

`/ca:release` derives the SemVer bump from the **ca-scoped** commit window (`plugins/ca/`). #125's `feat(site)` touches only `site/` and `.github/workflows/docs.yml` — not the ca payload — so it must not bump `ca`. The ca-scoped window holds only `fix(release)` + `fix(hooks)` (+ test commits), which is a **PATCH**. `plugin.json` shipped `2.6.0`; since no `v2.6.0` tag was ever published, the over-bump is corrected before tagging rather than burning a minor.

## Changes

- `plugin.json` `2.6.0 → 2.5.1`; README version badge tracks it (badge-consistency guard green).
- `CHANGELOG.md` `[2.5.1]` section, composed from the `fix(release)`/`fix(hooks)` commit bodies.
- `overrides.log`: the release Phase-1 CHANGELOG-footer BLOCK override (those commits carried no `CHANGELOG:` footer).

No code/behavior change — manifest, docs, and audit log only.

https://claude.ai/code/session_01T4A6F9wBtCkWknpry9m2D4