### PR TITLE
fix(release): accept Keep-a-Changelog bracket headings in release guards

### DIFF
--- a/.github/scripts/_releaselib.py
+++ b/.github/scripts/_releaselib.py
@@ -31,12 +31,23 @@ NONE_SENTINEL = "<none>"
 _CA_RELEASE_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 _PRERELEASE_MARKERS = ("-beta", "-rc", "-alpha")
 
-# `## vX.Y.Z - YYYY-MM-DD` (any separator between version and date) and the
-# annotated-tag `Released-at:` footer.
-_HEADING_RE = re.compile(r"^##\s+(v\d+\.\d+\.\d+)\b", re.MULTILINE)
+# A changelog section heading, in either the `## vX.Y.Z - DATE` form or the
+# Keep-a-Changelog `## [X.Y.Z] - DATE` form the repo actually ships (every
+# released section + every prior GitHub Release body uses the bracket style).
+# The capture is the bare `X.Y.Z`; the optional leading `v` and the surrounding
+# brackets sit OUTSIDE the group, so heading comparison is style-agnostic. Any
+# separator is allowed between version and date. Plus the annotated-tag
+# `Released-at:` footer.
+_HEADING_RE = re.compile(r"^##\s+\[?v?(\d+\.\d+\.\d+)\]?", re.MULTILINE)
 _CHANGELOG_DATE_RE = re.compile(
-    r"^##\s+v\d+\.\d+\.\d+\D+(\d{4}-\d{2}-\d{2})", re.MULTILINE)
+    r"^##\s+\[?v?\d+\.\d+\.\d+\]?\D+(\d{4}-\d{2}-\d{2})", re.MULTILINE)
 _RELEASED_AT_RE = re.compile(r"Released-at:\s*(\d{4}-\d{2}-\d{2})")
+
+
+def _bare_version(tag):
+    """`v2.6.0` / `[2.6.0]` / `2.6.0` -> `2.6.0`. Lets the heading match compare
+    a `vX.Y.Z` tag against a bracket-style heading without caring about style."""
+    return tag.strip().lstrip("v").strip("[]") if isinstance(tag, str) else tag
 
 
 def last_tag_select(tags):
@@ -63,7 +74,8 @@ def last_tag_select(tags):
 
 
 def notes_heading_matches(notes_text, tag):
-    """True iff the FIRST `## vX.Y.Z` heading in `notes_text` equals `tag`. A
+    """True iff the FIRST changelog heading in `notes_text` (either `## vX.Y.Z`
+    or the Keep-a-Changelog `## [X.Y.Z]` form) names the same version as `tag`. A
     stale notes-file (whose first section is an older version) returns False, so
     the release skill cannot publish the wrong changelog section under the right
     tag. Missing heading or non-string input -> False."""
@@ -72,12 +84,13 @@ def notes_heading_matches(notes_text, tag):
     m = _HEADING_RE.search(notes_text)
     if not m:
         return False
-    return m.group(1) == tag
+    return m.group(1) == _bare_version(tag)
 
 
 def release_dates_consistent(changelog_section, tag_message):
-    """True iff the `## vX.Y.Z - DATE` date in `changelog_section` equals the
-    `Released-at: DATE` date in `tag_message`. Guards against the date being
+    """True iff the date in `changelog_section`'s heading (`## vX.Y.Z - DATE` or
+    `## [X.Y.Z] - DATE`) equals the `Released-at: DATE` date in `tag_message`.
+    Guards against the date being
     hand-typed inconsistently across surfaces. Either date absent, or non-string
     input -> False."""
     if not isinstance(changelog_section, str) or not isinstance(tag_message, str):

--- a/.github/scripts/test_release_lib.py
+++ b/.github/scripts/test_release_lib.py
@@ -60,8 +60,23 @@ class NotesHeadingTest(unittest.TestCase):
         notes = "## v2.6.0 — 2026-06-26\n\n### Added\n- thing\n"
         self.assertTrue(_releaselib.notes_heading_matches(notes, "v2.6.0"))
 
+    def test_matching_bracket_heading(self):
+        # Keep-a-Changelog bracket form — the repo's actual CHANGELOG convention
+        # (every released section + every prior GitHub Release body). The tag is
+        # `vX.Y.Z`; the heading carries `[X.Y.Z]` with no leading `v`. Regression
+        # for the v2.6.0 publish, where this guard no-matched purely on style.
+        notes = "## [2.6.0] — 2026-06-27\n\n### Added\n- thing\n"
+        self.assertTrue(_releaselib.notes_heading_matches(notes, "v2.6.0"))
+
     def test_mismatched_heading(self):
         notes = "## v2.5.0 — 2026-06-01\n\n### Fixed\n- bug\n"
+        self.assertFalse(_releaselib.notes_heading_matches(notes, "v2.6.0"))
+
+    def test_mismatched_bracket_heading(self):
+        # Protective value preserved: a stale bracket-form notes file whose first
+        # section is an older version must still fail, so accepting the bracket
+        # style never degrades into matching any version.
+        notes = "## [2.5.0] — 2026-06-01\n\n### Fixed\n- bug\n"
         self.assertFalse(_releaselib.notes_heading_matches(notes, "v2.6.0"))
 
     def test_first_heading_is_authoritative(self):
@@ -82,6 +97,13 @@ class ReleaseDatesTest(unittest.TestCase):
     def test_consistent_dates(self):
         section = "## v2.6.0 — 2026-06-26\n\n### Added\n- thing\n"
         tagmsg = "codeArbiter 2.6.0\n\nstuff\n\nReleased-at: 2026-06-26\n"
+        self.assertTrue(_releaselib.release_dates_consistent(section, tagmsg))
+
+    def test_consistent_dates_bracket_heading(self):
+        # Bracket-form changelog section (the repo convention). The date must be
+        # read from `## [X.Y.Z] — DATE`, not only from `## vX.Y.Z — DATE`.
+        section = "## [2.6.0] — 2026-06-27\n\n### Added\n- thing\n"
+        tagmsg = "codeArbiter 2.6.0\n\nstuff\n\nReleased-at: 2026-06-27\n"
         self.assertTrue(_releaselib.release_dates_consistent(section, tagmsg))
 
     def test_inconsistent_dates(self):


### PR DESCRIPTION
## What

`_releaselib`'s `notes_heading_matches` and `release_dates_consistent` only matched the `## vX.Y.Z` changelog heading form, but the repo's `CHANGELOG.md` — and every prior GitHub Release body — uses the Keep-a-Changelog `## [X.Y.Z]` convention. So both `/ca:release` guards returned `False` against every real release.

This surfaced during the **v2.6.0 publish**: `notes-match v2.6.0` no-matched purely on heading style, and the guard quietly did nothing (CI is the real backstop).

## Fix

- Both regexes now accept **either** `## vX.Y.Z` or `## [X.Y.Z]` — the optional leading `v` and the brackets sit outside the capture group, so the bare `X.Y.Z` is compared style-agnostically via a new `_bare_version` helper.
- Protective value preserved: a stale notes file whose first section is an older version still fails the match (regression-pinned).

## Tests (regression-first)

Added to `test_release_lib.py`, red before the fix, green after:
- `test_matching_bracket_heading` — `## [2.6.0]` matches tag `v2.6.0`
- `test_consistent_dates_bracket_heading` — date read from `## [X.Y.Z] — DATE`
- `test_mismatched_bracket_heading` — stale `## [2.5.0]` still rejected

Full `.github/scripts/test_*.py` suite green (17 files); `py_compile` clean. Scope is `.github/scripts/` only — no `plugins/ca/**` payload change, so no version bump.

## Follow-up (not in this PR)

`release/SKILL.md` Phase-1 prose still says roll into `## vMAJOR.MINOR.PATCH — DATE`; now harmless (the guards tolerate both forms) but worth aligning to the bracket convention. Deferred because it touches `plugins/ca/**` and would force a version bump — better bundled into the next versioned docs change.

https://claude.ai/code/session_015tNUy37dx7DJGDzmVUB8Wf
