### PR TITLE
docs(site): document the 2.6.0 feature tracks (provenance, injection, board, farm)

### DIFF
--- a/.codearbiter/plans/docs-2.6.0-feature-coverage.md
+++ b/.codearbiter/plans/docs-2.6.0-feature-coverage.md
@@ -1,0 +1,91 @@
+# Plan — 2.6.0 docs push: narrative coverage for the release feature tracks
+
+**Spec:** `.codearbiter/specs/docs-2.6.0-feature-coverage.md` (approved 2026-06-27, Lane: full, docs/no-TDD)
+**Branch:** `docs/2.6.0-feature-coverage` · gates the `v2.6.0` tag alongside the relicense (PR #147).
+
+Prose/asset work: there is **no `tdd`**. Each task's `maps-to` is the docs-site CI gate or grep that
+proves it, in place of a tdd obligation. Execution authoring agent = `frontend-author` (Astro/Starlight
+is frontend) with `design-quality-reviewer`.
+
+---
+
+## AC ledger (from the spec)
+
+- **AC-1** — `concepts.md` "Provenance & context drift" section: drift detection, `code-map.md`, `/ca:context-check`, commit-gate auto-heal.
+- **AC-2** — `concepts.md` "Just-in-time context injection" section: the `PreToolUse:Read` hook, the four tiers in priority order, the `**Governs:**` line.
+- **AC-3** — `enforcement.md` board-transitions section: `/ca:task`, ADR-0008 commit-coupled flips.
+- **AC-4** — `hooks.md` `PreToolUse:Read` injection-hook entry.
+- **AC-5** — README farm var table gains `FARM_SAMPLES` + `FARM_TEMPERATURE` rows and a best-of-N note, inside the Feature Forge preview subsection.
+- **AC-6** — README **How it works** mentions each of the three stable tracks with a link resolving to its docs-site section.
+- **AC-7** — two new SVG diagrams (four-tier map; provenance drift→auto-heal flow), each with a non-empty `<title>`, referenced by a base-path-correct href from its concept section.
+- **AC-8** — every hand-authored content page is reachable from the `astro.config.mjs` sidebar; no orphaned new page.
+- **AC-9** — docs-site CI green: `npm run typecheck`, `npm run test`, `npm run build`, `npm run link-audit` each exit 0 in `site/`.
+- **AC-10** — `design-quality-reviewer` clears the new prose and diagrams against `anti-slop-design` §3.A + §3.B; zero unresolved findings.
+- **AC-11** — `python .github/scripts/check_badge_consistency.py` stays green.
+
+---
+
+## Task table
+
+Docs-site content lives in `site/src/content/docs/`. Diagrams: match the **committed source location**
+of the existing diagrams (verify `site/public/diagrams/` vs `site/src/assets/diagrams/` — whichever is
+git-tracked, not a build artifact), referenced as `/codeArbiter/diagrams/<name>.svg`. "→ exit 0" means
+the cited command passes.
+
+| id | path(s) | verification (maps-to) | covers | depends-on |
+|----|---------|------------------------|--------|------------|
+| **T-01** | `site/<diagram-src>/four-tier-map.svg`, `…/provenance-drift-flow.svg` | both SVGs exist at the tracked diagram source path, each with a non-empty `<title>`; `grep '<title>'` matches; style matches an existing diagram (gate-model.svg) | AC-7 | — |
+| **T-02** | `site/src/content/docs/concepts.md` | a "Provenance & context drift" heading exists naming drift detection, `code-map.md`, `/ca:context-check`, and auto-heal; references `/codeArbiter/diagrams/provenance-drift-flow.svg` (grep heading + terms + img ref) | AC-1 | T-01 |
+| **T-03** | `site/src/content/docs/concepts.md` | a "Just-in-time context injection" heading naming the `PreToolUse:Read` hook, the four tiers in order, and the `**Governs:**` line; references `/codeArbiter/diagrams/four-tier-map.svg` (grep) | AC-2 | T-01, T-02 (same file) |
+| **T-04** | `site/src/content/docs/enforcement.md` | a board-transitions section naming `/ca:task` and ADR-0008 commit-coupled flips (grep heading + terms) | AC-3 | — |
+| **T-05** | `site/src/content/docs/hooks.md` | a `PreToolUse:Read` injection-hook entry describing the at-read context injection (grep) | AC-4 | — |
+| **T-06** | `README.md` (Feature Forge → farm subsection) | the farm env-var table contains `FARM_SAMPLES` and `FARM_TEMPERATURE` rows plus a best-of-N note (grep) | AC-5 | — |
+| **T-07** | `README.md` (How it works) | brief mentions of provenance, JIT injection, and board transitions, each with a link to its docs-site section anchor (grep mentions + links; link-audit confirms resolution) | AC-6 | T-02, T-03, T-04, T-06 (same file) |
+| **T-08** | `site/` (+ `site/astro.config.mjs` only if an orphan is found) | `cd site && npm run typecheck && npm run test && npm run build && npm run link-audit` → all exit 0 (build catches orphan pages; link-audit catches dangling diagram/section links — covers AC-8 too) | AC-8, AC-9 | T-01..T-07 |
+| **T-09** | new prose + diagrams (review) | `design-quality-reviewer` clears §3.A (no em-dash prose separators) + §3.B copy self-audit; zero unresolved findings | AC-10 | T-01..T-07 |
+| **T-10** | (verification) | `python .github/scripts/check_badge_consistency.py` → exit 0 (docs changes do not touch command/skill/agent counts) | AC-11 | T-06, T-07 |
+
+---
+
+## Order & MVP slice
+
+Dependency order: T-01 → T-02 → T-03; T-04, T-05, T-06 independent; T-07 (after T-02/03/04/06) →
+T-08, T-09 (after all authoring) → T-10.
+
+**MVP slice = the whole push** (T-01–T-10). This is one cohesive docs deliverable: the four tracks
+documented, diagrams integral (the concept sections reference them, so link-audit fails if they are
+missing), gates green. There is no smaller shippable slice that satisfies the spec's "each track has a
+narrative home" core without leaving a dangling reference or an ungated change. No incremental tail.
+
+---
+
+## Coverage proof
+
+AC-1→T-02 · AC-2→T-03 · AC-3→T-04 · AC-4→T-05 · AC-5→T-06 · AC-6→T-07 · AC-7→T-01 · AC-8→T-08 · AC-9→T-08 · AC-10→T-09 · AC-11→T-10.
+
+Every AC has ≥1 task; every task covers ≥1 AC. Bijective.
+
+---
+
+## Status ledger
+
+| task | status |
+|------|--------|
+| T-01 | ACCEPTED |
+| T-02 | ACCEPTED |
+| T-03 | ACCEPTED |
+| T-04 | ACCEPTED |
+| T-05 | ACCEPTED |
+| T-06 | ACCEPTED |
+| T-07 | ACCEPTED |
+| T-08 | ACCEPTED |
+| T-09 | ACCEPTED |
+| T-10 | ACCEPTED |
+
+---
+
+## Notes (no `[NEEDS-TRIAGE]` raised)
+
+- No `forge-status.ts` change: the three stable tracks (provenance, JIT injection, board transitions) are on-by-default, not Feature Forge previews; only the farm sampling (T-06) extends the existing farm preview and needs no allowlist entry.
+- Do NOT edit auto-generated `reference/` pages.
+- README edits are scoped to the How-it-works + Feature-Forge sections to avoid conflict with the relicense PR's license-section edits (both target `main`).

--- a/.codearbiter/specs/docs-2.6.0-feature-coverage.md
+++ b/.codearbiter/specs/docs-2.6.0-feature-coverage.md
@@ -1,0 +1,107 @@
+# Spec — 2.6.0 docs push: narrative coverage for the release feature tracks
+
+**Slug:** `docs-2.6.0-feature-coverage` · **Lane:** full (docs, no TDD) · **Status:** approved (2026-06-27)
+**Governs:** site/src/content/docs/concepts.md, site/src/content/docs/enforcement.md, site/src/content/docs/hooks.md, README.md
+
+> Gates the `v2.6.0` tag. The release is paused on branch `release/v2.6.0` (nothing tagged).
+> This is prose/asset work: there is no TDD. The quality gates are the docs-site CI
+> (`typecheck` + `vitest` + `build` + `link-audit`), `anti-slop-design`, and the
+> `design-quality-reviewer`, in place of unit tests.
+
+---
+
+## Problem
+
+ca 2.6.0 bundles four user-facing capability tracks, but their narrative coverage lags the code.
+Three (context-drift provenance #145, commit-gate board transitions #144, file-scoped context
+injection #146) appear only as command-catalog rows or not at all; #146 is absent from every
+narrative surface. A consumer reading the README or the docs site cannot learn what these features
+do or how to use them. Releasing now tags a payload whose marquee features are unexplained.
+
+**Caller who feels it:** a consumer or evaluator reading `README.md` and the docs site to adopt or
+understand codeArbiter; and the maintainer who wants 2.6.0 to ship documented.
+
+**Done looks like:** each 2.6.0 track has a narrative home (a docs-site concept section, a hooks
+entry, or a README table row), registered and rendering, supported by a diagram where it clarifies,
+anti-slop-clean, with every docs-site CI gate green.
+
+---
+
+## Scope
+
+**In scope**
+- **Docs site (primary narrative home), `site/src/content/docs/`:**
+  - `concepts.md` — a new **Provenance & context drift** section (#145): drift detection, the
+    SessionStart drift line, `.codearbiter/code-map.md`, `/ca:context-check`, and commit-gate
+    auto-heal.
+  - `concepts.md` — a new **Just-in-time context injection** section (#146): the `PreToolUse:Read`
+    hook, the four-tier file-to-knowledge map (security-controls > decisions > specs > provenance),
+    the `**Governs:**` spec-header line, and the budget/dedup/fail-open properties.
+  - `enforcement.md` — a new **Board transitions land with the work** section (#144): `/ca:task`,
+    the commit-gate board-sync chokepoint, and ADR-0008 (flips ride the work commit).
+  - `hooks.md` — a new entry for the `PreToolUse:Read` injection hook.
+- **Two new SVG diagrams** in the docs-site diagram asset dir, matching the existing diagram style:
+  the four-tier file-to-knowledge map, and the provenance drift-to-auto-heal flow. Each carries an
+  accessible `<title>`/`<desc>`, a base-path-correct href, and is referenced from its section.
+- **README (light touch):**
+  - A brief mention of provenance, JIT injection, and board transitions in **How it works**, each
+    linking to its docs-site section (no full duplicate narrative).
+  - **Feature Forge → Pluggable execution farm**: add `FARM_SAMPLES` and `FARM_TEMPERATURE` rows to
+    the env-var table plus a one-line best-of-N note (#137), inside the existing preview subsection.
+
+**Out of scope**
+- Editing the auto-generated `reference/` pages (regenerated from `plugins/ca/**` at build).
+- New features, and any `forge-status.ts` `PREVIEW_COMMANDS` change — the three stable tracks are
+  on-by-default, NOT Feature Forge previews; only the farm sampling extends the existing farm preview
+  and needs no new allowlist entry.
+- Wholesale rewrite of existing pages; a docs-site redesign; new top-level pages or sidebar groups
+  (coverage lands as sections in already-registered pages).
+- `plugins/ca/README.md` deep changes (it intentionally defers to the repo README).
+- The CHANGELOG reconciliation and the tag itself — those are the paused `/ca:release` flow, resumed
+  after this ships.
+
+---
+
+## Acceptance criteria
+
+Each is verifiable by a single structural check or a named reviewer.
+
+- **AC-1** — `concepts.md` contains a "Provenance & context drift" section naming drift detection,
+  `code-map.md`, `/ca:context-check`, and commit-gate auto-heal (grep headings + terms).
+- **AC-2** — `concepts.md` contains a "Just-in-time context injection" section naming the
+  `PreToolUse:Read` hook, the four tiers in priority order, and the `**Governs:**` line (grep).
+- **AC-3** — `enforcement.md` contains a board-transitions section naming `/ca:task` and ADR-0008
+  commit-coupled flips (grep).
+- **AC-4** — `hooks.md` contains a `PreToolUse:Read` injection-hook entry (grep).
+- **AC-5** — the README farm var table contains `FARM_SAMPLES` and `FARM_TEMPERATURE` rows and a
+  best-of-N note, within the Feature Forge preview subsection (grep).
+- **AC-6** — README **How it works** mentions each of the three stable tracks with a link resolving
+  to its docs-site section (grep links; link-audit confirms resolution).
+- **AC-7** — two new SVG diagram files exist in the diagram asset dir, each with a non-empty
+  `<title>`, referenced by a base-path-correct href from its concept section (file exists + grep
+  `<title>` + grep the reference).
+- **AC-8** — every hand-authored content page is reachable from the `astro.config.mjs` sidebar; no
+  orphaned new page (build + sidebar check).
+- **AC-9** — the docs-site CI gates pass: `npm run typecheck`, `npm test`, `npm run build`, and
+  `npm run link-audit` each exit 0 in `site/`.
+- **AC-10** — `design-quality-reviewer` clears the new prose and diagrams against `anti-slop-design`
+  §3.A (no em-dash prose separators) and §3.B (copy self-audit); zero unresolved findings.
+- **AC-11** — `python .github/scripts/check_badge_consistency.py` stays green (docs changes do not
+  touch command/skill/agent counts).
+
+---
+
+## Open questions
+
+None blocking. Two scope choices resolved during brainstorming, recorded here:
+- README depth: docs-site is the primary narrative home; README gets brief linking mentions only,
+  not duplicate sections (avoids two-place drift).
+- Diagrams: in scope (two new SVGs), matching the existing diagram style.
+
+## Notes
+
+- Execution is prose/asset work: tasks route to `frontend-author` (the docs site is Astro/Starlight
+  frontend) with `design-quality-reviewer`, and each task's verification maps to a docs-site CI gate
+  or a grep assertion, NOT a `tdd` obligation.
+- On approval and completion, resume `/ca:release` for 2.6.0 (CHANGELOG reconciliation already
+  scoped: roll in #138/#139/#143/#145/#146, broaden the intro, date 2026-06-27), then tag.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The plugin itself → `~/.claude/plugins/cache/`
 </tr>
 </table>
 
+Three features added in 2.6.0 extend what the plugin tracks across a session. [Provenance and context drift](https://arbiterforge.github.io/codeArbiter/concepts/#provenance--context-drift): derived docs record their sources; stale derivations surface at `SessionStart` and the commit gate auto-heals them. [Just-in-time context injection](https://arbiterforge.github.io/codeArbiter/concepts/#just-in-time-context-injection): on a read of a governed file, the controlling decision or spec is surfaced at the point of touch. [Board transitions land with the work](https://arbiterforge.github.io/codeArbiter/enforcement/#commit-gate-board-transitions-adr-0008): `/ca:task` flips ride the work commit (ADR-0008), not a separate trailing chore.
+
 ## The gates
 
 The non-negotiables codeArbiter enforces in every enabled repo:
@@ -395,6 +397,11 @@ After a few sessions, [**open a "prune data" issue**](https://github.com/arbiter
 | `FARM_MODEL` | _(unset)_ | Skip selection; otherwise the model is auto-selected by measured canary at dispatch. |
 | `FARM_ENRICH_MAX_BYTES` | `131072` | Cap on test-source + in-scope context injected into the worker prompt (redacted for secrets). |
 | `FARM_CONCURRENCY` | `4` | Max concurrent task workers. |
+| `FARM_SAMPLES` | `1` | Parallel candidate draws per task, each in its own scratch worktree; the first to pass the gate is accepted. `FARM_SAMPLES=1` is byte-for-byte the single-candidate path. Total in-flight workers never exceed `FARM_CONCURRENCY`. |
+| `FARM_TEMPERATURE` | `0` | Sampling temperature; auto-bumped to `0.7` when `FARM_SAMPLES>1` so samples diversify. Set explicitly to override. |
+| `FARM_MAX_TOKENS` | _(unset)_ | Token ceiling per worker call; unset defers to the provider default. |
+
+**Best-of-N sampling.** Because the gate is a deterministic pass/fail oracle, `FARM_SAMPLES` candidates are drawn in parallel and the first to pass is accepted; the N-fold token cost is recorded in `farm-report.json`.
 
 Full config (endpoint, retries, circuit breaker, mutation guard, sovereignty note) is in <kbd>/ca:sprint</kbd> and the farm setup doc.
 

--- a/site/public/diagrams/four-tier-map.svg
+++ b/site/public/diagrams/four-tier-map.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 380" role="img"
+     aria-label="File to knowledge map for file-scoped context injection. A Read of a governed file is matched against four tiers in priority order: security-controls.md, accepted ADRs, approved specs, and provenance. The highest-priority match's pointer is injected within a 150-token budget. A Read of a non-governed file injects nothing and makes no git call.">
+  <title>File-scoped context injection: the four-tier file-to-knowledge map</title>
+  <defs>
+    <linearGradient id="ftm-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#131a23"/>
+    </linearGradient>
+    <pattern id="ftm-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#e6edf3" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <marker id="ftm-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#46505a"/>
+    </marker>
+    <marker id="ftm-arrow-gold" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#d29922"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="380" fill="url(#ftm-bg)"/>
+  <rect width="900" height="380" fill="url(#ftm-grid)"/>
+  <rect x="8" y="8" width="884" height="364" fill="none" stroke="#e3b341" stroke-opacity="0.14" stroke-width="1"/>
+
+  <!-- header -->
+  <text x="30" y="36" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="10" letter-spacing="3" fill="#8b95a2">FILE → KNOWLEDGE MAP</text>
+  <text x="30" y="57" font-family="'Segoe UI', -apple-system, 'Helvetica Neue', Arial, sans-serif"
+        font-size="15" fill="#e6edf3" font-weight="600">a Read, matched against four tiers in priority order</text>
+
+  <!-- Read node -->
+  <rect x="30" y="150" width="150" height="64" rx="5" fill="#1c2430" stroke="#6e7b8b" stroke-width="1.2"/>
+  <text x="105" y="178" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="12" fill="#e6edf3">Read(file)</text>
+  <text x="105" y="197" text-anchor="middle" font-family="'Segoe UI', -apple-system, Arial, sans-serif"
+        font-size="10" fill="#8b95a2">PreToolUse hook</text>
+  <line x1="180" y1="182" x2="246" y2="182" stroke="#46505a" stroke-width="1.5" marker-end="url(#ftm-arrow)"/>
+
+  <!-- tier stack (priority: top = highest) -->
+  <!-- tier 1 -->
+  <rect x="250" y="78" width="380" height="48" rx="4" fill="#1c2430" stroke="#d29922" stroke-width="1.4"/>
+  <text x="266" y="100" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#d29922">1 · security-controls.md</text>
+  <text x="266" y="117" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">security-entry files (auth · middleware · jwt)</text>
+  <!-- tier 2 -->
+  <rect x="250" y="134" width="380" height="48" rx="4" fill="#1c2430" stroke="#46505a" stroke-width="1.2"/>
+  <text x="266" y="156" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">2 · decisions/</text>
+  <text x="266" y="173" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">accepted ADR whose governs: glob matches</text>
+  <!-- tier 3 -->
+  <rect x="250" y="190" width="380" height="48" rx="4" fill="#1c2430" stroke="#46505a" stroke-width="1.2"/>
+  <text x="266" y="212" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">3 · specs/</text>
+  <text x="266" y="229" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">approved spec with a **Governs:** header</text>
+  <!-- tier 4 -->
+  <rect x="250" y="246" width="380" height="48" rx="4" fill="#1c2430" stroke="#46505a" stroke-width="1.2"/>
+  <text x="266" y="268" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">4 · provenance (enrichment)</text>
+  <text x="266" y="285" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">claim whose stored hash still matches the file</text>
+
+  <!-- priority bracket -->
+  <text x="232" y="92" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#6e7b8b">high</text>
+  <line x1="240" y1="100" x2="240" y2="272" stroke="#2a3340" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="232" y="284" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#6e7b8b">low</text>
+
+  <!-- highest match injects -->
+  <line x1="630" y1="102" x2="700" y2="102" stroke="#d29922" stroke-width="1.5" marker-end="url(#ftm-arrow-gold)"/>
+  <rect x="700" y="74" width="172" height="58" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.2"/>
+  <text x="786" y="98" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">inject the pointer</text>
+  <text x="786" y="116" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="#8b95a2">budget ≤ 150 tokens</text>
+
+  <!-- miss path -->
+  <text x="105" y="250" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#6e7b8b">no tier matches?</text>
+  <path d="M 105 214 L 105 332 L 246 332" fill="none" stroke="#2a3340" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#ftm-arrow)"/>
+  <rect x="250" y="312" width="622" height="40" rx="4" fill="#11161d" stroke="#2a3340" stroke-width="1"/>
+  <text x="561" y="337" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#8b95a2">non-governed Read: nothing fires, zero git calls, deduped once per (session, file)</text>
+</svg>

--- a/site/public/diagrams/provenance-drift-flow.svg
+++ b/site/public/diagrams/provenance-drift-flow.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img"
+     aria-label="Context-drift provenance flow. When a derived doc's tracked source changes, drift is detected by a git hash-object mismatch. A SessionStart line surfaces it passively, and commit-gate auto-heal re-baselines the provenance or proposes a doc update with the work commit. The /ca:context-check command runs the same detection as a manual audit.">
+  <title>Context-drift provenance: detect, surface, and auto-heal</title>
+  <defs>
+    <linearGradient id="pdf-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#131a23"/>
+    </linearGradient>
+    <pattern id="pdf-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#e6edf3" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <marker id="pdf-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#46505a"/>
+    </marker>
+    <marker id="pdf-arrow-gold" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#d29922"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="300" fill="url(#pdf-bg)"/>
+  <rect width="900" height="300" fill="url(#pdf-grid)"/>
+  <rect x="8" y="8" width="884" height="284" fill="none" stroke="#e3b341" stroke-opacity="0.14" stroke-width="1"/>
+
+  <text x="30" y="36" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="10" letter-spacing="3" fill="#8b95a2">CONTEXT-DRIFT PROVENANCE</text>
+  <text x="30" y="57" font-family="'Segoe UI', -apple-system, 'Helvetica Neue', Arial, sans-serif"
+        font-size="15" fill="#e6edf3" font-weight="600">detect · surface · auto-heal</text>
+
+  <!-- step 1 -->
+  <rect x="30" y="98" width="180" height="66" rx="5" fill="#1c2430" stroke="#6e7b8b" stroke-width="1.2"/>
+  <text x="120" y="124" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">tracked source changes</text>
+  <text x="120" y="142" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">a doc's cited file is edited</text>
+  <line x1="210" y1="131" x2="248" y2="131" stroke="#46505a" stroke-width="1.5" marker-end="url(#pdf-arrow)"/>
+
+  <!-- step 2 -->
+  <rect x="250" y="98" width="180" height="66" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.3"/>
+  <text x="340" y="124" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">drift detected</text>
+  <text x="340" y="142" text-anchor="middle" font-family="ui-monospace, Consolas, monospace" font-size="10" fill="#8b95a2">git hash-object mismatch</text>
+  <line x1="430" y1="131" x2="468" y2="131" stroke="#46505a" stroke-width="1.5" marker-end="url(#pdf-arrow)"/>
+
+  <!-- step 3 -->
+  <rect x="470" y="98" width="180" height="66" rx="5" fill="#1c2430" stroke="#6e7b8b" stroke-width="1.2"/>
+  <text x="560" y="124" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">SessionStart line</text>
+  <text x="560" y="142" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">passive, one line</text>
+  <line x1="650" y1="131" x2="688" y2="131" stroke="#d29922" stroke-width="1.5" marker-end="url(#pdf-arrow-gold)"/>
+
+  <!-- step 4 -->
+  <rect x="690" y="92" width="182" height="78" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.3"/>
+  <text x="781" y="116" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">commit-gate auto-heal</text>
+  <text x="781" y="134" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">re-baseline, or propose a</text>
+  <text x="781" y="149" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">doc update with the work commit</text>
+
+  <!-- manual audit entry -->
+  <rect x="250" y="208" width="180" height="52" rx="5" fill="#11161d" stroke="#46505a" stroke-width="1"/>
+  <text x="340" y="230" text-anchor="middle" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">/ca:context-check</text>
+  <text x="340" y="247" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">manual audit, same detection</text>
+  <line x1="340" y1="208" x2="340" y2="166" stroke="#2a3340" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#pdf-arrow)"/>
+
+  <text x="690" y="232" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#8b95a2">A drifted claim is suppressed,</text>
+  <text x="690" y="249" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#6e7b8b">never injected as if it were fresh.</text>
+</svg>

--- a/site/src/assets/diagrams/four-tier-map.svg
+++ b/site/src/assets/diagrams/four-tier-map.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 380" role="img"
+     aria-label="File to knowledge map for file-scoped context injection. A Read of a governed file is matched against four tiers in priority order: security-controls.md, accepted ADRs, approved specs, and provenance. The highest-priority match's pointer is injected within a 150-token budget. A Read of a non-governed file injects nothing and makes no git call.">
+  <title>File-scoped context injection: the four-tier file-to-knowledge map</title>
+  <defs>
+    <linearGradient id="ftm-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#131a23"/>
+    </linearGradient>
+    <pattern id="ftm-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#e6edf3" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <marker id="ftm-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#46505a"/>
+    </marker>
+    <marker id="ftm-arrow-gold" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#d29922"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="380" fill="url(#ftm-bg)"/>
+  <rect width="900" height="380" fill="url(#ftm-grid)"/>
+  <rect x="8" y="8" width="884" height="364" fill="none" stroke="#e3b341" stroke-opacity="0.14" stroke-width="1"/>
+
+  <!-- header -->
+  <text x="30" y="36" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="10" letter-spacing="3" fill="#8b95a2">FILE → KNOWLEDGE MAP</text>
+  <text x="30" y="57" font-family="'Segoe UI', -apple-system, 'Helvetica Neue', Arial, sans-serif"
+        font-size="15" fill="#e6edf3" font-weight="600">a Read, matched against four tiers in priority order</text>
+
+  <!-- Read node -->
+  <rect x="30" y="150" width="150" height="64" rx="5" fill="#1c2430" stroke="#6e7b8b" stroke-width="1.2"/>
+  <text x="105" y="178" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="12" fill="#e6edf3">Read(file)</text>
+  <text x="105" y="197" text-anchor="middle" font-family="'Segoe UI', -apple-system, Arial, sans-serif"
+        font-size="10" fill="#8b95a2">PreToolUse hook</text>
+  <line x1="180" y1="182" x2="246" y2="182" stroke="#46505a" stroke-width="1.5" marker-end="url(#ftm-arrow)"/>
+
+  <!-- tier stack (priority: top = highest) -->
+  <!-- tier 1 -->
+  <rect x="250" y="78" width="380" height="48" rx="4" fill="#1c2430" stroke="#d29922" stroke-width="1.4"/>
+  <text x="266" y="100" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#d29922">1 · security-controls.md</text>
+  <text x="266" y="117" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">security-entry files (auth · middleware · jwt)</text>
+  <!-- tier 2 -->
+  <rect x="250" y="134" width="380" height="48" rx="4" fill="#1c2430" stroke="#46505a" stroke-width="1.2"/>
+  <text x="266" y="156" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">2 · decisions/</text>
+  <text x="266" y="173" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">accepted ADR whose governs: glob matches</text>
+  <!-- tier 3 -->
+  <rect x="250" y="190" width="380" height="48" rx="4" fill="#1c2430" stroke="#46505a" stroke-width="1.2"/>
+  <text x="266" y="212" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">3 · specs/</text>
+  <text x="266" y="229" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">approved spec with a **Governs:** header</text>
+  <!-- tier 4 -->
+  <rect x="250" y="246" width="380" height="48" rx="4" fill="#1c2430" stroke="#46505a" stroke-width="1.2"/>
+  <text x="266" y="268" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">4 · provenance (enrichment)</text>
+  <text x="266" y="285" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">claim whose stored hash still matches the file</text>
+
+  <!-- priority bracket -->
+  <text x="232" y="92" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#6e7b8b">high</text>
+  <line x1="240" y1="100" x2="240" y2="272" stroke="#2a3340" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="232" y="284" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#6e7b8b">low</text>
+
+  <!-- highest match injects -->
+  <line x1="630" y1="102" x2="700" y2="102" stroke="#d29922" stroke-width="1.5" marker-end="url(#ftm-arrow-gold)"/>
+  <rect x="700" y="74" width="172" height="58" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.2"/>
+  <text x="786" y="98" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">inject the pointer</text>
+  <text x="786" y="116" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="#8b95a2">budget ≤ 150 tokens</text>
+
+  <!-- miss path -->
+  <text x="105" y="250" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#6e7b8b">no tier matches?</text>
+  <path d="M 105 214 L 105 332 L 246 332" fill="none" stroke="#2a3340" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#ftm-arrow)"/>
+  <rect x="250" y="312" width="622" height="40" rx="4" fill="#11161d" stroke="#2a3340" stroke-width="1"/>
+  <text x="561" y="337" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#8b95a2">non-governed Read: nothing fires, zero git calls, deduped once per (session, file)</text>
+</svg>

--- a/site/src/assets/diagrams/provenance-drift-flow.svg
+++ b/site/src/assets/diagrams/provenance-drift-flow.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img"
+     aria-label="Context-drift provenance flow. When a derived doc's tracked source changes, drift is detected by a git hash-object mismatch. A SessionStart line surfaces it passively, and commit-gate auto-heal re-baselines the provenance or proposes a doc update with the work commit. The /ca:context-check command runs the same detection as a manual audit.">
+  <title>Context-drift provenance: detect, surface, and auto-heal</title>
+  <defs>
+    <linearGradient id="pdf-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#131a23"/>
+    </linearGradient>
+    <pattern id="pdf-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#e6edf3" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <marker id="pdf-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#46505a"/>
+    </marker>
+    <marker id="pdf-arrow-gold" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 Z" fill="#d29922"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="300" fill="url(#pdf-bg)"/>
+  <rect width="900" height="300" fill="url(#pdf-grid)"/>
+  <rect x="8" y="8" width="884" height="284" fill="none" stroke="#e3b341" stroke-opacity="0.14" stroke-width="1"/>
+
+  <text x="30" y="36" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="10" letter-spacing="3" fill="#8b95a2">CONTEXT-DRIFT PROVENANCE</text>
+  <text x="30" y="57" font-family="'Segoe UI', -apple-system, 'Helvetica Neue', Arial, sans-serif"
+        font-size="15" fill="#e6edf3" font-weight="600">detect · surface · auto-heal</text>
+
+  <!-- step 1 -->
+  <rect x="30" y="98" width="180" height="66" rx="5" fill="#1c2430" stroke="#6e7b8b" stroke-width="1.2"/>
+  <text x="120" y="124" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">tracked source changes</text>
+  <text x="120" y="142" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">a doc's cited file is edited</text>
+  <line x1="210" y1="131" x2="248" y2="131" stroke="#46505a" stroke-width="1.5" marker-end="url(#pdf-arrow)"/>
+
+  <!-- step 2 -->
+  <rect x="250" y="98" width="180" height="66" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.3"/>
+  <text x="340" y="124" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">drift detected</text>
+  <text x="340" y="142" text-anchor="middle" font-family="ui-monospace, Consolas, monospace" font-size="10" fill="#8b95a2">git hash-object mismatch</text>
+  <line x1="430" y1="131" x2="468" y2="131" stroke="#46505a" stroke-width="1.5" marker-end="url(#pdf-arrow)"/>
+
+  <!-- step 3 -->
+  <rect x="470" y="98" width="180" height="66" rx="5" fill="#1c2430" stroke="#6e7b8b" stroke-width="1.2"/>
+  <text x="560" y="124" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">SessionStart line</text>
+  <text x="560" y="142" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">passive, one line</text>
+  <line x1="650" y1="131" x2="688" y2="131" stroke="#d29922" stroke-width="1.5" marker-end="url(#pdf-arrow-gold)"/>
+
+  <!-- step 4 -->
+  <rect x="690" y="92" width="182" height="78" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.3"/>
+  <text x="781" y="116" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#e6edf3">commit-gate auto-heal</text>
+  <text x="781" y="134" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">re-baseline, or propose a</text>
+  <text x="781" y="149" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">doc update with the work commit</text>
+
+  <!-- manual audit entry -->
+  <rect x="250" y="208" width="180" height="52" rx="5" fill="#11161d" stroke="#46505a" stroke-width="1"/>
+  <text x="340" y="230" text-anchor="middle" font-family="ui-monospace, Consolas, monospace" font-size="11" fill="#e6edf3">/ca:context-check</text>
+  <text x="340" y="247" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="10" fill="#8b95a2">manual audit, same detection</text>
+  <line x1="340" y1="208" x2="340" y2="166" stroke="#2a3340" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#pdf-arrow)"/>
+
+  <text x="690" y="232" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#8b95a2">A drifted claim is suppressed,</text>
+  <text x="690" y="249" font-family="'Segoe UI', Arial, sans-serif" font-size="11" fill="#6e7b8b">never injected as if it were fresh.</text>
+</svg>

--- a/site/src/content/docs/concepts.md
+++ b/site/src/content/docs/concepts.md
@@ -92,6 +92,37 @@ register keeps each role sharp. The orchestrator isn't trying to also be a backe
 and a security reviewer isn't trying to also be a copywriter. Each agent loads only the
 context its role needs, which is also what keeps the standing footprint small.
 
+## Provenance & context drift
+
+Every derived document under `.codearbiter/` traces its claims to source files in the repo. codeArbiter records this mapping as **provenance**: which files back a given doc, and the `git hash-object` hash of each file at the time the doc was authored. When a tracked source changes, the stored hash no longer matches. That mismatch is **context drift**.
+
+Drift is surfaced once, passively, as a single line at SessionStart. It does not interrupt work. `.codearbiter/code-map.md` provides a coarse orientation map: it names the main source files and the docs that depend on them. `/ca:context-check` runs the same detection on demand, as a manual audit.
+
+When a commit lands, the **commit-gate auto-heal** step checks whether any staged source files have drifted their dependent docs. If they have, it re-baselines the provenance in the same commit or proposes a doc update to accompany the work. A drifted claim is suppressed rather than surfaced as if fresh. A stale assertion cannot appear as current fact.
+
+<figure class="ca-diagram">
+  <img src="/codeArbiter/diagrams/provenance-drift-flow.svg" alt="Context-drift provenance flow: a tracked source change is detected by a git hash-object mismatch, surfaced at SessionStart, and healed by commit-gate which re-baselines or proposes a doc update with the work commit." loading="lazy" />
+  <figcaption>Provenance tracks source hashes. A mismatch is detected at SessionStart and healed when the commit lands.</figcaption>
+</figure>
+
+## Just-in-time context injection
+
+When any agent reads a file, a `PreToolUse:Read` hook fires first. It checks whether the file is governed by any knowledge document and, if so, injects a short pointer capped at a 150-token budget. The Read always proceeds. The hook is fail-open and never blocks it.
+
+The check follows a four-tier priority map. Each tier is evaluated in order; the first match wins:
+
+1. **Security controls:** if the file path is a security-entry point in `security-controls.md`, that document governs it.
+2. **Accepted ADRs:** any accepted ADR whose `governs:` glob matches the path.
+3. **Approved specs:** any spec carrying a `**Governs:**` header line whose glob matches the path. A spec opts in by adding that line.
+4. **Provenance claims:** a provenance claim whose stored `git hash-object` hash still matches the current file.
+
+A file that matches none of these tiers is non-governed. The hook injects nothing and makes no git call. Injection is deduplicated once per session and file, so repeated reads of the same file do not accumulate pointer tokens.
+
+<figure class="ca-diagram">
+  <img src="/codeArbiter/diagrams/four-tier-map.svg" alt="The four-tier file-to-knowledge map: a Read is matched against security-controls.md, accepted ADRs, approved specs, and provenance in priority order, and the highest-priority match's pointer is injected within a 150-token budget." loading="lazy" />
+  <figcaption>Four tiers, evaluated in priority order. The highest match governs; a non-governed Read injects nothing.</figcaption>
+</figure>
+
 ## Auditability
 
 Taken together, these concepts make a codeArbiter repository auditable after the fact. ADRs

--- a/site/src/content/docs/enforcement.md
+++ b/site/src/content/docs/enforcement.md
@@ -42,6 +42,16 @@ The gate **fails closed when the diff cannot be read.** If git is unavailable or
 
 The detection corpus is shared. `CRYPTO_RE` and `SECRET_RE` live once in `_hooklib.py`, so the redactor and the gate cannot drift on what counts as crypto or a secret.
 
+## Commit-gate board transitions (ADR-0008)
+
+`open-tasks.md` has one sanctioned writer: `/ca:task`. No other agent, hook, or workflow is permitted to modify that file directly. The three mutations it performs are a queued add (a new task in `[ ]` state), the start-flip (`[ ]` to `[~]` with a stamped date), and the done-flip (`[~]` to `[x]`).
+
+The commit gate is the single board-sync chokepoint. Phase 6 of the commit-gate skill identifies a schema-valid board transition and exempts it from the scope-creep check; Phase 7 stages it alongside the work. The board flip therefore lands atomically with the code it describes: an abandoned PR abandons the flip with it, and there is no window where the board reads done while the corresponding work is not yet merged.
+
+This replaces the old pattern of a separate, lagging `chore(board)` PR. Cross-session board drift (a task left open after its work lands) is eliminated by construction rather than by process discipline. See ADR-0008 for the full design rationale.
+
+`/ca:standup` and `/ca:doctor` each run a read-only reconciliation sweep and surface any merged-but-not-flipped task. They report; they do not write.
+
 ## Advisory, non-blocking reminders
 
 `post-write-edit.py` (`PostToolUse(Write|Edit)`) surfaces reminders right after a write. These **never block**. They nudge so the blocking gate is not a surprise at commit time.

--- a/site/src/content/docs/hooks.md
+++ b/site/src/content/docs/hooks.md
@@ -15,6 +15,7 @@ Every hook is registered **twice** in `hooks.json`: once under `python3`, and on
 | `PreToolUse` | `Bash\|PowerShell` | `pre-bash.py` |
 | `PreToolUse` | `Write` | `pre-write.py` |
 | `PreToolUse` | `Edit\|MultiEdit` | `pre-edit.py` |
+| `PreToolUse` | `Read` | `pre-read.py` |
 | `PostToolUse` | `Write\|Edit` | `post-write-edit.py` |
 | `UserPromptSubmit` | (any) | `prune-transcript.py` |
 | `PreCompact` | (any) | `prune-transcript.py` |
@@ -75,6 +76,19 @@ Every hook is registered **twice** in `hooks.json`: once under `python3`, and on
   - **H-11:** the same fresh `adr-authoring-active` marker requirement for `decisions/` `.md` files.
 - **Why:** Closes the Edit/MultiEdit flank; an append-only log accepts only verifiable appends.
 - **Fail posture:** Blocking (exit 2).
+
+---
+
+### pre-read.py
+
+- **Event:** `PreToolUse`, matcher `Read`.
+- **Script:** `pre-read.py`.
+- **What it does:** On a Read of a governed file, assembles a budgeted (150-token ceiling), freshness-gated note naming the decision, control, or spec that governs that path, and delivers it via `additionalContext` while always allowing the Read. See [Concepts: just-in-time context injection](/concepts#just-in-time-context-injection) for the four-tier governing map.
+  - Searches four tiers in priority order: `security-controls.md` for security-classified files; an accepted ADR whose `governs:` glob matches the path; an approved spec whose `**Governs:**` header matches; a provenance enrichment entry whose stored hash still equals the file's current content.
+  - Each `(session, file)` pair is injected at most once. A second Read of the same file in the same session produces no injection.
+  - On a Read of a non-governed file, nothing fires. No git call runs; cost is a single index lookup.
+- **Why:** Surfaces the governing context the moment a file opens, without requiring the agent's session to have already loaded the full doc set.
+- **Fail posture:** Advisory, fail-open (always exits 0). Any error in the governing-map lookup, git call, or budget computation degrades to allow-with-no-injection. A Read is never blocked.
 
 ---
 

--- a/site/test/generator/diagrams.test.ts
+++ b/site/test/generator/diagrams.test.ts
@@ -14,7 +14,7 @@ const SITE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DIAGRAM_DIR = join(SITE_ROOT, "src", "assets", "diagrams");
 const SRC_DIR = join(SITE_ROOT, "src");
 
-const DIAGRAMS = ["lane-flow.svg", "two-axis-model.svg", "gate-model.svg"];
+const DIAGRAMS = ["lane-flow.svg", "two-axis-model.svg", "gate-model.svg", "four-tier-map.svg", "provenance-drift-flow.svg"];
 
 /** Recursively read every page-ish source file under src/ as one big string. */
 function readAllPageSources(dir: string): string {


### PR DESCRIPTION
## What this does

Adds the user-facing narrative for the four feature tracks that shipped in 2.6.0 but whose documentation lagged. Implements the approved spec `docs-2.6.0-feature-coverage`.

## Why

2.6.0 bundled four capability tracks, but three appeared only as command-catalog rows and file-scoped context injection was absent from every page. A consumer reading the docs site or README could not learn what provenance, context injection, or commit-coupled board transitions do. This closes that gap, with the docs site as the primary narrative home and the README carrying brief linking mentions.

## Changes

**Docs site (`site/src/content/docs/`):**
- `concepts.md`: new "Provenance & context drift" section (#145) and "Just-in-time context injection" section (#146), each with a diagram.
- `enforcement.md`: a "Commit-gate board transitions (ADR-0008)" section (#144).
- `hooks.md`: a `pre-read.py` `PreToolUse:Read` entry.

**Diagrams:** `four-tier-map.svg` and `provenance-drift-flow.svg`, matching the existing diagram palette and style, added to the `diagrams.test.ts` AC-9 guard.

**README:** `FARM_SAMPLES` / `FARM_TEMPERATURE` rows and a best-of-N note in the farm preview table (#137); brief How-it-works mentions linking to the new docs-site sections. The README license sections are untouched here, so this does not conflict with the relicense PR (#147).

## Test plan

- `cd site && npm run typecheck` clean.
- `npm run test`: vitest 129 passed (the AC-9 diagram guard now covers the two new diagrams).
- `npm run build`: 81 pages built.
- `npm run link-audit`: 7292 internal links resolve.
- `design-quality-reviewer`: 0 CRITICAL/HIGH/MEDIUM (two LOW diagram issues fixed before merge).
- `python .github/scripts/check_badge_consistency.py`: green.

## Notes

- No behavioral product code, so `coverage-auditor` is not applicable; the docs-site CI is the gate.
- No version bump: `site/` + README + `.codearbiter/` only, no `plugins/ca/**` change.
- The three stable tracks are on by default and documented as stable. Only the farm sampling extends the existing Feature Forge preview.

Ref: specs/docs-2.6.0-feature-coverage.md
