### PR TITLE
docs(governance): resolve CONFIRM-08/09, add ADR-0010 security-gate trust model

### DIFF
--- a/.codearbiter/decisions/0010-security-gate-pass-cooperative-attestation.md
+++ b/.codearbiter/decisions/0010-security-gate-pass-cooperative-attestation.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+date: 2026-07-02
+title: Security-gate pass is a cooperative-agent attestation, not a non-fabricable proof
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: plugins/ca/hooks/security-pass.py, plugins/ca/hooks/pre-bash.py, .codearbiter/security-controls.md
+---
+
+# ADR-0010 — Security-gate pass is a cooperative-agent attestation, not a non-fabricable proof
+
+## Status
+Accepted — ratified 2026-07-02 by SUaDtL@users.noreply.github.com. Resolves tribunal finding
+appsec-003 (issue #196).
+
+## Context
+`security-pass.py` mints the `.codearbiter/.markers/security-gate-passed` marker by hashing every
+sensitive line (`CRYPTO_RE`/`SECRET_RE`) currently in the worktree and recording their digests, with
+no evidence that a crypto/secret review actually occurred. `pre-bash.py` H-09b/H-10b (and
+`git-enforce.py`) then admit the commit because every sensitive line is covered. The H-19 shell-forge
+guard blocks writing the marker via `echo`/`cp`/`tee`, but invoking the sanctioned producer directly
+(`python3 plugins/ca/hooks/security-pass.py`) is unguarded and yields the same marker — so
+`python3 .../security-pass.py && git commit ...` clears the gate the crypto-compliance/secret-handling
+skills exist to force, without the review itself happening. This is the same trust-model seam as
+appsec-002 (issue #175, `--no-verify` indirection): the control raises friction and leaves an audit
+trail but does not cryptographically bind to a real review event.
+
+## Decision
+codeArbiter's gate markers are cooperative-agent attestations, not tamper-proof proofs. Direct
+invocation of `security-pass.py` is the intended attestation mechanism, and the trust boundary is
+stated explicitly in `security-controls.md`. No code change to the producer. Rationale: codeArbiter
+governs a cooperating orchestrator; a Bash-capable non-cooperating agent can defeat most controls
+regardless (per appsec-002/#175), so binding the marker to a non-fabricable reviewer artifact adds
+real complexity for a threat the product does not claim to stop. The gate's value is raising friction
+and leaving an audit trail on the cooperative path, and that value is preserved.
+
+## Alternatives considered
+- **Bind the marker to a non-fabricable review artifact** (require the reviewer agent's signed verdict
+  as input to `security-pass.py`) — declined. M-effort and brittle, and it defends against a
+  non-cooperating Bash-capable agent that already bypasses the surrounding controls; the product's
+  threat model is a cooperative orchestrator, so the binding buys little.
+- **Narrower / soft measures** (invoke `security-pass.py` only as a subprocess of the reviewer skill;
+  a soft warning without changing gate semantics) — declined. Hard to guarantee and brittle; a warning
+  that changes nothing is noise.
+
+## Consequences
+Easier: no new machinery; the existing producer and gate stand. The trust boundary is now documented,
+so the posture is a stated design choice rather than a latent gap a future audit re-files. Harder: a
+non-cooperating agent with shell access can still self-mint a pass — accepted, and out of scope for the
+product's threat model.
+
+## Risks
+The documented boundary must not be read as "the gate is unnecessary" — it still enforces the
+cooperative path and the audit trail. This decision is proven wrong if codeArbiter's threat model
+expands to untrusted/adversarial agents, at which point the self-mint path becomes a real
+vulnerability and option 2 (non-fabricable binding) becomes the fix.

--- a/.codearbiter/decisions/decision-log.md
+++ b/.codearbiter/decisions/decision-log.md
@@ -319,3 +319,28 @@ A maintainer strategic decision rather than a technical multi-lens arbitration. 
 Follow-on /ca:chore: replace LICENSE with the canonical AGPLv3 text plus a sole-owner copyright line, add a README license-transition notice and a Dual-Licensing & Contributions section, and add CLA.md. No per-file headers (single-root-LICENSE convention retained). ADR-0009 governs LICENSE, README.md, CLA.md. ADR-0006 is superseded by ADR-0009 on the forward chain; its status field stays accepted on disk per the no-edit-prior-ADR rule, and /ca:adr-status will report the supersession.
 
 ---
+
+## DECISION-0010 — security-gate-pass-cooperative-attestation — Security-gate pass is a cooperative-agent attestation, not a non-fabricable proof
+
+**Date:** 2026-07-02
+**Status:** accepted
+**Supersedes:** none
+**Decided by:** SUaDtL@users.noreply.github.com
+**Decision category:** security / trust model
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** security-controls.md documented gate markers as enforcement without stating whether minting one proves a review occurred; tribunal appsec-003 (#196) surfaced that `security-pass.py` self-mints from the worktree with no review evidence.
+- **Scaffold position:** n/a — an open trust-model design question, not a scaffold-derived variance.
+- **Status type:** open-decision-closure
+
+### Decision
+codeArbiter's gate markers are cooperative-agent attestations, not tamper-proof proofs. Direct invocation of `security-pass.py` is the intended attestation mechanism; the trust boundary is documented in `security-controls.md`. No code change. Declined binding the marker to a non-fabricable reviewer-signed artifact — it defends a non-cooperating Bash-capable agent that already bypasses surrounding controls (appsec-002/#175), outside the product's cooperative-agent threat model. Recorded as ADR-0010.
+
+### SMARTS rationale
+Security-and-audit-trail lens (level 1) weighed against maintainability (level 3): the non-fabricable binding is real, brittle M-effort complexity that raises the review bar for a threat the product explicitly does not claim to stop. For a cooperating orchestrator, the marker's value is friction plus an audit trail, both preserved. The maintainer chose the documented-boundary posture over machinery whose protection evaporates against the very agent it would target.
+
+### Implementation implication
+No producer change. Add a "Gate-marker trust boundary" note to `security-controls.md` stating markers are cooperative-agent attestations and direct `security-pass.py` invocation is the intended attestation. Close issue #196 referencing ADR-0010. Reopens if the threat model expands to untrusted/adversarial agents.
+
+---

--- a/.codearbiter/open-questions.md
+++ b/.codearbiter/open-questions.md
@@ -14,36 +14,15 @@ set and thresholds; until then the farm stays `preview`.
 
 _Previously resolved: the four Phase 1 gate decisions, 2026-06-04 (see `legacy/ASSESSMENT.md` §10)._
 
-## [CONFIRM-08] Approve LGPL-3.0-or-later + 0BSD build-time docs-site dependencies?
-
-Deep-review 2026-06-24-root (secrets-003) found 18 `@img/sharp-libvips-*` packages licensed
-`LGPL-3.0-or-later` and `tslib` licensed `0BSD` in `site/package-lock.json` — both outside the
-`security-controls.md` approved-license list. They are docs-site / build-time only (the shipped
-plugin payload carries no runtime npm deps), so there is no payload-inclusion risk; LGPL-3.0's
-replaceable-component obligation is low-stakes for a build-time image optimizer, and 0BSD is
-effectively public-domain (more permissive than MIT). **Decision:** approve both (add to the
-approved list with a docs-site/build-time scope note, the same SMARTS-arbitration path used for
-`BlueOak-1.0.0`/`CC0-1.0` on 2026-06-22), OR record `overrides.log` entries for the specific
-packages. Until resolved, a dependency review flags them as unapproved. Tracked as `v2.rev.0026`.
-
-## [CONFIRM-09] "Compel a log write" — pick an audit-completeness enforcement strategy
-
-Deep-review 2026-06-24-root (observability-002) confirmed and scoped the long-deferred gap (see
-the Deferred-decisions note below, review finding #6 sibling): the H-05 guards protect the audit
-logs from destruction once written, but NO hook forces the required append for an `/override`, a
-`/sprint` auto-decision (`sprint-log.md`), or a `/dev` entry — those rely on prose instruction
-only, so a model lapse / interruption / future skill edit could skip the write undetected.
-Promoted from non-blocking to a tracked CONFIRM. **Decision:** choose an enforcement strategy —
-(a) a lightweight PostToolUse/UserPromptSubmit staleness check (warn if an active sprint's
-sprint-log wasn't appended in N minutes); (b) a per-action PreToolUse check on the bypassed tool
-that requires a recent matching log entry (more invasive, the "test-running commit hook" class);
-or (c) accept prose-enforcement and close. No-regrets regardless: document the integrity-vs-
-completeness distinction in `security-controls.md` §Audit trail (queued in `v2.rev.0021`).
-Tracked as `v2.rev.0027`.
+_Resolved 2026-07-02 (BY SUaDtL@users.noreply.github.com): the license question (LGPL-3.0-or-later +
+0BSD build-time `site/` deps) — approved with a docs-site/build-time scope note, see
+`security-controls.md` §Approved licenses. The "compel a log write" audit-completeness question —
+strategy (a), a lightweight staleness *warn* paired with the #186 gate-events sink, see
+`security-controls.md` §Audit trail; implementation rides with #186._
 
 ## Deferred decisions (non-blocking — deliberately NOT a `CONFIRM-NN`, so it does not gate stage promotion)
 
-- **Mechanical enforcement of "no commit on a red suite" / "no commit without commit-gate" (review finding #6).** The 2026-06-15 review confirmed these ORCHESTRATOR §3 rules are skill-discipline only — no hook runs or inspects test status, and `pre-bash.py` lets a raw `git commit` (no secrets, feature branch) through. The `review-remediation` sprint deferred this to its own decision per the user (2026-06-16): a test-running commit hook is slow and invasive, so whether to build one (vs. accept the rules as prose-enforced) is a separate design call. Its siblings ride along: the "compel a log write" half of audit logging (hooks protect logs once written but never force a write) and the secret-to-logger/prompt sink breadth (`SECRET_RE` only matches assignment literals). Pick a direction when enforcement strategy is next revisited. _Update 2026-06-22 (checkpoint remediation): the `SECRET_RE`-breadth half is resolved — `CRYPTO_RE` now sees the Node/TS TLS-disable forms and `SECRET_RE` matches colon/object-literal forms and high-entropy key prefixes (`AKIA`/`ghp_`/`sk-ant-`), with the `farm.ts` outbound redactor aligned and `test_hooklib.py` guarding it. The test-running commit hook and the "compel a log write" siblings remain open._
+- **Mechanical enforcement of "no commit on a red suite" / "no commit without commit-gate" (review finding #6).** The 2026-06-15 review confirmed these ORCHESTRATOR §3 rules are skill-discipline only — no hook runs or inspects test status, and `pre-bash.py` lets a raw `git commit` (no secrets, feature branch) through. The `review-remediation` sprint deferred this to its own decision per the user (2026-06-16): a test-running commit hook is slow and invasive, so whether to build one (vs. accept the rules as prose-enforced) is a separate design call. Its siblings ride along: the "compel a log write" half of audit logging (hooks protect logs once written but never force a write) and the secret-to-logger/prompt sink breadth (`SECRET_RE` only matches assignment literals). Pick a direction when enforcement strategy is next revisited. _Update 2026-06-22 (checkpoint remediation): the `SECRET_RE`-breadth half is resolved — `CRYPTO_RE` now sees the Node/TS TLS-disable forms and `SECRET_RE` matches colon/object-literal forms and high-entropy key prefixes (`AKIA`/`ghp_`/`sk-ant-`), with the `farm.ts` outbound redactor aligned and `test_hooklib.py` guarding it. The test-running commit hook remains open; the "compel a log write" sibling was resolved 2026-07-02 (staleness-warn strategy — see the Resolved note above and `security-controls.md` §Audit trail)._
 
 ### `task-board-lifecycle` feature deferrals (spec: `specs/task-board-lifecycle.md`, 2026-06-21)
 

--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -132,6 +132,16 @@ npm dependencies; the docs site under `site/` is not part of that payload):
   payload, and `lightningcss` is a build tool whose output (minified CSS) carries
   no MPL obligation. NOT approved for the plugin payload (`plugins/**`) or any
   distributed artifact.
+- LGPL-3.0-or-later (build-time, `site/` ONLY): weak, library-level copyleft
+  discharged by keeping the component replaceable. Approved solely for the 18
+  `@img/sharp-libvips-*` prebuilt binaries pulled by `sharp` as a build-time
+  docs-site image optimizer under `site/`. The obligation is low-stakes for a
+  replaceable build tool, and its output (optimized images) carries no LGPL
+  obligation. NOT approved for the plugin payload (`plugins/**`) or any
+  distributed artifact.
+- 0BSD (build-time, `site/` ONLY): a public-domain-equivalent BSD variant with no
+  attribution requirement — more permissive than MIT. Approved for the `tslib`
+  runtime helper pulled transitively under `site/`.
 
 `BlueOak-1.0.0` and `CC0-1.0` were approved 2026-06-22 (user decision via SMARTS
 arbitration, checkpoint 2026-06-22) to cover transitive `site/` dependencies
@@ -147,6 +157,12 @@ boundary. `satteri@0.9.3` (and its `@bruits/satteri-*` platform variants), Astro
 (`github.com/bruits/satteri`, published by an Astro core maintainer via OIDC)
 ships an MIT license, so it is accepted as MIT on the same packaging-mislabel
 basis as `argparse`, build-time `site/` only.
+
+`LGPL-3.0-or-later` and `0BSD` were approved 2026-07-02 (user decision,
+BY SUaDtL@users.noreply.github.com, via SMARTS arbitration; resolves
+`[CONFIRM-08]`), scoped to build-time `site/` dependencies only, to cover the 18
+`@img/sharp-libvips-*` binaries (`sharp` docs-site image optimizer) and `tslib`.
+Neither reaches the shipped plugin payload.
 
 Any new dependency with a license outside this list requires an explicit
 review and an entry in `overrides.log` before merging.
@@ -173,7 +189,14 @@ tool-call boundary.
 
 **Enforcement scope (accepted residual risk).** These guards are *integrity*
 controls, not *completeness* controls — they protect a log once written, they do
-not compel a write (see `observability-002` / the "compel a log write" CONFIRM).
+not compel a write. The completeness half is resolved by `[CONFIRM-09]`
+(2026-07-02, BY SUaDtL@users.noreply.github.com): strategy (a) — a lightweight
+staleness check (PostToolUse/UserPromptSubmit) warns when an active `/sprint`,
+`/override`, or `/dev` flow has not appended its expected log line within a
+bounded window — paired with the durable gate-events sink from `observability-001`
+(issue #186). It is a *warn*, not a hard gate: a missed write is surfaced, not
+blocked, keeping the integrity guards the sole true STOP. Implementation lands
+with #186.
 The `pre-bash.py` shell guard is lexical and anchored on the literal log name, so
 the following truncation/indirection spellings are out of scope and accepted as
 residual risk (the sanctioned bypass for legitimate log management is
@@ -200,6 +223,19 @@ framework, not a user action: on session start, if a prior session entered
 is append-only and best-effort. This is the only writer of `overrides.log` other
 than the three sanctioned mutators (`/override`, `/sprint` auto-decisions,
 `/dev` entry/exit).
+
+**Gate-marker trust boundary (ADR-0010).** codeArbiter's gate markers (e.g.
+`.codearbiter/.markers/security-gate-passed`) are *cooperative-agent
+attestations*, not tamper-proof proofs. `security-pass.py` mints the
+security-gate marker by re-deriving the sensitive-line digests from the current
+worktree; direct invocation of the sanctioned producer is the *intended*
+attestation mechanism. A Bash-capable non-cooperating agent can self-mint a pass
+(as it can defeat the `--no-verify` and shell-indirection controls, appsec-002 /
+#175) — this is an accepted trust boundary, out of scope for the product's
+cooperative-orchestrator threat model, not a defect. The marker's value is the
+friction and audit trail it adds on the cooperative path. Reopens (→ non-fabricable
+reviewer-signed binding) only if the threat model expands to untrusted agents. See
+ADR-0010 (resolves appsec-003 / #196).
 
 ---
 


### PR DESCRIPTION
Paperwork lane of the tribunal remediation campaign — runs in parallel with the code lanes, unblocking dependent work.

## Decisions recorded (all user-attributed, BY SUaDtL@users.noreply.github.com, 2026-07-02)
- **ADR-0010** — security-gate pass is a *cooperative-agent attestation*, not a non-fabricable proof. Resolves appsec-003 (#196). No code change; the trust boundary is documented in `security-controls.md`. Declined binding the marker to a reviewer-signed artifact (defends a non-cooperating Bash-capable agent already outside the threat model).
- **CONFIRM-08** — approve `LGPL-3.0-or-later` (18 `@img/sharp-libvips-*`) + `0BSD` (`tslib`), scoped to build-time `site/` only. Neither reaches the shipped plugin payload.
- **CONFIRM-09** — audit-completeness = strategy (a): a lightweight staleness **warn** (not a hard gate), paired with the #186 gate-events sink. Implementation rides with #186.

## Effect
- `open-questions.md` CONFIRM count drops **3 → 1** (only CONFIRM-05, the farm promotion bar, remains).
- Doc-only, `.codearbiter/` project state — no plugin payload change, no version bump, no CI code-suite impact.

Conflict-hierarchy note: level 1 (audit-trail/security) vs level 3 (maintainability) — chose the documented-boundary posture over brittle machinery.

Closes #196

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa