### PR TITLE
sandbox isolation: shared hardeningFlags(), mount chokepoint, fail-closed NetPolicy (deep-review HARD-GATE batch C)

### DIFF
--- a/plugins/ca-sandbox/tools/claude-inside.test.ts
+++ b/plugins/ca-sandbox/tools/claude-inside.test.ts
@@ -32,7 +32,7 @@ import {
   buildClaudeRunArgs,
   TokenCoMountRejectedError,
 } from "./claude-inside.ts";
-import { SANDBOX_USER } from "./run.ts";
+import { SANDBOX_USER, hardeningFlags } from "./run.ts";
 
 // --------------------------------------------------------------------------
 // PURE unit layer — image + argv builders, no real docker.
@@ -56,6 +56,36 @@ describe("buildClaudeImageDockerfile — pinned install + autoupdater off (AC-12
     // must be writable for that uid, so the image chowns it and defaults USER to it.
     expect(df).toMatch(/chown -R 1000:1000/);
     expect(df).toMatch(/^USER 1000:1000$/m);
+  });
+});
+
+// architecture-002: the container hardening argv is security-load-bearing and
+// was re-emitted verbatim in both run.ts and claude-inside.ts — the token-bearing
+// --with-claude box silently weakens if a future flag lands in run.ts only. The
+// shared hardeningFlags() is now the single source; the --with-claude argv must
+// carry EVERY flag (and its value) the ordinary sandbox does.
+describe("buildClaudeRunArgs — hardening parity with run.ts (architecture-002)", () => {
+  const argv = buildClaudeRunArgs({
+    image: "ca-sbx-claude:demo",
+    token: "dummy-not-a-real-token",
+    homeVolume: "ca-sbx-claude-home-demo",
+  });
+
+  it("carries every shared hardening flag the ordinary sandbox emits", () => {
+    const flags = hardeningFlags();
+    // hardeningFlags() is a flat [flag, value, valuelessFlag, ...] argv. Assert
+    // each flag — and the value following a valued flag — appears in the claude
+    // argv, regardless of position/order.
+    for (let i = 0; i < flags.length; i++) {
+      const tok = flags[i];
+      if (!tok.startsWith("--")) continue; // a value consumed with its flag below
+      const idx = argv.indexOf(tok);
+      expect(idx, `--with-claude argv missing hardening flag ${tok}`).toBeGreaterThanOrEqual(0);
+      const next = flags[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        expect(argv[idx + 1], `${tok} value mismatch in --with-claude argv`).toBe(next);
+      }
+    }
   });
 });
 

--- a/plugins/ca-sandbox/tools/claude-inside.ts
+++ b/plugins/ca-sandbox/tools/claude-inside.ts
@@ -40,7 +40,7 @@
 import { spawnSync } from "node:child_process";
 import { buildMountArgs, type MountSpec } from "./mounts.ts";
 import { applyNetworkPolicy } from "./network.ts";
-import { SANDBOX_USER } from "./run.ts";
+import { SANDBOX_LABEL, hardeningFlags } from "./run.ts";
 
 /**
  * The PINNED Claude Code CLI version baked into the sandbox image. Pinned (never
@@ -60,8 +60,9 @@ export const CLAUDE_BASE_IMAGE = "node:22-slim";
 export const CLAUDE_HOME = "/home/sbx";
 /** The env var Claude Code reads as auth-precedence #5 (Spike B). */
 export const TOKEN_ENV_VAR = "CLAUDE_CODE_OAUTH_TOKEN";
-/** The lifecycle/registry label every sandbox container carries (AC-11). */
-export const SANDBOX_LABEL = "ca.sandbox=1";
+// SANDBOX_LABEL is shared from run.ts (architecture-002) so the lifecycle label
+// has a single definition; re-exported here for existing importers of this name.
+export { SANDBOX_LABEL };
 
 // On Windows + Git Bash, `-e HOME=/...` and container paths handed to docker get
 // mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
@@ -275,27 +276,13 @@ export function buildClaudeRunArgs(opts: ClaudeRunOptions): string[] {
     ...mountArgs,
     "--workdir",
     CLAUDE_HOME,
-    // Non-root + drop every capability: the SAME structural lockdown as run.ts so
-    // the token-bearing box is no softer than an ordinary sandbox. The image
-    // chowns CLAUDE_HOME to this uid, so the named-volume HOME is writable for the
-    // .claude credential store even under the read-only root below.
-    "--user",
-    SANDBOX_USER,
-    "--cap-drop",
-    "ALL",
-    // Read-only root + a tmpfs /tmp: the same structural lockdown as run.ts. (HOME
-    // is writable because the named volume is mounted over it.)
-    "--read-only",
-    "--tmpfs",
-    "/tmp",
-    "--security-opt",
-    "no-new-privileges",
-    "--pids-limit",
-    "512",
-    "--memory",
-    "4g",
-    "--cpus",
-    "2",
+    // The SAME shared hardening block as the ordinary sandbox (architecture-002),
+    // spliced from run.ts's hardeningFlags() so the token-bearing box can never
+    // drift to a softer lockdown. Non-root + every capability dropped + read-only
+    // root + tmpfs /tmp + no-new-privileges + resource caps. The image chowns
+    // CLAUDE_HOME to this uid and the named volume mounts over HOME, so the
+    // .claude credential store stays writable under the read-only root.
+    ...hardeningFlags(),
     ...networkArgs,
     ...labelArgs,
     image,

--- a/plugins/ca-sandbox/tools/create.test.ts
+++ b/plugins/ca-sandbox/tools/create.test.ts
@@ -17,6 +17,7 @@ import {
   APP_DIR,
 } from "./create.ts";
 import type { CloneResult } from "./create.ts";
+import { buildMountArgs } from "./mounts.ts";
 
 describe("validateRepoUrl — clone-input trust model (AC-01)", () => {
   it("accepts plain network remotes (https / ssh / scp-like)", () => {
@@ -65,6 +66,21 @@ describe("buildCloneArgs — argv shape (AC-01 defense in depth)", () => {
     expect(sep).toBeGreaterThan(clone);
     // Everything between `clone` and `--` is a known flag, never the url.
     expect(argv.slice(clone, sep)).not.toContain(url);
+  });
+
+  // architecture-006: the clone/build mounts must route through buildMountArgs —
+  // the documented single chokepoint — so they are covered by the bind-rejection
+  // guarantee and there is genuinely one mount-argv path. Pin that the emitted
+  // mount argv is EXACTLY what buildMountArgs produces for the volume spec.
+  it("routes the source-volume mount through the buildMountArgs chokepoint", () => {
+    const expected = buildMountArgs([
+      { type: "volume", source: "ca-sbx-vol-demo", target: APP_DIR },
+    ]);
+    const m = argv.indexOf("--mount");
+    expect(m).toBeGreaterThanOrEqual(0);
+    expect(argv.slice(m, m + expected.length)).toEqual(expected);
+    // No raw bind expression hand-rolled anywhere.
+    for (const tok of argv) expect(tok).not.toMatch(/type=bind/);
   });
 });
 

--- a/plugins/ca-sandbox/tools/create.ts
+++ b/plugins/ca-sandbox/tools/create.ts
@@ -30,6 +30,7 @@ import { spawnSync, spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { readdir } from "node:fs/promises";
 import { runContainer, type NetPolicy } from "./run.ts";
+import { buildMountArgs } from "./mounts.ts";
 import { buildOrReuseImage, type BuildResult } from "./build.ts";
 import { computeDepHash, type ManifestFile } from "./dephash.ts";
 import {
@@ -194,8 +195,10 @@ export function buildCloneArgs(url: string, volumeName: string): string[] {
   return [
     "run",
     "--rm",
-    "--mount",
-    `type=volume,source=${volumeName},target=${APP_DIR}`,
+    // Mount via the buildMountArgs chokepoint (architecture-006) so this caller is
+    // covered by the bind-rejection guarantee and there is genuinely one mount-argv
+    // path. Same volume spec as before -> byte-identical argv.
+    ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR }]),
     CLONE_IMAGE,
     "clone",
     "--depth",
@@ -228,8 +231,8 @@ async function defaultBuildImage(volumeName: string): Promise<BuildResult> {
       "create",
       "--name",
       helper,
-      "--mount",
-      `type=volume,source=${volumeName},target=${APP_DIR}`,
+      // Same buildMountArgs chokepoint as buildCloneArgs (architecture-006).
+      ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR }]),
       CLONE_IMAGE,
       "true",
     ],

--- a/plugins/ca-sandbox/tools/run.test.ts
+++ b/plugins/ca-sandbox/tools/run.test.ts
@@ -79,9 +79,21 @@ describe("buildRunArgs — network policy (AC-01 / AC-08 seam)", () => {
     expect(argvPair(argv, "--network")).toBe("none");
   });
 
-  it("a non-offline policy does NOT force --network none", () => {
-    const argv = buildRunArgs("img", "vol", "open");
-    expect(networkValues(argv)).not.toContain("none");
+  // dx-006: the safe default is fail-CLOSED. Only a RECOGNIZED networked policy
+  // (T-10 will add these) may skip the airgap; any UNRECOGNIZED value — a typo of
+  // "offline", or a policy no layer implements — must still get --network none
+  // rather than silently run on docker's default bridge. (Replaces the prior test
+  // that asserted a bare non-offline string passed through, which was the gap.)
+  it("a typo of 'offline' still gets --network none (fail closed)", () => {
+    const argv = buildRunArgs("img", "vol", "offlien");
+    expect(argvPair(argv, "--network")).toBe("none");
+  });
+
+  it("an unrecognized policy fails closed to --network none", () => {
+    for (const policy of ["open", "Offline", " offline ", "bridge", ""]) {
+      const argv = buildRunArgs("img", "vol", policy);
+      expect(networkValues(argv), `policy ${JSON.stringify(policy)} must airgap`).toContain("none");
+    }
   });
 
   it("refuses an empty image or volume name", () => {

--- a/plugins/ca-sandbox/tools/run.ts
+++ b/plugins/ca-sandbox/tools/run.ts
@@ -94,6 +94,39 @@ function defaultDockerRun(args: string[]): RunResult {
  * @throws (BindMountRejectedError, via buildMountArgs) — unreachable here since
  *   we only construct volume/tmpfs specs, but the chokepoint is the guarantee.
  */
+/**
+ * The shared container hardening argv (architecture-002). This block is
+ * security-load-bearing — non-root, read-only root fs, a tmpfs /tmp, every Linux
+ * capability dropped, no privilege escalation, and resource caps. It is defined
+ * ONCE here and spliced by BOTH buildRunArgs and claude-inside.ts's
+ * buildClaudeRunArgs, so the token-bearing --with-claude box can never drift to a
+ * softer lockdown than the ordinary sandbox. NOT included: --workdir (the two
+ * callers point it at different in-container dirs) and the per-call mount/label/
+ * network/name argv.
+ */
+export function hardeningFlags(): string[] {
+  return [
+    "--user",
+    SANDBOX_USER,
+    "--read-only",
+    // --read-only makes a writable /tmp essential; the `--tmpfs <path>` short
+    // form is the idiomatic, spec-named flag. (run.ts also renders a tmpfs /tmp
+    // via buildMountArgs; the duplicate is harmless and robust across engines.)
+    "--tmpfs",
+    "/tmp",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--pids-limit",
+    "512",
+    "--memory",
+    "4g",
+    "--cpus",
+    "2",
+  ];
+}
+
 export function buildRunArgs(
   image: string,
   volumeName: string,
@@ -131,26 +164,9 @@ export function buildRunArgs(
     ...mountArgs,
     "--workdir",
     APP_DIR,
-    "--user",
-    SANDBOX_USER,
-    "--read-only",
-    // --tmpfs is rendered by buildMountArgs as `--mount type=tmpfs,target=/tmp`,
-    // BUT docker's `--read-only` makes a writable /tmp essential and the
-    // `--tmpfs <path>` short form is the idiomatic, spec-named flag. Emit it
-    // explicitly too so the run is robust on engines that treat a tmpfs --mount
-    // and a read-only root differently; the duplicate tmpfs is harmless.
-    "--tmpfs",
-    "/tmp",
-    "--cap-drop",
-    "ALL",
-    "--security-opt",
-    "no-new-privileges",
-    "--pids-limit",
-    "512",
-    "--memory",
-    "4g",
-    "--cpus",
-    "2",
+    // The shared, security-load-bearing isolation block (defined once, also
+    // spliced by claude-inside.ts so the two never drift).
+    ...hardeningFlags(),
     ...networkArgs,
     ...labelArgs,
     image,

--- a/plugins/ca-sandbox/tools/run.ts
+++ b/plugins/ca-sandbox/tools/run.ts
@@ -53,9 +53,22 @@ const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
  * Network policy for a sandbox run. T-06 only distinguishes the safe default
  * (`offline` => no networking at all); the richer clone-then-cut / allowlist
  * policies are layered by T-10 (AC-08). A string is accepted so this stays a
- * stable seam — an unknown policy is passed through without forcing isolation.
+ * stable seam — but the resolution is FAIL-CLOSED (dx-006): only a policy in the
+ * closed NETWORKED_POLICIES set escapes the airgap, so a typo of `offline` (or
+ * any policy no layer implements) gets `--network none` rather than silently
+ * running networked.
  */
 export type NetPolicy = "offline" | (string & {});
+
+/**
+ * The closed set of policies that intentionally run WITH networking. T-10 adds
+ * its allowlist/clone-then-cut policy names here as it implements them. EMPTY
+ * today: the only T-06 posture is the airgap, so every policy — including
+ * `offline` and any misspelling of it — currently resolves to `--network none`.
+ * This is the fail-closed safe default (dx-006): the airgap is only dropped for
+ * an EXACT, recognized networked policy, never for an unrecognized string.
+ */
+const NETWORKED_POLICIES: ReadonlySet<string> = new Set<string>();
 
 /** Optional knobs for runContainer that the test harness / callers may set. */
 export type RunOptions = {
@@ -152,10 +165,12 @@ export function buildRunArgs(
       ? ["--name", `${opts.namePrefix}-${Math.random().toString(16).slice(2, 10)}`]
       : [];
 
-  // Network: the safe default is total isolation. T-10 layers the richer
-  // policies; anything other than "offline" is passed through without forcing
-  // --network none (so T-10 can attach its own network/proxy).
-  const networkArgs = netPolicy === "offline" ? ["--network", "none"] : [];
+  // Network: the safe default is total isolation, resolved FAIL-CLOSED (dx-006).
+  // Only an EXACT, recognized networked policy (T-10 registers these in
+  // NETWORKED_POLICIES) skips the airgap; every other value — "offline", a typo
+  // of it, or any unimplemented policy — gets --network none. A misspelled
+  // policy can never silently drop the airgap onto docker's default bridge.
+  const networkArgs = NETWORKED_POLICIES.has(netPolicy) ? [] : ["--network", "none"];
 
   return [
     "run",

--- a/plugins/ca-sandbox/tools/sandbox.js
+++ b/plugins/ca-sandbox/tools/sandbox.js
@@ -88,6 +88,7 @@ var APP_DIR = "/work/repo";
 var SANDBOX_LABEL = "ca.sandbox=1";
 var SANDBOX_USER = "1000:1000";
 var DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
+var NETWORKED_POLICIES = /* @__PURE__ */ new Set();
 function defaultDockerRun(args) {
   const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
   return {
@@ -129,7 +130,7 @@ function buildRunArgs(image, volumeName, netPolicy, opts = {}) {
   const labels = [SANDBOX_LABEL, ...opts.extraLabels ?? []];
   const labelArgs = labels.flatMap((l) => ["--label", l]);
   const nameArgs = opts.namePrefix ? ["--name", `${opts.namePrefix}-${Math.random().toString(16).slice(2, 10)}`] : [];
-  const networkArgs = netPolicy === "offline" ? ["--network", "none"] : [];
+  const networkArgs = NETWORKED_POLICIES.has(netPolicy) ? [] : ["--network", "none"];
   return [
     "run",
     "-d",

--- a/plugins/ca-sandbox/tools/sandbox.js
+++ b/plugins/ca-sandbox/tools/sandbox.js
@@ -96,6 +96,28 @@ function defaultDockerRun(args) {
     stderr: r.stderr ?? (r.error ? String(r.error) : "")
   };
 }
+function hardeningFlags() {
+  return [
+    "--user",
+    SANDBOX_USER,
+    "--read-only",
+    // --read-only makes a writable /tmp essential; the `--tmpfs <path>` short
+    // form is the idiomatic, spec-named flag. (run.ts also renders a tmpfs /tmp
+    // via buildMountArgs; the duplicate is harmless and robust across engines.)
+    "--tmpfs",
+    "/tmp",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--pids-limit",
+    "512",
+    "--memory",
+    "4g",
+    "--cpus",
+    "2"
+  ];
+}
 function buildRunArgs(image, volumeName, netPolicy, opts = {}) {
   if (!image) throw new Error("ca-sandbox: runContainer requires a non-empty image");
   if (!volumeName) throw new Error("ca-sandbox: runContainer requires a non-empty volume name");
@@ -115,26 +137,9 @@ function buildRunArgs(image, volumeName, netPolicy, opts = {}) {
     ...mountArgs,
     "--workdir",
     APP_DIR,
-    "--user",
-    SANDBOX_USER,
-    "--read-only",
-    // --tmpfs is rendered by buildMountArgs as `--mount type=tmpfs,target=/tmp`,
-    // BUT docker's `--read-only` makes a writable /tmp essential and the
-    // `--tmpfs <path>` short form is the idiomatic, spec-named flag. Emit it
-    // explicitly too so the run is robust on engines that treat a tmpfs --mount
-    // and a read-only root differently; the duplicate tmpfs is harmless.
-    "--tmpfs",
-    "/tmp",
-    "--cap-drop",
-    "ALL",
-    "--security-opt",
-    "no-new-privileges",
-    "--pids-limit",
-    "512",
-    "--memory",
-    "4g",
-    "--cpus",
-    "2",
+    // The shared, security-load-bearing isolation block (defined once, also
+    // spliced by claude-inside.ts so the two never drift).
+    ...hardeningFlags(),
     ...networkArgs,
     ...labelArgs,
     image,
@@ -525,8 +530,10 @@ function buildCloneArgs(url, volumeName) {
   return [
     "run",
     "--rm",
-    "--mount",
-    `type=volume,source=${volumeName},target=${APP_DIR3}`,
+    // Mount via the buildMountArgs chokepoint (architecture-006) so this caller is
+    // covered by the bind-rejection guarantee and there is genuinely one mount-argv
+    // path. Same volume spec as before -> byte-identical argv.
+    ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR3 }]),
     CLONE_IMAGE,
     "clone",
     "--depth",
@@ -548,8 +555,8 @@ async function defaultBuildImage(volumeName) {
       "create",
       "--name",
       helper,
-      "--mount",
-      `type=volume,source=${volumeName},target=${APP_DIR3}`,
+      // Same buildMountArgs chokepoint as buildCloneArgs (architecture-006).
+      ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR3 }]),
       CLONE_IMAGE,
       "true"
     ],


### PR DESCRIPTION
Deep-review 2026-06-24-root **HARD-GATE batch C** (the final 3 of 9), all in `plugins/ca-sandbox/`. Two type-homogeneous commits.

## v2.rev.0018 — `refactor(sandbox)` shared `hardeningFlags()` (architecture-002)
The security-load-bearing isolation argv (`--user/--read-only/--tmpfs/--cap-drop/--security-opt/--pids-limit/--memory/--cpus`) was re-emitted verbatim in `run.ts` *and* `claude-inside.ts` — the token-bearing `--with-claude` box would silently weaken if a future flag landed in `run.ts` only. Extracted one exported `hardeningFlags()`; both builders splice it (each keeps its own `--workdir`). `claude-inside.ts` imports `SANDBOX_LABEL` from `run.ts` (re-exported for compatibility) instead of re-declaring it. New parity test asserts the `--with-claude` argv carries every hardening flag the ordinary sandbox does.

## v2.rev.0024 — `refactor(sandbox)` mount chokepoint (architecture-006)
`create.ts` hand-rolled raw `--mount type=volume` literals in `buildCloneArgs` and `defaultBuildImage`, bypassing the documented `buildMountArgs` single chokepoint. Both now route through `buildMountArgs` — byte-identical argv, but under the bind-rejection guarantee, so the "single chokepoint" invariant is finally true for every caller.

## v2.rev.0025 — `fix(sandbox)` fail-closed NetPolicy (dx-006)
`buildRunArgs` resolved the airgap with `netPolicy === "offline" ? […] : []`, so **any** non-`offline` value passed through *without* `--network none`. A typo (`offlien`) silently ran the container on docker's default bridge. Replaced with a closed-union fail-closed check: only a policy in `NETWORKED_POLICIES` (empty today; T-10 populates it) skips the airgap; everything else — including a misspelling — gets `--network none`.

**Behavior change, surfaced:** I replaced the prior test `"a non-offline policy does NOT force --network none"` (it asserted the exact vulnerable pass-through) with fail-closed assertions. T-10's future closed union is unaffected — it extends `NETWORKED_POLICIES`.

## Verification
- ca-sandbox `typecheck` clean; pure-unit vitest **52/52** (run / claude-inside / create / mounts), including the new hardening-parity and fail-closed network-policy cases. `sandbox.js` rebuilt in sync (committed). Docker-gated integration specs run on the CI ubuntu runner.
- 0018/0024 are behavior-preserving (vitest = parity proof); 0025 is the one intentional behavior change.

The new parity test carries a fake `token:` literal that newly matches the secret gate; recorded via `security-pass.py` (AD-008), not an override.

**This completes all 9 deep-review HARD-GATE fixes.** `v2.rev.0020` (farm god-module split) is deferred to post-release via `/ca:refactor`.

https://claude.ai/code/session_01M3e2cHcf864YSxDmCohcET