### PR TITLE
fix(farm): scrub dispatcher secrets from the pluggable mutation hook env

### DIFF
--- a/plugins/ca/tools/exec.ts
+++ b/plugins/ca/tools/exec.ts
@@ -59,6 +59,20 @@ export function treeKill(child: ReturnType<typeof spawn>): void {
   }
 }
 
+// Least-privilege child env — the single source of truth for every spawned
+// child. The dispatcher's secrets (the Zen API key and the OAuth token) are
+// used only by the in-process fetch; NO child — git, the operator-authored
+// gate/setup/test commands, or the pluggable mutation hook — needs them. Build
+// the env from process.env plus any caller-supplied vars, then delete the
+// secrets LAST so a caller var can never re-introduce one (CodeQL #5). Every
+// spawn routes through here so the scrub cannot drift between call sites.
+export function scrubbedEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...(extra ?? {}) };
+  delete env.FARM_API_KEY;
+  delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  return env;
+}
+
 // `timeoutMs` (opts) bounds the child's wall-clock; 0/undefined disables the
 // timeout (used by git, which must not be killed mid-operation). On timeout the
 // child tree is killed and a RunResult tagged `timedOut` resolves, so the caller
@@ -71,15 +85,7 @@ export function run(
   timeoutMs = 0,
 ): Promise<RunResult> {
   return new Promise<RunResult>((resolve) => {
-    // Least-privilege: child commands (git, operator gate/setup/test, mutation)
-    // never need the dispatcher's secrets — the API key is used only by the
-    // in-process fetch. Scrub them from the inherited env so a gate command
-    // can't read FARM_API_KEY / the OAuth token (and shrinks the blast radius
-    // of the operator-authored-but-shell-run gate commands, CodeQL #5).
-    const childEnv: NodeJS.ProcessEnv = { ...process.env };
-    delete childEnv.FARM_API_KEY;
-    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
-    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
+    const c = spawn(cmd, args, { cwd, env: scrubbedEnv(), ...opts });
     let stdout = "";
     let stderr = "";
     let settled = false;

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -23,12 +23,15 @@ function treeKill(child) {
   } catch {
   }
 }
+function scrubbedEnv(extra) {
+  const env = { ...process.env, ...extra ?? {} };
+  delete env.FARM_API_KEY;
+  delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  return env;
+}
 function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
   return new Promise((resolve) => {
-    const childEnv = { ...process.env };
-    delete childEnv.FARM_API_KEY;
-    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
-    const c = spawn(cmd, args, { cwd, env: childEnv, ...opts });
+    const c = spawn(cmd, args, { cwd, env: scrubbedEnv(), ...opts });
     let stdout = "";
     let stderr = "";
     let settled = false;
@@ -221,7 +224,7 @@ async function mutationCheck(wt, task) {
     const r = await new Promise((resolve) => {
       const c = spawn2(SHELL_BIN, [SHELL_FLAG, MUT.cmd], {
         cwd: wt,
-        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
+        env: scrubbedEnv({ FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd }),
         ...SHELL_OPTS
       });
       let out = "";

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -513,6 +513,69 @@ describe("farm.ts smoke tests", () => {
     expect(report.results[0].note).toMatch(/mutation score/);
   });
 
+  it("runs FARM_MUTATION_CMD under the scrubbed env — the pluggable hook cannot read FARM_API_KEY / OAuth (least-privilege parity)", async () => {
+    // The pluggable mutation hook runs operator-supplied, possibly third-party
+    // code in the worktree. Like every other child (gate/setup/test/git via
+    // run()), it must NOT inherit the dispatcher's secrets — only the
+    // FARM_MUTATION_* contract vars. Probe: a committed script the hook invokes
+    // records its own env to an absolute PROBE_OUT path (an env value, so no
+    // shell quoting), then prints a score line so mutationCheck parses cleanly.
+    const probeOut = join(tmpdir(), `farm-mut-env-probe-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+    const probe = [
+      "const fs = require('node:fs');",
+      "fs.writeFileSync(process.env.PROBE_OUT, JSON.stringify({",
+      "  key: process.env.FARM_API_KEY ?? 'ABSENT',",
+      "  tok: process.env.CLAUDE_CODE_OAUTH_TOKEN ?? 'ABSENT',",
+      "  files: process.env.FARM_MUTATION_FILES ?? 'ABSENT',",
+      "  testPath: process.env.FARM_MUTATION_TEST_PATH ?? 'ABSENT',",
+      "  testCmd: process.env.FARM_MUTATION_TEST_CMD ?? 'ABSENT',",
+      "}));",
+      "process.stdout.write('{\"score\":1,\"total\":5}');",
+    ].join("\n");
+    // Commit the probe so it lands in the ephemeral worktree the hook runs in.
+    writeFileSync(join(tmpDir, "mut-probe.cjs"), probe);
+    execSync("git add mut-probe.cjs", { cwd: tmpDir, stdio: "pipe" });
+    execSync("git commit -m probe --no-gpg-sign", { cwd: tmpDir, stdio: "pipe" });
+
+    ({ server: mockServer, port } = await startMockServer(() =>
+      ["```javascript", "// path: src/m.js", "module.exports.f = (a, b) => a + b;", "```"].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "mutation-env-scrub", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Add",
+          deps: [],
+          filesInScope: ["src/m.js"],
+          test: { path: "src/m.test.js" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "sk-must-not-leak-to-hook",
+      CLAUDE_CODE_OAUTH_TOKEN: "tok-must-not-leak",
+      FARM_MUTATION: "on",
+      FARM_MUTATION_CMD: "node mut-probe.cjs",
+      PROBE_OUT: probeOut,
+    });
+
+    expect(existsSync(probeOut)).toBe(true); // the pluggable hook actually ran
+    const seen = JSON.parse(readFileSync(probeOut, "utf8"));
+    expect(seen.key).toBe("ABSENT"); // SEC-1: FARM_API_KEY scrubbed from the hook env
+    expect(seen.tok).toBe("ABSENT"); // SEC-1: OAuth token scrubbed
+    expect(seen.files).toContain("src/m.js"); // CON-1: feature env still delivered
+    expect(seen.testPath).toBe("src/m.test.js"); // CON-1
+    expect(seen.testCmd).toBe("node -p 0"); // CON-1
+    rmSync(probeOut, { force: true });
+  });
+
   it("enriches the worker prompt with the test source AND an in-scope sibling's contents (AC-03/AC-04)", async () => {
     // Capture every prompt the worker is sent. The mock returns a benign
     // in-scope file so the task can settle; the assertion is on what reached it.

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter } from "./farm.ts";
 import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
+import { scrubbedEnv } from "./exec.ts";
 
 // ---------------------------------------------------------------------------
 // redactSecrets — outbound-boundary redactor must stay aligned with the hook
@@ -1353,6 +1354,23 @@ describe("T-08c mutant-restore Map-miss preserves the file (dx-003)", () => {
     let wrote: string | null = null;
     if (orig !== undefined) wrote = orig;
     expect(wrote).toBeNull(); // file preserved, never overwritten with "undefined"
+  });
+});
+
+describe("scrubbedEnv() deletes secrets LAST so a caller var cannot reintroduce one (CodeQL #5)", () => {
+  it("strips FARM_API_KEY / OAuth token even when they are passed in `extra`", () => {
+    // The delete-last ordering is the load-bearing defense: a caller that
+    // (accidentally or maliciously) puts a secret in `extra` must not be able
+    // to re-add it. A future reorder of the delete before the merge would pass
+    // every other test but silently break this; this test pins the ordering.
+    const env = scrubbedEnv({
+      FARM_API_KEY: "extra-should-be-deleted",
+      CLAUDE_CODE_OAUTH_TOKEN: "extra-tok-should-be-deleted",
+      FARM_MUTATION_FILES: "a.ts,b.ts", // a non-secret contract var survives
+    });
+    expect(env.FARM_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(env.FARM_MUTATION_FILES).toBe("a.ts,b.ts");
   });
 });
 

--- a/plugins/ca/tools/mutation.ts
+++ b/plugins/ca/tools/mutation.ts
@@ -17,6 +17,7 @@ import {
   run,
   treeKill,
   readWorktreeFile,
+  scrubbedEnv,
   SHELL_BIN,
   SHELL_FLAG,
   SHELL_OPTS,
@@ -175,9 +176,13 @@ export async function mutationCheck(wt: string, task: Task): Promise<MutationRes
   // Pluggable hook — hand off to a real per-language framework if configured.
   if (MUT.cmd) {
     const r = await new Promise<{ code: number; out: string }>((resolve) => {
+      // Least-privilege parity with run(): the operator-authored mutation hook
+      // is a child like any other and must not inherit the dispatcher's
+      // secrets. Route its env through scrubbedEnv(), passing only the
+      // FARM_MUTATION_* contract vars on top of the scrubbed base.
       const c = spawn(SHELL_BIN, [SHELL_FLAG, MUT.cmd!], {
         cwd: wt,
-        env: { ...process.env, FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd },
+        env: scrubbedEnv({ FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd }),
         ...SHELL_OPTS,
       });
       let out = "";


### PR DESCRIPTION
## What

Closes a least-privilege gap in the farm dispatcher: the pluggable `FARM_MUTATION_CMD` mutation hook spawned with `{ ...process.env }`, so an operator-wired (possibly third-party) mutation framework inherited `FARM_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN`. It was the one child-spawn path that bypassed `run()`'s existing secret scrub, against the intent stated in `run()`'s own comment.

The fix adds a single shared helper in `exec.ts`:

```ts
export function scrubbedEnv(extra?) {
  const env = { ...process.env, ...(extra ?? {}) };
  delete env.FARM_API_KEY;
  delete env.CLAUDE_CODE_OAUTH_TOKEN;   // deleted LAST, after the merge
  return env;
}
```

Both `run()` and the mutation-hook spawn now route through it, so there is one scrub, not two that can drift. The hook still receives the `FARM_MUTATION_*` contract vars; only the credentials are stripped.

## Why

This is the same least-privilege control `run()` already applied to git, gate, setup, and test commands (CodeQL #5). The mutation hook runs operator-supplied code in the worktree and has no need for the dispatcher's API key. Deleting the secrets after merging `extra` means a caller var can never re-introduce one.

Surfaced by `auth-crypto-reviewer` during the #140 (v2.rev.0020) review as a pre-existing gap, not introduced by that refactor. Conflict-hierarchy: a level-1 (security) tightening with no behavior change to any non-secret path.

## Test plan

- [x] New subprocess integration test (`farm.test.ts`): the hook runs a committed probe that records its own env; the test asserts `FARM_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` read `ABSENT` while `FARM_MUTATION_FILES/TEST_PATH/TEST_CMD` are present. Fails on the pre-fix code (the secret leaks), passes after.
- [x] New unit test (`farm.unit.test.ts`): pins the delete-last ordering by passing a secret in `extra` and asserting it is stripped, so a future reorder cannot silently break the defense.
- [x] Existing `run()` scrub test still green (now exercises the shared helper).
- [x] `npx vitest run`: 171/171. `npx tsc --noEmit`: clean. `farm.js` rebuilt and deterministic.

## Reviews

All three path-matrix reviewers PASS, no CRITICAL or HIGH:

- `auth-crypto-reviewer`: `scrubbedEnv()` removes both secrets after the merge; `run()` behavior identical; no real secret, TLS downgrade, or banned primitive.
- `security-reviewer`: tightens the secret-store control; `SHELL_OPTS` cannot override the scrubbed env; the two `sk-`/`tok-` shaped values are fake test sentinels matching the sanctioned dummy-value convention.
- `coverage-auditor`: about 85 percent, both `scrubbedEnv` paths exercised, both obligations verified. Its one LOW (untested delete-last ordering) is closed by the unit test in this PR.

## Note on the commit gate

The compound-name secret detection from v2.rev.0016 (shipping in 2.6.0) flags the test's `FARM_API_KEY:`/`CLAUDE_CODE_OAUTH_TOKEN:` fixture lines. The secret-handling gate reviewed them (fake sentinels) and recorded a diff-bound pass before commit. The currently installed plugin (2.5.2) predates that detection, so its local hook does not flag them, which is expected release lag, not a gap.

Ref: v2.rev.0020 follow-up (auth-crypto-reviewer finding)
