### PR TITLE
ci: add dispatch-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: release
+
+# Manual publish path for the `ca` plugin, driven by workflow_dispatch so a
+# release can be cut without a local machine. The runner's GITHUB_TOKEN carries
+# `contents: write`, so it can create the tag and GitHub Release that a
+# fine-grained integration token may not. This is the mechanical publish only:
+# the version, the README/badge surfaces, and the CHANGELOG section must already
+# be merged to the default branch (that is the /ca:release skill's Phase 1). The
+# job asserts the requested version equals plugins/ca/.claude-plugin/plugin.json,
+# extracts the matching CHANGELOG section as the notes, and is idempotent — a
+# re-run when the tag/Release already exists is a no-op, not a failure.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "ca version to release (must equal plugins/ca/.claude-plugin/plugin.json), e.g. 2.6.1"
+        required: true
+      summary:
+        description: "Optional release-title summary (appended after the version)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Publish only from the default branch, where the merged CHANGELOG section lives.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and verify version against the manifest
+        id: v
+        run: |
+          set -euo pipefail
+          MANIFEST=$(node -p "require('./plugins/ca/.claude-plugin/plugin.json').version")
+          REQ="${{ github.event.inputs.confirm }}"
+          if [ "$REQ" != "$MANIFEST" ]; then
+            echo "::error::requested '$REQ' does not equal plugin.json version '$MANIFEST' — bump/align first"
+            exit 1
+          fi
+          echo "version=$MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "tag=v$MANIFEST" >> "$GITHUB_OUTPUT"
+
+      - name: Extract the CHANGELOG section as release notes
+        run: |
+          set -euo pipefail
+          VER="${{ steps.v.outputs.version }}"
+          # Capture from "## [VER]" up to (not including) the next "## [" section heading.
+          awk -v v="## [$VER]" 'index($0,v)==1{f=1;print;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md > notes.md
+          # Trim a trailing Keep-a-Changelog "---" separator and blank lines.
+          python3 - <<'PY'
+          import re
+          t = open("notes.md").read().rstrip()
+          open("notes.md", "w").write(re.sub(r"\n+---$", "", t).rstrip() + "\n")
+          PY
+          test -s notes.md || { echo "::error::no CHANGELOG section found for $VER"; exit 1; }
+          # The notes' first heading must match the tag (the same guard /ca:release Phase 3 runs).
+          python3 .github/scripts/_releaselib.py notes-match "${{ steps.v.outputs.tag }}" notes.md
+          echo "---- notes.md ----"; head -1 notes.md
+
+      - name: Create the tag and GitHub Release (idempotent)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.v.outputs.tag }}"
+          VER="${{ steps.v.outputs.version }}"
+          SUM="${{ github.event.inputs.summary }}"
+          if [ -n "$SUM" ]; then TITLE="codeArbiter $VER: $SUM"; else TITLE="codeArbiter $VER"; fi
+
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "tag $TAG already on remote — skipping tag creation"
+          else
+            printf '%s\n\nReleased-at: %s\n' "$(cat notes.md)" "$(date +%F)" > tagmsg.txt
+            git tag -a "$TAG" -F tagmsg.txt "$GITHUB_SHA"
+            git push origin "refs/tags/$TAG"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists — nothing to publish"
+          else
+            # This dispatched release is the newest by publish time; mark it latest.
+            gh release create "$TAG" \
+              --title "$TITLE" \
+              --notes-file notes.md \
+              --target "$GITHUB_SHA" \
+              --latest --verify-tag
+          fi
+
+          # Verify publication rather than assume it (a create can partially succeed).
+          gh release view "$TAG" --json url,isDraft,tagName
+          DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)
+          [ "$DRAFT" = "false" ] || { echo "::error::release $TAG is draft/unpublished"; exit 1; }


### PR DESCRIPTION
## What & why

Adds a `workflow_dispatch` **release** workflow so a `ca` release can be published without a local machine. The 2.6.1 release is fully staged on `main` (version, README badges, CHANGELOG section, `farm.js` all in sync), but the only credentials available to the assistant session can push branches, not **tags** (GitHub returns 403 on tag pushes), and there's no `gh`/Release API access. A GitHub Actions runner's `GITHUB_TOKEN` **can** create tags and Releases with `contents: write`, so this workflow is the publish path.

It is the **mechanical publish only** — `/ca:release` Phase 1 (version bump, badge/count sync, CHANGELOG roll) already landed via #164/#165. On dispatch the job:
1. asserts the requested version equals `plugins/ca/.claude-plugin/plugin.json`,
2. extracts the matching `## [X.Y.Z]` CHANGELOG section as the notes and runs the `_releaselib notes-match` guard,
3. creates the annotated tag at the dispatched `main` SHA and publishes the GitHub Release (`--latest --verify-tag`),
4. verifies the Release is non-draft.

Idempotent: a re-run when the tag/Release already exists is a no-op, not a failure. Runs only from `main`, `contents: write` only.

## Type of change

- [ ] `fix`: bug fix
- [ ] `feat`: new behavior
- [ ] `docs`: documentation only
- [ ] `refactor`: no behavior change
- [x] `chore`: deps, tooling, reverts

## Checklist

- [x] Branched off `main` (not a direct write to `main`)
- [x] Conventional Commits used in the commit messages
- [ ] Tests added/updated — N/A (CI workflow; extraction + notes-match guard validated locally against main's CHANGELOG)
- [x] Full suite green locally (YAML parses; notes extraction + `_releaselib.py notes-match v2.6.1` exit 0)
- [x] Version bumped if any shipped payload file changed — N/A, no `plugins/ca/**` payload change
- [ ] `CHANGELOG.md` entry — N/A (tooling)
- [x] Hooks unchanged

## Notes for the reviewer

After you merge this, I'll trigger it (`workflow_dispatch`, input `confirm: 2.6.1`, `summary: P1 security hardening`) to tag `v2.6.1` and publish the Release, then confirm the read-back. If an org ruleset blocks *all* tag creation (even Actions), the run will fail on the tag push and it'll need an admin — but the app-token 403 is most likely an integration-scope limit, not a repo-wide tag ban.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqTxpxEkbDHb6AuADohtMR)_