### PR TITLE
ci(release): set git committer identity before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
           SUM="${{ github.event.inputs.summary }}"
           if [ -n "$SUM" ]; then TITLE="codeArbiter $VER: $SUM"; else TITLE="codeArbiter $VER"; fi
 
+          # An annotated tag needs a committer identity; the runner has none by default.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
             echo "tag $TAG already on remote — skipping tag creation"
           else


### PR DESCRIPTION
## What & why

The first `release` dispatch (for v2.6.1) failed at `git tag -a` with `fatal: empty ident name ... not allowed` — GitHub-hosted runners ship no `git user.name`/`user.email`, which an **annotated** tag requires. This sets the `github-actions[bot]` identity in the tag step.

One-line fix, no behavior change otherwise. The run reached the tag step cleanly: the version-equals-manifest and `_releaselib notes-match` guards both passed, so this is the only thing between us and a published `v2.6.1`.

## Type of change

- [x] `fix`: bug fix
- [ ] `feat`: new behavior
- [ ] `docs`: documentation only
- [ ] `refactor`: no behavior change
- [ ] `chore`: deps, tooling, reverts

## Checklist

- [x] Branched off `main` (not a direct write to `main`)
- [x] Conventional Commits used in the commit messages
- [ ] Tests added/updated — N/A (CI workflow; YAML re-validated)
- [x] Full suite green locally (YAML parses)
- [x] Version bumped if payload changed — N/A
- [x] Hooks unchanged

## Notes for the reviewer

Merge this and I'll re-trigger the release (idempotent — it'll create `v2.6.1` + the Release, or no-op if somehow already present) and confirm the read-back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqTxpxEkbDHb6AuADohtMR)_