### PR TITLE
fix(farm): bound body reads, complete abort accounting, validate numeric env, surface mutation-hook failures, cover entitlement probe (#192 #187 #183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.2" src="https://img.shields.io/badge/version-2.8.2-2b7489">
+<img alt="version 2.8.3" src="https://img.shields.io/badge/version-2.8.3-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/tools/exec.ts
+++ b/plugins/ca/tools/exec.ts
@@ -34,6 +34,35 @@ export const [SHELL_BIN, SHELL_FLAG] =
 export const SHELL_OPTS =
   process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
 
+// reliability-014: a single hardened numeric-env reader shared by farm.ts and
+// mutation.ts (every FARM_*/MUT_* numeric knob routes through here). Plain
+// `Number(process.env.X ?? default)` silently yields NaN on a typo (e.g.
+// FARM_CONCURRENCY="four"), and NaN reads FALSE in every safety comparison
+// built on it — the concurrency cap (`running.size >= ENV.concurrency`), the
+// escalation-rate circuit breaker, and retry limits all silently disable with
+// zero signal. Falls back to the default LOUDLY (stderr) on any non-finite
+// parse; an optional `min` clamps a parsed-but-too-low value up to the floor
+// the knob needs to stay meaningful (also logged). Lives in exec.ts (not
+// farm.ts) so mutation.ts can use it too without a farm.ts -> mutation.ts ->
+// farm.ts import cycle (function declarations hoist, so GATE_TIMEOUT_MS below
+// can call it before this point in file order).
+export function numEnv(name: string, def: number, opts: { min?: number } = {}): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return def;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    process.stderr.write(
+      `[FARM] ${name}=${JSON.stringify(raw)} is not a finite number — falling back to the default ${def}\n`,
+    );
+    return def;
+  }
+  if (opts.min !== undefined && n < opts.min) {
+    process.stderr.write(`[FARM] ${name}=${n} is below the minimum ${opts.min} — clamping to ${opts.min}\n`);
+    return opts.min;
+  }
+  return n;
+}
+
 // T-06 (reliability-001): per-command wall-clock timeout. The shared run() helper
 // previously resolved ONLY on the child's close/error event, so a gate/setup/
 // mutation command that never exits (a test blocking on stdin, a watch/dev-server
@@ -41,7 +70,7 @@ export const SHELL_OPTS =
 // scheduler's Promise.race never settled, so the whole run hung with no report.
 // This mirrors the AbortController discipline the API path already uses. Default a
 // few minutes; configurable, independent of FARM_REQUEST_TIMEOUT_MS.
-export const GATE_TIMEOUT_MS = Number(process.env.FARM_GATE_TIMEOUT_MS ?? 300_000);
+export const GATE_TIMEOUT_MS = numEnv("FARM_GATE_TIMEOUT_MS", 300_000, { min: 1000 });
 
 // Kill a spawned child and its descendants. On Windows a plain child.kill() does
 // not reap the process tree (cmd.exe /c spawns the real command as a grandchild),

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -13,7 +13,25 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 var [SHELL_BIN, SHELL_FLAG] = process.platform === "win32" ? ["cmd.exe", "/c"] : ["bash", "-c"];
 var SHELL_OPTS = process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
-var GATE_TIMEOUT_MS = Number(process.env.FARM_GATE_TIMEOUT_MS ?? 3e5);
+function numEnv(name, def, opts = {}) {
+  const raw = process.env[name];
+  if (raw === void 0 || raw === "") return def;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    process.stderr.write(
+      `[FARM] ${name}=${JSON.stringify(raw)} is not a finite number \u2014 falling back to the default ${def}
+`
+    );
+    return def;
+  }
+  if (opts.min !== void 0 && n < opts.min) {
+    process.stderr.write(`[FARM] ${name}=${n} is below the minimum ${opts.min} \u2014 clamping to ${opts.min}
+`);
+    return opts.min;
+  }
+  return n;
+}
+var GATE_TIMEOUT_MS = numEnv("FARM_GATE_TIMEOUT_MS", 3e5, { min: 1e3 });
 function treeKill(child) {
   try {
     if (process.platform === "win32" && child.pid !== void 0) {
@@ -116,10 +134,14 @@ import { writeFile } from "node:fs/promises";
 import path2 from "node:path";
 var MUT = {
   enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
-  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
-  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 3e4),
-  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
-  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
+  // reliability-014: routed through the shared numEnv reader (exec.ts) so a
+  // typo'd FARM_MUTATION_* value falls back to the default loudly instead of
+  // silently becoming NaN (every comparison against MUT.warnBelow/escalateBelow
+  // would then read false, disabling the anti-gaming mutation signal).
+  sample: numEnv("FARM_MUTATION_SAMPLE", 15, { min: 1 }),
+  budgetMs: numEnv("FARM_MUTATION_BUDGET_MS", 3e4, { min: 0 }),
+  warnBelow: numEnv("FARM_MUTATION_WARN_BELOW", 0.5, { min: 0 }),
+  escalateBelow: numEnv("FARM_MUTATION_ESCALATE_BELOW", 0.1, { min: 0 }),
   cmd: process.env.FARM_MUTATION_CMD ?? null
 };
 function extractLiterals(testSrc) {
@@ -245,7 +267,10 @@ async function mutationCheck(wt, task) {
       c.on("error", (e) => finish({ code: 1, out: String(e) }));
       c.on("close", (code) => finish({ code: code ?? 1, out }));
     });
-    return parseMutationHookOutput(r.out);
+    const parsed = parseMutationHookOutput(r.out);
+    if (parsed !== null) return parsed;
+    const tail = redactSecrets(r.out.slice(-500)).trim();
+    return { failed: true, detail: `exit ${r.code}${tail ? `: ${tail}` : " (no output)"}` };
   }
   const originals = /* @__PURE__ */ new Map();
   let candidates = [];
@@ -292,24 +317,28 @@ var ENV = {
   // user who sets just FARM_API_KEY (per the docs) is not hard-blocked.
   apiBaseUrl: process.env.FARM_API_BASE_URL ?? null,
   apiKey: process.env.FARM_API_KEY ?? null,
-  concurrency: Number(process.env.FARM_CONCURRENCY ?? 4),
-  maxRetries: Number(process.env.FARM_MAX_RETRIES ?? 2),
+  // reliability-014: every numeric knob below routes through numEnv (exec.ts)
+  // so a typo'd value (e.g. FARM_CONCURRENCY="four") falls back to the default
+  // LOUDLY instead of silently becoming NaN, which reads false in every
+  // downstream safety comparison (concurrency cap, escalation breaker).
+  concurrency: numEnv("FARM_CONCURRENCY", 4, { min: 1 }),
+  maxRetries: numEnv("FARM_MAX_RETRIES", 2, { min: 0 }),
   base: process.env.FARM_BASE_BRANCH ?? "main",
   integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
   worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
   // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
-  requestTimeoutMs: Number(process.env.FARM_REQUEST_TIMEOUT_MS ?? 12e4),
+  requestTimeoutMs: numEnv("FARM_REQUEST_TIMEOUT_MS", 12e4, { min: 1 }),
   // Per-candidate wall-clock cap for the #93 entitlement pre-screen, so one
   // slow/dead model can't dominate the probe. Kept short (35s) — a screen, not a
   // capability run — and ≤ the per-request timeout.
-  entitlementProbeTimeoutMs: Number(process.env.FARM_ENTITLEMENT_PROBE_TIMEOUT_MS ?? 35e3),
+  entitlementProbeTimeoutMs: numEnv("FARM_ENTITLEMENT_PROBE_TIMEOUT_MS", 35e3, { min: 1 }),
   // Transport-level retries (429 / 5xx) — distinct from model-quality retries.
-  apiMaxRetries: Number(process.env.FARM_API_MAX_RETRIES ?? 3),
+  apiMaxRetries: numEnv("FARM_API_MAX_RETRIES", 3, { min: 0 }),
   // Circuit breaker: abort dispatch once the escalation rate exceeds this,
   // after at least abortMinTasks have settled.
-  abortEscalationRate: Number(process.env.FARM_ABORT_ESCALATION_RATE ?? 0.5),
-  abortMinTasks: Number(process.env.FARM_ABORT_MIN_TASKS ?? 3),
+  abortEscalationRate: numEnv("FARM_ABORT_ESCALATION_RATE", 0.5, { min: 0 }),
+  abortMinTasks: numEnv("FARM_ABORT_MIN_TASKS", 3, { min: 1 }),
   // Default endpoint, used only when neither env nor plan.meta provides one.
   defaultApiBaseUrl: process.env.FARM_DEFAULT_API_BASE_URL ?? DEFAULT_API_BASE_URL,
   // Comma-separated candidate model ids for --canary mode.
@@ -323,7 +352,7 @@ var ENV = {
   // budget and to bound per-task token spend. Truncation past the cap is
   // deterministic (in-order) with a visible marker; we never silently drop the
   // boundedness guarantee.
-  enrichMaxBytes: Number(process.env.FARM_ENRICH_MAX_BYTES ?? 131072)
+  enrichMaxBytes: numEnv("FARM_ENRICH_MAX_BYTES", 131072, { min: 1 })
 };
 var git = (args, cwd) => run("git", args, cwd);
 var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -593,8 +622,8 @@ function parseChatCompletion(text, apiBaseUrl) {
 }
 function readSampling() {
   return {
-    temperature: Number(process.env.FARM_TEMPERATURE ?? 0),
-    maxTokens: Number(process.env.FARM_MAX_TOKENS ?? 0)
+    temperature: numEnv("FARM_TEMPERATURE", 0),
+    maxTokens: numEnv("FARM_MAX_TOKENS", 0, { min: 0 })
   };
 }
 function buildChatBody(model, messages, sampling = readSampling()) {
@@ -626,27 +655,36 @@ async function callApi(prompt, model, apiBaseUrl, apiKey, sampling = readSamplin
       }
       return { ok: false, error: aborted ? `request timed out after ${ENV.requestTimeoutMs}ms` : `fetch failed: ${e}` };
     }
-    clearTimeout(timer);
-    if (resp.status === 429 || resp.status >= 500) {
-      if (attempt < ENV.apiMaxRetries) {
-        const ra = Number(resp.headers.get("retry-after"));
-        const wait = Number.isFinite(ra) && ra > 0 ? ra * 1e3 : Math.min(2 ** attempt * 1e3, 16e3);
-        await sleep(wait);
-        continue;
+    try {
+      if (resp.status === 429 || resp.status >= 500) {
+        if (attempt < ENV.apiMaxRetries) {
+          const ra = Number(resp.headers.get("retry-after"));
+          const wait = Number.isFinite(ra) && ra > 0 ? ra * 1e3 : Math.min(2 ** attempt * 1e3, 16e3);
+          await sleep(wait);
+          continue;
+        }
+        const body = await resp.text();
+        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 300)}
+`);
+        return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries` };
       }
-      const body = await resp.text().catch(() => "(unreadable)");
-      process.stderr.write(`API ${resp.status} body: ${body.slice(0, 300)}
+      if (!resp.ok) {
+        const body = await resp.text();
+        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 500)}
 `);
-      return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries` };
+        return { ok: false, error: `API ${resp.status}` };
+      }
+      const text = await resp.text();
+      return parseChatCompletion(text, apiBaseUrl);
+    } catch (e) {
+      const aborted = e?.name === "AbortError";
+      return {
+        ok: false,
+        error: aborted ? `request timed out after ${ENV.requestTimeoutMs}ms (reading response body)` : `failed reading response body: ${e}`
+      };
+    } finally {
+      clearTimeout(timer);
     }
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "(unreadable)");
-      process.stderr.write(`API ${resp.status} body: ${body.slice(0, 500)}
-`);
-      return { ok: false, error: `API ${resp.status}` };
-    }
-    const text = await resp.text().catch(() => "");
-    return parseChatCompletion(text, apiBaseUrl);
   }
   return { ok: false, error: "exhausted API retries" };
 }
@@ -851,8 +889,7 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   const effectiveModel = t.model ?? model;
   const allowed = new Set(t.filesInScope);
   const forbidden = /* @__PURE__ */ new Set([t.test.path]);
-  const rawSamples = Number(process.env.FARM_SAMPLES ?? 1);
-  const samples = Number.isFinite(rawSamples) ? Math.max(1, Math.floor(rawSamples)) : 1;
+  const samples = Math.max(1, Math.floor(numEnv("FARM_SAMPLES", 1, { min: 1 })));
   const sampling = effectiveSampling(samples);
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
@@ -940,7 +977,7 @@ ${gate.tail}`);
     let riskNote = gaming.note;
     if (risk !== "high") {
       const mut = await deps.mutationCheck(wt, t);
-      if (mut) {
+      if (mut && "score" in mut) {
         mutationScore = mut.score;
         if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
           risk = "high";
@@ -950,6 +987,13 @@ ${gate.tail}`);
             risk = "warn";
             riskNote = `mutation-risk: score ${mut.score.toFixed(2)} (${mut.survivors.length}/${mut.evaluated} survived) \u2014 weak test or under-implemented logic`;
           }
+        }
+      } else if (mut && "failed" in mut) {
+        process.stderr.write(`[FARM] mutation hook failed for task ${t.id}: ${mut.detail}
+`);
+        if (risk === "none") {
+          risk = "warn";
+          riskNote = `mutation-hook-failed: ${mut.detail}`;
         }
       }
     }
@@ -1237,40 +1281,42 @@ async function main() {
       return escalated.size / settled > ENV.abortEscalationRate;
     };
     while (pending.size > 0 || running.size > 0) {
-      if (tripped()) {
-        aborted = true;
-        break;
-      }
-      for (const id2 of ready()) {
-        if (running.size >= ENV.concurrency) break;
-        pending.delete(id2);
-        running.set(
-          id2,
-          runTask(byId.get(id2), model, apiBaseUrl, apiKey).then(
-            (r2) => ({ id: id2, r: r2 }),
-            // observability-003 (T-07c): a crash produces an escalate Result with
-            // a correlated, stack-bearing note. The truncated err.stack gives the
-            // post-mortem a call site (e.g. the spawn TypeError from
-            // reliability-004) instead of a one-line message with no origin.
-            (e) => ({
-              id: id2,
-              r: {
+      if (!aborted && tripped()) aborted = true;
+      if (!aborted) {
+        for (const id2 of ready()) {
+          if (running.size >= ENV.concurrency) break;
+          pending.delete(id2);
+          running.set(
+            id2,
+            runTask(byId.get(id2), model, apiBaseUrl, apiKey).then(
+              (r2) => ({ id: id2, r: r2 }),
+              // observability-003 (T-07c): a crash produces an escalate Result with
+              // a correlated, stack-bearing note. The truncated err.stack gives the
+              // post-mortem a call site (e.g. the spawn TypeError from
+              // reliability-004) instead of a one-line message with no origin.
+              (e) => ({
                 id: id2,
-                status: "escalate",
-                attempts: 0,
-                branch: `farm/${id2}`,
-                worktree: path3.resolve(ENV.worktreeRoot, id2),
-                note: `crashed: ${e?.message ?? e}${e?.stack ? `
+                r: {
+                  id: id2,
+                  status: "escalate",
+                  attempts: 0,
+                  branch: `farm/${id2}`,
+                  worktree: path3.resolve(ENV.worktreeRoot, id2),
+                  note: `crashed: ${e?.message ?? e}${e?.stack ? `
 ${String(e.stack).slice(0, 1500)}` : ""}`
-              }
-            })
-          )
-        );
+                }
+              })
+            )
+          );
+        }
       }
       if (running.size === 0) break;
       const { id, r } = await Promise.race(running.values());
       running.delete(id);
       r.runId = runId;
+      if (aborted && r.status === "escalate" && !/run aborted/.test(r.note ?? "")) {
+        r.note = r.note ? `${r.note} (run aborted by circuit breaker while in flight)` : "escalate: run aborted (in flight)";
+      }
       done.set(id, r);
       await appendFile(resultsStream, JSON.stringify(r) + "\n").catch((e) => console.error("results stream append failed:", e));
       if (r.status === "escalate") escalated.add(id);
@@ -1364,7 +1410,9 @@ export {
   extractFileBlocks,
   extractLiterals,
   httpWorker,
+  makeEntitlementProbe,
   mintRunId,
+  numEnv,
   parseChatCompletion,
   parseMutationHookOutput,
   readSampling,

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -24,7 +24,10 @@ import type { Server } from "node:http";
 // --------------------------------------------------------------------------
 // Mini mock HTTP server that returns canned file-block responses
 // --------------------------------------------------------------------------
-type MockHandler = (body: unknown) => string;
+// reliability-013 test support: a handler may return a Promise<string> to
+// deliberately delay a response, so a test can arrange one task to stay
+// "in flight" while a sibling settles fast enough to trip the circuit breaker.
+type MockHandler = (body: unknown) => string | Promise<string>;
 
 function startMockServer(handler: MockHandler): Promise<{ server: Server; port: number }> {
   return new Promise((resolve) => {
@@ -33,13 +36,14 @@ function startMockServer(handler: MockHandler): Promise<{ server: Server; port: 
       req.on("data", (chunk) => (data += chunk));
       req.on("end", () => {
         const body = JSON.parse(data || "{}");
-        const content = handler(body);
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({
-            choices: [{ message: { content } }],
-          }),
-        );
+        Promise.resolve(handler(body)).then((content) => {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              choices: [{ message: { content } }],
+            }),
+          );
+        });
       });
     });
     server.listen(0, "127.0.0.1", () => {
@@ -102,6 +106,65 @@ function runFarm(
     child.stderr.on("data", (d: Buffer) => (out += d));
     child.on("close", (code: number | null) => resolve({ code: code ?? 1, out }));
     child.on("error", (e: Error) => resolve({ code: 1, out: String(e) }));
+  });
+}
+
+// coverage-003 (#183): same launcher as runFarm, but with an extra leading CLI
+// arg (e.g. "--canary") so runCanary's early-exit validation paths can be
+// exercised — those paths read ENV.candidateModels/ENV.apiKey, which are fixed
+// at module import time in the CHILD process, so they can only be varied via a
+// fresh subprocess per test (not a same-process unit test).
+function runFarmWithArgs(
+  repoDir: string,
+  extraArgs: string[],
+  planPath: string,
+  env: Record<string, string>,
+  // Some early-exit assertions (e.g. "FARM_API_KEY is not set") require the
+  // var to be ABSENT, not merely un-overridden — a dev/CI shell may already
+  // export a real FARM_API_KEY (this repo's one live secret), which would
+  // otherwise leak through the `...process.env` spread below and silently
+  // invalidate the "missing key" test case. `unset` deletes it from the
+  // child's env after the spread, regardless of the ambient shell.
+  unset: string[] = [],
+): Promise<{ code: number; out: string }> {
+  return new Promise((resolve) => {
+    const spawnEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "commit.gpgsign",
+      GIT_CONFIG_VALUE_0: "false",
+      ...env,
+    };
+    for (const k of unset) delete spawnEnv[k];
+    const child = spawn(
+      process.execPath,
+      ["--import", TSX_LOADER, farmTs, ...extraArgs, planPath],
+      { cwd: repoDir, env: spawnEnv },
+    );
+    let out = "";
+    child.stdout.on("data", (d: Buffer) => (out += d));
+    child.stderr.on("data", (d: Buffer) => (out += d));
+    child.on("close", (code: number | null) => resolve({ code: code ?? 1, out }));
+    child.on("error", (e: Error) => resolve({ code: 1, out: String(e) }));
+  });
+}
+
+// reliability-012: a raw http server that sends response HEADERS then never
+// closes/writes the body — the exact "slow-loris" / stalled-body shape the
+// fix must bound. Distinct from startMockServer (which always completes the
+// response) because callApi's OLD bug was specifically that the timer was
+// cleared right after headers arrived, leaving the body read unbounded.
+function startStalledBodyServer(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer((_req: IncomingMessage, res: ServerResponse) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.write("{"); // headers + partial body sent; body deliberately never closes
+      // no res.end() — the connection is held open indefinitely
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ server, port: addr.port });
+    });
   });
 }
 
@@ -1100,5 +1163,172 @@ describe("farm.ts smoke tests", () => {
     const raw = readFileSync(join(tmpDir, ".farm/farm-results.jsonl"), "utf8");
     const lines = raw.split("\n").filter((l) => l.trim().length > 0);
     expect(lines).toHaveLength(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // reliability-012 — callApi must bound the response BODY read, not just the
+  // time-to-headers.
+  // -------------------------------------------------------------------------
+  it("reliability-012: a stalled response body (headers sent, body never closes) fails within FARM_REQUEST_TIMEOUT_MS instead of hanging", async () => {
+    ({ server: mockServer, port } = await startStalledBodyServer());
+
+    const plan = {
+      meta: { name: "stalled-body-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Write hello",
+          deps: [],
+          filesInScope: ["src/hello.ts"],
+          test: { path: "src/hello.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const start = Date.now();
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_REQUEST_TIMEOUT_MS: "500",
+      FARM_API_MAX_RETRIES: "0",
+    });
+    const elapsed = Date.now() - start;
+
+    // Must fail (escalate), not hang — bounded well under a "forever" wedge.
+    // Generous ceiling for CI/Windows process-spawn overhead; the point under
+    // test is "bounded", not a tight latency budget.
+    expect(elapsed).toBeLessThan(15_000);
+    expect(result.code).toBe(2);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.results[0].status).toBe("escalate");
+    expect(report.results[0].note).toMatch(/timed out/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // reliability-013 — a circuit-breaker abort must not drop in-flight tasks
+  // from accounting, and must not tear down the integration worktree while a
+  // merge could still be in flight.
+  // -------------------------------------------------------------------------
+  it("reliability-013: every dispatched task appears in farm-report.json with a status after a breaker abort, none vanish", async () => {
+    ({ server: mockServer, port } = await startMockServer((body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      // task-fail gets malformed (unparseable) content → escalates fast.
+      if (content.includes("src/fail.ts")) return "no code fence here, sorry";
+      // The other three tasks succeed, but only after a short delay, so they
+      // are still IN FLIGHT ("running") when task-fail's fast escalation trips
+      // the circuit breaker.
+      const file = ["src/b.ts", "src/c.ts", "src/d.ts"].find((f) => content.includes(f)) ?? "src/b.ts";
+      return new Promise<string>((resolve) => {
+        setTimeout(() => resolve(["```typescript", `// path: ${file}`, "export const x = 1;", "```"].join("\n")), 300);
+      });
+    }));
+
+    const plan = {
+      meta: { name: "breaker-abort-test", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        { id: "task-fail", description: "fail fast", deps: [], filesInScope: ["src/fail.ts"], test: { path: "src/fail.test.ts" }, gate: { commands: ["node -p 0"] }, maxRetries: 0 },
+        { id: "task-b", description: "b", deps: [], filesInScope: ["src/b.ts"], test: { path: "src/b.test.ts" }, gate: { commands: ["node -p 0"] } },
+        { id: "task-c", description: "c", deps: [], filesInScope: ["src/c.ts"], test: { path: "src/c.test.ts" }, gate: { commands: ["node -p 0"] } },
+        { id: "task-d", description: "d", deps: [], filesInScope: ["src/d.ts"], test: { path: "src/d.test.ts" }, gate: { commands: ["node -p 0"] } },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_CONCURRENCY: "4", // all four dispatch concurrently — no scope overlap
+      FARM_ABORT_MIN_TASKS: "1",
+      FARM_ABORT_ESCALATION_RATE: "0", // any escalation trips the breaker immediately
+    });
+
+    expect(result.out).toContain("ABORTED by circuit breaker");
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(report.aborted).toBe(true);
+    // The load-bearing assertion: every task the scheduler DISPATCHED appears
+    // with a real status — none vanish from the report because they were
+    // still "running" (in-flight) when the breaker tripped.
+    const ids = report.results.map((r: { id: string }) => r.id).sort();
+    expect(ids).toEqual(["task-b", "task-c", "task-d", "task-fail"]);
+    for (const r of report.results) expect(["green", "escalate"]).toContain(r.status);
+    // Nothing dispatched should show up as merely "blocked" — dispatched means
+    // it left `pending`, so it must settle to green/escalate, not blocked.
+    expect(report.blocked.map((b: { id: string }) => b.id)).not.toEqual(
+      expect.arrayContaining(["task-b", "task-c", "task-d"]),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // observability-002 (#187) — a crashing/unparseable FARM_MUTATION_CMD must
+  // surface a diagnostic distinct from "mutation checking is not configured".
+  // -------------------------------------------------------------------------
+  it("#187: a crashing FARM_MUTATION_CMD surfaces a distinct diagnostic — never silently indistinguishable from not-configured", async () => {
+    ({ server: mockServer, port } = await startMockServer(() =>
+      ["```typescript", "// path: src/m.ts", "export const add = (a, b) => a + b;", "```"].join("\n"),
+    ));
+
+    const plan = {
+      meta: { name: "mutation-hook-fail", model: "test-model", apiBaseUrl: `http://127.0.0.1:${port}` },
+      tasks: [
+        {
+          id: "task-a",
+          description: "Add",
+          deps: [],
+          filesInScope: ["src/m.ts"],
+          test: { path: "src/m.test.ts" },
+          gate: { commands: ["node -p 0"] },
+          maxRetries: 0,
+        },
+      ],
+    };
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const withCrashingHook = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_MUTATION: "on",
+      FARM_MUTATION_CMD: 'node -e "process.exit(1)"',
+    });
+    // A broken mutation-hook integration is a diagnostic, not a task failure —
+    // the task itself still goes green.
+    expect(withCrashingHook.code).toBe(0);
+    expect(withCrashingHook.out).toMatch(/mutation hook failed for task task-a/);
+
+    const withoutHook = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key" });
+    expect(withoutHook.code).toBe(0);
+    expect(withoutHook.out).not.toMatch(/mutation hook failed/);
+  });
+
+  // -------------------------------------------------------------------------
+  // coverage-003 (#183) — runCanary's early-exit validation paths.
+  // -------------------------------------------------------------------------
+  it("#183: --canary exits 1 with a named error when FARM_CANDIDATE_MODELS is missing", async () => {
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(JSON.parse(readFileSync(join(__dirname, "__fixtures__/simple.plan.json"), "utf8"))));
+
+    const result = await runFarmWithArgs(tmpDir, ["--canary"], planPath, {
+      FARM_API_KEY: "test-key",
+      // FARM_CANDIDATE_MODELS deliberately unset
+    });
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("--canary requires FARM_CANDIDATE_MODELS");
+  });
+
+  it("#183: --canary exits 1 with a named error when FARM_API_KEY is missing", async () => {
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, JSON.stringify(JSON.parse(readFileSync(join(__dirname, "__fixtures__/simple.plan.json"), "utf8"))));
+
+    const result = await runFarmWithArgs(
+      tmpDir,
+      ["--canary"],
+      planPath,
+      { FARM_CANDIDATE_MODELS: "some-model" },
+      ["FARM_API_KEY"], // force-absent regardless of the ambient shell
+    );
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("FARM_API_KEY is not set");
   });
 });

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -45,11 +45,11 @@ import { fileURLToPath } from "node:url";
 // the members the test suite + external consumers import from "./farm.ts", so
 // this file stays the stable public surface. The graph is one-way: farm.ts ->
 // {exec, redactor, mutation} and mutation -> exec (no cycle).
-import { run, readWorktreeFile, SHELL_BIN, SHELL_FLAG, SHELL_OPTS, GATE_TIMEOUT_MS } from "./exec.ts";
+import { run, readWorktreeFile, SHELL_BIN, SHELL_FLAG, SHELL_OPTS, GATE_TIMEOUT_MS, numEnv } from "./exec.ts";
 import type { RunResult } from "./exec.ts";
 import { redactSecrets, isSecretBearingFilename } from "./redactor.ts";
 import { MUT, mutationCheck, antiGamingCheck } from "./mutation.ts";
-export { run, redactSecrets };
+export { run, redactSecrets, numEnv };
 export { extractLiterals, codeLineCount, parseMutationHookOutput } from "./mutation.ts";
 
 // --------------------------------------------------------------------------
@@ -99,24 +99,28 @@ const ENV = {
   // user who sets just FARM_API_KEY (per the docs) is not hard-blocked.
   apiBaseUrl: process.env.FARM_API_BASE_URL ?? null,
   apiKey: process.env.FARM_API_KEY ?? null,
-  concurrency: Number(process.env.FARM_CONCURRENCY ?? 4),
-  maxRetries: Number(process.env.FARM_MAX_RETRIES ?? 2),
+  // reliability-014: every numeric knob below routes through numEnv (exec.ts)
+  // so a typo'd value (e.g. FARM_CONCURRENCY="four") falls back to the default
+  // LOUDLY instead of silently becoming NaN, which reads false in every
+  // downstream safety comparison (concurrency cap, escalation breaker).
+  concurrency: numEnv("FARM_CONCURRENCY", 4, { min: 1 }),
+  maxRetries: numEnv("FARM_MAX_RETRIES", 2, { min: 0 }),
   base: process.env.FARM_BASE_BRANCH ?? "main",
   integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
   worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
   // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
-  requestTimeoutMs: Number(process.env.FARM_REQUEST_TIMEOUT_MS ?? 120_000),
+  requestTimeoutMs: numEnv("FARM_REQUEST_TIMEOUT_MS", 120_000, { min: 1 }),
   // Per-candidate wall-clock cap for the #93 entitlement pre-screen, so one
   // slow/dead model can't dominate the probe. Kept short (35s) — a screen, not a
   // capability run — and ≤ the per-request timeout.
-  entitlementProbeTimeoutMs: Number(process.env.FARM_ENTITLEMENT_PROBE_TIMEOUT_MS ?? 35_000),
+  entitlementProbeTimeoutMs: numEnv("FARM_ENTITLEMENT_PROBE_TIMEOUT_MS", 35_000, { min: 1 }),
   // Transport-level retries (429 / 5xx) — distinct from model-quality retries.
-  apiMaxRetries: Number(process.env.FARM_API_MAX_RETRIES ?? 3),
+  apiMaxRetries: numEnv("FARM_API_MAX_RETRIES", 3, { min: 0 }),
   // Circuit breaker: abort dispatch once the escalation rate exceeds this,
   // after at least abortMinTasks have settled.
-  abortEscalationRate: Number(process.env.FARM_ABORT_ESCALATION_RATE ?? 0.5),
-  abortMinTasks: Number(process.env.FARM_ABORT_MIN_TASKS ?? 3),
+  abortEscalationRate: numEnv("FARM_ABORT_ESCALATION_RATE", 0.5, { min: 0 }),
+  abortMinTasks: numEnv("FARM_ABORT_MIN_TASKS", 3, { min: 1 }),
   // Default endpoint, used only when neither env nor plan.meta provides one.
   defaultApiBaseUrl:
     process.env.FARM_DEFAULT_API_BASE_URL ?? DEFAULT_API_BASE_URL,
@@ -134,7 +138,7 @@ const ENV = {
   // budget and to bound per-task token spend. Truncation past the cap is
   // deterministic (in-order) with a visible marker; we never silently drop the
   // boundedness guarantee.
-  enrichMaxBytes: Number(process.env.FARM_ENRICH_MAX_BYTES ?? 131_072),
+  enrichMaxBytes: numEnv("FARM_ENRICH_MAX_BYTES", 131_072, { min: 1 }),
 };
 
 // --------------------------------------------------------------------------
@@ -639,8 +643,8 @@ export type Sampling = { temperature: number; maxTokens: number };
 
 export function readSampling(): Sampling {
   return {
-    temperature: Number(process.env.FARM_TEMPERATURE ?? 0),
-    maxTokens: Number(process.env.FARM_MAX_TOKENS ?? 0),
+    temperature: numEnv("FARM_TEMPERATURE", 0),
+    maxTokens: numEnv("FARM_MAX_TOKENS", 0, { min: 0 }),
   };
 }
 
@@ -685,36 +689,62 @@ async function callApi(
       }
       return { ok: false, error: aborted ? `request timed out after ${ENV.requestTimeoutMs}ms` : `fetch failed: ${e}` };
     }
-    clearTimeout(timer);
 
-    // Transport-level failure (rate limit / server) — back off and retry the
-    // REQUEST, not the task. A 429 is not a failed implementation attempt.
-    if (resp.status === 429 || resp.status >= 500) {
-      if (attempt < ENV.apiMaxRetries) {
-        const ra = Number(resp.headers.get("retry-after"));
-        const wait = Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(2 ** attempt * 1000, 16_000);
-        await sleep(wait);
-        continue;
+    // reliability-012: fetch() resolving only means the HEADERS arrived — the
+    // body may still be streaming. The old code cleared the timer here, which
+    // left every subsequent resp.text() call (below, and the error-path reads)
+    // completely unbounded: an endpoint that sends headers then stalls the
+    // body (slow-loris, buggy proxy buffering, a half-open connection) wedged
+    // the worker slot forever, since the scheduler's Promise.race never
+    // settles for the wedged task. Keep `ctrl`/`timer` ARMED through every body
+    // read below — fetch's AbortSignal covers the whole request lifecycle,
+    // including body consumption, so an abort here rejects an in-flight
+    // resp.text() the same way it rejects a hung fetch() — and clear the timer
+    // exactly once, in the finally, after the LAST body read on every branch.
+    try {
+      // Transport-level failure (rate limit / server) — back off and retry the
+      // REQUEST, not the task. A 429 is not a failed implementation attempt.
+      if (resp.status === 429 || resp.status >= 500) {
+        if (attempt < ENV.apiMaxRetries) {
+          const ra = Number(resp.headers.get("retry-after"));
+          const wait = Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(2 ** attempt * 1000, 16_000);
+          await sleep(wait);
+          continue;
+        }
+        const body = await resp.text();
+        // D-3: log raw body to stderr for diagnostics; do NOT include it in the
+        // error field that flows into priorFailure and the next worker prompt.
+        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 300)}\n`);
+        return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries` };
       }
-      const body = await resp.text().catch(() => "(unreadable)");
-      // D-3: log raw body to stderr for diagnostics; do NOT include it in the
-      // error field that flows into priorFailure and the next worker prompt.
-      process.stderr.write(`API ${resp.status} body: ${body.slice(0, 300)}\n`);
-      return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries` };
-    }
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "(unreadable)");
-      process.stderr.write(`API ${resp.status} body: ${body.slice(0, 500)}\n`);
-      return { ok: false, error: `API ${resp.status}` };
-    }
+      if (!resp.ok) {
+        const body = await resp.text();
+        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 500)}\n`);
+        return { ok: false, error: `API ${resp.status}` };
+      }
 
-    // Read the body as text first, then parse — so a 2xx-with-non-JSON-body (the
-    // #90 stale-endpoint failure: a 200 whose body is "Not Found") yields an
-    // actionable, endpoint-naming error instead of an opaque SyntaxError. The
-    // body is consumed once, so a re-read on parse failure is not possible —
-    // parseChatCompletion works off the text we already hold.
-    const text = await resp.text().catch(() => "");
-    return parseChatCompletion(text, apiBaseUrl);
+      // Read the body as text first, then parse — so a 2xx-with-non-JSON-body
+      // (the #90 stale-endpoint failure: a 200 whose body is "Not Found")
+      // yields an actionable, endpoint-naming error instead of an opaque
+      // SyntaxError. The body is consumed once, so a re-read on parse failure
+      // is not possible — parseChatCompletion works off the text we already
+      // hold.
+      const text = await resp.text();
+      return parseChatCompletion(text, apiBaseUrl);
+    } catch (e) {
+      // reliability-012: a stalled body triggers the SAME armed AbortController
+      // as a stalled header, so this catches it as a timeout (not an opaque
+      // "fetch failed" — the request already succeeded at the transport level).
+      const aborted = (e as Error)?.name === "AbortError";
+      return {
+        ok: false,
+        error: aborted
+          ? `request timed out after ${ENV.requestTimeoutMs}ms (reading response body)`
+          : `failed reading response body: ${e}`,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
   }
   return { ok: false, error: "exhausted API retries" };
 }
@@ -1159,8 +1189,12 @@ export async function runTask(
   // the run with NaN — `Math.max(1, NaN)` is NaN, which would empty every sample
   // batch and silently mass-escalate the run. `sampling` carries the temperature
   // (auto-bumped when N>1, AC-F1.3).
-  const rawSamples = Number(process.env.FARM_SAMPLES ?? 1);
-  const samples = Number.isFinite(rawSamples) ? Math.max(1, Math.floor(rawSamples)) : 1;
+  // reliability-014: FARM_SAMPLES now routes through the shared numEnv reader
+  // (generalizing this pre-existing NaN hardening to every other FARM/MUT
+  // numeric knob) — a non-finite value falls back to 1 with a stderr warning
+  // rather than poisoning the run with NaN (`Math.max(1, NaN)` is NaN, which
+  // would empty every sample batch and silently mass-escalate the run).
+  const samples = Math.max(1, Math.floor(numEnv("FARM_SAMPLES", 1, { min: 1 })));
   const sampling = effectiveSampling(samples);
 
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
@@ -1309,7 +1343,7 @@ export async function runTask(
     let riskNote = gaming.note;
     if (risk !== "high") {
       const mut = await deps.mutationCheck(wt, t);
-      if (mut) {
+      if (mut && "score" in mut) {
         mutationScore = mut.score;
         if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
           risk = "high";
@@ -1319,6 +1353,20 @@ export async function runTask(
             risk = "warn";
             riskNote = `mutation-risk: score ${mut.score.toFixed(2)} (${mut.survivors.length}/${mut.evaluated} survived) — weak test or under-implemented logic`;
           }
+        }
+      } else if (mut && "failed" in mut) {
+        // observability-002 (#187): mutationCheck's pluggable-hook branch
+        // distinguishes "configured but failed" (non-zero exit, timeout,
+        // unparseable output) from "not configured" (both previously
+        // collapsed to `null`, so a broken FARM_MUTATION_CMD integration
+        // produced a report indistinguishable from one that never ran mutation
+        // checking). Surface it — mirroring the diagnostic discipline the
+        // primary API path already uses (callApi's stderr body dump) — without
+        // escalating or blocking the task on a hook-infrastructure failure.
+        process.stderr.write(`[FARM] mutation hook failed for task ${t.id}: ${mut.detail}\n`);
+        if (risk === "none") {
+          risk = "warn";
+          riskNote = `mutation-hook-failed: ${mut.detail}`;
         }
       }
     }
@@ -1591,7 +1639,11 @@ export async function screenEntitlements(
 // fetch so a hung socket is actually torn down (the screen's race is the
 // higher-level cap). A network/abort failure maps to status 0 → screened as a
 // survivor, not an entitlement drop (only a real 401 drops a candidate).
-function makeEntitlementProbe(apiBaseUrl: string, apiKey: string, timeoutMs: number): EntitlementProbe {
+// coverage-003 (#183): exported so the request-shape (Bearer header, POST body)
+// and the AbortController timeout behavior are directly unit-testable against a
+// mocked global fetch, rather than only through the pure screenEntitlements
+// decision logic (which is already tested with an injected fake probe).
+export function makeEntitlementProbe(apiBaseUrl: string, apiKey: string, timeoutMs: number): EntitlementProbe {
   return async (model) => {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -1778,34 +1830,43 @@ async function main() {
     };
 
     while (pending.size > 0 || running.size > 0) {
-      if (tripped()) {
-        aborted = true;
-        break;
-      }
-      for (const id of ready()) {
-        if (running.size >= ENV.concurrency) break;
-        pending.delete(id);
-        running.set(
-          id,
-          runTask(byId.get(id)!, model, apiBaseUrl, apiKey).then(
-            (r) => ({ id, r }),
-            // observability-003 (T-07c): a crash produces an escalate Result with
-            // a correlated, stack-bearing note. The truncated err.stack gives the
-            // post-mortem a call site (e.g. the spawn TypeError from
-            // reliability-004) instead of a one-line message with no origin.
-            (e) => ({
-              id,
-              r: {
+      // reliability-013: once tripped, stop DISPATCHING new tasks, but do NOT
+      // break out of the loop while `running` still holds in-flight promises —
+      // the old `break` here left those ids in neither `done` nor `pending`
+      // (they vanish from farm-report.json entirely) and let the `finally`
+      // remove the integration worktree while an in-flight task could still be
+      // inside its withMergeLock merge into that same worktree. Falling through
+      // to the existing drain-and-record logic below instead means every
+      // dispatched task is awaited to a real, recorded status before the loop
+      // exits, so the integration worktree is only torn down once no merge can
+      // still be in flight.
+      if (!aborted && tripped()) aborted = true;
+      if (!aborted) {
+        for (const id of ready()) {
+          if (running.size >= ENV.concurrency) break;
+          pending.delete(id);
+          running.set(
+            id,
+            runTask(byId.get(id)!, model, apiBaseUrl, apiKey).then(
+              (r) => ({ id, r }),
+              // observability-003 (T-07c): a crash produces an escalate Result with
+              // a correlated, stack-bearing note. The truncated err.stack gives the
+              // post-mortem a call site (e.g. the spawn TypeError from
+              // reliability-004) instead of a one-line message with no origin.
+              (e) => ({
                 id,
-                status: "escalate" as const,
-                attempts: 0,
-                branch: `farm/${id}`,
-                worktree: path.resolve(ENV.worktreeRoot, id),
-                note: `crashed: ${e?.message ?? e}${e?.stack ? `\n${String(e.stack).slice(0, 1500)}` : ""}`,
-              },
-            }),
-          ),
-        );
+                r: {
+                  id,
+                  status: "escalate" as const,
+                  attempts: 0,
+                  branch: `farm/${id}`,
+                  worktree: path.resolve(ENV.worktreeRoot, id),
+                  note: `crashed: ${e?.message ?? e}${e?.stack ? `\n${String(e.stack).slice(0, 1500)}` : ""}`,
+                },
+              }),
+            ),
+          );
+        }
       }
       if (running.size === 0) break;
       const { id, r } = await Promise.race(running.values());
@@ -1813,6 +1874,14 @@ async function main() {
       // observability-003 (T-07c): stamp the run-id onto every settled result —
       // crash or clean — so the JSONL line and the report header share it.
       r.runId = runId;
+      // reliability-013: a task that was still in flight when the breaker
+      // tripped settles here with its REAL outcome (the drain above waits for
+      // its actual completion, including any merge) — annotate an escalate
+      // note so the report distinguishes "aborted while in flight" from an
+      // ordinary escalation, without discarding a genuine result.
+      if (aborted && r.status === "escalate" && !/run aborted/.test(r.note ?? "")) {
+        r.note = r.note ? `${r.note} (run aborted by circuit breaker while in flight)` : "escalate: run aborted (in flight)";
+      }
       done.set(id, r);
       // Streaming rail (AC-08 / D7): append this settled task as one JSONL line
       // the moment it settles, so a pipelined consumer can act in completion

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -2,13 +2,13 @@
  * Unit tests for farm.ts pure-function core.
  * These test the exported helpers directly without spawning a subprocess.
  */
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, rm as fsRm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot } from "./farm.ts";
+import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, makeEntitlementProbe, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot, numEnv } from "./farm.ts";
 import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 import { scrubbedEnv } from "./exec.ts";
@@ -1050,6 +1050,117 @@ describe("#93 screenEntitlements", () => {
     const { survivors, skipped } = await screenEntitlements(["flaky"], probe, { sleepFn: neverSleep });
     expect(survivors).toEqual(["flaky"]);
     expect(skipped).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coverage-003 (#183) — makeEntitlementProbe: the real network-facing probe
+// screenEntitlements is fed. Only the pure decision logic above had coverage;
+// this exercises the Bearer-auth header, body shape, and AbortController
+// timeout the probe itself builds, against a mocked global fetch.
+// ---------------------------------------------------------------------------
+describe("coverage-003 (#183) makeEntitlementProbe", () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("sends the Bearer apiKey header and a minimal POST body naming the model", async () => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const probe = makeEntitlementProbe("https://api.example/v1", "DUMMY-KEY-do-not-leak", 5_000);
+    const res = await probe("candidate-model");
+
+    expect(res.status).toBe(200);
+    expect(capturedUrl).toBe("https://api.example/v1/chat/completions");
+    expect(capturedInit?.method).toBe("POST");
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer DUMMY-KEY-do-not-leak");
+    const body = JSON.parse(String(capturedInit?.body)) as { model?: string; max_tokens?: number; messages?: unknown[] };
+    expect(body.model).toBe("candidate-model");
+    expect(body.max_tokens).toBe(1);
+    expect(Array.isArray(body.messages)).toBe(true);
+  });
+
+  it("distinguishes a real 401 response from a network throw (both map to a status, not an exception)", async () => {
+    global.fetch = vi.fn(async () => new Response("nope", { status: 401 })) as unknown as typeof fetch;
+    const probe401 = makeEntitlementProbe("https://api.example/v1", "DUMMY-KEY", 5_000);
+    await expect(probe401("m")).resolves.toEqual({ status: 401 });
+
+    global.fetch = vi.fn(async () => {
+      throw new TypeError("network down");
+    }) as unknown as typeof fetch;
+    const probeNetworkFail = makeEntitlementProbe("https://api.example/v1", "DUMMY-KEY", 5_000);
+    // A network failure maps to status 0 — never an unhandled rejection — so
+    // screenEntitlements' caller can tell it apart from a genuine 401.
+    await expect(probeNetworkFail("m")).resolves.toEqual({ status: 0 });
+  });
+
+  it("the AbortController-driven timeout actually fires and maps to status 0, bounded by timeoutMs", async () => {
+    global.fetch = vi.fn((_url: string | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const probe = makeEntitlementProbe("https://api.example/v1", "DUMMY-KEY", 20);
+    const start = Date.now();
+    const res = await probe("slow-model");
+    const elapsed = Date.now() - start;
+
+    expect(res).toEqual({ status: 0 });
+    // Bounded — proves the AbortController actually tore the hung fetch down
+    // rather than the probe just happening to resolve on its own.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reliability-014 — numEnv: the shared hardened numeric-env reader every
+// FARM_*/MUT_* knob routes through. A non-finite parse must fall back to the
+// default LOUDLY (stderr) rather than silently becoming NaN.
+// ---------------------------------------------------------------------------
+describe("reliability-014 numEnv", () => {
+  const saved = { X: process.env.FARM_TEST_NUMENV_X };
+  afterEach(() => {
+    if (saved.X === undefined) delete process.env.FARM_TEST_NUMENV_X;
+    else process.env.FARM_TEST_NUMENV_X = saved.X;
+    vi.restoreAllMocks();
+  });
+
+  it("returns the default when the env var is unset", () => {
+    delete process.env.FARM_TEST_NUMENV_X;
+    expect(numEnv("FARM_TEST_NUMENV_X", 7)).toBe(7);
+  });
+
+  it("parses a valid numeric value", () => {
+    process.env.FARM_TEST_NUMENV_X = "42";
+    expect(numEnv("FARM_TEST_NUMENV_X", 7)).toBe(42);
+  });
+
+  it("falls back to the default AND logs a stderr warning on a non-finite value", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.env.FARM_TEST_NUMENV_X = "not-a-number";
+    expect(numEnv("FARM_TEST_NUMENV_X", 7)).toBe(7);
+    expect(spy).toHaveBeenCalledWith(expect.stringMatching(/FARM_TEST_NUMENV_X.*not a finite number/));
+  });
+
+  it("clamps a below-minimum value up to min and logs a warning", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.env.FARM_TEST_NUMENV_X = "-5";
+    expect(numEnv("FARM_TEST_NUMENV_X", 7, { min: 1 })).toBe(1);
+    expect(spy).toHaveBeenCalled();
   });
 });
 

--- a/plugins/ca/tools/mutation.ts
+++ b/plugins/ca/tools/mutation.ts
@@ -18,11 +18,13 @@ import {
   treeKill,
   readWorktreeFile,
   scrubbedEnv,
+  numEnv,
   SHELL_BIN,
   SHELL_FLAG,
   SHELL_OPTS,
   GATE_TIMEOUT_MS,
 } from "./exec.ts";
+import { redactSecrets } from "./redactor.ts";
 import type { Task } from "./farm.ts";
 
 // Mutation guard — a zero-token quality signal. After the gate goes green we
@@ -37,10 +39,14 @@ import type { Task } from "./farm.ts";
 // and must print a trailing JSON line containing a numeric "score").
 export const MUT = {
   enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
-  sample: Number(process.env.FARM_MUTATION_SAMPLE ?? 15),
-  budgetMs: Number(process.env.FARM_MUTATION_BUDGET_MS ?? 30_000),
-  warnBelow: Number(process.env.FARM_MUTATION_WARN_BELOW ?? 0.5),
-  escalateBelow: Number(process.env.FARM_MUTATION_ESCALATE_BELOW ?? 0.1),
+  // reliability-014: routed through the shared numEnv reader (exec.ts) so a
+  // typo'd FARM_MUTATION_* value falls back to the default loudly instead of
+  // silently becoming NaN (every comparison against MUT.warnBelow/escalateBelow
+  // would then read false, disabling the anti-gaming mutation signal).
+  sample: numEnv("FARM_MUTATION_SAMPLE", 15, { min: 1 }),
+  budgetMs: numEnv("FARM_MUTATION_BUDGET_MS", 30_000, { min: 0 }),
+  warnBelow: numEnv("FARM_MUTATION_WARN_BELOW", 0.5, { min: 0 }),
+  escalateBelow: numEnv("FARM_MUTATION_ESCALATE_BELOW", 0.1, { min: 0 }),
   cmd: process.env.FARM_MUTATION_CMD ?? null,
 };
 
@@ -146,6 +152,19 @@ function generateMutants(file: string, src: string): Array<{ file: string; mutat
 
 export type MutationResult = { score: number; evaluated: number; survivors: string[] };
 
+// observability-002 (#187): the pluggable-hook branch of mutationCheck used to
+// collapse EVERY failure mode (non-zero exit, timeout, crash, unparseable
+// output) to the same `null` the caller sees for "mutation checking is not
+// configured", so a broken FARM_MUTATION_CMD integration produced a report
+// indistinguishable from one that never ran mutation checking. `null` still
+// means "not configured / nothing to evaluate" (unchanged — existing callers
+// that only check truthiness keep working); MutationHookFailure is a NEW,
+// narrow, explicit member the caller uses to distinguish "configured but
+// failed" and surface a diagnostic (mirrors the primary API path's stderr body
+// dump on a callApi failure).
+export type MutationHookFailure = { failed: true; detail: string };
+export type MutationCheckResult = MutationResult | MutationHookFailure | null;
+
 // dx-002 (T-08b): parse a pluggable FARM_MUTATION_CMD's stdout for its trailing
 // JSON score line. Extracted as a pure, exported function so the shape guard is
 // unit-testable without spawning a process. The last `{...\"score\"...}` match is
@@ -167,7 +186,7 @@ export function parseMutationHookOutput(out: string): MutationResult | null {
   return null;
 }
 
-export async function mutationCheck(wt: string, task: Task): Promise<MutationResult | null> {
+export async function mutationCheck(wt: string, task: Task): Promise<MutationCheckResult> {
   if (!MUT.enabled) return null;
   const testCmd = task.gate.commands[0];
   if (!testCmd) return null;
@@ -207,7 +226,15 @@ export async function mutationCheck(wt: string, task: Task): Promise<MutationRes
       c.on("close", (code) => finish({ code: code ?? 1, out }));
     });
     // dx-002 (T-08b): shape-guarded parse of the hook's trailing score line.
-    return parseMutationHookOutput(r.out);
+    const parsed = parseMutationHookOutput(r.out);
+    if (parsed !== null) return parsed;
+    // observability-002 (#187): MUT.cmd WAS configured but produced no
+    // parseable score (non-zero exit, timeout, crash, or unparseable trailing
+    // output) — this is a "configured but failed" outcome, distinct from "not
+    // configured". redactSecrets guards the tail the same way runGate's
+    // failure tail is guarded before it can reach a report/log.
+    const tail = redactSecrets(r.out.slice(-500)).trim();
+    return { failed: true, detail: `exit ${r.code}${tail ? `: ${tail}` : " (no output)"}` };
   }
 
   // Built-in text mutation.


### PR DESCRIPTION
Lane C — farm.ts run-scheduler hardening + coverage.

## What
- **#192 (reliability):** rel-012 — `callApi` keeps the AbortController armed until the response body is fully consumed (a stalled body no longer wedges a worker slot forever); rel-013 — a circuit-breaker abort now drains in-flight tasks through the existing accounting loop so every dispatched task appears in farm-report.json with a status (none vanish) and the integration worktree is torn down only after in-flight merges settle; rel-014 — a new `numEnv()` reader rejects non-finite `FARM_*`/`MUT_*` values (a typo can no longer silently disable the concurrency cap or the escalation breaker).
- **#187 (observability):** `mutationCheck` returns a discriminated `MutationHookFailure` — a crashing/timing-out `FARM_MUTATION_CMD` now surfaces a distinct redacted diagnostic instead of looking identical to "not configured."
- **#183 (coverage):** exports `makeEntitlementProbe` and adds mocked-fetch unit tests (Bearer header, 401-vs-network, AbortController timeout) plus `runCanary` early-exit coverage.

## Verification
- `npx tsc --noEmit` clean; **192/192 vitest** (up from 159/21); `npm run build` idempotent (farm.js rebuilt). TDD confirmed: reverted sources → 10 new tests fail for the expected reasons → restored → green.
- **security-reviewer: PASS** — 0 critical/high/medium. Verified no apiKey/Authorization/body leak in the restructured `callApi`, redaction parity on the mutation diagnostic, export-only `makeEntitlementProbe` reaching only the `assertSecureBaseUrl`-validated HTTPS base with DUMMY-key tests, and `numEnv` failing safe. 2 no-action LOWs (pre-existing stderr body slice; documented redactor keyword-anchoring).

Bumps ca 2.8.2 → 2.8.3.

> ⚠️ Merge note: the farm.js rebuild re-raises the **accepted** CodeQL shell-injection-from-env alert on farm's spawns (standing won't-fix, ADR-tracked) — it must be re-dismissed before merge; not a new finding.

Closes #192
Closes #187
Closes #183

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa