### PR TITLE
refactor(hooks): thin entry points for babysit/metrics/preview command helpers (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.7" src="https://img.shields.io/badge/version-2.8.7-2b7489">
+<img alt="version 2.8.8" src="https://img.shields.io/badge/version-2.8.8-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/commands/metrics.md
+++ b/plugins/ca/commands/metrics.md
@@ -15,16 +15,17 @@ glance; reach for `/ca:audit` when you need the full evidentiary packet.
 
 ## Flow
 
-1. **Invoke the helper.** Call `compute` from `_metricslib.py` via a Windows-safe
-   `python3 … || python …` fallback one-liner. Pass `${CLAUDE_PROJECT_DIR}` as the
-   project root. If `--window N` was supplied, pass `N` as `window_size`; otherwise
-   use the default (20).
+1. **Invoke the helper.** Call the thin entry hook `metrics.py`, which wraps
+   `compute` from `_metricslib.py`, via a Windows-safe `python3 … || python …`
+   fallback. Pass `${CLAUDE_PROJECT_DIR}` as `--root`. If `--window N` was
+   supplied, pass it through as `--window N`; otherwise omit it (the helper
+   applies the default of 20).
 
    ```
-   python3 -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}')))" || python -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}')))"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/metrics.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/metrics.py" --root "${CLAUDE_PROJECT_DIR}"
    ```
 
-   > **`ensure_ascii` note — do not remove this.** The one-liner uses `json.dumps`
+   > **`ensure_ascii` note — do not remove this.** `metrics.py` calls `json.dumps`
    > with its default `ensure_ascii=True`. This ASCII-escapes the arrow glyphs
    > (↑↓→) in the subprocess stdout, which avoids a `UnicodeEncodeError` on Windows
    > `cp1252` consoles that cannot encode those code-points raw. The rendered output
@@ -34,7 +35,7 @@ glance; reach for `/ca:audit` when you need the full evidentiary packet.
 
    With a custom window size:
    ```
-   python3 -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}', window_size=N)))" || python -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _metricslib, json; print(json.dumps(_metricslib.compute('${CLAUDE_PROJECT_DIR}', window_size=N)))"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/metrics.py" --root "${CLAUDE_PROJECT_DIR}" --window N || python "${CLAUDE_PLUGIN_ROOT}/hooks/metrics.py" --root "${CLAUDE_PROJECT_DIR}" --window N
    ```
    Replace `N` with the integer the user supplied.
 

--- a/plugins/ca/commands/pr.md
+++ b/plugins/ca/commands/pr.md
@@ -31,7 +31,7 @@ apply, then:
 6. **Auto-attach the babysitter** — resolve the flag with the canonical resolver, never by eyeballing
    the env var (so the accepted `on|true|1` spellings and the dormancy gate can't drift):
    ```
-   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/babysit.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/babysit.py" --root "${CLAUDE_PROJECT_DIR}"
    ```
    It prints one JSON line, e.g. `{"enabled": true, "on_red": "propose"}`. Only when `enabled` is
    true (the global flag `CODEARBITER_BABYSIT` is on — default off, mirrors `CODEARBITER_PRUNE` — and

--- a/plugins/ca/commands/preview.md
+++ b/plugins/ca/commands/preview.md
@@ -15,11 +15,12 @@ not the index, not `.codearbiter/`. `git status` is unchanged by a run.
 
 ## Flow
 
-1. **Collect the diff.** Call `collect_diff` from `${CLAUDE_PLUGIN_ROOT}/hooks/_previewlib.py`. It
-   unions HEAD-vs-worktree changes, staged changes, and untracked files (forward-slash paths). Run
-   it from the project root so `_hooklib` resolves on the same `sys.path`:
+1. **Collect the diff.** Call the thin entry hook `preview.py` in `diff` mode, which wraps
+   `collect_diff` from `${CLAUDE_PLUGIN_ROOT}/hooks/_previewlib.py`. It unions HEAD-vs-worktree
+   changes, staged changes, and untracked files (forward-slash paths). Run it from the project
+   root so `_previewlib`/`_hooklib` resolve on the same `sys.path`:
    ```
-   python3 -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _previewlib, json; print(json.dumps({p: sorted(cf.kinds) for p, cf in _previewlib.collect_diff().items()}))" || python -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _previewlib, json; print(json.dumps({p: sorted(cf.kinds) for p, cf in _previewlib.collect_diff().items()}))"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/preview.py" diff || python "${CLAUDE_PLUGIN_ROOT}/hooks/preview.py" diff
    ```
    If the result is empty (clean tree, or not a git repo), print a friendly **"Nothing to
    preview"** line and STOP. This is a clean exit, not an error: no stack trace, no failure.
@@ -31,12 +32,12 @@ not the index, not `.codearbiter/`. `git status` is unchanged by a run.
    dispatch and name the triggering path for each. This is the same mapping `/ca:review` uses, so
    the predicted set matches what a real review would dispatch.
 
-3. **Run the state-free secret scan.** Call `scan_secrets` from
-   `${CLAUDE_PLUGIN_ROOT}/hooks/_previewlib.py`. It reads each changed file's current content and
-   returns `SecretFinding(path, line_no, snippet)` for every credential line, with the secret VALUE
-   already masked to `****` in `snippet`:
+3. **Run the state-free secret scan.** Call the thin entry hook `preview.py` in `secrets` mode,
+   which wraps `scan_secrets` from `${CLAUDE_PLUGIN_ROOT}/hooks/_previewlib.py`. It reads each
+   changed file's current content and returns `SecretFinding(path, line_no, snippet)` for every
+   credential line, with the secret VALUE already masked to `****` in `snippet`:
    ```
-   python3 -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _previewlib, json; print(json.dumps([f._asdict() for f in _previewlib.scan_secrets()]))" || python -c "import sys; sys.path.insert(0, r'${CLAUDE_PLUGIN_ROOT}/hooks'); import _previewlib, json; print(json.dumps([f._asdict() for f in _previewlib.scan_secrets()]))"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/preview.py" secrets || python "${CLAUDE_PLUGIN_ROOT}/hooks/preview.py" secrets
    ```
    Report each finding by `path:line_no` with its redacted snippet. The snippet arrives already
    masked: never reconstruct or print a raw secret value.

--- a/plugins/ca/commands/watch.md
+++ b/plugins/ca/commands/watch.md
@@ -33,7 +33,7 @@ a phantom watcher.
    canonical resolver rather than reading the env var by hand (so the accepted
    values can't drift):
    ```
-   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/_babysitlib.py" --root "${CLAUDE_PROJECT_DIR}"
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/babysit.py" --root "${CLAUDE_PROJECT_DIR}" || python "${CLAUDE_PLUGIN_ROOT}/hooks/babysit.py" --root "${CLAUDE_PROJECT_DIR}"
    ```
    It prints one JSON line; act at its `on_red` value (`CODEARBITER_BABYSIT_ONRED`,
    default `propose`):

--- a/plugins/ca/hooks/_babysitlib.py
+++ b/plugins/ca/hooks/_babysitlib.py
@@ -56,7 +56,11 @@ def main(argv=None):
     resolver instead of re-implementing the flag check in prose (no drift from
     the accepted on|true|1 spellings or the PB-10 dormancy gate). Fail-safe:
     any error degrades to the OFF default and still exits 0 — a broken resolver
-    must never become a reason to auto-attach a watcher."""
+    must never become a reason to auto-attach a watcher.
+
+    Import-only module (no `__main__` entry point, per the thin-entry-hook
+    convention): the thin entry hook `babysit.py` imports and calls this
+    function; this underscore module is never run as a script directly."""
     import argparse
     import json
     import os
@@ -70,8 +74,3 @@ def main(argv=None):
         cfg = {"enabled": False, "on_red": _ONRED_DEFAULT}
     print(json.dumps(cfg))
     return 0
-
-
-if __name__ == "__main__":
-    import sys
-    sys.exit(main())

--- a/plugins/ca/hooks/babysit.py
+++ b/plugins/ca/hooks/babysit.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# codeArbiter — thin entry point for the pr-babysitter config resolver
+# (architecture-006/#179).
+#
+# Wraps _babysitlib.main (the CLI shim over babysit_config) so /ca:pr and
+# /ca:watch invoke a thin, non-underscore entry hook instead of running the
+# underscore library itself as a script. Mirrors doctor.py / taskwrite.py:
+# entry point stays thin, all resolution logic lives in _babysitlib.
+#
+# Invoked by command prose as:
+#   python3 "<plugin>/hooks/babysit.py" --root "<dir>"
+#   || python "<plugin>/hooks/babysit.py" --root "<dir>"
+#
+# Prints one JSON line, e.g. {"enabled": true, "on_red": "propose"}. Fail-safe:
+# _babysitlib.main() itself never raises past its own try/except (any resolver
+# error degrades to the OFF default) — this wrapper adds no additional risk.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _babysitlib  # noqa: E402
+
+
+def main(argv=None):
+    return _babysitlib.main(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ca/hooks/metrics.py
+++ b/plugins/ca/hooks/metrics.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# codeArbiter — thin entry point for /ca:metrics (architecture-006/#179).
+#
+# Wraps _metricslib.compute and prints its JSON-serialized result, so the
+# field-access/serialization step /ca:metrics needs is import-covered
+# (py_compile + unit tests) instead of living as an inline `python -c`
+# multi-statement block in command prose. Mirrors doctor.py / taskwrite.py:
+# entry point stays thin, all computation lives in _metricslib.
+#
+# Invoked by commands/metrics.md as:
+#   python3 "<plugin>/hooks/metrics.py" --root "<dir>" [--window N]
+#   || python "<plugin>/hooks/metrics.py" --root "<dir>" [--window N]
+#
+# Read-only: _metricslib.compute() never writes; this wrapper only prints its
+# return value. json.dumps is called with its default ensure_ascii=True so the
+# arrow glyphs (up/down/right arrows) are ASCII-escaped on the way out — this
+# avoids a UnicodeEncodeError on Windows cp1252 consoles. Do NOT pass
+# ensure_ascii=False here; the command prose renders the real glyphs itself
+# from the parsed JSON, not from this process's raw stdout.
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _metricslib  # noqa: E402
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="metrics", add_help=True)
+    parser.add_argument("--root", default=os.getcwd())
+    parser.add_argument("--window", type=int, default=None)
+    args = parser.parse_args(argv)
+
+    if args.window is not None:
+        result = _metricslib.compute(args.root, window_size=args.window)
+    else:
+        result = _metricslib.compute(args.root)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ca/hooks/preview.py
+++ b/plugins/ca/hooks/preview.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# codeArbiter — thin entry point for /ca:preview (architecture-006/#179).
+#
+# Wraps _previewlib.collect_diff / scan_secrets and prints the JSON-serialized
+# form command prose needs, so the field-access/serialization step (reaching
+# into ChangedFile.kinds and SecretFinding._asdict()) is import-covered
+# (py_compile + unit tests) instead of living as inline `python -c`
+# multi-statement blocks coupled to the lib's namedtuple internals. Mirrors
+# doctor.py / taskwrite.py: entry point stays thin, all logic lives in
+# _previewlib.
+#
+# Invoked by commands/preview.md as:
+#   python3 "<plugin>/hooks/preview.py" diff    || python "<plugin>/hooks/preview.py" diff
+#   python3 "<plugin>/hooks/preview.py" secrets || python "<plugin>/hooks/preview.py" secrets
+#
+# Read-only, mirrors _previewlib's own read-only contract (git rev-parse/diff/
+# ls-files and read-only file opens only): this wrapper writes nothing.
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _previewlib  # noqa: E402
+
+
+def diff_json():
+    """JSON-serializable form of collect_diff(): path -> sorted kind list."""
+    return {p: sorted(cf.kinds) for p, cf in _previewlib.collect_diff().items()}
+
+
+def secrets_json():
+    """JSON-serializable form of scan_secrets(): list of finding dicts, each
+    already carrying the redacted (never plaintext) snippet."""
+    return [f._asdict() for f in _previewlib.scan_secrets()]
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="preview", add_help=True)
+    parser.add_argument("mode", choices=("diff", "secrets"))
+    args = parser.parse_args(argv)
+
+    result = diff_json() if args.mode == "diff" else secrets_json()
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ca/hooks/tests/test_babysit_entry.py
+++ b/plugins/ca/hooks/tests/test_babysit_entry.py
@@ -1,0 +1,59 @@
+import io
+import json
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+# Ensure hooks/ is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import babysit  # noqa: E402 — the thin entry hook for /ca:pr, /ca:watch (#179)
+import _babysitlib  # noqa: E402
+
+
+class TestBabysitEntry(unittest.TestCase):
+    """babysit.py: thin entry hook delegating to _babysitlib.main. Proves
+    /ca:pr and /ca:watch now invoke a non-underscore entry point rather than
+    running the underscore library itself as a script (architecture-006/#179)."""
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k)
+                       for k in ("CODEARBITER_BABYSIT", "CODEARBITER_BABYSIT_ONRED")}
+        for k in self._saved:
+            os.environ.pop(k, None)
+        self.root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_no_such_repo_xyz")
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_delegates_to_babysitlib_main(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = babysit.main(["--root", self.root])
+        self.assertEqual(rc, 0)
+        cfg = json.loads(buf.getvalue().strip())
+        self.assertIn("enabled", cfg)
+        self.assertIn("on_red", cfg)
+
+    def test_babysitlib_has_no_dunder_main_guard(self):
+        # Convention check: _babysitlib is import-only (no `if __name__ ==
+        # "__main__"` block) — the __main__ entry point now lives only in the
+        # thin babysit.py wrapper.
+        src_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "_babysitlib.py",
+        )
+        with open(src_path, encoding="utf-8") as f:
+            src = f.read()
+        self.assertNotIn('__name__ == "__main__"', src)
+        self.assertNotIn("__name__ == '__main__'", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_metrics_entry.py
+++ b/plugins/ca/hooks/tests/test_metrics_entry.py
@@ -1,0 +1,67 @@
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+# Ensure hooks/ is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import metrics  # noqa: E402 — the thin entry hook for /ca:metrics (#179)
+
+
+class TestMetricsEntry(unittest.TestCase):
+    """metrics.py: thin entry hook wrapping _metricslib.compute. Proves the
+    serialization/argv-parsing glue that formerly lived as inline `python -c`
+    prose in commands/metrics.md is now import-covered."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        # Not a git repo: commit_timeline() degrades to an empty timeline,
+        # so compute() runs its full degrade-safe path with no git dependency.
+        self.root = self.tmp.name
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = metrics.main(argv)
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue().strip())
+
+    def test_prints_valid_json_with_fixed_keys(self):
+        result = self._run(["--root", self.root])
+        self.assertEqual(
+            set(result.keys()),
+            {"override_rate", "small_lane_rate", "sprint_low_conf_ratio"},
+        )
+
+    def test_default_window_matches_direct_compute_call(self):
+        import _metricslib
+
+        expected = _metricslib.compute(self.root)
+        result = self._run(["--root", self.root])
+        self.assertEqual(result, expected)
+
+    def test_custom_window_is_threaded_through(self):
+        import _metricslib
+
+        expected = _metricslib.compute(self.root, window_size=5)
+        result = self._run(["--root", self.root, "--window", "5"])
+        self.assertEqual(result, expected)
+
+    def test_degrades_gracefully_on_nonexistent_root(self):
+        # Never raise — a missing/garbage root must still print the fixed
+        # sentinel shape rather than crash.
+        missing = os.path.join(self.root, "_no_such_dir_xyz")
+        result = self._run(["--root", missing])
+        self.assertEqual(result["override_rate"], {"current": 0, "prior": 0, "arrow": "→"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_preview_entry.py
+++ b/plugins/ca/hooks/tests/test_preview_entry.py
@@ -1,0 +1,102 @@
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+# Ensure hooks/ is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import preview  # noqa: E402 — the thin entry hook for /ca:preview (#179)
+
+
+def _git(args, cwd):
+    r = subprocess.run(
+        ["git"] + args, cwd=cwd, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=60,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr}")
+    return r
+
+
+class TestPreviewEntry(unittest.TestCase):
+    """preview.py: thin entry hook wrapping _previewlib.collect_diff /
+    scan_secrets. Proves the field-access/serialization glue (ChangedFile.kinds,
+    SecretFinding._asdict()) formerly embedded as inline `python -c` prose in
+    commands/preview.md is now import-covered."""
+
+    # A literal the shared SECRET_RE genuinely matches: keyword=quoted-value,
+    # value length >= 4. Built via string formatting (not a literal
+    # `api_key = "..."` line in this file's own source) for the same reason
+    # .github/scripts/test_preview_lib.py does: the repo's own commit-time
+    # secret gate (H-10b) scans the literal diff text, not just runtime
+    # values, so a directly-matching literal here would itself trip the gate.
+    SECRET_VALUE = "DUMMY-not-a-real-key"
+    SECRET_LINE = 'api_key = "%s"' % SECRET_VALUE
+
+    def setUp(self):
+        self._saved_cwd = os.getcwd()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+        _git(["init", "-q"], self.root)
+        _git(["config", "user.email", "test@example.com"], self.root)
+        _git(["config", "user.name", "Test"], self.root)
+        with open(os.path.join(self.root, "committed.txt"), "w", encoding="utf-8") as f:
+            f.write("hello\n")
+        _git(["add", "committed.txt"], self.root)
+        _git(["commit", "-q", "-m", "init"], self.root)
+        os.chdir(self.root)
+
+    def tearDown(self):
+        os.chdir(self._saved_cwd)
+        self.tmp.cleanup()
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = preview.main(argv)
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue().strip())
+
+    def test_diff_mode_matches_direct_collect_diff_call(self):
+        with open(os.path.join(self.root, "new_untracked.txt"), "w", encoding="utf-8") as f:
+            f.write("data\n")
+        import _previewlib
+
+        expected = {p: sorted(cf.kinds) for p, cf in _previewlib.collect_diff().items()}
+        result = self._run(["diff"])
+        self.assertEqual(result, expected)
+        self.assertIn("new_untracked.txt", result)
+        self.assertEqual(result["new_untracked.txt"], ["untracked"])
+
+    def test_diff_mode_empty_on_clean_repo(self):
+        result = self._run(["diff"])
+        self.assertEqual(result, {})
+
+    def test_secrets_mode_matches_direct_scan_secrets_call(self):
+        with open(os.path.join(self.root, "config.py"), "w", encoding="utf-8") as f:
+            f.write(self.SECRET_LINE + "\n")
+        import _previewlib
+
+        expected = [f._asdict() for f in _previewlib.scan_secrets()]
+        result = self._run(["secrets"])
+        self.assertEqual(result, expected)
+        self.assertTrue(result)
+        self.assertNotIn(self.SECRET_VALUE, json.dumps(result))
+
+    def test_secrets_mode_empty_on_clean_repo(self):
+        result = self._run(["secrets"])
+        self.assertEqual(result, [])
+
+    def test_rejects_unknown_mode(self):
+        with self.assertRaises(SystemExit):
+            preview.main(["bogus"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lane #179 (architecture-006, low): three command helpers bypassed the thin-entry-hook convention — `_babysitlib` ran as a script, and the `metrics`/`preview` command surfaces embedded multi-statement `python -c` blocks coupled to lib namedtuple internals that no `py_compile`/test covered.

## What
Added three thin entry points that import + call their libs, so the logic is import-covered and reachable by tests; the command docs now invoke them instead of inline `python -c`:
- `hooks/babysit.py` → `_babysitlib.main` (removed its run-as-script block); `commands/pr.md`, `commands/watch.md` repointed.
- `hooks/metrics.py` → `_metricslib.compute` (`--root`/`--window`, `json.dumps`); `commands/metrics.md` repointed.
- `hooks/preview.py` → `_previewlib.collect_diff`/`scan_secrets` (the serialization moved out of `commands/preview.md` prose); repointed to `preview.py diff` / `preview.py secrets`.

## Verification — behavior-preserving
- **722 hook tests pass**; `check-plugin-refs.py` (reference graph intact), `test_metrics_lib.py`, `test_preview_lib.py`, `test_hook_guards.py`, `test_hooks_cold_install.py` all green; `py_compile` clean; LF.
- **Byte-identical output verified** by running the old inline `python -c` and the new entry hook side-by-side against a fixture repo for all four surfaces (diff, secrets, babysit config, metrics — incl. the `→` JSON-escaped glyphs). New `test_{babysit,metrics,preview}_entry.py` cover each entry.
- No behavior change, stdlib-only (ADR-0004). A test secret literal uses the established `'api_key = "%s"' % SECRET_VALUE` convention so the committed source carries no `SECRET_RE`-matching string (prior art, `test_preview_lib.py`).

Bumps ca 2.8.7 → 2.8.8.

Closes #179

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa