### PR TITLE
fix(hooks): tail-anchor H-05 audit-log append + reject replace_all; block literal --no-verify (#172 #175)

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -230,6 +230,22 @@ empty-`old_string` Edit, which is not a verifiable append). The append-only path
 set is centralized in `_hooklib` (`is_audit_log`, `AUDIT_LOG_NAMES`) so the three
 guards never drift on which files are covered.
 
+**H-05 tail-anchor + H-20 `--no-verify` (2026-07-02, #172 / #175).** The H-05
+append check (`pre-edit.py`, via `_hooklib.is_tail_append`) now **tail-anchors** —
+an audit-log Edit is admitted only as a strict append (`new` = current content +
+appended tail, with `old` occurring exactly once), and a `replace_all` Edit on an
+audit-log path is **rejected outright** (reliability-003/#172), closing the prior
+`new.startswith(old)` hole that let a mid-file insertion or a multi-site suffix
+rewrite pass as an "append". The new **H-20** guard (`pre-bash.py`) blocks a
+literal `--no-verify`/`-n` on `git commit` — including bundled and attached-value
+short-flag spellings (`-nm`, `-nm=x`, `-vnm=y`; the char-walk mirrors git's own
+cluster parsing) — and a literal `--no-verify` on `git push` (appsec-002/#175),
+because that flag skips the `.git/hooks` git-enforce backstop (voiding
+H-01/H-02/H-09b/H-10b/H-14 for that operation). The residual is the same accepted
+**shell-indirection** class listed above (`g=git; $g commit --no-verify` defeats
+the lexical `COMMIT_RE`/`PUSH_RE` matcher itself) — out of scope per ADR-0010's
+cooperative-agent trust model.
+
 **Automated writer of record.** One write to `overrides.log` is performed by the
 framework, not a user action: on session start, if a prior session entered
 `/ca:dev` and ended without `/ca:arbiter`, `session-start.py` appends a

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.4" src="https://img.shields.io/badge/version-2.8.4-2b7489">
+<img alt="version 2.8.5" src="https://img.shields.io/badge/version-2.8.5-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -42,6 +42,8 @@
 #   is_ci_path(rel, root) -> bool         True iff rel is a CI/CD workflow (H-15)
 #   is_deploy_path(rel, root) -> bool     True iff rel is a deployment/IaC manifest (H-16)
 #   is_audit_log(rel) -> bool             True iff rel is an append-only audit log (H-05)
+#   is_tail_append(current, old, new) -> bool  True iff old_string is current's exact
+#                                          trailing content AND new_string extends it (H-05)
 #   is_decisions_path(rel) -> bool        True iff rel is an ADR under decisions/ (H-11)
 #   is_context_md(rel) -> bool            True iff rel is the CONTEXT.md activation file (#159)
 #   is_marker_path(rel) -> bool           True iff rel is under .codearbiter/.markers/ (#160)
@@ -141,6 +143,24 @@ def is_audit_log(rel):
     """True iff `rel` is one of the append-only .codearbiter audit logs
     (overrides.log, triage.log, sprint-log.md) — the H-05 guard set."""
     return bool(AUDIT_LOG_RE.search(norm_path(rel)))
+
+
+def is_tail_append(current, old, new):
+    """True iff an Edit's (old_string, new_string) pair is a verifiable,
+    TAIL-ANCHORED pure append against `current` (the file's REAL on-disk
+    content) — the H-05 guard (reliability-003, #172).
+
+    `new.startswith(old)` alone is not sufficient: `old` could be any interior
+    line that happens to be a prefix of `new`, which inserts content BETWEEN
+    existing lines rather than appending at the end. This requires TWO things:
+    `current` must literally END with `old` (old_string is the file's actual
+    trailing content, not just some substring elsewhere), and `new` must
+    extend `old`. An empty `old` is never a valid append — every string
+    "ends with" the empty string, so the tail-anchor check would trivially
+    pass and reopen the migration-003 empty-old_string hole this closes."""
+    if not old:
+        return False
+    return current.endswith(old) and new.startswith(old)
 
 
 def is_decisions_path(rel):

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -157,8 +157,16 @@ def is_tail_append(current, old, new):
     trailing content, not just some substring elsewhere), and `new` must
     extend `old`. An empty `old` is never a valid append — every string
     "ends with" the empty string, so the tail-anchor check would trivially
-    pass and reopen the migration-003 empty-old_string hole this closes."""
+    pass and reopen the migration-003 empty-old_string hole this closes.
+
+    `old` must also occur EXACTLY ONCE in `current`: a non-unique old_string
+    that happens to also match the tail is not self-evidently an append — this
+    keeps the guard correct on its own terms rather than depending on the Edit
+    tool's own (client-side, not re-verified here) uniqueness enforcement for
+    a non-replace_all Edit."""
     if not old:
+        return False
+    if current.count(old) != 1:
         return False
     return current.endswith(old) and new.startswith(old)
 

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -49,25 +49,68 @@ def _read_err_hint():
 # appsec-002 (#175): a literal `--no-verify` / `-n` on `git commit`/`git push`
 # skips `.git/hooks` entirely — the documented "spelling-proof backstop"
 # (git-enforce.py) never runs for that operation, voiding H-01/H-02/H-09b/
-# H-10b/H-14 for it. `-n` is git-commit's short spelling of --no-verify; `git
-# push` has NO short spelling (its own `-n` is `--dry-run`, an unrelated flag),
-# so only the long form is checked there. Token-equality (not substring) so a
-# commit MESSAGE merely quoting the text ('-m "explain --no-verify"') is never
-# misclassified — the quoted phrase tokenizes as one whole argument, never
-# equal to the bare flag. The deeper shell-indirection spelling (`g=git; $g
-# commit --no-verify`) defeats this lexical check same as it defeats COMMIT_RE
-# itself; that residual is documented separately, out of scope for this guard.
+# H-10b/H-14 for it. `-n` is git-commit's short spelling of --no-verify — but
+# NOT only as its own token: git bundles short flags into one cluster
+# (`-nm "x"` = `-n` + `-m x`, the everyday spelling), so the exact-token check
+# alone missed it (HIGH, security-reviewer finding on the first pass). `git
+# push` has NO short spelling for this (its own `-n` is `--dry-run`, an
+# unrelated flag), so only the long form is checked there, and it never
+# clusters this way in practice for our purposes.
+# Token-equality (not substring) so a commit MESSAGE merely quoting the text
+# ('-m "explain --no-verify"') is never misclassified — the quoted phrase
+# tokenizes as one whole argument, never equal to the bare flag. Scanning
+# stops at a bare `--` token (end-of-options): `git commit -- --no-verify`
+# passes `--no-verify` as a pathspec, not a flag, and must not be misblocked.
+# The deeper shell-indirection spelling (`g=git; $g commit --no-verify`)
+# defeats this lexical check same as it defeats COMMIT_RE itself; that
+# residual is documented separately, out of scope for this guard.
 COMMIT_NO_VERIFY_FLAGS = frozenset({"--no-verify", "-n"})
 PUSH_NO_VERIFY_FLAGS = frozenset({"--no-verify"})
+# `git commit` short options that consume the REST of their cluster as a
+# value (bundled short-flag form, e.g. `-mMSG`, `-Cref`): once one of these is
+# hit while scanning a cluster left-to-right, every character after it is that
+# option's value, not a further flag — so a `-mn` cluster's trailing `n` is
+# the MESSAGE "n", not `-n`/--no-verify, and must not block.
+COMMIT_SHORT_VALUE_CHARS = frozenset("mcCFtSu")
 
 
 def _has_literal_flag(args, flags):
     """True iff `args` contains one of `flags` as its own token — quote-aware
     (a fully-quoted token, e.g. a `-m "..."` message, tokenizes as ONE token
-    and is compared whole, so it can never equal a single bare flag)."""
+    and is compared whole, so it can never equal a single bare flag).
+    Scanning stops at a bare `--` (end-of-options): anything after it is a
+    pathspec/value, never a flag."""
     for raw in re.findall(r'"[^"]+"|\'[^\']+\'|\S+', args):
-        if raw.strip("\"'") in flags:
+        tok = raw.strip("\"'")
+        if tok == "--":
+            break
+        if tok in flags:
             return True
+    return False
+
+
+def _commit_no_verify_in_cluster(args):
+    """True iff a `git commit` bundled short-flag cluster token (e.g. `-nm`,
+    `-vn`) carries `-n` (no-verify) BEFORE any argument-taking short option in
+    that same cluster consumes the rest of it as a value. Walks each
+    `-[A-Za-z]+` token left-to-right (never `--...`, never touching values with
+    an `=`): hitting `n` first means no-verify; hitting a
+    COMMIT_SHORT_VALUE_CHARS member first means every following character in
+    that token is that flag's value (e.g. `-mn` is `-m` with value "n" — NOT
+    no-verify), so scanning that token stops there. Complements the exact-
+    token `-n` case in COMMIT_NO_VERIFY_FLAGS, which only catches `-n` as its
+    OWN whole token. Scanning stops at a bare `--` (end-of-options)."""
+    for raw in re.findall(r'"[^"]+"|\'[^\']+\'|\S+', args):
+        tok = raw.strip("\"'")
+        if tok == "--":
+            break
+        if not re.fullmatch(r"-[A-Za-z]+", tok):
+            continue  # not a short-flag cluster (long flag, value, pathspec, …)
+        for ch in tok[1:]:
+            if ch == "n":
+                return True
+            if ch in COMMIT_SHORT_VALUE_CHARS:
+                break  # rest of THIS token is that flag's value; stop here
     return False
 
 
@@ -479,8 +522,13 @@ def _run(root):
 
     # H-20: block a literal --no-verify / -n on `git commit` — it skips
     # .git/hooks (the git-enforce backstop) entirely, voiding every enforcement
-    # hook for that commit (appsec-002, #175).
-    if commit and _has_literal_flag(commit.group("args"), COMMIT_NO_VERIFY_FLAGS):
+    # hook for that commit (appsec-002, #175). Checks BOTH the exact-token
+    # spelling (`-n` / `--no-verify` on its own) and the bundled short-flag
+    # cluster spelling (`-nm "x"`) — the everyday way `-n` actually gets typed
+    # alongside `-m`, missed by an exact-token-only check (security-reviewer
+    # HIGH, first pass).
+    if commit and (_has_literal_flag(commit.group("args"), COMMIT_NO_VERIFY_FLAGS)
+                   or _commit_no_verify_in_cluster(commit.group("args"))):
         block("H-20", "'--no-verify' / '-n' on git commit skips the .git/hooks "
                       "git-enforce backstop entirely (appsec-002) — every commit-time "
                       "gate (H-01/H-02/H-09b/H-10b/H-14) would go unenforced for this "

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -51,11 +51,13 @@ def _read_err_hint():
 # (git-enforce.py) never runs for that operation, voiding H-01/H-02/H-09b/
 # H-10b/H-14 for it. `-n` is git-commit's short spelling of --no-verify — but
 # NOT only as its own token: git bundles short flags into one cluster
-# (`-nm "x"` = `-n` + `-m x`, the everyday spelling), so the exact-token check
-# alone missed it (HIGH, security-reviewer finding on the first pass). `git
-# push` has NO short spelling for this (its own `-n` is `--dry-run`, an
-# unrelated flag), so only the long form is checked there, and it never
-# clusters this way in practice for our purposes.
+# (`-nm "x"` = `-n` + `-m x`, the everyday spelling), including with an
+# attached value (`-nm=x`, `-nm123`), so the exact-token check alone missed it
+# (security-reviewer HIGH x2: the bare cluster case, then the attached-value
+# cluster case — see `_commit_no_verify_in_cluster`). `git push` has NO short
+# spelling for this (its own `-n` is `--dry-run`, an unrelated flag), so only
+# the long form is checked there, and it never clusters this way in practice
+# for our purposes.
 # Token-equality (not substring) so a commit MESSAGE merely quoting the text
 # ('-m "explain --no-verify"') is never misclassified — the quoted phrase
 # tokenizes as one whole argument, never equal to the bare flag. Scanning
@@ -91,26 +93,48 @@ def _has_literal_flag(args, flags):
 
 def _commit_no_verify_in_cluster(args):
     """True iff a `git commit` bundled short-flag cluster token (e.g. `-nm`,
-    `-vn`) carries `-n` (no-verify) BEFORE any argument-taking short option in
-    that same cluster consumes the rest of it as a value. Walks each
-    `-[A-Za-z]+` token left-to-right (never `--...`, never touching values with
-    an `=`): hitting `n` first means no-verify; hitting a
-    COMMIT_SHORT_VALUE_CHARS member first means every following character in
-    that token is that flag's value (e.g. `-mn` is `-m` with value "n" — NOT
-    no-verify), so scanning that token stops there. Complements the exact-
-    token `-n` case in COMMIT_NO_VERIFY_FLAGS, which only catches `-n` as its
-    OWN whole token. Scanning stops at a bare `--` (end-of-options)."""
+    `-vn`, `-nm=x`, `-nm123`) carries `-n` (no-verify) BEFORE any
+    argument-taking short option — or any attached-value byte — in that same
+    token ends the flag-cluster portion. Walks each token that starts with
+    `-`+letter (and is not `--...`) left-to-right past the leading `-`:
+
+      * `n`   seen first  -> no-verify -> BLOCK.
+      * a COMMIT_SHORT_VALUE_CHARS member seen first -> that flag consumes the
+        REST of the token as its value (e.g. `-mn` is `-m` with value "n") ->
+        stop scanning this token, not a match.
+      * the first NON-ALPHABETIC character (`=`, a digit, `.`, `"`, …) seen
+        first -> an attached value has begun (e.g. `-nm=x`, `-nm123`) -> stop
+        scanning this token's REMAINDER, but everything scanned so far still
+        counts — this is what closes `-nm=x`/`-nm123` (the `n` before the
+        `m`/`=`/digit still blocks) while never mis-reading the attached value
+        itself as more flag letters.
+
+    security-reviewer HIGH (second pass): a `re.fullmatch(r"-[A-Za-z]+", tok)`
+    gate previously skipped the whole token whenever ANY character after the
+    dashes wasn't a letter — so `-nm=x`/`-nm123`/`-vnm=y` (a leading `-n`
+    immediately followed by an attached value) were never even inspected,
+    silently letting `-n`/no-verify through. Matching on `-[A-Za-z]` (just the
+    first character after `-`) instead of requiring the WHOLE token to be
+    letters fixes this at the root: every token that OPENS a short-flag
+    cluster is now walked, and the walk itself (not the initial token shape)
+    decides where the flag portion ends.
+
+    Complements the exact-token `-n`/`--no-verify` case in
+    COMMIT_NO_VERIFY_FLAGS, which only catches `-n` as its OWN whole token.
+    Scanning stops at a bare `--` (end-of-options)."""
     for raw in re.findall(r'"[^"]+"|\'[^\']+\'|\S+', args):
         tok = raw.strip("\"'")
         if tok == "--":
             break
-        if not re.fullmatch(r"-[A-Za-z]+", tok):
-            continue  # not a short-flag cluster (long flag, value, pathspec, …)
+        if tok.startswith("--") or not re.match(r"-[A-Za-z]", tok):
+            continue  # a long flag, a value, a pathspec, or not a flag at all
         for ch in tok[1:]:
             if ch == "n":
                 return True
             if ch in COMMIT_SHORT_VALUE_CHARS:
                 break  # rest of THIS token is that flag's value; stop here
+            if not ch.isalpha():
+                break  # an attached value (=, digit, ., "…) has begun; stop here
     return False
 
 

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -46,6 +46,31 @@ def _read_err_hint():
 # `git` followed by any run of global options (-C <dir>, -c k=v, --git-dir=…,
 # --no-pager, …) before the subcommand — `git -C ../x commit` must not slip
 # past a bare `git\s+commit` match.
+# appsec-002 (#175): a literal `--no-verify` / `-n` on `git commit`/`git push`
+# skips `.git/hooks` entirely — the documented "spelling-proof backstop"
+# (git-enforce.py) never runs for that operation, voiding H-01/H-02/H-09b/
+# H-10b/H-14 for it. `-n` is git-commit's short spelling of --no-verify; `git
+# push` has NO short spelling (its own `-n` is `--dry-run`, an unrelated flag),
+# so only the long form is checked there. Token-equality (not substring) so a
+# commit MESSAGE merely quoting the text ('-m "explain --no-verify"') is never
+# misclassified — the quoted phrase tokenizes as one whole argument, never
+# equal to the bare flag. The deeper shell-indirection spelling (`g=git; $g
+# commit --no-verify`) defeats this lexical check same as it defeats COMMIT_RE
+# itself; that residual is documented separately, out of scope for this guard.
+COMMIT_NO_VERIFY_FLAGS = frozenset({"--no-verify", "-n"})
+PUSH_NO_VERIFY_FLAGS = frozenset({"--no-verify"})
+
+
+def _has_literal_flag(args, flags):
+    """True iff `args` contains one of `flags` as its own token — quote-aware
+    (a fully-quoted token, e.g. a `-m "..."` message, tokenizes as ONE token
+    and is compared whole, so it can never equal a single bare flag)."""
+    for raw in re.findall(r'"[^"]+"|\'[^\']+\'|\S+', args):
+        if raw.strip("\"'") in flags:
+            return True
+    return False
+
+
 GIT = r"\bgit(?:\s+(?:-[Cc]\s+\S+|--[\w-]+(?:=\S+)?|-\w+))*"
 # The args capture stops at an unquoted `|`, `;`, or `&` (the next shell command
 # is not this git command's business) but consumes quoted strings whole — a
@@ -452,6 +477,15 @@ def _run(root):
     commit = COMMIT_RE.search(git_view) or COMMIT_RE.search(cmd)
     cwd = git_cwd(git_view, root)
 
+    # H-20: block a literal --no-verify / -n on `git commit` — it skips
+    # .git/hooks (the git-enforce backstop) entirely, voiding every enforcement
+    # hook for that commit (appsec-002, #175).
+    if commit and _has_literal_flag(commit.group("args"), COMMIT_NO_VERIFY_FLAGS):
+        block("H-20", "'--no-verify' / '-n' on git commit skips the .git/hooks "
+                      "git-enforce backstop entirely (appsec-002) — every commit-time "
+                      "gate (H-01/H-02/H-09b/H-10b/H-14) would go unenforced for this "
+                      "commit. Remove the flag; use /override for a sanctioned bypass.")
+
     # H-01: no commit directly to main/master — case-insensitive, and a detached
     # HEAD sitting on a protected branch's tip counts (the commit lands on its
     # history regardless of the absent branch name).
@@ -465,6 +499,16 @@ def _run(root):
     push = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
     if push:
         pargs = push.group("args")
+
+        # H-20: block a literal --no-verify on `git push` (same rationale as
+        # the commit flank above). `git push` has no short `-n` spelling for
+        # this — its own `-n` is `--dry-run`, an unrelated flag — so only the
+        # long form is checked here.
+        if _has_literal_flag(pargs, PUSH_NO_VERIFY_FLAGS):
+            block("H-20", "'--no-verify' on git push skips the .git/hooks git-enforce "
+                          "backstop entirely (appsec-002) — every push-time gate would "
+                          "go unenforced for this push. Remove the flag; use /override "
+                          "for a sanctioned bypass.")
 
         # H-02: no force-push — any spelling, including --force-with-lease and +refspec
         if FORCE_RE.search(pargs) or FORCE_REFSPEC_RE.search(pargs):
@@ -667,7 +711,7 @@ def main():
     # reliability-002 (#189): everything past this point runs only in an
     # arbiter-enabled repo, so a dormant/non-codeArbiter repo can never be
     # bricked by a crash here. An uncaught exception in the scan path below
-    # (H-01/H-03/H-05/H-09b/H-10b/H-11/H-14/H-18/H-19) must fail CLOSED (exit 2,
+    # (H-01/H-03/H-05/H-09b/H-10b/H-11/H-14/H-18/H-19/H-20) must fail CLOSED (exit 2,
     # a BLOCK) rather than exit 1 — a non-2 exit is a NON-blocking error under
     # the Claude Code hook contract (_hooklib.py:11-15), which would silently
     # ALLOW the very tool call this guard exists to scan. read_input()'s

--- a/plugins/ca/hooks/pre-edit.py
+++ b/plugins/ca/hooks/pre-edit.py
@@ -7,7 +7,9 @@
 # (#162 — raw path AND realpath-resolved repo-relative form):
 #   H-18  CONTEXT.md may not be edited to drop `arbiter: enabled` (#159).
 #   H-19  .codearbiter/.markers/* are never edited via the Edit tools (#160).
-#   H-05  audit-log Edits must be pure appends (new_string extends old_string).
+#   H-05  audit-log Edits must be pure, tail-anchored appends: old_string must
+#         be the file's REAL current trailing content, new_string must extend
+#         it, and replace_all is rejected outright (reliability-003, #172).
 #   H-11  ADRs under decisions/ are edited only via /adr.
 #
 # NotebookEdit is guarded too (a notebook has no append/frontmatter semantics, so
@@ -21,8 +23,23 @@ import traceback
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
-    marker_fresh, project_root, read_input, tool_input, utf8_stdio,
+    is_tail_append, marker_fresh, project_root, read_input, tool_input,
+    utf8_stdio,
 )
+
+
+def _read_real_text(root, fpath):
+    """Best-effort current on-disk content of `fpath` (symlink-resolved), or
+    "" if unreadable. Shared by the #159 CONTEXT.md replay and the H-05
+    tail-anchor check (reliability-003, #172) — both need the file's REAL
+    current content, not just the edit's own old_string, to verify what the
+    edit actually does to the file."""
+    path = fpath if os.path.isabs(fpath) else os.path.join(root, fpath)
+    try:
+        with open(os.path.realpath(path), encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:  # noqa: BLE001
+        return ""
 
 
 def _resulting_context(root, fpath, tool, ti):
@@ -31,12 +48,7 @@ def _resulting_context(root, fpath, tool, ti):
     Reads the real (symlink-resolved) file and replays the edit(s) the way the
     tool would. An old_string that isn't present leaves the text unchanged (the
     tool would error anyway) — harmless for the check."""
-    path = fpath if os.path.isabs(fpath) else os.path.join(root, fpath)
-    try:
-        with open(os.path.realpath(path), encoding="utf-8", errors="replace") as f:
-            text = f.read()
-    except Exception:  # noqa: BLE001
-        text = ""
+    text = _read_real_text(root, fpath)
     if tool == "MultiEdit":
         edits = ti.get("edits", []) or []
     else:
@@ -92,8 +104,9 @@ def _run(root):
                           "dormant. Keep `arbiter: enabled` in a well-formed frontmatter block.")
 
     # H-05: the audit logs (and the /sprint decision record) are append-only — an
-    # Edit must leave existing lines intact (new_string extends old_string), never
-    # alter or delete them. (path set: _hooklib.is_audit_log)
+    # Edit must be a verifiable TAIL-ANCHORED append: old_string must be the
+    # file's REAL current trailing content, and new_string must extend it.
+    # (path set: _hooklib.is_audit_log)
     if "audit" in classes:
         # MultiEdit applies a batch of edits and cannot express a verifiable pure
         # append to an append-only file — the sanctioned append path is a single
@@ -102,6 +115,18 @@ def _run(root):
             block("H-05", "MultiEdit cannot guarantee a pure append to an append-only "
                           ".codearbiter audit log (overrides.log, triage.log, sprint-log.md) "
                           "(ORCHESTRATOR §7). Append with a single Edit or '>>'.")
+        # reliability-003 (#172): replace_all can never be a verifiable append —
+        # it rewrites EVERY occurrence of old_string, not just the tail (a
+        # single-occurrence replace_all is indistinguishable from a targeted
+        # rewrite, and a multi-occurrence one alters interior lines outright).
+        # Reject it outright before even looking at old_string/new_string.
+        if ti.get("replace_all"):
+            block("H-05", "An Edit with replace_all=true on an append-only .codearbiter "
+                          "audit log (overrides.log, triage.log, sprint-log.md) cannot be a "
+                          "verifiable pure append (ORCHESTRATOR §7) — replace_all rewrites "
+                          "every matching occurrence, not just the file's tail. Append with "
+                          "'>>', or a single non-replace_all Edit whose old_string is the "
+                          "file's current trailing content.")
         old = ti.get("old_string", "") or ""
         new = ti.get("new_string", "") or ""
         # migration-003: `new.startswith("")` is ALWAYS True, so an empty
@@ -120,6 +145,20 @@ def _run(root):
                           "sprint-log.md) are append-only (ORCHESTRATOR §7). This Edit alters "
                           "existing audit lines; only pure appends are permitted (new text "
                           "must extend the old text).")
+        # reliability-003 (#172): new.startswith(old) alone is not enough — an
+        # old_string that matches an INTERIOR line (not the file's actual
+        # trailing content) still satisfies startswith, but inserts content
+        # BETWEEN existing lines rather than truly appending at the end.
+        # Tail-anchor against the REAL on-disk content: old_string must be
+        # exactly what the file currently ends with.
+        current = _read_real_text(root, fpath)
+        if not is_tail_append(current, old, new):
+            block("H-05", "The .codearbiter audit logs (overrides.log, triage.log, "
+                          "sprint-log.md) are append-only (ORCHESTRATOR §7). This Edit's "
+                          "old_string is not the file's current TRAILING content — a mid-file "
+                          "insertion reorders the audit record even though new_string extends "
+                          "old_string. Append with '>>', or a single Edit whose old_string is "
+                          "exactly the file's current tail.")
 
     # H-11: ADRs may only be edited via /adr — any .md anywhere under decisions/
     # (a non-numbered draft or a nested path is still an immutable decision).

--- a/plugins/ca/hooks/tests/test_pre_bash_no_verify.py
+++ b/plugins/ca/hooks/tests/test_pre_bash_no_verify.py
@@ -103,6 +103,37 @@ class TestNoVerifyCommit(_PreBashFixture):
         res = self.run_bash('git commit -mn "x"')
         self.assertNotIn("H-20", res.stderr)
 
+    # -- attached-value cluster (security-reviewer HIGH, second pass) --------
+    # A `re.fullmatch(r"-[A-Za-z]+", tok)` gate previously skipped the WHOLE
+    # token whenever any character after the dashes wasn't a letter — so a
+    # leading `-n` immediately followed by an attached value (`=x`, `123`, …)
+    # was never even inspected. Proven live against a real .git/hooks/pre-commit:
+    # -nm=x, -nm123, -vnm=y all committed with the hook skipped.
+
+    def test_commit_nm_equals_value_cluster_is_blocked(self):
+        # -nm=x: walk hits 'n' before 'm' (and before the '=') -> no-verify.
+        self.assertBlocked(self.run_bash("git commit -nm=x"), "H-20")
+
+    def test_commit_nm_digit_value_cluster_is_blocked(self):
+        # -nm123: walk hits 'n' before 'm' (and before the digits) -> no-verify.
+        self.assertBlocked(self.run_bash("git commit -nm123"), "H-20")
+
+    def test_commit_vnm_equals_value_cluster_is_blocked(self):
+        # -vnm=y: 'v' has no special meaning, walk continues to 'n' -> no-verify.
+        self.assertBlocked(self.run_bash("git commit -vnm=y"), "H-20")
+
+    def test_commit_mn_equals_value_cluster_is_not_blocked(self):
+        # -mn=x: 'm' (argument-taking) is hit FIRST -> the rest ("n=x") is the
+        # message value, not a further -n flag. Must NOT block on H-20.
+        res = self.run_bash("git commit -mn=x")
+        self.assertNotIn("H-20", res.stderr)
+
+    def test_commit_Sn_cluster_is_not_blocked(self):
+        # -Sn: 'S' (--gpg-sign, argument-taking) is hit FIRST -> "n" is its
+        # value (the signing key id), not a further -n flag.
+        res = self.run_bash("git commit -Sn -m x")
+        self.assertNotIn("H-20", res.stderr)
+
 
 class TestNoVerifyPush(_PreBashFixture):
     def test_push_with_long_no_verify_is_blocked(self):

--- a/plugins/ca/hooks/tests/test_pre_bash_no_verify.py
+++ b/plugins/ca/hooks/tests/test_pre_bash_no_verify.py
@@ -83,6 +83,26 @@ class TestNoVerifyCommit(_PreBashFixture):
         res = self.run_bash('git commit -m "docs: explain --no-verify guard"')
         self.assertNotIn("H-20", res.stderr)
 
+    # -- bundled short-flag cluster (security-reviewer HIGH, first pass) -----
+
+    def test_commit_bundled_nm_cluster_is_blocked(self):
+        # `-nm "x"` bundles `-n` (no-verify) with `-m x` — the everyday way
+        # `-n` actually gets typed alongside a message flag. An exact-token
+        # check against "-n" alone misses this cluster spelling entirely.
+        self.assertBlocked(self.run_bash('git commit -nm "x"'), "H-20")
+
+    def test_commit_bundled_vn_cluster_is_blocked(self):
+        # `-v` (verbose) does not consume a value, so scanning continues to
+        # the trailing `n` in the same cluster -> no-verify.
+        self.assertBlocked(self.run_bash("git commit -vn -m x"), "H-20")
+
+    def test_commit_bundled_mn_cluster_is_not_blocked(self):
+        # `-mn "x"` is `-m` (message, ARGUMENT-TAKING) immediately followed by
+        # "n" -> "n" is the flag's VALUE (message text "n"), not a further
+        # `-n`/no-verify flag. Must NOT block on H-20.
+        res = self.run_bash('git commit -mn "x"')
+        self.assertNotIn("H-20", res.stderr)
+
 
 class TestNoVerifyPush(_PreBashFixture):
     def test_push_with_long_no_verify_is_blocked(self):

--- a/plugins/ca/hooks/tests/test_pre_bash_no_verify.py
+++ b/plugins/ca/hooks/tests/test_pre_bash_no_verify.py
@@ -1,0 +1,102 @@
+"""appsec-002 (#175): pre-bash.py must block a literal --no-verify / -n flag on
+`git commit` / `git push` — that spelling skips the .git/hooks git-enforce
+backstop entirely (COMMIT_RE/PUSH_RE match the literal `git` verb; nothing
+inspected the flag list for a verify-skip). The deeper shell-indirection
+residual (`g=git; $g commit --no-verify`) is out of scope for this guard and is
+documented as an accepted residual elsewhere — this covers only the literal
+spelling.
+
+Stdlib only; hook JSON piped to pre-bash.py on stdin in a throwaway
+arbiter-enabled git repo (mirrors test_pre_bash_activation.py).
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
+
+
+def _sh(args, cwd, **kw):
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": cwd}
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=60,
+                          env=env, **kw)
+
+
+def _git(args, cwd):
+    r = _sh(["git"] + args, cwd)
+    if r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr}")
+    return r
+
+
+class _PreBashFixture(unittest.TestCase):
+    ARBITER = "---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\n"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "repo")
+        os.makedirs(self.root)
+        _git(["init", "-q", "-b", "feat/work"], self.root)
+        _git(["config", "user.email", "h@example.com"], self.root)
+        _git(["config", "user.name", "harness"], self.root)
+        os.makedirs(os.path.join(self.root, ".codearbiter"))
+        with open(os.path.join(self.root, ".codearbiter", "CONTEXT.md"), "w",
+                  encoding="utf-8") as f:
+            f.write(self.ARBITER)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def run_bash(self, command):
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+        return _sh([sys.executable, PRE_BASH], self.root, input=payload)
+
+    def assertBlocked(self, res, tag):
+        self.assertEqual(res.returncode, 2,
+                         f"expected BLOCK (exit 2); got {res.returncode} / {res.stderr[:200]!r}")
+        self.assertIn(tag, res.stderr)
+
+    def assertAllowed(self, res):
+        self.assertEqual(res.returncode, 0,
+                         f"expected ALLOW (exit 0); got {res.returncode} / {res.stderr[:200]!r}")
+
+
+class TestNoVerifyCommit(_PreBashFixture):
+    def test_commit_with_long_no_verify_is_blocked(self):
+        self.assertBlocked(self.run_bash("git commit --no-verify -m x"), "H-20")
+
+    def test_commit_with_short_n_is_blocked(self):
+        self.assertBlocked(self.run_bash("git commit -n -m x"), "H-20")
+
+    def test_normal_commit_is_unaffected(self):
+        self.assertAllowed(self.run_bash("git commit -m x"))
+
+    def test_commit_message_mentioning_no_verify_is_not_blocked_on_h20(self):
+        # A commit message QUOTING --no-verify (not passed as a real flag) must
+        # not be misclassified — ambiguity here would over-block legitimate
+        # commit messages describing this very fix.
+        res = self.run_bash('git commit -m "docs: explain --no-verify guard"')
+        self.assertNotIn("H-20", res.stderr)
+
+
+class TestNoVerifyPush(_PreBashFixture):
+    def test_push_with_long_no_verify_is_blocked(self):
+        self.assertBlocked(self.run_bash("git push --no-verify"), "H-20")
+
+    def test_push_with_long_no_verify_and_remote_is_blocked(self):
+        self.assertBlocked(self.run_bash("git push --no-verify origin feat/work"), "H-20")
+
+    def test_normal_push_is_unaffected(self):
+        # No remote configured in the fixture, but the guard runs before any
+        # network operation — this only proves H-20 does not fire.
+        res = self.run_bash("git push origin feat/work")
+        self.assertNotIn("H-20", res.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_pre_edit.py
+++ b/plugins/ca/hooks/tests/test_pre_edit.py
@@ -95,15 +95,15 @@ class _PreEditFixture(unittest.TestCase):
             os.utime(m, (past, past))
         return m
 
-    def run_edit(self, file_path, old_string, new_string):
-        payload = json.dumps({
-            "tool_name": "Edit",
-            "tool_input": {
-                "file_path": file_path,
-                "old_string": old_string,
-                "new_string": new_string,
-            },
-        })
+    def run_edit(self, file_path, old_string, new_string, replace_all=False):
+        ti = {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string,
+        }
+        if replace_all:
+            ti["replace_all"] = True
+        payload = json.dumps({"tool_name": "Edit", "tool_input": ti})
         return _sh([sys.executable, PRE_EDIT], self.root, input=payload)
 
     def run_multiedit(self, file_path, edits):
@@ -215,6 +215,71 @@ class TestH05AppendOnly(_PreEditFixture):
             win_path,
             old_string="[2026-01-01T00:00:00Z] | BY: harness | GATE: none | REASON: seed\n",
             new_string="totally different content\n",
+        )
+        self.assertBlocked(res, "H-05")
+
+    # -- reliability-003 (#172): tail-anchor the append check ----------------
+
+    def test_mid_file_insertion_on_overrides_log_is_blocked(self):
+        # old_string is a real line in the file, but the file has MORE content
+        # after it, so old_string is NOT the file's actual trailing content —
+        # new.startswith(old) is satisfied, but the resulting edit would insert
+        # content between the two existing lines rather than truly append.
+        seed = "[2026-01-01T00:00:00Z] | BY: harness | GATE: none | REASON: seed\n"
+        tail = "[2026-01-02T00:00:00Z] | BY: harness | GATE: none | REASON: second\n"
+        self._write(os.path.join(self.ca, "overrides.log"), seed + tail)
+        res = self.run_edit(
+            os.path.join(self.ca, "overrides.log"),
+            old_string=seed,
+            new_string=seed + "[2099-01-01T00:00:00Z] | BY: attacker | GATE: none | REASON: injected\n",
+        )
+        self.assertBlocked(res, "H-05")
+
+    def test_replace_all_on_overrides_log_is_blocked(self):
+        # replace_all is never a verifiable append, even when new.startswith(old)
+        # holds for a tail-shaped old_string — reject outright.
+        old = "[2026-01-01T00:00:00Z] | BY: harness | GATE: none | REASON: seed\n"
+        res = self.run_edit(
+            os.path.join(self.ca, "overrides.log"),
+            old_string=old,
+            new_string=old + "extra\n",
+            replace_all=True,
+        )
+        self.assertBlocked(res, "H-05")
+
+    def test_replace_all_multi_site_suffix_rewrite_on_overrides_log_is_blocked(self):
+        # A replace_all with an old_string occurring multiple times rewrites
+        # every occurrence, not just the tail — must be rejected outright.
+        line = "REPEATED\n"
+        self._write(os.path.join(self.ca, "overrides.log"), line + line)
+        res = self.run_edit(
+            os.path.join(self.ca, "overrides.log"),
+            old_string=line,
+            new_string=line + "suffix\n",
+            replace_all=True,
+        )
+        self.assertBlocked(res, "H-05")
+
+    def test_tail_anchored_append_to_overrides_log_is_allowed(self):
+        # old_string genuinely IS the file's current trailing content — a
+        # legitimate append must still pass.
+        current = "[2026-01-01T00:00:00Z] | BY: harness | GATE: none | REASON: seed\n"
+        res = self.run_edit(
+            os.path.join(self.ca, "overrides.log"),
+            old_string=current,
+            new_string=current + "[2026-02-02T00:00:00Z] | BY: harness | GATE: H-07 | REASON: ok\n",
+        )
+        self.assertAllowed(res)
+
+    def test_mid_file_insertion_on_sprint_log_is_blocked(self):
+        head = "# Sprint log\n\n"
+        entry1 = "## SD-01 seed\n- chosen: X\n"
+        entry2 = "## SD-02\n- chosen: Y\n"
+        self._write(os.path.join(self.ca, "sprint-log.md"), head + entry1 + entry2)
+        res = self.run_edit(
+            os.path.join(self.ca, "sprint-log.md"),
+            old_string=entry1,
+            new_string=entry1 + "## SD-99 injected\n- chosen: forged\n",
         )
         self.assertBlocked(res, "H-05")
 


### PR DESCRIPTION
Lane A2 — two guard-boundary hardenings from the tribunal audit.

## What
- **#172 (security / audit-trail — reliability-003):** the H-05 append-only guard (`pre-edit.py`, via new `_hooklib.is_tail_append`) now **tail-anchors** — an audit-log Edit is admitted only as a strict append (`new` = current + appended tail, `old` unique), and a `replace_all` Edit on an audit-log path is **rejected outright**. Closes the prior `new.startswith(old)` hole that let a mid-file insertion or multi-site suffix rewrite pass as an "append". Audit-trail integrity is conflict-hierarchy level 1.
- **#175 (security — appsec-002):** new **H-20** guard blocks a literal `--no-verify`/`-n` on `git commit` and a literal `--no-verify` on `git push` — the flag skips the `.git/hooks` git-enforce backstop, voiding H-01/H-02/H-09b/H-10b/H-14 for that op. Handles bundled/attached short-flag spellings (`-nm`, `-nm=x`, `-vnm=y`) via a char-walk that mirrors git's own cluster parsing; `git push -n` (=`--dry-run`) is correctly left alone.

## Verification
- **631 hook tests pass** (+20 new across the two issues incl. the full bundled-flag matrix); `py_compile` clean; LF.
- **security-reviewer: PASS** — after two rounds that caught real bypasses (bundled `-nm`, then attached-value `-nm=x`), the final adversarial pass drove every literal `git commit -n` spelling against the actual guard *and* cross-checked the allowed ones against real git: the entire literal bundled-`-n` class is closed, no over-block regression, only the documented shell-indirection residual remains (out of scope per ADR-0010). The `is_tail_append` tail-anchor was verified not to over-reject any valid append.

Bumps ca 2.8.4 → 2.8.5. Documents both guards + the accepted residual in `security-controls.md` §Audit trail.

Closes #172
Closes #175

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa