### PR TITLE
fix(hooks): atomic writes for prune/settings/githooks state; single-parse prune transcript (#191 #188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.6" src="https://img.shields.io/badge/version-2.8.6-2b7489">
+<img alt="version 2.8.7" src="https://img.shields.io/badge/version-2.8.7-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -31,6 +31,8 @@ import stat
 import subprocess
 import sys
 
+import _hooklib
+
 SENTINEL = "# codeArbiter-managed git hook (#161) — refreshed each session; edits are overwritten."
 PHASES = ("pre-commit", "pre-push")
 
@@ -123,8 +125,13 @@ def install(root):
             if existing == desired:
                 continue  # already current — no churn
         try:
-            with open(dest, "w", encoding="utf-8", newline="\n") as f:
-                f.write(desired)
+            # reliability-010: atomic sibling-temp + os.replace (mirrors
+            # write_provenance/save_state). A crash mid-write with a plain
+            # open('w') could leave a sentinel-less partial shim that the
+            # foreign-hook guard above then preserves forever; os.replace
+            # guarantees `dest` is either the complete new shim or the prior
+            # (sentinel-bearing, or absent) file — never a torn write.
+            _hooklib.write_text_atomic(dest, desired, newline="\n")
             st = os.stat(dest)
             os.chmod(dest, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
             actions.append(f"{phase}: installed")

--- a/plugins/ca/hooks/_prunelib.py
+++ b/plugins/ca/hooks/_prunelib.py
@@ -28,6 +28,8 @@ import shutil
 import sys
 import time
 
+import _hooklib
+
 BOM = b"\xef\xbb\xbf"
 MARKER_PREFIX = "[ca-condensed "
 
@@ -1059,11 +1061,16 @@ def load_state():
 
 
 def save_state(state):
+    """Persist the global cross-session prune-state.json atomically
+    (reliability-008): a sibling temp file + os.replace via
+    _hooklib.write_text_atomic, so a crash mid-write leaves the PRIOR valid
+    state file intact instead of a torn/truncated one. Best-effort: any
+    failure (including the simulated one write_text_atomic re-raises) is
+    swallowed here — a prune-state write must never break the user's turn."""
     d = os.path.dirname(state_path())
     try:
         os.makedirs(d, exist_ok=True)
-        with open(state_path(), "w", encoding="utf-8") as f:
-            f.write(_dumps(state))
+        _hooklib.write_text_atomic(state_path(), _dumps(state))
     except Exception:  # noqa: BLE001
         pass
 
@@ -1248,15 +1255,23 @@ def hook_run(payload, env=None):
             pass
     if rec and (st.st_size - rec.get("last_pruned_size", 0)) < cfg.min_growth:
         return 0  # cheap stat short-circuit: not enough new bytes
+    # performance-001: read + parse the transcript ONCE here and thread the
+    # bytes/lines/pre_stat through to run() below, instead of letting run()
+    # re-open and re-parse the identical on-disk content a second time. The
+    # fstat is captured from the SAME open fd as the read (not a separate
+    # os.stat afterwards) so it reflects exactly the bytes just read, matching
+    # what run()'s own self-contained read would have captured.
     try:
         with open(path, "rb") as f:
             data = f.read()
+            pre_stat = os.fstat(f.fileno())
     except Exception:  # noqa: BLE001
         return 0
-    if not tail_is_settled(load_lines(data)):
+    lines = load_lines(data)
+    if not tail_is_settled(lines):
         return 0
     try:
-        res = run(path, cfg, session=session)
+        res = run(path, cfg, session=session, data=data, lines=lines, pre_stat=pre_stat)
     except Exception:  # noqa: BLE001 — never let pruning break the turn
         return 0
     b0, b1 = res["bytes_before"], res["bytes_after"]
@@ -1313,19 +1328,35 @@ def append_audit_log(record):
 # Top-level run (dry-run analysis; execute optionally writes)
 # --------------------------------------------------------------------------- #
 
-def run(path, cfg, session="session"):
+def run(path, cfg, session="session", data=None, lines=None, pre_stat=None):
     """Prune `path` per `cfg`. Always computes the report; writes only when
-    cfg.execute and validation passes. Returns a result dict."""
-    if cfg.execute:
-        # A prior prune killed between write and truncate leaves a spliced
-        # file; restore it from backup before analyzing. (Dry-run never writes,
-        # including this.)
-        self_heal(path, session)
-    with open(path, "rb") as f:
-        orig_bytes = f.read()
-        pre_stat = os.fstat(f.fileno())
+    cfg.execute and validation passes. Returns a result dict.
 
-    lines = load_lines(orig_bytes)
+    performance-001: `data`/`lines`/`pre_stat` let a caller that has ALREADY
+    read+parsed the transcript (hook_run's tail_is_settled check) hand that
+    single read straight to the pruning pass, instead of run() re-opening and
+    re-parsing the identical on-disk bytes a second time. When `data` is None
+    (the default — direct/standalone callers, e.g. the CLI and tests), run()
+    self-heals and reads the file itself exactly as before, so behavior for
+    those callers is unchanged."""
+    if data is None:
+        if cfg.execute:
+            # A prior prune killed between write and truncate leaves a spliced
+            # file; restore it from backup before analyzing. (Dry-run never
+            # writes, including this.)
+            self_heal(path, session)
+        with open(path, "rb") as f:
+            orig_bytes = f.read()
+            pre_stat = os.fstat(f.fileno())
+        lines = load_lines(orig_bytes)
+    else:
+        # Caller already read (and self-healed, if executing) the file once —
+        # reuse its bytes/parse rather than re-reading path from disk.
+        orig_bytes = data
+        if lines is None:
+            lines = load_lines(orig_bytes)
+        if pre_stat is None:
+            pre_stat = os.stat(path)
     index = build_index(lines, cfg)
     report = apply_strategies(lines, index, cfg)
     new_bytes = serialize(lines)

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -18,6 +18,7 @@
 # In any repo WITHOUT the flag, the hook exits silently (dormant) — the plugin
 # can be installed globally and stays out of the way everywhere else.
 
+import copy
 import datetime
 import os
 import re
@@ -372,7 +373,15 @@ def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None)
     """Refresh a stale ca-OWNED statusLine pin to the current renderer path.
     Returns True iff settings.json was rewritten. Fully guarded: any failure —
     including a corrupt settings.json (which wire-statusline raises SystemExit on)
-    — degrades to False so it never crashes session startup."""
+    — degrades to False so it never crashes session startup.
+
+    reliability-009: settings.json is the user's WHOLE host configuration, not
+    a ca-owned file — a full read-modify-write of it must not clobber a change
+    made by a concurrent session (or the user) between our load and our save.
+    Narrow that window by reloading the file fresh immediately before writing:
+    if it differs from what we loaded, some other writer touched it in the
+    interim, so we SKIP this heal entirely (never overwrite that write with
+    our now-stale snapshot) — a later session's heal simply retries."""
     try:
         ws = (loader or _load_wire_statusline)(plugin)
         if ws is None:
@@ -383,10 +392,14 @@ def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None)
         settings, exists = ws.load_settings(spath)
         if not exists:
             return False
-        if ws.refresh_if_stale(settings, script_abs, interp):
-            ws.save_settings(spath, settings)
-            return True
-        return False
+        original = copy.deepcopy(settings)
+        if not ws.refresh_if_stale(settings, script_abs, interp):
+            return False
+        fresh, fresh_exists = ws.load_settings(spath)
+        if not fresh_exists or fresh != original:
+            return False  # changed underneath us — skip, retry next session
+        ws.save_settings(spath, settings)
+        return True
     except (Exception, SystemExit):  # noqa: BLE001 — heal is best-effort, never fatal
         return False
 

--- a/plugins/ca/hooks/tests/test_atomic_writes.py
+++ b/plugins/ca/hooks/tests/test_atomic_writes.py
@@ -1,0 +1,284 @@
+"""Reliability hardening (issue #191): route bare open('w') writers through
+_hooklib's atomic temp+os.replace primitive so a crash mid-write leaves the
+PRIOR valid file intact instead of a torn/truncated one.
+
+Covers:
+  reliability-008 — _prunelib.save_state (global cross-session prune-state.json)
+  reliability-010 — _githooks.install (git-hook shim write)
+  reliability-009 — wire-statusline.save_settings (per-pid temp name) AND
+                     session-start.heal_statusline_wiring (reload-before-save)
+
+(reliability-016, _provenancelib.write_provenance, was already fixed in a
+prior tribunal pass — see .github/scripts/test_provenancelib.py
+WriteProvenanceAtomicTest — and is not re-covered here.)
+"""
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOKS_DIR = os.path.dirname(_TESTS_DIR)
+sys.path.insert(0, _HOOKS_DIR)
+sys.path.insert(0, _TESTS_DIR)
+
+import _githooks  # noqa: E402
+import _prunelib as P  # noqa: E402
+from _helpers import redirect_home, restore_home  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# reliability-008 — _prunelib.save_state
+# ---------------------------------------------------------------------------
+
+class SaveStateAtomicTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._home = redirect_home(self.tmp.name)
+
+    def tearDown(self):
+        restore_home(self._home)
+        self.tmp.cleanup()
+
+    def test_crash_mid_write_leaves_previous_state_intact(self):
+        P.save_state({"sess1": {"last_run_ts": 1}})
+        self.assertEqual(P.load_state(), {"sess1": {"last_run_ts": 1}})
+
+        # save_state is fail-open (best-effort): a crash mid-write must be
+        # swallowed, never propagate and never break the caller's turn.
+        with patch("os.replace", side_effect=OSError("simulated crash")):
+            P.save_state({"sess1": {"last_run_ts": 2}})
+
+        # The PRIOR, complete state must survive — never partially overwritten.
+        self.assertEqual(P.load_state(), {"sess1": {"last_run_ts": 1}})
+
+        # No stray .tmp file left behind in ~/.codearbiter/.
+        d = os.path.dirname(P.state_path())
+        leftovers = [n for n in os.listdir(d) if n != "prune-state.json"]
+        self.assertEqual(leftovers, [], f"no temp file should linger: {leftovers}")
+
+    def test_uses_atomic_write_primitive(self):
+        """save_state must route through _hooklib.write_text_atomic, not a
+        bare open('w') — proven by spying on the shared primitive."""
+        calls = []
+        orig = P._hooklib.write_text_atomic
+
+        def spy(path, text, newline=None):
+            calls.append(path)
+            return orig(path, text, newline=newline)
+
+        with patch.object(P._hooklib, "write_text_atomic", side_effect=spy):
+            P.save_state({"a": 1})
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0], P.state_path())
+
+
+# ---------------------------------------------------------------------------
+# reliability-010 — _githooks.install
+# ---------------------------------------------------------------------------
+
+def _git(args, cwd):
+    return subprocess.run(["git"] + args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=30, check=True)
+
+
+class GitHooksInstallAtomicTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self.tmp.name, "repo")
+        os.makedirs(self.root)
+        _git(["init", "-q", "-b", "main"], self.root)
+        _git(["config", "user.email", "h@example.com"], self.root)
+        _git(["config", "user.name", "harness"], self.root)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_crash_mid_write_leaves_prior_shim_intact(self):
+        _githooks.install(self.root)
+        dest = os.path.join(self.root, ".git", "hooks", "pre-commit")
+        with open(dest, encoding="utf-8") as f:
+            prior = f.read()
+        self.assertIn(_githooks.SENTINEL, prior)
+
+        # Force install() to actually attempt a REWRITE (not the idempotent
+        # no-op skip) by pointing the enforcer at a different path, then crash
+        # os.replace mid-install.
+        with patch.object(_githooks, "_enforcer_path", return_value="/new/enforcer.py"):
+            with patch("os.replace", side_effect=OSError("simulated crash")):
+                _githooks.install(self.root)  # must not raise (caught internally)
+
+        with open(dest, encoding="utf-8") as f:
+            after = f.read()
+        self.assertEqual(after, prior,
+                         "a crash mid-write must leave the PRIOR sentinel-bearing shim intact")
+        self.assertIn(_githooks.SENTINEL, after,
+                      "the surviving shim must still carry the sentinel (never a torn write)")
+
+        hd = os.path.dirname(dest)
+        leftovers = [n for n in os.listdir(hd)
+                     if n not in ("pre-commit", "pre-push") and not n.endswith(".sample")]
+        self.assertEqual(leftovers, [], f"no temp file should linger: {leftovers}")
+
+    def test_crash_on_fresh_install_leaves_no_partial_shim(self):
+        """No prior hook at all: a crash mid-write must leave NO file behind
+        (never a sentinel-less partial the foreign-hook guard would then
+        preserve forever)."""
+        dest = os.path.join(self.root, ".git", "hooks", "pre-commit")
+        self.assertFalse(os.path.exists(dest))
+        with patch("os.replace", side_effect=OSError("simulated crash")):
+            _githooks.install(self.root)
+        self.assertFalse(os.path.exists(dest),
+                         "a crashed fresh install must not leave a partial shim")
+
+
+# ---------------------------------------------------------------------------
+# reliability-009 — wire-statusline.save_settings: per-pid/unique temp name
+# ---------------------------------------------------------------------------
+
+def _load_wire_statusline():
+    import importlib.util as ilu
+    path = os.path.join(_HOOKS_DIR, "wire-statusline.py")
+    spec = ilu.spec_from_file_location("wire_statusline_atomic_test", path)
+    mod = ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class SaveSettingsAtomicTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        d = os.path.join(self.tmp.name, ".claude")
+        os.makedirs(d)
+        self.settings = os.path.join(d, "settings.json")
+        self.ws = _load_wire_statusline()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_does_not_stage_to_the_fixed_sibling_tmp_name(self):
+        captured = {}
+        real_replace = os.replace
+
+        def spy(src, dst):
+            captured["src"] = src
+            return real_replace(src, dst)
+
+        with patch("os.replace", side_effect=spy):
+            self.ws.save_settings(self.settings, {"a": 1})
+        fixed_name = self.settings + ".tmp"
+        self.assertNotEqual(
+            captured.get("src"), fixed_name,
+            "save_settings must stage to a UNIQUE per-process temp file, "
+            "not the fixed sibling .tmp name two concurrent writers could collide on")
+
+    def test_crash_mid_write_leaves_prior_settings_intact(self):
+        self.ws.save_settings(self.settings, {"a": 1})
+        with patch("os.replace", side_effect=OSError("simulated crash")):
+            with self.assertRaises(OSError):
+                self.ws.save_settings(self.settings, {"a": 2})
+        with open(self.settings, encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertEqual(data, {"a": 1})
+        leftovers = [n for n in os.listdir(os.path.dirname(self.settings))
+                     if n != os.path.basename(self.settings)]
+        self.assertEqual(leftovers, [], f"no temp file should linger: {leftovers}")
+
+
+# ---------------------------------------------------------------------------
+# reliability-009 — session-start.heal_statusline_wiring: reload-before-save
+# ---------------------------------------------------------------------------
+
+import importlib.util as _ilu  # noqa: E402
+
+_SS_SPEC = _ilu.spec_from_file_location(
+    "session_start_atomic_test",
+    os.path.join(_HOOKS_DIR, "session-start.py"))
+_ss = _ilu.module_from_spec(_SS_SPEC)
+_SS_SPEC.loader.exec_module(_ss)
+
+
+class HealReloadBeforeSaveTest(unittest.TestCase):
+    """The settings-heal must re-read settings.json immediately before saving
+    and SKIP (never overwrite) when it changed since the initial load — the
+    concurrent-session clobber this fix closes."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.plugin = os.path.dirname(os.path.dirname(os.path.abspath(_ss.__file__)))
+        d = os.path.join(self.tmp.name, ".claude")
+        os.makedirs(d)
+        self.settings = os.path.join(d, "settings.json")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, obj):
+        with open(self.settings, "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2)
+
+    def _read(self):
+        with open(self.settings, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _stale_ours(self):
+        return {"statusLine": {"type": "command",
+                "command": '"python" "C:\\old\\ca\\2.0.1\\hooks\\statusline.py"'}}
+
+    def test_skips_when_settings_changed_between_load_and_save(self):
+        self._write(self._stale_ours())
+
+        real_ws = _ss._load_wire_statusline(self.plugin)
+        calls = {"n": 0}
+        orig_load = real_ws.load_settings
+
+        concurrent = {"statusLine": {"type": "command", "command": "concurrent-writer --x"}}
+
+        def flaky_load(path):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return orig_load(path)
+            # Simulate a concurrent writer's edit actually landing ON DISK
+            # between our initial load and the reload-before-save check.
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(concurrent, f, indent=2)
+            return copy.deepcopy(concurrent), True
+
+        real_ws.load_settings = flaky_load
+        save_calls = []
+        orig_save = real_ws.save_settings
+
+        def spy_save(path, data):
+            save_calls.append(copy.deepcopy(data))
+            return orig_save(path, data)
+
+        real_ws.save_settings = spy_save
+
+        changed = _ss.heal_statusline_wiring(
+            self.plugin, settings_path=self.settings, interp="python",
+            loader=lambda _p: real_ws)
+
+        self.assertFalse(changed, "heal must skip when settings changed underneath it")
+        self.assertEqual(save_calls, [],
+                         "save_settings must never be called on a detected concurrent change")
+        self.assertGreaterEqual(calls["n"], 2,
+                                "heal must reload settings.json before saving")
+        # The concurrent writer's edit must survive completely untouched.
+        on_disk = self._read()
+        self.assertEqual(on_disk["statusLine"]["command"], "concurrent-writer --x")
+
+    def test_saves_when_unchanged_between_load_and_save(self):
+        self._write(self._stale_ours())
+        changed = _ss.heal_statusline_wiring(
+            self.plugin, settings_path=self.settings, interp="python")
+        self.assertTrue(changed)
+        cmd = self._read()["statusLine"]["command"]
+        self.assertNotIn("2.0.1", cmd)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/ca/hooks/tests/test_prune_single_parse.py
+++ b/plugins/ca/hooks/tests/test_prune_single_parse.py
@@ -1,0 +1,119 @@
+"""performance-001 (issue #188): hook_run's tail_is_settled check and run()'s
+pruning pass must operate on a SINGLE read+parse of the transcript file per
+hook_run() invocation, not two independent open()+load_lines() cycles on the
+identical on-disk bytes.
+
+Verified two ways, per the issue's own acceptance criteria:
+  1. A call-count spy on _prunelib.load_lines — parsing happens exactly once.
+  2. A call-count spy on builtins.open for the transcript path itself — the
+     file is opened at most twice (the pre-existing, in-scope self_heal
+     corruption-check read, plus the ONE read that is then threaded through to
+     the pruning pass) — never four times, which is what two independent
+     read+parse cycles (one in hook_run, one re-done inside run()) would cost.
+"""
+import builtins
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOKS_DIR = os.path.dirname(_TESTS_DIR)
+sys.path.insert(0, _HOOKS_DIR)
+sys.path.insert(0, _TESTS_DIR)
+
+import _prunelib as P  # noqa: E402
+from _helpers import make_transcript, redirect_home, restore_home  # noqa: E402
+
+
+class SingleParseTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._home = redirect_home(self.tmp.name)
+        self.repo = os.path.join(self.tmp.name, "repo")
+        os.makedirs(os.path.join(self.repo, ".codearbiter"))
+        with open(os.path.join(self.repo, ".codearbiter", "CONTEXT.md"), "w") as f:
+            f.write("---\narbiter: enabled\n---\n# ctx\n")
+        claude_dir = os.path.join(self.tmp.name, ".claude", "projects", "test")
+        os.makedirs(claude_dir, exist_ok=True)
+        self.path = os.path.join(claude_dir, "sess.jsonl")
+        with open(self.path, "wb") as f:
+            f.write(make_transcript(n_pairs=8, result_bytes=20000))
+        # Fresh state: no prior record, so the growth short-circuit never fires.
+        P.save_state({})
+
+    def tearDown(self):
+        restore_home(self._home)
+        self.tmp.cleanup()
+
+    def _env(self):
+        return {"CODEARBITER_PRUNE": "on",
+                "CODEARBITER_PRUNE_KEEP_RECENT": "2",
+                "CODEARBITER_PRUNE_MIN_SIZE": "1000",
+                "CODEARBITER_PRUNE_MIN_GROWTH": "1000"}
+
+    def _payload(self):
+        return {"hook_event_name": "UserPromptSubmit", "transcript_path": self.path,
+                "session_id": "sess", "cwd": self.repo}
+
+    def test_load_lines_called_exactly_once_per_hook_run(self):
+        calls = []
+        orig = P.load_lines
+
+        def spy(data):
+            calls.append(len(data))
+            return orig(data)
+
+        with patch.object(P, "load_lines", side_effect=spy):
+            rc = P.hook_run(self._payload(), env=self._env())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            len(calls), 1,
+            "the transcript must be parsed (load_lines) exactly ONCE per "
+            "hook_run invocation, not once for tail_is_settled and again "
+            "inside run()")
+
+    def test_transcript_path_opened_at_most_five_times(self):
+        """Opens of the transcript path per hook_run invocation must drop from
+        7 (pre-fix baseline, measured directly against the unfixed code) to 5:
+        self_heal's corruption check (1), the ONE read now threaded through to
+        the pruning pass (1), and write_in_place's own pre-write read + write
+        + post-write verify re-read (3) — all four of those are out of scope
+        for this fix. Pre-fix, hook_run and run() each independently
+        self_heal'd and read+parsed the identical bytes, costing 2 EXTRA opens
+        (self_heal called twice, the transcript read+parsed twice) on top of
+        those same 5 — this assertion is the regression guard against that
+        duplication coming back."""
+        real_open = builtins.open
+        opens_of_path = []
+
+        def spy_open(file, *a, **kw):
+            if isinstance(file, str) and os.path.abspath(file) == os.path.abspath(self.path):
+                opens_of_path.append(a[0] if a else kw.get("mode", "r"))
+            return real_open(file, *a, **kw)
+
+        with patch("builtins.open", side_effect=spy_open):
+            rc = P.hook_run(self._payload(), env=self._env())
+
+        self.assertEqual(rc, 0)
+        self.assertLessEqual(
+            len(opens_of_path), 5,
+            f"transcript opened {len(opens_of_path)} times per hook_run "
+            f"invocation; expected at most 5 (self_heal + the single threaded "
+            f"read + write_in_place's 3 own opens) — 7 means hook_run and "
+            f"run() are each independently self-healing and re-reading the "
+            f"transcript again")
+
+    def test_prune_still_executes_and_shrinks(self):
+        """Sanity: the single-parse plumbing must not silently break pruning
+        itself — existing behavior (transcript shrinks) is preserved."""
+        before = os.path.getsize(self.path)
+        rc = P.hook_run(self._payload(), env=self._env())
+        self.assertEqual(rc, 0)
+        self.assertLess(os.path.getsize(self.path), before)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/ca/hooks/tests/test_prune_single_parse.py
+++ b/plugins/ca/hooks/tests/test_prune_single_parse.py
@@ -77,15 +77,19 @@ class SingleParseTest(unittest.TestCase):
 
     def test_transcript_path_opened_at_most_five_times(self):
         """Opens of the transcript path per hook_run invocation must drop from
-        7 (pre-fix baseline, measured directly against the unfixed code) to 5:
-        self_heal's corruption check (1), the ONE read now threaded through to
-        the pruning pass (1), and write_in_place's own pre-write read + write
-        + post-write verify re-read (3) — all four of those are out of scope
-        for this fix. Pre-fix, hook_run and run() each independently
-        self_heal'd and read+parsed the identical bytes, costing 2 EXTRA opens
-        (self_heal called twice, the transcript read+parsed twice) on top of
-        those same 5 — this assertion is the regression guard against that
-        duplication coming back."""
+        the pre-fix baseline (7 on Windows / 8 on POSIX, measured directly
+        against the unfixed code) to the no-duplicate baseline: self_heal's
+        corruption check (1), the ONE read now threaded through to the pruning
+        pass (1), and write_in_place's own pre-write read + write + post-write
+        verify re-read (3 on Windows, 4 on POSIX — os.replace/verify does one
+        extra open there) — all of which are out of scope for this fix. Pre-fix,
+        hook_run and run() each independently self_heal'd and read+parsed the
+        identical bytes, costing 2 EXTRA opens on top of that baseline — this
+        assertion is the regression guard against that duplication coming back.
+        The bound is 6 (the max no-duplicate baseline, on POSIX); the +2
+        regression (8/9) still trips it on either platform. The platform-
+        independent single-parse proof is the sibling `load_lines`-count-1
+        test; this one guards the raw-open regression only."""
         real_open = builtins.open
         opens_of_path = []
 
@@ -99,12 +103,12 @@ class SingleParseTest(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertLessEqual(
-            len(opens_of_path), 5,
+            len(opens_of_path), 6,
             f"transcript opened {len(opens_of_path)} times per hook_run "
-            f"invocation; expected at most 5 (self_heal + the single threaded "
-            f"read + write_in_place's 3 own opens) — 7 means hook_run and "
-            f"run() are each independently self-healing and re-reading the "
-            f"transcript again")
+            f"invocation; expected at most 6 (self_heal + the single threaded "
+            f"read + write_in_place's own opens, 3 on Windows / 4 on POSIX) — "
+            f"7+ means hook_run and run() are each independently self-healing "
+            f"and re-reading the transcript again")
 
     def test_prune_still_executes_and_shrinks(self):
         """Sanity: the single-parse plumbing must not silently break pruning

--- a/plugins/ca/hooks/wire-statusline.py
+++ b/plugins/ca/hooks/wire-statusline.py
@@ -27,6 +27,13 @@ import json
 import os
 import sys
 
+# Self-sufficient regardless of how this file is loaded (direct `python
+# wire-statusline.py` run, or importlib spec_from_file_location as
+# session-start.py and the test suite both do) — always resolve _hooklib
+# relative to THIS file rather than relying on the caller's sys.path state.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _hooklib  # noqa: E402
+
 BACKUP_KEY = "_codearbiterStatuslineBackup"       # holds the prior statusLine value
 SPINNER_BACKUP_KEY = "_codearbiterSpinnerVerbsBackup"  # holds prior spinnerVerbs
 MARKER = "statusline.py"                          # how we recognize our own line
@@ -108,12 +115,18 @@ def load_settings(path):
 
 
 def save_settings(path, data):
+    """Write `data` to `path` atomically (reliability-009).
+
+    Routed through _hooklib.write_text_atomic, which stages to a UNIQUE
+    per-process temp file (tempfile.mkstemp, not a fixed `path + ".tmp"`
+    sibling name) before os.replace(). settings.json is the user's WHOLE host
+    configuration, not a ca-owned file: two sessions racing a heal/install
+    right after a plugin update previously both staged to the same fixed
+    `.tmp` name and could clobber each other's temp content on interleave. A
+    unique name per call removes that collision entirely."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp = path + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
-    os.replace(tmp, path)
+    text = json.dumps(data, indent=2) + "\n"
+    _hooklib.write_text_atomic(path, text)
 
 
 def cmd_status(settings, exists, script_abs):


### PR DESCRIPTION
Lane E2 — reliability + performance from the tribunal audit.

## What
- **#191 (reliability — atomic-writes group):** routes bare `open('w')` state writers through `_hooklib.write_text_atomic` (unique-per-call temp + `os.replace`) so a torn/interrupted write leaves the prior file intact:
  - `_prunelib.save_state` (reliability-008), `_githooks.install`'s shim (reliability-010 — a partial shim can no longer silently disable the #161 git-enforce backstop), and `wire-statusline.py`'s `save_settings` (reliability-009 — no more fixed-`.tmp` collision between concurrent sessions).
  - The SessionStart settings-heal now **reloads settings.json immediately before saving and skips if it changed underneath**, so a concurrent session's edits aren't clobbered.
  - reliability-016 (`write_provenance`) was already atomic since PR #197 — left untouched.
- **#188 (performance-001):** the prune hook read+parsed the full transcript (up to ~50MB) twice per prompt; `hook_run` now threads its single read+parse through `run()`. Byte-identical pruning behavior (a consistency improvement — the settle check and prune now see the same snapshot).

## Verification
- **711 hook tests pass** (+11 new: `test_atomic_writes.py`, `test_prune_single_parse.py`); TDD-verified red→green (reverting the impl corrupts state / double-parses); `py_compile` clean; LF.
- **security-reviewer: PASS** — 0 critical/high/medium. Verified the `_githooks` shim atomicity (backstop preserved), the settings-heal concurrency correctness (no clobber, no wedge), single-parse parity, and the `wire-statusline` sys.path insert resolving only its trusted hooks dir. 2 no-action LOWs (benign 0711 shim perms; inert mkstemp-leak-on-SIGKILL).

Bumps ca 2.8.6 → 2.8.7.

Closes #191
Closes #188

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa