### PR TITLE
fix: close five P1 enforcement-bypass issues (#159–#163)

### DIFF
--- a/.github/scripts/test_hooklib.py
+++ b/.github/scripts/test_hooklib.py
@@ -494,5 +494,44 @@ class MarkerDigestTest(unittest.TestCase):
         self.assertNotEqual(_hooklib.content_digest("a\nb\n"), _hooklib.content_digest("a\nc\n"))
 
 
+class ActivationAndMarkerHelpersTest(unittest.TestCase):
+    """#159/#160/#162 path classifiers and the text-based frontmatter check."""
+
+    def test_is_context_md(self):
+        self.assertTrue(_hooklib.is_context_md(".codearbiter/CONTEXT.md"))
+        self.assertTrue(_hooklib.is_context_md("/a/b/.codearbiter/CONTEXT.md"))
+        self.assertTrue(_hooklib.is_context_md(r".codearbiter\CONTEXT.md"))
+        self.assertFalse(_hooklib.is_context_md(".codearbiter/other.md"))
+        self.assertFalse(_hooklib.is_context_md("CONTEXT.md"))
+
+    def test_is_marker_path(self):
+        self.assertTrue(_hooklib.is_marker_path(".codearbiter/.markers/security-gate-passed"))
+        self.assertTrue(_hooklib.is_marker_path("x/.codearbiter/.markers/adr-authoring-active"))
+        self.assertFalse(_hooklib.is_marker_path(".codearbiter/CONTEXT.md"))
+        self.assertFalse(_hooklib.is_marker_path(".codearbiter/markers/x"))  # no dot
+
+    def test_frontmatter_enabled_text(self):
+        self.assertEqual(_hooklib.frontmatter_enabled_text("---\narbiter: enabled\n---\n"),
+                         (True, False))
+        self.assertEqual(_hooklib.frontmatter_enabled_text("---\narbiter: disabled\n---\n"),
+                         (False, False))
+        # opened, never closed -> malformed
+        self.assertEqual(_hooklib.frontmatter_enabled_text("---\narbiter: enabled\n"),
+                         (False, True))
+        # no frontmatter at all -> dormant, not malformed
+        self.assertEqual(_hooklib.frontmatter_enabled_text("# ctx\n"), (False, False))
+
+    def test_classify_protected_resolves_symlink(self):
+        with tempfile.TemporaryDirectory() as d:
+            ca = os.path.join(d, ".codearbiter")
+            os.makedirs(ca)
+            with open(os.path.join(ca, "overrides.log"), "w") as f:
+                f.write("x")
+            os.symlink(ca, os.path.join(d, "alias"))
+            # raw path lacks .codearbiter/, but realpath resolves inside it.
+            hits = _hooklib.classify_protected(os.path.join(d, "alias", "overrides.log"), d)
+            self.assertIn("audit", hits)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/scripts/test_hooklib.py
+++ b/.github/scripts/test_hooklib.py
@@ -26,6 +26,17 @@ sys.path.insert(0, HOOKS)
 import _hooklib  # noqa: E402 — needs sys.path mutation above
 
 
+def _sym_ok():
+    """Windows CI runners often lack symlink privilege; skip symlink-dependent
+    cases there (ubuntu/macos exercise them fully)."""
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            os.symlink(os.path.join(d, "t"), os.path.join(d, "l"))
+        return True
+    except (OSError, NotImplementedError, AttributeError):
+        return False
+
+
 class CryptoReTest(unittest.TestCase):
     """CRYPTO_RE drives the H-09/H-09b crypto gate. It must see the TLS-disable
     and banned-primitive forms in BOTH Python and Node/TS, since all networked
@@ -521,6 +532,7 @@ class ActivationAndMarkerHelpersTest(unittest.TestCase):
         # no frontmatter at all -> dormant, not malformed
         self.assertEqual(_hooklib.frontmatter_enabled_text("# ctx\n"), (False, False))
 
+    @unittest.skipUnless(_sym_ok(), "symlink creation not permitted here")
     def test_classify_protected_resolves_symlink(self):
         with tempfile.TemporaryDirectory() as d:
             ca = os.path.join(d, ".codearbiter")

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# codeArbiter — installs the git-level enforcement hooks (#161).
+#
+# The PreToolUse Bash hook (pre-bash.py) gates git operations by matching the
+# literal command string, so shell indirection (`g=git; c=commit; $g $c`) walks
+# past it. There is no enforcement below that layer. This module installs
+# repo-level .git/hooks/pre-commit and pre-push that invoke git-enforce.py at the
+# git operation itself, where spelling no longer matters.
+#
+# Design decisions:
+#   * The shim is a tiny POSIX `sh` script that detects the interpreter ONCE
+#     (python3 else python) and runs the enforcer EXACTLY once — never
+#     `python3 X || python X`, which would (a) swallow a BLOCK when python3 both
+#     exists and blocks, and (b) drain stdin before the fallback (pre-push feeds
+#     the ref list on stdin). Same hazard hooks.json avoids via two entries; a
+#     single hook file must guard it inline.
+#   * The shim points at the enforcer by ABSOLUTE PATH, resolved from THIS file's
+#     location (inside the plugin) at install time. install() is re-run every
+#     SessionStart, so the path is refreshed each session — if a plugin update
+#     moves the install dir, the next session rewrites the shim. During the brief
+#     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
+#     our OWN staleness only — never brick a user's commits because our path
+#     drifted; the pre-bash + Claude layers still apply).
+#   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
+#     so an existing husky / pre-commit-framework setup is preserved.
+#   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
+#     ours-hook is refreshed.
+
+import os
+import stat
+import subprocess
+import sys
+
+SENTINEL = "# codeArbiter-managed git hook (#161) — refreshed each session; edits are overwritten."
+PHASES = ("pre-commit", "pre-push")
+
+
+def _warn(msg):
+    print(f"codeArbiter git-hooks: {msg}", file=sys.stderr)
+
+
+def _git(args, cwd):
+    try:
+        return subprocess.run(
+            ["git"] + args, cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=5,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def hooks_dir(root):
+    """The directory git actually reads hooks from for `root`, or None.
+
+    Honors core.hooksPath (when set, git IGNORES .git/hooks entirely), and
+    resolves the real git dir via `rev-parse --git-path hooks` so linked
+    worktrees and submodules land in the right place. Falls back to
+    <root>/.git/hooks only if git can't answer."""
+    cfg = _git(["config", "--get", "core.hooksPath"], root)
+    if cfg is not None and cfg.returncode == 0 and cfg.stdout.strip():
+        hp = cfg.stdout.strip()
+        return hp if os.path.isabs(hp) else os.path.join(root, hp)
+    gp = _git(["rev-parse", "--git-path", "hooks"], root)
+    if gp is not None and gp.returncode == 0 and gp.stdout.strip():
+        hp = gp.stdout.strip()
+        return hp if os.path.isabs(hp) else os.path.join(root, hp)
+    default = os.path.join(root, ".git", "hooks")
+    return default if os.path.isdir(os.path.join(root, ".git")) else None
+
+
+def _enforcer_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-enforce.py")
+
+
+def _shim(enforcer, phase):
+    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK exit
+    # code. `exit 0` when the enforcer file is absent is deliberate fail-open on
+    # our own path staleness (see module header).
+    return (
+        "#!/bin/sh\n"
+        f"{SENTINEL}\n"
+        f'E="{enforcer}"\n'
+        '[ -f "$E" ] || exit 0\n'
+        'if python3 -c "" 2>/dev/null; then PY=python3; else PY=python; fi\n'
+        f'exec "$PY" "$E" {phase}\n'
+    )
+
+
+def _read(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def install(root):
+    """Ensure the git-level enforcement hooks are installed for `root`.
+    Idempotent and safe to call every session. Returns a list of human-readable
+    actions taken (possibly empty). Never raises for an expected condition
+    (no git dir, foreign hook) — those are reported, not fatal."""
+    hd = hooks_dir(root)
+    if not hd:
+        return []
+    enforcer = _enforcer_path()
+    try:
+        os.makedirs(hd, exist_ok=True)
+    except Exception:  # noqa: BLE001
+        _warn(f"could not create hooks dir {hd}; skipping git-hook install")
+        return []
+    actions = []
+    for phase in PHASES:
+        dest = os.path.join(hd, phase)
+        desired = _shim(enforcer, phase)
+        if os.path.exists(dest):
+            existing = _read(dest)
+            if existing is not None and SENTINEL not in existing:
+                _warn(f"an existing {phase} hook is not codeArbiter-managed — leaving it "
+                      f"untouched. For git-level enforcement, call "
+                      f"'{os.path.basename(enforcer)} {phase}' from it (see includes docs).")
+                actions.append(f"{phase}: foreign hook preserved (not installed)")
+                continue
+            if existing == desired:
+                continue  # already current — no churn
+        try:
+            with open(dest, "w", encoding="utf-8", newline="\n") as f:
+                f.write(desired)
+            st = os.stat(dest)
+            os.chmod(dest, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            actions.append(f"{phase}: installed")
+        except Exception as e:  # noqa: BLE001
+            _warn(f"could not write {dest}: {e}")
+    return actions
+
+
+def uninstall(root):
+    """Remove ONLY codeArbiter-managed hooks (identified by the sentinel);
+    a foreign hook is left in place. Returns the actions taken."""
+    hd = hooks_dir(root)
+    if not hd:
+        return []
+    actions = []
+    for phase in PHASES:
+        dest = os.path.join(hd, phase)
+        existing = _read(dest)
+        if existing is not None and SENTINEL in existing:
+            try:
+                os.remove(dest)
+                actions.append(f"{phase}: removed")
+            except Exception as e:  # noqa: BLE001
+                _warn(f"could not remove {dest}: {e}")
+    return actions
+
+
+if __name__ == "__main__":
+    # Manual install/uninstall: `python _githooks.py [install|uninstall] [root]`.
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "install"
+    where = sys.argv[2] if len(sys.argv) > 2 else os.getcwd()
+    done = uninstall(where) if cmd == "uninstall" else install(where)
+    print(f"{cmd}: " + (", ".join(done) if done else "no changes"))

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -27,6 +27,7 @@
 #   utf8_stdio() -> None                 force UTF-8 on stdout/stderr
 #   norm_path(p) -> str                  normalize path separators to forward-slash
 #   frontmatter_enabled(ctx_path) -> tuple[bool, bool]   (enabled, malformed)
+#   frontmatter_enabled_text(text) -> tuple[bool, bool]  same, over content not a path
 #   arbiter_active(root) -> bool         True iff repo opted in via CONTEXT.md frontmatter
 #   read_input() -> dict                 parse hook JSON from stdin; fail-open on error
 #   tool_input(data) -> dict             extract tool_input sub-dict from hook payload
@@ -42,6 +43,9 @@
 #   is_deploy_path(rel, root) -> bool     True iff rel is a deployment/IaC manifest (H-16)
 #   is_audit_log(rel) -> bool             True iff rel is an append-only audit log (H-05)
 #   is_decisions_path(rel) -> bool        True iff rel is an ADR under decisions/ (H-11)
+#   is_context_md(rel) -> bool            True iff rel is the CONTEXT.md activation file (#159)
+#   is_marker_path(rel) -> bool           True iff rel is under .codearbiter/.markers/ (#160)
+#   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
@@ -117,6 +121,21 @@ AUDIT_LOG_RE = re.compile(r"\.codearbiter/" + AUDIT_LOG_NAMES + r"$")
 DECISIONS_DIR_RE = r"\.codearbiter[\\/]+decisions"
 DECISIONS_PATH_RE = re.compile(DECISIONS_DIR_RE + r"[\\/]+.+\.md$")
 
+# The activation file (#159) and the gate-marker store (#160). CONTEXT.md is the
+# master switch every hook gates on via arbiter_active(); .markers/ holds the
+# gate-pass tokens (security-gate-passed, migration-gate-passed,
+# adr-authoring-active). Both were writable project state with no Write/Edit
+# guard — the token strings are centralized here beside the audit-log/decisions
+# sets so the pre-* hooks import ONE definition (same anti-drift rationale).
+CONTEXT_MD_RE = re.compile(r"\.codearbiter/CONTEXT\.md$")
+MARKERS_RE = re.compile(r"\.codearbiter/\.markers(?:/|$)")
+# The two load-bearing gate-pass markers a commit gate consumes (H-09b/H-10b,
+# H-14). Their bare filenames feed pre-bash.py's shell flank — these are NEVER
+# legitimately shell-written (the sanctioned producers are the python
+# security-pass.py / migration-pass.py helpers), unlike adr-authoring-active
+# which /adr legitimately `touch`es.
+GATE_MARKER_NAMES = r"(?:security-gate-passed|migration-gate-passed)"
+
 
 def is_audit_log(rel):
     """True iff `rel` is one of the append-only .codearbiter audit logs
@@ -128,6 +147,47 @@ def is_decisions_path(rel):
     """True iff `rel` is a `.md` ADR anywhere under .codearbiter/decisions/ —
     the H-11 guard set (a non-numbered draft or a nested path still counts)."""
     return bool(DECISIONS_PATH_RE.search(norm_path(rel)))
+
+
+def is_context_md(rel):
+    """True iff `rel` is the .codearbiter/CONTEXT.md activation file (#159) —
+    the master switch arbiter_active() reads. Guarded so it can't be flipped to
+    `arbiter: disabled` (or corrupted) to make every enforcement hook dormant."""
+    return bool(CONTEXT_MD_RE.search(norm_path(rel)))
+
+
+def is_marker_path(rel):
+    """True iff `rel` is anywhere under .codearbiter/.markers/ (#160) — the
+    gate-pass token store. Load-bearing markers turn a BLOCK into an allow, so a
+    hand-written marker must not be admitted by the Write/Edit tools."""
+    return bool(MARKERS_RE.search(norm_path(rel)))
+
+
+def classify_protected(fpath, root):
+    """The set of protected classes a Write/Edit `fpath` targets, resolving
+    symlinks (#162). Each classifier runs against BOTH the raw normalized path
+    AND the realpath-resolved repo-relative form: a symlink alias whose visible
+    path lacks `.codearbiter/` still realpaths back inside the repo, so an alias
+    can no longer launder a write past the guard. Centralized so pre-write.py and
+    pre-edit.py apply the identical symlink-safe check to every class (H-05,
+    H-11, #159 CONTEXT.md, #160 markers) instead of re-encoding it twice.
+
+    Classes: "audit", "decisions", "context", "marker". repo_rel() returns "" for
+    a target outside the repo (which cannot be a `.codearbiter` path), so that
+    flank is simply skipped."""
+    hits = set()
+    for p in (norm_path(fpath), repo_rel(fpath, root)):
+        if not p:
+            continue
+        if is_audit_log(p):
+            hits.add("audit")
+        if is_decisions_path(p):
+            hits.add("decisions")
+        if is_context_md(p):
+            hits.add("context")
+        if is_marker_path(p):
+            hits.add("marker")
+    return hits
 
 
 def utf8_stdio():
@@ -146,17 +206,13 @@ def norm_path(p):
     return (p or "").replace("\\", "/")
 
 
-def frontmatter_enabled(ctx_path):
-    """Return (enabled, malformed). `enabled` iff `arbiter: enabled` appears in a
-    properly-closed leading YAML frontmatter block. `malformed` iff a block opens
-    (`---` on line 1) but never closes — the fail-loud case. A file with no
-    frontmatter at all is simply dormant (not malformed)."""
-    try:
-        with open(ctx_path, encoding="utf-8", errors="replace") as f:
-            text = f.read()
-    except Exception:  # noqa: BLE001
-        return (False, False)
-    lines = text.split("\n")
+def frontmatter_enabled_text(text):
+    """(enabled, malformed) for CONTEXT.md *content* (see frontmatter_enabled).
+    Split out so the #159 Write/Edit guard can vet the RESULTING content of an
+    edit — 'does this edit keep the repo arbiter-enabled?' — without going to
+    disk, sharing one parser with the on-disk activation check so the two never
+    disagree on what 'enabled' means."""
+    lines = (text or "").split("\n")
     if not lines:
         return (False, False)
     first = lines[0].lstrip("﻿")  # tolerate a leading UTF-8 BOM
@@ -169,6 +225,20 @@ def frontmatter_enabled(ctx_path):
         if ARBITER_RE.match(ln):
             found = True
     return (False, True)  # opened but never closed — malformed
+
+
+def frontmatter_enabled(ctx_path):
+    """Return (enabled, malformed) for CONTEXT.md ON DISK. `enabled` iff
+    `arbiter: enabled` appears in a properly-closed leading YAML frontmatter
+    block. `malformed` iff a block opens (`---` on line 1) but never closes — the
+    fail-loud case. A file with no frontmatter at all is simply dormant (not
+    malformed). Unreadable file -> (False, False)."""
+    try:
+        with open(ctx_path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001
+        return (False, False)
+    return frontmatter_enabled_text(text)
 
 
 def arbiter_active(root):

--- a/plugins/ca/hooks/git-enforce.py
+++ b/plugins/ca/hooks/git-enforce.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# codeArbiter — git-level enforcement backstop (#161).
+#
+# Installed into .git/hooks/pre-commit and .git/hooks/pre-push by _githooks.py.
+# It runs at the GIT OPERATION itself, OUTSIDE Claude Code — so a commit built
+# through shell indirection (`g=git; c=commit; $g $c -m x`) still triggers it,
+# unlike the PreToolUse Bash hook (pre-bash.py), which only ever sees the literal
+# command string and is defeated by variable/expansion spellings. The two layers
+# are complementary: pre-bash.py gives fast, well-worded feedback on the common
+# spellings; this is the spelling-proof backstop underneath.
+#
+# It mirrors pre-bash.py's commit/push gates and reuses the SAME detection
+# primitives from _hooklib (CRYPTO_RE / SECRET_RE / line_digest / content_digest
+# / is_migration_path / marker_fresh), so the two enforcement points can never
+# drift on what counts as sensitive or as a migration, or on how a gate-pass
+# marker binds to the lines it approved.
+#
+# Contract: a git hook aborts its operation on ANY non-zero exit, so a BLOCK is
+# exit 1 with a loud stderr message. Exit 0 allows. The security/migration scans
+# fail CLOSED on a git read error (pre-bash's "ambiguity resolves CLOSED"
+# stance); a repo that is not arbiter-enabled is a no-op (exit 0).
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _hooklib import (  # noqa: E402
+    CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
+    line_digest, marker_fresh, project_root, utf8_stdio,
+)
+
+
+def _git(args, cwd):
+    try:
+        return subprocess.run(
+            ["git"] + args, cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=10,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def block(tag, msg):
+    print(f"BLOCKED [{tag}]: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def is_protected_branch(branch):
+    return (branch or "").lower() in ("main", "master")
+
+
+def current_branch(cwd):
+    r = _git(["branch", "--show-current"], cwd)
+    return r.stdout.strip() if r and r.returncode == 0 else ""
+
+
+def head_on_protected_tip(cwd):
+    """True when HEAD (typically detached) points at a protected branch's tip —
+    a commit there still lands on main/master's history. Mirrors pre-bash.py."""
+    r = _git(["show-ref", "--head", "refs/heads/main", "refs/heads/master"], cwd)
+    if r is None or r.returncode not in (0, 1):
+        return False
+    head_sha, protected = None, set()
+    for ln in r.stdout.splitlines():
+        parts = ln.split()
+        if len(parts) != 2:
+            continue
+        sha, ref = parts
+        if ref == "HEAD":
+            head_sha = sha
+        elif ref in ("refs/heads/main", "refs/heads/master"):
+            protected.add(sha)
+    return head_sha is not None and head_sha in protected
+
+
+def cached_added_lines(cwd):
+    """Added (`+`) lines of the staged diff — exactly what a commit records
+    (including `commit -a` sweeps, which git has already staged by pre-commit
+    time). None on a git read error → caller fails closed."""
+    r = _git(["diff", "--cached"], cwd)
+    if r is None or r.returncode != 0:
+        return None
+    return [ln[1:] for ln in r.stdout.splitlines()
+            if ln.startswith("+") and not ln.startswith("+++")]
+
+
+def cached_names(cwd):
+    r = _git(["diff", "--cached", "--name-only"], cwd)
+    if r is None or r.returncode != 0:
+        return None
+    return {p for p in r.stdout.splitlines() if p.strip()}
+
+
+def read_worktree(cwd, rel):
+    p = rel if os.path.isabs(rel) else os.path.join(cwd, rel)
+    try:
+        if os.path.getsize(p) > 1_000_000:
+            return None
+        with open(p, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _marker_set(root, name):
+    try:
+        with open(os.path.join(root, ".codearbiter", ".markers", name),
+                  encoding="utf-8") as f:
+            return set(f.read().split())
+    except Exception:  # noqa: BLE001
+        return set()
+
+
+def pre_commit(root):
+    cwd = root
+    # H-01: no commit onto a protected branch (or a detached HEAD on its tip).
+    branch = current_branch(cwd)
+    if is_protected_branch(branch) or (not branch and head_on_protected_tip(cwd)):
+        target = branch or "main/master (detached HEAD)"
+        block("H-01", f"Direct commit to {target} is prohibited (ORCHESTRATOR §3) — this is "
+                      f"the git-level backstop (#161). Create a feature branch.")
+
+    # H-09b / H-10b: a commit introducing crypto/secret changes needs a fresh,
+    # line-covering security-gate pass. Reuses the exact _hooklib primitives.
+    added = cached_added_lines(cwd)
+    if added is None:
+        block("H-09b", "the staged diff for the crypto/secret scan could not be read — "
+                       "failing closed (ORCHESTRATOR §2).")
+    sensitive = [ln for ln in added if CRYPTO_RE.search(ln) or SECRET_RE.search(ln)]
+    if sensitive:
+        joined = "\n".join(added)
+        touches_crypto = bool(CRYPTO_RE.search(joined))
+        kind = "crypto/TLS" if touches_crypto else "secret"
+        tag = "H-09b" if touches_crypto else "H-10b"
+        skill = "crypto-compliance" if touches_crypto else "secret-handling"
+        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        if not marker_fresh(marker, 30):
+            block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
+                       f"recorded (#161 git backstop). Run the {skill} gate, then commit.")
+        approved = _marker_set(root, "security-gate-passed")
+        uncovered = [ln for ln in sensitive if line_digest(ln) not in approved]
+        if uncovered:
+            block(tag, f"{len(uncovered)} {kind} line(s) in this commit are not covered by the "
+                       f"recorded security-gate pass (#161 git backstop) — re-run the {skill} "
+                       f"gate so it reviews the current diff, then commit.")
+
+    # H-14: a staged migration needs a content-bound migration-review pass.
+    names = cached_names(cwd)
+    if names is None:
+        block("H-14", "the staged file list for the migration scan could not be read — "
+                      "failing closed (ORCHESTRATOR §2).")
+    migs = sorted(p for p in names if is_migration_path(p, root))
+    if migs:
+        approved = _marker_set(root, "migration-gate-passed")
+        uncovered = []
+        for rel in migs:
+            text = read_worktree(cwd, rel)
+            if text is None or content_digest(text) not in approved:
+                uncovered.append(rel)
+        if uncovered:
+            block("H-14", f"{len(uncovered)} staged migration file(s) lack a recorded "
+                          f"migration-review pass (#161 git backstop): {', '.join(uncovered)}. "
+                          f"Run the migration-review gate, then commit.")
+
+
+def pre_push(root):
+    cwd = root
+    # Git feeds pre-push one line per ref: `<local ref> <local sha> <remote ref>
+    # <remote sha>`. A deletion has an all-zero local sha; a create has an
+    # all-zero remote sha.
+    data = ""
+    try:
+        data = sys.stdin.read()
+    except Exception:  # noqa: BLE001
+        data = ""
+    for ln in data.splitlines():
+        parts = ln.split()
+        if len(parts) < 4:
+            continue
+        _lref, lsha, rref, rsha = parts[0], parts[1], parts[2], parts[3]
+        # H-01: no push whose destination is a protected branch (main/master),
+        # in any refspec spelling — `HEAD:main`, `feature:main`, `:main`.
+        if rref.startswith("refs/heads/") and is_protected_branch(rref.rsplit("/", 1)[-1]):
+            block("H-01", f"Pushing to a protected branch ('{rref}') is prohibited "
+                          f"(ORCHESTRATOR §3, #161 git backstop) — main moves only via a merged PR.")
+        # H-02: no force / non-fast-forward update. Skip creates/deletes
+        # (all-zero sha). A non-ff update is one where the remote sha is NOT an
+        # ancestor of the local sha; treat an unresolvable check as force (closed).
+        zero = lambda s: set(s) == {"0"}  # noqa: E731
+        if lsha and rsha and not zero(lsha) and not zero(rsha):
+            anc = _git(["merge-base", "--is-ancestor", rsha, lsha], cwd)
+            if anc is None or anc.returncode != 0:
+                block("H-02", "Force-push / non-fast-forward update is prohibited "
+                              "(ORCHESTRATOR §3, #161 git backstop).")
+
+
+def main():
+    utf8_stdio()
+    root = project_root()
+    if not arbiter_active(root):
+        sys.exit(0)
+    phase = sys.argv[1] if len(sys.argv) > 1 else ""
+    if phase == "pre-commit":
+        pre_commit(root)
+    elif phase == "pre-push":
+        pre_push(root)
+    # Unknown phase: no-op allow.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/ca/hooks/hooks.json
+++ b/plugins/ca/hooks/hooks.json
@@ -24,7 +24,7 @@
         ]
       },
       {
-        "matcher": "Edit|MultiEdit",
+        "matcher": "Edit|MultiEdit|NotebookEdit",
         "hooks": [
           { "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit.py\"" },
           { "type": "command", "command": "python3 -c \"\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit.py\"" }

--- a/plugins/ca/hooks/init-codearbiter.py
+++ b/plugins/ca/hooks/init-codearbiter.py
@@ -152,6 +152,19 @@ def main(argv=None):
                 f.write(content)
             created.append(fname)
 
+    # #161: install the git-level enforcement backstop (pre-commit/pre-push) so
+    # git mutations are gated at the operation itself, not only at the literal
+    # Bash command string. Best-effort — a repo without a git dir, or a foreign
+    # existing hook, is reported by install(), never fatal to scaffolding.
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from _githooks import install as _install_git_hooks
+        gh = _install_git_hooks(root)
+        if gh:
+            print("git hooks: " + ", ".join(gh))
+    except Exception as e:  # noqa: BLE001
+        print(f"git hooks: install skipped ({e})", file=sys.stderr)
+
     print(f"SCAFFOLDED .codearbiter/ at {cad}")
     print("created: " + ", ".join(created))
     print(f"arbiter: enabled (stage {args.stage}); CONTEXT.md is a stub (no <!--INITIALIZED--> sentinel).")

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -21,9 +21,9 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE, SECRET_RE, arbiter_active, block,
-    content_digest, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, tool_input, utf8_stdio,
+    AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE, GATE_MARKER_NAMES, SECRET_RE,
+    arbiter_active, block, content_digest, is_migration_path, line_digest,
+    marker_fresh, project_root, read_input, tool_input, utf8_stdio,
 )
 
 # `git` followed by any run of global options (-C <dir>, -c k=v, --git-dir=…,
@@ -93,6 +93,40 @@ DECISIONS_WRITE_RE = re.compile(
     r"\b(rm|del|mv|cp|copy|dd|tee|sed|touch|truncate|ni"
     r"|New-Item|Remove-Item|Move-Item|Copy-Item|Clear-Content|Set-Content"
     r"|Out-File|Add-Content)\b[^|;&]*" + DECISIONS, re.I,
+)
+
+# H-18's shell flank: .codearbiter/CONTEXT.md is the activation switch every hook
+# gates on (#159). The Write/Edit tools are guarded by pre-write/pre-edit; this
+# guards the shell — a redirect into CONTEXT.md, or a write/delete verb naming
+# it, would flip `arbiter: enabled` off (or corrupt the frontmatter) and make
+# every gate dormant. Init writes CONTEXT.md via the Write tool, never the shell,
+# so no legitimate path is blocked; `cat`/`grep` reads pass untouched. Same
+# lexical limitation as the audit-log/decisions flanks (N-3): the Write/Edit
+# guard is the primary boundary, this is defense in depth.
+CONTEXT_MD = r"\.codearbiter[\\/]+CONTEXT\.md"
+CONTEXT_REDIRECT_RE = re.compile(r">>?\|?\s*\S*" + CONTEXT_MD, re.I)
+CONTEXT_WRITE_RE = re.compile(
+    r"\b(rm|del|mv|cp|copy|dd|tee|sed|truncate|ni"
+    r"|New-Item|Remove-Item|Move-Item|Copy-Item|Clear-Content|Set-Content"
+    r"|Out-File|Add-Content)\b[^|;&]*" + CONTEXT_MD, re.I,
+)
+
+# H-19's shell flank: the two gate-pass markers (#160) are recorded ONLY by the
+# python producers (security-pass.py / migration-pass.py), which write via
+# os.replace and NEVER name the marker on the command line. So blocking any shell
+# command that names a gate marker as a redirect or write/move/copy target closes
+# the `echo <digest> > .markers/security-gate-passed` (and `cp goodmarker
+# security-gate-passed`) forge without touching the sanctioned producers.
+# adr-authoring-active is intentionally excluded: /adr legitimately `touch`es it,
+# and an empty/forged gate marker fails H-09b/H-14's digest-coverage check anyway
+# — only a marker carrying valid digests forges a pass, which shell verbs against
+# the marker name are how you'd inject.
+GATE_MARKER = r"\.markers[\\/]+" + GATE_MARKER_NAMES
+GATE_MARKER_REDIRECT_RE = re.compile(r">>?\|?\s*\S*" + GATE_MARKER, re.I)
+GATE_MARKER_WRITE_RE = re.compile(
+    r"\b(mv|cp|copy|dd|tee|sed|truncate"
+    r"|Move-Item|Copy-Item|Clear-Content|Set-Content|Out-File|Add-Content)\b"
+    r"[^|;&]*" + GATE_MARKER, re.I,
 )
 
 
@@ -409,6 +443,24 @@ def main():
         block("H-11", "ADR files under .codearbiter/decisions/ are authored only via "
                       "/adr and are immutable history (ORCHESTRATOR §6) — shell writes, "
                       "edits, and deletions there are prohibited.")
+
+    # H-18: CONTEXT.md is the activation switch (#159) — shell flank. A shell
+    # rewrite/delete of it would make every gate dormant; init writes it via the
+    # Write tool, so nothing legitimate is blocked. Reads pass.
+    if CONTEXT_REDIRECT_RE.search(cmd) or CONTEXT_WRITE_RE.search(cmd):
+        block("H-18", ".codearbiter/CONTEXT.md is the activation switch every enforcement "
+                      "hook reads (#159) — shell rewrites, edits, or deletions that could flip "
+                      "`arbiter: enabled` off or corrupt its frontmatter are prohibited. Edit it "
+                      "through the sanctioned init path.")
+
+    # H-19: the gate-pass markers (#160) are recorded only by the sanctioned
+    # python producers — shell flank against `echo <digest> > security-gate-passed`
+    # and `cp`/`sed`/`tee` forges naming a gate marker.
+    if GATE_MARKER_REDIRECT_RE.search(cmd) or GATE_MARKER_WRITE_RE.search(cmd):
+        block("H-19", "The .codearbiter/.markers/ security-gate-passed / migration-gate-passed "
+                      "tokens are recorded only by the sanctioned gate producers (#160) — a shell "
+                      "redirect or write verb naming a gate marker forges a security/migration "
+                      "gate pass and is prohibited.")
 
     # H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     # a recorded security-gate pass. The crypto-compliance / secret-handling skills

--- a/plugins/ca/hooks/pre-edit.py
+++ b/plugins/ca/hooks/pre-edit.py
@@ -1,21 +1,53 @@
 #!/usr/bin/env python3
-# codeArbiter v2 — PreToolUse(Edit) guard. Audit-log + ADR authoring integrity.
-# Python port of pre-edit.sh (#25): no jq, fails loud, blocks via exit 2.
+# codeArbiter v2 — PreToolUse(Edit|MultiEdit|NotebookEdit) guard. Activation +
+# audit-log + marker + ADR integrity. Python port of pre-edit.sh (#25): no jq,
+# fails loud, blocks via exit 2.
 #
-# Edits to overrides.log are allowed only when they are pure appends (the new
-# text starts with the old text) — that is how /override adds entries; any
-# other Edit rewrites history and is blocked (H-05). Kept: H-11 (ADRs only via
-# /adr). Paths are separator-normalized so the guards fire on Windows
-# backslash paths too. Runs only in arbiter-enabled repos.
+# Guards (arbiter-enabled repo only), symlink-resolved via classify_protected
+# (#162 — raw path AND realpath-resolved repo-relative form):
+#   H-18  CONTEXT.md may not be edited to drop `arbiter: enabled` (#159).
+#   H-19  .codearbiter/.markers/* are never edited via the Edit tools (#160).
+#   H-05  audit-log Edits must be pure appends (new_string extends old_string).
+#   H-11  ADRs under decisions/ are edited only via /adr.
+#
+# NotebookEdit is guarded too (a notebook has no append/frontmatter semantics, so
+# a protected target is refused outright) — defense in depth; none of the
+# protected files is a .ipynb, but the tool must not be a hole.
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    arbiter_active, block, is_audit_log, is_decisions_path, marker_fresh,
-    norm_path, project_root, read_input, tool_input, utf8_stdio,
+    arbiter_active, block, classify_protected, frontmatter_enabled_text,
+    marker_fresh, project_root, read_input, tool_input, utf8_stdio,
 )
+
+
+def _resulting_context(root, fpath, tool, ti):
+    """Best-effort resulting content of an Edit/MultiEdit applied to CONTEXT.md,
+    so the #159 guard can vet whether the edit keeps the repo arbiter-enabled.
+    Reads the real (symlink-resolved) file and replays the edit(s) the way the
+    tool would. An old_string that isn't present leaves the text unchanged (the
+    tool would error anyway) — harmless for the check."""
+    path = fpath if os.path.isabs(fpath) else os.path.join(root, fpath)
+    try:
+        with open(os.path.realpath(path), encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001
+        text = ""
+    if tool == "MultiEdit":
+        edits = ti.get("edits", []) or []
+    else:
+        edits = [ti]
+    for e in edits:
+        old = (e.get("old_string", "") or "")
+        new = (e.get("new_string", "") or "")
+        if e.get("replace_all"):
+            text = text.replace(old, new)
+        else:
+            text = text.replace(old, new, 1)
+    return text
 
 
 def main():
@@ -26,12 +58,46 @@ def main():
     payload = read_input()
     tool = payload.get("tool_name", "") or ""
     ti = tool_input(payload)
-    fpath = norm_path(ti.get("file_path", "") or "")
+    # NotebookEdit carries `notebook_path`; Edit/MultiEdit carry `file_path`.
+    fpath = ti.get("file_path", "") or ti.get("notebook_path", "") or ""
+    classes = classify_protected(fpath, root)
+
+    # The tag that names each protected class, in message priority order.
+    _CLASS_TAG = (("marker", "H-19"), ("context", "H-18"),
+                  ("audit", "H-05"), ("decisions", "H-11"))
+
+    # NotebookEdit: a notebook is never one of the protected text artifacts, and
+    # cell edits have no append/frontmatter semantics to reason about — refuse any
+    # protected target outright with a class-appropriate tag (defense in depth).
+    if tool == "NotebookEdit":
+        for cls, tag in _CLASS_TAG:
+            if cls in classes:
+                block(tag, "NotebookEdit may not target a protected .codearbiter artifact "
+                           "(CONTEXT.md, audit logs, ADRs, or markers) — use the sanctioned "
+                           "skill path.")
+        sys.exit(0)
+
+    # H-19: markers are never edited via the Edit tools (#160) — the sanctioned
+    # producers write them; an Edit is tampering. Block outright.
+    if "marker" in classes:
+        block("H-19", "The .codearbiter/.markers/ gate tokens are not editable via the Edit "
+                      "tools (#160) — editing one forges or tampers with a security/migration/ADR "
+                      "gate pass. Markers are recorded only by the sanctioned gate producers.")
+
+    # H-18: an Edit to CONTEXT.md may not drop `arbiter: enabled` or corrupt the
+    # frontmatter (#159) — replay the edit and require the result stays enabled.
+    if "context" in classes:
+        enabled, malformed = frontmatter_enabled_text(_resulting_context(root, fpath, tool, ti))
+        if malformed or not enabled:
+            block("H-18", "This Edit would remove or alter the `arbiter: enabled` frontmatter in "
+                          ".codearbiter/CONTEXT.md (#159) — the activation switch every enforcement "
+                          "hook reads. Disabling it from inside the repo would make every gate "
+                          "dormant. Keep `arbiter: enabled` in a well-formed frontmatter block.")
 
     # H-05: the audit logs (and the /sprint decision record) are append-only — an
     # Edit must leave existing lines intact (new_string extends old_string), never
     # alter or delete them. (path set: _hooklib.is_audit_log)
-    if is_audit_log(fpath):
+    if "audit" in classes:
         # MultiEdit applies a batch of edits and cannot express a verifiable pure
         # append to an append-only file — the sanctioned append path is a single
         # Edit (or '>>'). Block it outright rather than reason about the batch.
@@ -61,7 +127,7 @@ def main():
     # H-11: ADRs may only be edited via /adr — any .md anywhere under decisions/
     # (a non-numbered draft or a nested path is still an immutable decision).
     # (path set: _hooklib.is_decisions_path)
-    if is_decisions_path(fpath):
+    if "decisions" in classes:
         marker = os.path.join(root, ".codearbiter", ".markers", "adr-authoring-active")
         if not os.path.isfile(marker):
             block("H-11", "ADR files are edited only via /adr (ORCHESTRATOR §3) — user "

--- a/plugins/ca/hooks/pre-write.py
+++ b/plugins/ca/hooks/pre-write.py
@@ -1,19 +1,29 @@
 #!/usr/bin/env python3
-# codeArbiter v2 — PreToolUse(Write) guard. Audit-log + ADR authoring integrity.
-# Python port of pre-write.sh (#25): no jq, fails loud, blocks via exit 2.
+# codeArbiter v2 — PreToolUse(Write) guard. Activation + audit-log + marker + ADR
+# integrity. Python port of pre-write.sh (#25): no jq, fails loud, blocks via
+# exit 2.
 #
-# Kept: H-05 (overrides.log append-only) and H-11 (ADRs only via /adr) — both
-# guard the audit trail / decision record. Paths are separator-normalized so
-# the guards fire on Windows backslash paths too. Runs only in arbiter-enabled
-# repos.
+# Guards (all on the arbiter-enabled repo only):
+#   H-18  .codearbiter/CONTEXT.md is the activation switch every hook gates on
+#         (#159) — a Write may not flip `arbiter: enabled` off or corrupt the
+#         frontmatter, which would make every gate dormant.
+#   H-19  .codearbiter/.markers/* are the gate-pass tokens that turn a hard-gate
+#         BLOCK into an allow (#160) — never writable via the Write tool.
+#   H-05  audit logs (overrides.log, triage.log, sprint-log.md) are append-only.
+#   H-11  ADRs under decisions/ are authored only via /adr.
+#
+# Every protected-path decision resolves symlinks (#162): classify_protected()
+# checks the raw path AND its realpath-resolved repo-relative form, so a symlink
+# alias whose visible path lacks `.codearbiter/` can't launder a write past a
+# guard.
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    arbiter_active, block, is_audit_log, is_decisions_path, marker_fresh,
-    norm_path, project_root, read_input, tool_input, utf8_stdio,
+    arbiter_active, block, classify_protected, frontmatter_enabled_text,
+    marker_fresh, project_root, read_input, tool_input, utf8_stdio,
 )
 
 
@@ -22,18 +32,42 @@ def main():
     root = project_root()
     if not arbiter_active(root):
         sys.exit(0)
-    fpath = norm_path(tool_input(read_input()).get("file_path", "") or "")
+    ti = tool_input(read_input())
+    fpath = ti.get("file_path", "") or ""
+    classes = classify_protected(fpath, root)
+
+    # H-19: the gate-pass markers are the mechanism that turns a hard-gate BLOCK
+    # into an allow (#160). They are recorded only by the sanctioned producers
+    # (security-pass.py / migration-pass.py) and the /adr `touch` — a Write here
+    # is a hand-forged marker. Block outright.
+    if "marker" in classes:
+        block("H-19", "The .codearbiter/.markers/ gate tokens are not writable via the Write "
+                      "tool (#160) — a hand-written marker forges a security/migration/ADR gate "
+                      "pass. Markers are recorded only by the sanctioned gate producers.")
+
+    # H-18: CONTEXT.md is the master switch arbiter_active() reads (#159). A Write
+    # is a full overwrite, so vet the RESULTING content: allow only if it still
+    # carries a well-formed `arbiter: enabled` frontmatter. Disabling arbiter
+    # from inside the repo it governs is exactly the kill-switch this closes (a
+    # human can still opt out by editing the file outside the agent's tools).
+    if "context" in classes:
+        enabled, malformed = frontmatter_enabled_text(ti.get("content", "") or "")
+        if malformed or not enabled:
+            block("H-18", "This Write would remove or alter the `arbiter: enabled` frontmatter in "
+                          ".codearbiter/CONTEXT.md (#159) — the activation switch every enforcement "
+                          "hook reads. Disabling it from inside the repo would make every gate "
+                          "dormant. Keep `arbiter: enabled` in a well-formed frontmatter block.")
 
     # H-05: the audit logs (and the /sprint decision record) are append-only —
     # a Write is a full overwrite. (path set: _hooklib.is_audit_log)
-    if is_audit_log(fpath):
+    if "audit" in classes:
         block("H-05", "The .codearbiter audit logs (overrides.log, triage.log, sprint-log.md) "
                       "are append-only (ORCHESTRATOR §7). Append with Edit or '>>', never Write.")
 
     # H-11: ADRs may only be authored via /adr (the skill drops the marker first).
     # Any .md anywhere under decisions/ is covered — a non-numbered draft or a
     # nested path is still an immutable decision artifact. (set: is_decisions_path)
-    if is_decisions_path(fpath):
+    if "decisions" in classes:
         marker = os.path.join(root, ".codearbiter", ".markers", "adr-authoring-active")
         if not os.path.isfile(marker):
             block("H-11", "ADR files are authored only via /adr (ORCHESTRATOR §3) — user "

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -470,6 +470,17 @@ def main():
                   "fix the frontmatter to activate.", file=sys.stderr)
         sys.exit(0)
 
+    # #161: arbiter is active — ensure the git-level enforcement backstop
+    # (pre-commit/pre-push) is installed and points at the CURRENT plugin path.
+    # Idempotent and best-effort: a foreign existing hook is preserved, and any
+    # failure here must never break session startup.
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from _githooks import install as _install_git_hooks
+        _install_git_hooks(root)
+    except Exception:  # noqa: BLE001
+        pass
+
     # --- Arbiter active: inject persona ---
     orch = os.path.join(plugin, "ORCHESTRATOR.md")
     orch_text = read_text(orch)

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -1,0 +1,170 @@
+"""Behavioral coverage for the git-level enforcement backstop (#161).
+
+pre-bash.py gates git operations by matching the literal Bash command string, so
+shell indirection (`g=git; c=commit; $g $c`) walks straight past it. _githooks.py
+installs .git/hooks/pre-commit and pre-push that run git-enforce.py at the git
+operation itself, where spelling no longer matters. These tests prove:
+
+  * install() writes ours-hooks, is idempotent, and NEVER clobbers a foreign hook
+  * git-enforce.py blocks a commit onto main — including via VARIABLE INDIRECTION,
+    the exact bypass #161 is about — and allows a feature-branch commit
+  * it blocks a crypto commit lacking a security-gate marker (H-09b)
+  * pre-push blocks a protected-branch push (H-01), allows a feature fast-forward
+  * a non-arbiter repo is a no-op
+
+Stdlib only; a real throwaway git repo per test (git hooks only fire against a
+real repo).
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ENFORCE = os.path.join(HOOKS, "git-enforce.py")
+
+sys.path.insert(0, HOOKS)
+import _githooks  # noqa: E402
+
+
+def _sh(args, cwd, **kw):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=60, **kw)
+
+
+def _git(args, cwd, check=True):
+    r = _sh(["git"] + args, cwd)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr}")
+    return r
+
+
+class _GitFixture(unittest.TestCase):
+    ARBITER = "---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\n"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "repo")
+        os.makedirs(self.root)
+        _git(["init", "-q", "-b", "main"], self.root)
+        _git(["config", "user.email", "h@example.com"], self.root)
+        _git(["config", "user.name", "harness"], self.root)
+        os.makedirs(os.path.join(self.root, ".codearbiter"))
+        self._write(os.path.join(self.root, ".codearbiter", "CONTEXT.md"), self.ARBITER)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, path, text):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def _disable_arbiter(self):
+        self._write(os.path.join(self.root, ".codearbiter", "CONTEXT.md"),
+                    "# ctx\nno frontmatter\n")
+
+    def enforce(self, phase, stdin=""):
+        return _sh([sys.executable, ENFORCE, phase], self.root, input=stdin)
+
+
+class TestInstall(_GitFixture):
+    def _hooks_dir(self):
+        return os.path.join(self.root, ".git", "hooks")
+
+    def test_install_writes_both_hooks(self):
+        _githooks.install(self.root)
+        for phase in ("pre-commit", "pre-push"):
+            dest = os.path.join(self._hooks_dir(), phase)
+            self.assertTrue(os.path.isfile(dest))
+            with open(dest, encoding="utf-8") as f:
+                self.assertIn(_githooks.SENTINEL, f.read())
+            self.assertTrue(os.access(dest, os.X_OK))
+
+    def test_install_is_idempotent(self):
+        _githooks.install(self.root)
+        second = _githooks.install(self.root)
+        self.assertEqual(second, [])  # already current -> no churn
+
+    def test_foreign_hook_is_preserved(self):
+        dest = os.path.join(self._hooks_dir(), "pre-commit")
+        os.makedirs(self._hooks_dir(), exist_ok=True)
+        self._write(dest, "#!/bin/sh\necho husky\n")
+        _githooks.install(self.root)
+        with open(dest, encoding="utf-8") as f:
+            body = f.read()
+        self.assertIn("husky", body)
+        self.assertNotIn(_githooks.SENTINEL, body)
+
+    def test_uninstall_removes_only_ours(self):
+        _githooks.install(self.root)
+        _githooks.uninstall(self.root)
+        self.assertFalse(os.path.isfile(os.path.join(self._hooks_dir(), "pre-commit")))
+
+
+class TestPreCommitEnforce(_GitFixture):
+    def _stage(self, name, content):
+        self._write(os.path.join(self.root, name), content)
+        _git(["add", name], self.root)
+
+    def test_direct_commit_to_main_is_blocked(self):
+        self._stage("f.txt", "x\n")
+        res = self.enforce("pre-commit")
+        self.assertEqual(res.returncode, 1, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_variable_indirection_commit_is_blocked_at_git_layer(self):
+        # The #161 bypass: build `git commit` from shell vars. pre-bash never sees
+        # a git token, but the git hook fires on the real operation. Run a REAL
+        # indirected commit with our hook installed and assert it aborts.
+        _githooks.install(self.root)
+        self._stage("f.txt", "x\n")
+        res = _sh(["sh", "-c", "g=git; c=commit; $g $c -m sneaky"], self.root)
+        self.assertNotEqual(res.returncode, 0, "indirected commit should have been blocked")
+        self.assertIn("H-01", res.stderr + res.stdout)
+        # nothing committed
+        log = _git(["rev-list", "--all", "--count"], self.root, check=False)
+        self.assertEqual(log.stdout.strip(), "0")
+
+    def test_feature_branch_commit_is_allowed(self):
+        _git(["checkout", "-q", "-b", "feat/x"], self.root)
+        self._stage("f.txt", "x\n")
+        res = self.enforce("pre-commit")
+        self.assertEqual(res.returncode, 0, res.stderr)
+
+    def test_crypto_commit_without_marker_is_blocked(self):
+        _git(["checkout", "-q", "-b", "feat/c"], self.root)
+        self._stage("c.js", 'const h = crypto.createHash("md5");\n')
+        res = self.enforce("pre-commit")
+        self.assertEqual(res.returncode, 1, res.stderr)
+        self.assertIn("H-09b", res.stderr)
+
+    def test_dormant_repo_is_noop(self):
+        self._disable_arbiter()
+        self._stage("f.txt", "x\n")
+        res = self.enforce("pre-commit")
+        self.assertEqual(res.returncode, 0, res.stderr)
+
+
+class TestPrePushEnforce(_GitFixture):
+    def test_push_to_protected_branch_is_blocked(self):
+        line = "refs/heads/feat/x abc123 refs/heads/main def456\n"
+        res = self.enforce("pre-push", stdin=line)
+        self.assertEqual(res.returncode, 1, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_feature_fast_forward_push_is_allowed(self):
+        _git(["checkout", "-q", "-b", "feat/x"], self.root)
+        self._write(os.path.join(self.root, "f.txt"), "x\n")
+        _git(["add", "f.txt"], self.root)
+        _git(["commit", "-q", "-m", "ok", "--no-verify"], self.root)
+        sha = _git(["rev-parse", "HEAD"], self.root).stdout.strip()
+        zero = "0" * 40
+        line = f"refs/heads/feat/x {sha} refs/heads/feat/x {zero}\n"  # create -> no force
+        res = self.enforce("pre-push", stdin=line)
+        self.assertEqual(res.returncode, 0, res.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_pre_bash_activation.py
+++ b/plugins/ca/hooks/tests/test_pre_bash_activation.py
@@ -1,0 +1,100 @@
+"""Shell-flank coverage for pre-bash.py's #159 (CONTEXT.md) and #160 (gate
+markers) guards.
+
+The Write/Edit tools are guarded by pre-write/pre-edit; these prove the shell
+flank: a redirect or write-verb that would rewrite the activation switch, or
+forge a gate-pass marker, is blocked — while reads and the sanctioned
+`touch adr-authoring-active` / producer-script invocation still pass.
+
+Stdlib only; hook JSON piped to pre-bash.py on stdin in a throwaway
+arbiter-enabled git repo (mirrors .github/scripts/test_hook_guards.py).
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
+
+
+def _sh(args, cwd, **kw):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=60, **kw)
+
+
+def _git(args, cwd):
+    r = _sh(["git"] + args, cwd)
+    if r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr}")
+    return r
+
+
+class _PreBashFixture(unittest.TestCase):
+    ARBITER = "---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\n"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "repo")
+        os.makedirs(self.root)
+        _git(["init", "-q", "-b", "feat/work"], self.root)
+        _git(["config", "user.email", "h@example.com"], self.root)
+        _git(["config", "user.name", "harness"], self.root)
+        os.makedirs(os.path.join(self.root, ".codearbiter"))
+        with open(os.path.join(self.root, ".codearbiter", "CONTEXT.md"), "w",
+                  encoding="utf-8") as f:
+            f.write(self.ARBITER)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def run_bash(self, command):
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+        return _sh([sys.executable, PRE_BASH], self.root, input=payload)
+
+    def assertBlocked(self, res, tag):
+        self.assertEqual(res.returncode, 2,
+                         f"expected BLOCK (exit 2); got {res.returncode} / {res.stderr[:200]!r}")
+        self.assertIn(tag, res.stderr)
+
+    def assertAllowed(self, res):
+        self.assertEqual(res.returncode, 0,
+                         f"expected ALLOW (exit 0); got {res.returncode} / {res.stderr[:200]!r}")
+
+
+class TestContextShellFlank(_PreBashFixture):
+    def test_redirect_into_context_is_blocked(self):
+        self.assertBlocked(self.run_bash("echo x > .codearbiter/CONTEXT.md"), "H-18")
+
+    def test_sed_inplace_on_context_is_blocked(self):
+        self.assertBlocked(self.run_bash("sed -i s/enabled/disabled/ .codearbiter/CONTEXT.md"), "H-18")
+
+    def test_rm_context_is_blocked(self):
+        self.assertBlocked(self.run_bash("rm .codearbiter/CONTEXT.md"), "H-18")
+
+    def test_read_context_is_allowed(self):
+        self.assertAllowed(self.run_bash("cat .codearbiter/CONTEXT.md"))
+
+
+class TestGateMarkerShellFlank(_PreBashFixture):
+    def test_redirect_forge_security_marker_is_blocked(self):
+        self.assertBlocked(
+            self.run_bash("echo deadbeef > .codearbiter/.markers/security-gate-passed"), "H-19")
+
+    def test_cp_forge_migration_marker_is_blocked(self):
+        self.assertBlocked(
+            self.run_bash("cp good .codearbiter/.markers/migration-gate-passed"), "H-19")
+
+    def test_touch_adr_marker_is_allowed(self):
+        # /adr legitimately touches the ADR-authoring marker.
+        self.assertAllowed(self.run_bash("touch .codearbiter/.markers/adr-authoring-active"))
+
+    def test_running_producer_script_is_allowed(self):
+        # The sanctioned producer names the script, not the marker file.
+        self.assertAllowed(self.run_bash('python "$CLAUDE_PLUGIN_ROOT/hooks/security-pass.py"'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_pre_edit.py
+++ b/plugins/ca/hooks/tests/test_pre_edit.py
@@ -302,6 +302,75 @@ class TestMultiEditGuards(_PreEditFixture):
         self.assertAllowed(res)
 
 
+class TestH18ContextEdit(_PreEditFixture):
+    """#159: an Edit to CONTEXT.md may not drop `arbiter: enabled`."""
+
+    def _ctx(self):
+        return os.path.join(self.ca, "CONTEXT.md")
+
+    def test_edit_disabling_arbiter_is_blocked(self):
+        res = self.run_edit(self._ctx(),
+                            old_string="arbiter: enabled",
+                            new_string="arbiter: disabled")
+        self.assertBlocked(res, "H-18")
+
+    def test_edit_removing_frontmatter_delimiter_is_blocked(self):
+        # Dropping the opening '---' leaves no frontmatter -> not enabled.
+        res = self.run_edit(self._ctx(),
+                            old_string="---\narbiter: enabled",
+                            new_string="arbiter: enabled")
+        self.assertBlocked(res, "H-18")
+
+    def test_stage_bump_keeping_arbiter_enabled_is_allowed(self):
+        res = self.run_edit(self._ctx(), old_string="stage: 2", new_string="stage: 3")
+        self.assertAllowed(res)
+
+
+class TestH19MarkerEdit(_PreEditFixture):
+    """#160: gate markers are not editable via the Edit tools."""
+
+    def test_edit_security_gate_marker_is_blocked(self):
+        m = os.path.join(self.markers, "security-gate-passed")
+        os.makedirs(self.markers, exist_ok=True)
+        self._write(m, "olddigest\n")
+        res = self.run_edit(m, old_string="olddigest\n", new_string="olddigest\nforged\n")
+        self.assertBlocked(res, "H-19")
+
+    def test_multiedit_marker_is_blocked(self):
+        m = os.path.join(self.markers, "migration-gate-passed")
+        os.makedirs(self.markers, exist_ok=True)
+        self._write(m, "d\n")
+        res = self.run_multiedit(m, [{"old_string": "d", "new_string": "d\nx"}])
+        self.assertBlocked(res, "H-19")
+
+
+class TestNotebookEditGuard(_PreEditFixture):
+    """NotebookEdit is matched by the Edit hook (#159/#160 defense-in-depth): a
+    protected `.codearbiter` target is refused; a real notebook passes."""
+
+    def run_notebook(self, notebook_path):
+        payload = json.dumps({
+            "tool_name": "NotebookEdit",
+            "tool_input": {"notebook_path": notebook_path, "new_source": "print(1)"},
+        })
+        return _sh([sys.executable, PRE_EDIT], self.root, input=payload)
+
+    def test_notebookedit_targeting_context_is_blocked(self):
+        self.assertBlocked(self.run_notebook(os.path.join(self.ca, "CONTEXT.md")), "H-18")
+
+    def test_notebookedit_targeting_audit_log_is_blocked(self):
+        self.assertBlocked(self.run_notebook(os.path.join(self.ca, "overrides.log")), "H-05")
+
+    def test_notebookedit_targeting_marker_is_blocked(self):
+        self.assertBlocked(
+            self.run_notebook(os.path.join(self.markers, "security-gate-passed")), "H-19")
+
+    def test_notebookedit_on_real_notebook_is_allowed(self):
+        nb = os.path.join(self.root, "analysis.ipynb")
+        self._write(nb, "{}")
+        self.assertAllowed(self.run_notebook(nb))
+
+
 class TestPreEditAllowPaths(_PreEditFixture):
     """Cases where neither guard should fire."""
 

--- a/plugins/ca/hooks/tests/test_pre_write.py
+++ b/plugins/ca/hooks/tests/test_pre_write.py
@@ -117,6 +117,74 @@ class TestH11Write(_PreWriteFixture):
         self.assertBlocked(self.run_write(os.path.join(self.ddir, "0002-new.md")), "H-11")
 
 
+class TestH18ContextMd(_PreWriteFixture):
+    """#159: CONTEXT.md is the activation switch; a Write may not drop
+    `arbiter: enabled` or corrupt the frontmatter."""
+    CTX = None
+
+    def setUp(self):
+        super().setUp()
+        self.CTX = os.path.join(self.ca, "CONTEXT.md")
+
+    def test_disable_arbiter_is_blocked(self):
+        self.assertBlocked(self.run_write(self.CTX, content="---\narbiter: disabled\n---\n"), "H-18")
+
+    def test_strip_frontmatter_is_blocked(self):
+        self.assertBlocked(self.run_write(self.CTX, content="# ctx\nno frontmatter\n"), "H-18")
+
+    def test_unclosed_frontmatter_is_blocked(self):
+        # opens '---' but never closes -> malformed -> not enabled.
+        self.assertBlocked(self.run_write(self.CTX, content="---\narbiter: enabled\n"), "H-18")
+
+    def test_keep_enabled_stage_bump_is_allowed(self):
+        self.assertAllowed(self.run_write(
+            self.CTX, content="---\narbiter: enabled\nstage: 3\n---\n<!--INITIALIZED-->\nx\n"))
+
+
+class TestH19Markers(_PreWriteFixture):
+    """#160: gate-pass markers are not writable via the Write tool."""
+    def test_write_security_gate_marker_is_blocked(self):
+        self.assertBlocked(
+            self.run_write(os.path.join(self.markers, "security-gate-passed"), content="d\n"), "H-19")
+
+    def test_write_migration_gate_marker_is_blocked(self):
+        self.assertBlocked(
+            self.run_write(os.path.join(self.markers, "migration-gate-passed"), content="d\n"), "H-19")
+
+    def test_write_adr_marker_is_blocked(self):
+        self.assertBlocked(
+            self.run_write(os.path.join(self.markers, "adr-authoring-active"), content="x\n"), "H-19")
+
+
+class TestSymlinkAlias(_PreWriteFixture):
+    """#162: a symlink whose visible path lacks .codearbiter/ but resolves into
+    it must still be classified as protected."""
+    def _symlink(self, link, target):
+        os.symlink(target, os.path.join(self.root, link))
+
+    def test_symlinked_dir_to_codearbiter_blocks_audit_log(self):
+        self._symlink("alias", ".codearbiter")
+        self.assertBlocked(
+            self.run_write(os.path.join(self.root, "alias", "overrides.log")), "H-05")
+
+    def test_symlinked_dir_to_decisions_blocks_adr(self):
+        self._symlink("dlink", os.path.join(".codearbiter", "decisions"))
+        self.assertBlocked(
+            self.run_write(os.path.join(self.root, "dlink", "0002-x.md")), "H-11")
+
+    def test_symlinked_file_to_context_blocks_disable(self):
+        self._symlink("ctxlink", os.path.join(".codearbiter", "CONTEXT.md"))
+        self.assertBlocked(
+            self.run_write(os.path.join(self.root, "ctxlink"),
+                           content="---\narbiter: disabled\n---\n"), "H-18")
+
+    def test_symlinked_marker_dir_blocks_write(self):
+        self._symlink("mlink", os.path.join(".codearbiter", ".markers"))
+        self.assertBlocked(
+            self.run_write(os.path.join(self.root, "mlink", "security-gate-passed"),
+                           content="d\n"), "H-19")
+
+
 class TestPreWriteAllowPaths(_PreWriteFixture):
     def test_disabled_arbiter_is_noop(self):
         self._disable_arbiter()

--- a/plugins/ca/hooks/tests/test_pre_write.py
+++ b/plugins/ca/hooks/tests/test_pre_write.py
@@ -156,11 +156,28 @@ class TestH19Markers(_PreWriteFixture):
             self.run_write(os.path.join(self.markers, "adr-authoring-active"), content="x\n"), "H-19")
 
 
+def _symlinks_supported():
+    """Windows CI runners often lack the privilege to create symlinks; skip the
+    symlink cases there (ubuntu/macos exercise the #162 path fully)."""
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            os.symlink(os.path.join(d, "t"), os.path.join(d, "l"))
+        return True
+    except (OSError, NotImplementedError, AttributeError):
+        return False
+
+
+@unittest.skipUnless(_symlinks_supported(), "symlink creation not permitted here")
 class TestSymlinkAlias(_PreWriteFixture):
     """#162: a symlink whose visible path lacks .codearbiter/ but resolves into
     it must still be classified as protected."""
     def _symlink(self, link, target):
-        os.symlink(target, os.path.join(self.root, link))
+        # target_is_directory matters on Windows: a dir symlink to a
+        # (possibly not-yet-existing) directory must be created as a dir link,
+        # or realpath won't resolve paths beneath it. POSIX ignores the flag.
+        tgt_abs = os.path.join(self.root, target)
+        os.symlink(target, os.path.join(self.root, link),
+                   target_is_directory=os.path.isdir(tgt_abs))
 
     def test_symlinked_dir_to_codearbiter_blocks_audit_log(self):
         self._symlink("alias", ".codearbiter")
@@ -179,6 +196,7 @@ class TestSymlinkAlias(_PreWriteFixture):
                            content="---\narbiter: disabled\n---\n"), "H-18")
 
     def test_symlinked_marker_dir_blocks_write(self):
+        os.makedirs(self.markers, exist_ok=True)  # target must exist for a Windows dir symlink
         self._symlink("mlink", os.path.join(".codearbiter", ".markers"))
         self.assertBlocked(
             self.run_write(os.path.join(self.root, "mlink", "security-gate-passed"),

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -3,6 +3,7 @@
 // farm.ts
 import { readFile as readFile2, writeFile as writeFile2, appendFile, mkdir, rm } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import path3 from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -362,6 +363,48 @@ function isInside(root, target) {
   const rel = path3.relative(root, target);
   return rel === "" || !rel.startsWith("..") && !path3.isAbsolute(rel);
 }
+function repoTopLevel() {
+  try {
+    const out = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      timeout: 5e3
+    });
+    const top = (out.stdout || "").trim();
+    if (out.status === 0 && top) return path3.resolve(top);
+  } catch {
+  }
+  return path3.resolve(process.cwd());
+}
+function validateWorktreeRoot(rawRoot, repo, external) {
+  const root = path3.resolve(rawRoot);
+  if (!external && !isInside(path3.resolve(repo), root))
+    throw new Error(
+      `FARM_WORKTREE_ROOT resolves to '${root}', outside the repository root '${path3.resolve(repo)}'. farm recursively deletes task worktrees under this root, so an out-of-repo root is refused (#163). Point it inside the repo, or set FARM_ALLOW_EXTERNAL_WORKTREE_ROOT=1 to override.`
+    );
+  return root;
+}
+var _allowedWorktreeRoot = null;
+function allowedWorktreeRoot() {
+  if (_allowedWorktreeRoot) return _allowedWorktreeRoot;
+  _allowedWorktreeRoot = validateWorktreeRoot(
+    ENV.worktreeRoot,
+    repoTopLevel(),
+    process.env.FARM_ALLOW_EXTERNAL_WORKTREE_ROOT === "1"
+  );
+  return _allowedWorktreeRoot;
+}
+function _resetAllowedWorktreeRoot() {
+  _allowedWorktreeRoot = null;
+}
+function assertContainedWorktree(wt) {
+  const root = allowedWorktreeRoot();
+  const abs = path3.resolve(wt);
+  if (abs === root || !isInside(root, abs))
+    throw new Error(
+      `refusing to operate on worktree path '${abs}': it must be strictly inside the allowed farm worktree root '${root}' (#163).`
+    );
+  return abs;
+}
 async function runGate(cwd, commands) {
   for (const cmd of commands) {
     const r = await run(SHELL_BIN, [SHELL_FLAG, cmd], cwd, SHELL_OPTS, GATE_TIMEOUT_MS);
@@ -695,6 +738,11 @@ function withMergeLock(fn) {
   return next;
 }
 async function prepareWorktree(branch, wt, from) {
+  try {
+    assertContainedWorktree(wt);
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
   await git(["worktree", "remove", "--force", wt]).catch(() => {
   });
   await rm(wt, { recursive: true, force: true }).catch(() => {
@@ -971,6 +1019,8 @@ function validate(plan) {
   for (const t of plan.tasks) {
     if (!SAFE_TASK_ID.test(t.id))
       throw new Error(`task id "${t.id}" must match [A-Za-z0-9._-], max 64 chars`);
+    if (t.id === "." || t.id === "..")
+      throw new Error(`task id "${t.id}" is reserved (resolves to the worktree root or its parent)`);
     if (ids.has(t.id)) throw new Error(`duplicate task id: ${t.id}`);
     ids.add(t.id);
     if (!t.test || typeof t.test.path !== "string")
@@ -1301,6 +1351,9 @@ if (_thisFile === _entryFile) {
 export {
   DEFAULT_API_BASE_URL,
   SAFE_TASK_ID,
+  _resetAllowedWorktreeRoot,
+  allowedWorktreeRoot,
+  assertContainedWorktree,
   assertSecureBaseUrl,
   buildChatBody,
   buildPrompt,
@@ -1320,5 +1373,6 @@ export {
   runGate,
   runTask,
   screenEntitlements,
-  validate
+  validate,
+  validateWorktreeRoot
 };

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -36,6 +36,7 @@
  */
 import { readFile, writeFile, appendFile, mkdir, rm, stat } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 // v2.rev.0020 god-module split (architecture-003): the process/shell layer, the
@@ -200,6 +201,74 @@ const NOSIGN = ["-c", "commit.gpgsign=false"];
 function isInside(root: string, target: string): boolean {
   const rel = path.relative(root, target);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+// #163: the farm worktree root is env-controlled (FARM_WORKTREE_ROOT) and each
+// task worktree path is <root>/<task.id>, which prepareWorktree rm()'s
+// recursively BEFORE git validates it as a real worktree. Without containment, a
+// broad/misconfigured root (e.g. FARM_WORKTREE_ROOT=/Users/alice) plus a
+// plausible task id (Desktop) recursively deletes an arbitrary directory. Two
+// defenses, both fail-closed: (1) the resolved root must live inside the repo
+// unless an explicit unsafe override is set; (2) every worktree path must be
+// strictly inside that root (never the root itself) at the destructive op.
+function repoTopLevel(): string {
+  try {
+    const out = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+    const top = (out.stdout || "").trim();
+    if (out.status === 0 && top) return path.resolve(top);
+  } catch {
+    /* fall through to cwd */
+  }
+  return path.resolve(process.cwd());
+}
+
+// Pure, side-effect-free root validation (directly unit-testable): the resolved
+// worktree root must live inside `repo` unless `external` opts out. Throws with a
+// remediating message otherwise; returns the resolved absolute root.
+export function validateWorktreeRoot(rawRoot: string, repo: string, external: boolean): string {
+  const root = path.resolve(rawRoot);
+  if (!external && !isInside(path.resolve(repo), root))
+    throw new Error(
+      `FARM_WORKTREE_ROOT resolves to '${root}', outside the repository root '${path.resolve(repo)}'. ` +
+        `farm recursively deletes task worktrees under this root, so an out-of-repo root is ` +
+        `refused (#163). Point it inside the repo, or set FARM_ALLOW_EXTERNAL_WORKTREE_ROOT=1 ` +
+        `to override.`,
+    );
+  return root;
+}
+
+let _allowedWorktreeRoot: string | null = null;
+export function allowedWorktreeRoot(): string {
+  if (_allowedWorktreeRoot) return _allowedWorktreeRoot;
+  _allowedWorktreeRoot = validateWorktreeRoot(
+    ENV.worktreeRoot,
+    repoTopLevel(),
+    process.env.FARM_ALLOW_EXTERNAL_WORKTREE_ROOT === "1",
+  );
+  return _allowedWorktreeRoot;
+}
+
+// Test seam: the module-level cache would otherwise pin the first-resolved root
+// for the whole process, so a suite that varies FARM_WORKTREE_ROOT across cases
+// must reset it. No effect on production (resolved once at run start).
+export function _resetAllowedWorktreeRoot(): void {
+  _allowedWorktreeRoot = null;
+}
+
+// Assert a task worktree path is safely contained before any recursive delete /
+// worktree removal. Returns the resolved path so callers can reuse it.
+export function assertContainedWorktree(wt: string): string {
+  const root = allowedWorktreeRoot();
+  const abs = path.resolve(wt);
+  if (abs === root || !isInside(root, abs))
+    throw new Error(
+      `refusing to operate on worktree path '${abs}': it must be strictly inside the allowed ` +
+        `farm worktree root '${root}' (#163).`,
+    );
+  return abs;
 }
 
 // --------------------------------------------------------------------------
@@ -883,6 +952,15 @@ function withMergeLock<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 async function prepareWorktree(branch: string, wt: string, from: string): Promise<string | null> {
+  // #163: fail closed before the recursive delete — the resolved path must be
+  // strictly inside the allowed (in-repo) farm worktree root. This is the
+  // load-bearing guard: `rm(wt, {recursive, force})` below is the exact
+  // destructive op an out-of-repo root + plausible task id would weaponize.
+  try {
+    assertContainedWorktree(wt);
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
   // Clean any stale worktree dir and branch so a re-run doesn't trip over the
   // leftovers of a prior run (git worktree add -b fails if the branch exists).
   await git(["worktree", "remove", "--force", wt]).catch(() => {});
@@ -1377,6 +1455,13 @@ export function validate(plan: Plan) {
     // names and worktree paths derived from it
     if (!SAFE_TASK_ID.test(t.id))
       throw new Error(`task id "${t.id}" must match [A-Za-z0-9._-], max 64 chars`);
+    // #163: SAFE_TASK_ID admits "." and ".." (both are all-dot strings), which
+    // as a worktree path segment resolve to the root itself or its parent —
+    // `path.resolve(worktreeRoot, "..")` escapes the root, and "." names the
+    // root, both feeding a recursive delete. Reject them explicitly at the
+    // authoring boundary (assertContainedWorktree is the runtime backstop).
+    if (t.id === "." || t.id === "..")
+      throw new Error(`task id "${t.id}" is reserved (resolves to the worktree root or its parent)`);
     if (ids.has(t.id)) throw new Error(`duplicate task id: ${t.id}`);
     ids.add(t.id);
 

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -2,13 +2,13 @@
  * Unit tests for farm.ts pure-function core.
  * These test the exported helpers directly without spawning a subprocess.
  */
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, rm as fsRm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter } from "./farm.ts";
+import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot } from "./farm.ts";
 import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 import { scrubbedEnv } from "./exec.ts";
@@ -274,6 +274,17 @@ describe("validate — task id safety (B-2)", () => {
 
   it("accepts an id of exactly 64 characters", () => {
     expect(() => validate(basePlan({ id: "a".repeat(64) }))).not.toThrow();
+  });
+
+  // #163: "." and ".." satisfy SAFE_TASK_ID (all-dot strings) but as a worktree
+  // path segment resolve to the root itself / its parent, feeding a recursive
+  // delete. They must be rejected explicitly.
+  it("rejects the reserved id '.'", () => {
+    expect(() => validate(basePlan({ id: "." }))).toThrow(/reserved/);
+  });
+
+  it("rejects the reserved id '..'", () => {
+    expect(() => validate(basePlan({ id: ".." }))).toThrow(/reserved/);
   });
 });
 
@@ -1717,5 +1728,55 @@ describe("F2 — captureInScope (failed-attempt capture before reset)", () => {
     } finally {
       await fsRm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #163 — worktree-root containment. The env-controlled FARM_WORKTREE_ROOT plus a
+// plan-controlled task id feed a recursive delete; these guard that a
+// misconfigured (out-of-repo) root is refused and no worktree path escapes it.
+// ---------------------------------------------------------------------------
+describe("validateWorktreeRoot — out-of-repo root refused (#163)", () => {
+  it("rejects a root outside the repo (the /Users/alice misconfig)", () => {
+    expect(() => validateWorktreeRoot("/Users/alice", "/Users/alice/proj", false)).toThrow(
+      /outside the repository root/,
+    );
+  });
+
+  it("accepts an in-repo relative root (the default)", () => {
+    const repo = path.resolve(".");
+    expect(() => validateWorktreeRoot(".farm/worktrees", repo, false)).not.toThrow();
+    expect(validateWorktreeRoot(".farm/worktrees", repo, false)).toBe(
+      path.resolve(".farm/worktrees"),
+    );
+  });
+
+  it("accepts an in-repo absolute root", () => {
+    expect(() => validateWorktreeRoot("/repo/.farm/wt", "/repo", false)).not.toThrow();
+  });
+
+  it("permits an out-of-repo root only with the explicit override", () => {
+    expect(() => validateWorktreeRoot("/tmp/wt", "/repo", true)).not.toThrow();
+  });
+});
+
+describe("assertContainedWorktree — no path escapes the root (#163)", () => {
+  beforeEach(() => _resetAllowedWorktreeRoot());
+  afterEach(() => _resetAllowedWorktreeRoot());
+
+  it("allows a normal task worktree under the default root", () => {
+    const wt = path.resolve(allowedWorktreeRoot(), "task-a");
+    expect(assertContainedWorktree(wt)).toBe(wt);
+  });
+
+  it("refuses the root itself (a '.' id resolves here)", () => {
+    expect(() => assertContainedWorktree(allowedWorktreeRoot())).toThrow(/strictly inside/);
+  });
+
+  it("refuses a path outside the root (a '..' id / sibling escape)", () => {
+    expect(() => assertContainedWorktree(path.resolve(allowedWorktreeRoot(), "..", "evil"))).toThrow(
+      /strictly inside/,
+    );
+    expect(() => assertContainedWorktree("/etc")).toThrow(/strictly inside/);
   });
 });


### PR DESCRIPTION
## What & why

Five P1 reports (thanks @tg12) each showed the enforcement layer being enforced against a *forgeable or lexical* surface rather than the real underlying operation. Each is fixed below, and for every fix the rest of the repo was swept for the same class.

**#159 — CONTEXT.md was an unprotected kill switch.** Every hook gates on `arbiter: enabled` in `.codearbiter/CONTEXT.md`, but nothing protected that file — writing `arbiter: disabled` made every gate dormant. `pre-write`/`pre-edit` now block a CONTEXT.md write/edit whose *resulting* content drops `arbiter: enabled` or corrupts the frontmatter (`H-18`, reusing a new `frontmatter_enabled_text`); `pre-bash` adds the shell flank. Stage bumps that keep it enabled still pass.

**#160 — gate-pass markers were forgeable.** `.codearbiter/.markers/*` were writable repo files, so a hand-written marker forged a security/migration/ADR gate pass. `pre-write`/`pre-edit` (`H-19`) block tool writes to any marker; `pre-bash` blocks shell redirects/verbs naming `security-gate-passed`/`migration-gate-passed`. This closes every forge-*by-write* vector (the demonstrated exploit). Note: *blocking the producer scripts themselves is unworkable* — the sanctioned gate runs the identical command, so the hook can't distinguish a genuine post-review run from a forged one. That residual is inherent to a single-agent session and is documented in-code; the `/adr` `touch` and the python producers keep working.

**#161 — shell indirection bypassed the git gates → real git hooks.** `pre-bash` matches the literal command string, so `g=git; c=commit; $g $c` builds a real commit it never sees, and there was no enforcement below it. Added repo-level `pre-commit`/`pre-push` hooks (`git-enforce.py` installed by `_githooks.py`) that enforce H-01/H-02/H-09b/H-10b/H-14 at the git operation itself — spelling-proof. They reuse the same `_hooklib` detection primitives (no drift), fail closed on git read errors, select one interpreter (never `python3 X || python X`, which would swallow a BLOCK / drain pre-push stdin), honor `core.hooksPath`/worktrees, and **never clobber a foreign hook**. Installed idempotently at `/ca:init` and every SessionStart. `pre-bash` stays as the fast first line.

**#162 — symlink aliases bypassed the Write/Edit path guards.** `pre-write`/`pre-edit` classified the raw `file_path`, so a symlink whose visible path lacked `.codearbiter/` slipped past H-05/H-11. All protected-path checks now route through a new `classify_protected()` that resolves realpath (the approach `post-write-edit`/`pre-read` already used) and checks raw + resolved. Also wired `NotebookEdit` into the guard (it was matched by no hook).

**#163 — farm could `rm -rf` outside its workspace.** `prepareWorktree` resolved a delete path from env-controlled `FARM_WORKTREE_ROOT` + plan-controlled task id with no containment (and `SAFE_TASK_ID` admitted `.`/`..`). Now: an out-of-repo root is refused unless `FARM_ALLOW_EXTERNAL_WORKTREE_ROOT=1`; every worktree path is asserted strictly inside that root before the recursive delete (reusing the existing `isInside()`); and `validate()` rejects `.`/`..` ids.

Closes #159. Closes #160. Closes #161. Closes #162. Closes #163.

## Type of change

- [x] `fix`: bug fix
- [ ] `feat`: new behavior
- [ ] `docs`: documentation only
- [ ] `refactor`: no behavior change
- [ ] `chore`: deps, tooling, reverts

## Checklist

- [x] Branched off `main` (not a direct write to `main`)
- [x] Conventional Commits used in the commit messages
- [x] Tests added/updated for behavioral changes (`plugins/ca/hooks/tests/`)
- [x] Full suite green locally (585 hook tests + 5 CI guard matrices; farm typecheck + 180 vitest tests; `farm.js` rebuilt in sync)
- [ ] Version bumped if any shipped payload file changed — the current version `2.6.1` is **unpublished** (no `v2.6.1` tag), so these ride it and the CI version-bump gate passes; no bump needed
- [ ] `CHANGELOG.md` entry added — deferred to the per-release "roll the notes" step, matching repo convention
- [ ] ADR recorded — see reviewer notes: the git-hooks-install surface may warrant one
- [x] New behavior ships off-by-default / `preview` where appropriate — all new gates run **only in arbiter-enabled repos**; the git-hook install is idempotent and non-clobbering
- [ ] `docs/hooks.md` updated — see reviewer notes

## Notes for the reviewer

- **New hook files:** `git-enforce.py` (git-level enforcer), `_githooks.py` (installer). No network access added — `git-enforce.py` shells out only to local `git`, preserving the no-network invariant. `docs/hooks.md` was **not** updated in this PR; happy to follow up, or fold it in here.
- **The #160 scope call is deliberate** — I did not add a producer-blocking gate because it would break the legitimate gate flow (identical command line); the honest boundary is documented in `pre-bash.py`/`security-pass.py` comments. If you'd prefer the heavier SubagentStop-attestation route, that's a larger follow-up.
- **git-hook install surface** (`_githooks.py` wired into `init-codearbiter.py` + `session-start.py`) is the one arguably-architectural addition — flagging in case you want an ADR before merge.
- Tested cross-platform-safely (stdlib only, interpreter-fallback shim mirroring `hooks.json`), but the Windows `sh`-shim path was reasoned about, not run here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqTxpxEkbDHb6AuADohtMR)_