### PR TITLE
fix(hooks): DEV:exit audit completeness, atomic gate-marker writes, single-spawn protected-tip check (deep-review HARD-GATE batch B)

### DIFF
--- a/.github/scripts/test_hook_guards.py
+++ b/.github/scripts/test_hook_guards.py
@@ -201,6 +201,31 @@ def main():
         git(["checkout", "--detach"], fx_main)
         expect_block(fx_main, "git commit -m x", "H-01",
                      "H-01 block: commit in detached HEAD at main tip")
+        # performance-006 parity lock: head_on_protected_tip now resolves HEAD +
+        # both protected branches in a SINGLE `git rev-parse HEAD main master`.
+        # When `master` is absent that spawn exits nonzero and echoes the
+        # unresolved name as a non-SHA line — the detection must read SHA-shaped
+        # lines only and still BLOCK a detached HEAD on the `master` tip when
+        # master is the default branch (main absent).
+        master_base = os.path.join(base, "master-case")
+        os.makedirs(master_base)
+        fx_master = make_fixture(master_base, "master")
+        git(["checkout", "--detach"], fx_master)
+        expect_block(fx_master, "git commit -m x", "H-01",
+                     "H-01 block: commit in detached HEAD at master tip")
+        # And the converse: a detached HEAD on an OLDER commit (main exists but
+        # HEAD != its tip) must ALLOW — the single spawn must not misread a
+        # resolved-but-different protected SHA as a tip match.
+        detach_base = os.path.join(base, "detach-old")
+        os.makedirs(detach_base)
+        fx_old = make_fixture(detach_base, "main")
+        with open(os.path.join(fx_old, "notes.txt"), "a", encoding="utf-8") as f:
+            f.write("second commit\n")
+        git(["add", "notes.txt"], fx_old)
+        git(["commit", "-q", "-m", "second"], fx_old)
+        git(["checkout", "--detach", "HEAD~1"], fx_old)
+        expect_allow(fx_old, "git commit -m x",
+                     "allow: detached HEAD on an older commit is not a protected tip")
         expect_block(fx, "git push --force origin feat/work", "H-02", "H-02 block: force push")
 
         # ---- H-09b: the diff-bound security gate (TOCTOU closed) -------------

--- a/.github/scripts/test_hooklib.py
+++ b/.github/scripts/test_hooklib.py
@@ -15,6 +15,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
@@ -424,6 +425,43 @@ class FrontmatterTest(unittest.TestCase):
     def test_dormant_when_no_frontmatter(self):
         p = self._write("# just a heading, no frontmatter\n")
         self.assertEqual(_hooklib.frontmatter_enabled(p), (False, False))
+
+
+class WriteAtomicTest(unittest.TestCase):
+    """migration-002: write_text_atomic writes via a sibling temp file then
+    os.replace() so a crash mid-write never leaves a half-written file at the
+    destination — the marker writers (migration-pass/security-pass) rely on this
+    so a partial digest set can't force a spurious gate re-run. ZERO behaviour
+    change on the happy path is the constraint."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+
+    def test_creates_file_with_exact_content(self):
+        p = os.path.join(self._tmp, "marker")
+        _hooklib.write_text_atomic(p, "a\nb\n")
+        with open(p, encoding="utf-8") as f:
+            self.assertEqual(f.read(), "a\nb\n")
+
+    def test_overwrites_existing_atomically(self):
+        p = os.path.join(self._tmp, "marker")
+        _hooklib.write_text_atomic(p, "old\n")
+        _hooklib.write_text_atomic(p, "new\n")
+        with open(p, encoding="utf-8") as f:
+            self.assertEqual(f.read(), "new\n")
+
+    def test_replace_failure_leaves_original_intact_and_no_tmp(self):
+        """If os.replace raises (the crash-equivalent), the destination keeps its
+        PRIOR content (never truncated) and no stray .tmp is left behind."""
+        p = os.path.join(self._tmp, "marker")
+        _hooklib.write_text_atomic(p, "original\n")
+        with mock.patch("os.replace", side_effect=OSError("simulated crash")):
+            with self.assertRaises(OSError):
+                _hooklib.write_text_atomic(p, "corrupt-partial")
+        with open(p, encoding="utf-8") as f:
+            self.assertEqual(f.read(), "original\n", "destination must not be truncated")
+        leftovers = [n for n in os.listdir(self._tmp) if n != "marker"]
+        self.assertEqual(leftovers, [], f"no temp file should linger: {leftovers}")
 
 
 class MarkerDigestTest(unittest.TestCase):

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -43,6 +43,7 @@
 #   is_audit_log(rel) -> bool             True iff rel is an append-only audit log (H-05)
 #   is_decisions_path(rel) -> bool        True iff rel is an ADR under decisions/ (H-11)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
+#   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -53,6 +54,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 
 # Crypto/TLS and secret patterns — shared by the post-write reminder (H-09/H-10)
@@ -479,6 +481,28 @@ def is_ci_path(rel, root):
 def is_deploy_path(rel, root):
     """True iff `rel` is a deployment / IaC manifest (H-16, advisory)."""
     return path_in_globs(rel, root, DEPLOY_DEFAULT_GLOBS, _DEPLOY_DECL_RE)
+
+
+def write_text_atomic(path, text):
+    """Write `text` to `path` atomically: a sibling temp file in the same dir,
+    then os.replace() into place (atomic on POSIX; a same-volume rename on
+    Windows). A crash between open() and the rename never leaves a half-written
+    file at `path`. The gate-marker writers (migration-pass / security-pass) rely
+    on this so a partial digest set can't be read back as an unrecognized token
+    and force a spurious gate re-run (migration-002). On any failure the temp
+    file is cleaned up and the original `path` is left untouched."""
+    d = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=os.path.basename(path) + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def marker_fresh(path, minutes):

--- a/plugins/ca/hooks/migration-pass.py
+++ b/plugins/ca/hooks/migration-pass.py
@@ -29,6 +29,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
     content_digest, is_migration_path, project_root, utf8_stdio, warn,
+    write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -88,8 +89,10 @@ def main():
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "migration-gate-passed")
     digests = sorted(digests)
-    with open(marker, "w", encoding="utf-8") as f:
-        f.write("\n".join(digests) + ("\n" if digests else ""))
+    # Atomic write (migration-002): a crash mid-write never leaves a half-written
+    # marker, which the backstop would read as an unrecognized digest and force a
+    # spurious gate re-run.
+    write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"migration-gate pass recorded: {len(digests)} migration file(s) "
           f"bound to {os.path.relpath(marker, root)}")
 

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -122,26 +122,38 @@ def is_protected_branch(branch):
     return branch.lower() in ("main", "master")
 
 
-def _rev(cwd, ref):
-    try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--verify", "-q", ref], cwd=cwd,
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=5,
-        )
-        return out.stdout.strip() if out.returncode == 0 else ""
-    except Exception:  # noqa: BLE001
-        return ""
-
-
 def head_on_protected_tip(cwd):
     """True when HEAD (typically detached) points at the commit a protected
     branch tips — a commit there still writes onto main/master's history even
-    though `git branch --show-current` reports no branch name."""
-    head = _rev(cwd, "HEAD")
-    if not head:
+    though `git branch --show-current` reports no branch name.
+
+    One spawn (performance-006): `git show-ref --head refs/heads/main
+    refs/heads/master` lists `<sha> HEAD` plus a `<sha> refs/heads/<branch>` line
+    for each protected branch that EXISTS — a missing branch is simply omitted
+    (exit 0), with no fatal. (`git rev-parse HEAD main master` cannot be used: it
+    stops at the first unresolvable arg, so a missing `main` would hide a present
+    `master` tip and silently allow a commit onto it.) HEAD sits on a protected
+    tip iff its sha matches a listed main/master tip. A non-repo / unborn HEAD
+    lists no HEAD sha -> False."""
+    try:
+        out = subprocess.run(
+            ["git", "show-ref", "--head", "refs/heads/main", "refs/heads/master"],
+            cwd=cwd, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=5,
+        )
+    except Exception:  # noqa: BLE001
         return False
-    return any(_rev(cwd, b) == head for b in ("main", "master"))
+    head_sha, protected = None, set()
+    for ln in out.stdout.splitlines():
+        parts = ln.split()
+        if len(parts) != 2:
+            continue
+        sha, ref = parts
+        if ref == "HEAD":
+            head_sha = sha
+        elif ref in ("refs/heads/main", "refs/heads/master"):
+            protected.add(sha)
+    return head_sha is not None and head_sha in protected
 
 
 def added_lines(cwd, ref, paths=None):

--- a/plugins/ca/hooks/security-pass.py
+++ b/plugins/ca/hooks/security-pass.py
@@ -24,6 +24,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, line_digest, project_root, utf8_stdio, warn,
+    write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -81,8 +82,10 @@ def main():
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "security-gate-passed")
     digests = sorted({line_digest(ln) for ln in sensitive})
-    with open(marker, "w", encoding="utf-8") as f:
-        f.write("\n".join(digests) + ("\n" if digests else ""))
+    # Atomic write (migration-002): a crash mid-write never leaves a half-written
+    # marker, which the backstop would read as an unrecognized digest and force a
+    # spurious gate re-run.
+    write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"security-gate pass recorded: {len(digests)} sensitive line(s) "
           f"bound to {os.path.relpath(marker, root)}")
 

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -406,6 +406,30 @@ def has_source(root):
     return False
 
 
+def clear_dev_marker(root):
+    """Clear the per-session /dev statusline marker on startup. If the marker is
+    LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
+    synthetic DEV: exit line to overrides.log BEFORE removing it
+    (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
+    with no matching close. Append-only (it never rewrites); best-effort — a write
+    or remove failure must never brick session startup."""
+    marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
+    if os.path.isfile(marker):
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        line = (f"[{ts}] | BY: session-cleanup | DEV: exit | NOTE: cleared by "
+                f"SessionStart (prior session ended mid-dev without /ca:arbiter)\n")
+        try:
+            with open(os.path.join(root, ".codearbiter", "overrides.log"),
+                      "a", encoding="utf-8") as f:
+                f.write(line)
+        except OSError:
+            pass
+    try:
+        os.remove(marker)
+    except OSError:
+        pass
+
+
 def main():
     utf8_stdio()
     root = project_root()
@@ -415,11 +439,9 @@ def main():
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
 
     # /dev developer-override is per-session: clear its statusline marker on
-    # startup — a new session restores orchestration.
-    try:
-        os.remove(os.path.join(root, ".codearbiter", ".markers", "dev-active"))
-    except OSError:
-        pass
+    # startup — a new session restores orchestration. A live marker means a prior
+    # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
+    clear_dev_marker(root)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/plugins/ca/hooks/tests/test_security_pass.py
+++ b/plugins/ca/hooks/tests/test_security_pass.py
@@ -122,6 +122,18 @@ class TestSecurityPassBranches(_Fixture):
         self.assertEqual(res.returncode, 0)
         self.assertIn("1 sensitive line", res.stdout)
 
+    def test_marker_write_leaves_no_temp_file(self):
+        # migration-002: the marker is written atomically (temp + os.replace), so
+        # after a successful run the .markers dir holds the marker and no .tmp.
+        self._ca()
+        self._write("auth.js", CRYPTO_LINE)
+        res = self.run_pass()
+        self.assertEqual(res.returncode, 0)
+        markers_dir = os.path.join(self.root, ".codearbiter", ".markers")
+        entries = sorted(os.listdir(markers_dir))
+        self.assertEqual(entries, ["security-gate-passed"],
+                         f"only the marker should remain, got {entries}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -271,6 +271,65 @@ class TestMainHealsBeforeDormantGate(unittest.TestCase):
         self.assertNotIn("2.0.1", cmd)
 
 
+class TestDevExitAudit(unittest.TestCase):
+    """observability-001: when SessionStart clears a LIVE dev-active marker (a
+    prior session entered /ca:dev and ended without /ca:arbiter), it must append
+    a synthetic DEV: exit line to overrides.log BEFORE removing the marker — so
+    the audit trail keeps a matched DEV: enter/exit pair instead of an orphaned
+    enter. Append-only (never rewrites); no append when there is no live marker."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.ca = os.path.join(self.root, ".codearbiter")
+        self.markers = os.path.join(self.ca, ".markers")
+        os.makedirs(self.markers)
+        self.log = os.path.join(self.ca, "overrides.log")
+        self.marker = os.path.join(self.markers, "dev-active")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _seed_log(self, text):
+        with open(self.log, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def _read_log(self):
+        with open(self.log, encoding="utf-8") as f:
+            return f.read()
+
+    def _drop_marker(self):
+        with open(self.marker, "w", encoding="utf-8") as f:
+            f.write("active\n")
+
+    def test_live_marker_appends_dev_exit_and_removes_marker(self):
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.marker), "live marker must be removed")
+        log = self._read_log()
+        self.assertIn("DEV: exit", log)
+        self.assertIn("BY: session-cleanup", log)
+        # append-only: the prior DEV: enter line is preserved.
+        self.assertIn("DEV: enter", log)
+
+    def test_no_marker_appends_nothing(self):
+        seed = "[2026-01-01T00:00:00Z] | BY: x | GATE: none | REASON: seed\n"
+        self._seed_log(seed)
+        self.assertFalse(os.path.isfile(self.marker))
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(self._read_log(), seed, "no marker -> overrides.log untouched")
+
+    def test_append_is_a_single_line_after_existing_content(self):
+        seed = "[2026-01-01T00:00:00Z] | BY: dev | DEV: enter | NOTE: —\n"
+        self._seed_log(seed)
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        log = self._read_log()
+        self.assertTrue(log.startswith(seed), "existing lines must remain a prefix (pure append)")
+        self.assertEqual(len(log.splitlines()), 2, "exactly one DEV: exit line appended")
+
+
 class TestStandupBriefingGating(unittest.TestCase):
     """#61 regression: pin the once-per-LOCAL-day briefing contract so the
     documented behavior (and the absence of a marker/timezone misfire) cannot


### PR DESCRIPTION
Deep-review 2026-06-24-root **HARD-GATE batch B** (3 of the 9). Rides untagged **2.5.2** (no new bump). Two type-homogeneous commits.

## v2.rev.0017 — `fix(hooks)` DEV:exit audit completeness (observability-001)
SessionStart unconditionally removed the `dev-active` marker, so a session that entered `/ca:dev` and ended without `/ca:arbiter` left an orphaned `DEV: enter` in `overrides.log` with no close. Now, when the marker is **live**, `clear_dev_marker()` appends `[<ISO-8601 UTC>] | BY: session-cleanup | DEV: exit | NOTE: cleared by SessionStart …` *before* removing it — append-only, best-effort (a write failure never bricks startup). No marker -> no append.

## v2.rev.0022 — `fix(hooks)` atomic gate-marker writes (migration-002)
`migration-pass.py` / `security-pass.py` wrote their markers with a plain truncate-then-write; a crash mid-write left a half-written marker the backstop reads as an unrecognized digest, forcing a spurious gate re-run. New `_hooklib.write_text_atomic` (sibling `mkstemp` + `os.replace`, temp cleaned on failure) is the one writer both use. Fail-closed behavior preserved.

## v2.rev.0023 — `perf(hooks)` single-spawn protected-tip check (performance-006)
`head_on_protected_tip` spawned three sequential `git rev-parse`. Replaced with one `git show-ref --head refs/heads/main refs/heads/master`.

**Correctness note:** the finding suggested `git rev-parse HEAD main master`, but `rev-parse` **stops at the first unresolvable arg** — a missing `main` would hide a present `master` tip and silently allow a commit onto it. `show-ref` lists only the refs that exist (exit 0 on missing) and includes the detached HEAD line, so it is the robust one-spawn form. Block/allow decisions unchanged; two parity cases added (detached HEAD on a `master` tip blocks; on an older commit allows).

## Verification
- `test_hooklib` 64/0, `test_hook_guards` **88/0** (86 -> 88), `test_hooks_cold_install` PASS, `test_migration_backstop` 31/0, hooks unittest **529/0**.
- No TS artifacts touched. No new crypto/secret literals — the commit gate did not fire.

https://claude.ai/code/session_01M3e2cHcf864YSxDmCohcET