### PR TITLE
refactor(farm): split farm.ts god-module into exec/redactor/mutation

### DIFF
--- a/plugins/ca/tools/exec.ts
+++ b/plugins/ca/tools/exec.ts
@@ -1,0 +1,120 @@
+/**
+ * exec.ts — codeArbiter's low-level process / shell execution layer.
+ *
+ * The shared, domain-free primitives that spawn child processes under the
+ * farm's least-privilege discipline (secret-scrubbed env, per-command
+ * wall-clock timeout, cross-platform tree-kill), the gate shell config, and the
+ * single worktree-file reader. Extracted verbatim from farm.ts (v2.rev.0020 /
+ * architecture-003) so the mutation engine can reuse them WITHOUT importing
+ * farm.ts — the dependency graph stays one-way (farm.ts -> exec.ts and
+ * mutation.ts -> exec.ts, never back). This is a move, not a rewrite: behaviour
+ * is identical to the prior in-farm.ts definitions.
+ */
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+// Result of a spawned process. `out` stays the merged stdout+stderr string that
+// existing consumers (runGate, diagnostics) read. `stdout`/`stderr` are kept
+// SEPARATE so parsing contexts (checkDrift — #91) read only stdout: on Windows
+// with core.safecrlf, git writes a `warning: ... LF will be replaced by CRLF`
+// line to stderr that, when merged, was parsed as a changed file path and tripped
+// a false `drift:` escalation. `timedOut` is set when a per-command wall-clock
+// timeout fired and the child was killed (T-06 / reliability-001) — consumers
+// surface it as a gate/setup/mutation failure rather than a clean exit.
+export type RunResult = { code: number; out: string; stdout: string; stderr: string; timedOut?: true };
+
+// gate shell — pure determinism, no model. Use a non-login shell (`-c`, not
+// `-lc`) so user dotfiles don't bleed in. On Windows, fall back to cmd.exe /c.
+export const [SHELL_BIN, SHELL_FLAG] =
+  process.platform === "win32" ? ["cmd.exe", "/c"] : ["bash", "-c"];
+// Node's default arg-quoting backslash-escapes embedded quotes, which cmd.exe
+// does not understand — a gate like `node -e "process.exit(1)"` silently
+// mangles. Pass the command line through verbatim on Windows.
+export const SHELL_OPTS =
+  process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
+
+// T-06 (reliability-001): per-command wall-clock timeout. The shared run() helper
+// previously resolved ONLY on the child's close/error event, so a gate/setup/
+// mutation command that never exits (a test blocking on stdin, a watch/dev-server
+// invocation, an interactive prompt) wedged the awaiting worker forever — and the
+// scheduler's Promise.race never settled, so the whole run hung with no report.
+// This mirrors the AbortController discipline the API path already uses. Default a
+// few minutes; configurable, independent of FARM_REQUEST_TIMEOUT_MS.
+export const GATE_TIMEOUT_MS = Number(process.env.FARM_GATE_TIMEOUT_MS ?? 300_000);
+
+// Kill a spawned child and its descendants. On Windows a plain child.kill() does
+// not reap the process tree (cmd.exe /c spawns the real command as a grandchild),
+// so use `taskkill /T /F` by PID; elsewhere SIGKILL the child. Best-effort —
+// errors are swallowed (the child may already be gone).
+export function treeKill(child: ReturnType<typeof spawn>): void {
+  try {
+    if (process.platform === "win32" && child.pid !== undefined) {
+      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
+    } else {
+      child.kill("SIGKILL");
+    }
+  } catch {
+    /* already exited / unkillable — best effort */
+  }
+}
+
+// `timeoutMs` (opts) bounds the child's wall-clock; 0/undefined disables the
+// timeout (used by git, which must not be killed mid-operation). On timeout the
+// child tree is killed and a RunResult tagged `timedOut` resolves, so the caller
+// treats it as a non-zero failure instead of awaiting forever.
+export function run(
+  cmd: string,
+  args: string[],
+  cwd?: string,
+  opts: object = {},
+  timeoutMs = 0,
+): Promise<RunResult> {
+  return new Promise<RunResult>((resolve) => {
+    // Least-privilege: child commands (git, operator gate/setup/test, mutation)
+    // never need the dispatcher's secrets — the API key is used only by the
+    // in-process fetch. Scrub them from the inherited env so a gate command
+    // can't read FARM_API_KEY / the OAuth token (and shrinks the blast radius
+    // of the operator-authored-but-shell-run gate commands, CodeQL #5).
+    const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    delete childEnv.FARM_API_KEY;
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const done = (r: RunResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(r);
+    };
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        treeKill(c);
+        const note = `\n[FARM] command exceeded ${timeoutMs}ms wall-clock timeout — killed (FARM_GATE_TIMEOUT_MS)`;
+        done({ code: 124, out: stdout + stderr + note, stdout, stderr: stderr + note, timedOut: true });
+      }, timeoutMs);
+    }
+    c.stdout.on("data", (d) => (stdout += d));
+    c.stderr.on("data", (d) => (stderr += d));
+    c.on("error", (e) => done({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
+    c.on("close", (code) => done({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
+  });
+}
+
+// shared file reader — single read path for every consumer that needs the
+// current contents of a worktree file. Returns the file text, or null on any
+// read failure (missing file, not yet created, permission). antiGamingCheck,
+// mutationCheck, AND the prompt enrichment (AC-03/AC-04) all go through here
+// rather than growing their own parallel try/catch read paths (spec Risks:
+// "Duplicated file reads"). `wt`-relative paths are resolved against the
+// worktree the caller passes.
+export async function readWorktreeFile(wt: string, relPath: string): Promise<string | null> {
+  try {
+    return await readFile(path.resolve(wt, relPath), "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1,11 +1,283 @@
 #!/usr/bin/env node
 
 // farm.ts
-import { spawn } from "node:child_process";
-import { readFile, writeFile, appendFile, mkdir, rm } from "node:fs/promises";
+import { readFile as readFile2, writeFile as writeFile2, appendFile, mkdir, rm } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
-import path from "node:path";
+import path3 from "node:path";
 import { fileURLToPath } from "node:url";
+
+// exec.ts
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+var [SHELL_BIN, SHELL_FLAG] = process.platform === "win32" ? ["cmd.exe", "/c"] : ["bash", "-c"];
+var SHELL_OPTS = process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
+var GATE_TIMEOUT_MS = Number(process.env.FARM_GATE_TIMEOUT_MS ?? 3e5);
+function treeKill(child) {
+  try {
+    if (process.platform === "win32" && child.pid !== void 0) {
+      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
+    } else {
+      child.kill("SIGKILL");
+    }
+  } catch {
+  }
+}
+function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
+  return new Promise((resolve) => {
+    const childEnv = { ...process.env };
+    delete childEnv.FARM_API_KEY;
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timer;
+    const done = (r) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(r);
+    };
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        treeKill(c);
+        const note = `
+[FARM] command exceeded ${timeoutMs}ms wall-clock timeout \u2014 killed (FARM_GATE_TIMEOUT_MS)`;
+        done({ code: 124, out: stdout + stderr + note, stdout, stderr: stderr + note, timedOut: true });
+      }, timeoutMs);
+    }
+    c.stdout.on("data", (d) => stdout += d);
+    c.stderr.on("data", (d) => stderr += d);
+    c.on("error", (e) => done({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
+    c.on("close", (code) => done({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
+  });
+}
+async function readWorktreeFile(wt, relPath) {
+  try {
+    return await readFile(path.resolve(wt, relPath), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// redactor.ts
+var SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36})/i;
+var PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
+var PEM_END = /^-----END .*-----\s*$/;
+var REDACTION_MARKER = "[REDACTED \u2014 secret-pattern match removed before transmission]";
+var SECRET_FILENAME_DENYLIST = [
+  /^\.env$/i,
+  // .env
+  /^\.env\..+$/i,
+  // .env.local, .env.production, ...
+  /\.pem$/i,
+  // *.pem
+  /\.key$/i,
+  // *.key
+  /^id_rsa(\..+)?$/i,
+  // id_rsa, id_rsa.pub, id_rsa.bak
+  /^id_ed25519(\..+)?$/i,
+  // id_ed25519, id_ed25519.pub
+  /^id_ecdsa(\..+)?$/i,
+  // id_ecdsa, id_ecdsa.pub
+  /\.p12$/i,
+  // PKCS#12 keystore
+  /\.pfx$/i
+  // PKCS#12 keystore (Windows)
+];
+function isSecretBearingFilename(relPath) {
+  const base = relPath.split(/[\\/]/).pop() ?? relPath;
+  return SECRET_FILENAME_DENYLIST.some((re) => re.test(base));
+}
+function redactSecrets(contents) {
+  const lines = contents.split("\n");
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (PEM_BEGIN.test(line.trim())) {
+      out.push(REDACTION_MARKER);
+      i++;
+      while (i < lines.length && !PEM_END.test(lines[i].trim())) i++;
+      continue;
+    }
+    out.push(SECRET_LINE.test(line) ? REDACTION_MARKER : line);
+  }
+  return out.join("\n");
+}
+
+// mutation.ts
+import { spawn as spawn2 } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import path2 from "node:path";
+var MUT = {
+  enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
+  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
+  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 3e4),
+  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
+  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
+  cmd: process.env.FARM_MUTATION_CMD ?? null
+};
+function extractLiterals(testSrc) {
+  const lits = /* @__PURE__ */ new Set();
+  for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
+  for (const m of testSrc.matchAll(/\b(\d{2,}|[2-9])\b/g)) lits.add(m[1]);
+  return [...lits];
+}
+function codeLineCount(src) {
+  return src.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
+}
+async function antiGamingCheck(cwd, task) {
+  const testSrc = await readWorktreeFile(cwd, task.test.path);
+  if (testSrc === null) return { risk: "none" };
+  const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
+  if (literals.length === 0) return { risk: "none" };
+  const hits = [];
+  let anyTiny = false;
+  for (const f of task.filesInScope) {
+    if (f === task.test.path) continue;
+    const src = await readWorktreeFile(cwd, f);
+    if (src === null) continue;
+    const tiny = codeLineCount(src) <= 5;
+    for (const lit of literals) {
+      if (src.includes(lit)) {
+        hits.push(`${f} contains test literal ${JSON.stringify(lit)}`);
+        if (tiny) anyTiny = true;
+      }
+    }
+  }
+  if (hits.length === 0) return { risk: "none" };
+  if (anyTiny) return { risk: "high", note: `gaming: ${hits[0]} (impl is trivial)` };
+  return { risk: "warn", note: `gaming-risk: ${hits[0]}` };
+}
+function shuffle(a) {
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+function generateMutants(file, src) {
+  const lines = src.split("\n");
+  const rules = [
+    [/ >= /, " > ", ">=>"],
+    [/ <= /, " < ", "<=<"],
+    [/ === /, " !== ", "===>!=="],
+    [/ !== /, " === ", "!==>==="],
+    [/ == /, " != ", "==>!="],
+    [/ != /, " == ", "!=>=="],
+    [/ > /, " >= ", ">>="],
+    [/ < /, " <= ", "<<="],
+    [/ \+ /, " - ", "+>-"],
+    [/ - /, " + ", "->+"],
+    [/ \* /, " / ", "*>/"],
+    [/ && /, " || ", "&&>||"],
+    [/ \|\| /, " && ", "||>&&"],
+    [/\btrue\b/, "false", "true>false"],
+    [/\bfalse\b/, "true", "false>true"]
+  ];
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    const t = ln.trim();
+    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("*") || t.startsWith("/*")) continue;
+    for (const [re, rep, name] of rules) {
+      if (re.test(ln)) {
+        const mline = ln.replace(re, rep);
+        if (mline !== ln) {
+          const m = [...lines];
+          m[i] = mline;
+          out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} ${name}` });
+        }
+      }
+    }
+    const rm2 = ln.match(/\breturn\s+(.+?);/);
+    if (rm2 && rm2[1].trim() !== "null" && rm2[1].trim() !== "") {
+      const m = [...lines];
+      m[i] = ln.replace(/\breturn\s+.+?;/, "return null;");
+      out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} return>null` });
+    }
+  }
+  return out;
+}
+function parseMutationHookOutput(out) {
+  const j = [...out.matchAll(/\{[^\n]*"score"[^\n]*\}/g)].pop();
+  if (!j) return null;
+  try {
+    const parsed = JSON.parse(j[0]);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    if (typeof parsed.score === "number")
+      return { score: parsed.score, evaluated: parsed.total ?? parsed.evaluated ?? 99, survivors: parsed.survived ?? [] };
+  } catch {
+  }
+  return null;
+}
+async function mutationCheck(wt, task) {
+  if (!MUT.enabled) return null;
+  const testCmd = task.gate.commands[0];
+  if (!testCmd) return null;
+  const impl = task.filesInScope.filter((f) => f !== task.test.path);
+  if (MUT.cmd) {
+    const r = await new Promise((resolve) => {
+      const c = spawn2(SHELL_BIN, [SHELL_FLAG, MUT.cmd], {
+        cwd: wt,
+        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
+        ...SHELL_OPTS
+      });
+      let out = "";
+      let settled = false;
+      const finish = (res) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(res);
+      };
+      const timer = setTimeout(() => {
+        treeKill(c);
+        finish({ code: 124, out: out + "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout \u2014 killed" });
+      }, GATE_TIMEOUT_MS);
+      c.stdout.on("data", (d) => out += d);
+      c.stderr.on("data", (d) => out += d);
+      c.on("error", (e) => finish({ code: 1, out: String(e) }));
+      c.on("close", (code) => finish({ code: code ?? 1, out }));
+    });
+    return parseMutationHookOutput(r.out);
+  }
+  const originals = /* @__PURE__ */ new Map();
+  let candidates = [];
+  for (const f of impl) {
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
+    if (codeLineCount(src) <= 2) continue;
+    originals.set(f, src);
+    candidates.push(...generateMutants(f, src));
+  }
+  if (candidates.length === 0) return null;
+  candidates = shuffle(candidates).slice(0, MUT.sample);
+  const start = Date.now();
+  let killed = 0;
+  let evaluated = 0;
+  const survivors = [];
+  try {
+    for (const c of candidates) {
+      if (Date.now() - start > MUT.budgetMs) break;
+      await writeFile(path2.resolve(wt, c.file), c.mutated);
+      const r = await run(SHELL_BIN, [SHELL_FLAG, testCmd], wt, SHELL_OPTS, GATE_TIMEOUT_MS);
+      const orig = originals.get(c.file);
+      if (orig !== void 0) await writeFile(path2.resolve(wt, c.file), orig);
+      evaluated++;
+      if (r.code !== 0) killed++;
+      else survivors.push(c.tag);
+    }
+  } finally {
+    for (const [f, src] of originals) await writeFile(path2.resolve(wt, f), src).catch(() => {
+    });
+  }
+  if (evaluated < 3) return null;
+  return { score: killed / evaluated, evaluated, survivors };
+}
+
+// farm.ts
 var DEFAULT_API_BASE_URL = "https://opencode.ai/zen/v1";
 var ENV = {
   // Model: plan.meta.model (set by subagent-driven-development before dispatch),
@@ -49,55 +321,6 @@ var ENV = {
   // boundedness guarantee.
   enrichMaxBytes: Number(process.env.FARM_ENRICH_MAX_BYTES ?? 131072)
 };
-var MUT = {
-  enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
-  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
-  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 3e4),
-  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
-  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
-  cmd: process.env.FARM_MUTATION_CMD ?? null
-};
-var GATE_TIMEOUT_MS = Number(process.env.FARM_GATE_TIMEOUT_MS ?? 3e5);
-function treeKill(child) {
-  try {
-    if (process.platform === "win32" && child.pid !== void 0) {
-      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
-    } else {
-      child.kill("SIGKILL");
-    }
-  } catch {
-  }
-}
-function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
-  return new Promise((resolve) => {
-    const childEnv = { ...process.env };
-    delete childEnv.FARM_API_KEY;
-    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
-    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    let timer;
-    const done = (r) => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      resolve(r);
-    };
-    if (timeoutMs > 0) {
-      timer = setTimeout(() => {
-        treeKill(c);
-        const note = `
-[FARM] command exceeded ${timeoutMs}ms wall-clock timeout \u2014 killed (FARM_GATE_TIMEOUT_MS)`;
-        done({ code: 124, out: stdout + stderr + note, stdout, stderr: stderr + note, timedOut: true });
-      }, timeoutMs);
-    }
-    c.stdout.on("data", (d) => stdout += d);
-    c.stderr.on("data", (d) => stderr += d);
-    c.on("error", (e) => done({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
-    c.on("close", (code) => done({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
-  });
-}
 var git = (args, cwd) => run("git", args, cwd);
 var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 function createLimiter(max) {
@@ -133,11 +356,9 @@ function createLimiter(max) {
 var workerLimit = createLimiter(ENV.concurrency);
 var NOSIGN = ["-c", "commit.gpgsign=false"];
 function isInside(root, target) {
-  const rel = path.relative(root, target);
-  return rel === "" || !rel.startsWith("..") && !path.isAbsolute(rel);
+  const rel = path3.relative(root, target);
+  return rel === "" || !rel.startsWith("..") && !path3.isAbsolute(rel);
 }
-var [SHELL_BIN, SHELL_FLAG] = process.platform === "win32" ? ["cmd.exe", "/c"] : ["bash", "-c"];
-var SHELL_OPTS = process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
 async function runGate(cwd, commands) {
   for (const cmd of commands) {
     const r = await run(SHELL_BIN, [SHELL_FLAG, cmd], cwd, SHELL_OPTS, GATE_TIMEOUT_MS);
@@ -145,56 +366,6 @@ async function runGate(cwd, commands) {
       return { ok: false, failed: cmd, tail: redactSecrets(r.out.slice(-3500)) };
   }
   return { ok: true };
-}
-async function readWorktreeFile(wt, relPath) {
-  try {
-    return await readFile(path.resolve(wt, relPath), "utf8");
-  } catch {
-    return null;
-  }
-}
-var SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36})/i;
-var PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
-var PEM_END = /^-----END .*-----\s*$/;
-var REDACTION_MARKER = "[REDACTED \u2014 secret-pattern match removed before transmission]";
-var SECRET_FILENAME_DENYLIST = [
-  /^\.env$/i,
-  // .env
-  /^\.env\..+$/i,
-  // .env.local, .env.production, ...
-  /\.pem$/i,
-  // *.pem
-  /\.key$/i,
-  // *.key
-  /^id_rsa(\..+)?$/i,
-  // id_rsa, id_rsa.pub, id_rsa.bak
-  /^id_ed25519(\..+)?$/i,
-  // id_ed25519, id_ed25519.pub
-  /^id_ecdsa(\..+)?$/i,
-  // id_ecdsa, id_ecdsa.pub
-  /\.p12$/i,
-  // PKCS#12 keystore
-  /\.pfx$/i
-  // PKCS#12 keystore (Windows)
-];
-function isSecretBearingFilename(relPath) {
-  const base = relPath.split(/[\\/]/).pop() ?? relPath;
-  return SECRET_FILENAME_DENYLIST.some((re) => re.test(base));
-}
-function redactSecrets(contents) {
-  const lines = contents.split("\n");
-  const out = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (PEM_BEGIN.test(line.trim())) {
-      out.push(REDACTION_MARKER);
-      i++;
-      while (i < lines.length && !PEM_END.test(lines[i].trim())) i++;
-      continue;
-    }
-    out.push(SECRET_LINE.test(line) ? REDACTION_MARKER : line);
-  }
-  return out.join("\n");
 }
 function renderInjectedFile(file) {
   const label = file.prior ? `${file.path} (your previous attempt \u2014 FAILED)` : file.readOnly ? `${file.path} (read-only \u2014 the failing test)` : file.path;
@@ -440,16 +611,16 @@ async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden, samp
   const filesWritten = [];
   for (const { path: filePath, body } of blocks) {
     const cleanPath = filePath.trim();
-    const absPath = path.resolve(cwd, cleanPath);
+    const absPath = path3.resolve(cwd, cleanPath);
     if (!isInside(cwd, absPath)) {
       return { ok: false, filesWritten, error: `path escapes worktree: ${cleanPath}` };
     }
-    const rel = path.relative(cwd, absPath).split(path.sep).join("/");
+    const rel = path3.relative(cwd, absPath).split(path3.sep).join("/");
     if (forbidden.has(rel)) {
       return { ok: false, filesWritten, error: `worker tried to write read-only path: ${rel}` };
     }
-    await mkdir(path.dirname(absPath), { recursive: true });
-    await writeFile(absPath, body.endsWith("\n") ? body : body + "\n");
+    await mkdir(path3.dirname(absPath), { recursive: true });
+    await writeFile2(absPath, body.endsWith("\n") ? body : body + "\n");
     filesWritten.push(rel);
   }
   if (filesWritten.length === 0) {
@@ -486,52 +657,20 @@ async function checkDrift(cwd, allowed, gitRunner = git) {
 }
 function postApplySweep(cwd, filesWritten, forbidden) {
   for (const f of filesWritten) {
-    const absPath = path.resolve(cwd, f);
+    const absPath = path3.resolve(cwd, f);
     if (!isInside(cwd, absPath)) {
       return `path escapes worktree: ${f}`;
     }
-    const rel = path.relative(cwd, absPath).split(path.sep).join("/");
+    const rel = path3.relative(cwd, absPath).split(path3.sep).join("/");
     if (forbidden.has(rel)) {
       return `worker wrote read-only path: ${rel}`;
     }
   }
   return null;
 }
-function extractLiterals(testSrc) {
-  const lits = /* @__PURE__ */ new Set();
-  for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
-  for (const m of testSrc.matchAll(/\b(\d{2,}|[2-9])\b/g)) lits.add(m[1]);
-  return [...lits];
-}
-function codeLineCount(src) {
-  return src.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
-}
-async function antiGamingCheck(cwd, task) {
-  const testSrc = await readWorktreeFile(cwd, task.test.path);
-  if (testSrc === null) return { risk: "none" };
-  const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
-  if (literals.length === 0) return { risk: "none" };
-  const hits = [];
-  let anyTiny = false;
-  for (const f of task.filesInScope) {
-    if (f === task.test.path) continue;
-    const src = await readWorktreeFile(cwd, f);
-    if (src === null) continue;
-    const tiny = codeLineCount(src) <= 5;
-    for (const lit of literals) {
-      if (src.includes(lit)) {
-        hits.push(`${f} contains test literal ${JSON.stringify(lit)}`);
-        if (tiny) anyTiny = true;
-      }
-    }
-  }
-  if (hits.length === 0) return { risk: "none" };
-  if (anyTiny) return { risk: "high", note: `gaming: ${hits[0]} (impl is trivial)` };
-  return { risk: "warn", note: `gaming-risk: ${hits[0]}` };
-}
 async function fileHash(p) {
   try {
-    const buf = await readFile(p);
+    const buf = await readFile2(p);
     return createHash("sha256").update(buf).digest("hex");
   } catch {
     return null;
@@ -540,132 +679,6 @@ async function fileHash(p) {
 async function resetWorktree(wt) {
   await git(["reset", "--hard", "HEAD"], wt);
   await git(["clean", "-fd"], wt);
-}
-function shuffle(a) {
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}
-function generateMutants(file, src) {
-  const lines = src.split("\n");
-  const rules = [
-    [/ >= /, " > ", ">=>"],
-    [/ <= /, " < ", "<=<"],
-    [/ === /, " !== ", "===>!=="],
-    [/ !== /, " === ", "!==>==="],
-    [/ == /, " != ", "==>!="],
-    [/ != /, " == ", "!=>=="],
-    [/ > /, " >= ", ">>="],
-    [/ < /, " <= ", "<<="],
-    [/ \+ /, " - ", "+>-"],
-    [/ - /, " + ", "->+"],
-    [/ \* /, " / ", "*>/"],
-    [/ && /, " || ", "&&>||"],
-    [/ \|\| /, " && ", "||>&&"],
-    [/\btrue\b/, "false", "true>false"],
-    [/\bfalse\b/, "true", "false>true"]
-  ];
-  const out = [];
-  for (let i = 0; i < lines.length; i++) {
-    const ln = lines[i];
-    const t = ln.trim();
-    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("*") || t.startsWith("/*")) continue;
-    for (const [re, rep, name] of rules) {
-      if (re.test(ln)) {
-        const mline = ln.replace(re, rep);
-        if (mline !== ln) {
-          const m = [...lines];
-          m[i] = mline;
-          out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} ${name}` });
-        }
-      }
-    }
-    const rm2 = ln.match(/\breturn\s+(.+?);/);
-    if (rm2 && rm2[1].trim() !== "null" && rm2[1].trim() !== "") {
-      const m = [...lines];
-      m[i] = ln.replace(/\breturn\s+.+?;/, "return null;");
-      out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} return>null` });
-    }
-  }
-  return out;
-}
-function parseMutationHookOutput(out) {
-  const j = [...out.matchAll(/\{[^\n]*"score"[^\n]*\}/g)].pop();
-  if (!j) return null;
-  try {
-    const parsed = JSON.parse(j[0]);
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    if (typeof parsed.score === "number")
-      return { score: parsed.score, evaluated: parsed.total ?? parsed.evaluated ?? 99, survivors: parsed.survived ?? [] };
-  } catch {
-  }
-  return null;
-}
-async function mutationCheck(wt, task) {
-  if (!MUT.enabled) return null;
-  const testCmd = task.gate.commands[0];
-  if (!testCmd) return null;
-  const impl = task.filesInScope.filter((f) => f !== task.test.path);
-  if (MUT.cmd) {
-    const r = await new Promise((resolve) => {
-      const c = spawn(SHELL_BIN, [SHELL_FLAG, MUT.cmd], {
-        cwd: wt,
-        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
-        ...SHELL_OPTS
-      });
-      let out = "";
-      let settled = false;
-      const finish = (res) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(res);
-      };
-      const timer = setTimeout(() => {
-        treeKill(c);
-        finish({ code: 124, out: out + "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout \u2014 killed" });
-      }, GATE_TIMEOUT_MS);
-      c.stdout.on("data", (d) => out += d);
-      c.stderr.on("data", (d) => out += d);
-      c.on("error", (e) => finish({ code: 1, out: String(e) }));
-      c.on("close", (code) => finish({ code: code ?? 1, out }));
-    });
-    return parseMutationHookOutput(r.out);
-  }
-  const originals = /* @__PURE__ */ new Map();
-  let candidates = [];
-  for (const f of impl) {
-    const src = await readWorktreeFile(wt, f);
-    if (src === null) continue;
-    if (codeLineCount(src) <= 2) continue;
-    originals.set(f, src);
-    candidates.push(...generateMutants(f, src));
-  }
-  if (candidates.length === 0) return null;
-  candidates = shuffle(candidates).slice(0, MUT.sample);
-  const start = Date.now();
-  let killed = 0;
-  let evaluated = 0;
-  const survivors = [];
-  try {
-    for (const c of candidates) {
-      if (Date.now() - start > MUT.budgetMs) break;
-      await writeFile(path.resolve(wt, c.file), c.mutated);
-      const r = await run(SHELL_BIN, [SHELL_FLAG, testCmd], wt, SHELL_OPTS, GATE_TIMEOUT_MS);
-      const orig = originals.get(c.file);
-      if (orig !== void 0) await writeFile(path.resolve(wt, c.file), orig);
-      evaluated++;
-      if (r.code !== 0) killed++;
-      else survivors.push(c.tag);
-    }
-  } finally {
-    for (const [f, src] of originals) await writeFile(path.resolve(wt, f), src).catch(() => {
-    });
-  }
-  if (evaluated < 3) return null;
-  return { score: killed / evaluated, evaluated, survivors };
 }
 function mintRunId() {
   return randomBytes(3).toString("hex");
@@ -715,17 +728,17 @@ function effectiveSampling(samples) {
 }
 async function writeFilesInto(wt, files) {
   for (const f of files) {
-    const abs = path.resolve(wt, f.path);
+    const abs = path3.resolve(wt, f.path);
     if (!isInside(wt, abs)) continue;
-    await mkdir(path.dirname(abs), { recursive: true });
-    await writeFile(abs, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
+    await mkdir(path3.dirname(abs), { recursive: true });
+    await writeFile2(abs, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
   }
 }
 async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden, allowed, n, deps) {
   const taskBranch = `farm/${t.id}`;
   const runSample = (k) => workerLimit.run(async () => {
     const branch = `farm/${t.id}__s${k}`;
-    const wt = path.resolve(ENV.worktreeRoot, `${t.id}__s${k}`);
+    const wt = path3.resolve(ENV.worktreeRoot, `${t.id}__s${k}`);
     const base = {
       green: false,
       filesWritten: [],
@@ -744,14 +757,14 @@ async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden
         if (!sr.ok) return { ...base, note: redactSecrets(`setup failed: ${sr.failed}
 ${sr.tail}`) };
       }
-      const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
+      const testHashBefore = await deps.fileHash(path3.resolve(wt, t.test.path));
       const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
       const pt = w.promptTokens ?? 0;
       const ct = w.completionTokens ?? 0;
       if (!w.ok) return { ...base, note: redactSecrets(`worker error: ${w.error}`), promptTokens: pt, completionTokens: ct };
       const sweep = postApplySweep(wt, w.filesWritten, forbidden);
       if (sweep) return { ...base, filesWritten: w.filesWritten, note: sweep, promptTokens: pt, completionTokens: ct };
-      const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
+      const testHashAfter = await deps.fileHash(path3.resolve(wt, t.test.path));
       if (testHashBefore !== null && testHashAfter !== testHashBefore)
         return { ...base, filesWritten: w.filesWritten, note: `tampered test: ${t.test.path}`, promptTokens: pt, completionTokens: ct };
       const drift = await deps.checkDrift(wt, allowed);
@@ -782,7 +795,7 @@ ${gate.tail}`), promptTokens: pt, completionTokens: ct };
 }
 async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()) {
   const branch = `farm/${t.id}`;
-  const wt = path.resolve(ENV.worktreeRoot, t.id);
+  const wt = path3.resolve(ENV.worktreeRoot, t.id);
   const limit = t.maxRetries ?? ENV.maxRetries;
   const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
@@ -793,7 +806,7 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
     return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
-  const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
+  const testHashBefore = await deps.fileHash(path3.resolve(wt, t.test.path));
   let priorFailure;
   let driftedOnce = false;
   let lastFilesWritten = [];
@@ -852,7 +865,7 @@ ${setupResult.tail}`), promptTokens, completionTokens };
     if (sweepErr) {
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
-    const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
+    const testHashAfter = await deps.fileHash(path3.resolve(wt, t.test.path));
     if (testHashBefore !== null && testHashAfter !== testHashBefore) {
       return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
     }
@@ -963,10 +976,10 @@ function validate(plan) {
       throw new Error(`task ${t.id}: filesInScope is required (array of relative paths)`);
     if (!t.gate || !Array.isArray(t.gate.commands))
       throw new Error(`task ${t.id}: gate.commands is required (array of strings)`);
-    if (t.test.path.includes("..") || path.isAbsolute(t.test.path))
+    if (t.test.path.includes("..") || path3.isAbsolute(t.test.path))
       throw new Error(`task ${t.id}: test.path must be a relative path with no ".." segments`);
     for (const f of t.filesInScope)
-      if (f.includes("..") || path.isAbsolute(f))
+      if (f.includes("..") || path3.isAbsolute(f))
         throw new Error(`task ${t.id}: filesInScope entry "${f}" must be a relative path with no ".." segments`);
     for (const cmd of t.gate.commands) {
       if (!cmd || typeof cmd !== "string")
@@ -1070,7 +1083,7 @@ async function runCanary(plan) {
   await mkdir(ENV.worktreeRoot, { recursive: true });
   await mkdir(ENV.reportDir, { recursive: true });
   await git(["branch", "-f", ENV.integration, ENV.base]);
-  integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+  integrationWorktree = path3.resolve(ENV.reportDir, "integration-wt");
   await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
   });
   await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {
@@ -1090,7 +1103,7 @@ async function runCanary(plan) {
     const t0 = Date.now();
     const r = await runTask({ ...task, id: `canary-${task.id}` }, model, apiBaseUrl, apiKey);
     results.push({ model, green: r.status === "green", attempts: r.attempts, ms: Date.now() - t0, note: r.note });
-    await git(["worktree", "remove", "--force", path.resolve(ENV.worktreeRoot, `canary-${task.id}`)]).catch(() => {
+    await git(["worktree", "remove", "--force", path3.resolve(ENV.worktreeRoot, `canary-${task.id}`)]).catch(() => {
     });
     await git(["branch", "-D", `farm/canary-${task.id}`]).catch(() => {
     });
@@ -1098,7 +1111,7 @@ async function runCanary(plan) {
   await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
   });
   results.sort((a, b) => Number(b.green) - Number(a.green) || a.attempts - b.attempts || a.ms - b.ms);
-  await writeFile(path.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, skipped, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
+  await writeFile2(path3.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, skipped, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
   const summary = [
     "\nCanary results (best first):",
     ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`),
@@ -1114,7 +1127,7 @@ async function main() {
   const args = process.argv.slice(2);
   const canary = args.includes("--canary");
   const planPath = args.find((a) => !a.startsWith("--")) ?? "plan.json";
-  const plan = JSON.parse(await readFile(planPath, "utf8"));
+  const plan = JSON.parse(await readFile2(planPath, "utf8"));
   validate(plan);
   if (plan.meta.setup) {
     for (const t of plan.tasks) if (t.setup === void 0) t.setup = plan.meta.setup;
@@ -1124,8 +1137,8 @@ async function main() {
   const runId = mintRunId();
   await mkdir(ENV.worktreeRoot, { recursive: true });
   await mkdir(ENV.reportDir, { recursive: true });
-  const resultsStream = path.join(ENV.reportDir, "farm-results.jsonl");
-  await writeFile(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
+  const resultsStream = path3.join(ENV.reportDir, "farm-results.jsonl");
+  await writeFile2(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
   const done = /* @__PURE__ */ new Map();
   const blocked = [];
   let aborted = false;
@@ -1133,7 +1146,7 @@ async function main() {
     const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
     if (branchResult.code !== 0)
       throw new Error(`could not create integration branch '${ENV.integration}' from '${ENV.base}': ${branchResult.out}`);
-    integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+    integrationWorktree = path3.resolve(ENV.reportDir, "integration-wt");
     await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
     });
     await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {
@@ -1193,7 +1206,7 @@ async function main() {
                 status: "escalate",
                 attempts: 0,
                 branch: `farm/${id2}`,
-                worktree: path.resolve(ENV.worktreeRoot, id2),
+                worktree: path3.resolve(ENV.worktreeRoot, id2),
                 note: `crashed: ${e?.message ?? e}${e?.stack ? `
 ${String(e.stack).slice(0, 1500)}` : ""}`
               }
@@ -1233,25 +1246,25 @@ ABORTED by circuit breaker \u2014 escalation rate exceeded ${ENV.abortEscalation
 Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
-    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
+    `Report: ${path3.join(ENV.reportDir, "farm-report.md")}`,
     ""
   ].join("\n");
   await new Promise((resolve) => process.stdout.write(summary, () => resolve()));
   process.exit(exitCode);
 }
 async function writeReport(plan, results, blocked, aborted, runId) {
-  await mkdir(path.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {
+  await mkdir(path3.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {
   });
   for (const r of results) {
     const d = await git(["diff", `${ENV.base}...${r.branch}`]);
     if (d.code === 0 && d.out.trim())
-      await writeFile(path.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {
+      await writeFile2(path3.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {
       });
   }
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
-  await writeFile(
-    path.join(ENV.reportDir, "farm-report.json"),
+  await writeFile2(
+    path3.join(ENV.reportDir, "farm-report.json"),
     JSON.stringify({ run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)
   );
   const md = [
@@ -1270,12 +1283,12 @@ async function writeReport(plan, results, blocked, aborted, runId) {
     ...results.filter((r) => r.status === "escalate").map((r) => `- **${r.id}** \u2014 worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
     ``,
     `## Warnings \u2014 review during spec-compliance`,
-    ...results.filter((r) => r.warning).map((r) => `- **${r.id}** \u2014 ${r.warning} (diff: \`${path.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`)
+    ...results.filter((r) => r.warning).map((r) => `- **${r.id}** \u2014 ${r.warning} (diff: \`${path3.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`)
   ].join("\n");
-  await writeFile(path.join(ENV.reportDir, "farm-report.md"), md);
+  await writeFile2(path3.join(ENV.reportDir, "farm-report.md"), md);
 }
 var _thisFile = fileURLToPath(import.meta.url);
-var _entryFile = path.resolve(process.argv[1] ?? "");
+var _entryFile = path3.resolve(process.argv[1] ?? "");
 if (_thisFile === _entryFile) {
   main().catch((e) => {
     console.error(e);

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -34,11 +34,22 @@
  * model in FARM_CANDIDATE_MODELS and reports a measured pass-rate ranking, so
  * model selection is objective rather than web hearsay. No merge, no mutation.
  */
-import { spawn } from "node:child_process";
 import { readFile, writeFile, appendFile, mkdir, rm, stat } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+// v2.rev.0020 god-module split (architecture-003): the process/shell layer, the
+// outbound secret redactor, and the zero-token mutation engine now live in their
+// own focused, tested modules. farm.ts imports what it consumes and re-exports
+// the members the test suite + external consumers import from "./farm.ts", so
+// this file stays the stable public surface. The graph is one-way: farm.ts ->
+// {exec, redactor, mutation} and mutation -> exec (no cycle).
+import { run, readWorktreeFile, SHELL_BIN, SHELL_FLAG, SHELL_OPTS, GATE_TIMEOUT_MS } from "./exec.ts";
+import type { RunResult } from "./exec.ts";
+import { redactSecrets, isSecretBearingFilename } from "./redactor.ts";
+import { MUT, mutationCheck, antiGamingCheck } from "./mutation.ts";
+export { run, redactSecrets };
+export { extractLiterals, codeLineCount, parseMutationHookOutput } from "./mutation.ts";
 
 // --------------------------------------------------------------------------
 // Types — the handoff contract. Claude emits plan.json conforming to this.
@@ -125,108 +136,13 @@ const ENV = {
   enrichMaxBytes: Number(process.env.FARM_ENRICH_MAX_BYTES ?? 131_072),
 };
 
-// Mutation guard — a zero-token quality signal. After the gate goes green we
-// mutate the worker's in-scope impl and re-run ONLY the task's narrow test
-// (gate.commands[0]); a mutant the test fails to catch ("survivor") is code the
-// test does not constrain — gaming, dead code, or a weak test. Bounded by test
-// strength, so a LOW score is a strong red flag but a high one is only
-// necessary-not-sufficient. Low score → warning into Phase 3; only a near-zero
-// score on a non-trivial impl hard-escalates. Pluggable: set FARM_MUTATION_CMD
-// to a real per-language framework (it runs in the worktree with
-// FARM_MUTATION_FILES / FARM_MUTATION_TEST_PATH / FARM_MUTATION_TEST_CMD set,
-// and must print a trailing JSON line containing a numeric "score").
-const MUT = {
-  enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
-  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
-  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 30_000),
-  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
-  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
-  cmd: process.env.FARM_MUTATION_CMD ?? null,
-};
-
 // --------------------------------------------------------------------------
-// process helpers
+// process helpers — run(), treeKill(), SHELL_*, GATE_TIMEOUT_MS, the RunResult
+// type, and the shared readWorktreeFile reader now live in ./exec.ts
+// (v2.rev.0020 split); MUT and the mutation engine live in ./mutation.ts. Only
+// the git/sleep wrappers stay here, over the imported run().
 // --------------------------------------------------------------------------
-// Result of a spawned process. `out` stays the merged stdout+stderr string that
-// existing consumers (runGate, diagnostics) read. `stdout`/`stderr` are kept
-// SEPARATE so parsing contexts (checkDrift — #91) read only stdout: on Windows
-// with core.safecrlf, git writes a `warning: ... LF will be replaced by CRLF`
-// line to stderr that, when merged, was parsed as a changed file path and tripped
-// a false `drift:` escalation. `timedOut` is set when a per-command wall-clock
-// timeout fired and the child was killed (T-06 / reliability-001) — consumers
-// surface it as a gate/setup/mutation failure rather than a clean exit.
-type RunResult = { code: number; out: string; stdout: string; stderr: string; timedOut?: true };
 type GitRunner = (args: string[], cwd?: string) => Promise<RunResult>;
-
-// T-06 (reliability-001): per-command wall-clock timeout. The shared run() helper
-// previously resolved ONLY on the child's close/error event, so a gate/setup/
-// mutation command that never exits (a test blocking on stdin, a watch/dev-server
-// invocation, an interactive prompt) wedged the awaiting worker forever — and the
-// scheduler's Promise.race never settled, so the whole run hung with no report.
-// This mirrors the AbortController discipline the API path already uses. Default a
-// few minutes; configurable, independent of FARM_REQUEST_TIMEOUT_MS.
-const GATE_TIMEOUT_MS = Number(process.env.FARM_GATE_TIMEOUT_MS ?? 300_000);
-
-// Kill a spawned child and its descendants. On Windows a plain child.kill() does
-// not reap the process tree (cmd.exe /c spawns the real command as a grandchild),
-// so use `taskkill /T /F` by PID; elsewhere SIGKILL the child. Best-effort —
-// errors are swallowed (the child may already be gone).
-function treeKill(child: ReturnType<typeof spawn>): void {
-  try {
-    if (process.platform === "win32" && child.pid !== undefined) {
-      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
-    } else {
-      child.kill("SIGKILL");
-    }
-  } catch {
-    /* already exited / unkillable — best effort */
-  }
-}
-
-// `timeoutMs` (opts) bounds the child's wall-clock; 0/undefined disables the
-// timeout (used by git, which must not be killed mid-operation). On timeout the
-// child tree is killed and a RunResult tagged `timedOut` resolves, so the caller
-// treats it as a non-zero failure instead of awaiting forever.
-export function run(
-  cmd: string,
-  args: string[],
-  cwd?: string,
-  opts: object = {},
-  timeoutMs = 0,
-): Promise<RunResult> {
-  return new Promise<RunResult>((resolve) => {
-    // Least-privilege: child commands (git, operator gate/setup/test, mutation)
-    // never need the dispatcher's secrets — the API key is used only by the
-    // in-process fetch. Scrub them from the inherited env so a gate command
-    // can't read FARM_API_KEY / the OAuth token (and shrinks the blast radius
-    // of the operator-authored-but-shell-run gate commands, CodeQL #5).
-    const childEnv: NodeJS.ProcessEnv = { ...process.env };
-    delete childEnv.FARM_API_KEY;
-    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
-    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const done = (r: RunResult) => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      resolve(r);
-    };
-    if (timeoutMs > 0) {
-      timer = setTimeout(() => {
-        treeKill(c);
-        const note = `\n[FARM] command exceeded ${timeoutMs}ms wall-clock timeout — killed (FARM_GATE_TIMEOUT_MS)`;
-        done({ code: 124, out: stdout + stderr + note, stdout, stderr: stderr + note, timedOut: true });
-      }, timeoutMs);
-    }
-    c.stdout.on("data", (d) => (stdout += d));
-    c.stderr.on("data", (d) => (stderr += d));
-    c.on("error", (e) => done({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
-    c.on("close", (code) => done({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
-  });
-}
 const git: GitRunner = (args, cwd) => run("git", args, cwd);
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -287,17 +203,10 @@ function isInside(root: string, target: string): boolean {
 }
 
 // --------------------------------------------------------------------------
-// gate — pure determinism, no model. Use a non-login shell (`-c`, not `-lc`)
-// so user dotfiles don't bleed in. On Windows, fall back to cmd.exe /c.
+// gate — pure determinism, no model. Each command runs through the shared
+// SHELL_* config + run() from ./exec.ts (non-login shell so user dotfiles don't
+// bleed in; cmd.exe /c with verbatim args on Windows).
 // --------------------------------------------------------------------------
-const [SHELL_BIN, SHELL_FLAG] =
-  process.platform === "win32" ? ["cmd.exe", "/c"] : ["bash", "-c"];
-// Node's default arg-quoting backslash-escapes embedded quotes, which cmd.exe
-// does not understand — a gate like `node -e "process.exit(1)"` silently
-// mangles. Pass the command line through verbatim on Windows.
-const SHELL_OPTS =
-  process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
-
 export async function runGate(cwd: string, commands: string[]) {
   for (const cmd of commands) {
     // T-06: bound each gate/setup command by the wall-clock timeout so a hung
@@ -318,21 +227,11 @@ export async function runGate(cwd: string, commands: string[]) {
 }
 
 // --------------------------------------------------------------------------
-// shared file reader — single read path for every consumer that needs the
-// current contents of a worktree file. Returns the file text, or null on any
-// read failure (missing file, not yet created, permission). antiGamingCheck,
-// mutationCheck, AND the prompt enrichment (AC-03/AC-04) all go through here
-// rather than growing their own parallel try/catch read paths (spec Risks:
-// "Duplicated file reads"). `wt`-relative paths are resolved against the
-// worktree the caller passes.
+// shared worktree-file reader — readWorktreeFile now lives in ./exec.ts
+// (v2.rev.0020). It is still the single read path every consumer goes through
+// (buildEnrichment here, antiGamingCheck + mutationCheck in ./mutation.ts), so
+// there are no parallel try/catch read paths; it is imported at the top.
 // --------------------------------------------------------------------------
-async function readWorktreeFile(wt: string, relPath: string): Promise<string | null> {
-  try {
-    return await readFile(path.resolve(wt, relPath), "utf8");
-  } catch {
-    return null;
-  }
-}
 
 // --------------------------------------------------------------------------
 // prompt enrichment (AC-03 / AC-04). Gathers the read-only source of the
@@ -353,86 +252,10 @@ async function readWorktreeFile(wt: string, relPath: string): Promise<string | n
 // retry refines rather than restarts. Rendered in its own labeled section.
 export type InjectedFile = { path: string; contents: string; readOnly: boolean; prior?: boolean };
 
-// AC-05 secret redaction. NEW code — there is no existing in-code secret sweep
-// to reuse (the repo's sweep is the manual/hook layer per tech-stack.md). This
-// is the exact secret-pattern set from tech-stack.md "Secrets scan", applied
-// case-insensitively. Any single line that matches a pattern is replaced
-// WHOLESALE with a `[REDACTED]` marker rather than surgically excising the
-// matched span — over-redaction is the safe direction, and the line is the
-// smallest unit guaranteed to contain the full secret value (e.g. the trailing
-// token after `api_key =`).
-//
-// SPAN-AWARE for PEM blocks (FINDING 1). A purely per-line redactor is unsafe
-// for multi-line secrets: a PEM private key's `-----BEGIN ... PRIVATE KEY-----`
-// header matches the trigger word, but the base64 BODY lines carry no trigger
-// word, so a per-line pass would transmit the key material. When a
-// `-----BEGIN ... -----` delimiter line is seen, we redact the WHOLE block
-// through the matching `-----END ... -----` delimiter (or to end-of-content if
-// no END is present) as a single unit. Single-line trigger-word matches keep
-// the existing per-line behavior. Matching, never transmitting a matched
-// secret, is the invariant — see spec AC-05 / D5.
-// Trigger words plus known high-entropy key prefixes (AWS / GitHub). This
-// outbound redactor is DELIBERATELY DISTINCT in shape from the hook-side
-// _hooklib.SECRET_RE commit gate (architecture-001): SECRET_LINE is BROAD — a
-// bare trigger word anywhere on a line redacts the whole line, because over-
-// redaction is the safe direction for content crossing the trust boundary;
-// SECRET_RE is NARROW — it requires a quoted-literal assignment so it does not
-// fire on every `token:` reference in committed source. They therefore disagree
-// by design on bare-keyword lines. What is pinned is the AGREEMENT region:
-// plugins/ca/hooks/secret-detection-corpus.json lists real secret shapes both
-// must flag and benign lines both must pass, asserted against SECRET_LINE here
-// (farm.unit.test.ts) and against SECRET_RE in test_hooklib.py, so neither side
-// can silently regress on it.
-const SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36})/i;
-// PEM-style armor delimiters. BEGIN opens a span; END closes it. Matched
-// independently of SECRET_LINE so even a `-----BEGIN CERTIFICATE-----` (no
-// trigger word) is span-redacted — armored material is opaque, redact it whole.
-const PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
-const PEM_END = /^-----END .*-----\s*$/;
-const REDACTION_MARKER = "[REDACTED — secret-pattern match removed before transmission]";
-
-// Data-minimization (defence in depth ahead of per-line/span redaction): some
-// filenames are secret-bearing by convention and should never be read into the
-// injected context AT ALL, regardless of whether their individual lines trip a
-// trigger word. Matched on the BASENAME so a nested `config/.env.production` or
-// `keys/id_rsa` is caught too. If a file is denylisted its contents are simply
-// never read — the strongest form of non-transmission.
-const SECRET_FILENAME_DENYLIST: RegExp[] = [
-  /^\.env$/i, // .env
-  /^\.env\..+$/i, // .env.local, .env.production, ...
-  /\.pem$/i, // *.pem
-  /\.key$/i, // *.key
-  /^id_rsa(\..+)?$/i, // id_rsa, id_rsa.pub, id_rsa.bak
-  /^id_ed25519(\..+)?$/i, // id_ed25519, id_ed25519.pub
-  /^id_ecdsa(\..+)?$/i, // id_ecdsa, id_ecdsa.pub
-  /\.p12$/i, // PKCS#12 keystore
-  /\.pfx$/i, // PKCS#12 keystore (Windows)
-];
-
-function isSecretBearingFilename(relPath: string): boolean {
-  const base = relPath.split(/[\\/]/).pop() ?? relPath;
-  return SECRET_FILENAME_DENYLIST.some((re) => re.test(base));
-}
-
-export function redactSecrets(contents: string): string {
-  const lines = contents.split("\n");
-  const out: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (PEM_BEGIN.test(line.trim())) {
-      // Span redaction: collapse BEGIN..END (inclusive) to one marker. If no
-      // END is found, redact through end-of-content — never let an unterminated
-      // armored body trickle out.
-      out.push(REDACTION_MARKER);
-      i++;
-      while (i < lines.length && !PEM_END.test(lines[i].trim())) i++;
-      // i now points at the END line (consumed by the span) or past the end.
-      continue;
-    }
-    out.push(SECRET_LINE.test(line) ? REDACTION_MARKER : line);
-  }
-  return out.join("\n");
-}
+// AC-05 secret redaction + the secret-bearing-filename denylist now live in
+// ./redactor.ts (v2.rev.0020). redactSecrets + isSecretBearingFilename are
+// imported at the top; behaviour, the span-aware PEM handling, and the
+// corpus-parity pin (architecture-001) are unchanged.
 
 // The single chokepoint for content that leaves the trust boundary. The byte
 // cap (applied over the rendered array in buildEnrichment) and the per-line
@@ -984,56 +807,11 @@ function postApplySweep(
 }
 
 // --------------------------------------------------------------------------
-// anti-gaming guard — zero-token heuristic. A cheap model can satisfy a narrow
-// test by hard-coding the asserted value. We extract the literals the test
-// asserts and flag an impl file that (a) is tiny and (b) reproduces a
-// non-trivial test literal verbatim. Egregious cases escalate; borderline
-// cases attach a warning that rides into the report for the human reviewer.
+// anti-gaming guard — extractLiterals, codeLineCount, and antiGamingCheck now
+// live in ./mutation.ts (v2.rev.0020). antiGamingCheck is imported above and
+// wired into defaultRunTaskDeps; the two pure helpers are re-exported from
+// "./farm.ts" at the top so the unit-test import surface is unchanged.
 // --------------------------------------------------------------------------
-export function extractLiterals(testSrc: string): string[] {
-  const lits = new Set<string>();
-  // quoted strings
-  for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
-  // multi-digit / non-0-1 numbers
-  for (const m of testSrc.matchAll(/\b(\d{2,}|[2-9])\b/g)) lits.add(m[1]);
-  return [...lits];
-}
-
-export function codeLineCount(src: string): number {
-  return src
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
-}
-
-async function antiGamingCheck(
-  cwd: string,
-  task: Task,
-): Promise<{ risk: "none" | "warn" | "high"; note?: string }> {
-  const testSrc = await readWorktreeFile(cwd, task.test.path);
-  if (testSrc === null) return { risk: "none" };
-  const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
-  if (literals.length === 0) return { risk: "none" };
-
-  const hits: string[] = [];
-  let anyTiny = false;
-  for (const f of task.filesInScope) {
-    if (f === task.test.path) continue;
-    const src = await readWorktreeFile(cwd, f);
-    if (src === null) continue;
-    const tiny = codeLineCount(src) <= 5;
-    for (const lit of literals) {
-      if (src.includes(lit)) {
-        hits.push(`${f} contains test literal ${JSON.stringify(lit)}`);
-        if (tiny) anyTiny = true;
-      }
-    }
-  }
-  if (hits.length === 0) return { risk: "none" };
-  if (anyTiny) return { risk: "high", note: `gaming: ${hits[0]} (impl is trivial)` };
-  return { risk: "warn", note: `gaming-risk: ${hits[0]}` };
-}
-
 async function fileHash(p: string): Promise<string | null> {
   try {
     const buf = await readFile(p);
@@ -1049,159 +827,12 @@ async function resetWorktree(wt: string) {
 }
 
 // --------------------------------------------------------------------------
-// mutation guard
+// mutation guard — shuffle, generateMutants, MutationResult, the exported
+// parseMutationHookOutput, and mutationCheck now live in ./mutation.ts
+// (v2.rev.0020). mutationCheck is imported above and wired into
+// defaultRunTaskDeps; parseMutationHookOutput is re-exported from "./farm.ts" at
+// the top so the unit-test import surface is unchanged.
 // --------------------------------------------------------------------------
-function shuffle<T>(a: T[]): T[] {
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}
-
-// Single-point text mutants. Space-padded operators bias toward real code (not
-// string/generic content); invalid mutants that break compilation just fail the
-// test and count as "killed" — the lenient direction (no false escalation).
-function generateMutants(file: string, src: string): Array<{ file: string; mutated: string; tag: string }> {
-  const lines = src.split("\n");
-  const rules: Array<[RegExp, string, string]> = [
-    [/ >= /, " > ", ">=>"], [/ <= /, " < ", "<=<"],
-    [/ === /, " !== ", "===>!=="], [/ !== /, " === ", "!==>==="],
-    [/ == /, " != ", "==>!="], [/ != /, " == ", "!=>=="],
-    [/ > /, " >= ", ">>="], [/ < /, " <= ", "<<="],
-    [/ \+ /, " - ", "+>-"], [/ - /, " + ", "->+"], [/ \* /, " \/ ", "*>/"],
-    [/ && /, " || ", "&&>||"], [/ \|\| /, " && ", "||>&&"],
-    [/\btrue\b/, "false", "true>false"], [/\bfalse\b/, "true", "false>true"],
-  ];
-  const out: Array<{ file: string; mutated: string; tag: string }> = [];
-  for (let i = 0; i < lines.length; i++) {
-    const ln = lines[i];
-    const t = ln.trim();
-    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("*") || t.startsWith("/*")) continue;
-    for (const [re, rep, name] of rules) {
-      if (re.test(ln)) {
-        const mline = ln.replace(re, rep);
-        if (mline !== ln) {
-          const m = [...lines]; m[i] = mline;
-          out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} ${name}` });
-        }
-      }
-    }
-    const rm = ln.match(/\breturn\s+(.+?);/);
-    if (rm && rm[1].trim() !== "null" && rm[1].trim() !== "") {
-      const m = [...lines];
-      m[i] = ln.replace(/\breturn\s+.+?;/, "return null;");
-      out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} return>null` });
-    }
-  }
-  return out;
-}
-
-type MutationResult = { score: number; evaluated: number; survivors: string[] };
-
-// dx-002 (T-08b): parse a pluggable FARM_MUTATION_CMD's stdout for its trailing
-// JSON score line. Extracted as a pure, exported function so the shape guard is
-// unit-testable without spawning a process. The last `{...\"score\"...}` match is
-// JSON.parsed; a value that is null, not an object, or an array (e.g. "score"
-// emitted inside a string, or a bare numeric literal) is rejected to null before
-// `parsed.score` is read, rather than silently mis-interpreted. A non-numeric
-// score, no match, or unparseable JSON all map to null (skip leniently).
-export function parseMutationHookOutput(out: string): MutationResult | null {
-  const j = [...out.matchAll(/\{[^\n]*"score"[^\n]*\}/g)].pop();
-  if (!j) return null;
-  try {
-    const parsed = JSON.parse(j[0]) as { score?: number; total?: number; evaluated?: number; survived?: string[] };
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    if (typeof parsed.score === "number")
-      return { score: parsed.score, evaluated: parsed.total ?? parsed.evaluated ?? 99, survivors: parsed.survived ?? [] };
-  } catch {
-    /* unparseable — skip leniently */
-  }
-  return null;
-}
-
-async function mutationCheck(wt: string, task: Task): Promise<MutationResult | null> {
-  if (!MUT.enabled) return null;
-  const testCmd = task.gate.commands[0];
-  if (!testCmd) return null;
-  const impl = task.filesInScope.filter((f) => f !== task.test.path);
-
-  // Pluggable hook — hand off to a real per-language framework if configured.
-  if (MUT.cmd) {
-    const r = await new Promise<{ code: number; out: string }>((resolve) => {
-      const c = spawn(SHELL_BIN, [SHELL_FLAG, MUT.cmd!], {
-        cwd: wt,
-        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
-        ...SHELL_OPTS,
-      });
-      let out = "";
-      let settled = false;
-      const finish = (res: { code: number; out: string }) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(res);
-      };
-      // T-06: bound the pluggable FARM_MUTATION_CMD by the same wall-clock
-      // timeout. A hung mutation framework would otherwise wedge the worker; on
-      // timeout the child tree is killed and the result is treated as
-      // unparseable (score skipped leniently — no false escalation).
-      const timer = setTimeout(() => {
-        treeKill(c);
-        finish({ code: 124, out: out + "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout — killed" });
-      }, GATE_TIMEOUT_MS);
-      c.stdout.on("data", (d) => (out += d));
-      c.stderr.on("data", (d) => (out += d));
-      c.on("error", (e) => finish({ code: 1, out: String(e) }));
-      c.on("close", (code) => finish({ code: code ?? 1, out }));
-    });
-    // dx-002 (T-08b): shape-guarded parse of the hook's trailing score line.
-    return parseMutationHookOutput(r.out);
-  }
-
-  // Built-in text mutation.
-  const originals = new Map<string, string>();
-  let candidates: Array<{ file: string; mutated: string; tag: string }> = [];
-  for (const f of impl) {
-    const src = await readWorktreeFile(wt, f);
-    if (src === null) continue;
-    if (codeLineCount(src) <= 2) continue; // trivial file — nothing to constrain
-    originals.set(f, src);
-    candidates.push(...generateMutants(f, src));
-  }
-  if (candidates.length === 0) return null;
-  candidates = shuffle(candidates).slice(0, MUT.sample);
-
-  const start = Date.now();
-  let killed = 0;
-  let evaluated = 0;
-  const survivors: string[] = [];
-  try {
-    for (const c of candidates) {
-      if (Date.now() - start > MUT.budgetMs) break;
-      await writeFile(path.resolve(wt, c.file), c.mutated);
-      // T-06: bound the mutant re-run by the wall-clock timeout. A hung test
-      // here (a mutant that turns the test into an infinite loop, say) would
-      // otherwise wedge the worker; the killed result counts as a "killed"
-      // mutant (code!=0), the lenient direction.
-      const r = await run(SHELL_BIN, [SHELL_FLAG, testCmd], wt, SHELL_OPTS, GATE_TIMEOUT_MS);
-      // T-08 (dx-003): skip the restore on a Map miss rather than writing the
-      // literal string "undefined" into the worktree file. The invariant
-      // (every candidate's file is a key in `originals`) holds for the built-in
-      // generator today; this guard preserves the file if that ever changes.
-      const orig = originals.get(c.file);
-      if (orig !== undefined) await writeFile(path.resolve(wt, c.file), orig); // restore
-      evaluated++;
-      if (r.code !== 0) killed++;
-      else survivors.push(c.tag);
-    }
-  } finally {
-    // defensive: guarantee every impl file is back to the worker's output
-    for (const [f, src] of originals) await writeFile(path.resolve(wt, f), src).catch(() => {});
-  }
-  if (evaluated < 3) return null; // too few mutants to judge fairly
-  return { score: killed / evaluated, evaluated, survivors };
-}
 
 // --------------------------------------------------------------------------
 // per-task lifecycle

--- a/plugins/ca/tools/mutation.ts
+++ b/plugins/ca/tools/mutation.ts
@@ -1,0 +1,250 @@
+/**
+ * mutation.ts — codeArbiter's zero-token quality-signal engine.
+ *
+ * The two cheap, model-free quality heuristics the dispatcher runs after a
+ * task's gate goes green: the anti-gaming check (does a tiny impl hard-code the
+ * test's asserted literals?) and the mutation guard (does the narrow test catch
+ * single-point mutants, or are there survivors?). Extracted from farm.ts
+ * (v2.rev.0020 / architecture-003); depends only on the shared exec layer
+ * (./exec.ts) and imports the Task contract type-only from farm.ts, so there is
+ * no runtime import cycle. This is a move, not a rewrite — behaviour is
+ * identical to the prior in-farm.ts definitions.
+ */
+import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  run,
+  treeKill,
+  readWorktreeFile,
+  SHELL_BIN,
+  SHELL_FLAG,
+  SHELL_OPTS,
+  GATE_TIMEOUT_MS,
+} from "./exec.ts";
+import type { Task } from "./farm.ts";
+
+// Mutation guard — a zero-token quality signal. After the gate goes green we
+// mutate the worker's in-scope impl and re-run ONLY the task's narrow test
+// (gate.commands[0]); a mutant the test fails to catch ("survivor") is code the
+// test does not constrain — gaming, dead code, or a weak test. Bounded by test
+// strength, so a LOW score is a strong red flag but a high one is only
+// necessary-not-sufficient. Low score → warning into Phase 3; only a near-zero
+// score on a non-trivial impl hard-escalates. Pluggable: set FARM_MUTATION_CMD
+// to a real per-language framework (it runs in the worktree with
+// FARM_MUTATION_FILES / FARM_MUTATION_TEST_PATH / FARM_MUTATION_TEST_CMD set,
+// and must print a trailing JSON line containing a numeric "score").
+export const MUT = {
+  enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
+  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
+  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 30_000),
+  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
+  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
+  cmd: process.env.FARM_MUTATION_CMD ?? null,
+};
+
+// --------------------------------------------------------------------------
+// anti-gaming guard — zero-token heuristic. A cheap model can satisfy a narrow
+// test by hard-coding the asserted value. We extract the literals the test
+// asserts and flag an impl file that (a) is tiny and (b) reproduces a
+// non-trivial test literal verbatim. Egregious cases escalate; borderline
+// cases attach a warning that rides into the report for the human reviewer.
+// --------------------------------------------------------------------------
+export function extractLiterals(testSrc: string): string[] {
+  const lits = new Set<string>();
+  // quoted strings
+  for (const m of testSrc.matchAll(/(['"`])((?:\\.|(?!\1).){2,})\1/g)) lits.add(m[2]);
+  // multi-digit / non-0-1 numbers
+  for (const m of testSrc.matchAll(/\b(\d{2,}|[2-9])\b/g)) lits.add(m[1]);
+  return [...lits];
+}
+
+export function codeLineCount(src: string): number {
+  return src
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("//") && !l.startsWith("#") && !l.startsWith("*") && !l.startsWith("/*")).length;
+}
+
+export async function antiGamingCheck(
+  cwd: string,
+  task: Task,
+): Promise<{ risk: "none" | "warn" | "high"; note?: string }> {
+  const testSrc = await readWorktreeFile(cwd, task.test.path);
+  if (testSrc === null) return { risk: "none" };
+  const literals = extractLiterals(testSrc).filter((l) => l.length > 1 || /\d{2,}/.test(l));
+  if (literals.length === 0) return { risk: "none" };
+
+  const hits: string[] = [];
+  let anyTiny = false;
+  for (const f of task.filesInScope) {
+    if (f === task.test.path) continue;
+    const src = await readWorktreeFile(cwd, f);
+    if (src === null) continue;
+    const tiny = codeLineCount(src) <= 5;
+    for (const lit of literals) {
+      if (src.includes(lit)) {
+        hits.push(`${f} contains test literal ${JSON.stringify(lit)}`);
+        if (tiny) anyTiny = true;
+      }
+    }
+  }
+  if (hits.length === 0) return { risk: "none" };
+  if (anyTiny) return { risk: "high", note: `gaming: ${hits[0]} (impl is trivial)` };
+  return { risk: "warn", note: `gaming-risk: ${hits[0]}` };
+}
+
+// --------------------------------------------------------------------------
+// mutation guard
+// --------------------------------------------------------------------------
+function shuffle<T>(a: T[]): T[] {
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// Single-point text mutants. Space-padded operators bias toward real code (not
+// string/generic content); invalid mutants that break compilation just fail the
+// test and count as "killed" — the lenient direction (no false escalation).
+function generateMutants(file: string, src: string): Array<{ file: string; mutated: string; tag: string }> {
+  const lines = src.split("\n");
+  const rules: Array<[RegExp, string, string]> = [
+    [/ >= /, " > ", ">=>"], [/ <= /, " < ", "<=<"],
+    [/ === /, " !== ", "===>!=="], [/ !== /, " === ", "!==>==="],
+    [/ == /, " != ", "==>!="], [/ != /, " == ", "!=>=="],
+    [/ > /, " >= ", ">>="], [/ < /, " <= ", "<<="],
+    [/ \+ /, " - ", "+>-"], [/ - /, " + ", "->+"], [/ \* /, " \/ ", "*>/"],
+    [/ && /, " || ", "&&>||"], [/ \|\| /, " && ", "||>&&"],
+    [/\btrue\b/, "false", "true>false"], [/\bfalse\b/, "true", "false>true"],
+  ];
+  const out: Array<{ file: string; mutated: string; tag: string }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    const t = ln.trim();
+    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("*") || t.startsWith("/*")) continue;
+    for (const [re, rep, name] of rules) {
+      if (re.test(ln)) {
+        const mline = ln.replace(re, rep);
+        if (mline !== ln) {
+          const m = [...lines]; m[i] = mline;
+          out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} ${name}` });
+        }
+      }
+    }
+    const rm = ln.match(/\breturn\s+(.+?);/);
+    if (rm && rm[1].trim() !== "null" && rm[1].trim() !== "") {
+      const m = [...lines];
+      m[i] = ln.replace(/\breturn\s+.+?;/, "return null;");
+      out.push({ file, mutated: m.join("\n"), tag: `${file}:${i + 1} return>null` });
+    }
+  }
+  return out;
+}
+
+export type MutationResult = { score: number; evaluated: number; survivors: string[] };
+
+// dx-002 (T-08b): parse a pluggable FARM_MUTATION_CMD's stdout for its trailing
+// JSON score line. Extracted as a pure, exported function so the shape guard is
+// unit-testable without spawning a process. The last `{...\"score\"...}` match is
+// JSON.parsed; a value that is null, not an object, or an array (e.g. "score"
+// emitted inside a string, or a bare numeric literal) is rejected to null before
+// `parsed.score` is read, rather than silently mis-interpreted. A non-numeric
+// score, no match, or unparseable JSON all map to null (skip leniently).
+export function parseMutationHookOutput(out: string): MutationResult | null {
+  const j = [...out.matchAll(/\{[^\n]*"score"[^\n]*\}/g)].pop();
+  if (!j) return null;
+  try {
+    const parsed = JSON.parse(j[0]) as { score?: number; total?: number; evaluated?: number; survived?: string[] };
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    if (typeof parsed.score === "number")
+      return { score: parsed.score, evaluated: parsed.total ?? parsed.evaluated ?? 99, survivors: parsed.survived ?? [] };
+  } catch {
+    /* unparseable — skip leniently */
+  }
+  return null;
+}
+
+export async function mutationCheck(wt: string, task: Task): Promise<MutationResult | null> {
+  if (!MUT.enabled) return null;
+  const testCmd = task.gate.commands[0];
+  if (!testCmd) return null;
+  const impl = task.filesInScope.filter((f) => f !== task.test.path);
+
+  // Pluggable hook — hand off to a real per-language framework if configured.
+  if (MUT.cmd) {
+    const r = await new Promise<{ code: number; out: string }>((resolve) => {
+      const c = spawn(SHELL_BIN, [SHELL_FLAG, MUT.cmd!], {
+        cwd: wt,
+        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
+        ...SHELL_OPTS,
+      });
+      let out = "";
+      let settled = false;
+      const finish = (res: { code: number; out: string }) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(res);
+      };
+      // T-06: bound the pluggable FARM_MUTATION_CMD by the same wall-clock
+      // timeout. A hung mutation framework would otherwise wedge the worker; on
+      // timeout the child tree is killed and the result is treated as
+      // unparseable (score skipped leniently — no false escalation).
+      const timer = setTimeout(() => {
+        treeKill(c);
+        finish({ code: 124, out: out + "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout — killed" });
+      }, GATE_TIMEOUT_MS);
+      c.stdout.on("data", (d) => (out += d));
+      c.stderr.on("data", (d) => (out += d));
+      c.on("error", (e) => finish({ code: 1, out: String(e) }));
+      c.on("close", (code) => finish({ code: code ?? 1, out }));
+    });
+    // dx-002 (T-08b): shape-guarded parse of the hook's trailing score line.
+    return parseMutationHookOutput(r.out);
+  }
+
+  // Built-in text mutation.
+  const originals = new Map<string, string>();
+  let candidates: Array<{ file: string; mutated: string; tag: string }> = [];
+  for (const f of impl) {
+    const src = await readWorktreeFile(wt, f);
+    if (src === null) continue;
+    if (codeLineCount(src) <= 2) continue; // trivial file — nothing to constrain
+    originals.set(f, src);
+    candidates.push(...generateMutants(f, src));
+  }
+  if (candidates.length === 0) return null;
+  candidates = shuffle(candidates).slice(0, MUT.sample);
+
+  const start = Date.now();
+  let killed = 0;
+  let evaluated = 0;
+  const survivors: string[] = [];
+  try {
+    for (const c of candidates) {
+      if (Date.now() - start > MUT.budgetMs) break;
+      await writeFile(path.resolve(wt, c.file), c.mutated);
+      // T-06: bound the mutant re-run by the wall-clock timeout. A hung test
+      // here (a mutant that turns the test into an infinite loop, say) would
+      // otherwise wedge the worker; the killed result counts as a "killed"
+      // mutant (code!=0), the lenient direction.
+      const r = await run(SHELL_BIN, [SHELL_FLAG, testCmd], wt, SHELL_OPTS, GATE_TIMEOUT_MS);
+      // T-08 (dx-003): skip the restore on a Map miss rather than writing the
+      // literal string "undefined" into the worktree file. The invariant
+      // (every candidate's file is a key in `originals`) holds for the built-in
+      // generator today; this guard preserves the file if that ever changes.
+      const orig = originals.get(c.file);
+      if (orig !== undefined) await writeFile(path.resolve(wt, c.file), orig); // restore
+      evaluated++;
+      if (r.code !== 0) killed++;
+      else survivors.push(c.tag);
+    }
+  } finally {
+    // defensive: guarantee every impl file is back to the worker's output
+    for (const [f, src] of originals) await writeFile(path.resolve(wt, f), src).catch(() => {});
+  }
+  if (evaluated < 3) return null; // too few mutants to judge fairly
+  return { score: killed / evaluated, evaluated, survivors };
+}

--- a/plugins/ca/tools/redactor.ts
+++ b/plugins/ca/tools/redactor.ts
@@ -1,0 +1,98 @@
+/**
+ * redactor.ts — codeArbiter's outbound-boundary secret redactor.
+ *
+ * The single security control that scrubs secret-shaped content before it
+ * crosses the trust boundary to the third-party Zen API (injected file bodies,
+ * gate-output tails) and the secret-bearing-filename denylist that keeps such
+ * files from being read at all. Extracted verbatim from farm.ts (v2.rev.0020 /
+ * architecture-003) — this is a move, not a rewrite.
+ *
+ * DELIBERATELY DISTINCT in shape from the hook-side _hooklib.SECRET_RE commit
+ * gate (architecture-001): SECRET_LINE here is BROAD (over-redaction is the safe
+ * direction for content leaving the trust boundary); SECRET_RE is NARROW. The
+ * AGREEMENT region between them is pinned by
+ * plugins/ca/hooks/secret-detection-corpus.json — asserted against redactSecrets
+ * here (farm.unit.test.ts) and against SECRET_RE in test_hooklib.py, so neither
+ * side can silently regress.
+ */
+
+// AC-05 secret redaction. NEW code — there is no existing in-code secret sweep
+// to reuse (the repo's sweep is the manual/hook layer per tech-stack.md). This
+// is the exact secret-pattern set from tech-stack.md "Secrets scan", applied
+// case-insensitively. Any single line that matches a pattern is replaced
+// WHOLESALE with a `[REDACTED]` marker rather than surgically excising the
+// matched span — over-redaction is the safe direction, and the line is the
+// smallest unit guaranteed to contain the full secret value (e.g. the trailing
+// token after `api_key =`).
+//
+// SPAN-AWARE for PEM blocks (FINDING 1). A purely per-line redactor is unsafe
+// for multi-line secrets: a PEM private key's `-----BEGIN ... PRIVATE KEY-----`
+// header matches the trigger word, but the base64 BODY lines carry no trigger
+// word, so a per-line pass would transmit the key material. When a
+// `-----BEGIN ... -----` delimiter line is seen, we redact the WHOLE block
+// through the matching `-----END ... -----` delimiter (or to end-of-content if
+// no END is present) as a single unit. Single-line trigger-word matches keep
+// the existing per-line behavior. Matching, never transmitting a matched
+// secret, is the invariant — see spec AC-05 / D5.
+// Trigger words plus known high-entropy key prefixes (AWS / GitHub). This
+// outbound redactor is DELIBERATELY DISTINCT in shape from the hook-side
+// _hooklib.SECRET_RE commit gate (architecture-001): SECRET_LINE is BROAD — a
+// bare trigger word anywhere on a line redacts the whole line, because over-
+// redaction is the safe direction for content crossing the trust boundary;
+// SECRET_RE is NARROW — it requires a quoted-literal assignment so it does not
+// fire on every `token:` reference in committed source. They therefore disagree
+// by design on bare-keyword lines. What is pinned is the AGREEMENT region:
+// plugins/ca/hooks/secret-detection-corpus.json lists real secret shapes both
+// must flag and benign lines both must pass, asserted against SECRET_LINE here
+// (farm.unit.test.ts) and against SECRET_RE in test_hooklib.py, so neither side
+// can silently regress on it.
+const SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36})/i;
+// PEM-style armor delimiters. BEGIN opens a span; END closes it. Matched
+// independently of SECRET_LINE so even a `-----BEGIN CERTIFICATE-----` (no
+// trigger word) is span-redacted — armored material is opaque, redact it whole.
+const PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
+const PEM_END = /^-----END .*-----\s*$/;
+const REDACTION_MARKER = "[REDACTED — secret-pattern match removed before transmission]";
+
+// Data-minimization (defence in depth ahead of per-line/span redaction): some
+// filenames are secret-bearing by convention and should never be read into the
+// injected context AT ALL, regardless of whether their individual lines trip a
+// trigger word. Matched on the BASENAME so a nested `config/.env.production` or
+// `keys/id_rsa` is caught too. If a file is denylisted its contents are simply
+// never read — the strongest form of non-transmission.
+const SECRET_FILENAME_DENYLIST: RegExp[] = [
+  /^\.env$/i, // .env
+  /^\.env\..+$/i, // .env.local, .env.production, ...
+  /\.pem$/i, // *.pem
+  /\.key$/i, // *.key
+  /^id_rsa(\..+)?$/i, // id_rsa, id_rsa.pub, id_rsa.bak
+  /^id_ed25519(\..+)?$/i, // id_ed25519, id_ed25519.pub
+  /^id_ecdsa(\..+)?$/i, // id_ecdsa, id_ecdsa.pub
+  /\.p12$/i, // PKCS#12 keystore
+  /\.pfx$/i, // PKCS#12 keystore (Windows)
+];
+
+export function isSecretBearingFilename(relPath: string): boolean {
+  const base = relPath.split(/[\\/]/).pop() ?? relPath;
+  return SECRET_FILENAME_DENYLIST.some((re) => re.test(base));
+}
+
+export function redactSecrets(contents: string): string {
+  const lines = contents.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (PEM_BEGIN.test(line.trim())) {
+      // Span redaction: collapse BEGIN..END (inclusive) to one marker. If no
+      // END is found, redact through end-of-content — never let an unterminated
+      // armored body trickle out.
+      out.push(REDACTION_MARKER);
+      i++;
+      while (i < lines.length && !PEM_END.test(lines[i].trim())) i++;
+      // i now points at the END line (consumed by the span) or past the end.
+      continue;
+    }
+    out.push(SECRET_LINE.test(line) ? REDACTION_MARKER : line);
+  }
+  return out.join("\n");
+}


### PR DESCRIPTION
## What

Splits the `farm.ts` god-module (the zero-token dispatcher) into three focused, individually-tested modules. Closes task `v2.rev.0020` (deep-review `2026-06-24-root`, finding `architecture-003`, a HARD-GATE item).

- `exec.ts` (120 lines): the process/shell layer. `run()` with its least-privilege env scrub, `treeKill()`, `SHELL_*`, `GATE_TIMEOUT_MS`, `RunResult`, and the shared `readWorktreeFile` reader.
- `redactor.ts` (98 lines): the outbound secret redactor and the secret-bearing-filename denylist. This is the one security control in the file (it scrubs secret-shaped content before it crosses the trust boundary to the third-party Zen API).
- `mutation.ts` (250 lines): `MUT` plus the anti-gaming and mutation-guard engine.

`farm.ts` drops from 2193 to 1824 lines. It imports what it consumes and re-exports `redactSecrets`, `run`, `extractLiterals`, `codeLineCount`, and `parseMutationHookOutput`, so `"./farm.ts"` stays the stable import surface and no pre-existing test changed.

## Why

`farm.ts` had grown to mix the dispatcher lifecycle with three separable concerns, which is the maintainability cost `architecture-003` flagged. The split isolates each concern behind a one-way import graph (`farm.ts` to `{exec, redactor, mutation}`, and `mutation` to `exec`). The `Task` contract is imported type-only into `mutation.ts`, so there is no runtime cycle.

Conflict-hierarchy note (per ORCHESTRATOR section 2): this trades only at level 3 (maintainability and reviewability). It is behavior-preserving, so levels 1 and 2 (audit-trail and correctness) are untouched, which the reviews below confirm.

## Behavior parity

This is a refactor, not a rewrite. Logic moved verbatim. Parity is proven by the pre-existing suite passing with zero edits to any test file.

- `npx vitest run`: 169 of 169 pass (20 integration, 149 unit), unchanged from the pre-split baseline.
- `npx tsc --noEmit`: clean (`strict: true`).
- `farm.js` rebuilt via `npm run build`; the rebuild is deterministic (a second build is byte-identical).
- The redactor corpus-parity pin still clamps both sides: `redactSecrets` against `secret-detection-corpus.json` in `farm.unit.test.ts`, and `SECRET_RE` against the same corpus in `test_hooklib.py` (64 of 64 pass). The corpus file is untouched.
- `check-plugin-refs.py`: reference graph intact.

## Test plan

- [x] `cd plugins/ca/tools && npx vitest run` (169/169)
- [x] `npx tsc --noEmit` (clean)
- [x] `npm run build` then `git diff --quiet -- farm.js` after staging (deterministic rebuild)
- [x] `python .github/scripts/test_hooklib.py` (64/64, corpus parity)
- [x] `python .github/scripts/check-plugin-refs.py`

## Reviews

All three path-matrix reviewers returned PASS with no CRITICAL or HIGH findings:

- `security-reviewer`: PASS. Verified `redactSecrets`, the env scrub, and the corpus pin are intact. One LOW finding: the `exec.ts` header comment says "mutation.ts to exec.ts, never back," which is precise at runtime but understates the type-only `Task` import. Documentation-only, no security impact.
- `auth-crypto-reviewer`: PASS. Redactor patterns, the `FARM_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` scrub, and the SHA-256 `fileHash` are byte-identical post-move.
- `coverage-auditor`: PASS. All 14 moved functions are exercised by the unmodified suite; stage-2 coverage threshold met.

## Follow-up (not in this PR)

`auth-crypto-reviewer` noted that the pluggable `FARM_MUTATION_CMD` spawn passes an unscrubbed env (it does not delete the two project secrets the gate/test path strips). This is pre-existing behavior reproduced verbatim by the move, so it is out of scope for a behavior-preserving refactor. Worth a separate board item to decide whether the operator-authored mutation hook should run under the scrubbed env for parity.

Ref: deep-review `2026-06-24-root` (`architecture-003`), task `v2.rev.0020`
