### PR TITLE
feat(farm): best-of-N sampling + iterative retries + sampling params (first-time-go, Slice 1)

### DIFF
--- a/.codearbiter/plans/farm-sampling-context.md
+++ b/.codearbiter/plans/farm-sampling-context.md
@@ -1,0 +1,103 @@
+# Plan — farm first-time-go accuracy (best-of-N + retry feedback + auto-context)
+
+Spec: `.codearbiter/specs/farm-sampling-context.md`. Each task is test-first via `tdd`.
+Status ledger: `PENDING` → `RED` (failing test in) → `GREEN` → `ACCEPTED` (reviewed + verified).
+All paths relative to repo root. Tools cwd = `plugins/ca/tools/`.
+
+## Landing structure
+
+**One PR per slice.** Slice 1 lands first (`feat/farm-best-of-n` off `main`); Slice 2 is planned
+**after** Slice 1 merges, with the merged code in hand (MVP-slice rule — Slice 2 is stubbed below, not
+detailed yet). Each slice: full `tech-stack.md` gate + `farm.js` rebuild + `plugin.json` version bump,
+one commit-gate, one PR; the merge decision is surfaced to the user.
+
+---
+
+## SLICE 1 — iterative best-of-N  (`feat/farm-best-of-n`)
+
+### Group F4 — sampling parameters
+
+- **TF4-1** `[PENDING]` — RED: unit test asserting the chat request body includes `temperature` (from
+  `FARM_TEMPERATURE`, default `0`) and includes `max_tokens` **iff** `FARM_MAX_TOKENS` > 0. Drives an
+  exported body-builder (e.g. `buildChatBody(model, messages)`) or captures the body via the injectable
+  fetch seam. Files: `plugins/ca/tools/farm.unit.test.ts`. Verify: fails (no params today). Maps: AC-F4.1, AC-F4.3.
+- **TF4-2** `[PENDING]` — GREEN: add `FARM_TEMPERATURE`/`FARM_MAX_TOKENS` to `ENV`; build the request
+  body with `temperature` always and `max_tokens` when > 0; usage-summing unchanged. Files: `farm.ts`.
+  Verify: TF4-1 green; suite green. Maps: AC-F4.1, AC-F4.2, AC-F4.3.
+
+### Group F2 — iterative retries (worker sees its own prior output)
+
+- **TF2-1** `[PENDING]` — RED: unit test for the prompt/enrichment builder given a `priorAttempt`
+  in-scope-files input — assert the rendered prompt contains that prior output labeled read-only
+  ("previous attempt (failed)"), passed through `redactSecrets`, and that nothing out-of-scope is
+  included. Files: `farm.unit.test.ts`. Verify: fails (builder has no prior-attempt param). Maps: AC-F2.1, AC-F2.3.
+- **TF2-2** `[PENDING]` — GREEN: thread an optional `priorAttempt` (in-scope file bodies) through
+  `buildEnrichment`/`buildPrompt` via the existing `renderInjectedFile` chokepoint (redaction + cap);
+  in `runTask`, capture the failed attempt's **in-scope** `filesWritten` contents BEFORE
+  `resetWorktree`, and feed them into the next attempt. Out-of-scope drift is still reset, never carried.
+  Files: `farm.ts`. Verify: TF2-1 green; a `RunTaskDeps`-stub test shows the retry prompt carries prior
+  in-scope output but not drift. Maps: AC-F2.1, AC-F2.2, AC-F2.3.
+
+### Group F1 — best-of-N, first-green-wins
+
+- **TF1-1** `[PENDING]` — RED: unit test for a shared worker-budget semaphore (extract a small
+  `limiter(n)`): with n=2, at most 2 concurrent acquisitions are live across interleaved acquires.
+  Files: `farm.unit.test.ts`. Verify: fails (no limiter). Maps: AC-F1.4.
+- **TF1-2** `[PENDING]` — GREEN: implement the shared limiter sized to `FARM_CONCURRENCY`; route every
+  `worker.apply` through it and refactor the scheduler so task-dispatch **and** per-task sampling both
+  acquire from the one budget (no `FARM_CONCURRENCY × FARM_SAMPLES` blow-up). Files: `farm.ts`. Verify:
+  TF1-1 green; existing scheduler/`runTask` tests green (back-compat). Maps: AC-F1.4. **(highest-risk task — scheduler refactor; keep the existing single-task concurrency behavior intact at `FARM_SAMPLES=1`.)**
+- **TF1-3** `[PENDING]` — RED: unit test for per-attempt sample-and-select — a stubbed multi-sample
+  runner returning `[gate-fail, gate-green]` → the green candidate is accepted, losers discarded;
+  all-fail → the best failure (first-settled non-green, carrying its in-scope output) is returned to
+  seed retry; `FARM_SAMPLES=1` → exactly one candidate (regression path). Files: `farm.unit.test.ts`.
+  Verify: fails. Maps: AC-F1.1, AC-F1.2, AC-F1.5.
+- **TF1-4** `[PENDING]` — GREEN: implement per-attempt best-of-N in `runTask` — draw
+  `min(FARM_SAMPLES, budget)` candidates concurrently into isolated sample worktrees (`farm/<id>-s<k>`)
+  cut from integration HEAD, gate each, first green wins (cancel/discard losers, remove their
+  worktrees); no-pass → best failure seeds `priorFailure` (composes with F2). `FARM_SAMPLES=1` is the
+  unchanged single-candidate path. Files: `farm.ts`. Verify: TF1-3 green; the `FARM_SAMPLES=1`
+  regression test (TF-REG) green. Maps: AC-F1.1, AC-F1.2, AC-F1.5. **(high-risk — worktree lifecycle.)**
+- **TF1-5** `[PENDING]` — GREEN: auto-bump temperature when `FARM_SAMPLES>1` and `FARM_TEMPERATURE=0`
+  (logged note); sum prompt+completion tokens across ALL samples into the `Result`, and surface
+  accepted-sample vs total-sample tokens in `farm-report.json` / `farm-results.jsonl`. Files: `farm.ts`.
+  Verify: unit tests for the bump (with note) and the token split. Maps: AC-F1.3, AC-F1.6.
+
+### Regression + docs + land
+
+- **TF-REG** `[PENDING]` — RED→GREEN: unit test pinning that `FARM_SAMPLES=1` + `FARM_CONTEXT_AUTO=off`
+  + default knobs drives a single `worker.apply` and the same gate→commit→merge sequence as today
+  (via `RunTaskDeps` stubs). Files: `farm.unit.test.ts`. Verify: green after TF1-4. Maps: AC-F1.1 / regression hard rule.
+- **TF-DOC** `[PENDING]` — docs: `plugins/ca/includes/farm.md` documents `FARM_SAMPLES`,
+  `FARM_TEMPERATURE`, `FARM_MAX_TOKENS` (defaults + the N×-tokens-for-acceptance tradeoff + interaction
+  with `FARM_CONCURRENCY`). Files: `plugins/ca/includes/farm.md`. Verify: knobs table updated; refs resolve. Maps: AC-F1.7, AC-F4 docs.
+- **TF-LAND** `[PENDING]` — build + land: bump `plugins/ca/.claude-plugin/plugin.json` version (+ README
+  badge + dated `CHANGELOG.md` section, derived from the ca-scoped window); `npm ci && npm run typecheck
+  && npm test && npm run build`; assert `git diff --quiet -- farm.js`; commit-gate; open PR off `main`.
+  Maps: cross-cutting hard rules / release invariants.
+
+---
+
+## SLICE 2 — auto-context enrichment (F3)  `[PLANNED AFTER SLICE 1 MERGES]`
+
+Detailed at the next planning pass with Slice 1's merged code in hand (MVP-slice rule). Shape: a RED
+test for a 1-level TS/JS import resolver that locates relative-import sources and injects them read-only
+through the existing denylist+redaction+cap chokepoint (graceful degrade on unsupported langs); GREEN
+the resolver + `buildEnrichment` wiring; `FARM_CONTEXT_AUTO`/`FARM_CONTEXT_MAX_FILES` knobs; docs +
+data-egress note; build/bump/land. Trust-boundary gate fires here — surfaced to the user.
+
+---
+
+## Execution order (Slice 1)
+
+One branch off `main`. Test-first throughout. Order: **F4 (TF4-1/2) → F2 (TF2-1/2) → F1 limiter
+(TF1-1/2) → F1 best-of-N (TF1-3/4) → F1 finish (TF1-5) → TF-REG → TF-DOC → TF-LAND.** TF1-2 and TF1-4
+are the load-bearing tasks (scheduler + worktree lifecycle); everything else is additive. Single final
+land: one typecheck/test/build + `git diff --quiet -- farm.js`, one commit-gate, one PR. The morning
+Receipt lists the PR + its merge decision.
+
+## Coverage check (Slice 1 ACs → tasks)
+
+F4.1→TF4-1/2, F4.2→TF4-2, F4.3→TF4-1/2; F2.1→TF2-1/2, F2.2→TF2-2, F2.3→TF2-1/2; F1.1→TF1-3/4+TF-REG,
+F1.2→TF1-3/4, F1.3→TF1-5, F1.4→TF1-1/2, F1.5→TF1-3/4, F1.6→TF1-5, F1.7→TF-DOC. Regression hard
+rule→TF-REG. Release invariants→TF-LAND. ✔  (Slice-2 F3 ACs covered in the Slice-2 plan.)

--- a/.codearbiter/specs/farm-sampling-context.md
+++ b/.codearbiter/specs/farm-sampling-context.md
@@ -1,0 +1,141 @@
+# Sprint spec — farm first-time-go accuracy (best-of-N + retry feedback + auto-context)
+
+**Status:** approved (Phase 1 gate) — 2026-06-26, user (brennonhuff@gmail.com); F2 kept in Slice 1
+**Mode:** `/ca:sprint` (premium subagent path — NOT `--farm`; we are improving the farm tool itself)
+**Author attribution:** user (brennonhuff@gmail.com), 2026-06-26
+**Origin:** `docs/reports/2026-06-26-farm/report.md` (deep review). Findings F1/F3/F4/F2 in scope; F8
+descoped to an ADR by user decision at the gate; F5/F6/F7 deferred.
+**Surface:** `plugins/ca/tools/farm.ts` (+ rebuilt `farm.js`), `plugins/ca/tools/farm.unit.test.ts`,
+`plugins/ca/includes/farm.md`, `plugins/ca/.claude-plugin/plugin.json` (version bump).
+**Landing:** one PR per slice (Slice 1, then Slice 2); MVP-slice order, plan the next slice with the
+merged code in hand.
+
+**Thesis.** The farm's worker is a single blind chat completion wrapped in an excellent deterministic
+gate (a perfect green/red oracle), worktree isolation, and a concurrency scheduler. That substrate is
+ideal for two accuracy multipliers it does not yet use — **best-of-N sampling against the oracle** and
+**rich automatic context** — plus making **retries actually iterative**. None of these touch the
+premium token axis; the cost is the cheap worker axis the farm exists to spend.
+
+---
+
+## Slice 1 (MVP) — iterative best-of-N against the gate
+
+Three tightly-coupled changes to the worker-call + retry path. Build order within the slice:
+F4 (params) → F2 (retry feedback) → F1 (best-of-N), since F1's sampling needs F4's temperature and
+composes with F2's feedback loop.
+
+### F4 — send sampling parameters (`callApi`)
+
+**Root.** `callApi` posts `{model, messages}` only (farm.ts:652) — no `temperature`, no `max_tokens`.
+No diversification is possible across samples/retries, and completion length is unbounded.
+
+- **AC-F4.1** — `callApi` includes `temperature` (from `FARM_TEMPERATURE`, default `0`) in the request
+  body, and `max_tokens` when `FARM_MAX_TOKENS` > 0 (default `0` = omit, preserving today's behavior).
+- **AC-F4.2** — Token-usage accounting (`prompt_tokens`/`completion_tokens` summing) is unchanged.
+- **AC-F4.3** — The request-body construction is unit-testable without network (assert `temperature`/
+  `max_tokens` presence and values given env), via the existing injectable-fetch seam or a small
+  exported body-builder.
+
+### F2 — make retries iterative (the worker sees its own prior attempt)
+
+**Root.** On retry, `resetWorktree` wipes the prior files (farm.ts:1189), `buildEnrichment` re-reads
+the *baseline* (farm.ts:1206), and only the gate tail feeds `priorFailure` (farm.ts:1266). The worker
+restarts from scratch each attempt and oscillates instead of converging.
+
+- **AC-F2.1** — On a retry (attempt > 1, or after a failed best-of-N round), the worker prompt includes
+  the **prior attempt's own in-scope file output** — the files it wrote that failed the gate — labeled
+  read-only as "your previous attempt (failed)", in addition to the existing gate-failure tail.
+- **AC-F2.2** — Out-of-scope drift from the prior attempt is still hard-reset and never carried
+  forward; only the prior **in-scope** output is re-shown as context.
+- **AC-F2.3** — Prior-attempt context flows through the SAME redaction + `FARM_ENRICH_MAX_BYTES` cap
+  chokepoint as all other injected content (no new boundary path).
+
+> *Added at review (was a "supporting" HIGH finding, not in the originally-named set). It directly
+> amplifies F1 — without it, the retry after a failed sampling round restarts blind. Cut it for a
+> tighter slice if you prefer; flagged for your call at the gate.*
+
+### F1 — best-of-N sampling, first-green-wins
+
+**Root.** `runTask` runs strictly sequential attempts: one worker call per attempt (farm.ts:1188).
+The gate is a perfect oracle, so N parallel cheap samples with first-green-wins is a step-change in
+first-time-go at linear cheap-token cost.
+
+- **AC-F1.1** — New env `FARM_SAMPLES` (default `1`). With `FARM_SAMPLES=1`, each attempt performs
+  exactly one worker completion and the task lifecycle is **behaviorally identical to today** (single
+  candidate, gated, merged) — the regression guard.
+- **AC-F1.2** — With `FARM_SAMPLES=N>1`, each attempt draws up to N candidate implementations
+  **concurrently**, each applied + gated in an isolated per-sample worktree cut from the same
+  integration HEAD as the task. The **first candidate to pass the full gate** is accepted and merged;
+  remaining in-flight samples are cancelled/discarded.
+- **AC-F1.3** — When `FARM_SAMPLES > 1` and `FARM_TEMPERATURE` is `0`, the temperature is auto-bumped
+  to a diversifying default (with a logged note) — N identical deterministic samples is a misconfig.
+- **AC-F1.4** — Total concurrent worker calls (across all tasks AND their samples) never exceed
+  `FARM_CONCURRENCY` — sampling shares the global worker budget via a semaphore; it does not multiply
+  it. (No `FARM_CONCURRENCY × FARM_SAMPLES` blow-up.)
+- **AC-F1.5** — If no sample passes the gate in an attempt, the best failure (first-settled non-green,
+  carrying its in-scope output per F2) seeds `priorFailure` and the existing retry loop runs as today —
+  sampling **composes with** retries, it does not replace them.
+- **AC-F1.6** — Per-task token spend in `farm-report.json` / `farm-results.jsonl` sums ALL samples
+  (prompt+completion) and distinguishes accepted-sample tokens from total-sample tokens, so best-of-N's
+  real cost is visible, never hidden.
+- **AC-F1.7** — `farm.md` documents `FARM_SAMPLES` (the N× worker-token-for-higher-acceptance
+  tradeoff), default 1, and its interaction with `FARM_CONCURRENCY` and `FARM_TEMPERATURE`.
+
+---
+
+## Slice 2 — automatic read-only context enrichment (F3)
+
+**Root.** `buildEnrichment` injects only the test + in-scope files (farm.ts:444); the imported types/
+interfaces the impl must conform to are absent unless Claude hand-writes the `context` field. The cheap
+model guesses signatures → gate-fail/drift.
+
+- **AC-F3.1** — Enrichment resolves the **direct imports** of the test file and of existing in-scope
+  files, locates the referenced sources in the worktree, and injects their contents **read-only**.
+- **AC-F3.2** — Resolution is language-scoped: TS/JS `import … from '…'` and `require('…')` (relative
+  specifiers) are resolved this slice; unsupported languages or unresolvable specifiers degrade
+  **silently** to today's behavior — no crash, hand-`context` still works.
+- **AC-F3.3** — Import-following is bounded to **1 level** (direct imports only, no transitive walk).
+- **AC-F3.4** — Auto-resolved context uses the SAME chokepoint as existing injected files: the
+  secret-bearing-filename denylist (never read), span-aware redaction, and the `FARM_ENRICH_MAX_BYTES`
+  total cap. Test + in-scope files retain budget priority; auto-context fills the remainder and is the
+  first to be truncated/dropped.
+- **AC-F3.5** — Auto-resolved files are injected read-only and are **NOT** added to `filesInScope`; the
+  drift guard and write-allowlist are unchanged (the worker still cannot write them).
+- **AC-F3.6** — A knob gates it: `FARM_CONTEXT_AUTO` (default `on`) and a `FARM_CONTEXT_MAX_FILES` cap;
+  `off` → exactly today's enrichment.
+- **AC-F3.7** — `farm.md` documents auto-context: language scope, the read-only/denylist/cap
+  guarantees, and the data-egress note (more repo content crosses the boundary; cap + redaction +
+  `FARM_MODEL` sovereignty knob are the controls).
+
+---
+
+## Cross-cutting hard rules (apply to every task)
+
+- **Regression guard:** `FARM_SAMPLES=1` + `FARM_CONTEXT_AUTO=off` + default knobs MUST be behaviorally
+  equivalent to today. A unit test pins the single-sample path.
+- **Trust-boundary touch (F3):** Slice 2 widens the repo content crossing to the third-party endpoint.
+  The trust-boundary / security-reviewer gate WILL fire in execution — this is expected and surfaced,
+  not hidden. The existing redaction, secret-filename denylist, and `FARM_ENRICH_MAX_BYTES` cap are the
+  controls and **MUST NOT be weakened**; a task that weakens any of them is a hard-gate STOP.
+- `assertSecureBaseUrl` and the secret-redaction/denylist paths are not weakened by any task.
+- Every task is test-first via `tdd`; the failing test is written and shown red before impl.
+- Every PR's gate runs the full `tech-stack.md` tools sequence: `npm ci && npm run typecheck &&
+  npm test && npm run build`, then `git diff --quiet -- farm.js` (a stale bundle blocks).
+- `plugins/ca/**` changed → bump `plugins/ca/.claude-plugin/plugin.json` version (+ README badge +
+  CHANGELOG), per the release invariant; derive the bump from the ca-scoped commit window only.
+- `/ca:sprint` never merges and never discards — each slice's PR merge decision is surfaced to you.
+- Every non-hard-gate auto-decision is logged to `.codearbiter/sprint-log.md` with a confidence flag.
+
+## Out of scope (noted, not done)
+
+- **F8 — worker process-sandboxing** → its own ADR + threat-model for agentic-worker containment,
+  designed against the real agentic worker when Track 2 is scoped (ties to CONFIRM-05). `ca-sandbox`'s
+  Docker/clone-into-container model does not fit farm's host-worktree architecture; forcing it now would
+  add a Docker dependency to a preview feature to protect a consumer that does not yet exist. *(User
+  decision at the Phase 1 gate, 2026-06-26.)*
+- **F5** — diff/search-replace worker response mode for large-file edits (efficiency; whole-file stays
+  the safe default).
+- **F6** — language-derived response-format example fence (currently hard-coded `typescript`).
+- **F7** — canary breadth (median/hardest no-dep task instead of smallest).
+- The non-reporting-worker path-containment sandbox (existing `[NEEDS-TRIAGE]`, farm.ts:819) — folded
+  into the F8 ADR.

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -654,3 +654,29 @@ do not stop to ask a question until there is a PR." Slice 1 = F4+F2+F1; Slice 2 
 ## D3 — FARM_SAMPLES>1 + FARM_TEMPERATURE=0 auto-bump · confidence: low
 - Bump to 0.7 (conventional diversifying default) with a logged note; N identical temp-0 samples is
   wasted spend. Strength: moderate. Confidence: LOW.
+
+## Two-pass independent review (per D0) — both PASS/SHIP, dispositions applied
+
+Dispatched read-only with fresh context before the PR (nothing accepted on the author's word):
+- **security-reviewer:** PASS — 0 CRIT/HIGH/MED. Traced all five trust-boundary paths; F2 prior-output
+  re-injection rides the SAME redactSecrets + capInjected + secret-filename-denylist chokepoint; bearer
+  token + assertSecureBaseUrl intact, no new egress channel. One LOW (note-redaction symmetry).
+- **correctness/spec-compliance:** SHIP — 0 BLOCK/HIGH. AC-F1.1/F1.4 verified sound; createLimiter
+  correct; no-winner cleanup verified. Two MEDIUM + three LOW surfaced.
+
+### Dispositions (all applied — confidence high)
+- **M1 (worktree leak if a sample THROWS):** per-sample try/catch returns a failure OUTCOME so
+  Promise.all never rejects and the cleanup loop always runs (+ test: a throwing sample → green sibling
+  still wins).
+- **M2 (sample baseline skew vs the moving farm/integration):** samples now cut from the TASK branch (a
+  frozen integration-at-task-start snapshot) — the exact baseline the task worktree re-gates/merges
+  against. True AC-F1.2 compliance; removes the false-escalation window. Real-worktree smoke test green.
+- **L1 (non-numeric FARM_SAMPLES → NaN mass-escalation):** Number.isFinite guard → falls back to 1 (+ test).
+- **L2 (explicit FARM_TEMPERATURE=0 still bumped):** distinguish unset from explicit 0; bump only when
+  unset (+ test).
+- **L3 (baseline mislabeled "previous attempt" on an API failure):** seed prior-attempt context only when
+  the prior worker actually wrote files.
+- **security LOW (note-redaction symmetry):** worker-error + setup notes now wrapped in redactSecrets,
+  matching the gate/merge notes (single-sample and best-of-N parity).
+
+Verification after fixes: 169 vitest green (+2), typecheck clean, farm.js rebuilt.

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -620,3 +620,37 @@ covered by the two-pass review's no-enforcement-weakening check — not promoted
 
 Real catch worth the run: an untested error path is now covered and a hung farm command can no longer
 wedge a walk-away run — clean green throughout, enforcement surface untouched.
+
+---
+
+# Sprint — farm-sampling-context (best-of-N + retry feedback + auto-context) · 2026-06-26 (autonomous; user asleep)
+
+Spec `.codearbiter/specs/farm-sampling-context.md`, plan `plans/farm-sampling-context.md` — APPROVED at
+the Phase-1 gate by brennonhuff@gmail.com. Premium backend (NOT --farm — the farm tool is the subject).
+Branch `feat/farm-best-of-n` off `main`. User: "approve, unless hard gate you cannot pass with SMARTS;
+do not stop to ask a question until there is a PR." Slice 1 = F4+F2+F1; Slice 2 (F3) planned after Slice
+1 merges. F8 descoped to an ADR at the gate. Origin: docs/reports/2026-06-26-farm/report.md.
+
+## D0 — execution strategy · confidence: low
+- Options: (a) one fresh subagent per task per subagent-driven-development; (b) coherent single author
+  (orchestrator, full farm.ts context) + independent review-agent passes before the PR.
+- SMARTS: Maintainable/Reliable favor (b) — the 11 Slice-1 tasks are deeply coupled on runTask + the
+  scheduler; 11 blind subagents each re-deriving 1868-line context risks integration drift. The sprint's
+  load-bearing property (independent review before acceptance) is preserved by dispatching fresh
+  reviewers. Mirrors prior accepted calls D-01 (ux-conversion) and SD-B2 (session-hygiene).
+- Chosen: (b). Strength: moderate. Confidence: LOW (process deviation — flagged for morning review).
+
+## D1 — F4 default knobs · confidence: high
+- FARM_TEMPERATURE default 0 (deterministic, closest to "make the test pass"); FARM_MAX_TOKENS default 0
+  = omit (preserve today's unbounded behavior; opt-in cap). Defaults make single-sample == today. Strong.
+
+## D2 — best-of-N concurrency model (AC-F1.2/F1.4) · confidence: low
+- Spec says samples run concurrently in isolated per-sample worktrees under a shared FARM_CONCURRENCY
+  budget. Faithful but higher-risk. If per-sample worktree promotion threatens correctness within the
+  run, the SMARTS fallback is sequential-in-worktree sampling (still raises acceptance via diversified
+  retries) with the AC-F1.2 "concurrently" deviation logged — rather than shipping unverified
+  concurrent-git or stopping. Strength: moderate. Confidence: LOW.
+
+## D3 — FARM_SAMPLES>1 + FARM_TEMPERATURE=0 auto-bump · confidence: low
+- Bump to 0.7 (conventional diversifying default) with a logged note; N identical temp-0 samples is
+  wasted spend. Strength: moderate. Confidence: LOW.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The plugin is the contents of `plugins/ca/`. Project state under a consumer's `.
 
 ---
 
+## [2.6.0] — 2026-06-26
+
+Farm first-time-go accuracy — Slice 1 of the `docs/reports/2026-06-26-farm/` deep-review (F8 worker-sandboxing descoped to an ADR; F3 auto-context is Slice 2). The `--farm` backend remains a Feature Forge preview, off by default; these are opt-in worker-quality levers that spend the cheap (worker-token) axis, with the single-sample path behaviorally unchanged.
+
+### Added
+- **Best-of-N sampling against the gate (`FARM_SAMPLES`, default 1).** Because the gate is a deterministic pass/fail oracle and each task runs in an isolated worktree, N candidates are drawn in parallel and the first to pass the gate is accepted. Each sample runs in its own scratch worktree cut from the integration HEAD; the winner's files are taken into the task worktree and merged, the losers discarded. Total in-flight worker calls never exceed `FARM_CONCURRENCY` — a shared limiter, so sampling shares the budget rather than multiplying it. `FARM_SAMPLES=1` is byte-for-byte today's single-candidate path (pinned by a regression test). (report F1)
+- **Sampling parameters on the worker call (`FARM_TEMPERATURE`, `FARM_MAX_TOKENS`).** The chat body now carries `temperature` (default 0; auto-bumped to 0.7 when `FARM_SAMPLES>1` so samples diversify) and an optional `max_tokens` cap (default unset = provider default, today's behavior). (report F4)
+- **Best-of-N cost transparency.** `farm-report.json` records both the summed sample-token spend and the accepted candidate's own tokens (`acceptedPromptTokens`/`acceptedCompletionTokens`), so the N×-tokens trade-off is visible rather than hidden. (report F1)
+
+### Changed
+- **Retries are now iterative.** On a retry — a failed gate, or a sampling round with no green — the worker is shown its own previous in-scope output, not just the gate-failure tail, so it refines rather than restarts blind. The prior output rides the same `FARM_ENRICH_MAX_BYTES` byte-cap and secret-redaction chokepoint as all injected context; out-of-scope drift is never carried forward. (report F2)
+
+---
+
 ## [2.5.2] — 2026-06-25
 
 Deep-review (`docs/reports/2026-06-24-root/`) remediation, in two parts. The quick-kill batch is mechanical robustness, diagnosability, and hot-path hardening with no enforcement-behavior change (guard matrix, cold-install, and statusline render verified unchanged or byte-identical). The HARD-GATE batch closes real gaps in the crypto/secret commit gate and the append-only audit guards; each enforcement change shipped test-first (a RED test proving the gap, then the fix), with the full guard matrix, cold-install, migration backstop, and hook unit suites green.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.5.2" src="https://img.shields.io/badge/version-2.5.2-2b7489">
+<img alt="version 2.6.0" src="https://img.shields.io/badge/version-2.6.0-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-37-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-20-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-15-555">

--- a/docs/reports/2026-06-26-farm/report.md
+++ b/docs/reports/2026-06-26-farm/report.md
@@ -1,0 +1,157 @@
+# Deep review — `/ca:sprint --farm` (the farm execution backend)
+
+- **Run:** 2026-06-26-farm
+- **Scope:** `plugins/ca/tools/farm.ts` (1868 ln) + `includes/farm.md`, `SPRINT.md`,
+  `skills/subagent-driven-development/references/farm-dispatch.md`,
+  `skills/writing-plans/references/farm-plan.md`
+- **Lens:** not a security audit. The brief is *autonomous code-completion accuracy* —
+  "first-time-go" acceptance when a non-premium worker writes the code — plus "stop it doing
+  things it shouldn't" on the path to agentic cross-model workers, plus token efficiency.
+- **Posture going in:** the code is genuinely mature. Batches #132–#134 hardened containment,
+  redaction, timeouts, drift, and the circuit breaker. There are **no manufactured security
+  findings here** — the shipped blind HTTP worker is safe. The real improvement surface is
+  *accuracy* and the *safe path to the agentic worker you actually want to build*.
+
+---
+
+## The one-paragraph thesis
+
+Today's worker is a **single blind chat completion** (`httpWorker`, farm.ts:776) — one shot,
+no file reading, no iteration, reset between attempts. The dispatcher wrapped around it is
+excellent: a **deterministic gate that is a perfect green/red oracle**, per-task worktree
+isolation, a concurrency scheduler, mutation + anti-gaming guards. That combination is the
+ideal substrate for two well-known accuracy multipliers the farm **does not yet use** —
+*best-of-N sampling against the oracle* and *rich automatic context* — and it is the safe seam
+for the *agentic cross-model worker*, which is gated on one missing control (a real sandbox).
+
+---
+
+## Findings (calibrated by impact on first-time-go, not severity-of-defect)
+
+### Track 1 — lift the SHIPPED blind worker's acceptance rate
+
+**F1 — [HIGH] No best-of-N sampling against the deterministic gate.**
+`runTask` runs strictly *sequential* attempts: one `worker.apply` per attempt, re-prompt only
+on failure (farm.ts:1188–1342). But the gate (`runGate`, farm.ts:258) is a *perfect oracle* and
+each task already runs in its own worktree. The canonical way to turn "cheap model, mediocre
+first-pass" into "high acceptance" is to draw **K samples in parallel and take the first that
+goes green** — the oracle makes selection free of judgment. The scheduler (farm.ts:1738) and
+`FARM_CONCURRENCY` already prove the farm can fan out.
+- *Impact:* the single biggest available lift in first-time-go, and it spends only the **cheap**
+  axis (worker tokens), never premium.
+- *Counter-argument:* K× worker tokens and K× gate runs per task. But worker tokens are exactly
+  what the farm is designed to spend cheaply, a green-on-sample-2 *avoids* a premium
+  re-dispatch (the expensive axis), and N can be adaptive (sample-then-fallback-to-retry).
+- *Shape:* `FARM_SAMPLES` (default 1 = today's behavior); draw N concurrently per attempt under a
+  sub-budget of `FARM_CONCURRENCY`; first green wins, losers' worktrees discarded; if none green,
+  feed the *best* failure into the existing retry loop.
+
+**F2 — [HIGH] The worker never sees its own prior attempt; retry feeds only the gate tail.**
+On retry, `resetWorktree` wipes the worker's prior files (farm.ts:1189), `buildEnrichment`
+re-reads the *baseline* (farm.ts:1206 → 444), and `priorFailure` carries only the gate stdout
+tail (farm.ts:1266). So a failing cheap model **restarts from scratch every attempt** and tends
+to oscillate rather than converge.
+- *Impact:* wasted retries; tasks that were one fix away from green escalate to premium.
+- *Counter-argument:* keeping prior output risks anchoring on a wrong approach. Mitigate by
+  labeling it clearly ("your previous attempt, which failed as follows") and retaining the gate
+  tail so the model has both the artifact and the error.
+- *Shape:* before the inter-attempt reset, stash the prior attempt's **in-scope** file bodies;
+  inject them as read-only context next attempt; still hard-reset out-of-scope drift.
+
+**F3 — [HIGH] Enrichment injects in-scope files + the test, but never the read-only context the
+impl must conform to.**
+`buildEnrichment` (farm.ts:444–486) injects the test source and the current contents of
+`filesInScope` only. The comment is explicit: "best-effort direct context — no deep import
+resolution" (farm.ts:296–301). Everything the implementation must *call into* — imported types,
+interfaces, sibling modules, the DTO/serializer it must match — is absent unless Claude
+hand-writes it into the optional `context` field (`farm-plan.md`). A cheap model then **guesses
+signatures**, which surfaces as a gate failure or as drift.
+- *Impact:* a top root-cause of cheap-model failure; *also* the ask-#1 lever — auto-context means
+  Claude writes far less hand-authored `context`, cutting premium token burn at plan time.
+- *Counter-argument:* more bytes cross the trust boundary (cost + sovereignty). Bounded by the
+  existing `FARM_ENRICH_MAX_BYTES` cap (farm.ts:412) and span-aware redaction (farm.ts:371),
+  which already govern outbound content; this rides the same chokepoint.
+- *Shape:* resolve the test's imports + the type/interface files referenced by `filesInScope`,
+  inject them **read-only** through `capInjected`, ranked by relevance before truncation.
+
+**F4 — [MEDIUM] No sampling parameters sent.**
+`callApi` posts `{model, messages}` only (farm.ts:652–655) — no `temperature`, `max_tokens`, or
+`stop`. There is no diversification across retries, and completion length is unbounded (cost +
+truncation risk against the 120 s request budget).
+- *Shape:* low temperature on attempt 1, raised on retries (and the *required* enabler for F1's
+  parallel samples — N identical temperature-0 calls are wasted); cap `max_tokens`.
+
+**F5 — [MEDIUM] Whole-file rewrite format.**
+The prompt demands "complete file content here" per file (farm.ts:522–534). To change three lines
+of a large in-scope file the worker must regenerate the whole file — high completion-token cost
+and a real regression/drift surface (it silently drops unrelated code, caught only by burning a
+gate attempt).
+- *Counter-argument:* whole-file is the *safe* apply path; diffs fuzz-fail. Keep whole-file for
+  new files; offer a search/replace block mode for edits to existing large files.
+
+**F6 — [LOW] The response-format example is hard-coded `typescript`.**
+`buildPrompt` shows a ```` ```typescript ```` example fence (farm.ts:529) regardless of project
+language; a Python/Rust/Go worker is anchored on the wrong tag. Derive it from `tech-stack.md`
+language threaded via `plan.meta`.
+
+**F7 — [LOW] Canary measures only the smallest no-dep task.**
+Model selection ranks candidates on the fewest-files, no-deps task (farm.ts:1597–1600) — a weak
+proxy for plan-wide capability; a model that clears a trivial slice can still fail the real work.
+Optionally probe the median-complexity (or hardest no-dep) task, configurable for canary cost.
+
+### Track 2 — the agentic cross-model worker you want to build ("stop it doing things it shouldn't")
+
+**F8 — [HIGH, roadmap-gating] The non-reporting-worker escape is unguarded — this is the
+prerequisite control before any agentic worker ships.**
+`postApplySweep` only inspects the worker's **reported** writes (farm.ts:831–851); `checkDrift`
+only sees paths **inside** the worktree (farm.ts:789–805). The shipped `httpWorker` reports its
+writes faithfully, so today is fully covered — and the code already says so honestly
+([NEEDS-TRIAGE], farm.ts:819–825). But the agentic/cross-model worker the brief is about can hold
+file tools and write **outside `cwd` without reporting it**, evading *both* guards.
+- *Impact:* containment for an agentic worker cannot rest on the worker's honesty. This is THE
+  gating safety item for Track 2, not an optional hardening.
+- *Counter-argument:* none — the file itself defers the robust fix to "a process-level sandbox /
+  cwd-jail," which is exactly right.
+- *Shape:* execute the worker through the repo's **ca-sandbox** (cwd-jail + network limited to the
+  model endpoint), so containment is OS-enforced. The existing post-hoc gate/drift/mutation guards
+  remain, but stop being the *only* containment.
+
+**F9 — [MEDIUM] Prompt "do not" instructions read as enforcement but are not.**
+"Do not run git. Do not install global packages." (farm.ts:517) is inert for the blind worker
+(it can't run anything) and non-binding for an agentic worker (it's prose). Keep as guidance, but
+document that the *binding* controls for agentic workers are the sandbox (F8) + the post-hoc
+guards — not the prompt line.
+
+---
+
+## Answer to ask #1 — "decrease the tokens to build the .ts script for farm"
+
+`farm.ts` is a **static, committed tool** — it is not regenerated per run, so there is no
+per-run token cost to "build" it. Premium (Claude) token spend in a `--farm` run lives entirely
+in *plan time*: deriving obligations, writing each failing test, and emitting `plan.json` +ahead
+the hand-authored `context` field. The levers that actually reduce that spend:
+- **F3 auto-enrichment** removes most hand-written `context` (the largest discretionary chunk).
+- The **one-MVP-slice-at-a-time** rule (`farm-plan.md`) already caps up-front test authoring —
+  keep it; do not front-load the whole plan's tests.
+
+So: as you suspected, there's little to win on "building the .ts" itself — the win is on the
+*plan-authoring* tokens, and F3 is that win. Per your steer, the focus stays on Track 1/Track 2.
+
+---
+
+## The two step-change recommendations (if you do nothing else)
+
+1. **F1 best-of-N against the gate** — the architecture is almost uniquely built for it (perfect
+   oracle + worktree isolation + concurrency). Largest first-time-go lift, cheap-token-only.
+2. **F3 automatic read-only context** — kills the #1 cheap-model failure cause (guessed
+   signatures) *and* cuts premium plan-time tokens. Reuses the existing cap+redaction chokepoint.
+
+And the gating item for the future you're excited about: **F8 sandbox the worker** before any
+agentic/cross-model worker leaves the seam. The agentic worker subsumes F2/F3 (it reads and
+iterates itself) but is unsafe without F8.
+
+## Decisions deferred to you (not auto-resolvable)
+
+- Which of Track 1 (F1/F2/F3/F4) to build first, and at what `FARM_SAMPLES`/budget defaults.
+- Whether Track 2 (agentic worker) is in scope now — it changes CONFIRM-05's promotion bar.
+- F5 (diff response mode) and F7 (canary breadth) are real but lower-priority; defer unless cheap.

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "author": { "name": "arbiterForge" },
   "license": "MIT",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -41,6 +41,25 @@ Note: `writing-plans --farm` MUST place the task's narrow behavioral test first 
 the mutation guard runs `gate.commands[0]` as the per-mutant test (running the full suite per mutant
 would be too slow).
 
+### Best-of-N sampling and iterative retries
+
+By default the farm draws one worker completion per task attempt (`FARM_SAMPLES=1` — unchanged
+behavior). Because the gate is a deterministic pass/fail oracle and each task runs in an isolated
+worktree, you can instead draw **N candidates in parallel** and accept the first that passes the gate:
+set `FARM_SAMPLES=N`. Each sample runs in its own scratch worktree cut from the integration HEAD; the
+winner's files are taken into the task worktree and merged, the losers discarded. Total in-flight
+worker calls never exceed `FARM_CONCURRENCY` — sampling **shares** that budget, it does not multiply
+it. The cost is up to N× worker tokens (the cheap axis) for a higher first-time-go rate;
+`farm-report.json` records both the summed sample-token spend (`promptTokens`/`completionTokens`) and
+the accepted candidate's own tokens (`acceptedPromptTokens`/`acceptedCompletionTokens`) so the
+trade-off is visible. With `FARM_SAMPLES>1` the worker temperature is auto-bumped off 0 (to 0.7) so the
+samples actually diversify; set `FARM_TEMPERATURE` to control it.
+
+On a **retry** — a failed gate, or a sampling round with no green — the worker is shown its own previous
+in-scope output, not just the gate-failure tail, so it refines rather than restarts blind. That prior
+output rides the same byte-cap (`FARM_ENRICH_MAX_BYTES`) and secret-redaction chokepoint as all other
+injected context; out-of-scope drift is never carried forward.
+
 ## Required
 
 ### `FARM_API_KEY`
@@ -82,7 +101,10 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MODEL` | _(unset)_ | Skip selection and use this model id directly. Power-user/CI override. |
 | `FARM_API_BASE_URL` | `https://opencode.ai/zen/v1` | Endpoint URL (env → plan.json → this default). |
 | `FARM_CANDIDATE_MODELS` | _(unset)_ | Comma-separated ids for `--canary` probing. Set by the dispatch skill. |
-| `FARM_CONCURRENCY` | `4` | Max concurrent task workers. |
+| `FARM_CONCURRENCY` | `4` | Max concurrent task workers — and the shared ceiling on TOTAL in-flight worker calls, including best-of-N samples. |
+| `FARM_SAMPLES` | `1` | Best-of-N: candidates drawn per task attempt; first to pass the gate wins. `1` = today's single-candidate path. N>1 trades up to N× worker tokens for higher first-time-go; shares the `FARM_CONCURRENCY` budget (never N× it). |
+| `FARM_TEMPERATURE` | `0` | Sampling temperature sent to the worker. Auto-bumped to `0.7` when `FARM_SAMPLES>1` and left at `0` (so samples diversify); set explicitly to override. |
+| `FARM_MAX_TOKENS` | _(unset)_ | Max completion tokens per worker call. `0`/unset = provider default (today's unbounded behavior). |
 | `FARM_MAX_RETRIES` | `2` | Max gate retries per task before escalating. |
 | `FARM_BASE_BRANCH` | `main` | Branch the integration branch is cut from. |
 | `FARM_REQUEST_TIMEOUT_MS` | `120000` | Per-request hard timeout (prevents worker-slot deadlock). |

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -100,6 +100,37 @@ function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
 }
 var git = (args, cwd) => run("git", args, cwd);
 var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function createLimiter(max) {
+  const cap = Math.max(1, Math.floor(max) || 1);
+  let active = 0;
+  const queue = [];
+  const pump = () => {
+    if (active < cap && queue.length) {
+      active++;
+      queue.shift()();
+    }
+  };
+  const acquire = () => new Promise((resolve) => {
+    queue.push(resolve);
+    pump();
+  });
+  const release = () => {
+    active--;
+    pump();
+  };
+  return {
+    async run(fn) {
+      await acquire();
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    },
+    active: () => active
+  };
+}
+var workerLimit = createLimiter(ENV.concurrency);
 var NOSIGN = ["-c", "commit.gpgsign=false"];
 function isInside(root, target) {
   const rel = path.relative(root, target);
@@ -166,7 +197,7 @@ function redactSecrets(contents) {
   return out.join("\n");
 }
 function renderInjectedFile(file) {
-  const label = file.readOnly ? `${file.path} (read-only \u2014 the failing test)` : file.path;
+  const label = file.prior ? `${file.path} (your previous attempt \u2014 FAILED)` : file.readOnly ? `${file.path} (read-only \u2014 the failing test)` : file.path;
   return [`--- ${label} ---`, redactSecrets(file.contents)].join("\n");
 }
 var TRUNCATION_MARKER = "--- [TRUNCATED \u2014 injected context exceeded FARM_ENRICH_MAX_BYTES] ---";
@@ -193,7 +224,7 @@ function capInjected(injected, maxBytes) {
   }
   return out;
 }
-async function buildEnrichment(wt, t) {
+async function buildEnrichment(wt, t, priorInScope = []) {
   const injected = [];
   const seen = /* @__PURE__ */ new Set();
   if (!isSecretBearingFilename(t.test.path)) {
@@ -216,14 +247,38 @@ async function buildEnrichment(wt, t) {
     injected.push({ path: f, contents: src, readOnly: false });
     seen.add(f);
   }
+  for (const pf of priorInScope) {
+    if (isSecretBearingFilename(pf.path)) continue;
+    injected.push({ path: pf.path, contents: pf.contents, readOnly: true, prior: true });
+  }
   return capInjected(injected, ENV.enrichMaxBytes);
 }
+async function captureInScope(wt, t) {
+  const out = [];
+  for (const f of t.filesInScope) {
+    if (f === t.test.path) continue;
+    if (isSecretBearingFilename(f)) continue;
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
+    out.push({ path: f, contents: src });
+  }
+  return out;
+}
 function buildPrompt(t, injected, priorFailure, forbiddenExtra) {
-  const enrichment = injected.length ? [
+  const current = injected.filter((f) => !f.prior);
+  const priorFiles = injected.filter((f) => f.prior);
+  const enrichment = current.length ? [
     ``,
     `Current source of the relevant files (the test is read-only; implement against it):`,
     ``,
-    ...injected.map(renderInjectedFile),
+    ...current.map(renderInjectedFile),
+    ``
+  ] : [];
+  const priorBlock = priorFiles.length ? [
+    ``,
+    `Your PREVIOUS attempt FAILED the gate. Here is what you wrote last time \u2014 do NOT just repeat it; change it to fix the cause shown at the end:`,
+    ``,
+    ...priorFiles.map(renderInjectedFile),
     ``
   ] : [];
   return [
@@ -245,6 +300,7 @@ ${t.context}
 Your previous attempt wrote these FORBIDDEN paths \u2014 do NOT touch them again:
 ${forbiddenExtra.map((f) => `  - ${f}`).join("\n")}` : ``,
     ...enrichment,
+    ...priorBlock,
     `Solve the task with REAL logic. Do not hard-code the literal values the`,
     `test asserts \u2014 an implementation that only returns the expected constant`,
     `will be rejected.`,
@@ -318,7 +374,18 @@ function parseChatCompletion(text, apiBaseUrl) {
   }
   return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
 }
-async function callApi(prompt, model, apiBaseUrl, apiKey) {
+function readSampling() {
+  return {
+    temperature: Number(process.env.FARM_TEMPERATURE ?? 0),
+    maxTokens: Number(process.env.FARM_MAX_TOKENS ?? 0)
+  };
+}
+function buildChatBody(model, messages, sampling = readSampling()) {
+  const body = { model, messages, temperature: sampling.temperature };
+  if (sampling.maxTokens > 0) body.max_tokens = sampling.maxTokens;
+  return body;
+}
+async function callApi(prompt, model, apiBaseUrl, apiKey, sampling = readSampling()) {
   for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), ENV.requestTimeoutMs);
@@ -330,10 +397,7 @@ async function callApi(prompt, model, apiBaseUrl, apiKey) {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`
         },
-        body: JSON.stringify({
-          model,
-          messages: [{ role: "user", content: prompt }]
-        }),
+        body: JSON.stringify(buildChatBody(model, [{ role: "user", content: prompt }], sampling)),
         signal: ctrl.signal
       });
     } catch (e) {
@@ -369,8 +433,8 @@ async function callApi(prompt, model, apiBaseUrl, apiKey) {
   }
   return { ok: false, error: "exhausted API retries" };
 }
-async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden) {
-  const api = await callApi(prompt, model, apiBaseUrl, apiKey);
+async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden, sampling) {
+  const api = await callApi(prompt, model, apiBaseUrl, apiKey, sampling ?? readSampling());
   if (!api.ok) return { ok: false, filesWritten: [], error: api.error };
   const blocks = extractFileBlocks(api.content);
   const filesWritten = [];
@@ -405,7 +469,7 @@ async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden) {
   };
 }
 var httpWorker = {
-  apply: (ctx) => runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden)
+  apply: (ctx) => runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden, ctx.sampling)
 };
 async function checkDrift(cwd, allowed, gitRunner = git) {
   const tracked = await gitRunner(["diff", "--name-only", "HEAD"], cwd);
@@ -637,6 +701,79 @@ var defaultRunTaskDeps = () => ({
   git,
   withMergeLock
 });
+function effectiveSampling(samples) {
+  const s = readSampling();
+  if (samples > 1 && s.temperature === 0) {
+    process.stderr.write(
+      `[FARM] FARM_SAMPLES=${samples} with FARM_TEMPERATURE=0 \u2014 bumping temperature to 0.7 so samples diversify (set FARM_TEMPERATURE to override)
+`
+    );
+    return { ...s, temperature: 0.7 };
+  }
+  return s;
+}
+async function writeFilesInto(wt, files) {
+  for (const f of files) {
+    const abs = path.resolve(wt, f.path);
+    if (!isInside(wt, abs)) continue;
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
+  }
+}
+async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden, allowed, n, deps) {
+  const runSample = (k) => workerLimit.run(async () => {
+    const branch = `farm/${t.id}__s${k}`;
+    const wt = path.resolve(ENV.worktreeRoot, `${t.id}__s${k}`);
+    const base = {
+      green: false,
+      filesWritten: [],
+      files: [],
+      inScope: [],
+      promptTokens: 0,
+      completionTokens: 0,
+      wt,
+      branch
+    };
+    const prep = await deps.prepareWorktree(branch, wt, ENV.integration);
+    if (prep) return { ...base, note: prep };
+    if (t.setup && t.setup.length > 0) {
+      const sr = await deps.runGate(wt, t.setup);
+      if (!sr.ok) return { ...base, note: `setup failed: ${sr.failed}
+${sr.tail}` };
+    }
+    const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
+    const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
+    const pt = w.promptTokens ?? 0;
+    const ct = w.completionTokens ?? 0;
+    if (!w.ok) return { ...base, note: `worker error: ${w.error}`, promptTokens: pt, completionTokens: ct };
+    const sweep = postApplySweep(wt, w.filesWritten, forbidden);
+    if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
+    const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
+    if (testHashBefore !== null && testHashAfter !== testHashBefore)
+      return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
+    const drift = await deps.checkDrift(wt, allowed);
+    if (drift.length > 0)
+      return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: `drift: ${drift.join(", ")}`, promptTokens: pt, completionTokens: ct };
+    const gate = await deps.runGate(wt, t.gate.commands);
+    if (!gate.ok)
+      return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: redactSecrets(`failed: ${gate.failed}
+${gate.tail}`), promptTokens: pt, completionTokens: ct };
+    const inScope = await captureInScope(wt, t);
+    return { green: true, filesWritten: w.filesWritten, files: inScope, inScope, promptTokens: pt, completionTokens: ct, wt, branch };
+  });
+  const outcomes = await Promise.all(Array.from({ length: n }, (_, k) => runSample(k)));
+  const promptTokens = outcomes.reduce((s, o) => s + o.promptTokens, 0);
+  const completionTokens = outcomes.reduce((s, o) => s + o.completionTokens, 0);
+  const winner = outcomes.find((o) => o.green) ?? null;
+  const bestFailure = outcomes.find((o) => !o.green && o.inScope.length > 0) ?? outcomes.find((o) => !o.green) ?? null;
+  for (const o of outcomes) {
+    await deps.git(["worktree", "remove", "--force", o.wt]).catch(() => {
+    });
+    await deps.git(["branch", "-D", o.branch]).catch(() => {
+    });
+  }
+  return { winner, bestFailure, promptTokens, completionTokens };
+}
 async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()) {
   const branch = `farm/${t.id}`;
   const wt = path.resolve(ENV.worktreeRoot, t.id);
@@ -644,6 +781,8 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
   const forbidden = /* @__PURE__ */ new Set([t.test.path]);
+  const samples = Math.max(1, Number(process.env.FARM_SAMPLES ?? 1));
+  const sampling = effectiveSampling(samples);
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
     return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
@@ -651,33 +790,56 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   let priorFailure;
   let driftedOnce = false;
   let lastFilesWritten = [];
+  let priorInScope = [];
+  let acceptedPromptTokens = 0;
+  let acceptedCompletionTokens = 0;
   let promptTokens = 0;
   let completionTokens = 0;
   let lastWarning;
   let mutationScore = null;
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
-    if (attempt > 1) await deps.resetWorktree(wt);
+    if (attempt > 1) {
+      if (samples <= 1) priorInScope = await captureInScope(wt, t);
+      await deps.resetWorktree(wt);
+    }
     if (t.setup && t.setup.length > 0) {
       const setupResult = await deps.runGate(wt, t.setup);
       if (!setupResult.ok)
         return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `setup failed: ${setupResult.failed}
 ${setupResult.tail}`, promptTokens, completionTokens };
     }
-    const injected = await buildEnrichment(wt, t);
-    const worker = await deps.worker.apply({
-      cwd: wt,
-      prompt: buildPrompt(t, injected, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0),
-      model: effectiveModel,
-      apiBaseUrl,
-      apiKey,
-      forbidden
-    });
-    promptTokens += worker.promptTokens ?? 0;
-    completionTokens += worker.completionTokens ?? 0;
-    lastFilesWritten = worker.filesWritten;
-    if (!worker.ok) {
-      priorFailure = `worker error: ${worker.error}`;
-      continue;
+    const injected = await buildEnrichment(wt, t, priorInScope);
+    const forbiddenExtra = driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0;
+    const prompt = buildPrompt(t, injected, priorFailure, forbiddenExtra);
+    let worker;
+    if (samples <= 1) {
+      worker = await workerLimit.run(
+        () => deps.worker.apply({ cwd: wt, prompt, model: effectiveModel, apiBaseUrl, apiKey, forbidden, sampling })
+      );
+      promptTokens += worker.promptTokens ?? 0;
+      completionTokens += worker.completionTokens ?? 0;
+      acceptedPromptTokens = worker.promptTokens ?? 0;
+      acceptedCompletionTokens = worker.completionTokens ?? 0;
+      lastFilesWritten = worker.filesWritten;
+      if (!worker.ok) {
+        priorFailure = `worker error: ${worker.error}`;
+        continue;
+      }
+    } else {
+      const sel = await bestOfN(t, prompt, effectiveModel, apiBaseUrl, apiKey, sampling, forbidden, allowed, samples, deps);
+      promptTokens += sel.promptTokens;
+      completionTokens += sel.completionTokens;
+      acceptedPromptTokens = sel.winner?.promptTokens ?? 0;
+      acceptedCompletionTokens = sel.winner?.completionTokens ?? 0;
+      if (!sel.winner) {
+        lastFilesWritten = sel.bestFailure?.filesWritten ?? [];
+        priorInScope = sel.bestFailure?.inScope ?? [];
+        priorFailure = sel.bestFailure?.note ?? "all samples failed the gate";
+        continue;
+      }
+      await writeFilesInto(wt, sel.winner.files);
+      worker = { ok: true, filesWritten: sel.winner.filesWritten };
+      lastFilesWritten = worker.filesWritten;
     }
     const sweepErr = postApplySweep(wt, worker.filesWritten, forbidden);
     if (sweepErr) {
@@ -754,7 +916,7 @@ ${String(merged).slice(0, 160)}`);
     }
     await deps.git(["worktree", "remove", "--force", wt]).catch(() => {
     });
-    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore };
+    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore, samples, acceptedPromptTokens, acceptedCompletionTokens };
   }
   return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore };
 }
@@ -1117,14 +1279,19 @@ export {
   DEFAULT_API_BASE_URL,
   SAFE_TASK_ID,
   assertSecureBaseUrl,
+  buildChatBody,
+  buildPrompt,
+  captureInScope,
   checkDrift,
   codeLineCount,
+  createLimiter,
   extractFileBlocks,
   extractLiterals,
   httpWorker,
   mintRunId,
   parseChatCompletion,
   parseMutationHookOutput,
+  readSampling,
   redactSecrets,
   run,
   runGate,

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -703,9 +703,10 @@ var defaultRunTaskDeps = () => ({
 });
 function effectiveSampling(samples) {
   const s = readSampling();
-  if (samples > 1 && s.temperature === 0) {
+  const explicit = (process.env.FARM_TEMPERATURE ?? "") !== "";
+  if (samples > 1 && s.temperature === 0 && !explicit) {
     process.stderr.write(
-      `[FARM] FARM_SAMPLES=${samples} with FARM_TEMPERATURE=0 \u2014 bumping temperature to 0.7 so samples diversify (set FARM_TEMPERATURE to override)
+      `[FARM] FARM_SAMPLES=${samples} with no FARM_TEMPERATURE set \u2014 bumping temperature to 0.7 so samples diversify (set FARM_TEMPERATURE to override)
 `
     );
     return { ...s, temperature: 0.7 };
@@ -721,6 +722,7 @@ async function writeFilesInto(wt, files) {
   }
 }
 async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden, allowed, n, deps) {
+  const taskBranch = `farm/${t.id}`;
   const runSample = (k) => workerLimit.run(async () => {
     const branch = `farm/${t.id}__s${k}`;
     const wt = path.resolve(ENV.worktreeRoot, `${t.id}__s${k}`);
@@ -734,32 +736,36 @@ async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden
       wt,
       branch
     };
-    const prep = await deps.prepareWorktree(branch, wt, ENV.integration);
-    if (prep) return { ...base, note: prep };
-    if (t.setup && t.setup.length > 0) {
-      const sr = await deps.runGate(wt, t.setup);
-      if (!sr.ok) return { ...base, note: `setup failed: ${sr.failed}
-${sr.tail}` };
-    }
-    const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
-    const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
-    const pt = w.promptTokens ?? 0;
-    const ct = w.completionTokens ?? 0;
-    if (!w.ok) return { ...base, note: `worker error: ${w.error}`, promptTokens: pt, completionTokens: ct };
-    const sweep = postApplySweep(wt, w.filesWritten, forbidden);
-    if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
-    const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
-    if (testHashBefore !== null && testHashAfter !== testHashBefore)
-      return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
-    const drift = await deps.checkDrift(wt, allowed);
-    if (drift.length > 0)
-      return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: `drift: ${drift.join(", ")}`, promptTokens: pt, completionTokens: ct };
-    const gate = await deps.runGate(wt, t.gate.commands);
-    if (!gate.ok)
-      return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: redactSecrets(`failed: ${gate.failed}
+    try {
+      const prep = await deps.prepareWorktree(branch, wt, taskBranch);
+      if (prep) return { ...base, note: prep };
+      if (t.setup && t.setup.length > 0) {
+        const sr = await deps.runGate(wt, t.setup);
+        if (!sr.ok) return { ...base, note: redactSecrets(`setup failed: ${sr.failed}
+${sr.tail}`) };
+      }
+      const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
+      const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
+      const pt = w.promptTokens ?? 0;
+      const ct = w.completionTokens ?? 0;
+      if (!w.ok) return { ...base, note: redactSecrets(`worker error: ${w.error}`), promptTokens: pt, completionTokens: ct };
+      const sweep = postApplySweep(wt, w.filesWritten, forbidden);
+      if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
+      const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
+      if (testHashBefore !== null && testHashAfter !== testHashBefore)
+        return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
+      const drift = await deps.checkDrift(wt, allowed);
+      if (drift.length > 0)
+        return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: `drift: ${drift.join(", ")}`, promptTokens: pt, completionTokens: ct };
+      const gate = await deps.runGate(wt, t.gate.commands);
+      if (!gate.ok)
+        return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: redactSecrets(`failed: ${gate.failed}
 ${gate.tail}`), promptTokens: pt, completionTokens: ct };
-    const inScope = await captureInScope(wt, t);
-    return { green: true, filesWritten: w.filesWritten, files: inScope, inScope, promptTokens: pt, completionTokens: ct, wt, branch };
+      const inScope = await captureInScope(wt, t);
+      return { green: true, filesWritten: w.filesWritten, files: inScope, inScope, promptTokens: pt, completionTokens: ct, wt, branch };
+    } catch (e) {
+      return { ...base, note: `sample error: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
   const outcomes = await Promise.all(Array.from({ length: n }, (_, k) => runSample(k)));
   const promptTokens = outcomes.reduce((s, o) => s + o.promptTokens, 0);
@@ -781,7 +787,8 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
   const forbidden = /* @__PURE__ */ new Set([t.test.path]);
-  const samples = Math.max(1, Number(process.env.FARM_SAMPLES ?? 1));
+  const rawSamples = Number(process.env.FARM_SAMPLES ?? 1);
+  const samples = Number.isFinite(rawSamples) ? Math.max(1, Math.floor(rawSamples)) : 1;
   const sampling = effectiveSampling(samples);
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
@@ -799,14 +806,14 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   let mutationScore = null;
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
     if (attempt > 1) {
-      if (samples <= 1) priorInScope = await captureInScope(wt, t);
+      if (samples <= 1) priorInScope = lastFilesWritten.length > 0 ? await captureInScope(wt, t) : [];
       await deps.resetWorktree(wt);
     }
     if (t.setup && t.setup.length > 0) {
       const setupResult = await deps.runGate(wt, t.setup);
       if (!setupResult.ok)
-        return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `setup failed: ${setupResult.failed}
-${setupResult.tail}`, promptTokens, completionTokens };
+        return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: redactSecrets(`setup failed: ${setupResult.failed}
+${setupResult.tail}`), promptTokens, completionTokens };
     }
     const injected = await buildEnrichment(wt, t, priorInScope);
     const forbiddenExtra = driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0;
@@ -822,7 +829,7 @@ ${setupResult.tail}`, promptTokens, completionTokens };
       acceptedCompletionTokens = worker.completionTokens ?? 0;
       lastFilesWritten = worker.filesWritten;
       if (!worker.ok) {
-        priorFailure = `worker error: ${worker.error}`;
+        priorFailure = redactSecrets(`worker error: ${worker.error}`);
         continue;
       }
     } else {

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -964,6 +964,55 @@ describe("farm.ts smoke tests", () => {
     expect(integB).toContain("export const b = 2;");
   });
 
+  it("best-of-N (FARM_SAMPLES>1) draws N samples in real isolated worktrees, accepts a green one, and cleans up scratch worktrees", async () => {
+    // Real-worktree validation of F1 (stubs can't exercise git worktree add /
+    // cleanup / winner materialization). The mock returns a valid impl for every
+    // sample, so all samples pass the gate and the first (index 0) is accepted.
+    let calls = 0;
+    ({ server: mockServer, port } = await startMockServer(() => {
+      calls++;
+      return ["```typescript", "// path: src/hello.ts", "export function hello() { return 'hello'; }", "```"].join("\n");
+    }));
+
+    const plan = {
+      meta: { name: "best-of-n", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_SAMPLES: "3", FARM_TEMPERATURE: "0.5" });
+    if (result.code !== 0) console.error("BEST-OF-N OUTPUT:", result.out);
+
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("green=1");
+    // One worker call PER sample for the single task → exactly 3.
+    expect(calls).toBe(3);
+
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results[0].status).toBe("green");
+    expect(report.results[0].samples).toBe(3);
+
+    // The winning impl actually landed on the integration branch.
+    const integHello = execSync("git show farm/integration:src/hello.ts", { cwd: tmpDir, encoding: "utf8" });
+    expect(integHello).toContain("export function hello()");
+
+    // Scratch sample worktrees AND the task worktree are removed on success.
+    expect(existsSync(join(tmpDir, ".farm/worktrees/task-a__s0"))).toBe(false);
+    expect(existsSync(join(tmpDir, ".farm/worktrees/task-a__s2"))).toBe(false);
+    expect(existsSync(join(tmpDir, ".farm/worktrees/task-a"))).toBe(false);
+  });
+
   it("is safe to run twice in a row (stale branches cleaned)", async () => {
     ({ server: mockServer, port } = await startMockServer((body) => {
       const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -1298,9 +1298,14 @@ const defaultRunTaskDeps = (): RunTaskDeps => ({
 // diversifying default (logged) unless the operator set FARM_TEMPERATURE.
 function effectiveSampling(samples: number): Sampling {
   const s = readSampling();
-  if (samples > 1 && s.temperature === 0) {
+  // Bump only when the temperature is an UNSET default 0. An operator who set
+  // FARM_TEMPERATURE explicitly — including to 0 — gets exactly what they asked
+  // for; the stderr hint ("set FARM_TEMPERATURE to override") would otherwise lie
+  // for the explicit-0 case.
+  const explicit = (process.env.FARM_TEMPERATURE ?? "") !== "";
+  if (samples > 1 && s.temperature === 0 && !explicit) {
     process.stderr.write(
-      `[FARM] FARM_SAMPLES=${samples} with FARM_TEMPERATURE=0 — bumping temperature to 0.7 so samples diversify (set FARM_TEMPERATURE to override)\n`,
+      `[FARM] FARM_SAMPLES=${samples} with no FARM_TEMPERATURE set — bumping temperature to 0.7 so samples diversify (set FARM_TEMPERATURE to override)\n`,
     );
     return { ...s, temperature: 0.7 };
   }
@@ -1359,6 +1364,13 @@ async function bestOfN(
   // All sample worktrees are cut from the same integration HEAD as the task
   // worktree, so they share the baseline the single `prompt` was enriched
   // against — the prompt is reused rather than rebuilt per sample.
+  // Samples are cut from the TASK branch (a frozen snapshot of integration HEAD
+  // at task start) — NOT from the live `farm/integration` ref — so every sample
+  // shares the EXACT baseline the task worktree re-gates and merges against
+  // (AC-F1.2). This is immune to a non-overlapping sibling task moving
+  // farm/integration mid-flight (which would otherwise gate a sample against a
+  // newer baseline than the task worktree, causing a false escalation).
+  const taskBranch = `farm/${t.id}`;
   const runSample = (k: number): Promise<SampleOutcome> =>
     workerLimit.run(async () => {
       const branch = `farm/${t.id}__s${k}`;
@@ -1366,30 +1378,38 @@ async function bestOfN(
       const base: SampleOutcome = {
         green: false, filesWritten: [], files: [], inScope: [], promptTokens: 0, completionTokens: 0, wt, branch,
       };
-      const prep = await deps.prepareWorktree(branch, wt, ENV.integration);
-      if (prep) return { ...base, note: prep };
-      if (t.setup && t.setup.length > 0) {
-        const sr = await deps.runGate(wt, t.setup);
-        if (!sr.ok) return { ...base, note: `setup failed: ${sr.failed}\n${sr.tail}` };
+      try {
+        const prep = await deps.prepareWorktree(branch, wt, taskBranch);
+        if (prep) return { ...base, note: prep };
+        if (t.setup && t.setup.length > 0) {
+          const sr = await deps.runGate(wt, t.setup);
+          if (!sr.ok) return { ...base, note: redactSecrets(`setup failed: ${sr.failed}\n${sr.tail}`) };
+        }
+        const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
+        const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
+        const pt = w.promptTokens ?? 0;
+        const ct = w.completionTokens ?? 0;
+        if (!w.ok) return { ...base, note: redactSecrets(`worker error: ${w.error}`), promptTokens: pt, completionTokens: ct };
+        const sweep = postApplySweep(wt, w.filesWritten, forbidden);
+        if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
+        const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
+        if (testHashBefore !== null && testHashAfter !== testHashBefore)
+          return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
+        const drift = await deps.checkDrift(wt, allowed);
+        if (drift.length > 0)
+          return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: `drift: ${drift.join(", ")}`, promptTokens: pt, completionTokens: ct };
+        const gate = await deps.runGate(wt, t.gate.commands);
+        if (!gate.ok)
+          return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: redactSecrets(`failed: ${gate.failed}\n${gate.tail}`), promptTokens: pt, completionTokens: ct };
+        const inScope = await captureInScope(wt, t);
+        return { green: true, filesWritten: w.filesWritten, files: inScope, inScope, promptTokens: pt, completionTokens: ct, wt, branch };
+      } catch (e) {
+        // A sample that THROWS (fs/git error mid-flight) must still resolve to a
+        // failure OUTCOME, not reject — so Promise.all below never rejects and the
+        // cleanup loop always removes every scratch worktree (M1: no leak on the
+        // exception path). `base` already carries this sample's wt/branch.
+        return { ...base, note: `sample error: ${e instanceof Error ? e.message : String(e)}` };
       }
-      const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
-      const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
-      const pt = w.promptTokens ?? 0;
-      const ct = w.completionTokens ?? 0;
-      if (!w.ok) return { ...base, note: `worker error: ${w.error}`, promptTokens: pt, completionTokens: ct };
-      const sweep = postApplySweep(wt, w.filesWritten, forbidden);
-      if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
-      const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
-      if (testHashBefore !== null && testHashAfter !== testHashBefore)
-        return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
-      const drift = await deps.checkDrift(wt, allowed);
-      if (drift.length > 0)
-        return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: `drift: ${drift.join(", ")}`, promptTokens: pt, completionTokens: ct };
-      const gate = await deps.runGate(wt, t.gate.commands);
-      if (!gate.ok)
-        return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: redactSecrets(`failed: ${gate.failed}\n${gate.tail}`), promptTokens: pt, completionTokens: ct };
-      const inScope = await captureInScope(wt, t);
-      return { green: true, filesWritten: w.filesWritten, files: inScope, inScope, promptTokens: pt, completionTokens: ct, wt, branch };
     });
 
   const outcomes = await Promise.all(Array.from({ length: n }, (_, k) => runSample(k)));
@@ -1426,8 +1446,12 @@ export async function runTask(
   const allowed = new Set(t.filesInScope);
   const forbidden = new Set([t.test.path]);
   // F1: best-of-N. FARM_SAMPLES read live (default 1 = today's single-candidate
-  // path). `sampling` carries the temperature (auto-bumped when N>1, AC-F1.3).
-  const samples = Math.max(1, Number(process.env.FARM_SAMPLES ?? 1));
+  // path). A non-numeric / non-finite value falls back to 1 rather than poisoning
+  // the run with NaN — `Math.max(1, NaN)` is NaN, which would empty every sample
+  // batch and silently mass-escalate the run. `sampling` carries the temperature
+  // (auto-bumped when N>1, AC-F1.3).
+  const rawSamples = Number(process.env.FARM_SAMPLES ?? 1);
+  const samples = Number.isFinite(rawSamples) ? Math.max(1, Math.floor(rawSamples)) : 1;
   const sampling = effectiveSampling(samples);
 
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
@@ -1458,7 +1482,10 @@ export async function runTask(
       // Only meaningful for the single-sample path (which writes into `wt`); under
       // best-of-N `priorInScope` is seeded explicitly from the best failing sample
       // below, so the task worktree (never sample-written) must not clobber it.
-      if (samples <= 1) priorInScope = await captureInScope(wt, t);
+      // And only re-show output the worker ACTUALLY wrote: if the prior attempt
+      // failed at the API level (no files written), captureInScope would return the
+      // inherited baseline, which must not be mislabeled "your previous attempt".
+      if (samples <= 1) priorInScope = lastFilesWritten.length > 0 ? await captureInScope(wt, t) : [];
       await deps.resetWorktree(wt); // never accumulate stale files
     }
 
@@ -1471,7 +1498,7 @@ export async function runTask(
     if (t.setup && t.setup.length > 0) {
       const setupResult = await deps.runGate(wt, t.setup);
       if (!setupResult.ok)
-        return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `setup failed: ${setupResult.failed}\n${setupResult.tail}`, promptTokens, completionTokens };
+        return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: redactSecrets(`setup failed: ${setupResult.failed}\n${setupResult.tail}`), promptTokens, completionTokens };
     }
 
     // Enrichment (AC-03/AC-04): read the per-attempt worktree state — AFTER any
@@ -1495,7 +1522,7 @@ export async function runTask(
       acceptedCompletionTokens = worker.completionTokens ?? 0;
       lastFilesWritten = worker.filesWritten;
       if (!worker.ok) {
-        priorFailure = `worker error: ${worker.error}`;
+        priorFailure = redactSecrets(`worker error: ${worker.error}`);
         continue;
       }
     } else {

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -230,6 +230,49 @@ export function run(
 const git: GitRunner = (args, cwd) => run("git", args, cwd);
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// --------------------------------------------------------------------------
+// Concurrency limiter (F1). A shared worker-call budget so best-of-N sampling
+// (up to FARM_SAMPLES worker calls per task) never exceeds FARM_CONCURRENCY
+// TOTAL in-flight calls, across tasks AND their samples (AC-F1.4). With
+// FARM_SAMPLES=1 each task makes exactly one call and the scheduler already caps
+// concurrent tasks at the same bound, so the limiter never blocks — behavior is
+// identical to today. A job that throws still releases its slot (no leak).
+// --------------------------------------------------------------------------
+export type Limiter = { run<T>(fn: () => Promise<T>): Promise<T>; active(): number };
+export function createLimiter(max: number): Limiter {
+  const cap = Math.max(1, Math.floor(max) || 1);
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const pump = () => {
+    if (active < cap && queue.length) {
+      active++;
+      queue.shift()!();
+    }
+  };
+  const acquire = () =>
+    new Promise<void>((resolve) => {
+      queue.push(resolve);
+      pump();
+    });
+  const release = () => {
+    active--;
+    pump();
+  };
+  return {
+    async run(fn) {
+      await acquire();
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    },
+    active: () => active,
+  };
+}
+// Shared worker-call budget, sized to FARM_CONCURRENCY at module load.
+const workerLimit = createLimiter(ENV.concurrency);
+
 // Commit without signing — the farm makes mechanical commits; signing servers
 // in CI environments reject unattended commits and would be misreported as
 // merge conflicts. The integration PR the human opens is the signed artifact.
@@ -305,7 +348,10 @@ async function readWorktreeFile(wt: string, relPath: string): Promise<string | n
 // without touching buildPrompt or the call site. (T-04 does the injection +
 // shared reader only — cap and redaction are explicitly NOT done here.)
 // --------------------------------------------------------------------------
-export type InjectedFile = { path: string; contents: string; readOnly: boolean };
+// `prior` (F2): this file is the worker's OWN output from a FAILED previous
+// attempt, captured before the inter-attempt reset and shown read-only so a
+// retry refines rather than restarts. Rendered in its own labeled section.
+export type InjectedFile = { path: string; contents: string; readOnly: boolean; prior?: boolean };
 
 // AC-05 secret redaction. NEW code — there is no existing in-code secret sweep
 // to reuse (the repo's sweep is the manual/hook layer per tech-stack.md). This
@@ -393,7 +439,11 @@ export function redactSecrets(contents: string): string {
 // secret redaction (here) wrap every injected file body. Keep this the only
 // place injected file bodies are formatted so the boundary stays in one spot.
 function renderInjectedFile(file: InjectedFile): string {
-  const label = file.readOnly ? `${file.path} (read-only — the failing test)` : file.path;
+  const label = file.prior
+    ? `${file.path} (your previous attempt — FAILED)`
+    : file.readOnly
+      ? `${file.path} (read-only — the failing test)`
+      : file.path;
   return [`--- ${label} ---`, redactSecrets(file.contents)].join("\n");
 }
 
@@ -441,7 +491,11 @@ function capInjected(injected: InjectedFile[], maxBytes: number): InjectedFile[]
   return out;
 }
 
-async function buildEnrichment(wt: string, t: Task): Promise<InjectedFile[]> {
+async function buildEnrichment(
+  wt: string,
+  t: Task,
+  priorInScope: Array<{ path: string; contents: string }> = [],
+): Promise<InjectedFile[]> {
   const injected: InjectedFile[] = [];
   const seen = new Set<string>();
 
@@ -477,6 +531,15 @@ async function buildEnrichment(wt: string, t: Task): Promise<InjectedFile[]> {
     seen.add(f);
   }
 
+  // F2: the worker's OWN prior failed in-scope output (captured before the
+  // inter-attempt reset). Appended AFTER current files so the byte cap truncates
+  // prior context FIRST — the current baseline keeps budget priority. Same
+  // secret-bearing-filename denylist as everything else that leaves the boundary.
+  for (const pf of priorInScope) {
+    if (isSecretBearingFilename(pf.path)) continue;
+    injected.push({ path: pf.path, contents: pf.contents, readOnly: true, prior: true });
+  }
+
   // AC-05: byte-cap the TOTAL injected context before it leaves the trust
   // boundary. Redaction is applied per-file inside renderInjectedFile (the
   // chokepoint), but the truncation stub here means contents already carry the
@@ -485,21 +548,56 @@ async function buildEnrichment(wt: string, t: Task): Promise<InjectedFile[]> {
   return capInjected(injected, ENV.enrichMaxBytes);
 }
 
+// F2: snapshot the worker's in-scope output from the worktree BEFORE the
+// inter-attempt reset wipes it, so the next attempt can refine rather than
+// restart blind. Reads only filesInScope (never the read-only test, never a
+// secret-bearing filename), through the shared reader; a not-yet-written file is
+// skipped. Out-of-scope drift is never in filesInScope, so it is never captured
+// (AC-F2.2).
+export async function captureInScope(
+  wt: string,
+  t: Task,
+): Promise<Array<{ path: string; contents: string }>> {
+  const out: Array<{ path: string; contents: string }> = [];
+  for (const f of t.filesInScope) {
+    if (f === t.test.path) continue;
+    if (isSecretBearingFilename(f)) continue;
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
+    out.push({ path: f, contents: src });
+  }
+  return out;
+}
+
 // --------------------------------------------------------------------------
 // worker prompt
 // --------------------------------------------------------------------------
-function buildPrompt(
+export function buildPrompt(
   t: Task,
   injected: InjectedFile[],
   priorFailure?: string,
   forbiddenExtra?: string[],
 ) {
-  const enrichment = injected.length
+  // F2: split current source (the baseline + the read-only test) from the
+  // worker's prior failed output, so each renders in its own clearly-labeled
+  // section. A retry then sees BOTH what to build against and what it tried last.
+  const current = injected.filter((f) => !f.prior);
+  const priorFiles = injected.filter((f) => f.prior);
+  const enrichment = current.length
     ? [
         ``,
         `Current source of the relevant files (the test is read-only; implement against it):`,
         ``,
-        ...injected.map(renderInjectedFile),
+        ...current.map(renderInjectedFile),
+        ``,
+      ]
+    : [];
+  const priorBlock = priorFiles.length
+    ? [
+        ``,
+        `Your PREVIOUS attempt FAILED the gate. Here is what you wrote last time — do NOT just repeat it; change it to fix the cause shown at the end:`,
+        ``,
+        ...priorFiles.map(renderInjectedFile),
         ``,
       ]
     : [];
@@ -519,6 +617,7 @@ function buildPrompt(
       ? `\nYour previous attempt wrote these FORBIDDEN paths — do NOT touch them again:\n${forbiddenExtra.map((f) => `  - ${f}`).join("\n")}`
       : ``,
     ...enrichment,
+    ...priorBlock,
     `Solve the task with REAL logic. Do not hard-code the literal values the`,
     `test asserts — an implementation that only returns the expected constant`,
     `will be rejected.`,
@@ -632,11 +731,43 @@ export function parseChatCompletion(
   return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
 }
 
+// --------------------------------------------------------------------------
+// Sampling parameters (F4). Today the request body is only {model, messages};
+// without a `temperature` the provider default applies and best-of-N samples
+// cannot diversify, and an unbounded completion can run past the request budget.
+// `readSampling` reads the knobs LIVE from the environment (FARM_TEMPERATURE
+// default 0 — deterministic, closest to "make the test pass"; FARM_MAX_TOKENS
+// default 0 = omit, preserving today's unbounded behavior). `buildChatBody`
+// renders the OpenAI-compatible body; max_tokens is included ONLY when > 0 so
+// the default body is byte-equivalent to today plus the explicit temperature.
+// An explicit `sampling` override is the seam runTask uses to vary temperature
+// per run (the best-of-N auto-bump, AC-F1.3).
+// --------------------------------------------------------------------------
+export type Sampling = { temperature: number; maxTokens: number };
+
+export function readSampling(): Sampling {
+  return {
+    temperature: Number(process.env.FARM_TEMPERATURE ?? 0),
+    maxTokens: Number(process.env.FARM_MAX_TOKENS ?? 0),
+  };
+}
+
+export function buildChatBody(
+  model: string,
+  messages: Array<{ role: string; content: string }>,
+  sampling: Sampling = readSampling(),
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { model, messages, temperature: sampling.temperature };
+  if (sampling.maxTokens > 0) body.max_tokens = sampling.maxTokens;
+  return body;
+}
+
 async function callApi(
   prompt: string,
   model: string,
   apiBaseUrl: string,
   apiKey: string,
+  sampling: Sampling = readSampling(),
 ): Promise<{ ok: true; content: string; usage?: { prompt_tokens?: number; completion_tokens?: number } } | { ok: false; error: string }> {
   for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
     const ctrl = new AbortController();
@@ -649,10 +780,7 @@ async function callApi(
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
         },
-        body: JSON.stringify({
-          model,
-          messages: [{ role: "user", content: prompt }],
-        }),
+        body: JSON.stringify(buildChatBody(model, [{ role: "user", content: prompt }], sampling)),
         signal: ctrl.signal,
       });
     } catch (e) {
@@ -706,8 +834,9 @@ async function runWorker(
   apiBaseUrl: string,
   apiKey: string,
   forbidden: Set<string>,
+  sampling?: Sampling,
 ): Promise<WorkerResult> {
-  const api = await callApi(prompt, model, apiBaseUrl, apiKey);
+  const api = await callApi(prompt, model, apiBaseUrl, apiKey, sampling ?? readSampling());
   if (!api.ok) return { ok: false, filesWritten: [], error: api.error };
 
   const blocks = extractFileBlocks(api.content);
@@ -766,6 +895,10 @@ export type WorkerContext = {
   apiBaseUrl: string;
   apiKey: string;
   forbidden: Set<string>;
+  // F4/F1: the effective sampling for this worker call. runTask computes it
+  // (FARM_TEMPERATURE, with the best-of-N auto-bump applied per AC-F1.3) and
+  // threads it here; absent → the worker reads the live env defaults.
+  sampling?: Sampling;
 };
 
 export interface Worker {
@@ -775,7 +908,7 @@ export interface Worker {
 // Default worker: the existing blind HTTP-chat author, unchanged.
 export const httpWorker: Worker = {
   apply: (ctx) =>
-    runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden),
+    runWorker(ctx.cwd, ctx.prompt, ctx.model, ctx.apiBaseUrl, ctx.apiKey, ctx.forbidden, ctx.sampling),
 };
 
 // --------------------------------------------------------------------------
@@ -1086,6 +1219,13 @@ type Result = {
   promptTokens?: number;
   completionTokens?: number;
   mutationScore?: number | null;
+  // F1/AC-F1.6: best-of-N cost transparency. `samples` = candidates drawn for
+  // the accepted attempt; `promptTokens`/`completionTokens` already SUM every
+  // sample (total spend), and these expose the ACCEPTED candidate's own tokens
+  // so the report can show accepted-vs-total. Absent / equal at FARM_SAMPLES=1.
+  samples?: number;
+  acceptedPromptTokens?: number;
+  acceptedCompletionTokens?: number;
   // observability-003 (T-07c): run-level correlation id, stamped onto every
   // result before it is appended to farm-results.jsonl, so concurrent farm runs
   // writing to the same .farm/ directory produce distinguishable lines that tie
@@ -1153,6 +1293,121 @@ const defaultRunTaskDeps = (): RunTaskDeps => ({
   withMergeLock,
 });
 
+// F1 — effective sampling for a run. AC-F1.3: N>1 with a deterministic
+// temperature 0 produces N identical samples, which defeats best-of-N; bump to a
+// diversifying default (logged) unless the operator set FARM_TEMPERATURE.
+function effectiveSampling(samples: number): Sampling {
+  const s = readSampling();
+  if (samples > 1 && s.temperature === 0) {
+    process.stderr.write(
+      `[FARM] FARM_SAMPLES=${samples} with FARM_TEMPERATURE=0 — bumping temperature to 0.7 so samples diversify (set FARM_TEMPERATURE to override)\n`,
+    );
+    return { ...s, temperature: 0.7 };
+  }
+  return s;
+}
+
+// F1 — materialize the winning sample's in-scope files into the task worktree,
+// so the unchanged post-selection pipeline (sweep/tamper/drift/gate/anti-gaming/
+// commit/merge) runs against `wt` exactly as in the single-sample path. Only
+// in-scope impl files are written (the test is already present in `wt`); a path
+// that would escape the worktree is refused (defense-in-depth — winner files are
+// in-scope already).
+async function writeFilesInto(wt: string, files: Array<{ path: string; contents: string }>): Promise<void> {
+  for (const f of files) {
+    const abs = path.resolve(wt, f.path);
+    if (!isInside(wt, abs)) continue;
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
+  }
+}
+
+// F1 — one best-of-N sample: a full candidate gating (worker → containment sweep
+// → test-tamper → drift → gate) in an isolated scratch worktree cut from
+// integration HEAD. Drawn through the shared worker-call limiter (AC-F1.4). On
+// green it captures the in-scope impl files so the winner can be materialized
+// into the task worktree.
+type SampleOutcome = {
+  green: boolean;
+  filesWritten: string[];
+  files: Array<{ path: string; contents: string }>;
+  inScope: Array<{ path: string; contents: string }>;
+  note?: string;
+  promptTokens: number;
+  completionTokens: number;
+  wt: string;
+  branch: string;
+};
+
+async function bestOfN(
+  t: Task,
+  prompt: string,
+  model: string,
+  apiBaseUrl: string,
+  apiKey: string,
+  sampling: Sampling,
+  forbidden: Set<string>,
+  allowed: Set<string>,
+  n: number,
+  deps: RunTaskDeps,
+): Promise<{
+  winner: SampleOutcome | null;
+  bestFailure: SampleOutcome | null;
+  promptTokens: number;
+  completionTokens: number;
+}> {
+  // All sample worktrees are cut from the same integration HEAD as the task
+  // worktree, so they share the baseline the single `prompt` was enriched
+  // against — the prompt is reused rather than rebuilt per sample.
+  const runSample = (k: number): Promise<SampleOutcome> =>
+    workerLimit.run(async () => {
+      const branch = `farm/${t.id}__s${k}`;
+      const wt = path.resolve(ENV.worktreeRoot, `${t.id}__s${k}`);
+      const base: SampleOutcome = {
+        green: false, filesWritten: [], files: [], inScope: [], promptTokens: 0, completionTokens: 0, wt, branch,
+      };
+      const prep = await deps.prepareWorktree(branch, wt, ENV.integration);
+      if (prep) return { ...base, note: prep };
+      if (t.setup && t.setup.length > 0) {
+        const sr = await deps.runGate(wt, t.setup);
+        if (!sr.ok) return { ...base, note: `setup failed: ${sr.failed}\n${sr.tail}` };
+      }
+      const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
+      const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
+      const pt = w.promptTokens ?? 0;
+      const ct = w.completionTokens ?? 0;
+      if (!w.ok) return { ...base, note: `worker error: ${w.error}`, promptTokens: pt, completionTokens: ct };
+      const sweep = postApplySweep(wt, w.filesWritten, forbidden);
+      if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
+      const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
+      if (testHashBefore !== null && testHashAfter !== testHashBefore)
+        return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
+      const drift = await deps.checkDrift(wt, allowed);
+      if (drift.length > 0)
+        return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: `drift: ${drift.join(", ")}`, promptTokens: pt, completionTokens: ct };
+      const gate = await deps.runGate(wt, t.gate.commands);
+      if (!gate.ok)
+        return { ...base, filesWritten: w.filesWritten, inScope: await captureInScope(wt, t), note: redactSecrets(`failed: ${gate.failed}\n${gate.tail}`), promptTokens: pt, completionTokens: ct };
+      const inScope = await captureInScope(wt, t);
+      return { green: true, filesWritten: w.filesWritten, files: inScope, inScope, promptTokens: pt, completionTokens: ct, wt, branch };
+    });
+
+  const outcomes = await Promise.all(Array.from({ length: n }, (_, k) => runSample(k)));
+  const promptTokens = outcomes.reduce((s, o) => s + o.promptTokens, 0);
+  const completionTokens = outcomes.reduce((s, o) => s + o.completionTokens, 0);
+  // First green by sample index wins (deterministic; avoids a wall-clock race).
+  const winner = outcomes.find((o) => o.green) ?? null;
+  // Best failure to seed the retry: prefer one that reached the gate (has its
+  // in-scope output for F2), else any failure.
+  const bestFailure = outcomes.find((o) => !o.green && o.inScope.length > 0) ?? outcomes.find((o) => !o.green) ?? null;
+  // Discard every sample worktree — the winner's files are already captured.
+  for (const o of outcomes) {
+    await deps.git(["worktree", "remove", "--force", o.wt]).catch(() => {});
+    await deps.git(["branch", "-D", o.branch]).catch(() => {});
+  }
+  return { winner, bestFailure, promptTokens, completionTokens };
+}
+
 export async function runTask(
   t: Task,
   model: string,
@@ -1170,6 +1425,10 @@ export async function runTask(
   const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
   const forbidden = new Set([t.test.path]);
+  // F1: best-of-N. FARM_SAMPLES read live (default 1 = today's single-candidate
+  // path). `sampling` carries the temperature (auto-bumped when N>1, AC-F1.3).
+  const samples = Math.max(1, Number(process.env.FARM_SAMPLES ?? 1));
+  const sampling = effectiveSampling(samples);
 
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
@@ -1180,13 +1439,28 @@ export async function runTask(
   let priorFailure: string | undefined;
   let driftedOnce = false;
   let lastFilesWritten: string[] = [];
+  // F2: the failed attempt's in-scope output, captured before each reset and
+  // shown read-only to the next attempt (empty on the first attempt).
+  let priorInScope: Array<{ path: string; contents: string }> = [];
+  // F1/AC-F1.6: the accepted candidate's own token spend (vs the summed total).
+  let acceptedPromptTokens = 0;
+  let acceptedCompletionTokens = 0;
   let promptTokens = 0;
   let completionTokens = 0;
   let lastWarning: string | undefined;
   let mutationScore: number | null = null;
 
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
-    if (attempt > 1) await deps.resetWorktree(wt); // never accumulate stale files
+    if (attempt > 1) {
+      // F2: snapshot the failed attempt's in-scope output BEFORE the reset wipes
+      // it, so the next attempt refines against what it wrote rather than
+      // restarting from the baseline blind. Out-of-scope drift is not captured.
+      // Only meaningful for the single-sample path (which writes into `wt`); under
+      // best-of-N `priorInScope` is seeded explicitly from the best failing sample
+      // below, so the task worktree (never sample-written) must not clobber it.
+      if (samples <= 1) priorInScope = await captureInScope(wt, t);
+      await deps.resetWorktree(wt); // never accumulate stale files
+    }
 
     // Per-worktree setup (#92): run dependency-setup commands in the worktree
     // before the worker. Runs every attempt because the reset above wipes
@@ -1203,23 +1477,48 @@ export async function runTask(
     // Enrichment (AC-03/AC-04): read the per-attempt worktree state — AFTER any
     // reset above — so the test source and existing in-scope file contents
     // reflect what the worker would actually see this attempt.
-    const injected = await buildEnrichment(wt, t);
+    const injected = await buildEnrichment(wt, t, priorInScope);
 
-    const worker = await deps.worker.apply({
-      cwd: wt,
-      prompt: buildPrompt(t, injected, priorFailure, driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : undefined),
-      model: effectiveModel,
-      apiBaseUrl,
-      apiKey,
-      forbidden,
-    });
-    promptTokens += worker.promptTokens ?? 0;
-    completionTokens += worker.completionTokens ?? 0;
-    lastFilesWritten = worker.filesWritten;
+    const forbiddenExtra = driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : undefined;
+    const prompt = buildPrompt(t, injected, priorFailure, forbiddenExtra);
 
-    if (!worker.ok) {
-      priorFailure = `worker error: ${worker.error}`;
-      continue;
+    let worker: WorkerResult;
+    if (samples <= 1) {
+      // Single-sample path — identical to today (one worker call into the task
+      // worktree), now drawn through the shared limiter (a no-op at N=1).
+      worker = await workerLimit.run(() =>
+        deps.worker.apply({ cwd: wt, prompt, model: effectiveModel, apiBaseUrl, apiKey, forbidden, sampling }),
+      );
+      promptTokens += worker.promptTokens ?? 0;
+      completionTokens += worker.completionTokens ?? 0;
+      acceptedPromptTokens = worker.promptTokens ?? 0;
+      acceptedCompletionTokens = worker.completionTokens ?? 0;
+      lastFilesWritten = worker.filesWritten;
+      if (!worker.ok) {
+        priorFailure = `worker error: ${worker.error}`;
+        continue;
+      }
+    } else {
+      // Best-of-N (AC-F1.2): draw `samples` candidates concurrently in isolated
+      // scratch worktrees, gate each, accept the first green. The winner's files
+      // are materialized into `wt`; the post-selection pipeline below then runs
+      // against `wt` UNCHANGED. No green → seed the retry from the best failure
+      // (its in-scope output, per F2) and loop (AC-F1.5). Token spend across ALL
+      // samples is summed; the winner's own tokens are recorded separately (AC-F1.6).
+      const sel = await bestOfN(t, prompt, effectiveModel, apiBaseUrl, apiKey, sampling, forbidden, allowed, samples, deps);
+      promptTokens += sel.promptTokens;
+      completionTokens += sel.completionTokens;
+      acceptedPromptTokens = sel.winner?.promptTokens ?? 0;
+      acceptedCompletionTokens = sel.winner?.completionTokens ?? 0;
+      if (!sel.winner) {
+        lastFilesWritten = sel.bestFailure?.filesWritten ?? [];
+        priorInScope = sel.bestFailure?.inScope ?? [];
+        priorFailure = sel.bestFailure?.note ?? "all samples failed the gate";
+        continue;
+      }
+      await writeFilesInto(wt, sel.winner.files);
+      worker = { ok: true, filesWritten: sel.winner.filesWritten };
+      lastFilesWritten = worker.filesWritten;
     }
 
     // Post-apply containment sweep (D6) — task-level enforcement over the
@@ -1338,7 +1637,7 @@ export async function runTask(
 
     // success — drop the worktree (branch stays, merged into integration)
     await deps.git(["worktree", "remove", "--force", wt]).catch(() => {});
-    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore };
+    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore, samples, acceptedPromptTokens, acceptedCompletionTokens };
   }
 
   // worktree intentionally left in place for inspection

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -2,11 +2,14 @@
  * Unit tests for farm.ts pure-function core.
  * These test the exported helpers directly without spawning a subprocess.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput } from "./farm.ts";
+import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, rm as fsRm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter } from "./farm.ts";
+import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 
 // ---------------------------------------------------------------------------
@@ -1380,6 +1383,296 @@ describe("run() scrubs dispatcher secrets from the child env (least-privilege, C
       restore("FARM_API_KEY", prev.key);
       restore("CLAUDE_CODE_OAUTH_TOKEN", prev.tok);
       restore("FARM_MODEL", prev.model);
+    }
+  });
+});
+
+// ===========================================================================
+// Slice 1 — first-time-go accuracy (best-of-N + retry feedback)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// F4 — sampling parameters in the chat request body. Today callApi posts only
+// {model, messages}; buildChatBody adds `temperature` (FARM_TEMPERATURE, default
+// 0) and `max_tokens` (only when FARM_MAX_TOKENS > 0, so today's unbounded
+// behavior is the default). Reads env LIVE so a test can set the knob and assert
+// the body, and accepts an explicit override (the seam best-of-N uses to vary
+// temperature per run).
+// ---------------------------------------------------------------------------
+describe("F4 — buildChatBody sampling params", () => {
+  const saved = { temp: process.env.FARM_TEMPERATURE, max: process.env.FARM_MAX_TOKENS };
+  afterEach(() => {
+    const restore = (k: string, v: string | undefined) =>
+      v === undefined ? delete process.env[k] : (process.env[k] = v);
+    restore("FARM_TEMPERATURE", saved.temp);
+    restore("FARM_MAX_TOKENS", saved.max);
+  });
+
+  it("includes temperature (default 0) and omits max_tokens by default", () => {
+    delete process.env.FARM_TEMPERATURE;
+    delete process.env.FARM_MAX_TOKENS;
+    const body = buildChatBody("m", [{ role: "user", content: "hi" }]);
+    expect(body.model).toBe("m");
+    expect(body.messages).toEqual([{ role: "user", content: "hi" }]);
+    expect(body.temperature).toBe(0);
+    expect("max_tokens" in body).toBe(false);
+  });
+
+  it("reads FARM_TEMPERATURE from the environment", () => {
+    process.env.FARM_TEMPERATURE = "0.7";
+    expect(buildChatBody("m", []).temperature).toBe(0.7);
+  });
+
+  it("includes max_tokens only when FARM_MAX_TOKENS > 0", () => {
+    process.env.FARM_MAX_TOKENS = "256";
+    expect(buildChatBody("m", []).max_tokens).toBe(256);
+    process.env.FARM_MAX_TOKENS = "0";
+    expect("max_tokens" in buildChatBody("m", [])).toBe(false);
+  });
+
+  it("honors an explicit sampling override (the best-of-N seam)", () => {
+    const body = buildChatBody("m", [], { temperature: 0.9, maxTokens: 100 });
+    expect(body.temperature).toBe(0.9);
+    expect(body.max_tokens).toBe(100);
+  });
+
+  it("readSampling reflects the live environment", () => {
+    process.env.FARM_TEMPERATURE = "0.3";
+    process.env.FARM_MAX_TOKENS = "512";
+    expect(readSampling()).toEqual({ temperature: 0.3, maxTokens: 512 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F2 — iterative retries: the worker sees its OWN prior failed in-scope output,
+// not just the gate tail. buildPrompt renders prior-attempt files in a distinct
+// "previous attempt" section (redacted, via the same chokepoint); captureInScope
+// gathers the failed attempt's in-scope contents BEFORE the inter-attempt reset,
+// excluding the read-only test path and secret-bearing files (AC-F2.1/2.2/2.3).
+// ---------------------------------------------------------------------------
+describe("F2 — prior-attempt context in buildPrompt", () => {
+  const task: Task = {
+    id: "t",
+    description: "d",
+    filesInScope: ["src/a.ts"],
+    test: { path: "src/a.test.ts" },
+    gate: { commands: ["x"] },
+  };
+
+  it("renders prior-attempt files in a distinct section, redacted, alongside the current baseline", () => {
+    const injected: InjectedFile[] = [
+      { path: "src/a.ts", contents: "export const x = BASELINE;", readOnly: false },
+      { path: "src/a.ts", contents: "const k = 'sk-ant-leak';\nexport const x = 1;", readOnly: true, prior: true },
+    ];
+    const prompt = buildPrompt(task, injected);
+    expect(prompt).toMatch(/previous attempt/i);
+    // the prior code is redacted through the same chokepoint
+    expect(prompt).not.toContain("sk-ant-leak");
+    expect(prompt).toContain("[REDACTED");
+    // the current baseline is still present, in its own (non-prior) section
+    expect(prompt).toContain("BASELINE");
+  });
+
+  it("omits the previous-attempt section entirely when no prior files are present (today's prompt)", () => {
+    const prompt = buildPrompt(task, [{ path: "src/a.ts", contents: "export const x = 1;", readOnly: false }]);
+    expect(prompt).not.toMatch(/previous attempt/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F1 — shared concurrency limiter. Best-of-N draws N worker calls per task; the
+// limiter is the shared budget that keeps TOTAL in-flight worker calls (across
+// tasks AND samples) at or under FARM_CONCURRENCY (AC-F1.4). With FARM_SAMPLES=1
+// each task makes one call and the limiter never blocks.
+// ---------------------------------------------------------------------------
+describe("F1 — createLimiter caps concurrency", () => {
+  async function peakUnder(cap: number, jobs: number): Promise<number> {
+    const limit = createLimiter(cap);
+    let active = 0;
+    let peak = 0;
+    await Promise.all(
+      Array.from({ length: jobs }, () =>
+        limit.run(async () => {
+          active++;
+          peak = Math.max(peak, active);
+          await new Promise((r) => setTimeout(r, 10));
+          active--;
+        }),
+      ),
+    );
+    return peak;
+  }
+
+  it("never runs more than `max` jobs concurrently, and does parallelize up to it", async () => {
+    expect(await peakUnder(2, 6)).toBe(2);
+  });
+
+  it("clamps a max < 1 to 1 (never deadlocks, never unbounded)", async () => {
+    expect(await peakUnder(0, 4)).toBe(1);
+  });
+
+  it("returns each job's resolved value", async () => {
+    const limit = createLimiter(2);
+    const out = await Promise.all([1, 2, 3].map((n) => limit.run(async () => n * 10)));
+    expect(out).toEqual([10, 20, 30]);
+  });
+
+  it("releases the slot even when a job throws (no slot leak)", async () => {
+    const limit = createLimiter(1);
+    await expect(limit.run(async () => { throw new Error("boom"); })).rejects.toThrow("boom");
+    // if the slot had leaked, this second job would hang; a fast resolve proves release.
+    await expect(limit.run(async () => "ok")).resolves.toBe("ok");
+    expect(limit.active()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F1 — best-of-N selection in runTask. With FARM_SAMPLES>1 the task draws N
+// candidates concurrently in isolated scratch worktrees, gates each, and accepts
+// the first green; no green seeds the existing retry from the best failure. The
+// stub deps are cwd-aware: a sample worktree path ends `__s<k>`, so the stub gate
+// can fail specific samples and the stub worker can record which worktree it ran
+// in. Worker writes are not materialized in stub-land (no real fs), which is fine
+// — selection is what's under test; the accepted Result reflects the winner.
+// ---------------------------------------------------------------------------
+describe("F1 — best-of-N in runTask", () => {
+  const saved = { samples: process.env.FARM_SAMPLES, temp: process.env.FARM_TEMPERATURE };
+  afterEach(() => {
+    const restore = (k: string, v: string | undefined) =>
+      v === undefined ? delete process.env[k] : (process.env[k] = v);
+    restore("FARM_SAMPLES", saved.samples);
+    restore("FARM_TEMPERATURE", saved.temp);
+  });
+
+  const task: Task = {
+    id: "bon",
+    description: "make the test pass",
+    filesInScope: ["src/bon.ts"],
+    test: { path: "src/bon.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  const sampleIdx = (cwd: string) => Number(cwd.match(/__s(\d+)$/)?.[1] ?? -1);
+
+  function bestOfNDeps(opts: {
+    gateFailSamples?: number[];
+    workerTokens?: number;
+    onWorkerCwd?: (cwd: string) => void;
+    capturedSampling?: { value?: Sampling };
+  }): RunTaskDeps {
+    const tok = opts.workerTokens ?? 5;
+    return {
+      worker: {
+        async apply(ctx) {
+          opts.onWorkerCwd?.(ctx.cwd);
+          if (opts.capturedSampling) opts.capturedSampling.value = ctx.sampling;
+          const k = ctx.cwd.match(/__s(\d+)$/)?.[1] ?? "main";
+          return { ok: true, filesWritten: [`src/s${k}.ts`], promptTokens: tok, completionTokens: tok * 2 } satisfies WorkerResult;
+        },
+      },
+      prepareWorktree: async () => null,
+      resetWorktree: async () => {},
+      fileHash: async () => null,
+      checkDrift: async () => [],
+      runGate: async (cwd: string) => {
+        if (opts.gateFailSamples?.includes(sampleIdx(cwd))) return { ok: false as const, failed: "node -p 0", tail: "red" };
+        return { ok: true as const };
+      },
+      antiGamingCheck: async () => ({ risk: "none" as const }),
+      mutationCheck: async () => null,
+      git: async () => ({ code: 0, out: "", stdout: "", stderr: "" }),
+      withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+    };
+  }
+
+  it("accepts the FIRST green sample by index and reports its files (AC-F1.2)", async () => {
+    process.env.FARM_SAMPLES = "3";
+    // sample 0 fails the gate; samples 1 and 2 pass → winner is index 1.
+    const r = await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ gateFailSamples: [0] }));
+    expect(r.status).toBe("green");
+    expect(r.filesWritten).toEqual(["src/s1.ts"]);
+  });
+
+  it("sums token spend across ALL samples and records the accepted candidate's separately (AC-F1.6)", async () => {
+    process.env.FARM_SAMPLES = "3";
+    const r = await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ gateFailSamples: [0], workerTokens: 5 }));
+    expect(r.samples).toBe(3);
+    expect(r.promptTokens).toBe(15); // 3 samples × 5
+    expect(r.completionTokens).toBe(30); // 3 × 10
+    expect(r.acceptedPromptTokens).toBe(5); // winner only
+    expect(r.acceptedCompletionTokens).toBe(10);
+  });
+
+  it("escalates when no sample passes the gate and retries are spent (AC-F1.5)", async () => {
+    process.env.FARM_SAMPLES = "2";
+    const r = await runTask({ ...task, maxRetries: 0 }, "m", "https://api.example/v1", "k", bestOfNDeps({ gateFailSamples: [0, 1] }));
+    expect(r.status).toBe("escalate");
+  });
+
+  it("auto-bumps temperature to 0.7 when FARM_SAMPLES>1 and FARM_TEMPERATURE=0 (AC-F1.3)", async () => {
+    process.env.FARM_SAMPLES = "2";
+    delete process.env.FARM_TEMPERATURE;
+    const cap: { value?: Sampling } = {};
+    await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ capturedSampling: cap }));
+    expect(cap.value?.temperature).toBe(0.7);
+  });
+
+  it("does NOT bump temperature when the operator set FARM_TEMPERATURE explicitly", async () => {
+    process.env.FARM_SAMPLES = "2";
+    process.env.FARM_TEMPERATURE = "0.2";
+    const cap: { value?: Sampling } = {};
+    await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ capturedSampling: cap }));
+    expect(cap.value?.temperature).toBe(0.2);
+  });
+
+  it("REGRESSION: FARM_SAMPLES=1 runs one worker call into the TASK worktree, not a sample (AC-F1.1)", async () => {
+    process.env.FARM_SAMPLES = "1";
+    const cwds: string[] = [];
+    const r = await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ onWorkerCwd: (c) => cwds.push(c) }));
+    expect(r.status).toBe("green");
+    expect(cwds).toHaveLength(1);
+    expect(cwds[0]).not.toMatch(/__s\d+$/); // the task worktree, never a sample scratch
+    expect(r.samples).toBe(1);
+  });
+});
+
+describe("F2 — captureInScope (failed-attempt capture before reset)", () => {
+  it("returns in-scope file contents, excluding the test path and secret-bearing files", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "farm-cap-"));
+    try {
+      await fsMkdir(path.join(dir, "src"), { recursive: true });
+      await fsWriteFile(path.join(dir, "src/a.ts"), "export const a = 1;");
+      await fsWriteFile(path.join(dir, "src/a.test.ts"), "the read-only test");
+      await fsWriteFile(path.join(dir, "deploy.key"), "PRIVATE-KEY-MATERIAL");
+      // test.path AND a secret-bearing file are both in filesInScope to prove
+      // they are excluded from the captured set; only src/a.ts survives.
+      const t: Task = {
+        id: "t",
+        description: "d",
+        filesInScope: ["src/a.ts", "src/a.test.ts", "deploy.key"],
+        test: { path: "src/a.test.ts" },
+        gate: { commands: ["x"] },
+      };
+      const captured = await captureInScope(dir, t);
+      expect(captured).toEqual([{ path: "src/a.ts", contents: "export const a = 1;" }]);
+    } finally {
+      await fsRm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns [] when no in-scope files exist on disk yet", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "farm-cap-"));
+    try {
+      const t: Task = {
+        id: "t",
+        description: "d",
+        filesInScope: ["src/not-written-yet.ts"],
+        test: { path: "src/x.test.ts" },
+        gate: { commands: ["x"] },
+      };
+      expect(await captureInScope(dir, t)).toEqual([]);
+    } finally {
+      await fsRm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -1556,6 +1556,7 @@ describe("F1 — best-of-N in runTask", () => {
 
   function bestOfNDeps(opts: {
     gateFailSamples?: number[];
+    throwSamples?: number[];
     workerTokens?: number;
     onWorkerCwd?: (cwd: string) => void;
     capturedSampling?: { value?: Sampling };
@@ -1566,6 +1567,7 @@ describe("F1 — best-of-N in runTask", () => {
         async apply(ctx) {
           opts.onWorkerCwd?.(ctx.cwd);
           if (opts.capturedSampling) opts.capturedSampling.value = ctx.sampling;
+          if (opts.throwSamples?.includes(sampleIdx(ctx.cwd))) throw new Error(`boom s${sampleIdx(ctx.cwd)}`);
           const k = ctx.cwd.match(/__s(\d+)$/)?.[1] ?? "main";
           return { ok: true, filesWritten: [`src/s${k}.ts`], promptTokens: tok, completionTokens: tok * 2 } satisfies WorkerResult;
         },
@@ -1609,7 +1611,7 @@ describe("F1 — best-of-N in runTask", () => {
     expect(r.status).toBe("escalate");
   });
 
-  it("auto-bumps temperature to 0.7 when FARM_SAMPLES>1 and FARM_TEMPERATURE=0 (AC-F1.3)", async () => {
+  it("auto-bumps temperature to 0.7 when FARM_SAMPLES>1 and FARM_TEMPERATURE is unset (AC-F1.3)", async () => {
     process.env.FARM_SAMPLES = "2";
     delete process.env.FARM_TEMPERATURE;
     const cap: { value?: Sampling } = {};
@@ -1617,12 +1619,35 @@ describe("F1 — best-of-N in runTask", () => {
     expect(cap.value?.temperature).toBe(0.7);
   });
 
-  it("does NOT bump temperature when the operator set FARM_TEMPERATURE explicitly", async () => {
+  it("does NOT bump temperature when the operator set FARM_TEMPERATURE explicitly (incl. an explicit 0)", async () => {
     process.env.FARM_SAMPLES = "2";
     process.env.FARM_TEMPERATURE = "0.2";
     const cap: { value?: Sampling } = {};
     await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ capturedSampling: cap }));
     expect(cap.value?.temperature).toBe(0.2);
+    // explicit 0 means deterministic-on-purpose — must NOT be bumped to 0.7
+    process.env.FARM_TEMPERATURE = "0";
+    const cap0: { value?: Sampling } = {};
+    await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ capturedSampling: cap0 }));
+    expect(cap0.value?.temperature).toBe(0);
+  });
+
+  it("treats a non-numeric FARM_SAMPLES as 1 (no NaN mass-escalation) (L1)", async () => {
+    process.env.FARM_SAMPLES = "not-a-number";
+    const cwds: string[] = [];
+    const r = await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ onWorkerCwd: (c) => cwds.push(c) }));
+    expect(r.status).toBe("green");
+    expect(r.samples).toBe(1);
+    expect(cwds).toHaveLength(1);
+    expect(cwds[0]).not.toMatch(/__s\d+$/);
+  });
+
+  it("survives a sample that THROWS — it resolves to a failure and a green sibling still wins (M1)", async () => {
+    process.env.FARM_SAMPLES = "3";
+    // sample 0 throws inside the worker; samples 1,2 are green → winner is index 1.
+    const r = await runTask(task, "m", "https://api.example/v1", "k", bestOfNDeps({ throwSamples: [0] }));
+    expect(r.status).toBe("green");
+    expect(r.filesWritten).toEqual(["src/s1.ts"]);
   });
 
   it("REGRESSION: FARM_SAMPLES=1 runs one worker call into the TASK worktree, not a sample (AC-F1.1)", async () => {


### PR DESCRIPTION
## What

Slice 1 of the `docs/reports/2026-06-26-farm/` deep review — opt-in levers to raise the `--farm` worker's **first-time-go acceptance**, spending only the cheap worker-token axis. `--farm` stays a Feature Forge preview (off by default); `FARM_SAMPLES=1` + default knobs are **behaviorally unchanged** (pinned by a regression test).

### F1 — best-of-N against the gate (`FARM_SAMPLES`, default 1)
The gate is a deterministic pass/fail oracle and each task runs in an isolated worktree, so N candidates are drawn **in parallel** (each in its own scratch worktree cut from the task's frozen baseline) and the **first to pass the gate wins**; the winner's files are taken into the task worktree and merged, losers discarded. A shared limiter caps **total** in-flight worker calls at `FARM_CONCURRENCY` — sampling shares the budget, never multiplies it. `farm-report.json` records both the summed sample-token spend and the accepted candidate's own tokens, so the N×-tokens trade-off is visible.

### F4 — sampling params (`FARM_TEMPERATURE`, `FARM_MAX_TOKENS`)
The chat body now carries `temperature` (default 0; auto-bumped to 0.7 when `FARM_SAMPLES>1` **and** temperature is unset, so samples diversify) and an optional `max_tokens` cap.

### F2 — iterative retries
On a retry (failed gate, or a sampling round with no green) the worker is shown its **own prior in-scope output**, not just the gate-failure tail, so it refines rather than restarts blind — through the same `FARM_ENRICH_MAX_BYTES` cap + secret-redaction + secret-filename-denylist chokepoint as all injected context. Out-of-scope drift is never carried forward.

## Scope decisions (at the sprint gate)
- **F8 (worker sandboxing) → descoped to an ADR.** `ca-sandbox` is a Docker/clone-into-container model that doesn't fit the farm's host-worktree architecture, and there's no agentic worker yet to protect; it'll be designed against the real consumer when Track 2 is scoped (ties to CONFIRM-05).
- **F3 (auto-context enrichment) → Slice 2** (planned after this merges; that's where the trust-boundary gate fires).

## Verification
- **169 vitest green** (typecheck clean), incl. a **real-worktree best-of-N smoke test** (3 samples, winner merged to integration, scratch cleaned) and an **N=1 regression pin**.
- `farm.js` rebuilt and in sync; version bumped 2.5.2 → 2.6.0 (badge + CHANGELOG).

## Independent two-pass review (pre-PR)
- **Security:** PASS — 0 CRIT/HIGH/MED. F2 re-injection preserves the redaction/cap/denylist invariants; bearer token + `assertSecureBaseUrl` intact, no new egress.
- **Correctness/spec-compliance:** SHIP — 0 BLOCK/HIGH. AC-F1.1/F1.4 verified sound.
- Two MEDIUM (worktree-leak-on-throw, sample-baseline skew) + three LOW were **all applied** in the fix commit (see `.codearbiter/sprint-log.md`).

Generated autonomously via `/ca:sprint`; full decision log in `.codearbiter/sprint-log.md`.

https://claude.ai/code/session_011nnQYBPd5Dt1rmtf9CHNfU