### PR TITLE
ci(actions): pin actions to SHAs + dependabot; harden cat-file/env-bind (#181 #198 #199)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Keeps the commit-SHA pins in .github/workflows/*.yml current (issue #181).
+  # Actions are pinned to full 40-hex commit SHAs for supply-chain integrity;
+  # Dependabot opens a version-bump PR (new SHA + updated comment) on a weekly
+  # cadence instead of us tracking upstream releases by hand.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       hooks: ${{ steps.filter.outputs.hooks }}
       manifests: ${{ steps.filter.outputs.manifests }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # A change to shared CI infra (.github/) flags BOTH plugins so the
@@ -76,8 +76,8 @@ jobs:
       run:
         working-directory: plugins/ca/tools
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -114,8 +114,8 @@ jobs:
       run:
         working-directory: plugins/ca-sandbox/tools
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -160,8 +160,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Run cold-install interpreter matrix
@@ -264,7 +264,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.ca == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Fail if a published version ships a changed payload
@@ -299,7 +299,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.ca-sandbox == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Fail if a published version ships a changed payload
@@ -318,9 +318,14 @@ jobs:
           # other git failure (transient fetch error, corrupted object store,
           # a race on origin/$BASE) must fail the step, not be swallowed as
           # "first introduction".
-          if ! git cat-file -e "origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json" 2>/dev/null; then
+          rc=0
+          git cat-file -e "origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json" 2>/dev/null || rc=$?
+          if [ "$rc" = 1 ]; then
             echo "ca-sandbox is new on $BASE (no prior plugin.json) - first introduction, version bump not required"
             exit 0
+          elif [ "$rc" != 0 ]; then
+            echo "::error::git cat-file probe on origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json failed with exit $rc (not a plain absence) - bad ref or corrupt object store"
+            exit "$rc"
           fi
           base_json=$(git show "origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json")
           base_ver=$(printf '%s' "$base_json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
@@ -340,8 +345,8 @@ jobs:
     if: needs.changes.outputs.ca == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Check cross-reference graph (ca)
@@ -357,8 +362,8 @@ jobs:
     if: needs.changes.outputs.ca == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Check README badge/count/catalog consistency (ca)
@@ -370,8 +375,8 @@ jobs:
     if: needs.changes.outputs.ca-sandbox == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Check cross-reference graph (ca-sandbox)
@@ -386,7 +391,7 @@ jobs:
     if: needs.changes.outputs.manifests == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Validate every tracked JSON parses
         run: |
           fail=0
@@ -410,8 +415,8 @@ jobs:
     # specs/license-consistency-check.md.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Check license declarations agree across surfaces

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,8 +48,8 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22 # Astro 6 requires Node >=22.12.0
           cache: npm
@@ -68,8 +68,8 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22 # Astro 6 requires Node >=22.12.0; the action defaults to 20
           cache: npm
@@ -81,7 +81,7 @@ jobs:
       - name: Link audit
         run: npm run link-audit # post-build dangling-link gate (AC-2/AC-4)
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: site/dist
 
@@ -101,4 +101,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -50,9 +50,11 @@ jobs:
           echo "tag=v$MANIFEST" >> "$GITHUB_OUTPUT"
 
       - name: Extract the CHANGELOG section as release notes
+        env:
+          VER: ${{ steps.v.outputs.version }}
+          TAG: ${{ steps.v.outputs.tag }}
         run: |
           set -euo pipefail
-          VER="${{ steps.v.outputs.version }}"
           # Capture from "## [VER]" up to (not including) the next "## [" section heading.
           awk -v v="## [$VER]" 'index($0,v)==1{f=1;print;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md > notes.md
           # Trim a trailing Keep-a-Changelog "---" separator and blank lines.
@@ -63,17 +65,17 @@ jobs:
           PY
           test -s notes.md || { echo "::error::no CHANGELOG section found for $VER"; exit 1; }
           # The notes' first heading must match the tag (the same guard /ca:release Phase 3 runs).
-          python3 .github/scripts/_releaselib.py notes-match "${{ steps.v.outputs.tag }}" notes.md
+          python3 .github/scripts/_releaselib.py notes-match "$TAG" notes.md
           echo "---- notes.md ----"; head -1 notes.md
 
       - name: Create the tag and GitHub Release (idempotent)
         env:
           GH_TOKEN: ${{ github.token }}
           SUMMARY: ${{ github.event.inputs.summary }}
+          TAG: ${{ steps.v.outputs.tag }}
+          VER: ${{ steps.v.outputs.version }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.v.outputs.tag }}"
-          VER="${{ steps.v.outputs.version }}"
           SUM="$SUMMARY"
           if [ -n "$SUM" ]; then TITLE="codeArbiter $VER: $SUM"; else TITLE="codeArbiter $VER"; fi
 


### PR DESCRIPTION
Lane B of the tribunal remediation campaign — CI/supply-chain. `.github/`-only, no plugin payload change (no version bump).

- **#181** (security, supply-chain): every `uses:` in all workflows pinned to a 40-hex commit SHA (`# vX.Y.Z` comment retained); new `.github/dependabot.yml` watches the `github-actions` ecosystem weekly. Write-scoped workflows (release.yml contents:write; docs.yml deploy pages:write+id-token:write) done first.
- **#198** (nit): ci.yml cat-file probe distinguishes rc==1 (absent) from fatal (exit 128) — no longer swallows a fatal git error as first-introduction.
- **#199** (nit): release.yml step outputs env-bound in `run:` blocks — zero `${{ }}` expansion in any run body, completing the #174 CWE-78 hardening.

**security-reviewer: PASS** — 0 findings; all 25 `uses:` verified 40-hex, env-bind complete, YAML parses.

Closes #181
Closes #198
Closes #199

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa