### PR TITLE
fix(hooks): resolve the repo the git op fires in — git-enforce/git_cwd/project_root (#190)

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -193,6 +193,22 @@ with nothing additional installed.
 Hook input parsing fails open (not closed) on malformed stdin — see
 `_hooklib.py:read_input()` for the documented rationale.
 
+**Repo resolution — the guards judge the repo the git op fires in (#190).** The
+`.git/hooks` enforcement backstop `git-enforce.py` resolves its target via
+`git rev-parse --show-toplevel` inheriting the hook's own cwd (which git sets to
+the target repo's work-tree top for `pre-commit`/`pre-push`), **not**
+`CLAUDE_PROJECT_DIR` — so a `git -C <other> commit` under a Claude session is
+gated against `<other>`, not the session's repo. The PreToolUse `pre-bash.py`
+`git_cwd` composes a **repeated** `-C` run the way git itself does (fold-left:
+absolute replaces the accumulator, relative joins onto it, seeded with
+`project_root`), closing the multi-`-C` fail-open where a crafted
+`git -C /abs/main -C . commit` would otherwise be judged against the wrong repo;
+a `-C` target that is not a real directory now fails **closed** (H-01 block).
+`session-start.py` and `taskwrite.py` resolve via the shared
+`_hooklib.project_root` (CLAUDE_PROJECT_DIR-first) rather than divergent local
+copies, so audit lines / the task board / installed hooks land in the
+harness-authoritative project dir.
+
 ---
 
 ## Audit trail

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.8" src="https://img.shields.io/badge/version-2.8.8-2b7489">
+<img alt="version 2.8.9" src="https://img.shields.io/badge/version-2.8.9-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/git-enforce.py
+++ b/plugins/ca/hooks/git-enforce.py
@@ -27,8 +27,44 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, project_root, utf8_stdio,
+    line_digest, marker_fresh, utf8_stdio,
 )
+
+
+def repo_root():
+    """The repo THIS git hook is firing in — deliberately does NOT use
+    _hooklib.project_root() (reliability-005, #190).
+
+    git-enforce.py is installed as `.git/hooks/pre-commit`/`pre-push` of
+    whatever repo the git OPERATION targets. _hooklib.project_root() trusts
+    CLAUDE_PROJECT_DIR first — the right contract for a Claude Code hook
+    subprocess, but the wrong one here: a `git -C ../otherRepo commit` issued
+    from a Claude session inherits CLAUDE_PROJECT_DIR pointing at the
+    session's repo, yet the pre-commit hook that fires is ../otherRepo's own,
+    invoked with its OWN cwd/GIT_DIR — never the session's. Trusting
+    CLAUDE_PROJECT_DIR here scanned the session's repo (branch/staged
+    diff/markers) while the commit actually landed in ../otherRepo, both a
+    fail-open (a dirty ../otherRepo passes if the session repo is clean) and
+    a false-block (a dirty session repo blocks a clean ../otherRepo commit).
+
+    Git invokes pre-commit/pre-push with the process cwd set to the target
+    repo's work-tree top-level, so `git rev-parse --show-toplevel` run with NO
+    cwd override (inheriting this process's actual cwd) resolves the repo the
+    hook is actually running in. GIT_DIR/GIT_WORK_TREE (set by git for some
+    invocation shapes, e.g. `git -C X commit` invoking the hook with those
+    exported) are honored by that same `git rev-parse` call automatically, so
+    no separate env read is needed here."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return os.getcwd()
 
 
 def _git(args, cwd):
@@ -241,7 +277,7 @@ def pre_push(root):
 
 def main():
     utf8_stdio()
-    root = project_root()
+    root = repo_root()
     if not arbiter_active(root):
         sys.exit(0)
     phase = sys.argv[1] if len(sys.argv) > 1 else ""

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -150,7 +150,18 @@ ARGS = r"(?P<args>(?:\"[^\"]*\"|'[^']*'|[^|;&])*)"
 COMMIT_RE = re.compile(GIT + r"\s+commit\b" + ARGS)
 PUSH_RE = re.compile(GIT + r"\s+push\b" + ARGS)
 ADD_RE = re.compile(GIT + r"\s+add\b" + ARGS)
-GIT_C_DIR_RE = re.compile(r"\bgit\s+-C\s+(\"[^\"]+\"|'[^']+'|\S+)")
+# reliability-004 (#190): GIT_C_DIR_RE previously matched `-C` ONLY as the
+# FIRST token after `git`, so a global option in front of it (`--no-pager`,
+# `-c k=v`, `--git-dir=…`) hid the -C target entirely and git_cwd() fell back
+# to `root` — while COMMIT_RE/PUSH_RE (built on the same GIT global-options
+# prefix as below) still matched, so the guards fired against the WRONG repo.
+# GIT_OPTS_RUN_RE captures the exact same global-options run GIT already
+# tolerates (group 1); GIT_C_IN_RUN_RE then finds every `-C <dir>` WITHIN that
+# captured run via findall, so a -C preceded by other global options is found
+# regardless of position.
+GIT_OPTS_RUN_RE = re.compile(
+    r"\bgit((?:\s+(?:-[Cc]\s+(?:\"[^\"]+\"|'[^']+'|\S+)|--[\w-]+(?:=\S+)?|-\w+))*)")
+GIT_C_IN_RUN_RE = re.compile(r"-C\s+(\"[^\"]+\"|'[^']+'|\S+)")
 # Force-push in any spelling: --force, --force-with-lease[=…], -f as its own
 # token (not a ref like `fix-f`), or a forcing `+refspec`.
 FORCE_RE = re.compile(r"(?:^|\s)(?:--force(?:-with-lease|-if-includes)?(?:=\S+)?|-f)(?=\s|$)")
@@ -248,11 +259,32 @@ GATE_MARKER_WRITE_RE = re.compile(
 
 
 def git_cwd(cmd, root):
-    """The directory a `git -C <dir>` invocation actually targets."""
-    m = GIT_C_DIR_RE.search(cmd)
+    """The directory a `git -C <dir>` invocation actually targets, or `root`
+    when there is no `-C` (reliability-004, #190).
+
+    Scans the SAME global-options run GIT/COMMIT_RE/PUSH_RE already tolerate
+    before the subcommand (GIT_OPTS_RUN_RE), so a `-C` preceded by other
+    global options (`git --no-pager -C ../x commit`, `git -c k=v -C ../x
+    commit`) is found exactly where the guards themselves look, instead of
+    only matching `-C` as the first token. Git itself allows repeated `-C`,
+    each composing relative to the previous — the LAST one in the run is what
+    actually wins, so this takes the last match.
+
+    A relative `-C` value is resolved against `root` (project_root), not the
+    hook process's own cwd — the hook's cwd is not guaranteed to be the
+    project dir (mirrors _hooklib.project_root's own rationale), so a
+    lexically-relative `-C ../x` must not be joined against wherever this
+    Python process happens to be running from."""
+    m = GIT_OPTS_RUN_RE.search(cmd)
     if not m:
         return root
-    return m.group(1).strip("\"'")
+    c_matches = GIT_C_IN_RUN_RE.findall(m.group(1))
+    if not c_matches:
+        return root
+    target = c_matches[-1].strip("\"'")
+    if not os.path.isabs(target):
+        target = os.path.join(root, target)
+    return target
 
 
 def current_branch(cwd):
@@ -542,7 +574,18 @@ def _run(root):
     git_view = _strip_heredoc_bodies(cmd) if "<<" in cmd else cmd
 
     commit = COMMIT_RE.search(git_view) or COMMIT_RE.search(cmd)
+    push_probe = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
     cwd = git_cwd(git_view, root)
+
+    # reliability-004 (#190): fail CLOSED for commit/push when the `-C` target
+    # git_cwd() resolved does not exist as a directory — an unresolvable -C
+    # target must not silently fall through to scanning some OTHER directory
+    # (or crash mid-scan); ambiguity resolves CLOSED here exactly as the
+    # git-read failures elsewhere in this file do.
+    if (commit or push_probe) and not os.path.isdir(cwd):
+        block("H-01", f"'git -C {cwd}' does not resolve to an existing directory — "
+                      f"failing closed (ORCHESTRATOR §2). Verify the -C target exists "
+                      f"before committing/pushing.")
 
     # H-20: block a literal --no-verify / -n on `git commit` — it skips
     # .git/hooks (the git-enforce backstop) entirely, voiding every enforcement

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -266,25 +266,36 @@ def git_cwd(cmd, root):
     before the subcommand (GIT_OPTS_RUN_RE), so a `-C` preceded by other
     global options (`git --no-pager -C ../x commit`, `git -c k=v -C ../x
     commit`) is found exactly where the guards themselves look, instead of
-    only matching `-C` as the first token. Git itself allows repeated `-C`,
-    each composing relative to the previous — the LAST one in the run is what
-    actually wins, so this takes the last match.
+    only matching `-C` as the first token.
 
-    A relative `-C` value is resolved against `root` (project_root), not the
-    hook process's own cwd — the hook's cwd is not guaranteed to be the
-    project dir (mirrors _hooklib.project_root's own rationale), so a
-    lexically-relative `-C ../x` must not be joined against wherever this
-    Python process happens to be running from."""
+    Git allows REPEATED `-C` and COMPOSES them sequentially, not
+    last-wins: each `-C` is resolved relative to the ACCUMULATED result of
+    every preceding `-C` (an absolute value REPLACES the accumulator; a
+    relative value is joined onto it) — see `git --help`'s `-C <path>`. A
+    naive "take the last -C, resolve if relative against root" is wrong for a
+    mixed run: `git -C /abs/main -C . commit` must resolve to `/abs/main`
+    (the `.` is relative to `/abs/main`, not to root), and `git -C feat -C
+    /abs/main commit` must resolve to `/abs/main` (the later absolute value
+    resets the accumulator, discarding the earlier relative one entirely) —
+    a last-wins-only implementation fails OPEN on exactly these spellings
+    (security-reviewer MEDIUM, #190 follow-up).
+
+    The accumulator is seeded with `root` (project_root), not the hook
+    process's own cwd — the hook's cwd is not guaranteed to be the project
+    dir (mirrors _hooklib.project_root's own rationale), so the FIRST
+    relative `-C` in a run resolves against `root`, exactly as a bare
+    relative `-C` (no preceding `-C`) already did."""
     m = GIT_OPTS_RUN_RE.search(cmd)
     if not m:
         return root
     c_matches = GIT_C_IN_RUN_RE.findall(m.group(1))
     if not c_matches:
         return root
-    target = c_matches[-1].strip("\"'")
-    if not os.path.isabs(target):
-        target = os.path.join(root, target)
-    return target
+    acc = root
+    for raw in c_matches:
+        val = raw.strip("\"'")
+        acc = val if os.path.isabs(val) else os.path.join(acc, val)
+    return acc
 
 
 def current_branch(cwd):

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -27,7 +27,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _hooklib import frontmatter_enabled, utf8_stdio  # noqa: E402
+from _hooklib import frontmatter_enabled, project_root, utf8_stdio  # noqa: E402
 from _standuplib import (  # noqa: E402
     any_actionable,
     ff_pull_eligible,
@@ -46,18 +46,13 @@ INITIALIZED_RE = re.compile(r"<!--\s*INITIALIZED\s*-->")
 STAGE_RE = re.compile(r"^stage:\s*([0-9]+)", re.I | re.M)
 CONFIRM_RE = re.compile(r"CONFIRM-[0-9]+")
 
-
-def project_root():
-    try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if out.returncode == 0:
-            return out.stdout.strip()
-    except Exception:  # noqa: BLE001
-        pass
-    return os.getcwd()
+# reliability-007 (#190): project_root() is now _hooklib.project_root — imported
+# above, not a local copy. The prior local copy ran `git rev-parse
+# --show-toplevel` from the hook's own cwd and fell back to os.getcwd(),
+# skipping the CLAUDE_PROJECT_DIR-first read _hooklib.project_root() exists
+# for. session-start is the linchpin hook (installs git-enforce hooks, writes
+# standup/dev markers, appends overrides.log) — a wrong root there silently
+# targeted the wrong repository.
 
 
 def read_text(path):

--- a/plugins/ca/hooks/taskwrite.py
+++ b/plugins/ca/hooks/taskwrite.py
@@ -21,25 +21,19 @@
 import argparse
 import datetime
 import os
-import subprocess
 import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import utf8_stdio  # noqa: E402
+from _hooklib import project_root, utf8_stdio  # noqa: E402
 
-
-def project_root():
-    try:
-        out = subprocess.run(["git", "rev-parse", "--show-toplevel"],
-                             capture_output=True, text=True, timeout=5)
-        top = out.stdout.strip()
-        if top:
-            return top
-    except Exception:  # noqa: BLE001
-        pass
-    return os.getcwd()
+# reliability-007 (#190): project_root() is now _hooklib.project_root —
+# imported above, not a local copy. The prior local copy ran `git rev-parse
+# --show-toplevel` from the hook's own cwd and fell back to os.getcwd(),
+# skipping the CLAUDE_PROJECT_DIR-first read _hooklib.project_root() exists
+# for; taskwrite mutates .codearbiter/open-tasks.md, so a wrong root silently
+# wrote into the wrong repository's board.
 
 
 def _date(s):

--- a/plugins/ca/hooks/tests/test_repo_resolution.py
+++ b/plugins/ca/hooks/tests/test_repo_resolution.py
@@ -1,0 +1,296 @@
+"""Issue #190 — hook-repo-resolution group (reliability-004/005/007).
+
+Three sites shared one bug class: a hook resolved "the project root" using a
+rule that can point at the WRONG repository when a git operation is indirected
+(`git -C <other>`) or the hook's own execution context is not
+`CLAUDE_PROJECT_DIR` (a `.git/hooks` script).
+
+  * reliability-007: session-start.py / taskwrite.py each defined a LOCAL
+    project_root() that skips the CLAUDE_PROJECT_DIR-first contract
+    _hooklib.project_root() exists for.
+  * reliability-005: git-enforce.py resolved its root via
+    _hooklib.project_root() (CLAUDE_PROJECT_DIR-first), but it runs as a
+    `.git/hooks/pre-commit|pre-push` script IN the repo the git operation
+    targets — which can differ from the session's CLAUDE_PROJECT_DIR.
+  * reliability-004: pre-bash.py's git_cwd()/GIT_C_DIR_RE only matched `-C` as
+    the FIRST token after `git`, so global options before it
+    (`--no-pager`, `-c k=v`) hid the -C target and the guards scanned the
+    wrong repo.
+
+Each test class proves BOTH directions: the wrong-repo bug is fixed, AND no
+fail-open regression is introduced (a genuine commit-to-main in the actually-
+targeted repo is still blocked).
+"""
+import importlib.util as _ilu
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
+ENFORCE = os.path.join(HOOKS, "git-enforce.py")
+
+sys.path.insert(0, HOOKS)
+import _githooks  # noqa: E402
+
+
+def _load_module(name, path):
+    """Import a hyphenated-filename hook fresh as a module (mirrors
+    test_git_hooks.py's _load_git_enforce) — a fresh module per call means no
+    monkeypatch state leaks between tests."""
+    spec = _ilu.spec_from_file_location(name, path)
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sh(args, cwd, env=None, **kw):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=60,
+                          env=env, **kw)
+
+
+def _git(args, cwd, check=True):
+    r = _sh(["git"] + args, cwd, env=os.environ.copy())
+    if check and r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr}")
+    return r
+
+
+ARBITER = "---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\n"
+
+
+def _init_repo(root, branch="main"):
+    os.makedirs(root)
+    _git(["init", "-q", "-b", branch], root)
+    _git(["config", "user.email", "h@example.com"], root)
+    _git(["config", "user.name", "harness"], root)
+    os.makedirs(os.path.join(root, ".codearbiter"))
+    with open(os.path.join(root, ".codearbiter", "CONTEXT.md"), "w",
+              encoding="utf-8") as f:
+        f.write(ARBITER)
+
+
+# ---------------------------------------------------------------------------
+# reliability-004: pre-bash.py's git_cwd() must extract -C past global options
+# ---------------------------------------------------------------------------
+
+class TestGitCwdUnit(unittest.TestCase):
+    """Pure unit coverage of git_cwd() — no subprocess, no git spawn."""
+
+    def setUp(self):
+        self.pb = _load_module("pre_bash_direct", PRE_BASH)
+
+    def test_bare_dash_c_is_still_extracted(self):
+        # Control: the pre-existing first-token spelling must keep working.
+        self.assertEqual(self.pb.git_cwd("git -C /abs/other commit -m x", "/root"),
+                         "/abs/other")
+
+    def test_dash_c_after_no_pager_is_extracted(self):
+        # The bug: --no-pager preceding -C used to hide it entirely (git_cwd
+        # fell back to `root`).
+        self.assertEqual(
+            self.pb.git_cwd("git --no-pager -C /abs/other commit -m x", "/root"),
+            "/abs/other")
+
+    def test_dash_c_after_config_option_is_extracted(self):
+        self.assertEqual(
+            self.pb.git_cwd("git -c user.name=x -C /abs/other commit -m x", "/root"),
+            "/abs/other")
+
+    def test_relative_dash_c_resolves_against_project_root_not_hook_cwd(self):
+        # Acceptance criterion: a relative -C path resolves against
+        # project_root, regardless of the hook process's own cwd.
+        joined = self.pb.git_cwd("git --no-pager -C ../other commit -m x", "/root/work")
+        self.assertEqual(os.path.normpath(joined),
+                         os.path.normpath("/root/work/../other"))
+
+    def test_no_dash_c_falls_back_to_root(self):
+        self.assertEqual(self.pb.git_cwd("git --no-pager commit -m x", "/root"), "/root")
+
+
+class TestGitCwdEndToEnd(unittest.TestCase):
+    """Subprocess-level proof: pre-bash.py judges H-01 against the -C TARGET
+    repo, not the session's CLAUDE_PROJECT_DIR root — for both the bare -C
+    spelling and the --no-pager-prefixed spelling (reliability-004)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.session_root = os.path.join(self._tmp.name, "session-repo")
+        _init_repo(self.session_root, branch="feat/work")  # session repo is NOT on main
+        self.other_root = os.path.join(self._tmp.name, "other-repo")
+        _init_repo(self.other_root, branch="main")  # the -C target IS on main
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _env(self):
+        # The session's CLAUDE_PROJECT_DIR is the session repo — pinned exactly
+        # as the production harness pins it — while the git op fires in
+        # other_root via -C.
+        return {**os.environ, "CLAUDE_PROJECT_DIR": self.session_root}
+
+    def run_bash(self, command):
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+        return _sh([sys.executable, PRE_BASH], self.session_root, input=payload,
+                  env=self._env())
+
+    def test_bare_dash_c_commit_is_judged_against_other_repo_main(self):
+        # Bug: previously scanned session_root (feat/work -> allowed); fixed:
+        # scans other_root (main -> BLOCKED).
+        res = self.run_bash(f'git -C "{self.other_root}" commit -m x')
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_no_pager_prefixed_dash_c_commit_is_judged_against_other_repo_main(self):
+        # The exact reliability-004 evidence spelling.
+        res = self.run_bash(f'git --no-pager -C "{self.other_root}" commit -m x')
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_no_fail_open_session_repo_itself_still_blocked_on_main(self):
+        # No-fail-open direction: a DIRECT commit (no -C) in a session repo
+        # that itself sits on main is still blocked — the -C fix must not
+        # weaken the ordinary (no -C) H-01 path.
+        main_root = os.path.join(self._tmp.name, "main-session")
+        _init_repo(main_root, branch="main")
+        res = _sh([sys.executable, PRE_BASH], main_root,
+                  input=json.dumps({"tool_name": "Bash",
+                                   "tool_input": {"command": 'git commit -m x'}}),
+                  env={**os.environ, "CLAUDE_PROJECT_DIR": main_root})
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_dash_c_commit_onto_other_repo_feature_branch_is_allowed(self):
+        # Converse: the -C target repo is genuinely on a feature branch ->
+        # allowed, proving the fix doesn't over-block a legitimate cross-repo
+        # commit either.
+        feature_other = os.path.join(self._tmp.name, "other-repo-2")
+        _init_repo(feature_other, branch="feat/other")
+        res = self.run_bash(f'git --no-pager -C "{feature_other}" commit -m x')
+        self.assertNotIn("H-01", res.stderr)
+
+
+# ---------------------------------------------------------------------------
+# reliability-005: git-enforce.py must scan the repo the git hook fires in
+# ---------------------------------------------------------------------------
+
+class TestGitEnforceOwnRepoResolution(unittest.TestCase):
+    """git-enforce.py runs as a .git/hooks/pre-commit|pre-push script of
+    whatever repo the git operation targets. It must resolve THAT repo, never
+    the session's CLAUDE_PROJECT_DIR (reliability-005)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.session_root = os.path.join(self._tmp.name, "session-repo")
+        _init_repo(self.session_root, branch="feat/work")  # clean feature branch
+        self.other_root = os.path.join(self._tmp.name, "other-repo")
+        _init_repo(self.other_root, branch="main")  # the repo actually committing
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _stage(self, root, name, content):
+        path = os.path.join(root, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        _git(["add", name], root)
+
+    def test_pre_commit_scans_the_repo_it_runs_in_not_claude_project_dir(self):
+        # Bug: git-enforce.py used _hooklib.project_root(), which trusts
+        # CLAUDE_PROJECT_DIR (session_root, clean feature branch) first, so a
+        # commit physically happening in other_root (on main) was scanned
+        # against session_root and ALLOWED (fail-open). Fixed: git-enforce
+        # ignores CLAUDE_PROJECT_DIR and resolves its own execution context.
+        self._stage(self.other_root, "f.txt", "x\n")
+        env = {**os.environ, "CLAUDE_PROJECT_DIR": self.session_root}
+        res = _sh([sys.executable, ENFORCE, "pre-commit"], self.other_root, env=env)
+        self.assertEqual(res.returncode, 1, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_installed_hook_fires_correctly_in_its_own_repo(self):
+        # End-to-end via the real installed shim: a genuine commit onto main
+        # in other_root is blocked even though CLAUDE_PROJECT_DIR points
+        # elsewhere.
+        _githooks.install(self.other_root)
+        self._stage(self.other_root, "g.txt", "y\n")
+        env = {**os.environ, "CLAUDE_PROJECT_DIR": self.session_root}
+        res = _sh(["git", "commit", "-q", "-m", "sneaky"], self.other_root, env=env)
+        self.assertNotEqual(res.returncode, 0, "commit onto main should have been blocked")
+        self.assertIn("H-01", res.stderr + res.stdout)
+        log = _git(["rev-list", "--all", "--count"], self.other_root, check=False)
+        self.assertEqual(log.stdout.strip(), "0")
+
+    def test_no_fail_open_feature_branch_commit_in_own_repo_still_allowed(self):
+        # No-fail-open converse: a clean feature-branch commit IN THE REPO
+        # GIT-ENFORCE ACTUALLY RUNS IN is still allowed — proves the fix
+        # didn't flip to over-blocking every commit regardless of branch.
+        feat_root = os.path.join(self._tmp.name, "feat-repo")
+        _init_repo(feat_root, branch="feat/x")
+        self._stage(feat_root, "f.txt", "x\n")
+        env = {**os.environ, "CLAUDE_PROJECT_DIR": self.session_root}
+        res = _sh([sys.executable, ENFORCE, "pre-commit"], feat_root, env=env)
+        self.assertEqual(res.returncode, 0, res.stderr)
+
+
+# ---------------------------------------------------------------------------
+# reliability-007: session-start.py / taskwrite.py must use
+# _hooklib.project_root (CLAUDE_PROJECT_DIR-first)
+# ---------------------------------------------------------------------------
+
+class TestSessionStartTaskwriteProjectRoot(unittest.TestCase):
+    """Unify session-start.py and taskwrite.py on _hooklib.project_root: with
+    CLAUDE_PROJECT_DIR pointed at a fixture repo and cwd elsewhere, both hooks
+    must resolve the fixture repo (reliability-007)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.fixture_root = os.path.join(self._tmp.name, "fixture-repo")
+        _init_repo(self.fixture_root, branch="main")
+        self.elsewhere = os.path.join(self._tmp.name, "elsewhere")
+        os.makedirs(self.elsewhere)
+        # elsewhere is itself a distinct repo — `git rev-parse --show-toplevel`
+        # from cwd would resolve HERE if CLAUDE_PROJECT_DIR were ignored.
+        _git(["init", "-q", "-b", "main"], self.elsewhere)
+
+        self._saved_cwd = os.getcwd()
+        self._saved_env = os.environ.get("CLAUDE_PROJECT_DIR")
+        os.chdir(self.elsewhere)
+        os.environ["CLAUDE_PROJECT_DIR"] = self.fixture_root
+
+    def tearDown(self):
+        os.chdir(self._saved_cwd)
+        if self._saved_env is None:
+            os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        else:
+            os.environ["CLAUDE_PROJECT_DIR"] = self._saved_env
+        self._tmp.cleanup()
+
+    def test_session_start_uses_hooklib_project_root(self):
+        mod = _load_module("session_start_repo_res", os.path.join(HOOKS, "session-start.py"))
+        self.assertEqual(os.path.normpath(mod.project_root()),
+                         os.path.normpath(self.fixture_root))
+
+    def test_taskwrite_uses_hooklib_project_root(self):
+        mod = _load_module("taskwrite_repo_res", os.path.join(HOOKS, "taskwrite.py"))
+        self.assertEqual(os.path.normpath(mod.project_root()),
+                         os.path.normpath(self.fixture_root))
+
+    def test_session_start_project_root_is_the_hooklib_function(self):
+        # Structural: the fix deletes the local copy and imports _hooklib's —
+        # not merely reimplements the same behavior under the same name.
+        import _hooklib
+        mod = _load_module("session_start_repo_res2", os.path.join(HOOKS, "session-start.py"))
+        self.assertIs(mod.project_root, _hooklib.project_root)
+
+    def test_taskwrite_project_root_is_the_hooklib_function(self):
+        import _hooklib
+        mod = _load_module("taskwrite_repo_res2", os.path.join(HOOKS, "taskwrite.py"))
+        self.assertIs(mod.project_root, _hooklib.project_root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_repo_resolution.py
+++ b/plugins/ca/hooks/tests/test_repo_resolution.py
@@ -111,6 +111,32 @@ class TestGitCwdUnit(unittest.TestCase):
     def test_no_dash_c_falls_back_to_root(self):
         self.assertEqual(self.pb.git_cwd("git --no-pager commit -m x", "/root"), "/root")
 
+    # -- security-reviewer MEDIUM follow-up (#190): -C COMPOSES sequentially,
+    # not last-wins. A relative -C is relative to the ACCUMULATED result of
+    # every preceding -C; an absolute -C REPLACES the accumulator entirely.
+
+    def test_repeated_dash_c_absolute_then_relative_composes_onto_absolute(self):
+        # `git -C /abs/main -C . commit`: the `.` is relative to /abs/main
+        # (already seen), NOT to root — a last-wins-only reading would wrongly
+        # resolve "." against root instead.
+        self.assertEqual(
+            os.path.normpath(self.pb.git_cwd("git -C /abs/main -C . commit -m x", "/root")),
+            os.path.normpath("/abs/main/."))
+
+    def test_repeated_dash_c_absolute_then_relative_subdir_joins_onto_absolute(self):
+        # `git -C /abs/main -C sub commit` -> /abs/main/sub.
+        self.assertEqual(
+            os.path.normpath(self.pb.git_cwd("git -C /abs/main -C sub commit -m x", "/root")),
+            os.path.normpath("/abs/main/sub"))
+
+    def test_repeated_dash_c_relative_then_absolute_resets_to_absolute(self):
+        # `git -C feat -C /abs/other commit`: the LATER absolute value resets
+        # the accumulator, discarding the earlier relative "feat" entirely —
+        # not joined, not ignored in favor of a stale last-wins read.
+        self.assertEqual(
+            self.pb.git_cwd("git -C feat -C /abs/other commit -m x", "/root"),
+            "/abs/other")
+
 
 class TestGitCwdEndToEnd(unittest.TestCase):
     """Subprocess-level proof: pre-bash.py judges H-01 against the -C TARGET
@@ -172,6 +198,28 @@ class TestGitCwdEndToEnd(unittest.TestCase):
         _init_repo(feature_other, branch="feat/other")
         res = self.run_bash(f'git --no-pager -C "{feature_other}" commit -m x')
         self.assertNotIn("H-01", res.stderr)
+
+    # -- security-reviewer MEDIUM follow-up (#190): repeated -C composition,
+    # end to end. A last-wins-only fix fails OPEN on these crafted spellings —
+    # it resolves "." or "feat" against `root` (the session repo, feature
+    # branch -> ALLOWED) instead of the real git-composed target (other_root,
+    # main -> must BLOCK).
+
+    def test_absolute_then_relative_dot_dash_c_is_judged_against_absolute_target(self):
+        # `git -C /abs/main -C . commit`: "." composes onto /abs/main (already
+        # seen), not onto root/session_root.
+        res = self.run_bash(f'git -C "{self.other_root}" -C . commit -m x')
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_relative_then_absolute_dash_c_is_judged_against_the_absolute_reset(self):
+        # `git -C feat -C /abs/main commit`: the later absolute -C RESETS the
+        # accumulator — "feat" (relative to session_root) is discarded
+        # entirely, not joined or left standing as a prior last-wins target.
+        os.makedirs(os.path.join(self.session_root, "feat"), exist_ok=True)
+        res = self.run_bash(f'git -C feat -C "{self.other_root}" commit -m x')
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Lane A3 — #190 (hook-repo-resolution group: reliability-004/005/007). The guards resolved the WRONG repo, so a check/write could target a different repo than the one the operation fires in.

## What
- **reliability-005:** `git-enforce.py` (a `.git/hooks` script) now resolves its target repo via `git rev-parse --show-toplevel` inheriting the hook's own cwd (git's contract sets it to the target work-tree top), **not** `CLAUDE_PROJECT_DIR` — so H-01/H-02/H-09b/H-10b/H-14 scan the repo the commit/push actually fires in.
- **reliability-004:** `pre-bash.py`'s `git_cwd` now finds `-C` past global options (`git --no-pager -C ../x commit`) and **composes a repeated `-C` run the way git does** (fold-left: absolute replaces the accumulator, relative joins onto it, seeded with project_root) — closing a fail-open where `git -C /abs/main -C . commit` would be judged against the wrong repo. A `-C` target that isn't a real dir now fails **closed** (H-01 block).
- **reliability-007:** `session-start.py`/`taskwrite.py` drop their divergent local `project_root()` copies and use the shared `_hooklib.project_root` (identity-checked), so audit lines / the task board / installed hooks land in the harness-authoritative project dir.

This is the bug that's been forcing worktree-commit workarounds this whole campaign (the guard resolving the *outer* repo's branch).

## Verification
- **743 hook tests pass** (+21 new in `test_repo_resolution.py` covering all three sites, the multi-`-C` composition, AND no-fail-open regressions); `test_hook_guards.py`/`test_hooks_cold_install.py`/`test_taskwriter.py`/`test_board_sync.py` green; existing `test_h01_failclosed`/`test_git_hooks`/`test_pre_bash_activation`/`test_pre_bash_no_verify` assertions UNMODIFIED and green; `py_compile` clean; LF.
- **security-reviewer: PASS** (0 critical/high) — fail-closed posture verified and *strengthened*; the primary wrong-repo scan is closed. It flagged one MEDIUM (last-wins vs git's fold-left `-C` composition, a crafted-spelling fail-open); **fixed in this branch** with the fold-left composition + proving tests (`git -C /abs/main -C . commit` now blocks against `/abs/main`). Two no-action LOWs (git-version cwd fallback residual; the new isdir fail-closed can only over-block, never allow).

Bumps ca 2.8.8 → 2.8.9. Documents the repo-resolution posture in `security-controls.md` §Hook security.

Closes #190

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa