### PR TITLE
fix(farm): scrub dispatcher secrets from child command env (CodeQL #5 hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Deep-review (`docs/reports/2026-06-24-root/`) quick-kills: mechanical robustness
 
 ### Security
 - **Commit-time gates can no longer be bypassed by `git commit <pathspec>`.** A `git commit <path>` records the *worktree* content of the named paths (bypassing the index), but the H-09b/H-10b crypto-secret gate and the H-14 migration gate scanned only the staged (`--cached`) diff — so an unstaged crypto/secret/migration change named as a pathspec committed with no recorded review. Both gates now union the worktree diff **scoped to the named pathspecs** (an unrelated worktree change elsewhere is not dragged in). The crypto/secret scan and the H-14 file-list read now also **fail closed** when `git diff` cannot be read (timeout/error) instead of silently passing. (appsec-001/002, reliability-003)
+- **Farm child commands no longer inherit dispatcher secrets.** `run()` scrubs `FARM_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` from the environment passed to every child (git, operator gate/setup/test, mutation) — the API key is used only by the in-process `fetch`. Least-privilege defense-in-depth; shrinks the blast radius of the operator-authored gate-command shell boundary (CodeQL `js/shell-command-injection-from-environment` #5, traced non-exploitable and dismissed).
 
 ### Fixed
 - **The task board can't be lost to a crashed write.** `taskwrite.py` writes `open-tasks.md` atomically (temp file in the board's own directory + `os.replace`), so an interrupted write leaves the prior board intact. (migration-001)

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -70,7 +70,10 @@ function treeKill(child) {
 }
 function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
   return new Promise((resolve) => {
-    const c = spawn(cmd, args, { cwd, env: process.env, ...opts });
+    const childEnv = { ...process.env };
+    delete childEnv.FARM_API_KEY;
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
     let stdout = "";
     let stderr = "";
     let settled = false;

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -195,7 +195,15 @@ export function run(
   timeoutMs = 0,
 ): Promise<RunResult> {
   return new Promise<RunResult>((resolve) => {
-    const c = spawn(cmd, args, { cwd, env: process.env, ...opts });
+    // Least-privilege: child commands (git, operator gate/setup/test, mutation)
+    // never need the dispatcher's secrets — the API key is used only by the
+    // in-process fetch. Scrub them from the inherited env so a gate command
+    // can't read FARM_API_KEY / the OAuth token (and shrinks the blast radius
+    // of the operator-authored-but-shell-run gate commands, CodeQL #5).
+    const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    delete childEnv.FARM_API_KEY;
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
     let stdout = "";
     let stderr = "";
     let settled = false;

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -1317,3 +1317,34 @@ describe("T-08c mutant-restore Map-miss preserves the file (dx-003)", () => {
     expect(wrote).toBeNull(); // file preserved, never overwritten with "undefined"
   });
 });
+
+describe("run() scrubs dispatcher secrets from the child env (least-privilege, CodeQL #5)", () => {
+  const PRINT = [
+    "-e",
+    "process.stdout.write(`KEY=${process.env.FARM_API_KEY ?? 'ABSENT'};TOK=${process.env.CLAUDE_CODE_OAUTH_TOKEN ?? 'ABSENT'};MODEL=${process.env.FARM_MODEL ?? 'ABSENT'}`)",
+  ];
+  it("hides FARM_API_KEY / OAuth token from a child command but still inherits non-secret config", async () => {
+    const prev = {
+      key: process.env.FARM_API_KEY,
+      tok: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+      model: process.env.FARM_MODEL,
+    };
+    process.env.FARM_API_KEY = "sk-should-not-leak";
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "tok-should-not-leak";
+    process.env.FARM_MODEL = "passes-through";
+    try {
+      const r = await run(process.execPath, PRINT, undefined, {}, 5000);
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("KEY=ABSENT"); // secret scrubbed
+      expect(r.stdout).toContain("TOK=ABSENT"); // secret scrubbed
+      expect(r.stdout).not.toContain("should-not-leak"); // value never reaches the child
+      expect(r.stdout).toContain("MODEL=passes-through"); // non-secret config still inherited
+    } finally {
+      const restore = (k: string, v: string | undefined) =>
+        v === undefined ? delete process.env[k] : (process.env[k] = v);
+      restore("FARM_API_KEY", prev.key);
+      restore("CLAUDE_CODE_OAUTH_TOKEN", prev.tok);
+      restore("FARM_MODEL", prev.model);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Defense-in-depth for **CodeQL #5** (`js/shell-command-injection-from-environment`, farm.ts gate-command shell boundary). The alert was **traced non-exploitable and dismissed won't-fix** — all 8 dataflow sources are operator/system-controlled (hardcoded `cmd.exe`/`bash`; validated operator `plan.json` gate/setup commands; operator env), matching the declared `security-controls.md` boundary. This PR shrinks the blast radius regardless.

## Change
`run()` previously passed the **full** `process.env` — including `FARM_API_KEY` — to every child it spawns (git, operator gate/setup/test, mutation commands). None need it; the API key is used only by the in-process `fetch`. Now `run()` scrubs `FARM_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` from the child env (least-privilege).

## Verification
- New test: a child sees `KEY=ABSENT` / `TOK=ABSENT` (secrets scrubbed, value never reaches the child) but `FARM_MODEL=passes-through` (non-secret config still inherited).
- `npx tsc --noEmit` clean; **114** unit tests pass; `farm.js` rebuilt in sync.
- Rides on the unreleased 2.5.2 (no version bump; `v2.5.2` untagged).

**Not merged — yours.**

https://claude.ai/code/session_01GJfiaYwjnURxGrP3JgcPbM