### PR TITLE
refactor(sandbox): single docker primitive; fix(sandbox): label + time-bound helper containers (#180 #173)

### DIFF
--- a/plugins/ca-sandbox/.claude-plugin/plugin.json
+++ b/plugins/ca-sandbox/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca-sandbox",
   "displayName": "codeArbiter Sandbox",
   "description": "Locally-hosted Codespace equivalent for codeArbiter. Pulls an untrusted repo into an ephemeral, isolated Docker container with no host-filesystem access and configurable egress, caches dependencies by content hash, then tears the box down. Requires Docker and nixpacks on PATH.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca-sandbox/tools/build.ts
+++ b/plugins/ca-sandbox/tools/build.ts
@@ -27,10 +27,15 @@
  * Toolchain note (Spike A driver note): `docker build --label` is unreliable, so
  * sandbox images are tracked by their namespaced TAG, never by an image label.
  * Windows (Spike A/B): MSYS_NO_PATHCONV=1 is set when shelling docker so in-
- * container paths and `-e HOME` are not mangled by Git Bash path conversion.
+ * container paths and `-e HOME` are not mangled by Git Bash path conversion —
+ * the guard itself is imported from the shared docker.ts primitive
+ * (architecture-007), the single definition site.
  *
  * Process/shell handling mirrors farm.ts: a `run()` child-process helper returning
- * a RunResult, and the docker/build effects are injectable (BuildDeps) so the pure
+ * a RunResult (this module's own shape — {code, out, stdout, stderr} — since
+ * callers here also want the merged stdout+stderr `out` for build logs; it is
+ * NOT the plain {code,stdout,stderr} docker.ts contract other modules share),
+ * and the docker/build effects are injectable (BuildDeps) so the pure
  * cache/tag/relocation logic is unit-testable without real docker, while the
  * docker-gated test drives the real defaults.
  */
@@ -38,6 +43,7 @@ import { spawn, type SpawnOptionsWithoutStdio } from "node:child_process";
 import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { DOCKER_ENV } from "./docker.ts";
 
 /** Image tag prefix for every sandbox image. */
 export const IMAGE_PREFIX = "ca-sbx";
@@ -56,10 +62,6 @@ export const NIXPACKS_INSTALL_URL = "https://nixpacks.com/install.sh";
 // process helper (mirrors farm.ts run()/RunResult)
 // --------------------------------------------------------------------------
 export type RunResult = { code: number; out: string; stdout: string; stderr: string };
-
-// On Windows + Git Bash, passing container paths / `-e HOME` to docker gets
-// mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
 
 // docker build of the nixpacks-generated Dockerfile needs BuildKit (it emits
 // `RUN --mount=type=cache`). Docker Desktop defaults to BuildKit, but set it

--- a/plugins/ca-sandbox/tools/claude-inside.ts
+++ b/plugins/ca-sandbox/tools/claude-inside.ts
@@ -35,12 +35,13 @@
  * Like run.ts / network.ts this module is PURE argv/script builders (so the
  * posture is unit-testable without docker); the caller shells docker. Windows
  * (Spike A/B): set MSYS_NO_PATHCONV=1 when shelling docker so `-e HOME=/...` and
- * container paths are not mangled by Git Bash path conversion.
+ * container paths are not mangled by Git Bash path conversion — routed through
+ * the shared docker.ts primitive (architecture-007).
  */
-import { spawnSync } from "node:child_process";
 import { buildMountArgs, type MountSpec } from "./mounts.ts";
 import { applyNetworkPolicy } from "./network.ts";
 import { SANDBOX_LABEL, hardeningFlags } from "./run.ts";
+import { defaultDockerRun, type RunResult } from "./docker.ts";
 
 /**
  * The PINNED Claude Code CLI version baked into the sandbox image. Pinned (never
@@ -63,10 +64,6 @@ export const TOKEN_ENV_VAR = "CLAUDE_CODE_OAUTH_TOKEN";
 // SANDBOX_LABEL is shared from run.ts (architecture-002) so the lifecycle label
 // has a single definition; re-exported here for existing importers of this name.
 export { SANDBOX_LABEL };
-
-// On Windows + Git Bash, `-e HOME=/...` and container paths handed to docker get
-// mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
 
 /**
  * The ONLY egress postures `--with-claude` permits. Both keep a stealable token
@@ -290,16 +287,9 @@ export function buildClaudeRunArgs(opts: ClaudeRunOptions): string[] {
   ];
 }
 
-export type ClaudeRunResult = { code: number; stdout: string; stderr: string };
-
-function defaultDockerRun(args: string[]): ClaudeRunResult {
-  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
-  };
-}
+/** Kept as a distinct exported name for existing importers — one underlying
+ * shape (docker.ts's RunResult), never a second parallel definition. */
+export type ClaudeRunResult = RunResult;
 
 /**
  * Start a `--with-claude` box and return the container id. Thin shell over

--- a/plugins/ca-sandbox/tools/cli.ts
+++ b/plugins/ca-sandbox/tools/cli.ts
@@ -27,8 +27,9 @@
  * host->container push.
  *
  * Windows/CRLF/MSYS handling is delegated entirely to the modules (each already
- * sets MSYS_NO_PATHCONV=1 when shelling docker — Spike A/B); cli.ts shells nothing
- * by default and so needs none of it for parsing.
+ * sets MSYS_NO_PATHCONV=1 when shelling docker — Spike A/B, via the shared
+ * docker.ts primitive, architecture-007); cli.ts shells nothing by default and
+ * so needs none of it for parsing.
  */
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -39,11 +40,7 @@ import { destroySandbox, prune, type DestroyResult, type PruneResult } from "./d
 import { execInSandbox, type ExecResult } from "./exec.ts";
 import { cpOut, type RunResult } from "./cp.ts";
 import { resolveContainerId } from "./registry.ts";
-
-// On Windows + Git Bash, container paths / args handed to docker get mangled by
-// MSYS path conversion; the modules set this themselves, and the interactive
-// `shell` handler (which shells docker directly) sets it too (Spike A/B).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
+import { DOCKER_ENV } from "./docker.ts";
 
 /** The three CLI-exposed network policies (run.ts treats the latter two as the
  * pass-through richer policies; cli.ts only accepts these known names). */

--- a/plugins/ca-sandbox/tools/cp.ts
+++ b/plugins/ca-sandbox/tools/cp.ts
@@ -17,34 +17,21 @@
  * structurally impossible to build from here — exactly the same guarantee run.ts
  * relies on.
  *
- * Process/shell handling mirrors farm.ts / run.ts: a child-process helper
- * returning a RunResult, and on Windows + Git Bash MSYS_NO_PATHCONV=1 is set so
- * the in-container path passed to `docker cp` (e.g. `<id>:/work/out.txt`) is not
- * mangled by MSYS path conversion (Spike A/B).
+ * Process/shell handling routes through docker.ts (architecture-007): a shared
+ * child-process helper returning a RunResult, and on Windows + Git Bash
+ * MSYS_NO_PATHCONV=1 is set so the in-container path passed to `docker cp`
+ * (e.g. `<id>:/work/out.txt`) is not mangled by MSYS path conversion (Spike A/B).
  */
-import { spawnSync } from "node:child_process";
 import { buildMountArgs, type MountSpec } from "./mounts.ts";
+import { defaultDockerRun, type RunResult } from "./docker.ts";
 
-// On Windows + Git Bash, the `<id>:/work/...` container ref handed to docker gets
-// mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
-
-export type RunResult = { code: number; stdout: string; stderr: string };
+export type { RunResult };
 
 /** Optional knobs for cpOut — chiefly an injectable docker runner for tests. */
 export type CpOptions = {
   /** Injectable docker runner (defaults to spawnSync("docker", ...)). */
   dockerRun?: (args: string[]) => RunResult;
 };
-
-function defaultDockerRun(args: string[]): RunResult {
-  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
-  };
-}
 
 /**
  * Assemble the `docker cp` argv (everything AFTER `docker`) for a PULL-only copy

--- a/plugins/ca-sandbox/tools/create.test.ts
+++ b/plugins/ca-sandbox/tools/create.test.ts
@@ -9,15 +9,19 @@
  * no docker; runs everywhere. The end-to-end clone is exercised by lifecycle.test.ts.
  */
 import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
 import {
   validateRepoUrl,
   InvalidRepoUrlError,
   buildCloneArgs,
+  buildCpHelperCreateArgs,
   createSandbox,
   APP_DIR,
 } from "./create.ts";
 import type { CloneResult } from "./create.ts";
 import { buildMountArgs } from "./mounts.ts";
+import { SANDBOX_LABEL, idLabel, listAllContainers } from "./registry.ts";
+import { prune } from "./destroy.ts";
 
 describe("validateRepoUrl — clone-input trust model (AC-01)", () => {
   it("accepts plain network remotes (https / ssh / scp-like)", () => {
@@ -48,7 +52,7 @@ describe("validateRepoUrl — clone-input trust model (AC-01)", () => {
 
 describe("buildCloneArgs — argv shape (AC-01 defense in depth)", () => {
   const url = "https://github.com/owner/repo.git";
-  const argv = buildCloneArgs(url, "ca-sbx-vol-demo");
+  const argv = buildCloneArgs(url, "ca-sbx-vol-demo", "demo-id");
 
   it("emits an end-of-options `--` immediately before the url", () => {
     const sep = argv.indexOf("--");
@@ -82,6 +86,163 @@ describe("buildCloneArgs — argv shape (AC-01 defense in depth)", () => {
     // No raw bind expression hand-rolled anywhere.
     for (const tok of argv) expect(tok).not.toMatch(/type=bind/);
   });
+});
+
+// ---------------------------------------------------------------------------
+// reliability-015 — label + time-bound the clone / cp-helper containers so a
+// hung clone or a host crash mid-create doesn't orphan an unreclaimable object.
+// ---------------------------------------------------------------------------
+describe("buildCloneArgs — carries the sandbox labels (reliability-015)", () => {
+  it("labels the throwaway clone container ca.sandbox=1 + ca.sandbox.id=<id>", () => {
+    const argv = buildCloneArgs("https://github.com/owner/repo.git", "ca-sbx-vol-demo", "abc123");
+    // Two independent --label flags (docker requires one per label, same
+    // discipline as buildRunArgs / registry.ts's labelFilterArgs).
+    const labelValues: string[] = [];
+    argv.forEach((tok, i) => {
+      if (tok === "--label") labelValues.push(argv[i + 1]);
+    });
+    expect(labelValues).toContain(SANDBOX_LABEL);
+    expect(labelValues).toContain(idLabel("abc123"));
+  });
+
+  it("a different id produces a different id-label (no cross-sandbox collision)", () => {
+    const a = buildCloneArgs("https://github.com/owner/repo.git", "vol-a", "id-a");
+    const b = buildCloneArgs("https://github.com/owner/repo.git", "vol-b", "id-b");
+    expect(a).toContain(idLabel("id-a"));
+    expect(b).toContain(idLabel("id-b"));
+    expect(a).not.toContain(idLabel("id-b"));
+  });
+});
+
+describe("buildCpHelperCreateArgs — carries the sandbox labels (reliability-015)", () => {
+  it("labels the docker-cp helper container ca.sandbox=1 + ca.sandbox.id=<id>", () => {
+    const argv = buildCpHelperCreateArgs("ca-sbx-vol-demo", "ca-sbx-cp-deadbeef", "abc123");
+    const labelValues: string[] = [];
+    argv.forEach((tok, i) => {
+      if (tok === "--label") labelValues.push(argv[i + 1]);
+    });
+    expect(labelValues).toContain(SANDBOX_LABEL);
+    expect(labelValues).toContain(idLabel("abc123"));
+    expect(argv).toContain("ca-sbx-cp-deadbeef");
+  });
+
+  it("still routes the volume mount through the buildMountArgs chokepoint", () => {
+    const argv = buildCpHelperCreateArgs("ca-sbx-vol-demo", "helper", "abc123");
+    const expected = buildMountArgs([{ type: "volume", source: "ca-sbx-vol-demo", target: APP_DIR }]);
+    const m = argv.indexOf("--mount");
+    expect(m).toBeGreaterThanOrEqual(0);
+    expect(argv.slice(m, m + expected.length)).toEqual(expected);
+    for (const tok of argv) expect(tok).not.toMatch(/type=bind/);
+  });
+});
+
+describe("createSandbox failure teardown — containers before volume (reliability-015)", () => {
+  it("removes leftover labeled containers BEFORE removing the volume", async () => {
+    const calls: string[][] = [];
+    const dockerRun = (args: string[]) => {
+      calls.push(args);
+      if (args[0] === "volume" && args[1] === "create") return { code: 0, stdout: "vol", stderr: "" };
+      if (args[0] === "ps") return { code: 0, stdout: "leftover-container-id", stderr: "" };
+      return { code: 0, stdout: "", stderr: "" };
+    };
+
+    await expect(
+      createSandbox("https://github.com/owner/repo.git", {
+        id: "test-teardown-order",
+        dockerRun,
+        cloneRepo: async (): Promise<CloneResult> => ({ code: 1, stderr: "fatal: boom" }),
+      }),
+    ).rejects.toThrow();
+
+    const rmContainerIdx = calls.findIndex((c) => c[0] === "rm" && c[1] === "-f");
+    const rmVolumeIdx = calls.findIndex((c) => c[0] === "volume" && c[1] === "rm");
+    expect(rmContainerIdx).toBeGreaterThanOrEqual(0);
+    expect(rmVolumeIdx).toBeGreaterThan(rmContainerIdx);
+  });
+});
+
+// --------------------------------------------------------------------------
+// DOCKER-GATED integration layer (reliability-015).
+// Proves an orphaned clone/cp-helper-shaped container — the exact object a
+// hung clone or a host crash mid-create would leave behind — is reclaimable by
+// prune() purely because it carries the ca.sandbox=1 label, even though it is
+// not a registered sandbox object.
+// --------------------------------------------------------------------------
+function dockerAvailable(): boolean {
+  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
+  return r.status === 0;
+}
+const HAS_DOCKER = dockerAvailable();
+const d = HAS_DOCKER ? describe : describe.skip;
+
+d("orphaned helper containers [docker] — prune() reclaims them (reliability-015)", () => {
+  it("a labeled, detached clone-shaped orphan is removed by prune()", () => {
+    const id = "t173-clone-orphan";
+    const name = `ca-sbx-clone-orphan-${Date.now()}`;
+    // Simulate the crash scenario: the host process died before the `--rm`
+    // clone container exited, so a labeled, still-running container is left
+    // behind. `-d` (detached) here stands in for "the parent process is gone
+    // but the container survives" — the label is what makes it reclaimable.
+    const run = spawnSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--label",
+        SANDBOX_LABEL,
+        "--label",
+        idLabel(id),
+        "--name",
+        name,
+        "alpine",
+        "sleep",
+        "300",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(run.status, run.stderr).toBe(0);
+    const cid = run.stdout.trim();
+
+    try {
+      expect(listAllContainers()).toContain(cid);
+      const result = prune();
+      expect(result.removedContainers).toContain(cid);
+      expect(listAllContainers()).not.toContain(cid);
+    } finally {
+      spawnSync("docker", ["rm", "-f", name]);
+    }
+  }, 60_000);
+
+  it("a labeled, detached cp-helper-shaped orphan is removed by prune()", () => {
+    const id = "t173-cphelper-orphan";
+    const name = `ca-sbx-cp-orphan-${Date.now()}`;
+    const run = spawnSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--label",
+        SANDBOX_LABEL,
+        "--label",
+        idLabel(id),
+        "--name",
+        name,
+        "alpine",
+        "sleep",
+        "300",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(run.status, run.stderr).toBe(0);
+    const cid = run.stdout.trim();
+
+    try {
+      const result = prune();
+      expect(result.removedContainers).toContain(cid);
+    } finally {
+      spawnSync("docker", ["rm", "-f", name]);
+    }
+  }, 60_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/ca-sandbox/tools/create.ts
+++ b/plugins/ca-sandbox/tools/create.ts
@@ -12,19 +12,29 @@
  *      networking UP for the clone (the only point egress is needed by default;
  *      the sandbox container itself defaults to offline). The clone container
  *      mounts the volume at /work/repo and is `--rm`'d immediately after — it is
- *      NOT a sandbox object and carries no sandbox label, and (critically) it is
- *      never co-run with the untrusted code: clone-then-cut.
+ *      NOT a sandbox object (destroy.ts never targets it directly), but it DOES
+ *      carry the `ca.sandbox=1` + `ca.sandbox.id=<id>` labels (reliability-015)
+ *      so prune()'s sweep can still reclaim it if it outlives its `--rm`, and it
+ *      is never co-run with the untrusted code: clone-then-cut.
  *   4. BUILD (or reuse) the image via build.ts (dephash-cached, deps to /deps).
  *   5. RUN the sandbox container via run.ts — structurally isolated, no host bind,
  *      offline by default — tagging it `ca.sandbox=1` + `ca.sandbox.id=<id>`.
  *
  * Everything created is labeled so destroy.ts / prune() can reclaim it by label
- * alone. On any failure AFTER the volume is created, the partial objects are torn
- * down so a failed create never leaks a labeled half-sandbox.
+ * alone — INCLUDING the throwaway clone container and the docker-cp helper
+ * (reliability-015): both now carry `ca.sandbox=1` + `ca.sandbox.id=<id>` even
+ * though neither is a sandbox object itself, so a hung clone / a host crash
+ * mid-create still leaves something `prune()` can reclaim, and each step is
+ * wall-clock timed out so a dead remote / giant repo cannot hang forever. On
+ * any failure AFTER the volume is created, the partial objects are torn down —
+ * containers FIRST, then the volume (matching destroySandbox's order, so an
+ * in-use volume never fails to remove) — so a failed create never leaks a
+ * labeled half-sandbox.
  *
- * Process/shell handling mirrors run.ts / build.ts: an injectable docker runner,
- * MSYS_NO_PATHCONV=1 on Windows + Git Bash (Spike A/B), and a deterministic id
- * derived from crypto random bytes (farm.ts hashing style).
+ * Process/shell handling routes through docker.ts (architecture-007): an
+ * injectable docker runner, MSYS_NO_PATHCONV=1 on Windows + Git Bash (Spike
+ * A/B), and a deterministic id derived from crypto random bytes (farm.ts
+ * hashing style).
  */
 import { spawnSync, spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
@@ -33,14 +43,8 @@ import { runContainer, type NetPolicy } from "./run.ts";
 import { buildMountArgs } from "./mounts.ts";
 import { buildOrReuseImage, type BuildResult } from "./build.ts";
 import { computeDepHash, type ManifestFile } from "./dephash.ts";
-import {
-  SANDBOX_LABEL,
-  idLabel,
-  type DockerRun,
-  type DockerResult,
-} from "./registry.ts";
-
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
+import { SANDBOX_LABEL, idLabel } from "./registry.ts";
+import { DOCKER_ENV, defaultDockerRun, type DockerRun } from "./docker.ts";
 
 /** Image used for the throwaway clone step (small, git built in). */
 export const CLONE_IMAGE = "alpine/git:latest";
@@ -48,6 +52,22 @@ export const CLONE_IMAGE = "alpine/git:latest";
 export const APP_DIR = "/work/repo";
 /** Prefix for the named volume of a sandbox. */
 export const VOLUME_PREFIX = "ca-sbx-vol";
+/**
+ * Wall-clock timeout (ms) for the throwaway clone step (reliability-015). A
+ * dead remote or a giant repo must not hang the helper container forever;
+ * exceeding this kills the local `docker run` client (SIGTERM, then the
+ * process's own close handling resolves). The clone container is labeled
+ * regardless of outcome, so even a kill that outlives the client-side timeout
+ * (docker's sig-proxy is best-effort) leaves an object `prune()` reclaims.
+ * Overridable for tests via CA_SANDBOX_CLONE_TIMEOUT_MS.
+ */
+export const CLONE_TIMEOUT_MS = Number(process.env.CA_SANDBOX_CLONE_TIMEOUT_MS ?? 5 * 60_000);
+/**
+ * Wall-clock timeout (ms) for each docker-cp helper step (create + cp) used to
+ * materialize a temp checkout for dephash/build (reliability-015). Overridable
+ * for tests via CA_SANDBOX_CP_TIMEOUT_MS.
+ */
+export const CP_TIMEOUT_MS = Number(process.env.CA_SANDBOX_CP_TIMEOUT_MS ?? 2 * 60_000);
 
 /** Result returned by the injectable repo cloner. */
 export type CloneResult = { code: number; stderr: string };
@@ -67,12 +87,12 @@ export type CreateOptions = {
    * error messages) or a plain exit-code number (backward-compatible with existing
    * tests; treated as having no stderr).
    */
-  cloneRepo?: (url: string, volumeName: string) => Promise<CloneResult | number>;
+  cloneRepo?: (url: string, volumeName: string, id: string) => Promise<CloneResult | number>;
   /**
    * Injectable image builder. Defaults to build.ts buildOrReuseImage over a
    * temp checkout. Tests inject a fake that returns a prebuilt tag.
    */
-  buildImage?: (volumeName: string) => Promise<BuildResult>;
+  buildImage?: (volumeName: string, id: string) => Promise<BuildResult>;
 };
 
 /** Error thrown when an untrusted repo url fails the clone-input trust check. */
@@ -135,15 +155,6 @@ export type CreateResult = {
   notes: string[];
 };
 
-function defaultDockerRun(args: string[]): DockerResult {
-  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
-  };
-}
-
 /** A short, url-safe random id (12 hex chars), mirroring run.ts's name suffix. */
 export function newSandboxId(): string {
   return randomBytes(6).toString("hex");
@@ -154,10 +165,22 @@ export function newSandboxId(): string {
  * surface actionable diagnostics (e.g. "fatal: repository not found"). argv and
  * env are never included in the returned value — only the child process's own
  * stderr stream is captured, keeping the secret-free contract of the failure path.
+ *
+ * `timeoutMs` (reliability-015) bounds the wall-clock time of the spawned
+ * process: Node's own `timeout` spawn option sends `killSignal` (default
+ * SIGTERM) once it elapses, so a dead remote / hung clone cannot block this
+ * promise forever. The underlying docker container may still carry on past
+ * the client-side kill (docker's sig-proxy is best-effort against SIGTERM) —
+ * that is exactly why the CALLER must label the container so `prune()` can
+ * reclaim it regardless.
  */
-function spawnAsync(cmd: string, args: string[]): Promise<CloneResult> {
+function spawnAsync(cmd: string, args: string[], timeoutMs?: number): Promise<CloneResult> {
   return new Promise((resolve) => {
-    const c = spawn(cmd, args, { env: DOCKER_ENV, stdio: ["ignore", "ignore", "pipe"] });
+    const c = spawn(cmd, args, {
+      env: DOCKER_ENV,
+      stdio: ["ignore", "ignore", "pipe"],
+      ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
+    });
     const stderrChunks: Buffer[] = [];
     c.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
     c.on("error", () => resolve({ code: 1, stderr: "" }));
@@ -174,12 +197,18 @@ function spawnAsync(cmd: string, args: string[]): Promise<CloneResult> {
 /**
  * Clone `url` INTO the named volume via a throwaway alpine/git container with
  * networking up. The container mounts the volume at /work/repo and is `--rm`'d
- * the instant the clone finishes — it carries NO sandbox label and is never the
- * sandbox itself. Cloning into an empty named volume's mount point; alpine/git's
- * entrypoint is `git`, so the args after the image are git's.
+ * the instant the clone finishes. It is NOT a sandbox object (destroy.ts never
+ * targets it directly), but it now carries `ca.sandbox=1` + `ca.sandbox.id=<id>`
+ * (reliability-015) so a hung clone / a host crash before the `--rm` fires still
+ * leaves something `prune()` can reclaim, and it is wall-clock timed out
+ * (CLONE_TIMEOUT_MS) so a dead remote cannot hang indefinitely.
  */
-export async function defaultCloneRepo(url: string, volumeName: string): Promise<CloneResult> {
-  return spawnAsync("docker", buildCloneArgs(url, volumeName));
+export async function defaultCloneRepo(
+  url: string,
+  volumeName: string,
+  id: string,
+): Promise<CloneResult> {
+  return spawnAsync("docker", buildCloneArgs(url, volumeName, id), CLONE_TIMEOUT_MS);
 }
 
 /**
@@ -190,8 +219,13 @@ export async function defaultCloneRepo(url: string, volumeName: string): Promise
  * git as a flag (belt to validateRepoUrl's suspenders). alpine/git ENTRYPOINT is
  * `git`, so the args after the image are git's; clone goes straight into the
  * volume mounted at /work/repo.
+ *
+ * Labeled `ca.sandbox=1` + `ca.sandbox.id=<id>` (reliability-015) — the ONE
+ * change from the pre-fix argv shape — so this throwaway container is
+ * discoverable by `prune()`'s label sweep even though it is never a registered
+ * sandbox object.
  */
-export function buildCloneArgs(url: string, volumeName: string): string[] {
+export function buildCloneArgs(url: string, volumeName: string, id: string): string[] {
   return [
     "run",
     "--rm",
@@ -199,6 +233,10 @@ export function buildCloneArgs(url: string, volumeName: string): string[] {
     // covered by the bind-rejection guarantee and there is genuinely one mount-argv
     // path. Same volume spec as before -> byte-identical argv.
     ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR }]),
+    "--label",
+    SANDBOX_LABEL,
+    "--label",
+    idLabel(id),
     CLONE_IMAGE,
     "clone",
     "--depth",
@@ -210,14 +248,43 @@ export function buildCloneArgs(url: string, volumeName: string): string[] {
 }
 
 /**
+ * The docker argv (everything after `docker`) for the `docker create` step of
+ * the throwaway docker-cp helper container. Pure so the labeling is
+ * unit-testable without docker. Labeled `ca.sandbox=1` + `ca.sandbox.id=<id>`
+ * (reliability-015) — the helper is never a registered sandbox object (it
+ * exists only to `docker cp` a temp checkout out of the volume), but the label
+ * makes it discoverable by `prune()`'s sweep if the host process dies before
+ * the `finally` block's `docker rm -f` runs.
+ */
+export function buildCpHelperCreateArgs(volumeName: string, helperName: string, id: string): string[] {
+  return [
+    "create",
+    "--name",
+    helperName,
+    "--label",
+    SANDBOX_LABEL,
+    "--label",
+    idLabel(id),
+    // Same buildMountArgs chokepoint as buildCloneArgs (architecture-006).
+    ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR }]),
+    CLONE_IMAGE,
+    "true",
+  ];
+}
+
+/**
  * Default image build: copy the cloned source OUT of the volume into a temp dir
  * (so build.ts can read manifests + run a docker build context), compute the
  * dephash from the manifest set, then buildOrReuseImage. The clone lives only in
  * the volume, so we materialize a transient checkout via a throwaway container's
  * `docker cp`. Kept injectable; the docker-gated lifecycle test exercises the
  * REAL default end to end on a tiny repo.
+ *
+ * The helper container is labeled and each docker step (create + cp) is
+ * wall-clock timed out (CP_TIMEOUT_MS, reliability-015) so a stuck copy cannot
+ * hang forever and, if it does, the label still makes it `prune()`-reclaimable.
  */
-async function defaultBuildImage(volumeName: string): Promise<BuildResult> {
+async function defaultBuildImage(volumeName: string, id: string): Promise<BuildResult> {
   const { mkdtemp, rm } = await import("node:fs/promises");
   const { tmpdir } = await import("node:os");
   const path = await import("node:path");
@@ -225,19 +292,11 @@ async function defaultBuildImage(volumeName: string): Promise<BuildResult> {
   // Materialize the volume contents to the host temp dir via a helper container:
   // mount the volume read-only and `docker cp` its /work/repo out.
   const helper = `ca-sbx-cp-${newSandboxId()}`;
-  const createResult = spawnSync(
-    "docker",
-    [
-      "create",
-      "--name",
-      helper,
-      // Same buildMountArgs chokepoint as buildCloneArgs (architecture-006).
-      ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR }]),
-      CLONE_IMAGE,
-      "true",
-    ],
-    { env: DOCKER_ENV, encoding: "utf8" },
-  );
+  const createResult = spawnSync("docker", buildCpHelperCreateArgs(volumeName, helper, id), {
+    env: DOCKER_ENV,
+    encoding: "utf8",
+    timeout: CP_TIMEOUT_MS,
+  });
   if ((createResult.status ?? 1) !== 0) {
     const hint = (createResult.stderr ?? "").trim();
     await rm(dir, { recursive: true, force: true }).catch(() => {});
@@ -249,6 +308,7 @@ async function defaultBuildImage(volumeName: string): Promise<BuildResult> {
     const cpResult = spawnSync("docker", ["cp", `${helper}:${APP_DIR}/.`, dir], {
       env: DOCKER_ENV,
       encoding: "utf8",
+      timeout: CP_TIMEOUT_MS,
     });
     if ((cpResult.status ?? 1) !== 0) {
       const hint = (cpResult.stderr ?? "").trim();
@@ -342,7 +402,7 @@ export async function createSandbox(
   // failed create never leaves a labeled half-sandbox behind.
   try {
     // 2. Clone INTO the volume via the throwaway alpine/git container (net up).
-    const cloneRaw = await cloneRepo(url, volumeName);
+    const cloneRaw = await cloneRepo(url, volumeName, id);
     // Accept either a plain exit code (backward-compatible) or a CloneResult with
     // captured stderr (preferred — surfaces actionable git diagnostics on failure).
     const cloneCode = typeof cloneRaw === "number" ? cloneRaw : cloneRaw.code;
@@ -355,7 +415,7 @@ export async function createSandbox(
     }
 
     // 3. Build (or reuse) the image — dephash-cached, deps relocated to /deps.
-    const build = await buildImage(volumeName);
+    const build = await buildImage(volumeName, id);
 
     // 4. Run the isolated sandbox container, labeled with the id.
     const containerId = runContainer(build.tag, volumeName, netPolicy, {
@@ -375,7 +435,11 @@ export async function createSandbox(
     };
   } catch (err) {
     // Best-effort teardown of the labeled objects of THIS id (label-only).
-    dockerRun(["volume", "rm", "-f", volumeName]);
+    // reliability-015: containers FIRST, then the volume — matching
+    // destroySandbox's order. A named volume still attached to a container
+    // (e.g. the clone container, now also labeled with this id) fails `volume
+    // rm` until that container is gone; removing the volume first (the old
+    // order) left it un-retried and orphaned in exactly that case.
     const leftover = dockerRun([
       "ps",
       "-a",
@@ -387,6 +451,7 @@ export async function createSandbox(
     for (const c of leftover.stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)) {
       dockerRun(["rm", "-f", c]);
     }
+    dockerRun(["volume", "rm", "-f", volumeName]);
     throw err;
   }
 }

--- a/plugins/ca-sandbox/tools/docker.ts
+++ b/plugins/ca-sandbox/tools/docker.ts
@@ -1,0 +1,70 @@
+/**
+ * docker.ts — ca-sandbox's single docker-primitive module (architecture-007).
+ *
+ * The ONE place that defines the Windows/Git-Bash env guard, the default
+ * spawnSync-based docker runner, and the `{code,stdout,stderr}` result shape.
+ * Mirrors `plugins/ca/tools/exec.ts`'s "every spawn routes through here"
+ * discipline: build.ts, claude-inside.ts, cli.ts, cp.ts, create.ts, exec.ts,
+ * registry.ts, and run.ts all import from here instead of each hand-rolling
+ * their own copy — previously the guard and the runner were pasted verbatim
+ * into every one of those modules (and the result shape recurred under three
+ * names: `RunResult`, `ClaudeRunResult`, `DockerResult`), so a fix to one could
+ * silently miss the other seven. This is a behavior-preserving extraction: no
+ * call site's observable behavior changes.
+ *
+ * The injectable-runner seam every command module exposes (`opts.dockerRun`)
+ * is unaffected — this module only supplies the DEFAULT implementation tests
+ * override.
+ */
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+
+// On Windows + Git Bash, container paths / label / `-e` values handed to docker
+// get mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike
+// A/B). Defined ONCE here; every module imports this constant rather than
+// re-spreading process.env itself.
+export const DOCKER_ENV: NodeJS.ProcessEnv = { ...process.env, MSYS_NO_PATHCONV: "1" };
+
+/** The one result shape every docker invocation in this plugin returns. */
+export type RunResult = { code: number; stdout: string; stderr: string };
+
+/** An injectable docker runner — the seam every command module's tests use. */
+export type DockerRun = (args: string[]) => RunResult;
+
+/**
+ * The actual spawnSync("docker", ...) call, shared by every default runner.
+ * `extra` lets a caller (e.g. exec.ts, which captures large in-container
+ * output) widen spawnSync's own options — such as maxBuffer — without forking
+ * a second copy of the env-guard / result-mapping logic.
+ */
+function runDocker(
+  args: string[],
+  extra: Partial<SpawnSyncOptionsWithStringEncoding> = {},
+): RunResult {
+  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV, ...extra });
+  return {
+    code: r.status ?? 1,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
+  };
+}
+
+/**
+ * The default docker runner every command module falls back to when no
+ * `dockerRun` is injected. `spawnSync("docker", args, { encoding: "utf8", env:
+ * DOCKER_ENV })` — no extra spawnSync options.
+ */
+export function defaultDockerRun(args: string[]): RunResult {
+  return runDocker(args);
+}
+
+/**
+ * Build a docker runner with additional spawnSync options layered on top of
+ * the shared env/encoding defaults. Used by exec.ts, whose captured
+ * in-container output needs a much larger `maxBuffer` than the plain default
+ * (spawnSync's own internal cap would otherwise throw on a large stream, where
+ * exec.ts's own `capBytes` is meant to be the authoritative, deterministic
+ * bound instead).
+ */
+export function makeDockerRun(extra: Partial<SpawnSyncOptionsWithStringEncoding>): DockerRun {
+  return (args) => runDocker(args, extra);
+}

--- a/plugins/ca-sandbox/tools/exec.ts
+++ b/plugins/ca-sandbox/tools/exec.ts
@@ -22,13 +22,13 @@
  *     `truncated:true`. The default (1 MiB/stream) is generous for interactive
  *     use yet bounded.
  *
- * Process/shell handling mirrors farm.ts / run.ts: a spawnSync-based docker
- * runner (injectable for unit tests), and on Windows + Git Bash MSYS_NO_PATHCONV=1
- * is set so container paths / `-e` values handed to docker are not mangled
- * (Spike A/B). docker exec is run NON-interactively (no `-it`) so a wrapped call
- * never blocks on a tty.
+ * Process/shell handling routes through docker.ts (architecture-007): a
+ * spawnSync-based docker runner (injectable for unit tests), and on Windows +
+ * Git Bash MSYS_NO_PATHCONV=1 is set so container paths / `-e` values handed to
+ * docker are not mangled (Spike A/B). docker exec is run NON-interactively (no
+ * `-it`) so a wrapped call never blocks on a tty.
  */
-import { spawnSync } from "node:child_process";
+import { makeDockerRun, type RunResult } from "./docker.ts";
 
 /**
  * Default per-stream output cap in bytes (1 MiB). Bounds the host-side capture
@@ -40,12 +40,8 @@ export const DEFAULT_EXEC_MAX_BYTES = Number(
   process.env.CA_SANDBOX_EXEC_MAX_BYTES ?? 1024 * 1024,
 );
 
-// On Windows + Git Bash, container paths / args handed to docker get mangled by
-// MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B, mirrors run.ts).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
-
 /** Raw result of a spawned docker process — farm's RunResult shape (separate streams). */
-export type RunResult = { code: number; stdout: string; stderr: string };
+export type { RunResult };
 
 /**
  * The exec JSON contract (AC-09). `exitCode` is the in-container command's exit
@@ -69,20 +65,9 @@ export type ExecOptions = {
   dockerRun?: (args: string[]) => RunResult;
 };
 
-function defaultDockerRun(args: string[]): RunResult {
-  // maxBuffer is set high so spawnSync itself does not throw on large output;
-  // our own byte cap (capBytes) is the authoritative, deterministic bound.
-  const r = spawnSync("docker", args, {
-    encoding: "utf8",
-    env: DOCKER_ENV,
-    maxBuffer: 256 * 1024 * 1024,
-  });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
-  };
-}
+// maxBuffer is set high so spawnSync itself does not throw on large output;
+// our own byte cap (capBytes) is the authoritative, deterministic bound.
+const defaultDockerRun = makeDockerRun({ maxBuffer: 256 * 1024 * 1024 });
 
 /**
  * Assemble the `docker exec` argv (everything AFTER `docker`). Pure: builds the

--- a/plugins/ca-sandbox/tools/registry.ts
+++ b/plugins/ca-sandbox/tools/registry.ts
@@ -9,36 +9,26 @@
  * and `docker` is the single source of truth. A manually-leaked labeled object is
  * therefore visible to `list()`/`prune()` for free — exactly what AC-11 asks for.
  *
- * Process/shell handling mirrors farm.ts / run.ts / build.ts: a thin docker
- * runner returning code/stdout/stderr, MSYS_NO_PATHCONV=1 set on Windows + Git
- * Bash so labels/paths handed to docker are not mangled (Spike A/B), and the
- * docker effect is injectable so the parsing logic is unit-testable without real
- * docker while the docker-gated tests drive the real default.
+ * Process/shell handling routes through docker.ts (architecture-007): a thin
+ * docker runner returning code/stdout/stderr, MSYS_NO_PATHCONV=1 set on
+ * Windows + Git Bash so labels/paths handed to docker are not mangled (Spike
+ * A/B), and the docker effect is injectable so the parsing logic is
+ * unit-testable without real docker while the docker-gated tests drive the
+ * real default.
  */
-import { spawnSync } from "node:child_process";
+import { defaultDockerRun, type RunResult, type DockerRun } from "./docker.ts";
+
+export { defaultDockerRun };
+export type { DockerRun };
+/** Kept as a distinct exported name for existing importers — one underlying
+ * shape (docker.ts's RunResult), never a second parallel definition. */
+export type DockerResult = RunResult;
 
 /** The label every ca-sandbox object carries — the registry membership marker. */
 export const SANDBOX_LABEL_KEY = "ca.sandbox";
 export const SANDBOX_LABEL = "ca.sandbox=1";
 /** The per-instance identity label key; value is the sandbox id. */
 export const SANDBOX_ID_LABEL_KEY = "ca.sandbox.id";
-
-// On Windows + Git Bash, label/path args handed to docker get mangled by MSYS
-// path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
-
-export type DockerResult = { code: number; stdout: string; stderr: string };
-/** Injectable docker runner (defaults to spawnSync("docker", ...)). */
-export type DockerRun = (args: string[]) => DockerResult;
-
-export function defaultDockerRun(args: string[]): DockerResult {
-  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
-  };
-}
 
 /** A discovered sandbox: its id plus the docker objects that make it up. */
 export type SandboxRecord = {

--- a/plugins/ca-sandbox/tools/run.ts
+++ b/plugins/ca-sandbox/tools/run.ts
@@ -31,12 +31,13 @@
  * richer policy). T-06 wires only the safe default: `offline` => `--network none`.
  * Any other policy is passed through untouched here (T-10 layers the real flags).
  *
- * Process/shell handling mirrors farm.ts / build.ts: a `run()` child-process
- * helper returning a RunResult, and on Windows + Git Bash MSYS_NO_PATHCONV=1 is
- * set so in-container paths passed to docker are not mangled (Spike A/B).
+ * Process/shell handling routes through docker.ts (architecture-007): a shared
+ * docker-runner returning a RunResult, and on Windows + Git Bash
+ * MSYS_NO_PATHCONV=1 is set so in-container paths passed to docker are not
+ * mangled (Spike A/B).
  */
-import { spawnSync } from "node:child_process";
 import { buildMountArgs, type MountSpec } from "./mounts.ts";
+import { defaultDockerRun, type RunResult } from "./docker.ts";
 
 /** In-container app dir; the live source named volume mounts here (Spike A). */
 export const APP_DIR = "/work/repo";
@@ -44,10 +45,6 @@ export const APP_DIR = "/work/repo";
 export const SANDBOX_LABEL = "ca.sandbox=1";
 /** Non-root uid:gid the container process runs as. */
 export const SANDBOX_USER = "1000:1000";
-
-// On Windows + Git Bash, container paths / `-e HOME` handed to docker get
-// mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
-const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
 
 /**
  * Network policy for a sandbox run. T-06 only distinguishes the safe default
@@ -83,19 +80,10 @@ export type RunOptions = {
    */
   namePrefix?: string;
   /** Injectable docker runner (defaults to spawnSync("docker", ...)). */
-  dockerRun?: (args: string[]) => { code: number; stdout: string; stderr: string };
+  dockerRun?: (args: string[]) => RunResult;
 };
 
-export type RunResult = { code: number; stdout: string; stderr: string };
-
-function defaultDockerRun(args: string[]): RunResult {
-  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
-  };
-}
+export type { RunResult };
 
 /**
  * Assemble the full `docker run` argv (everything AFTER `docker`) for an

--- a/plugins/ca-sandbox/tools/sandbox.js
+++ b/plugins/ca-sandbox/tools/sandbox.js
@@ -3,15 +3,12 @@
 // cli.ts
 import { fileURLToPath } from "node:url";
 import path2 from "node:path";
-import { spawnSync as spawnSync6 } from "node:child_process";
+import { spawnSync as spawnSync3 } from "node:child_process";
 
 // create.ts
-import { spawnSync as spawnSync3, spawn as spawn2 } from "node:child_process";
+import { spawnSync as spawnSync2, spawn as spawn2 } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { readdir } from "node:fs/promises";
-
-// run.ts
-import { spawnSync } from "node:child_process";
 
 // mounts.ts
 var BindMountRejectedError = class extends Error {
@@ -83,20 +80,29 @@ function buildMountArgs(specs) {
   return argv;
 }
 
-// run.ts
-var APP_DIR = "/work/repo";
-var SANDBOX_LABEL = "ca.sandbox=1";
-var SANDBOX_USER = "1000:1000";
+// docker.ts
+import { spawnSync } from "node:child_process";
 var DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
-var NETWORKED_POLICIES = /* @__PURE__ */ new Set();
-function defaultDockerRun(args) {
-  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV });
+function runDocker(args, extra = {}) {
+  const r = spawnSync("docker", args, { encoding: "utf8", env: DOCKER_ENV, ...extra });
   return {
     code: r.status ?? 1,
     stdout: r.stdout ?? "",
     stderr: r.stderr ?? (r.error ? String(r.error) : "")
   };
 }
+function defaultDockerRun(args) {
+  return runDocker(args);
+}
+function makeDockerRun(extra) {
+  return (args) => runDocker(args, extra);
+}
+
+// run.ts
+var APP_DIR = "/work/repo";
+var SANDBOX_LABEL = "ca.sandbox=1";
+var SANDBOX_USER = "1000:1000";
+var NETWORKED_POLICIES = /* @__PURE__ */ new Set();
 function hardeningFlags() {
   return [
     "--user",
@@ -170,11 +176,10 @@ var DEPS_DIR = "/deps";
 var APP_DIR2 = "/work/repo";
 var NIXPACKS_APP_DIR = "/app";
 var NIXPACKS_INSTALL_URL = "https://nixpacks.com/install.sh";
-var DOCKER_ENV2 = { ...process.env, MSYS_NO_PATHCONV: "1" };
-var BUILD_ENV = { ...DOCKER_ENV2, DOCKER_BUILDKIT: "1" };
+var BUILD_ENV = { ...DOCKER_ENV, DOCKER_BUILDKIT: "1" };
 function run(cmd, args, opts = {}) {
   return new Promise((resolve) => {
-    const c = spawn(cmd, args, { env: DOCKER_ENV2, ...opts });
+    const c = spawn(cmd, args, { env: DOCKER_ENV, ...opts });
     let stdout = "";
     let stderr = "";
     c.stdout?.on("data", (d) => stdout += d);
@@ -419,18 +424,8 @@ nixpacks=${nixpacksVersion}`;
 }
 
 // registry.ts
-import { spawnSync as spawnSync2 } from "node:child_process";
 var SANDBOX_LABEL2 = "ca.sandbox=1";
 var SANDBOX_ID_LABEL_KEY = "ca.sandbox.id";
-var DOCKER_ENV3 = { ...process.env, MSYS_NO_PATHCONV: "1" };
-function defaultDockerRun2(args) {
-  const r = spawnSync2("docker", args, { encoding: "utf8", env: DOCKER_ENV3 });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : "")
-  };
-}
 function idLabel(id) {
   return `${SANDBOX_ID_LABEL_KEY}=${id}`;
 }
@@ -438,31 +433,31 @@ function labelFilterArgs(labels) {
   const list = Array.isArray(labels) ? labels : [labels];
   return list.flatMap((l) => ["--filter", `label=${l}`]);
 }
-function listContainers(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun2) {
+function listContainers(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
   const r = dockerRun(["ps", "-a", "-q", "--no-trunc", ...labelFilterArgs(labels)]);
   return splitLines(r.stdout);
 }
-function listVolumes(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun2) {
+function listVolumes(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
   const r = dockerRun(["volume", "ls", "-q", ...labelFilterArgs(labels)]);
   return splitLines(r.stdout);
 }
 function splitLines(out) {
   return out.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
 }
-function listAllContainers(dockerRun = defaultDockerRun2) {
+function listAllContainers(dockerRun = defaultDockerRun) {
   return listContainers(SANDBOX_LABEL2, dockerRun);
 }
-function listAllVolumes(dockerRun = defaultDockerRun2) {
+function listAllVolumes(dockerRun = defaultDockerRun) {
   return listVolumes(SANDBOX_LABEL2, dockerRun);
 }
-function findSandbox(id, dockerRun = defaultDockerRun2) {
+function findSandbox(id, dockerRun = defaultDockerRun) {
   const labels = [SANDBOX_LABEL2, idLabel(id)];
   const containers = listContainers(labels, dockerRun);
   const volumes = listVolumes(labels, dockerRun);
   if (containers.length === 0 && volumes.length === 0) return null;
   return { id, containers, volumes };
 }
-function resolveContainerId(id, dockerRun = defaultDockerRun2) {
+function resolveContainerId(id, dockerRun = defaultDockerRun) {
   const rec = findSandbox(id, dockerRun);
   const containerId = rec?.containers[0];
   if (!containerId)
@@ -473,10 +468,11 @@ function resolveContainerId(id, dockerRun = defaultDockerRun2) {
 }
 
 // create.ts
-var DOCKER_ENV4 = { ...process.env, MSYS_NO_PATHCONV: "1" };
 var CLONE_IMAGE = "alpine/git:latest";
 var APP_DIR3 = "/work/repo";
 var VOLUME_PREFIX = "ca-sbx-vol";
+var CLONE_TIMEOUT_MS = Number(process.env.CA_SANDBOX_CLONE_TIMEOUT_MS ?? 5 * 6e4);
+var CP_TIMEOUT_MS = Number(process.env.CA_SANDBOX_CP_TIMEOUT_MS ?? 2 * 6e4);
 var InvalidRepoUrlError = class extends Error {
   constructor(url, reason) {
     super(
@@ -500,20 +496,16 @@ function validateRepoUrl(url) {
     );
   }
 }
-function defaultDockerRun3(args) {
-  const r = spawnSync3("docker", args, { encoding: "utf8", env: DOCKER_ENV4 });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : "")
-  };
-}
 function newSandboxId() {
   return randomBytes(6).toString("hex");
 }
-function spawnAsync(cmd, args) {
+function spawnAsync(cmd, args, timeoutMs) {
   return new Promise((resolve) => {
-    const c = spawn2(cmd, args, { env: DOCKER_ENV4, stdio: ["ignore", "ignore", "pipe"] });
+    const c = spawn2(cmd, args, {
+      env: DOCKER_ENV,
+      stdio: ["ignore", "ignore", "pipe"],
+      ...timeoutMs !== void 0 ? { timeout: timeoutMs } : {}
+    });
     const stderrChunks = [];
     c.stderr?.on("data", (chunk) => stderrChunks.push(chunk));
     c.on("error", () => resolve({ code: 1, stderr: "" }));
@@ -524,10 +516,10 @@ function spawnAsync(cmd, args) {
     });
   });
 }
-async function defaultCloneRepo(url, volumeName) {
-  return spawnAsync("docker", buildCloneArgs(url, volumeName));
+async function defaultCloneRepo(url, volumeName, id) {
+  return spawnAsync("docker", buildCloneArgs(url, volumeName, id), CLONE_TIMEOUT_MS);
 }
-function buildCloneArgs(url, volumeName) {
+function buildCloneArgs(url, volumeName, id) {
   return [
     "run",
     "--rm",
@@ -535,6 +527,10 @@ function buildCloneArgs(url, volumeName) {
     // covered by the bind-rejection guarantee and there is genuinely one mount-argv
     // path. Same volume spec as before -> byte-identical argv.
     ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR3 }]),
+    "--label",
+    SANDBOX_LABEL2,
+    "--label",
+    idLabel(id),
     CLONE_IMAGE,
     "clone",
     "--depth",
@@ -544,25 +540,32 @@ function buildCloneArgs(url, volumeName) {
     APP_DIR3
   ];
 }
-async function defaultBuildImage(volumeName) {
+function buildCpHelperCreateArgs(volumeName, helperName, id) {
+  return [
+    "create",
+    "--name",
+    helperName,
+    "--label",
+    SANDBOX_LABEL2,
+    "--label",
+    idLabel(id),
+    // Same buildMountArgs chokepoint as buildCloneArgs (architecture-006).
+    ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR3 }]),
+    CLONE_IMAGE,
+    "true"
+  ];
+}
+async function defaultBuildImage(volumeName, id) {
   const { mkdtemp: mkdtemp2, rm: rm2 } = await import("node:fs/promises");
   const { tmpdir } = await import("node:os");
   const path3 = await import("node:path");
   const dir = await mkdtemp2(path3.join(tmpdir(), "ca-sbx-checkout-"));
   const helper = `ca-sbx-cp-${newSandboxId()}`;
-  const createResult = spawnSync3(
-    "docker",
-    [
-      "create",
-      "--name",
-      helper,
-      // Same buildMountArgs chokepoint as buildCloneArgs (architecture-006).
-      ...buildMountArgs([{ type: "volume", source: volumeName, target: APP_DIR3 }]),
-      CLONE_IMAGE,
-      "true"
-    ],
-    { env: DOCKER_ENV4, encoding: "utf8" }
-  );
+  const createResult = spawnSync2("docker", buildCpHelperCreateArgs(volumeName, helper, id), {
+    env: DOCKER_ENV,
+    encoding: "utf8",
+    timeout: CP_TIMEOUT_MS
+  });
   if ((createResult.status ?? 1) !== 0) {
     const hint = (createResult.stderr ?? "").trim();
     await rm2(dir, { recursive: true, force: true }).catch(() => {
@@ -573,9 +576,10 @@ ${hint}` : ""}`
     );
   }
   try {
-    const cpResult = spawnSync3("docker", ["cp", `${helper}:${APP_DIR3}/.`, dir], {
-      env: DOCKER_ENV4,
-      encoding: "utf8"
+    const cpResult = spawnSync2("docker", ["cp", `${helper}:${APP_DIR3}/.`, dir], {
+      env: DOCKER_ENV,
+      encoding: "utf8",
+      timeout: CP_TIMEOUT_MS
     });
     if ((cpResult.status ?? 1) !== 0) {
       const hint = (cpResult.stderr ?? "").trim();
@@ -588,7 +592,7 @@ ${hint}` : ""}`
     const dephash = computeDepHash(manifests);
     return await buildOrReuseImage(dir, dephash);
   } finally {
-    spawnSync3("docker", ["rm", "-f", helper], { env: DOCKER_ENV4 });
+    spawnSync2("docker", ["rm", "-f", helper], { env: DOCKER_ENV });
     await rm2(dir, { recursive: true, force: true }).catch(() => {
     });
   }
@@ -627,7 +631,7 @@ async function readManifests(dir, path3) {
 }
 async function createSandbox(url, opts = {}) {
   validateRepoUrl(url);
-  const dockerRun = opts.dockerRun ?? defaultDockerRun3;
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const cloneRepo = opts.cloneRepo ?? defaultCloneRepo;
   const buildImage = opts.buildImage ?? defaultBuildImage;
   const netPolicy = opts.netPolicy ?? "offline";
@@ -643,7 +647,7 @@ ${mk.stderr.slice(-1e3)}`
     );
   }
   try {
-    const cloneRaw = await cloneRepo(url, volumeName);
+    const cloneRaw = await cloneRepo(url, volumeName, id);
     const cloneCode = typeof cloneRaw === "number" ? cloneRaw : cloneRaw.code;
     const cloneStderr = typeof cloneRaw === "number" ? "" : cloneRaw.stderr;
     if (cloneCode !== 0) {
@@ -653,7 +657,7 @@ ${cloneStderr.trim()}` : "";
         `ca-sandbox: clone of ${url} into ${volumeName} failed (exit ${cloneCode})${hint}`
       );
     }
-    const build = await buildImage(volumeName);
+    const build = await buildImage(volumeName, id);
     const containerId = runContainer(build.tag, volumeName, netPolicy, {
       extraLabels: [idLabel(id), ...opts.extraLabels ?? []],
       namePrefix: `ca-sbx-${id}`,
@@ -667,7 +671,6 @@ ${cloneStderr.trim()}` : "";
       notes: build.notes
     };
   } catch (err) {
-    dockerRun(["volume", "rm", "-f", volumeName]);
     const leftover = dockerRun([
       "ps",
       "-a",
@@ -679,6 +682,7 @@ ${cloneStderr.trim()}` : "";
     for (const c of leftover.stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)) {
       dockerRun(["rm", "-f", c]);
     }
+    dockerRun(["volume", "rm", "-f", volumeName]);
     throw err;
   }
 }
@@ -686,7 +690,7 @@ ${cloneStderr.trim()}` : "";
 // destroy.ts
 function destroySandbox(id, opts = {}) {
   if (!id) throw new Error("ca-sandbox: destroySandbox requires a sandbox id");
-  const dockerRun = opts.dockerRun ?? defaultDockerRun2;
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const labels = [SANDBOX_LABEL2, idLabel(id)];
   const containers = listContainers(labels, dockerRun);
   const volumes = listVolumes(labels, dockerRun);
@@ -708,7 +712,7 @@ function destroySandbox(id, opts = {}) {
   return { id, removedContainers, removedVolumes, keptVolumes };
 }
 function prune(opts = {}) {
-  const dockerRun = opts.dockerRun ?? defaultDockerRun2;
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const removedContainers = [];
   for (const c of listAllContainers(dockerRun)) {
     const r = dockerRun(["rm", "-f", c]);
@@ -723,23 +727,10 @@ function prune(opts = {}) {
 }
 
 // exec.ts
-import { spawnSync as spawnSync4 } from "node:child_process";
 var DEFAULT_EXEC_MAX_BYTES = Number(
   process.env.CA_SANDBOX_EXEC_MAX_BYTES ?? 1024 * 1024
 );
-var DOCKER_ENV5 = { ...process.env, MSYS_NO_PATHCONV: "1" };
-function defaultDockerRun4(args) {
-  const r = spawnSync4("docker", args, {
-    encoding: "utf8",
-    env: DOCKER_ENV5,
-    maxBuffer: 256 * 1024 * 1024
-  });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : "")
-  };
-}
+var defaultDockerRun2 = makeDockerRun({ maxBuffer: 256 * 1024 * 1024 });
 function buildExecArgs(id, argv) {
   if (!id) throw new Error("ca-sandbox: execInSandbox requires a non-empty container id");
   if (!argv || argv.length === 0)
@@ -757,7 +748,7 @@ function capBytes(s, maxBytes) {
 }
 function execInSandbox(id, argv, opts = {}) {
   const args = buildExecArgs(id, argv);
-  const dockerRun = opts.dockerRun ?? defaultDockerRun4;
+  const dockerRun = opts.dockerRun ?? defaultDockerRun2;
   const maxBytes = opts.maxBytes ?? DEFAULT_EXEC_MAX_BYTES;
   const start = Date.now();
   const r = dockerRun(args);
@@ -775,16 +766,6 @@ function execInSandbox(id, argv, opts = {}) {
 }
 
 // cp.ts
-import { spawnSync as spawnSync5 } from "node:child_process";
-var DOCKER_ENV6 = { ...process.env, MSYS_NO_PATHCONV: "1" };
-function defaultDockerRun5(args) {
-  const r = spawnSync5("docker", args, { encoding: "utf8", env: DOCKER_ENV6 });
-  return {
-    code: r.status ?? 1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? (r.error ? String(r.error) : "")
-  };
-}
 function buildCpOutArgs(id, containerPath, hostDest) {
   if (!id) throw new Error("ca-sandbox: cpOut requires a non-empty container id");
   if (!containerPath) throw new Error("ca-sandbox: cpOut requires a non-empty container path");
@@ -793,12 +774,11 @@ function buildCpOutArgs(id, containerPath, hostDest) {
 }
 function cpOut(id, containerPath, hostDest, opts = {}) {
   const args = buildCpOutArgs(id, containerPath, hostDest);
-  const dockerRun = opts.dockerRun ?? defaultDockerRun5;
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
   return dockerRun(args);
 }
 
 // cli.ts
-var DOCKER_ENV7 = { ...process.env, MSYS_NO_PATHCONV: "1" };
 var NET_POLICIES = ["offline", "clone-then-cut", "allowlist"];
 var DEFAULT_SHELL = "sh";
 var CliError = class extends Error {
@@ -959,9 +939,9 @@ function parsePrune(args) {
 }
 function defaultShell(id, shell) {
   const containerId = resolveContainerId(id);
-  const r = spawnSync6("docker", ["exec", "-it", containerId, shell], {
+  const r = spawnSync3("docker", ["exec", "-it", containerId, shell], {
     stdio: "inherit",
-    env: DOCKER_ENV7
+    env: DOCKER_ENV
   });
   return r.status ?? 1;
 }


### PR DESCRIPTION
Lane D — ca-sandbox dedup + container-lifecycle hardening.

## What
- **#180 (refactor, behavior-preserving):** extracts one shared `plugins/ca-sandbox/tools/docker.ts` primitive — a single `DOCKER_ENV` (the `MSYS_NO_PATHCONV` Windows guard), one `defaultDockerRun`/`makeDockerRun`, one canonical `{code,stdout,stderr}` `RunResult`. The ~8 duplicated copies across build/claude-inside/cli/cp/create/exec/registry/run now import it; `ClaudeRunResult`/`DockerResult` collapse to aliases. Injectable-runner test seam preserved. (typesafety-002 was already fixed in #197.)
- **#173 (reliability):** labels the throwaway clone + docker-cp helper containers `ca.sandbox=1` + `ca.sandbox.id=<id>` (so the AC-11 prune sweep can reclaim them), adds wall-clock timeouts to the clone/cp steps, and reorders createSandbox failure teardown to remove containers before the volume (closes a prior orphan-on-in-use-volume leak).

## Verification
- `npm run typecheck` 0 errors; `npm test` 164 passed / 31 docker-gated skipped (no Docker engine — expected); `npm run build` + `git diff --quiet -- sandbox.js` clean (rebuilt bundle committed). **No pre-existing test assertions modified** (refactor parity).
- **security-reviewer: PASS** — 0 critical/high/medium. Confirmed the `MSYS_NO_PATHCONV` guard survives on all 8 command paths, no `shell:true` introduced, every container-isolation control intact, and the #173 change strictly *reduces* leak surface. 3 LOWs, all no-action (timeout is a client-side bound backstopped by label+prune; stand-in test acceptable; global-prune blast radius arguably-correct).

Bumps ca-sandbox 0.1.2 → 0.1.3.

Closes #180
Closes #173

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa