### PR TITLE
fix(hooks): stop heredoc bodies false-blocking the commit gate (H-09b)

### DIFF
--- a/.github/scripts/test_hook_guards.py
+++ b/.github/scripts/test_hook_guards.py
@@ -29,6 +29,14 @@ HOOKS = os.path.join(REPO, "plugins", "ca", "hooks")
 PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
 SECURITY_PASS = os.path.join(HOOKS, "security-pass.py")
 
+# Load pre-bash.py as a module for direct unit tests of its pure parsers
+# (the file name has a hyphen, so import via spec). Import is side-effect-free:
+# pre-bash.py only reads stdin / acts inside main(), guarded by __main__.
+import importlib.util as _ilu  # noqa: E402
+_spec = _ilu.spec_from_file_location("pre_bash_mod", PRE_BASH)
+pre_bash = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(pre_bash)
+
 failures = []
 checks = 0
 
@@ -100,6 +108,54 @@ def make_fixture(base, branch):
     return root
 
 
+def check_commit_pathspecs():
+    """Unit-level: a heredoc BODY (stdin content via `-F -`) must not be parsed as
+    pathspecs (the false H-09b/H-14 block), but everything else — including a
+    multi-line quoted `-m` message AND a real trailing pathspec — must survive, or
+    the worktree-union scan (v2.rev.0015) under-scans. Redirect operators are
+    skipped while barewords after them stay over-included."""
+    strip = pre_bash._strip_heredoc_bodies
+    cp = pre_bash.commit_pathspecs
+
+    # the heredoc operator + body + delimiter is removed; nothing else is cut
+    s = strip(" -F - <<'EOF'\nfix: x\nbody ../docs\nEOF")
+    check("../docs" not in s and "<<" not in s, "strip-heredoc",
+          "the heredoc body+operator must be stripped from the arg string")
+    check(cp(strip(" -F - <<'EOF'\nfix: x\nsee ../docs\nEOF")) == [], "cp-heredoc",
+          "heredoc body tokens must not be parsed as pathspecs")
+    check(cp(" -F - <<'EOF'") == [], "cp-redirect-op",
+          "the heredoc operator token must not be a pathspec")
+    # a `\\`-newline continuation is joined, not cut
+    check("b.py" in strip(" a.py \\\n b.py"), "strip-continuation",
+          "a line-continuation must be joined, not truncated")
+
+    # NON-WEAKENING (the v2.rev.0015 regression the first cut introduced): a real
+    # pathspec after a MULTI-LINE quoted -m message must still be collected — a
+    # literal newline inside quotes must NOT drop the trailing path.
+    check(cp(strip(' -m "l1\nl2" secret.py')) == ["secret.py"], "cp-multiline-msg",
+          "a pathspec after a multi-line -m message must still be collected")
+    check(cp(strip(' -m "l1\n\nbody" -- secret.py')) == ["secret.py"],
+          "cp-multiline-dashdash",
+          "the canonical `-- path` form after a multi-line message must survive")
+    # a pathspec on the OPERATOR line, after `<<WORD`, is a real git pathspec
+    # (the shell passes it to git; only the body is stdin) — it must survive the
+    # heredoc strip, not be swallowed with the body (errs-open under-scan).
+    check(cp(strip(" -F - <<EOF secret.py\nbody\nEOF")) == ["secret.py"],
+          "cp-heredoc-opline-pathspec",
+          "a pathspec after `<<WORD` on the operator line must be preserved")
+
+    # ordinary pathspecs / flags
+    check(cp(" -m 'msg' src/app.py") == ["src/app.py"], "cp-pathspec",
+          "a real pathspec must still be collected")
+    check(cp(" -m x a.py b.py") == ["a.py", "b.py"], "cp-multi",
+          "multiple pathspecs collected")
+    check(cp(" -- a.py") == ["a.py"], "cp-dashdash", "explicit -- pathspec collected")
+    # a redirect OPERATOR is skipped, but a bareword after it is still over-included
+    # (so `git commit > log secret.py` cannot smuggle secret.py past the scan)
+    check("secret.py" in cp(" > log secret.py"), "cp-redirect-overinclude",
+          "a bareword after a redirect must still be over-included (no under-scan)")
+
+
 def main():
     for s in (sys.stdout, sys.stderr):
         try:
@@ -109,6 +165,7 @@ def main():
 
     base = tempfile.mkdtemp(prefix="ca-guards-")
     try:
+        check_commit_pathspecs()                    # pure parser units (no fixture)
         fx = make_fixture(base, "feat/work")        # the normal case: a feature branch
         fx_main = make_fixture(base, "main")        # only for on-main push/commit cases
 
@@ -343,6 +400,43 @@ def main():
             f.write("a benign note\n")
         expect_allow(fxp, "git commit -m 'notes' notes.txt",
                      "allow: benign pathspec commit is not over-blocked")
+
+        # 6l. the recommended `git commit -F - <<EOF` multi-line form must NOT
+        # false-block: its heredoc body is the message via stdin, not pathspecs.
+        # RED before the fix — body tokens (e.g. `../docs`) were parsed as
+        # pathspecs and `git diff HEAD -- ../docs` errored -> fail-closed.
+        expect_allow(
+            fxp,
+            "git commit -F - <<'EOF'\nchore: tidy\n\nSee ../docs for context.\nEOF",
+            "H-09b heredoc: benign -F - <<EOF must not false-block on body tokens")
+
+        # 6m. non-weakening lock-in: a heredoc commit that STAGES crypto must
+        # still block — the --cached scan catches it regardless of how the
+        # message is supplied (proves the fix narrows parsing, not the gate).
+        with open(appp, "a", encoding="utf-8") as f:
+            f.write("const h = createHash('sha256');\n")
+        git(["add", "src/app.py"], fxp)
+        expect_block(
+            fxp,
+            "git commit -F - <<'EOF'\nfeat: hashing\nEOF",
+            "H-09b",
+            "H-09b heredoc: staged crypto still blocks (fix does not weaken the gate)")
+        git(["restore", "--staged", "src/app.py"], fxp)
+        git(["checkout", "--", "src/app.py"], fxp)
+
+        # 6n. THE worktree-union non-weakening proof: an UNSTAGED crypto change
+        # committed by pathspec, with a MULTI-LINE `-m` message, must still block.
+        # A first-line split would truncate at the literal newline inside the
+        # quotes and drop the trailing pathspec -> bypass. (RED against that;
+        # GREEN once only heredoc bodies are stripped.)
+        with open(appp, "a", encoding="utf-8") as f:
+            f.write("const h3 = createHash('sha256');\n")
+        expect_block(
+            fxp,
+            'git commit -m "subject\n\nbody line" src/app.py',
+            "H-09b",
+            "H-09b: worktree crypto via multi-line -m pathspec commit still blocks")
+        git(["checkout", "--", "src/app.py"], fxp)
 
         # 6l. SCOPED, not over-scanned: an unstaged crypto change in app.py must
         # NOT block a pathspec commit that names only the benign notes.txt — the

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -261,15 +261,52 @@ COMMIT_VALUE_FLAGS = frozenset({
 })
 
 
+# A redirect operator token (`>`, `>>`, `2>`, `<`, `<<`, `<<'EOF'`, …). Never a
+# git pathspec — feeding one to `git diff -- <op>` can ERROR (not "diff to
+# nothing"), which is what failed the H-09b/H-14 scan CLOSED on heredoc commits.
+REDIRECT_RE = re.compile(r"\d*[<>]")
+
+
+# A heredoc: `<<` (optional `-`), optional quote, a word delimiter, optional
+# matching quote, the rest of that line, then body lines, up to a line that is
+# the delimiter alone. The body is stdin content (the commit message via `-F -`),
+# never git arguments — parsing it as pathspecs failed H-09b/H-10b/H-14 CLOSED on
+# the recommended `git commit -F - <<EOF` form.
+# Group 3 captures the REST OF THE OPERATOR LINE after `<<WORD` — `git commit -F
+# - <<EOF realfile.py` passes `realfile.py` to git as a pathspec (only the body
+# is stdin), so that tail is re-emitted, not swallowed with the body, or the
+# worktree-union scan would under-scan it (errs open).
+HEREDOC_RE = re.compile(
+    r"<<-?[ \t]*([\"']?)(\w+)\1([^\n]*)\n(?:.*?\n)?[ \t]*\2[ \t]*(?:\n|$)",
+    re.DOTALL)
+
+
+def _strip_heredoc_bodies(args):
+    """Remove heredoc operator+body+delimiter from a git-commit arg string so the
+    body is never parsed as flags/pathspecs (it false-blocked H-09b/H-10b/H-14 on
+    `git commit -F - <<EOF`). `\\`-newline continuations are joined first; the
+    operator-line tail (group 3) is preserved.
+
+    CRITICALLY nothing but the heredoc body is cut. An earlier attempt bounded to
+    the first newline (`split("\\n", 1)[0]`), which also truncated at a literal
+    newline inside a quoted `-m "subject\\n\\nbody"` message and dropped a trailing
+    pathspec — silently under-scanning a pathspec-scoped commit and reopening the
+    v2.rev.0015 worktree-union bypass. Stripping only the heredoc (and keeping the
+    operator-line tail) leaves a multi-line message and any real pathspec intact."""
+    joined = re.sub(r"\\\r?\n", " ", args)   # honor line-continuations
+    return HEREDOC_RE.sub(r"\3 ", joined)
+
+
 def commit_pathspecs(args):
     """The worktree paths a `git commit` names as pathspecs. A `git commit <path>`
     records the WORKTREE content of <path>, bypassing the index — content the
     index-only `--cached` scan never sees — so the security/migration gates must
     union the worktree diff for these paths. Best-effort parse: everything after
-    a `--` separator is a pathspec; otherwise bare tokens that are neither a flag
-    nor a value-taking flag's value. Bias is to OVER-include — a non-path token
-    diffs to nothing (harmless), whereas under-including would reopen the bypass,
-    so any ambiguity is treated as a pathspec."""
+    a `--` separator is a pathspec; otherwise bare tokens that are neither a flag,
+    a value-taking flag's value, nor a redirect operator. Bias is to OVER-include
+    — a non-path token diffs to nothing (harmless), whereas under-including would
+    reopen the bypass, so any ambiguity is treated as a pathspec. Callers pass a
+    `_strip_heredoc_bodies`-cleaned string so a heredoc body never reaches here."""
     toks = [t.strip("\"'") for t in re.findall(r'"[^"]+"|\'[^\']+\'|\S+', args)]
     if "--" in toks:
         return [t for t in toks[toks.index("--") + 1:] if t]
@@ -277,6 +314,8 @@ def commit_pathspecs(args):
     for t in toks:
         if expect_value:
             expect_value = False
+            continue
+        if REDIRECT_RE.match(t):  # a redirect operator, not a pathspec
             continue
         if t.startswith("-"):
             if "=" in t:  # --message=... carries its own value
@@ -381,7 +420,7 @@ def main():
     # the freshness window. Scans the staged diff, plus the worktree diff when
     # the commit uses -a/--all or the same command stages files.
     if commit:
-        cargs = commit.group("args")
+        cargs = _strip_heredoc_bodies(commit.group("args"))
         # Scan the staged diff, plus the worktree diff when the commit pulls in
         # worktree content: -a/--all (whole tree), an in-command `git add`, OR a
         # `git commit <pathspec>` (the named paths only — a pathspec commit
@@ -440,7 +479,7 @@ def main():
     # treated as no coverage (fail-closed), consistent with this layer's
     # "ambiguity resolves CLOSED" stance.
     if commit:
-        cargs = commit.group("args")
+        cargs = _strip_heredoc_bodies(commit.group("args"))
         # Index paths, plus worktree paths when the commit pulls them in: -a/add
         # (whole tree) or a `git commit <pathspec>` (named paths only). A None
         # from any path query means git could not read the file list -> fail


### PR DESCRIPTION
## What

Fixes a false-positive in the H-09b/H-10b/H-14 commit gate discovered while landing #138: a `git commit -F - <<EOF … EOF` (the recommended multi-line-commit form) was **blocked**. `COMMIT_RE` captures git-commit args greedily across newlines, so the heredoc body was parsed as pathspecs; `git diff HEAD -- <body tokens>` then errored and the gate failed **closed**.

## Fix

- `_strip_heredoc_bodies(args)` — join `\`-newline continuations, then remove **only** the heredoc operator+body+delimiter, **re-emitting the operator-line tail** (a pathspec after `<<WORD` is a real git arg).
- `commit_pathspecs` skips redirect-operator tokens.
- Applied at both gate call sites. The `--cached` staged scan and the worktree-union over-include for real pathspecs are untouched, so the v2.rev.0015 pathspec-bypass guard is preserved.

## Why this was risky — and how the review earned its keep

This touches the load-bearing security commit gate, so it went through adversarial security review, which caught **two** ways an earlier cut silently weakened the gate (both shifted BLOCK→ALLOW vs. baseline, both now closed and locked by tests):

1. A first-line `split("\n",1)[0]` also truncated at the literal newline inside a quoted `-m "subject\n\nbody"` message and dropped a trailing pathspec — reopening the worktree-union bypass.
2. The heredoc strip swallowed a pathspec sitting on the operator line after `<<WORD`.

The shipped form strips only the heredoc body.

## Tests

`test_hook_guards.py`:
- Unit assertions for `_strip_heredoc_bodies` / `commit_pathspecs`, including the two non-weakening cases above (multi-line message + pathspec, and operator-line pathspec).
- Integration **6l** (benign heredoc allows), **6m** (staged-crypto heredoc still blocks), **6n** (unstaged crypto via a multi-line `-m` pathspec commit still blocks).
- **102 guard assertions, 0 failed**; migration backstop + full hook suite green.

## Known residual (not introduced here, errs closed)

`COMMIT_RE`'s `[^|;&]*` truncates the captured args at a `|`/`;`/`&` inside a heredoc body, so a body line containing those chars can leave an unterminated heredoc that survives the strip and can still false-block. This errs **closed** (fail-safe), so it is not a weakening — noted for a future follow-up.

https://claude.ai/code/session_011nnQYBPd5Dt1rmtf9CHNfU
