### PR TITLE
fix(task): reject malformed multi-part --id; surface over-segmented task ids

### DIFF
--- a/.github/scripts/test_taskboardlib.py
+++ b/.github/scripts/test_taskboardlib.py
@@ -364,6 +364,36 @@ class SetStateGuardTest(unittest.TestCase):
         self.assertIn("- [x]", out)
 
 
+class MalformedIdHardeningTest(unittest.TestCase):
+    """issue #157: an over-segmented id (e.g. 'a.b.c.d', produced by a mistyped
+    --id) must NOT be silently absorbed into the title. It parses as an id so
+    validate_id rejects it, lint_board surfaces it, and set_state can target it
+    for repair — instead of stranding an un-targetable, un-lintable task."""
+
+    BOARD = ("# Open tasks\n\n## In-flight\n"
+             "- [ ] mvp1.store.0002.0001 - Fix the thing  (from review)\n")
+
+    def test_four_segment_token_parses_as_id(self):
+        self.assertEqual(tb.parse_board(self.BOARD)[0].id, "mvp1.store.0002.0001")
+
+    def test_validate_id_rejects_four_segments(self):
+        self.assertFalse(tb.validate_id("mvp1.store.0002.0001"))
+
+    def test_lint_surfaces_the_invalid_id(self):
+        self.assertTrue(any("invalid task id" in w for w in tb.lint_board(self.BOARD)))
+
+    def test_set_state_can_target_for_repair(self):
+        out = tb.set_state(self.BOARD, "mvp1.store.0002.0001", "done", _date(2026, 6, 28))
+        self.assertIn("- [x] mvp1.store.0002.0001", out)
+        self.assertIn("(done 2026-06-28)", out)
+
+    def test_well_formed_three_segment_unaffected(self):
+        board = "# Open tasks\n\n## In-flight\n- [ ] mvp1.store.0001 - X\n"
+        self.assertEqual(tb.parse_board(board)[0].id, "mvp1.store.0001")
+        self.assertTrue(tb.validate_id("mvp1.store.0001"))
+        self.assertEqual(tb.lint_board(board), [])
+
+
 class PromoteModeGuardTest(unittest.TestCase):
     """dx-005: promote with an unknown mode must not silently auto-apply."""
 

--- a/.github/scripts/test_taskwriter.py
+++ b/.github/scripts/test_taskwriter.py
@@ -292,6 +292,28 @@ class TaskwriteCliTest(unittest.TestCase):
         with open(p, encoding="utf-8") as f:
             self.assertIn("-rf important task", f.read())
 
+    def test_malformed_multipart_id_rejected_no_write(self):
+        """issue #157: a --id with more than GROUP.TYPE (e.g. a full 3-part id)
+        must be rejected (exit 1) and write nothing, rather than minting an
+        un-targetable 4-segment id like 'mvp1.store.0002.0001'."""
+        import taskwrite
+        d, p = self._board()
+        taskwrite.project_root = lambda: d
+        with open(p, encoding="utf-8") as f:
+            before = f.read()
+        self.assertEqual(taskwrite.main(["add", "--id", "mvp1.store.0002", "--", "x"]), 1)
+        with open(p, encoding="utf-8") as f:
+            self.assertEqual(f.read(), before)  # board untouched
+
+    def test_well_formed_group_type_id_still_mints(self):
+        """A proper GROUP.TYPE --id still mints group.type.NNNN (no regression)."""
+        import taskwrite
+        d, p = self._board()
+        taskwrite.project_root = lambda: d
+        self.assertEqual(taskwrite.main(["add", "--id", "mvp1.store", "--", "x"]), 0)
+        with open(p, encoding="utf-8") as f:
+            self.assertIn("mvp1.store.0001 - x", f.read())
+
     def test_atomic_write_board_survives_interrupted_write(self):
         """migration-001: the original board must survive a write interrupted after
         truncation.  We monkeypatch the temp-file write to raise, then assert the

--- a/plugins/ca/hooks/_taskboardlib.py
+++ b/plugins/ca/hooks/_taskboardlib.py
@@ -106,9 +106,11 @@ _TOP_RE = re.compile(r"^- ")                 # any top-level bullet (column 0)
 # body; group 2 is the actual content.
 _CONTENT_RE = re.compile(r"^- (\[[ xX~]\]\s*)?(.*)$")
 _ID_RE = re.compile(r"[a-z][a-z0-9]*\.[a-z][a-z0-9]*\.[0-9]{4,}\Z")
-# A token that LOOKS like an ID (three dot-separated parts) — accepts malformed
-# IDs too, so validate_id() can later flag them rather than the parser hiding them.
-_IDISH_RE = re.compile(r"^[^\s.]+\.[^\s.]+\.[^\s.]+$")
+# A token that LOOKS like an ID (three OR MORE dot-separated parts) — accepts
+# malformed IDs too (including an over-segmented "a.b.c.d"), so validate_id() can
+# later flag them and set_state() can target them, rather than the parser hiding a
+# 4-segment token inside the title where it becomes un-targetable and un-lintable.
+_IDISH_RE = re.compile(r"^[^\s.]+(?:\.[^\s.]+){2,}$")
 _SUB_RE = re.compile(r"^\s+-\s*([^:]+):\s*(.*)$")   # indented "  - Key: value"
 # A lifecycle marker sitting at (or near) the start of a line — used by lint to
 # catch a task whose marker is NOT in the canonical column-0 "- [m] " position

--- a/plugins/ca/hooks/taskwrite.py
+++ b/plugins/ca/hooks/taskwrite.py
@@ -84,8 +84,13 @@ def main(argv=None):
 
     if args.verb == "add":
         group = typ = None
-        if args.gid and "." in args.gid:
-            group, typ = args.gid.split(".", 1)
+        if args.gid:
+            parts = args.gid.split(".")
+            if len(parts) != 2 or not all(parts):
+                print(f"bad --id '{args.gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
+                      f"the 4-digit seq is minted automatically)", file=sys.stderr)
+                return 1
+            group, typ = parts
         boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
         new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
                            type=typ, boundaries=boundaries, section=args.section)


### PR DESCRIPTION
Fixes #157.

## Problem
`taskwrite add --id <value>` accepted a value with more than two dot-separated parts and silently minted a **4-segment task id** (e.g. `--id mvp1.store.0002` -> `mvp1.store.0002.0001`) via `split(".", 1)`. That id was then **un-targetable** by `start`/`done` and **invisible** to `validate_id`/`lint_board` — `_IDISH_RE` matched exactly three segments, so `_split_id_title` absorbed the 4-segment token into the title (`id=None`). A single mistyped `--id` permanently stranded a task with no tool path to flip or even detect it (the board hard-rule forbids hand-editing).

## Fix
- **`taskwrite.py`** — validate `--id` is exactly `GROUP.TYPE` (one dot, two non-empty parts); error clearly and write nothing otherwise, replacing the lossy `split(".", 1)`.
- **`_taskboardlib.py`** — widen `_IDISH_RE` to 3+ segments so a malformed id parses as an `id`: rejected by `validate_id`, surfaced by `lint_board`, and targetable by `set_state` for repair (defense in depth).

## Tests
- `test_taskwriter.py` (+2): `--id mvp1.store.0002` rejected (exit 1, board untouched); well-formed `--id mvp1.store` still mints `mvp1.store.0001`.
- `test_taskboardlib.py` (+5): a 4-segment token parses as id, `validate_id` rejects it, `lint_board` surfaces it, `set_state` targets it; a 3-segment id is unaffected.
- Suites green: taskboardlib 95, taskwriter 33.

## Notes
Found while dogfooding on a downstream project: a harvested follow-up was filed with `--id mvp1.store.0002` and could never be marked done. Backward-compatible — well-formed ids and all existing behavior are unchanged.

https://claude.ai/code/session_01Md7D2ufFrX254HkY1GJPZf