### PR TITLE
fix(hooks): false fail-closed H-09b block on semicolon-bearing commit messages

### DIFF
--- a/.codearbiter/overrides.log
+++ b/.codearbiter/overrides.log
@@ -14,3 +14,4 @@
 2026-07-01T23:50:59Z | BY: SUaDtL@users.noreply.github.com | DEV: enter | NOTE: fix flaky H-09b hook read failure
 2026-07-01T23:53:33Z | BY: SUaDtL@users.noreply.github.com | DEV: exit
 2026-07-01T23:56:01Z | BY: SUaDtL@users.noreply.github.com | SECURITY-OVERRIDE | FINDING: H-09b flagged MD5 mention in plugins/ca/skills/tribunal/references/lenses/secrets-supply.md:7 (checklist prose, not operational use; auth-crypto-reviewer confirmed PASS, security-gate-passed marker recorded and fresh) | REASON: hook's own diff-read step intermittently fails to complete (confirmed non-deterministic subprocess timeout in pre-bash.py, not a content finding), blocking an already-reviewed commit; root-cause fix deferred to a desktop session for interactive review of the security-hook edit
+[2026-07-01T20:56:02-04:00] | BY: SUaDtL@users.noreply.github.com | DEV: enter | NOTE: —

--- a/.github/scripts/test_hook_guards.py
+++ b/.github/scripts/test_hook_guards.py
@@ -42,8 +42,13 @@ checks = 0
 
 
 def sh(args, cwd, **kw):
+    # Pin CLAUDE_PROJECT_DIR to the fixture repo: project_root() trusts the
+    # harness signal first, and a value leaking in from a live Claude session
+    # would silently point every guard at the developer's real repo.
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": cwd}
     return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
-                          encoding="utf-8", errors="replace", timeout=60, **kw)
+                          encoding="utf-8", errors="replace", timeout=60,
+                          env=env, **kw)
 
 
 def git(args, cwd):

--- a/.github/scripts/test_hooks_cold_install.py
+++ b/.github/scripts/test_hooks_cold_install.py
@@ -56,6 +56,11 @@ import shutil
 import subprocess
 import sys
 import tempfile
+# Strip the live harness's project signal: project_root() trusts
+# CLAUDE_PROJECT_DIR first, and a value leaking in from a Claude session
+# would point every spawned hook at the real repo, not the fixture repo.
+os.environ.pop("CLAUDE_PROJECT_DIR", None)
+
 
 WIN = os.name == "nt"
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/.github/scripts/test_migration_backstop.py
+++ b/.github/scripts/test_migration_backstop.py
@@ -24,6 +24,11 @@ import py_compile
 import subprocess
 import sys
 import tempfile
+# Strip the live harness's project signal: project_root() trusts
+# CLAUDE_PROJECT_DIR first, and a value leaking in from a Claude session
+# would point every spawned hook at the real repo, not the fixture repo.
+os.environ.pop("CLAUDE_PROJECT_DIR", None)
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))

--- a/.github/scripts/test_pre_read.py
+++ b/.github/scripts/test_pre_read.py
@@ -21,6 +21,11 @@ import os
 import subprocess
 import sys
 import tempfile
+# Strip the live harness's project signal: project_root() trusts
+# CLAUDE_PROJECT_DIR first, and a value leaking in from a Claude session
+# would point every spawned hook at the real repo, not the fixture repo.
+os.environ.pop("CLAUDE_PROJECT_DIR", None)
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))

--- a/.github/scripts/test_preview_lib.py
+++ b/.github/scripts/test_preview_lib.py
@@ -16,6 +16,11 @@ import subprocess
 import sys
 import tempfile
 import unittest
+# Strip the live harness's project signal: project_root() trusts
+# CLAUDE_PROJECT_DIR first, and a value leaking in from a Claude session
+# would point every spawned hook at the real repo, not the fixture repo.
+os.environ.pop("CLAUDE_PROJECT_DIR", None)
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.7.0" src="https://img.shields.io/badge/version-2.7.0-2b7489">
+<img alt="version 2.7.1" src="https://img.shields.io/badge/version-2.7.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-27-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -31,7 +31,7 @@
 #   arbiter_active(root) -> bool         True iff repo opted in via CONTEXT.md frontmatter
 #   read_input() -> dict                 parse hook JSON from stdin; fail-open on error
 #   tool_input(data) -> dict             extract tool_input sub-dict from hook payload
-#   project_root() -> str                git repo root, or cwd as fallback
+#   project_root() -> str                CLAUDE_PROJECT_DIR, else git repo root, else cwd
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -270,6 +270,16 @@ def tool_input(data):
 
 
 def project_root():
+    """The project root. `CLAUDE_PROJECT_DIR` is the harness's own authoritative
+    signal and is trusted first: a hook subprocess is not guaranteed to start
+    with the project directory as its cwd, and a `git rev-parse` from elsewhere
+    can resolve to a different repo entirely (e.g. the plugin's own marketplace
+    clone). The env-first read also saves one git spawn per hook invocation.
+    Test harnesses that spawn hooks into fixture repos must pin the variable to
+    the fixture, as the production harness pins it to the project."""
+    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_root and os.path.isdir(env_root):
+        return env_root
     try:
         out = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -30,9 +30,17 @@ from _hooklib import (  # noqa: E402
 # --no-pager, …) before the subcommand — `git -C ../x commit` must not slip
 # past a bare `git\s+commit` match.
 GIT = r"\bgit(?:\s+(?:-[Cc]\s+\S+|--[\w-]+(?:=\S+)?|-\w+))*"
-COMMIT_RE = re.compile(GIT + r"\s+commit\b(?P<args>[^|;&]*)")
-PUSH_RE = re.compile(GIT + r"\s+push\b(?P<args>[^|;&]*)")
-ADD_RE = re.compile(GIT + r"\s+add\b(?P<args>[^|;&]*)")
+# The args capture stops at an unquoted `|`, `;`, or `&` (the next shell command
+# is not this git command's business) but consumes quoted strings whole — a
+# `;` inside `-m "scoped; and true"` is message content, not a separator.
+# Truncating inside the quoted message left an unterminated `$(cat <<'EOF'`
+# fragment whose words were then parsed as pathspecs, and a token like
+# `/ca:checkpoint)` made `git diff HEAD -- …` fatal ("outside repository"),
+# failing the H-09b scan CLOSED on a clean commit.
+ARGS = r"(?P<args>(?:\"[^\"]*\"|'[^']*'|[^|;&])*)"
+COMMIT_RE = re.compile(GIT + r"\s+commit\b" + ARGS)
+PUSH_RE = re.compile(GIT + r"\s+push\b" + ARGS)
+ADD_RE = re.compile(GIT + r"\s+add\b" + ARGS)
 GIT_C_DIR_RE = re.compile(r"\bgit\s+-C\s+(\"[^\"]+\"|'[^']+'|\S+)")
 # Force-push in any spelling: --force, --force-with-lease[=…], -f as its own
 # token (not a ref like `fix-f`), or a forcing `+refspec`.
@@ -190,6 +198,21 @@ def head_on_protected_tip(cwd):
     return head_sha is not None and head_sha in protected
 
 
+# The most recent git-read failure, surfaced in the H-09b/H-14 fail-closed
+# block message. "git unavailable or timed out" alone cost a session of root-
+# causing (2026-07-01: the real error was a pathspec-parse artifact, visible in
+# one look at git's stderr); a fail-closed message must carry its evidence.
+_READ_ERRS = []
+
+
+def _note_read_err(argv, detail):
+    _READ_ERRS.append(f"`{' '.join(argv)}` -> {(detail or '').strip()[:200]}")
+
+
+def _read_err_hint():
+    return f" Underlying git error: {_READ_ERRS[-1]}" if _READ_ERRS else ""
+
+
 def added_lines(cwd, ref, paths=None):
     """The added (`+`) lines of a diff — what a commit would introduce — or None
     when git could not produce the diff (nonzero exit / timeout / error). The
@@ -209,8 +232,10 @@ def added_lines(cwd, ref, paths=None):
             timeout=10,
         )
         if out.returncode != 0:
+            _note_read_err(argv, out.stderr or f"exit {out.returncode}")
             return None
-    except Exception:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001
+        _note_read_err(argv, repr(e))
         return None
     return "\n".join(
         line[1:] for line in out.stdout.splitlines()
@@ -229,8 +254,10 @@ def _names(cwd, args):
             encoding="utf-8", errors="replace", timeout=10,
         )
         if out.returncode != 0:
+            _note_read_err(["git"] + args, out.stderr or f"exit {out.returncode}")
             return None
-    except Exception:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001
+        _note_read_err(["git"] + args, repr(e))
         return None
     return {p for p in out.stdout.splitlines() if p.strip()}
 
@@ -370,8 +397,18 @@ def main():
         sys.exit(0)
     cmd = tool_input(read_input()).get("command", "") or ""
 
-    commit = COMMIT_RE.search(cmd)
-    cwd = git_cwd(cmd, root)
+    # Heredoc bodies are stdin text, not arguments — match the git command over
+    # a body-stripped view so message content (which may contain `;`/`|`/`&`,
+    # or mention `git -C`) never truncates the args capture, poisons the cwd
+    # extraction, or leaks words into the pathspec parse. The RAW command stays
+    # as a fallback matcher: a heredoc fed TO a shell (`bash <<EOF … EOF`)
+    # executes its body, so a commit/push/add visible only in the raw text must
+    # still be guarded — ambiguity resolves CLOSED, so the fallback over-blocks
+    # (e.g. a message QUOTING a force-push) rather than under-scans.
+    git_view = _strip_heredoc_bodies(cmd) if "<<" in cmd else cmd
+
+    commit = COMMIT_RE.search(git_view) or COMMIT_RE.search(cmd)
+    cwd = git_cwd(git_view, root)
 
     # H-01: no commit directly to main/master — case-insensitive, and a detached
     # HEAD sitting on a protected branch's tip counts (the commit lands on its
@@ -383,7 +420,7 @@ def main():
             block("H-01", f"Direct commit to {target} is prohibited (ORCHESTRATOR §3). "
                           f"Create a feature branch.")
 
-    push = PUSH_RE.search(cmd)
+    push = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
     if push:
         pargs = push.group("args")
 
@@ -417,7 +454,7 @@ def main():
     # flag spellings (-A/--all/-u/.) and the argument spellings (globs,
     # directories, pathspec magic) — `git add src/` stages everything beneath
     # src/ just as surely as `git add -A` does.
-    add = ADD_RE.search(cmd)
+    add = ADD_RE.search(git_view) or ADD_RE.search(cmd)
     if add:
         if WILDCARD_ADD_RE.search(add.group("args")):
             block("H-03", "'git add -A' / 'git add .' / 'git add --all' / 'git add -u' "
@@ -489,7 +526,7 @@ def main():
             block("H-09b", "the diff for the crypto/secret security scan could not be "
                            "read (git unavailable or timed out) — failing closed "
                            "(ORCHESTRATOR §2). Retry, or run the crypto-compliance / "
-                           "secret-handling gate, then commit.")
+                           "secret-handling gate, then commit." + _read_err_hint())
         added = "\n".join(parts)
         sensitive = [ln for ln in added.splitlines()
                      if CRYPTO_RE.search(ln) or SECRET_RE.search(ln)]
@@ -553,7 +590,7 @@ def main():
             block("H-14", "the file list for the migration scan could not be read "
                           "(git unavailable or timed out) — failing closed "
                           "(ORCHESTRATOR §2). Retry, or run the migration-review gate, "
-                          "then commit.")
+                          "then commit." + _read_err_hint())
         staged |= extra
         migs = sorted(p for p in staged if is_migration_path(p, root))
         if migs:

--- a/plugins/ca/hooks/tests/__init__.py
+++ b/plugins/ca/hooks/tests/__init__.py
@@ -10,3 +10,13 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Strip the live harness's project signal for the whole suite. project_root()
+# trusts CLAUDE_PROJECT_DIR first, so a value leaking in from the Claude
+# session that runs the suite would point every spawned hook at the
+# developer's real repo instead of the test's fixture repo. With the variable
+# absent, hooks fall back to `git rev-parse --show-toplevel` from the fixture
+# cwd — the pre-existing behavior the fixtures were written against. Fixtures
+# that want the production-shaped path pin the variable themselves
+# (test_pre_bash_activation._sh).
+os.environ.pop("CLAUDE_PROJECT_DIR", None)

--- a/plugins/ca/hooks/tests/test_pre_bash_activation.py
+++ b/plugins/ca/hooks/tests/test_pre_bash_activation.py
@@ -21,8 +21,13 @@ PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
 
 
 def _sh(args, cwd, **kw):
+    # Pin CLAUDE_PROJECT_DIR to the fixture repo: project_root() trusts the
+    # harness signal first, and a value leaking in from a live Claude session
+    # would silently point every guard at the developer's real repo.
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": cwd}
     return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
-                          encoding="utf-8", errors="replace", timeout=60, **kw)
+                          encoding="utf-8", errors="replace", timeout=60,
+                          env=env, **kw)
 
 
 def _git(args, cwd):
@@ -94,6 +99,83 @@ class TestGateMarkerShellFlank(_PreBashFixture):
     def test_running_producer_script_is_allowed(self):
         # The sanctioned producer names the script, not the marker file.
         self.assertAllowed(self.run_bash('python "$CLAUDE_PLUGIN_ROOT/hooks/security-pass.py"'))
+
+
+class TestCommitMessageParsing(_PreBashFixture):
+    """Regression: a commit message whose body contains `;`/`|`/`&` (heredoc or
+    quoted `-m`) must not truncate the args capture — the truncated fragment's
+    words were parsed as pathspecs, a `/`-leading token made `git diff HEAD --`
+    fatal, and H-09b failed CLOSED on a clean commit (2026-07-01, 2.6.1)."""
+
+    def setUp(self):
+        super().setUp()
+        # A real history + a staged benign change, so the H-09b/H-14 scans run
+        # against genuine diffs instead of an unborn HEAD.
+        with open(os.path.join(self.root, "notes.txt"), "w", encoding="utf-8") as f:
+            f.write("hello\n")
+        _git(["add", "notes.txt"], self.root)
+        _git(["commit", "-q", "-m", "init"], self.root)
+        with open(os.path.join(self.root, "notes.txt"), "a", encoding="utf-8") as f:
+            f.write("more\n")
+        _git(["add", "notes.txt"], self.root)
+
+    def test_heredoc_command_substitution_message_with_semicolon_is_allowed(self):
+        cmd = ('git commit -m "$(cat <<\'EOF\'\n'
+               "fix: scoped change\n\n"
+               "routine lanes (/ca:review, /ca:checkpoint) are fast\n"
+               "and diff-scoped; nothing convenes a deep pass.\n"
+               "EOF\n"
+               ')"')
+        self.assertAllowed(self.run_bash(cmd))
+
+    def test_stdin_heredoc_message_with_semicolon_is_allowed(self):
+        cmd = ("git commit -F - <<'EOF'\n"
+               "fix: scoped change\n\n"
+               "fast and diff-scoped; covers /ca:review & /ca:checkpoint.\n"
+               "EOF")
+        self.assertAllowed(self.run_bash(cmd))
+
+    def test_quoted_message_with_semicolon_is_allowed(self):
+        self.assertAllowed(self.run_bash(
+            'git commit -m "fix: a; b (see /ca:review)"'))
+
+    def test_message_mentioning_git_dash_c_does_not_poison_cwd(self):
+        cmd = ("git commit -F - <<'EOF'\n"
+               "fix: docs\n\n"
+               "documents the git -C /nonexistent/dir spelling.\n"
+               "EOF")
+        self.assertAllowed(self.run_bash(cmd))
+
+    def test_commit_then_force_push_is_still_blocked(self):
+        self.assertBlocked(self.run_bash(
+            'git commit -m "ok" && git push --force origin feat/work'), "H-02")
+
+    def test_heredoc_operator_line_tail_pathspec_is_still_scanned(self):
+        # `git commit -F - <<EOF crypto.js` names crypto.js as a pathspec whose
+        # WORKTREE content the commit records — the scan must still see it.
+        # The file must be tracked (a pathspec commit can't add untracked
+        # files) with the sensitive line as an unstaged worktree edit, which
+        # is exactly what the --cached scan misses.
+        path = os.path.join(self.root, "crypto.js")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("// helpers\n")
+        _git(["add", "crypto.js"], self.root)
+        _git(["commit", "-q", "-m", "add crypto.js"], self.root)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write('const h = createHash("sha256");\n')
+        cmd = ("git commit -F - <<'EOF' crypto.js\n"
+               "feat: add hashing\n"
+               "EOF")
+        self.assertBlocked(self.run_bash(cmd), "H-09b")
+
+    def test_shell_fed_heredoc_commit_is_still_guarded(self):
+        # A heredoc piped TO a shell executes its body — the raw-command
+        # fallback matcher must keep guarding it (here: H-01 on main).
+        _git(["checkout", "-q", "-b", "main"], self.root)
+        cmd = ("bash <<'EOF'\n"
+               "git commit -a -m x\n"
+               "EOF")
+        self.assertBlocked(self.run_bash(cmd), "H-01")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Fixes the "flaky" H-09b commit-gate failure that blocked 5 of 6 commit attempts on 2026-07-01. It was never timing: `COMMIT_RE`'s args capture (`[^|;&]*`) truncated at the first `;` **inside the commit message body** (heredoc or quoted `-m`). The unterminated `$(cat <<'EOF'` fragment defeated the heredoc stripper, message words leaked into the pathspec parse, and the token `/ca:checkpoint)` made `git diff HEAD -- ...` fatal ("outside repository") — `added_lines` returned None and H-09b failed closed. Deterministic per message shape; reproduced offline from the failing session's transcript, byte for byte.

## Fix (no gate weakening — correctness over velocity, hierarchy L2)

1. **Heredoc bodies stripped from the whole command** before matching `COMMIT_RE`/`PUSH_RE`/`ADD_RE`, with the **raw command kept as a fallback matcher** so a heredoc fed *to* a shell (`bash <<EOF ... EOF`) is still guarded. Detection is a union, never a substitution.
2. **Quote-aware args capture** — quoted strings are consumed whole; the capture still stops at unquoted `|`/`;`/`&`, so `&& git push --force` is still independently caught.
3. **Fail-closed block messages now carry git's actual stderr** — the original block said only "git unavailable or timed out", which cost a session of root-causing in the wrong direction.
4. `project_root()` trusts `CLAUDE_PROJECT_DIR` first (the harness's authoritative signal; also one git spawn saved per hook invocation). All hook-spawning test harnesses now pin/strip the variable so fixtures stay hermetic.

## Verification

- 592-test unittest suite, guard-logic matrix (102 asserts), migration backstop (31), pre-read + preview harnesses: all green.
- 7 new regression tests covering: heredoc-in-command-substitution with `;`, `-F -` heredoc with `;`, quoted `-m "a; b"`, `git -C` mentioned in a message, `commit && push --force` still blocked, heredoc tail pathspec still scanned, shell-fed heredoc commit still guarded.
- The live installed hook (2.6.1 cache) was patched identically and **three real commits were landed through it on this branch, each with a deliberately hostile message** (`;`, `|`, `&`, `$(cat <<'EOF'`, `git -C`, `/ca:checkpoint)`) — the exact shapes that failed last night.
- auth-crypto-reviewer: PASS (0 CRITICAL/HIGH; 2 LOW residual-risk notes — env-first root trust, and `-C` inside a shell-fed heredoc body no longer steering the H-01 cwd — both consistent with the documented lexical-guard posture).

Closes the root cause behind the 2026-07-01 SECURITY-OVERRIDE log entry.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa