### PR TITLE
docs(site): landing install demo + inline live search

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -62,6 +62,9 @@ export default defineConfig({
         // position-based scroll-spy so the last "On this page" item highlights
         // when scrolled to the bottom (the stock observer misses it)
         TableOfContents: "./src/components/TableOfContents.astro",
+        // inline search (live as you type, results drop below the box)
+        // replacing Starlight's stock modal-on-click search
+        Search: "./src/components/Search.astro",
       },
       customCss: [
         "./src/styles/theme.css",

--- a/site/src/components/InstallTerminal.astro
+++ b/site/src/components/InstallTerminal.astro
@@ -1,0 +1,74 @@
+---
+/**
+ * InstallTerminal.astro — the "get it running" companion to GateCatchTerminal.
+ *
+ * Renders an animated transcript of the commands a new user runs in Claude Code:
+ * the two install commands, then /ca:statusline to wire the bar. The rendered
+ * statusline itself is shown below the terminal (in index.mdx), using the
+ * canonical statusline.png single-source asset.
+ *
+ * Same design-system contract and animation grammar as GateCatchTerminal:
+ * CSS-only fade-in per line (--ca-term-delay), real DOM text for screen readers,
+ * and a static, fully-visible transcript under prefers-reduced-motion.
+ *
+ * Design-system contract (from theme.css):
+ *   .ca-terminal, .ca-terminal__titlebar, .ca-terminal__dot, .ca-terminal__title,
+ *   .ca-terminal__body, .ca-terminal__line, .ca-terminal__line--pass,
+ *   .ca-terminal__line--dim, .ca-terminal__prompt
+ */
+---
+
+<div
+  class="ca-terminal"
+  role="region"
+  aria-label="Install demo: the two install commands, then /ca:statusline, ending on the rendered statusline"
+>
+  <div class="ca-terminal__titlebar" aria-hidden="true">
+    <span class="ca-terminal__dot"></span>
+    <span class="ca-terminal__dot"></span>
+    <span class="ca-terminal__dot"></span>
+    <span class="ca-terminal__title">install codearbiter</span>
+  </div>
+
+  <ol
+    class="ca-terminal__body"
+    role="list"
+    aria-label="Terminal output: marketplace added, plugin installed, statusline wired, and the rendered bar"
+  >
+    <!-- Command 1: register the self-hosted marketplace -->
+    <li class="ca-terminal__line" role="listitem" style="--ca-term-delay: 0.1s">
+      <span class="ca-terminal__prompt" aria-hidden="true">$</span>
+      <span>/plugin marketplace add arbiterForge/codeArbiter</span>
+    </li>
+    <li class="ca-terminal__line ca-terminal__line--dim" role="listitem" style="--ca-term-delay: 0.4s">
+      <span>Marketplace added: codearbiter.</span>
+    </li>
+
+    <!-- Command 2: install the plugin -->
+    <li class="ca-terminal__line" role="listitem" style="--ca-term-delay: 0.8s">
+      <span class="ca-terminal__prompt" aria-hidden="true">$</span>
+      <span>/plugin install ca@codearbiter</span>
+    </li>
+    <li class="ca-terminal__line ca-terminal__line--dim" role="listitem" style="--ca-term-delay: 1.1s">
+      <span>Installing ca@codearbiter ...</span>
+    </li>
+    <li class="ca-terminal__line ca-terminal__line--pass" role="listitem" style="--ca-term-delay: 1.5s">
+      <span>Plugin installed. Hooks, commands, and agents loaded.</span>
+    </li>
+    <li class="ca-terminal__line ca-terminal__line--dim" role="listitem" style="--ca-term-delay: 1.8s">
+      <span>All commands resolve under the /ca: namespace.</span>
+    </li>
+
+    <!-- Command 3: wire the statusline -->
+    <li class="ca-terminal__line" role="listitem" style="--ca-term-delay: 2.2s">
+      <span class="ca-terminal__prompt" aria-hidden="true">$</span>
+      <span>/ca:statusline</span>
+    </li>
+    <li class="ca-terminal__line ca-terminal__line--dim" role="listitem" style="--ca-term-delay: 2.5s">
+      <span>Wiring the statusline into ~/.claude/settings.json ...</span>
+    </li>
+    <li class="ca-terminal__line ca-terminal__line--pass" role="listitem" style="--ca-term-delay: 2.9s">
+      <span>Statusline wired. It renders on every session.</span>
+    </li>
+  </ol>
+</div>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -5,10 +5,15 @@
  * Starlight's stock search is a header button that opens a full-screen Pagefind
  * modal the instant you click it (blank until you type). This replaces it with
  * an inline box: results drop in a panel directly below the box, live as you
- * type (debounced; Enter forces an immediate query). No modal, nothing pops
- * open empty.
+ * type (debounced). No modal, nothing pops open empty.
  *
- * It drives the Pagefind JS API directly (the same index Starlight builds at
+ * It implements the WAI-ARIA combobox pattern: the input is role="combobox"
+ * controlling a role="listbox" popup of role="option" results. Focus stays in
+ * the input; ArrowUp/ArrowDown move a virtual highlight via aria-activedescendant
+ * (the screen reader reads the active option), and Enter activates it. Mouse
+ * hover drives the same highlight so the two never fight.
+ *
+ * It drives the Pagefind JS API (the same index Starlight builds at
  * `astro build`), so search only works in a production build / on the deployed
  * site, not in `astro dev` (Pagefind has no dev index). In dev the box shows a
  * "build the site" hint instead of failing silently.
@@ -39,24 +44,26 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
     <input
       class="ca-search__input"
       type="search"
-      name="q"
-      enterkeyhint="search"
-      placeholder="Search the docs…"
-      aria-label="Search the docs"
-      aria-controls="ca-search-panel"
+      role="combobox"
+      aria-autocomplete="list"
       aria-expanded="false"
+      aria-controls="ca-search-listbox"
+      aria-activedescendant=""
+      aria-label="Search the docs"
+      placeholder="Search the docs…"
+      enterkeyhint="search"
     />
   </form>
 
-  <div
-    id="ca-search-panel"
-    class="ca-search__panel"
-    role="region"
-    aria-label="Search results"
-    hidden
-  >
+  <div class="ca-search__panel" hidden>
     <p class="ca-search__status" aria-live="polite"></p>
-    <ul class="ca-search__results"></ul>
+    <div
+      id="ca-search-listbox"
+      class="ca-search__results"
+      role="listbox"
+      aria-label="Search results"
+    >
+    </div>
   </div>
 </ca-site-search>
 
@@ -69,7 +76,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       const input = this.querySelector<HTMLInputElement>(".ca-search__input")!;
       const panel = this.querySelector<HTMLElement>(".ca-search__panel")!;
       const status = this.querySelector<HTMLElement>(".ca-search__status")!;
-      const list = this.querySelector<HTMLUListElement>(".ca-search__results")!;
+      const listbox = this.querySelector<HTMLElement>("#ca-search-listbox")!;
 
       /** Pagefind stores root-relative urls; prefix the base, never twice. */
       const withBase = (url: string) => {
@@ -91,6 +98,32 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
         }
       };
 
+      // --- Combobox state: the option elements and the active (highlighted) one.
+      let options: HTMLAnchorElement[] = [];
+      let active = -1;
+
+      const setActive = (i: number) => {
+        if (options.length === 0) {
+          active = -1;
+          input.setAttribute("aria-activedescendant", "");
+          return;
+        }
+        // Wrap around both ends.
+        active = (i + options.length) % options.length;
+        options.forEach((opt, idx) =>
+          opt.setAttribute("aria-selected", idx === active ? "true" : "false"),
+        );
+        const opt = options[active];
+        input.setAttribute("aria-activedescendant", opt.id);
+        opt.scrollIntoView({ block: "nearest" });
+      };
+
+      const clearActive = () => {
+        active = -1;
+        input.setAttribute("aria-activedescendant", "");
+        options.forEach((opt) => opt.setAttribute("aria-selected", "false"));
+      };
+
       const open = () => {
         panel.hidden = false;
         input.setAttribute("aria-expanded", "true");
@@ -98,6 +131,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
       const close = () => {
         panel.hidden = true;
         input.setAttribute("aria-expanded", "false");
+        clearActive();
       };
 
       // Monotonic token so a slow query that resolves late cannot overwrite the
@@ -108,7 +142,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
         await loadPagefind();
         if (token !== latest) return;
         if (loadErr || !pagefind) {
-          list.replaceChildren();
+          listbox.replaceChildren();
+          options = [];
+          clearActive();
           status.textContent =
             "Search runs on the built site. Run the production build to try it locally.";
           open();
@@ -116,12 +152,15 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
         }
         const search = await pagefind.search(query);
         if (token !== latest) return;
-        const results = await Promise.all(
+        const data = await Promise.all(
           search.results.slice(0, 8).map((r: any) => r.data()),
         );
         if (token !== latest) return;
-        list.replaceChildren();
-        if (results.length === 0) {
+        listbox.replaceChildren();
+        options = [];
+        active = -1;
+        input.setAttribute("aria-activedescendant", "");
+        if (data.length === 0) {
           status.textContent = `No results for "${query}".`;
           open();
           return;
@@ -129,11 +168,13 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
         status.textContent = `${search.results.length} result${
           search.results.length === 1 ? "" : "s"
         } for "${query}".`;
-        for (const r of results) {
-          const li = document.createElement("li");
-          li.className = "ca-search__result";
-          const a = document.createElement("a");
-          a.href = withBase(r.url);
+        data.forEach((r: any, i: number) => {
+          const opt = document.createElement("a");
+          opt.className = "ca-search__result-link";
+          opt.id = `ca-search-opt-${i}`;
+          opt.setAttribute("role", "option");
+          opt.setAttribute("aria-selected", "false");
+          opt.href = withBase(r.url);
           const title = document.createElement("span");
           title.className = "ca-search__result-title";
           title.textContent = r.meta?.title || r.url;
@@ -141,15 +182,17 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
           excerpt.className = "ca-search__result-excerpt";
           // Excerpt is our own content (Pagefind highlights with <mark>); safe.
           excerpt.innerHTML = r.excerpt || "";
-          a.append(title, excerpt);
-          li.append(a);
-          list.append(li);
-        }
+          opt.append(title, excerpt);
+          // Mouse and keyboard share one highlight.
+          opt.addEventListener("mousemove", () => setActive(i));
+          listbox.append(opt);
+          options.push(opt);
+        });
         open();
       };
 
       // Live search: debounce keystrokes so we query as the user types without
-      // firing on every character. Enter forces an immediate query.
+      // firing on every character. Enter activates the highlighted option.
       let debounceId = 0;
       input.addEventListener("input", () => {
         const q = input.value.trim();
@@ -172,17 +215,35 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
         render(q);
       });
 
-      // Warm the index on first focus so the first Enter is instant.
-      input.addEventListener("focus", () => void loadPagefind(), { once: true });
-
-      // Esc clears + closes; click outside closes; Ctrl/Cmd+K focuses.
+      // Combobox keyboard contract: arrows move the virtual highlight, Enter
+      // activates it, Escape closes. Focus never leaves the input.
       input.addEventListener("keydown", (e) => {
         if (e.key === "Escape") {
           input.value = "";
           close();
           input.blur();
+          return;
+        }
+        if (panel.hidden || options.length === 0) return;
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setActive(active + 1);
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setActive(active - 1);
+        } else if (e.key === "Enter") {
+          const target = active >= 0 ? options[active] : options[0];
+          if (target) {
+            e.preventDefault();
+            target.click();
+          }
         }
       });
+
+      // Warm the index on first focus so the first keystroke is instant.
+      input.addEventListener("focus", () => void loadPagefind(), { once: true });
+
+      // Click outside closes; Ctrl/Cmd+K focuses.
       document.addEventListener("click", (e) => {
         if (!this.contains(e.target as Node)) close();
       });

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -1,0 +1,198 @@
+---
+/**
+ * Search.astro — custom inline search, overriding Starlight's modal search.
+ *
+ * Starlight's stock search is a header button that opens a full-screen Pagefind
+ * modal the instant you click it (blank until you type). This replaces it with
+ * an inline box: results drop in a panel directly below the box, live as you
+ * type (debounced; Enter forces an immediate query). No modal, nothing pops
+ * open empty.
+ *
+ * It drives the Pagefind JS API directly (the same index Starlight builds at
+ * `astro build`), so search only works in a production build / on the deployed
+ * site, not in `astro dev` (Pagefind has no dev index). In dev the box shows a
+ * "build the site" hint instead of failing silently.
+ *
+ * Result URLs from Pagefind are site-root-relative (no base), so we prefix the
+ * configured base ourselves, guarding against double-prefixing.
+ */
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+---
+
+<ca-site-search class={Astro.props.class} data-base={base}>
+  <form class="ca-search__form" role="search" autocomplete="off">
+    <svg
+      class="ca-search__icon"
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="11" cy="11" r="7"></circle>
+      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+    </svg>
+    <input
+      class="ca-search__input"
+      type="search"
+      name="q"
+      enterkeyhint="search"
+      placeholder="Search the docs…"
+      aria-label="Search the docs"
+      aria-controls="ca-search-panel"
+      aria-expanded="false"
+    />
+  </form>
+
+  <div
+    id="ca-search-panel"
+    class="ca-search__panel"
+    role="region"
+    aria-label="Search results"
+    hidden
+  >
+    <p class="ca-search__status" aria-live="polite"></p>
+    <ul class="ca-search__results"></ul>
+  </div>
+</ca-site-search>
+
+<script>
+  class CaSiteSearch extends HTMLElement {
+    constructor() {
+      super();
+      const base = this.dataset.base || "";
+      const form = this.querySelector<HTMLFormElement>(".ca-search__form")!;
+      const input = this.querySelector<HTMLInputElement>(".ca-search__input")!;
+      const panel = this.querySelector<HTMLElement>(".ca-search__panel")!;
+      const status = this.querySelector<HTMLElement>(".ca-search__status")!;
+      const list = this.querySelector<HTMLUListElement>(".ca-search__results")!;
+
+      /** Pagefind stores root-relative urls; prefix the base, never twice. */
+      const withBase = (url: string) => {
+        if (!url.startsWith("/")) return url;
+        if (base && (url === base || url.startsWith(base + "/"))) return url;
+        return base + url;
+      };
+
+      let pagefind: any = null;
+      let loadErr = false;
+      const loadPagefind = async () => {
+        if (pagefind || loadErr) return;
+        try {
+          // Runtime path so Vite does not try to bundle the build-time asset.
+          pagefind = await import(/* @vite-ignore */ `${base}/pagefind/pagefind.js`);
+          await pagefind.options?.({ basePath: `${base}/pagefind/` });
+        } catch {
+          loadErr = true;
+        }
+      };
+
+      const open = () => {
+        panel.hidden = false;
+        input.setAttribute("aria-expanded", "true");
+      };
+      const close = () => {
+        panel.hidden = true;
+        input.setAttribute("aria-expanded", "false");
+      };
+
+      // Monotonic token so a slow query that resolves late cannot overwrite the
+      // results of a newer keystroke (live search fires overlapping queries).
+      let latest = 0;
+      const render = async (query: string) => {
+        const token = ++latest;
+        await loadPagefind();
+        if (token !== latest) return;
+        if (loadErr || !pagefind) {
+          list.replaceChildren();
+          status.textContent =
+            "Search runs on the built site. Run the production build to try it locally.";
+          open();
+          return;
+        }
+        const search = await pagefind.search(query);
+        if (token !== latest) return;
+        const results = await Promise.all(
+          search.results.slice(0, 8).map((r: any) => r.data()),
+        );
+        if (token !== latest) return;
+        list.replaceChildren();
+        if (results.length === 0) {
+          status.textContent = `No results for "${query}".`;
+          open();
+          return;
+        }
+        status.textContent = `${search.results.length} result${
+          search.results.length === 1 ? "" : "s"
+        } for "${query}".`;
+        for (const r of results) {
+          const li = document.createElement("li");
+          li.className = "ca-search__result";
+          const a = document.createElement("a");
+          a.href = withBase(r.url);
+          const title = document.createElement("span");
+          title.className = "ca-search__result-title";
+          title.textContent = r.meta?.title || r.url;
+          const excerpt = document.createElement("span");
+          excerpt.className = "ca-search__result-excerpt";
+          // Excerpt is our own content (Pagefind highlights with <mark>); safe.
+          excerpt.innerHTML = r.excerpt || "";
+          a.append(title, excerpt);
+          li.append(a);
+          list.append(li);
+        }
+        open();
+      };
+
+      // Live search: debounce keystrokes so we query as the user types without
+      // firing on every character. Enter forces an immediate query.
+      let debounceId = 0;
+      input.addEventListener("input", () => {
+        const q = input.value.trim();
+        window.clearTimeout(debounceId);
+        if (!q) {
+          close();
+          return;
+        }
+        debounceId = window.setTimeout(() => render(q), 140);
+      });
+
+      form.addEventListener("submit", (e) => {
+        e.preventDefault();
+        const q = input.value.trim();
+        window.clearTimeout(debounceId);
+        if (!q) {
+          close();
+          return;
+        }
+        render(q);
+      });
+
+      // Warm the index on first focus so the first Enter is instant.
+      input.addEventListener("focus", () => void loadPagefind(), { once: true });
+
+      // Esc clears + closes; click outside closes; Ctrl/Cmd+K focuses.
+      input.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          input.value = "";
+          close();
+          input.blur();
+        }
+      });
+      document.addEventListener("click", (e) => {
+        if (!this.contains(e.target as Node)) close();
+      });
+      window.addEventListener("keydown", (e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+          e.preventDefault();
+          input.focus();
+        }
+      });
+    }
+  }
+  customElements.define("ca-site-search", CaSiteSearch);
+</script>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -58,7 +58,7 @@ import InstallTerminal from '../../components/InstallTerminal.astro';
     </div>
 
     <div class="ca-hero__install-copy">
-      <p class="ca-hero__install-blurb">Get the Arbiter on Your Case</p>
+      <h2 class="ca-hero__install-blurb">Get the Arbiter on Your Case</h2>
       <p class="ca-hero__install-subtext">Two commands install it. One more wires in the statusline.</p>
     </div>
   </div>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -9,6 +9,7 @@ next: false
 ---
 
 import GateCatchTerminal from '../../components/GateCatchTerminal.astro';
+import InstallTerminal from '../../components/InstallTerminal.astro';
 
 <div class="ca-landing">
 
@@ -51,20 +52,27 @@ import GateCatchTerminal from '../../components/GateCatchTerminal.astro';
     <figcaption>Every request flows: command → route → gate → ship → pull request. Nothing skips the gate.</figcaption>
   </figure>
 
-  <p class="ca-hero__lead">
-    You drive with slash commands. Type one and the orchestrator runs that whole lane for
-    you: planning, tests, review, and the gate, then it opens the PR. Three of the most common:
-  </p>
+  <div class="ca-hero__install">
+    <div class="ca-hero__install-demo">
+      <InstallTerminal />
+    </div>
 
-  <div class="ca-hero__first-command">
-
-```bash
-/ca:feature "add rate limiting"   # brainstorm → plan → TDD → review → PR
-/ca:fix "login 500 on empty body" # test-first bug fix, gate before commit
-/ca:commit                        # the only sanctioned path to a commit
-```
-
+    <div class="ca-hero__install-copy">
+      <p class="ca-hero__install-blurb">Get the Arbiter on Your Case</p>
+      <p class="ca-hero__install-subtext">Two commands install it. One more wires in the statusline.</p>
+    </div>
   </div>
+
+  <figure class="ca-hero__statusline">
+    <img
+      src="/codeArbiter/diagrams/statusline.png"
+      alt="The codeArbiter statusline: a folder row; a git row with repo, branch, and a model pill; rate-limit percentages with reset countdowns; an arbiter row (green dot) showing stage, tasks, open questions, and overrides; and session/today token, cost, burn, and context-usage segments."
+      loading="lazy"
+      width="2174"
+      height="406"
+    />
+    <figcaption>The statusline you get, live in every session.</figcaption>
+  </figure>
 </div>
 
 </div>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -90,6 +90,11 @@
   transform: translateY(-2px);
 }
 
+.ca-landing__cta:focus-visible {
+  outline: 2px solid var(--ca-gold);
+  outline-offset: 2px;
+}
+
 .ca-landing__cta--primary {
   background: var(--ca-gold);
   border-color: var(--ca-gold);
@@ -169,9 +174,12 @@
 }
 
 /* Splashy headline, sized to match the above-the-fold hero title so the two
-   sections read as a matched pair. */
-.ca-hero__install-blurb {
+   sections read as a matched pair. It is a real <h2> (honest document outline);
+   the selector is scoped past Starlight's `.sl-markdown-content h2` chrome
+   (border + top margin) so none of that leaks in. */
+.ca-hero .ca-hero__install-blurb {
   margin: 0 0 1.1rem;
+  border: 0;
   color: var(--sl-color-white);
   font-size: clamp(2rem, 4.5vw, 3rem);
   line-height: 1.08;
@@ -251,5 +259,9 @@
   .ca-forge,
   .ca-landing__cta {
     transition: none;
+  }
+  /* Suppress the motion itself, not just its easing: no hover lift. */
+  .ca-landing__cta:hover {
+    transform: none;
   }
 }

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -142,22 +142,74 @@
   letter-spacing: 0.04em;
 }
 
-.ca-hero__lead {
-  margin-block: 1.5rem 0.75rem;
-  max-width: 70ch;
-  color: var(--sl-color-gray-2);
+/* Install block: a two-column mirror of the above-the-fold hero. The hero is
+   intro (left) + terminal (right) at 4fr/6fr; this flips it to terminal (left)
+   + copy (right) at 6fr/4fr, so the two sections balance as opposites. */
+.ca-hero__install {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 4fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: center;
+  margin-block: 2.5rem 0;
+}
+
+@media (max-width: 50rem) {
+  .ca-hero__install {
+    grid-template-columns: 1fr;
+    gap: 1.75rem;
+  }
+}
+
+.ca-hero__install-demo {
+  min-width: 0;
+}
+
+.ca-hero__install-copy {
+  min-width: 0;
+}
+
+/* Splashy headline, sized to match the above-the-fold hero title so the two
+   sections read as a matched pair. */
+.ca-hero__install-blurb {
+  margin: 0 0 1.1rem;
+  color: var(--sl-color-white);
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.ca-hero__install-subtext {
+  max-width: 40ch;
+  margin: 0;
+  color: var(--ca-text-muted);
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
   line-height: 1.6;
 }
 
-.ca-hero__first-command {
-  margin-block: 1.5rem;
+/* The terminal fills its (now narrower) left column. */
+.ca-hero__install .ca-terminal {
+  margin-block: 0;
 }
 
-.ca-hero__first-command pre,
-.ca-hero__first-command .expressive-code {
-  border: 1px solid color-mix(in srgb, var(--ca-gold) 28%, transparent);
-  border-radius: 0.5rem;
-  background: var(--ca-slate-mid);
+/* Payoff: the rendered statusline spans the full content width below the
+   two-column row, echoing the full-width lane-flow diagram under the splash. */
+.ca-hero__statusline {
+  margin: 1.5rem 0 0;
+}
+
+.ca-hero__statusline img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 0.4rem;
+}
+
+.ca-hero__statusline figcaption {
+  margin-top: 0.5rem;
+  color: var(--ca-text-muted);
+  font-size: 0.8rem;
+  font-style: italic;
 }
 
 /* =========================================================

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -461,3 +461,137 @@
     transform: none;
   }
 }
+
+/* =========================================================
+   INLINE SEARCH (custom Search.astro — replaces the modal)
+   The box lives in the header; results drop in an absolutely
+   positioned panel below it, so nothing pops open empty.
+   ========================================================= */
+ca-site-search {
+  display: block;
+  position: relative;
+  width: 100%;
+  max-width: 22rem;
+}
+
+.ca-search__form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 2.5rem;
+  padding-inline: 0.75rem;
+  border: 1px solid var(--ca-slate-border);
+  border-radius: 0.5rem;
+  background: var(--ca-slate);
+  color: var(--ca-text-muted);
+}
+
+.ca-search__form:focus-within {
+  border-color: var(--ca-gold);
+  color: var(--sl-color-white);
+}
+
+.ca-search__icon {
+  flex-shrink: 0;
+  color: inherit;
+}
+
+.ca-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--sl-color-white);
+  font-size: var(--sl-text-sm);
+}
+
+.ca-search__input::placeholder {
+  color: var(--ca-text-muted);
+}
+
+.ca-search__input:focus {
+  outline: none;
+}
+
+/* Strip the native search "clear" affordance; Esc clears instead. */
+.ca-search__input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+.ca-search__panel {
+  position: absolute;
+  z-index: 80;
+  inset-inline: 0;
+  top: calc(100% + 0.4rem);
+  max-height: min(70vh, 32rem);
+  overflow-y: auto;
+  padding: 0.5rem;
+  border: 1px solid var(--ca-slate-border);
+  border-radius: 0.6rem;
+  background: var(--ca-slate-mid);
+  box-shadow: 0 16px 40px -12px rgb(0 0 0 / 0.7);
+}
+
+.ca-search__panel[hidden] {
+  display: none;
+}
+
+.ca-search__status {
+  margin: 0.15rem 0.4rem 0.4rem;
+  color: var(--ca-text-muted);
+  font-size: var(--sl-text-xs);
+}
+
+.ca-search__results {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ca-search__result + .ca-search__result {
+  margin-top: 0.25rem;
+}
+
+.ca-search__result a {
+  display: block;
+  padding: 0.55rem 0.6rem;
+  border-radius: 0.4rem;
+  color: var(--sl-color-white);
+  text-decoration: none;
+}
+
+.ca-search__result a:hover,
+.ca-search__result a:focus-visible {
+  background: var(--ca-slate);
+  outline: none;
+}
+
+.ca-search__result-title {
+  display: block;
+  font-weight: 600;
+  font-size: var(--sl-text-sm);
+}
+
+.ca-search__result-excerpt {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--ca-text-muted);
+  font-size: var(--sl-text-xs);
+  line-height: 1.5;
+}
+
+.ca-search__result-excerpt mark {
+  background: transparent;
+  color: var(--ca-gold);
+  font-weight: 600;
+}
+
+/* Narrow viewports: let the panel grow a touch wider than the box. */
+@media (max-width: 50rem) {
+  ca-site-search {
+    max-width: 100%;
+  }
+  .ca-search__panel {
+    min-width: 16rem;
+  }
+}

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -545,14 +545,9 @@ ca-site-search {
 .ca-search__results {
   margin: 0;
   padding: 0;
-  list-style: none;
 }
 
-.ca-search__result + .ca-search__result {
-  margin-top: 0.25rem;
-}
-
-.ca-search__result a {
+.ca-search__result-link {
   display: block;
   padding: 0.55rem 0.6rem;
   border-radius: 0.4rem;
@@ -560,14 +555,21 @@ ca-site-search {
   text-decoration: none;
 }
 
-.ca-search__result a:hover {
+.ca-search__result-link + .ca-search__result-link {
+  margin-top: 0.25rem;
+}
+
+/* The active option (keyboard arrows or mouse hover) needs a clearly visible
+   highlight. Focus stays in the input under the combobox pattern, so options
+   never get :focus-visible; the active one is marked aria-selected. A bare
+   background shift is ~1.1:1 against the panel (WCAG 2.4.7), so pair it with a
+   gold ring. */
+.ca-search__result-link:hover,
+.ca-search__result-link[aria-selected="true"] {
   background: var(--ca-slate);
 }
 
-/* Keyboard focus needs a ring: the hover background shift alone is ~1.1:1
-   against the panel, effectively invisible (WCAG 2.4.7). */
-.ca-search__result a:focus-visible {
-  background: var(--ca-slate);
+.ca-search__result-link[aria-selected="true"] {
   outline: 2px solid var(--ca-gold);
   outline-offset: -2px;
 }

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -560,10 +560,16 @@ ca-site-search {
   text-decoration: none;
 }
 
-.ca-search__result a:hover,
+.ca-search__result a:hover {
+  background: var(--ca-slate);
+}
+
+/* Keyboard focus needs a ring: the hover background shift alone is ~1.1:1
+   against the panel, effectively invisible (WCAG 2.4.7). */
 .ca-search__result a:focus-visible {
   background: var(--ca-slate);
-  outline: none;
+  outline: 2px solid var(--ca-gold);
+  outline-offset: -2px;
 }
 
 .ca-search__result-title {

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -35,6 +35,8 @@ function readSrc(rel: string): string {
 const indexMdx = readSrc("src/content/docs/index.mdx");
 const terminalCmp = readSrc("src/components/GateCatchTerminal.astro");
 const installCmp = readSrc("src/components/InstallTerminal.astro");
+const searchCmp = readSrc("src/components/Search.astro");
+const astroConfig = readSrc("astro.config.mjs");
 const landingCss = readSrc("src/styles/landing.css");
 
 /** Combined source of the landing page artifacts. The Feature Forge showcase
@@ -169,6 +171,15 @@ describe("install demo terminal (get-it-running below the fold)", () => {
     expect(indexMdx).toMatch(/wires in the statusline/i);
   });
 
+  it("the install title is a real heading, not a paragraph styled as one", () => {
+    // Hierarchy honesty + a11y: a section title must be an <h2> so it joins the
+    // document outline and screen-reader heading navigation, not a <p> wearing
+    // h1-sized type.
+    expect(indexMdx).toMatch(
+      /<h2 class="ca-hero__install-blurb">Get the Arbiter on Your Case<\/h2>/,
+    );
+  });
+
   it("the old sample-command box was removed", () => {
     expect(indexMdx).not.toContain("ca-hero__first-command");
   });
@@ -194,6 +205,63 @@ describe("install demo terminal (get-it-running below the fold)", () => {
     expect(installCmp).toContain("ca-terminal__line");
     expect(installCmp).toContain('role="list"');
     expect(installCmp).toMatch(/aria-label="[^"]+"/);
+  });
+
+  it("the install terminal carries the full screen-reader contract", () => {
+    expect(installCmp).toContain('role="region"');
+    expect(installCmp).toContain('role="listitem"');
+    expect(installCmp).toContain('aria-hidden="true"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline search: custom Search.astro override (replaces Starlight's modal)
+// ---------------------------------------------------------------------------
+
+describe("inline search override (replaces Starlight's modal search)", () => {
+  it("is registered as the Starlight Search component override", () => {
+    expect(astroConfig).toMatch(/Search:\s*["']\.\/src\/components\/Search\.astro["']/);
+  });
+
+  it("defines the custom element that drives it", () => {
+    expect(searchCmp).toContain("class CaSiteSearch extends HTMLElement");
+    expect(searchCmp).toContain('customElements.define("ca-site-search"');
+  });
+
+  it("uses a semantic search form with a search input", () => {
+    expect(searchCmp).toContain('role="search"');
+    expect(searchCmp).toContain('type="search"');
+  });
+
+  it("carries the search ARIA contract (labelled, controls + expands the panel)", () => {
+    expect(searchCmp).toMatch(/aria-label="[^"]+"/);
+    expect(searchCmp).toContain('aria-controls="ca-search-panel"');
+    expect(searchCmp).toContain('aria-expanded="false"');
+    expect(searchCmp).toContain('id="ca-search-panel"');
+    expect(searchCmp).toContain('aria-live="polite"');
+  });
+
+  it("drives the Pagefind index via the base-safe runtime path", () => {
+    // Pagefind has no dev index, so the import is a runtime path (vite-ignored)
+    // built from BASE_URL, not a bundled/hardcoded one.
+    expect(searchCmp).toContain("import.meta.env.BASE_URL");
+    expect(searchCmp).toMatch(/\/pagefind\/pagefind\.js/);
+  });
+
+  it("keyboard focus on a result is visible (no bare outline:none)", () => {
+    // Guards the WCAG 2.4.7 fix: the result focus state must use a real ring,
+    // not just the ~1.1:1 background shift.
+    const themeCss = readSrc("src/styles/theme.css");
+    expect(themeCss).toMatch(
+      /\.ca-search__result a:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--ca-gold\)/,
+    );
+  });
+
+  it("Search.astro prose contains ≤3 em-dashes", () => {
+    const text = searchCmp
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\/\*[\s\S]*?\*\//g, " ");
+    expect((text.match(/—/g) ?? []).length).toBeLessThanOrEqual(3);
   });
 });
 

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -34,11 +34,12 @@ function readSrc(rel: string): string {
 
 const indexMdx = readSrc("src/content/docs/index.mdx");
 const terminalCmp = readSrc("src/components/GateCatchTerminal.astro");
+const installCmp = readSrc("src/components/InstallTerminal.astro");
 const landingCss = readSrc("src/styles/landing.css");
 
 /** Combined source of the landing page artifacts. The Feature Forge showcase
  *  moved off the home page into its own section — see feature-forge-content.test.ts. */
-const landingSrc = indexMdx + "\n" + terminalCmp;
+const landingSrc = indexMdx + "\n" + terminalCmp + "\n" + installCmp;
 
 // ---------------------------------------------------------------------------
 // AC-6: Bespoke landing — stock CardGrid replaced
@@ -142,12 +143,57 @@ describe("AC-16: above-fold hero answers what/why/first command + one primary CT
   });
 
   it("first command is shown in the hero section", () => {
-    // The hero body must show a copy-able first command
-    expect(indexMdx).toMatch(/\/ca:feature|\/ca:commit|\/ca:fix/);
+    // The hero now leads with the install commands (the new user's actual first
+    // commands), rendered in the animated install terminal. The old
+    // /ca:feature|/ca:fix|/ca:commit sample box was removed in favor of this
+    // get-it-running demo.
+    expect(landingSrc).toMatch(/\/plugin install/);
   });
 
   it("hero body answers 'what' (the orchestrator description)", () => {
     expect(indexMdx).toMatch(/orchestrat|gated|lane/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Install demo: the get-it-running terminal replaced the sample-command box
+// ---------------------------------------------------------------------------
+
+describe("install demo terminal (get-it-running below the fold)", () => {
+  it("index.mdx imports and renders the InstallTerminal component", () => {
+    expect(indexMdx).toContain("InstallTerminal");
+  });
+
+  it("the install title and statusline subtext are present above the demo", () => {
+    expect(indexMdx).toMatch(/Get the Arbiter on Your Case/);
+    expect(indexMdx).toMatch(/wires in the statusline/i);
+  });
+
+  it("the old sample-command box was removed", () => {
+    expect(indexMdx).not.toContain("ca-hero__first-command");
+  });
+
+  it("the install terminal shows both install commands", () => {
+    expect(installCmp).toContain("/plugin marketplace add arbiterForge/codeArbiter");
+    expect(installCmp).toContain("/plugin install ca@codearbiter");
+  });
+
+  it("the install terminal runs /ca:statusline as the third command", () => {
+    expect(installCmp).toContain("/ca:statusline");
+  });
+
+  it("the real rendered statusline sits below the terminal (single-source asset)", () => {
+    // The bar is shown below the terminal in index.mdx, using the canonical
+    // statusline.png — the same asset the statusline guide and README serve —
+    // via the base-safe root-absolute literal sanctioned for .mdx pages.
+    expect(indexMdx).toContain("ca-hero__statusline");
+    expect(indexMdx).toContain("/codeArbiter/diagrams/statusline.png");
+  });
+
+  it("the install terminal reuses the animated terminal contract (ca-terminal lines)", () => {
+    expect(installCmp).toContain("ca-terminal__line");
+    expect(installCmp).toContain('role="list"');
+    expect(installCmp).toMatch(/aria-label="[^"]+"/);
   });
 });
 
@@ -186,6 +232,12 @@ describe("AC-19: em-dash cap on landing prose", () => {
 
   it("GateCatchTerminal.astro prose contains ≤3 em-dashes", () => {
     const prose = extractProse(terminalCmp);
+    const emDashes = (prose.match(/—/g) ?? []).length;
+    expect(emDashes).toBeLessThanOrEqual(3);
+  });
+
+  it("InstallTerminal.astro prose contains ≤3 em-dashes", () => {
+    const prose = extractProse(installCmp);
     const emDashes = (prose.match(/—/g) ?? []).length;
     expect(emDashes).toBeLessThanOrEqual(3);
   });

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -233,12 +233,31 @@ describe("inline search override (replaces Starlight's modal search)", () => {
     expect(searchCmp).toContain('type="search"');
   });
 
-  it("carries the search ARIA contract (labelled, controls + expands the panel)", () => {
+  it("implements the WAI-ARIA combobox pattern (combobox + listbox + option)", () => {
+    // Input is a combobox controlling a listbox popup; results are options the
+    // input points at via aria-activedescendant (virtual focus).
+    expect(searchCmp).toContain('role="combobox"');
+    expect(searchCmp).toContain('aria-autocomplete="list"');
+    expect(searchCmp).toContain('aria-controls="ca-search-listbox"');
+    expect(searchCmp).toContain('aria-activedescendant');
+    expect(searchCmp).toContain('id="ca-search-listbox"');
+    expect(searchCmp).toContain('role="listbox"');
+    // Result options are created in the script with role="option".
+    expect(searchCmp).toMatch(/setAttribute\("role",\s*"option"\)/);
+  });
+
+  it("carries the rest of the search ARIA contract (labelled, expands, live count)", () => {
     expect(searchCmp).toMatch(/aria-label="[^"]+"/);
-    expect(searchCmp).toContain('aria-controls="ca-search-panel"');
     expect(searchCmp).toContain('aria-expanded="false"');
-    expect(searchCmp).toContain('id="ca-search-panel"');
     expect(searchCmp).toContain('aria-live="polite"');
+  });
+
+  it("wires the combobox keyboard contract (arrows move, Enter activates)", () => {
+    expect(searchCmp).toContain('"ArrowDown"');
+    expect(searchCmp).toContain('"ArrowUp"');
+    expect(searchCmp).toContain('"Enter"');
+    // The highlight is tracked on the input via aria-activedescendant.
+    expect(searchCmp).toMatch(/setAttribute\("aria-activedescendant"/);
   });
 
   it("drives the Pagefind index via the base-safe runtime path", () => {
@@ -248,12 +267,13 @@ describe("inline search override (replaces Starlight's modal search)", () => {
     expect(searchCmp).toMatch(/\/pagefind\/pagefind\.js/);
   });
 
-  it("keyboard focus on a result is visible (no bare outline:none)", () => {
-    // Guards the WCAG 2.4.7 fix: the result focus state must use a real ring,
-    // not just the ~1.1:1 background shift.
+  it("the active option is visibly highlighted (no invisible selection)", () => {
+    // Guards the WCAG 2.4.7 concern: focus stays in the input, so the active
+    // option (aria-selected) carries a real gold ring, not just a ~1.1:1
+    // background shift.
     const themeCss = readSrc("src/styles/theme.css");
     expect(themeCss).toMatch(
-      /\.ca-search__result a:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--ca-gold\)/,
+      /\.ca-search__result-link\[aria-selected="true"\]\s*\{[^}]*outline:\s*2px solid var\(--ca-gold\)/,
     );
   });
 


### PR DESCRIPTION
## Summary

Reworks the docs-site landing page below the fold and replaces the site search. The old static `/ca:feature` / `/ca:fix` / `/ca:commit` sample box is gone; in its place a get-it-running install demo shows how to actually adopt codeArbiter, and Starlight's modal search becomes an inline live-search box.

## What changed

**Landing install demo**
- New `InstallTerminal.astro`: an animated transcript (CSS fade-in per line, reduced-motion static fallback, real DOM text, ARIA) running the two install commands plus `/ca:statusline`.
- The real statusline render (`statusline.png`, the canonical single-source asset the guide and README already use) sits full-width below the terminal.
- The section mirrors the above-the-fold hero: hero is intro-left / terminal-right at 4fr/6fr, this flips to terminal-left / copy-right at 6fr/4fr, with a splashy `<h2>` headline and a full-width payoff below, so the two read as a matched pair.

**Inline search (replaces the modal)**
- New `Search.astro`, registered as the Starlight `Search` override. Results drop in a panel directly below the box, live as you type (debounced, with an out-of-order guard so a slow query cannot overwrite a newer one). Nothing pops open empty.
- It implements the full WAI-ARIA combobox pattern: the input is `role="combobox"` controlling a `role="listbox"` of `role="option"` results, with ArrowUp/ArrowDown virtual focus via `aria-activedescendant`, Enter to activate, and Escape to close. Mouse hover drives the same highlight.
- It drives the Pagefind JS API the build already produces, via a base-safe runtime path.

**Accessibility (from the review)**
- The install headline is a real `<h2>`, not a `<p>` styled like one, so it joins the document outline and heading navigation.
- The active search result carries a visible gold ring (the prior `outline: none` plus a ~1.1:1 background shift was a WCAG 2.4.7 failure).
- Hero CTAs gain a `:focus-visible` ring, and the hover lift is zeroed under reduced-motion.

## Reviews

- **coverage-auditor: PASS.** The initial MEDIUM (no source-level guards for `Search.astro`) is fixed: the suite asserts the override registration, semantic form, the combobox/listbox/option ARIA contract, the keyboard wiring, the custom-element definition, and the em-dash cap, and extends the InstallTerminal ARIA assertions.
- **design-quality-reviewer: 2 HIGH and 2 LOW, all resolved.** The two HIGH findings (paragraph-as-heading, invisible result focus) are fixed and guarded by tests; the rendered `<h2>` was confirmed clean in the build output. The one NEEDS-TRIAGE item (ARIA combobox pattern) was adopted in full rather than deferred.

## Test plan

- `cd site && npm test` (169 vitest tests) green.
- `cd site && npm run build` (103 pages, Pagefind index rebuilt), `npm run link-audit` (11543 internal links resolve), `npm run typecheck` clean.
- Verified in the build output that the inline search replaced the modal (`ca-site-search` present, `data-open-modal` absent), that the headline renders as a clean `<h2>`, and that `role="combobox"` + `role="listbox"` are present.

## Tradeoffs

- Pagefind builds its index only at `astro build`, so the inline search works on the production build and the deployed site, not in `astro dev` (the box shows a build-the-site hint there). This is a level-5 (developer velocity) cost accepted to keep the search self-contained on the existing Pagefind index.

No `plugins/ca/**` code is touched, so no plugin tooling rebuild and no version bump.

https://claude.ai/code/session_01AQ5aJtHZZ7EojYpRVkbPNz
