### PR TITLE
perf(hooks): cut SessionStart blocking git spawns + duplicate briefing reads (#194)

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -209,6 +209,24 @@ a `-C` target that is not a real directory now fails **closed** (H-01 block).
 copies, so audit lines / the task board / installed hooks land in the
 harness-authoritative project dir.
 
+**Hooks-install re-probe fast-path is fail-safe (#194).** To cut SessionStart
+latency, `_githooks.install()` may skip the git-spawn hooks-dir probe when a
+cheap on-disk cache proves the shims are already current. The skip fires ONLY
+when it can positively, spawn-free confirm no hooks redirect: the cached dir is
+exactly `<root>/.git/hooks` AND `_confirmed_no_local_hooks_path` finds no
+`core.hooksPath` (a **grammar-free** case-insensitive substring scan of
+`.git/config`/`.git/config.worktree` for `hookspath` — cannot under-detect any
+git-config spelling) AND no `[include]` directive AND the shims still match the
+current enforcer path. Any read failure, any `hookspath` occurrence, an
+`[include]`, a cached custom hooksPath, or a global-config change (a
+`~/.gitconfig` + XDG-config mtime token invalidates the cache) → fall through to
+the full probe. The fail direction is **install-when-unsure, never
+skip-when-unsure** — the fast path can never leave the #161 git-enforce backstop
+unwired. Accepted residual: a `$GIT_CONFIG_GLOBAL`/`$GIT_CONFIG_SYSTEM`
+env-repointed config or `/etc/gitconfig` `core.hooksPath` set AFTER a
+default-location install (the cold/first install always resolves those via the
+full probe).
+
 ---
 
 ## Audit trail

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.9" src="https://img.shields.io/badge/version-2.8.9-2b7489">
+<img alt="version 2.8.10" src="https://img.shields.io/badge/version-2.8.10-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_arbiterstatelib.py
+++ b/plugins/ca/hooks/_arbiterstatelib.py
@@ -21,10 +21,23 @@
 #   - Never raise on malformed user input — degrade to a safe default.
 #
 # Public API:
-#   frontmatter(path) -> dict                      parsed leading YAML frontmatter block
-#   count_matches(path, pattern) -> int             regex match count in a file (0 on any I/O error)
-#   arbiter_state(root, count_in_flight=None, read_board=None, frontmatter_enabled=None) -> dict|None
+#   frontmatter(path) -> dict                       parsed leading YAML frontmatter block
+#   frontmatter_text(text) -> dict                   same parse, given already-read text (performance-003)
+#   count_matches(path, pattern) -> int              regex match count in a file (0 on any I/O error)
+#   count_matches_text(text, pattern) -> int          same count, given already-read text (performance-003)
+#   arbiter_state(root, count_in_flight=None, read_board=None, frontmatter_enabled=None,
+#                 ctx_text=None, ot_text=None, oq_text=None) -> dict|None
 #   dev_active(root) -> bool                        True when the /dev marker is present
+#
+# performance-003 (#194): SessionStart's main() already reads CONTEXT.md,
+# open-tasks.md, and open-questions.md before the display-only governance line
+# is ever rendered. The optional ctx_text/ot_text/oq_text kwargs on
+# arbiter_state let a caller that already holds that content thread it through
+# instead of paying for a second disk read of the same file in the same
+# process. None (the default) means "not supplied" -> falls back to the
+# original read-from-disk behavior, so every existing caller (the standalone
+# statusline.py render, direct arbiter_state(root) calls in tests) is
+# unaffected.
 
 import os
 import re
@@ -39,22 +52,19 @@ _ARBITER_FILES = ("CONTEXT.md", "overrides.log", "last-checkpoint",
                   "open-tasks.md", "open-questions.md", "sprint-active")
 
 
-def frontmatter(path):
-    """Parse a properly-closed leading YAML frontmatter block into a key map. The
-    *arbiter-enabled* decision is NOT made here — that activation contract is owned
-    by _hooklib.frontmatter_enabled (see arbiter_state) so the box and the
-    enforcement hooks read it one way. This reader exists only to surface the
-    remaining display keys (e.g. `stage`) the boolean gate doesn't carry."""
+def frontmatter_text(text):
+    """Parse a properly-closed leading YAML frontmatter block out of already-read
+    `text` into a key map (see frontmatter() for the on-disk counterpart — this is
+    the pure text half, extracted for performance-003 so a caller holding the
+    content already can skip a second disk read). Tolerates a leading UTF-8 BOM
+    character (\\ufeff) on the first line the same way frontmatter()'s utf-8-sig
+    decode does, regardless of how the caller's text was originally decoded."""
     fm = {}
-    try:
-        # utf-8-sig transparently strips a leading BOM (Windows editors / PowerShell
-        # Out-File default to UTF-8-with-BOM); plain utf-8 would leave it on line 1
-        # and break the "---" frontmatter check.
-        with open(path, encoding="utf-8-sig", errors="replace") as f:
-            lines = f.read().splitlines()
-    except OSError:
+    lines = (text or "").splitlines()
+    if not lines:
         return fm
-    if not lines or lines[0].strip() != "---":
+    first = lines[0].lstrip("﻿")
+    if first.strip() != "---":
         return fm
     closed = False
     for ln in lines[1:]:
@@ -69,12 +79,36 @@ def frontmatter(path):
     return fm if closed else {}
 
 
+def frontmatter(path):
+    """Parse a properly-closed leading YAML frontmatter block into a key map. The
+    *arbiter-enabled* decision is NOT made here — that activation contract is owned
+    by _hooklib.frontmatter_enabled (see arbiter_state) so the box and the
+    enforcement hooks read it one way. This reader exists only to surface the
+    remaining display keys (e.g. `stage`) the boolean gate doesn't carry."""
+    try:
+        # utf-8-sig transparently strips a leading BOM (Windows editors / PowerShell
+        # Out-File default to UTF-8-with-BOM); plain utf-8 would leave it on line 1
+        # and break the "---" frontmatter check.
+        with open(path, encoding="utf-8-sig", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return {}
+    return frontmatter_text(text)
+
+
+def count_matches_text(text, pattern):
+    """Regex match count against already-read `text` (see count_matches() for the
+    on-disk counterpart — the pure text half, extracted for performance-003)."""
+    return len(re.findall(pattern, text or "", re.MULTILINE))
+
+
 def count_matches(path, pattern):
     try:
         with open(path, encoding="utf-8", errors="replace") as f:
-            return len(re.findall(pattern, f.read(), re.MULTILINE))
+            text = f.read()
     except OSError:
         return 0
+    return count_matches_text(text, pattern)
 
 
 def _arbiter_mtime_key(cad):
@@ -89,11 +123,16 @@ def _arbiter_mtime_key(cad):
     return latest
 
 
-def _arbiter_enabled(ctx_path, frontmatter_enabled=None):
+def _arbiter_enabled(ctx_path, frontmatter_enabled=None, ctx_text=None):
     """The arbiter-enabled gate, owned by _hooklib.frontmatter_enabled when the lib
     is importable (so the box and the enforcement hooks agree on the activation
     contract). Falls back to the local frontmatter() parser only if the import
-    failed — the defensive degrade path, never a hard dependency."""
+    failed — the defensive degrade path, never a hard dependency.
+
+    When `ctx_text` is supplied (performance-003: the caller already read
+    CONTEXT.md), the decision is made from that text — no re-read of ctx_path."""
+    if ctx_text is not None:
+        return frontmatter_text(ctx_text).get("arbiter", "").lower() == "enabled"
     if frontmatter_enabled is not None:
         try:
             enabled, _malformed = frontmatter_enabled(ctx_path)
@@ -103,21 +142,28 @@ def _arbiter_enabled(ctx_path, frontmatter_enabled=None):
     return frontmatter(ctx_path).get("arbiter", "").lower() == "enabled"
 
 
-def arbiter_state(root, count_in_flight=None, read_board=None, frontmatter_enabled=None):
+def arbiter_state(root, count_in_flight=None, read_board=None, frontmatter_enabled=None,
+                   ctx_text=None, ot_text=None, oq_text=None):
     cad = os.path.join(root, ".codearbiter")
     mkey = _arbiter_mtime_key(cad)
     cached = _ARBITER_CACHE.get(root)
     if cached is not None and cached[0] == mkey:
         return cached[1]
-    result = _arbiter_state_uncached(cad, count_in_flight, read_board, frontmatter_enabled)
+    result = _arbiter_state_uncached(cad, count_in_flight, read_board, frontmatter_enabled,
+                                      ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
     _ARBITER_CACHE[root] = (mkey, result)
     return result
 
 
-def _arbiter_state_uncached(cad, count_in_flight=None, read_board=None, frontmatter_enabled=None):
-    if not _arbiter_enabled(os.path.join(cad, "CONTEXT.md"), frontmatter_enabled):
+def _arbiter_state_uncached(cad, count_in_flight=None, read_board=None, frontmatter_enabled=None,
+                             ctx_text=None, ot_text=None, oq_text=None):
+    ctx_path = os.path.join(cad, "CONTEXT.md")
+    if not _arbiter_enabled(ctx_path, frontmatter_enabled, ctx_text=ctx_text):
         return None
-    fm = frontmatter(os.path.join(cad, "CONTEXT.md"))
+    # performance-003: reuse the caller's already-read CONTEXT.md/open-tasks.md/
+    # open-questions.md text when supplied, instead of a second disk read. `None`
+    # (the default) preserves the exact original read-from-disk behavior.
+    fm = frontmatter_text(ctx_text) if ctx_text is not None else frontmatter(ctx_path)
     total_over = count_matches(os.path.join(cad, "overrides.log"), r"^(?!\s*#)(?!\s*$).+")
     # last-checkpoint holds the override COUNT at the last /ca:checkpoint. A value
     # outside [0, total] is not a valid count (e.g. a timestamp from a stale writer)
@@ -131,16 +177,20 @@ def _arbiter_state_uncached(cad, count_in_flight=None, read_board=None, frontmat
         base = 0
     ot_path = os.path.join(cad, "open-tasks.md")
     if count_in_flight is not None:
-        tasks = count_in_flight(read_board(ot_path) or "")
+        board_text = ot_text if ot_text is not None else (read_board(ot_path) or "")
+        tasks = count_in_flight(board_text)
     else:
         # Degraded fallback (only if _taskboardlib failed to import): mirror
         # count_in_flight's done-exclusion inline so the segment never silently
         # re-inflates to the pre-schema count. Never crashes the box.
-        tasks = count_matches(ot_path, r"^- (?!\[[xX]\])")
+        tasks = (count_matches_text(ot_text, r"^- (?!\[[xX]\])") if ot_text is not None
+                 else count_matches(ot_path, r"^- (?!\[[xX]\])"))
+    q = (count_matches_text(oq_text, r"CONFIRM-[0-9]+") if oq_text is not None
+         else count_matches(os.path.join(cad, "open-questions.md"), r"CONFIRM-[0-9]+"))
     return {
         "stage": fm.get("stage", "-"),
         "tasks": tasks,
-        "q": count_matches(os.path.join(cad, "open-questions.md"), r"CONFIRM-[0-9]+"),
+        "q": q,
         "over": max(0, total_over - base),
         "sprint": os.path.exists(os.path.join(cad, "sprint-active")),
     }

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -35,8 +35,38 @@
 #     or absence (including a genuinely fresh/cold repo) falls through to the
 #     full git-based probe unchanged — the cache is a pure latency optimization,
 #     never load-bearing for correctness.
+#
+#     CRITICAL fix (security review, post-#194): the fast path must NEVER trust
+#     a cached hooks_dir without CHEAPLY (no git spawn) proving the EFFECTIVE
+#     hooks dir has not moved since that cache was written. The original cut
+#     only re-checked that the shims AT the cached location were current — it
+#     never re-checked that git would still read hooks FROM that location. A
+#     LOCAL core.hooksPath change after the cache was written (the realistic
+#     case: the user later adopts husky / pre-commit-framework, which set
+#     `core.hooksPath` in `.git/config`) left the fast path returning `[]`
+#     (success) while the NEW hooks dir got no codeArbiter shim at all — the
+#     #161 backstop silently unwired. Fixed: the fast path now ALSO requires
+#     (a) the cached dir be exactly the DEFAULT `<root>/.git/hooks` (never a
+#     cached custom hooksPath — those must always re-confirm via git, since a
+#     custom path is exactly the kind of thing that gets repointed), and (b) a
+#     direct read of `.git/config` (and `.git/config.worktree`, for
+#     extensions.worktreeConfig repos) positively CONFIRMS no local
+#     core.hooksPath key is set. Any read failure, parse ambiguity, or a
+#     detected key falls through to the full git-based probe — fail direction
+#     is "install when unsure," never "skip when unsure."
+#
+#     Documented residual (accepted, not cheaply closable): a GLOBAL/SYSTEM
+#     core.hooksPath (~/.gitconfig, /etc/gitconfig) set AFTER a default-location
+#     install is not caught by the `.git/config` read alone — closed for the
+#     common `~/.gitconfig` case by also keying the cache on that file's mtime
+#     (below), but a `/etc/gitconfig` (or an equivalent `GIT_CONFIG_*` env/
+#     `--system` override) change is not cheaply detectable and remains
+#     residual. This is rare (a system-wide hooksPath predating a later
+#     default-location install is the unusual order), and a cold/first install
+#     always resolves it correctly via the full git-based probe regardless.
 
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -51,6 +81,14 @@ PHASES = ("pre-commit", "pre-push")
 # naturally False there — the cache silently declines to engage and every call
 # falls through to the full probe, rather than ever risking a wrong-repo guess.
 _HOOKSDIR_CACHE_NAME = "codearbiter-hooksdir-cache"
+
+# Minimal git-config section/key matcher — used ONLY to detect the PRESENCE of
+# a `core.hooksPath` key (never its value) so the fast path can conservatively
+# decline whenever the answer isn't a clean "definitely not set". Deliberately
+# does not attempt full git-config-file fidelity (line continuations, quoted
+# subsections, etc.) — see _config_has_core_hooks_path's fail-direction note.
+_SECTION_RE = re.compile(r'^\[\s*([^\s\]"]+)\s*(?:"[^"]*")?\s*\]')
+_KEY_RE = re.compile(r'^([A-Za-z][A-Za-z0-9-]*)\s*(?:=.*)?$')
 
 
 def _warn(msg):
@@ -112,34 +150,126 @@ def _read(path):
         return None
 
 
+def _config_has_core_hooks_path(text):
+    """True iff git-config-file `text` sets `core.hooksPath` inside a `[core]`
+    section. Minimal section/key matcher, not a full git-config parser (no
+    line-continuation support) — it only answers "did I positively see a
+    hooksPath key under [core]?"."""
+    section = None
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        if not line or line.startswith((";", "#")):
+            continue
+        m = _SECTION_RE.match(line)
+        if m:
+            section = m.group(1).lower()
+            continue
+        if section == "core":
+            km = _KEY_RE.match(line)
+            if km and km.group(1).lower() == "hookspath":
+                return True
+    return False
+
+
+def _config_has_include_directive(text):
+    """True iff `text` contains an `[include]`/`[includeIf ...]` section —
+    git-config's mechanism for pulling in ANOTHER file (which this module's
+    minimal parser does not follow). Presence makes `.git/config` itself
+    unconfirmable for our purposes (a hooksPath could be set in the included
+    file instead), so the caller must fail safe on it — see
+    _confirmed_no_local_hooks_path."""
+    return bool(re.search(r'^\[\s*include(if\b[^\]]*)?\s*\]', text or "",
+                          re.IGNORECASE | re.MULTILINE))
+
+
+def _local_config_paths(root):
+    """git-config files whose `[core]` section could define a LOCAL
+    core.hooksPath override for `root` — `.git/config` (always checked, even
+    if the file happens to be missing — see _confirmed_no_local_hooks_path)
+    plus `.git/config.worktree` (extensions.worktreeConfig repos), when it
+    exists. Deliberately excludes global (~/.gitconfig) and system
+    (/etc/gitconfig) config — see the module header's documented residual."""
+    git_dir = os.path.join(root, ".git")
+    return [os.path.join(git_dir, "config"), os.path.join(git_dir, "config.worktree")]
+
+
+def _confirmed_no_local_hooks_path(root):
+    """True ONLY if a direct, no-git-spawn read of the config file(s) that
+    could set a LOCAL core.hooksPath for `root` positively confirms NONE of
+    them do. Any read failure (a file exists but can't be read) or a detected
+    hooksPath key returns False. A simply-ABSENT `config.worktree` is not an
+    error (most repos don't have one) and contributes no override, exactly
+    like git itself.
+
+    This is the fail-direction-critical check (CRITICAL fix, post-#194): the
+    fast path in install() must never trust a cached hooks_dir without this
+    positive confirmation, or a later `core.hooksPath` change (husky /
+    pre-commit-framework) would silently leave the NEW hooks dir unwired."""
+    for path in _local_config_paths(root):
+        if not os.path.isfile(path):
+            continue  # absent -> no override possible from this file
+        text = _read(path)
+        if text is None:
+            return False  # exists but unreadable -> can't confirm -> unsafe to skip
+        if _config_has_core_hooks_path(text):
+            return False
+        if _config_has_include_directive(text):
+            return False  # could pull in a hooksPath from elsewhere -> can't confirm
+    return True
+
+
+def _global_gitconfig_mtime_token():
+    """A cheap cache-invalidation token for ~/.gitconfig: its mtime, or the
+    literal 'absent' if the file doesn't exist. Included in the on-disk cache
+    so a LATER edit to the user's global config (e.g. adding a global
+    core.hooksPath) invalidates a previously-fast-pathable cache instead of
+    silently going unnoticed — narrows, but does not eliminate, the documented
+    global/system-config residual (module header)."""
+    try:
+        return repr(os.stat(os.path.join(os.path.expanduser("~"), ".gitconfig")).st_mtime)
+    except OSError:
+        return "absent"
+
+
 def _cached_hooks_dir(root):
     """The last hooks_dir() a successful resolution used for `root`, read from
     the on-disk cache — NO git spawn. Returns None (cache miss) if the cache
-    file is absent/unreadable/blank, or if it names a directory that no longer
-    exists (e.g. deleted between sessions). A None return always falls the
-    caller through to the real git-based hooks_dir() probe."""
+    file is absent/unreadable/blank/malformed, if it names a directory that no
+    longer exists (e.g. deleted between sessions), or if ~/.gitconfig has
+    changed since the cache was written (see _global_gitconfig_mtime_token). A
+    None return always falls the caller through to the real git-based
+    hooks_dir() probe."""
     git_dir = os.path.join(root, ".git")
     if not os.path.isdir(git_dir):
         return None
     text = _read(os.path.join(git_dir, _HOOKSDIR_CACHE_NAME))
     if not text:
         return None
-    hd = text.strip()
-    return hd if hd and os.path.isdir(hd) else None
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return None  # malformed/legacy cache shape -> treat as a miss
+    hd, stored_token = lines[0].strip(), lines[1].strip()
+    if not hd or not os.path.isdir(hd):
+        return None
+    if stored_token != _global_gitconfig_mtime_token():
+        return None  # ~/.gitconfig changed since this cache was written
+    return hd
 
 
 def _write_hooks_dir_cache(root, hd):
-    """Best-effort persistence of the resolved hooks_dir so a LATER session can
-    skip the git-config/rev-parse re-probe (performance-002) when nothing has
-    changed. Any failure — including `.git` being a FILE, not a directory, for
-    a linked worktree — is swallowed: this cache is a pure optimization and is
-    never allowed to affect whether hooks actually get installed."""
+    """Best-effort persistence of the resolved hooks_dir (+ the ~/.gitconfig
+    invalidation token) so a LATER session can skip the git-config/rev-parse
+    re-probe (performance-002) when nothing has changed. Any failure —
+    including `.git` being a FILE, not a directory, for a linked worktree — is
+    swallowed: this cache is a pure optimization and is never allowed to
+    affect whether hooks actually get installed."""
     git_dir = os.path.join(root, ".git")
     if not os.path.isdir(git_dir):
         return
     try:
+        payload = f"{hd}\n{_global_gitconfig_mtime_token()}\n"
         _hooklib.write_text_atomic(
-            os.path.join(git_dir, _HOOKSDIR_CACHE_NAME), hd + "\n", newline="\n")
+            os.path.join(git_dir, _HOOKSDIR_CACHE_NAME), payload, newline="\n")
     except Exception:  # noqa: BLE001 — best-effort cache, never fatal
         pass
 
@@ -160,6 +290,10 @@ def _hooks_current(hd, enforcer):
     return True
 
 
+def _default_hooks_dir(root):
+    return os.path.join(root, ".git", "hooks")
+
+
 def install(root):
     """Ensure the git-level enforcement hooks are installed for `root`.
     Idempotent and safe to call every session. Returns a list of human-readable
@@ -167,16 +301,36 @@ def install(root):
     (no git dir, foreign hook) — those are reported, not fatal.
 
     performance-002 (#194): before doing any git spawn, checks a cheap on-disk
-    cache of the last resolved hooks_dir; if the hooks there are ALREADY
-    current for the CURRENT enforcer path, returns immediately with no git
-    subprocess at all. Any cache miss/mismatch (including a genuine cold
-    install, a moved plugin path, a foreign hook, or a changed
-    core.hooksPath) falls through to the original git-based probe below,
-    unchanged."""
+    cache of the last resolved hooks_dir. The fast path (zero git subprocess
+    calls) fires ONLY when ALL of the following hold — every one of them is a
+    cheap, no-git-spawn check:
+      1. a cached hooks_dir exists and still exists on disk;
+      2. that cached dir is EXACTLY the default `<root>/.git/hooks` — a cached
+         CUSTOM hooksPath is never fast-pathed, since a custom path is exactly
+         the kind of value that gets repointed later;
+      3. a direct read of `.git/config` (+ `.git/config.worktree`) positively
+         CONFIRMS no local core.hooksPath override is set right now (see
+         _confirmed_no_local_hooks_path — CRITICAL fix, post-#194: the
+         original cut skipped this check entirely, so a LOCAL hooksPath added
+         after the cache was written — e.g. adopting husky / pre-commit-
+         framework — silently left the NEW hooks dir unwired while returning
+         `[]`);
+      4. the shims at that dir are already current for the CURRENT enforcer
+         path (_hooks_current).
+    Any single miss/mismatch — including a genuine cold install, a moved
+    plugin path, a foreign hook, a changed core.hooksPath, or ambiguity in the
+    config read — falls through to the original git-based probe below,
+    unchanged. Fail direction is "install when unsure," never "skip when
+    unsure"."""
     enforcer = _enforcer_path()
     cached_hd = _cached_hooks_dir(root)
-    if cached_hd is not None and _hooks_current(cached_hd, enforcer):
-        return []
+    if cached_hd is not None:
+        default_hd = os.path.normcase(os.path.abspath(_default_hooks_dir(root)))
+        cached_norm = os.path.normcase(os.path.abspath(cached_hd))
+        if (cached_norm == default_hd
+                and _confirmed_no_local_hooks_path(root)
+                and _hooks_current(cached_hd, enforcer)):
+            return []
     hd = hooks_dir(root)
     if not hd:
         return []

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -25,6 +25,16 @@
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
 #     ours-hook is refreshed.
+#   * performance-002 (#194): re-resolving hooks_dir() every SessionStart costs
+#     up to two blocking `git` subprocess spawns (config --get core.hooksPath,
+#     rev-parse --git-path hooks) even on the common steady-state call where
+#     nothing changed. install() first checks a cheap on-disk cache (a single
+#     small file read, no git spawn) recording the hooks_dir a prior successful
+#     resolution used; if BOTH phase shims at that cached location already
+#     match what we'd install right now, it returns immediately. Any mismatch
+#     or absence (including a genuinely fresh/cold repo) falls through to the
+#     full git-based probe unchanged — the cache is a pure latency optimization,
+#     never load-bearing for correctness.
 
 import os
 import stat
@@ -35,6 +45,12 @@ import _hooklib
 
 SENTINEL = "# codeArbiter-managed git hook (#161) — refreshed each session; edits are overwritten."
 PHASES = ("pre-commit", "pre-push")
+# The hooks_dir() resolution cache lives INSIDE .git/ itself (never under
+# .codearbiter/): a linked worktree's `.git` is a FILE (not a directory)
+# pointing at the real gitdir elsewhere, so os.path.isdir(...) on it is
+# naturally False there — the cache silently declines to engage and every call
+# falls through to the full probe, rather than ever risking a wrong-repo guess.
+_HOOKSDIR_CACHE_NAME = "codearbiter-hooksdir-cache"
 
 
 def _warn(msg):
@@ -96,15 +112,74 @@ def _read(path):
         return None
 
 
+def _cached_hooks_dir(root):
+    """The last hooks_dir() a successful resolution used for `root`, read from
+    the on-disk cache — NO git spawn. Returns None (cache miss) if the cache
+    file is absent/unreadable/blank, or if it names a directory that no longer
+    exists (e.g. deleted between sessions). A None return always falls the
+    caller through to the real git-based hooks_dir() probe."""
+    git_dir = os.path.join(root, ".git")
+    if not os.path.isdir(git_dir):
+        return None
+    text = _read(os.path.join(git_dir, _HOOKSDIR_CACHE_NAME))
+    if not text:
+        return None
+    hd = text.strip()
+    return hd if hd and os.path.isdir(hd) else None
+
+
+def _write_hooks_dir_cache(root, hd):
+    """Best-effort persistence of the resolved hooks_dir so a LATER session can
+    skip the git-config/rev-parse re-probe (performance-002) when nothing has
+    changed. Any failure — including `.git` being a FILE, not a directory, for
+    a linked worktree — is swallowed: this cache is a pure optimization and is
+    never allowed to affect whether hooks actually get installed."""
+    git_dir = os.path.join(root, ".git")
+    if not os.path.isdir(git_dir):
+        return
+    try:
+        _hooklib.write_text_atomic(
+            os.path.join(git_dir, _HOOKSDIR_CACHE_NAME), hd + "\n", newline="\n")
+    except Exception:  # noqa: BLE001 — best-effort cache, never fatal
+        pass
+
+
+def _hooks_current(hd, enforcer):
+    """True iff BOTH phase shims at `hd` already match what install() would
+    write right now for `enforcer` — i.e. install() would be a complete no-op.
+    Filesystem-only (no git spawn): this is exactly the check that lets
+    install() skip the git-config/rev-parse re-probe when a prior session
+    already installed current hooks. A foreign (non-sentinel) hook, a stale
+    shim, or a missing file all correctly return False here, falling the
+    caller through to the full probe (which then re-derives the right action:
+    refresh, warn-and-preserve, or install fresh)."""
+    for phase in PHASES:
+        existing = _read(os.path.join(hd, phase))
+        if existing is None or existing != _shim(enforcer, phase):
+            return False
+    return True
+
+
 def install(root):
     """Ensure the git-level enforcement hooks are installed for `root`.
     Idempotent and safe to call every session. Returns a list of human-readable
     actions taken (possibly empty). Never raises for an expected condition
-    (no git dir, foreign hook) — those are reported, not fatal."""
+    (no git dir, foreign hook) — those are reported, not fatal.
+
+    performance-002 (#194): before doing any git spawn, checks a cheap on-disk
+    cache of the last resolved hooks_dir; if the hooks there are ALREADY
+    current for the CURRENT enforcer path, returns immediately with no git
+    subprocess at all. Any cache miss/mismatch (including a genuine cold
+    install, a moved plugin path, a foreign hook, or a changed
+    core.hooksPath) falls through to the original git-based probe below,
+    unchanged."""
+    enforcer = _enforcer_path()
+    cached_hd = _cached_hooks_dir(root)
+    if cached_hd is not None and _hooks_current(cached_hd, enforcer):
+        return []
     hd = hooks_dir(root)
     if not hd:
         return []
-    enforcer = _enforcer_path()
     try:
         os.makedirs(hd, exist_ok=True)
     except Exception:  # noqa: BLE001
@@ -137,6 +212,9 @@ def install(root):
             actions.append(f"{phase}: installed")
         except Exception as e:  # noqa: BLE001
             _warn(f"could not write {dest}: {e}")
+    # Cache the resolved location so the NEXT call can skip the git-config/
+    # rev-parse re-probe entirely (performance-002) — best-effort, never fatal.
+    _write_hooks_dir_cache(root, hd)
     return actions
 
 

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -56,17 +56,20 @@
 #     is "install when unsure," never "skip when unsure."
 #
 #     Documented residual (accepted, not cheaply closable): a GLOBAL/SYSTEM
-#     core.hooksPath (~/.gitconfig, /etc/gitconfig) set AFTER a default-location
-#     install is not caught by the `.git/config` read alone — closed for the
-#     common `~/.gitconfig` case by also keying the cache on that file's mtime
-#     (below), but a `/etc/gitconfig` (or an equivalent `GIT_CONFIG_*` env/
-#     `--system` override) change is not cheaply detectable and remains
-#     residual. This is rare (a system-wide hooksPath predating a later
-#     default-location install is the unusual order), and a cold/first install
-#     always resolves it correctly via the full git-based probe regardless.
+#     core.hooksPath set AFTER a default-location install is not caught by the
+#     `.git/config` read alone. This covers ALL of git's global/system config
+#     locations, not just `~/.gitconfig`: `~/.config/git/config` (or
+#     `$XDG_CONFIG_HOME/git/config`), and a `$GIT_CONFIG_GLOBAL`/
+#     `$GIT_CONFIG_SYSTEM` env override repointing the file entirely. The cache
+#     is keyed on the mtime of `~/.gitconfig` AND the XDG path (below), which
+#     closes the common case of a later edit to either of those two files; a
+#     `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` env override, or an edit to
+#     `/etc/gitconfig`, is not cheaply detectable from a fixed path and remains
+#     residual. This is rare (those overrides predating a later default-location
+#     install is the unusual order), and a cold/first install always resolves
+#     it correctly via the full git-based probe regardless.
 
 import os
-import re
 import stat
 import subprocess
 import sys
@@ -81,14 +84,6 @@ PHASES = ("pre-commit", "pre-push")
 # naturally False there — the cache silently declines to engage and every call
 # falls through to the full probe, rather than ever risking a wrong-repo guess.
 _HOOKSDIR_CACHE_NAME = "codearbiter-hooksdir-cache"
-
-# Minimal git-config section/key matcher — used ONLY to detect the PRESENCE of
-# a `core.hooksPath` key (never its value) so the fast path can conservatively
-# decline whenever the answer isn't a clean "definitely not set". Deliberately
-# does not attempt full git-config-file fidelity (line continuations, quoted
-# subsections, etc.) — see _config_has_core_hooks_path's fail-direction note.
-_SECTION_RE = re.compile(r'^\[\s*([^\s\]"]+)\s*(?:"[^"]*")?\s*\]')
-_KEY_RE = re.compile(r'^([A-Za-z][A-Za-z0-9-]*)\s*(?:=.*)?$')
 
 
 def _warn(msg):
@@ -150,45 +145,12 @@ def _read(path):
         return None
 
 
-def _config_has_core_hooks_path(text):
-    """True iff git-config-file `text` sets `core.hooksPath` inside a `[core]`
-    section. Minimal section/key matcher, not a full git-config parser (no
-    line-continuation support) — it only answers "did I positively see a
-    hooksPath key under [core]?"."""
-    section = None
-    for raw in (text or "").splitlines():
-        line = raw.strip()
-        if not line or line.startswith((";", "#")):
-            continue
-        m = _SECTION_RE.match(line)
-        if m:
-            section = m.group(1).lower()
-            continue
-        if section == "core":
-            km = _KEY_RE.match(line)
-            if km and km.group(1).lower() == "hookspath":
-                return True
-    return False
-
-
-def _config_has_include_directive(text):
-    """True iff `text` contains an `[include]`/`[includeIf ...]` section —
-    git-config's mechanism for pulling in ANOTHER file (which this module's
-    minimal parser does not follow). Presence makes `.git/config` itself
-    unconfirmable for our purposes (a hooksPath could be set in the included
-    file instead), so the caller must fail safe on it — see
-    _confirmed_no_local_hooks_path."""
-    return bool(re.search(r'^\[\s*include(if\b[^\]]*)?\s*\]', text or "",
-                          re.IGNORECASE | re.MULTILINE))
-
-
 def _local_config_paths(root):
-    """git-config files whose `[core]` section could define a LOCAL
-    core.hooksPath override for `root` — `.git/config` (always checked, even
-    if the file happens to be missing — see _confirmed_no_local_hooks_path)
-    plus `.git/config.worktree` (extensions.worktreeConfig repos), when it
-    exists. Deliberately excludes global (~/.gitconfig) and system
-    (/etc/gitconfig) config — see the module header's documented residual."""
+    """git-config files that could define a LOCAL core.hooksPath override for
+    `root` — `.git/config` (always checked, even if the file happens to be
+    missing — see _confirmed_no_local_hooks_path) plus `.git/config.worktree`
+    (extensions.worktreeConfig repos), when it exists. Deliberately excludes
+    global/system config — see the module header's documented residual."""
     git_dir = os.path.join(root, ".git")
     return [os.path.join(git_dir, "config"), os.path.join(git_dir, "config.worktree")]
 
@@ -196,14 +158,33 @@ def _local_config_paths(root):
 def _confirmed_no_local_hooks_path(root):
     """True ONLY if a direct, no-git-spawn read of the config file(s) that
     could set a LOCAL core.hooksPath for `root` positively confirms NONE of
-    them do. Any read failure (a file exists but can't be read) or a detected
-    hooksPath key returns False. A simply-ABSENT `config.worktree` is not an
-    error (most repos don't have one) and contributes no override, exactly
-    like git itself.
+    them could possibly do so.
 
-    This is the fail-direction-critical check (CRITICAL fix, post-#194): the
-    fast path in install() must never trust a cached hooks_dir without this
-    positive confirmation, or a later `core.hooksPath` change (husky /
+    GRAMMAR-FREE by design (HIGH-severity fix, second spelling of the same
+    skip -> backstop-unwire class): git's config grammar honors a variable on
+    the SAME line as its section header (`[core] hooksPath = x`,
+    `[core]hooksPath=x`, `[CORE]HooksPath=x` are all valid and honored by real
+    git), plus quoting/continuation/case variations — a hand-rolled
+    line-oriented section/key parser reliably misses some of these spellings.
+    Rather than chase git's config grammar (an unbounded set of spellings),
+    this check is a single case-insensitive SUBSTRING scan for `hookspath`
+    anywhere in the file, plus a substring scan for an `[include`/`[includeif`
+    directive (which could pull a hooksPath in from elsewhere, unfollowed by
+    this check). Any occurrence of either substring — even inside a comment —
+    or any read failure, returns False (not confirmed). This can never
+    UNDER-detect a real hooksPath key (a real key always contains the
+    substring "hookspath" case-insensitively, by definition of the git-config
+    keyword), so it can only ever be OVER-cautious (an extra, harmless
+    git-spawn fall-through on a false positive, e.g. a stray comment
+    mentioning the word) — never falsely confirm an override is absent when
+    one is actually present. That asymmetry is exactly the fail-direction the
+    fast path requires: "install when unsure," never "skip when unsure." A
+    simply-ABSENT `config.worktree` is not an error (most repos don't have
+    one) and contributes no override, exactly like git itself.
+
+    This is the fail-direction-critical check (CRITICAL/HIGH fix, post-#194):
+    the fast path in install() must never trust a cached hooks_dir without
+    this positive confirmation, or a later `core.hooksPath` change (husky /
     pre-commit-framework) would silently leave the NEW hooks dir unwired."""
     for path in _local_config_paths(root):
         if not os.path.isfile(path):
@@ -211,34 +192,53 @@ def _confirmed_no_local_hooks_path(root):
         text = _read(path)
         if text is None:
             return False  # exists but unreadable -> can't confirm -> unsafe to skip
-        if _config_has_core_hooks_path(text):
-            return False
-        if _config_has_include_directive(text):
+        lowered = text.lower()
+        if "hookspath" in lowered:
+            return False  # ANY spelling/placement/casing -> can't confirm absent
+        if "[include" in lowered:
             return False  # could pull in a hooksPath from elsewhere -> can't confirm
     return True
 
 
-def _global_gitconfig_mtime_token():
-    """A cheap cache-invalidation token for ~/.gitconfig: its mtime, or the
-    literal 'absent' if the file doesn't exist. Included in the on-disk cache
-    so a LATER edit to the user's global config (e.g. adding a global
-    core.hooksPath) invalidates a previously-fast-pathable cache instead of
-    silently going unnoticed — narrows, but does not eliminate, the documented
-    global/system-config residual (module header)."""
+def _xdg_git_config_path():
+    """The XDG git global-config path git ALSO reads (lower precedence than
+    ~/.gitconfig, but still consulted): `$XDG_CONFIG_HOME/git/config`, or
+    `~/.config/git/config` when XDG_CONFIG_HOME is unset — matching git's own
+    fallback."""
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    return os.path.join(base, "git", "config")
+
+
+def _file_mtime_token(path):
+    """A cheap cache-invalidation token for `path`: its mtime, or the literal
+    'absent' if it doesn't exist."""
     try:
-        return repr(os.stat(os.path.join(os.path.expanduser("~"), ".gitconfig")).st_mtime)
+        return repr(os.stat(path).st_mtime)
     except OSError:
         return "absent"
+
+
+def _global_gitconfig_mtime_token():
+    """A cheap cache-invalidation token covering BOTH global git-config
+    locations codeArbiter can cheaply stat by a fixed path: `~/.gitconfig` and
+    the XDG `~/.config/git/config` (or `$XDG_CONFIG_HOME/git/config`).
+    Included in the on-disk cache so a LATER edit to either (e.g. adding a
+    global core.hooksPath) invalidates a previously-fast-pathable cache
+    instead of silently going unnoticed. Does NOT cover a `$GIT_CONFIG_GLOBAL`/
+    `$GIT_CONFIG_SYSTEM` env override repointing the file entirely, nor
+    `/etc/gitconfig` — see the module header's documented residual."""
+    return f"{_file_mtime_token(os.path.join(os.path.expanduser('~'), '.gitconfig'))}|" \
+           f"{_file_mtime_token(_xdg_git_config_path())}"
 
 
 def _cached_hooks_dir(root):
     """The last hooks_dir() a successful resolution used for `root`, read from
     the on-disk cache — NO git spawn. Returns None (cache miss) if the cache
     file is absent/unreadable/blank/malformed, if it names a directory that no
-    longer exists (e.g. deleted between sessions), or if ~/.gitconfig has
-    changed since the cache was written (see _global_gitconfig_mtime_token). A
-    None return always falls the caller through to the real git-based
-    hooks_dir() probe."""
+    longer exists (e.g. deleted between sessions), or if either global
+    git-config location (~/.gitconfig, the XDG git config) has changed since
+    the cache was written (see _global_gitconfig_mtime_token). A None return
+    always falls the caller through to the real git-based hooks_dir() probe."""
     git_dir = os.path.join(root, ".git")
     if not os.path.isdir(git_dir):
         return None
@@ -252,17 +252,17 @@ def _cached_hooks_dir(root):
     if not hd or not os.path.isdir(hd):
         return None
     if stored_token != _global_gitconfig_mtime_token():
-        return None  # ~/.gitconfig changed since this cache was written
+        return None  # a covered global git-config location changed since this cache was written
     return hd
 
 
 def _write_hooks_dir_cache(root, hd):
-    """Best-effort persistence of the resolved hooks_dir (+ the ~/.gitconfig
-    invalidation token) so a LATER session can skip the git-config/rev-parse
-    re-probe (performance-002) when nothing has changed. Any failure —
-    including `.git` being a FILE, not a directory, for a linked worktree — is
-    swallowed: this cache is a pure optimization and is never allowed to
-    affect whether hooks actually get installed."""
+    """Best-effort persistence of the resolved hooks_dir (+ the global
+    git-config invalidation token) so a LATER session can skip the
+    git-config/rev-parse re-probe (performance-002) when nothing has changed.
+    Any failure — including `.git` being a FILE, not a directory, for a linked
+    worktree — is swallowed: this cache is a pure optimization and is never
+    allowed to affect whether hooks actually get installed."""
     git_dir = os.path.join(root, ".git")
     if not os.path.isdir(git_dir):
         return

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -18,6 +18,7 @@
 # In any repo WITHOUT the flag, the hook exits silently (dormant) — the plugin
 # can be installed globally and stays out of the way everywhere else.
 
+import concurrent.futures
 import copy
 import datetime
 import os
@@ -240,15 +241,21 @@ def head_branch(root):
         return None
 
 
-def governance_line(root):
+def governance_line(root, ctx_text=None, ot_text=None, oq_text=None):
     """Display-only governance summary reused from statusline.arbiter_state:
     `stage:N tasks:N q:N over:N`. Returns "" when arbiter isn't enabled or on any
-    failure. DISPLAY ONLY — never acts on these counts."""
+    failure. DISPLAY ONLY — never acts on these counts.
+
+    performance-003 (#194): ctx_text/ot_text/oq_text let the caller (main(),
+    which already read CONTEXT.md/open-tasks.md/open-questions.md earlier in
+    the SAME invocation) thread that content through so arbiter_state doesn't
+    re-read those three files a second time. None (the default) preserves the
+    original behavior (arbiter_state reads them itself)."""
     sl_mod = _statusline()
     if sl_mod is None:
         return ""
     try:
-        st = sl_mod.arbiter_state(root)
+        st = sl_mod.arbiter_state(root, ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
     except Exception:  # noqa: BLE001
         return ""
     if not st:
@@ -257,9 +264,12 @@ def governance_line(root):
             f"q:{st['q']} over:{st['over']}")
 
 
-def render_full_briefing(root, summary):
+def render_full_briefing(root, summary, ctx_text=None, ot_text=None, oq_text=None):
     """Print the read-only daily briefing body: git hygiene state (with the
-    last-fetch staleness note) and the display-only governance line. No mutation."""
+    last-fetch staleness note) and the display-only governance line. No mutation.
+
+    ctx_text/ot_text/oq_text (performance-003) are threaded straight through to
+    governance_line — see its docstring."""
     print(f"  working tree: {'dirty' if summary['dirty'] else 'clean'} "
           f"(staged:{summary['staged']} unstaged:{summary['unstaged']} "
           f"untracked:{summary['untracked']})")
@@ -275,7 +285,7 @@ def render_full_briefing(root, summary):
               f"{', '.join(summary['prune_candidates'])}")
     if summary["stashes"]:
         print(f"  stashes: {summary['stashes']}")
-    gov = governance_line(root)
+    gov = governance_line(root, ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
     if gov:
         print(f"  {gov}")
 
@@ -297,30 +307,46 @@ def assemble_summary(root, runner=None, current=None, default="main", path_exist
     OR path missing on disk). The gone/merged set is derived from the SAME
     `branch -vv` text via merged_branch_candidates (the `: gone]` branches). The
     disk check uses an injectable `path_exists` so the field is deterministic in
-    tests. Read-only: identifies candidates only — never removes a worktree."""
-    porcelain = git_read(["status", "--porcelain=v1"], root, runner)
+    tests. Read-only: identifies candidates only — never removes a worktree.
+
+    performance-002 (#194): the five reads above are independent (each degrades
+    its own field on failure; none depends on another's output), so they fan out
+    across a small thread pool instead of running strictly sequentially — on
+    Windows especially, process-creation overhead for `git` compounds when five
+    spawns block one after another. Results are gathered before any parsing runs,
+    so the parsed values are byte-identical to the sequential form."""
+    reads = {
+        "porcelain": ["status", "--porcelain=v1"],
+        "revlist": ["rev-list", "--left-right", "--count", "@{u}...HEAD"],
+        "branch_vv": ["branch", "-vv"],
+        "worktree_raw": ["worktree", "list", "--porcelain"],
+        "stash_raw": ["stash", "list"],
+    }
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(reads)) as ex:
+        futures = {name: ex.submit(git_read, args, root, runner) for name, args in reads.items()}
+        out = {name: f.result() for name, f in futures.items()}
+
+    porcelain = out["porcelain"]
     p = parse_porcelain(porcelain)
 
-    revlist = git_read(["rev-list", "--left-right", "--count", "@{u}...HEAD"], root, runner)
+    revlist = out["revlist"]
     behind, ahead = parse_ahead_behind(revlist)
     # No tracking branch -> git errors -> git_read returns "". Distinguish that from
     # an in-sync upstream (which returns "0\t0") so the briefing can suppress the
     # misleading "behind 0, ahead 0 (as of last fetch)" line when no upstream exists.
     has_upstream = bool(revlist.strip())
 
-    branch_vv = git_read(["branch", "-vv"], root, runner)
+    branch_vv = out["branch_vv"]
     prune = merged_branch_candidates(branch_vv, current=current, default=default)
 
     # Stale-worktree candidates: parse `worktree list --porcelain`, derive the
     # gone/merged branch set from the same branch -vv text, classify. A read error
     # degrades to [] (parse_worktrees("") -> []), so the field never crashes.
-    worktrees = parse_worktrees(
-        git_read(["worktree", "list", "--porcelain"], root, runner), root
-    )
+    worktrees = parse_worktrees(out["worktree_raw"], root)
     gone = set(merged_branch_candidates(branch_vv, current=current, default=default))
     stale_worktrees = stale_worktree_candidates(worktrees, gone, path_exists=path_exists)
 
-    stashes = parse_stash_count(git_read(["stash", "list"], root, runner))
+    stashes = parse_stash_count(out["stash_raw"])
 
     return {
         "dirty": p["dirty"],
@@ -646,7 +672,11 @@ def main():
         print()
         print(f"=== codeArbiter daily briefing ({date_iso}) ===")
         print("First session of the day. Daily standup briefing (read-only).")
-        render_full_briefing(root, summary)
+        # performance-003 (#194): ctx_text/ot_text/oq_text were already read
+        # above for the startup-state block — thread them through so
+        # governance_line's arbiter_state() call doesn't re-read the same three
+        # files a second time in this same invocation.
+        render_full_briefing(root, summary, ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
         write_standup_marker(root, date_iso)
     elif mode == "offer":
         print(OFFER_LINE)

--- a/plugins/ca/hooks/statusline.py
+++ b/plugins/ca/hooks/statusline.py
@@ -248,8 +248,15 @@ try:
     def _arbiter_enabled(ctx_path):
         return _arbiterstatelib._arbiter_enabled(ctx_path, _frontmatter_enabled)
 
-    def arbiter_state(root):
-        return _arbiterstatelib.arbiter_state(root, _count_in_flight, _read_board, _frontmatter_enabled)
+    def arbiter_state(root, ctx_text=None, ot_text=None, oq_text=None):
+        # performance-003 (#194): ctx_text/ot_text/oq_text let a caller (e.g.
+        # session-start.py's governance_line) that already read CONTEXT.md/
+        # open-tasks.md/open-questions.md thread that content through instead of
+        # a second disk read. Every existing caller passes nothing and is
+        # unaffected.
+        return _arbiterstatelib.arbiter_state(
+            root, _count_in_flight, _read_board, _frontmatter_enabled,
+            ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
 except Exception:  # pragma: no cover — never let an import break the statusline
     _arbiterstatelib = None
     _ARBITER_CACHE = {}
@@ -267,7 +274,7 @@ except Exception:  # pragma: no cover — never let an import break the statusli
     def _arbiter_enabled(ctx_path):
         return False
 
-    def arbiter_state(root):
+    def arbiter_state(root, ctx_text=None, ot_text=None, oq_text=None):
         return None
 
     def dev_active(root):

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -267,12 +267,68 @@ class TestInstallSkipsReprobeWhenCurrent(_GitFixture):
 
     def test_confirmed_no_local_hooks_path_false_on_include_directive(self):
         # An [include] directive could pull in a hooksPath from elsewhere —
-        # our minimal parser doesn't follow it, so it must fail SAFE (treat as
-        # "not confirmed absent"), never silently ignore it.
+        # our grammar-free substring scan doesn't follow it, so it must fail
+        # SAFE (treat as "not confirmed absent"), never silently ignore it.
         cfg = os.path.join(self.root, ".git", "config")
         with open(cfg, "a", encoding="utf-8") as f:
             f.write("[include]\n\tpath = ../shared.gitconfig\n")
         self.assertFalse(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    # ------------------------------------------------------------------
+    # HIGH regression (re-review): git's config grammar honors a variable on
+    # the SAME line as its section header — `[core] hooksPath = x`,
+    # `[core]hooksPath=x`, `[CORE]HooksPath=x` are all valid, real-git-honored
+    # spellings a hand-rolled line-oriented section/key parser can miss. The
+    # grammar-free substring scan must catch every one of these regardless.
+    # ------------------------------------------------------------------
+
+    def _append_raw_config(self, text):
+        cfg = os.path.join(self.root, ".git", "config")
+        with open(cfg, "a", encoding="utf-8") as f:
+            f.write(text)
+
+    def test_confirmed_no_local_hooks_path_false_on_same_line_spaced(self):
+        self._append_raw_config("[core] hooksPath = customhooks\n")
+        self.assertFalse(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    def test_confirmed_no_local_hooks_path_false_on_same_line_no_space(self):
+        self._append_raw_config("[core]hooksPath=customhooks\n")
+        self.assertFalse(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    def test_confirmed_no_local_hooks_path_false_on_upper_section_and_key(self):
+        self._append_raw_config("[CORE]HooksPath=customhooks\n")
+        self.assertFalse(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    def test_same_line_hooks_path_is_not_skipped_end_to_end(self):
+        # End-to-end proof (not just the unit-level confirmation helper): a
+        # cold install, then a SAME-LINE hooksPath spelling written directly
+        # into .git/config (the same-line form real `git config` itself does
+        # not produce, but real git STILL HONORS when reading — verified by
+        # the sanity assertion below), then re-install must land in the
+        # custom dir, never be skipped as a no-op.
+        first = _githooks.install(self.root)
+        self.assertIn("pre-commit: installed", first)
+
+        custom_dir = os.path.join(self.root, "customhooks")
+        os.makedirs(custom_dir, exist_ok=True)
+        self._append_raw_config("[core] hooksPath = customhooks\n")
+
+        # Sanity: real git actually honors this same-line spelling (confirms
+        # the repro is real, not an artifact of our own parsing).
+        cfg_check = _git(["config", "--get", "core.hooksPath"], self.root)
+        self.assertEqual(cfg_check.stdout.strip(), "customhooks",
+                         "real git must honor the same-line hooksPath spelling "
+                         "for this regression to be meaningful")
+
+        second = _githooks.install(self.root)
+        self.assertNotEqual(second, [],
+                            "a same-line hooksPath spelling must never be skipped as a no-op")
+        for phase in ("pre-commit", "pre-push"):
+            dest = os.path.join(custom_dir, phase)
+            self.assertTrue(os.path.isfile(dest),
+                            f"{phase} must be installed into the NEW (same-line-configured) dir")
+            with open(dest, encoding="utf-8") as f:
+                self.assertIn(_githooks.SENTINEL, f.read())
 
     def test_cached_custom_hooks_path_is_never_fast_pathed(self):
         # Even if the shims at a CACHED custom hooksPath are still current and

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -200,6 +200,105 @@ class TestInstallSkipsReprobeWhenCurrent(_GitFixture):
         with open(os.path.join(self._hooks_dir(), "pre-commit"), encoding="utf-8") as f:
             self.assertIn("/moved/enforcer.py", f.read())
 
+    # ------------------------------------------------------------------
+    # CRITICAL regression (security review, post-#194): a LOCAL core.hooksPath
+    # change after a default-location install must NEVER be skipped past. The
+    # realistic trigger is the user later adopting husky / pre-commit-
+    # framework, which sets core.hooksPath in .git/config.
+    # ------------------------------------------------------------------
+
+    def test_local_hooks_path_added_after_install_is_not_skipped(self):
+        # Cold install at the default location.
+        first = _githooks.install(self.root)
+        self.assertIn("pre-commit: installed", first)
+        default_dir = self._hooks_dir()
+        for phase in ("pre-commit", "pre-push"):
+            self.assertTrue(os.path.isfile(os.path.join(default_dir, phase)))
+
+        # The user (or a tool like husky) now points core.hooksPath at a new,
+        # repo-local directory.
+        custom_dir = os.path.join(self.root, "customhooks")
+        _git(["config", "core.hooksPath", "customhooks"], self.root)
+
+        # Re-install MUST resolve into the NEW location — never silently skip
+        # past it because the OLD (.git/hooks) shims are still "current".
+        second = _githooks.install(self.root)
+        self.assertNotEqual(second, [],
+                            "a local core.hooksPath change must never be skipped as a no-op")
+        for phase in ("pre-commit", "pre-push"):
+            dest = os.path.join(custom_dir, phase)
+            self.assertTrue(os.path.isfile(dest),
+                            f"{phase} must be installed into the NEW hooksPath dir")
+            with open(dest, encoding="utf-8") as f:
+                self.assertIn(_githooks.SENTINEL, f.read())
+
+    def test_local_hooks_path_removed_after_install_falls_back_to_default(self):
+        # Symmetric case: install with a custom hooksPath already set, then
+        # unset it — re-install must land back in the default .git/hooks, not
+        # be skipped because SOME cached location happened to be current.
+        custom_dir = os.path.join(self.root, "customhooks")
+        _git(["config", "core.hooksPath", "customhooks"], self.root)
+        first = _githooks.install(self.root)
+        self.assertIn("pre-commit: installed", first)
+        for phase in ("pre-commit", "pre-push"):
+            self.assertTrue(os.path.isfile(os.path.join(custom_dir, phase)))
+
+        _git(["config", "--unset", "core.hooksPath"], self.root)
+
+        second = _githooks.install(self.root)
+        self.assertNotEqual(second, [],
+                            "unsetting a local core.hooksPath must never be skipped as a no-op")
+        default_dir = self._hooks_dir()
+        for phase in ("pre-commit", "pre-push"):
+            dest = os.path.join(default_dir, phase)
+            self.assertTrue(os.path.isfile(dest),
+                            f"{phase} must be (re)installed into the DEFAULT hooks dir")
+            with open(dest, encoding="utf-8") as f:
+                self.assertIn(_githooks.SENTINEL, f.read())
+
+    def test_confirmed_no_local_hooks_path_true_when_config_silent(self):
+        # Direct unit coverage of the confirmation helper itself: a bare repo
+        # with no hooksPath key anywhere in .git/config confirms absent.
+        self.assertTrue(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    def test_confirmed_no_local_hooks_path_false_when_set(self):
+        _git(["config", "core.hooksPath", "customhooks"], self.root)
+        self.assertFalse(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    def test_confirmed_no_local_hooks_path_false_on_include_directive(self):
+        # An [include] directive could pull in a hooksPath from elsewhere —
+        # our minimal parser doesn't follow it, so it must fail SAFE (treat as
+        # "not confirmed absent"), never silently ignore it.
+        cfg = os.path.join(self.root, ".git", "config")
+        with open(cfg, "a", encoding="utf-8") as f:
+            f.write("[include]\n\tpath = ../shared.gitconfig\n")
+        self.assertFalse(_githooks._confirmed_no_local_hooks_path(self.root))
+
+    def test_cached_custom_hooks_path_is_never_fast_pathed(self):
+        # Even if the shims at a CACHED custom hooksPath are still current and
+        # no local override is newly detected, a cached hooks_dir that is not
+        # the DEFAULT location must always re-confirm via the real probe —
+        # never trust a cached custom path blindly.
+        custom_dir = os.path.join(self.root, "customhooks")
+        _git(["config", "core.hooksPath", "customhooks"], self.root)
+        _githooks.install(self.root)  # writes cache pointing at customhooks
+
+        calls = []
+        orig = _githooks._git
+
+        def spy(args, cwd):
+            calls.append(list(args))
+            return orig(args, cwd)
+
+        _githooks._git = spy
+        try:
+            result = _githooks.install(self.root)
+        finally:
+            _githooks._git = orig
+        self.assertEqual(result, [])  # still a no-op...
+        self.assertTrue(calls, "a cached CUSTOM hooksPath must always re-confirm via git, "
+                              "never take the zero-spawn fast path")
+
 
 class TestPreCommitEnforce(_GitFixture):
     def _stage(self, name, content):

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ENFORCE = os.path.join(HOOKS, "git-enforce.py")
@@ -115,6 +116,89 @@ class TestInstall(_GitFixture):
         _githooks.install(self.root)
         _githooks.uninstall(self.root)
         self.assertFalse(os.path.isfile(os.path.join(self._hooks_dir(), "pre-commit")))
+
+
+class TestInstallSkipsReprobeWhenCurrent(_GitFixture):
+    """performance-002 (#194): a second install() call for the SAME repo, with
+    nothing changed, must skip the git-config/rev-parse re-probe entirely — the
+    cheap on-disk cache proves the hooks are already current without spawning
+    git at all. This is the semantic property the acceptance criteria asks for:
+    a SPECIFIC re-probe skipped, not a raw platform-varying spawn count."""
+
+    def _hooks_dir(self):
+        return os.path.join(self.root, ".git", "hooks")
+
+    def test_second_call_makes_zero_git_hooks_dir_probe_calls(self):
+        # First call: genuine cold install — the probe (_git) legitimately runs.
+        first_calls = []
+        orig = _githooks._git
+
+        def spy1(args, cwd):
+            first_calls.append(list(args))
+            return orig(args, cwd)
+
+        _githooks._git = spy1
+        try:
+            _githooks.install(self.root)
+        finally:
+            _githooks._git = orig
+        self.assertTrue(first_calls, "cold install must resolve hooks_dir via git")
+
+        # Second call against the SAME repo, nothing changed: the cached
+        # hooks_dir + up-to-date shim check must short-circuit BEFORE hooks_dir()
+        # ever calls _git — zero git-hooks-dir-probe spawns this time.
+        second_calls = []
+
+        def spy2(args, cwd):
+            second_calls.append(list(args))
+            return orig(args, cwd)
+
+        _githooks._git = spy2
+        try:
+            result = _githooks.install(self.root)
+        finally:
+            _githooks._git = orig
+        self.assertEqual(result, [])
+        self.assertEqual(second_calls, [],
+                         "install() must skip the hooks_dir git-config/rev-parse "
+                         "re-probe when the cached hooks are already current")
+
+    def test_cache_miss_falls_through_to_full_probe(self):
+        # A cache-miss (nothing installed yet, no cache file) must still fully
+        # resolve and install via the real git-based probe — the fast path
+        # never substitutes for a genuine cold install.
+        cache_file = os.path.join(self.root, ".git", _githooks._HOOKSDIR_CACHE_NAME)
+        self.assertFalse(os.path.isfile(cache_file))
+        actions = _githooks.install(self.root)
+        self.assertIn("pre-commit: installed", actions)
+        self.assertIn("pre-push: installed", actions)
+        self.assertTrue(os.path.isfile(cache_file),
+                        "a successful resolution must persist the hooks_dir cache")
+
+    def test_stale_cached_hooks_dir_falls_through(self):
+        # A cache file naming a directory that no longer exists must be treated
+        # as a miss (never trusted blindly).
+        os.makedirs(os.path.join(self.root, ".git"), exist_ok=True)
+        cache_file = os.path.join(self.root, ".git", _githooks._HOOKSDIR_CACHE_NAME)
+        with open(cache_file, "w", encoding="utf-8") as f:
+            f.write(os.path.join(self.root, "_nonexistent_hooks_dir") + "\n")
+        actions = _githooks.install(self.root)
+        self.assertIn("pre-commit: installed", actions)
+        for phase in ("pre-commit", "pre-push"):
+            self.assertTrue(os.path.isfile(os.path.join(self._hooks_dir(), phase)))
+
+    def test_mismatched_enforcer_path_falls_through_not_silently_skipped(self):
+        # If the enforcer path changed (e.g. a plugin update moved the install
+        # dir) since the cache was written, the shim content no longer matches
+        # -> _hooks_current() must return False -> the full probe must run and
+        # refresh the shim, never silently skip a needed update.
+        _githooks.install(self.root)  # writes the cache with the real enforcer path
+        with mock.patch.object(_githooks, "_enforcer_path", return_value="/moved/enforcer.py"):
+            actions = _githooks.install(self.root)
+        self.assertIn("pre-commit: installed", actions)
+        self.assertIn("pre-push: installed", actions)
+        with open(os.path.join(self._hooks_dir(), "pre-commit"), encoding="utf-8") as f:
+            self.assertIn("/moved/enforcer.py", f.read())
 
 
 class TestPreCommitEnforce(_GitFixture):

--- a/plugins/ca/hooks/tests/test_standup.py
+++ b/plugins/ca/hooks/tests/test_standup.py
@@ -801,6 +801,54 @@ class TestAssembleSummaryStaleWorktrees(unittest.TestCase):
         self.assertTrue(sl.any_actionable(summary))
 
 
+class TestAssembleSummaryFanOut(unittest.TestCase):
+    """performance-002 (#194): assemble_summary's five git reads are independent
+    (documented in its own docstring), so they must run CONCURRENTLY rather than
+    strictly sequentially — on Windows especially, git process-creation overhead
+    compounds when five spawns block one after another.
+
+    Proof: an injected runner that sleeps a fixed delay per call. Five
+    sequential calls would take >= 5x the delay; a fan-out takes roughly ONE
+    delay (all five overlapping). This is a semantic property of the
+    concurrency, not a raw platform-varying spawn count — the exact assertion
+    the acceptance criteria calls for."""
+
+    def test_five_reads_run_concurrently_not_sequentially(self):
+        import time as _time
+
+        DELAY = 0.15
+
+        def slow_runner(args, root):
+            _time.sleep(DELAY)
+            joined = " ".join(args)
+            if "rev-list" in joined:
+                return "0\t0"
+            if "branch" in joined:
+                return "* main aaa [origin/main] mainline\n"
+            return ""
+
+        t0 = _time.time()
+        summary = _mod.assemble_summary(
+            "/root", runner=slow_runner, current="main", default="main",
+        )
+        elapsed = _time.time() - t0
+
+        # Sanity: the summary still assembled correctly despite the fan-out.
+        self.assertFalse(summary["dirty"])
+        self.assertEqual(summary["behind"], 0)
+        self.assertEqual(summary["ahead"], 0)
+
+        # Sequential would take >= 5 * DELAY (0.75s); concurrent takes roughly
+        # one DELAY plus scheduling slack. A generous 3x-single-delay ceiling
+        # proves fan-out without being a flaky tight bound.
+        self.assertLess(
+            elapsed, DELAY * 3,
+            f"assemble_summary's 5 git reads took {elapsed:.3f}s for a "
+            f"{DELAY}s-per-call runner — they are running sequentially, not "
+            f"concurrently (sequential would take >= {DELAY * 5:.3f}s)",
+        )
+
+
 class _MainHarness(unittest.TestCase):
     """Shared scaffolding for exercising session-start.py main() deterministically.
 
@@ -1121,6 +1169,70 @@ class TestReadOnlyProof(_MainHarness):
         self.assertTrue(os.path.isfile(
             _mod.standup_marker_path(self.root, date_iso)
         ))
+
+
+class TestMainDoesNotDoubleReadGovernanceInputs(_MainHarness):
+    """performance-003 (#194): the full-briefing path's governance_line() call
+    reuses main()'s own CONTEXT.md/open-tasks.md/open-questions.md reads
+    instead of arbiter_state() re-reading them from disk a second time.
+
+    open-tasks.md and open-questions.md have exactly ONE legitimate reader in
+    main() (main()'s own read_text) — so after the fix each is opened exactly
+    once for the whole invocation. CONTEXT.md has TWO legitimate readers
+    (the up-front dormancy gate via _hooklib.frontmatter_enabled, and main()'s
+    own read_text for the INITIALIZED/stage checks) — that pre-existing pair is
+    out of scope for this fix (a different concern, #194 only targets
+    arbiter_state's re-read); the assertion pins it at exactly 2, proving the
+    THIRD and FOURTH reads (arbiter_state's own frontmatter()/_arbiter_enabled()
+    disk reads) are gone."""
+
+    def setUp(self):
+        super().setUp()
+        self._write_context(_ENABLED_INITIALIZED_CONTEXT)
+        cad = os.path.join(self.root, ".codearbiter")
+        with open(os.path.join(cad, "open-tasks.md"), "w", encoding="utf-8") as f:
+            f.write("- [ ] t.t.0001 - a task\n")
+        with open(os.path.join(cad, "open-questions.md"), "w", encoding="utf-8") as f:
+            f.write("no confirms\n")
+        _mod._default_git_runner = lambda args, root: ""
+        _mod._detached_fetch_spawner = lambda args, root: _FakeProc()
+
+    def test_ot_and_oq_opened_exactly_once_ctx_opened_exactly_twice(self):
+        ctx_path = os.path.normcase(os.path.abspath(
+            os.path.join(self.root, ".codearbiter", "CONTEXT.md")))
+        ot_path = os.path.normcase(os.path.abspath(
+            os.path.join(self.root, ".codearbiter", "open-tasks.md")))
+        oq_path = os.path.normcase(os.path.abspath(
+            os.path.join(self.root, ".codearbiter", "open-questions.md")))
+        counts = {"ctx": 0, "ot": 0, "oq": 0}
+        real_open = open
+
+        def spy_open(path, *a, **kw):
+            try:
+                norm = os.path.normcase(os.path.abspath(path))
+            except Exception:  # noqa: BLE001
+                norm = None
+            if norm == ctx_path:
+                counts["ctx"] += 1
+            elif norm == ot_path:
+                counts["ot"] += 1
+            elif norm == oq_path:
+                counts["oq"] += 1
+            return real_open(path, *a, **kw)
+
+        import unittest.mock as _mock
+        with _mock.patch("builtins.open", side_effect=spy_open):
+            out = self._run_main()
+
+        self.assertIn("daily briefing", out)  # sanity: full-briefing path ran
+        self.assertEqual(counts["ot"], 1,
+                         "open-tasks.md must be opened exactly once per invocation")
+        self.assertEqual(counts["oq"], 1,
+                         "open-questions.md must be opened exactly once per invocation")
+        self.assertEqual(counts["ctx"], 2,
+                         "CONTEXT.md's two LEGITIMATE readers (the dormancy gate + "
+                         "main()'s own read) must survive, but arbiter_state's extra "
+                         "re-reads must be gone")
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -557,6 +557,85 @@ class TestArbiterStateCache(unittest.TestCase):
         sl._ARBITER_CACHE.clear()
         self.assertIsNone(sl.arbiter_state(self.tmp))
 
+
+class TestArbiterStatePreread(unittest.TestCase):
+    """performance-003 (#194): arbiter_state(root, ctx_text=, ot_text=, oq_text=)
+    must use the SUPPLIED content instead of re-reading CONTEXT.md/open-tasks.md/
+    open-questions.md from disk — SessionStart's main() already read those three
+    files earlier in the same invocation before calling into the governance
+    line. Proven two ways: (1) the returned values reflect the SUPPLIED text
+    even when it deliberately diverges from what's on disk, and (2) a spy on
+    open() shows the three preread paths are never opened a second time."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.cad = os.path.join(self.tmp, ".codearbiter")
+        os.makedirs(self.cad, exist_ok=True)
+        # Disk content deliberately WRONG — if the code fell back to reading
+        # disk instead of using the supplied text, these values would leak
+        # through and the assertions below would catch it.
+        self._write("CONTEXT.md", "---\narbiter: enabled\nstage: DISK-STAGE\n---\n")
+        self._write("open-tasks.md", "- [ ] t.t.0001 - disk task a\n"
+                                     "- [ ] t.t.0002 - disk task b\n"
+                                     "- [ ] t.t.0003 - disk task c\n")
+        self._write("open-questions.md", "no confirms here on disk\n")
+        self._write("overrides.log", "")
+        self._write("last-checkpoint", "0")
+        sl._ARBITER_CACHE.clear()
+
+    def _write(self, name, body):
+        with open(os.path.join(self.cad, name), "w", encoding="utf-8", newline="\n") as f:
+            f.write(body)
+
+    def test_supplied_text_wins_over_disk_content(self):
+        ctx_text = "---\narbiter: enabled\nstage: SUPPLIED-STAGE\n---\n"
+        ot_text = "- [ ] t.t.0009 - supplied task\n"
+        oq_text = "[CONFIRM-01] one supplied question\n"
+
+        st = sl.arbiter_state(self.tmp, ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
+
+        self.assertIsNotNone(st)
+        self.assertEqual(st["stage"], "SUPPLIED-STAGE")
+        self.assertEqual(st["tasks"], 1)
+        self.assertEqual(st["q"], 1)
+
+    def test_no_preread_args_still_reads_disk_as_before(self):
+        # Backward compatibility: every existing caller passes nothing, and
+        # must see the ORIGINAL disk-derived behavior unchanged.
+        st = sl.arbiter_state(self.tmp)
+        self.assertEqual(st["stage"], "DISK-STAGE")
+        self.assertEqual(st["tasks"], 3)
+        self.assertEqual(st["q"], 0)
+
+    def test_supplied_text_means_the_three_files_are_never_reopened(self):
+        ctx_path = os.path.join(self.cad, "CONTEXT.md")
+        ot_path = os.path.join(self.cad, "open-tasks.md")
+        oq_path = os.path.join(self.cad, "open-questions.md")
+        forbidden = {os.path.normcase(ctx_path), os.path.normcase(ot_path),
+                    os.path.normcase(oq_path)}
+        opened = []
+        real_open = open
+
+        def spy_open(path, *a, **kw):
+            try:
+                norm = os.path.normcase(os.path.abspath(path))
+            except Exception:  # noqa: BLE001
+                norm = None
+            opened.append(norm)
+            if norm in forbidden:
+                raise AssertionError(f"unexpected re-open of preread path: {path}")
+            return real_open(path, *a, **kw)
+
+        ctx_text = "---\narbiter: enabled\nstage: SUPPLIED-STAGE\n---\n"
+        ot_text = "- [ ] t.t.0009 - supplied task\n"
+        oq_text = "[CONFIRM-01] one supplied question\n"
+
+        with mock.patch("builtins.open", side_effect=spy_open):
+            st = sl.arbiter_state(self.tmp, ctx_text=ctx_text, ot_text=ot_text, oq_text=oq_text)
+
+        self.assertIsNotNone(st)
+        self.assertEqual(st["stage"], "SUPPLIED-STAGE")
+
     def test_enabled_gate_routes_through_hooklib_when_available(self):
         # When _hooklib is importable, the gate uses frontmatter_enabled — confirm
         # the activation decision still resolves correctly via that path.


### PR DESCRIPTION
Lane E3 — #194 (performance — sessionstart-latency: performance-002/003). The linchpin SessionStart hook blocked on redundant work before the persona reached the model.

## What
- **performance-002:** (a) the hooks-install re-probe (`_githooks.install`) now skips its git spawns when a cheap on-disk cache proves the shims are current — **fail-safe** (see below); (b) the 5 independent `assemble_summary` git reads (status/rev-list/branch/worktree/stash) now run concurrently via a `ThreadPoolExecutor` instead of strictly sequentially — parsing is unchanged, output byte-identical.
- **performance-003:** the first-of-day briefing re-read `CONTEXT.md`/`open-tasks.md`/`open-questions.md` via `arbiter_state` after `main()` already read them — the already-read text is now threaded through (new optional `ctx_text`/`ot_text`/`oq_text` kwargs, `None` = original disk-read behavior for all other callers).

## Fail-safe hooks-install skip (reviewed hard — this touches the #161 backstop)
The skip fires ONLY when it can positively, spawn-free confirm no hooks redirect: cached dir is exactly `<root>/.git/hooks` AND `_confirmed_no_local_hooks_path` (a **grammar-free** case-insensitive `hookspath` substring scan of `.git/config`/`config.worktree` — cannot under-detect any git-config spelling) finds none AND no `[include]` AND the shims still match the current enforcer path. Any read failure / `hookspath` / `[include]` / cached custom hooksPath / global-config change (`~/.gitconfig`+XDG mtime token) → fall through to the full install. Fail direction is **install-when-unsure, never skip-when-unsure** — the fast path can never leave the git-enforce backstop unwired.

## Verification
- **762 hook tests pass** (+ new spies: zero-git-spawn second probe, concurrent-not-sequential fan-out timing, exact governance-file open counts, and the same-line/no-space/upper-case `core.hooksPath` regressions); `test_hooks_cold_install.py` PASS (a genuine cold install still wires the hooks); existing `session-start`/`wire-statusline`/`git-enforce` assertions UNMODIFIED and green; `py_compile` clean; LF.
- **security-reviewer: PASS after two fix rounds.** The initial skip could leave the #161 backstop unwired on a post-install `core.hooksPath` change (CRITICAL) — fixed with the spawn-free `.git/config` confirmation; a follow-up caught git's same-line config spelling (HIGH) — fixed with the grammar-free substring scan. Both regressions verified to fail against the pre-fix commits. Fan-out (no shared state, best-effort) and thread-through (identical parsing) cleared first pass.

Bumps ca 2.8.9 → 2.8.10. Documents the fast-path posture in `security-controls.md` §Hook security.

Closes #194

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa