### PR TITLE
feat(hooks): durable gate-events sink + audit staleness-warn (#186, CONFIRM-09)

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -240,12 +240,22 @@ tool-call boundary.
 controls, not *completeness* controls — they protect a log once written, they do
 not compel a write. The completeness half is resolved by `[CONFIRM-09]`
 (2026-07-02, BY SUaDtL@users.noreply.github.com): strategy (a) — a lightweight
-staleness check (PostToolUse/UserPromptSubmit) warns when an active `/sprint`,
-`/override`, or `/dev` flow has not appended its expected log line within a
-bounded window — paired with the durable gate-events sink from `observability-001`
-(issue #186). It is a *warn*, not a hard gate: a missed write is surfaced, not
-blocked, keeping the integrity guards the sole true STOP. Implementation lands
-with #186.
+staleness check (UserPromptSubmit) warns when an active `/sprint` or `/dev`
+flow has not appended its expected log line (`sprint-log.md` / `overrides.log`)
+within a bounded window — paired with the durable gate-events sink from
+`observability-001` (issue #186). It is a *warn*, not a hard gate: a missed write
+is surfaced, not blocked, keeping the integrity guards the sole true STOP.
+**Shipped in ca 2.8.11 (#186):** `_hooklib` `block()`/`remind()`/`warn()`
+best-effort append a structured line to `.codearbiter/gate-events.log` (fail-open
+— a locked/missing/unwritable log never changes a hook's exit code nor suppresses
+a BLOCK; the write is wrapped so no exception escapes into any of the 16 entry
+hooks), and `_hooklib.staleness_warning` surfaces stale active flows only through
+`warn()` (non-blocking by construction). `gate-events.log` is append-only —
+added to `AUDIT_LOG_BASENAMES`, the single source that `AUDIT_LOG_NAMES` and all
+three H-05 flanks (shell pre-filter + regex, Write, Edit) derive from, so the set
+cannot drift. `/override` is deliberately **not** staleness-tracked: it is a
+single synchronous announce-then-log action with no in-progress marker to key
+off (per CONFIRM-09's "don't invent new state" constraint).
 The `pre-bash.py` shell guard is lexical and anchored on the literal log name, so
 the following truncation/indirection spellings are out of scope and accepted as
 residual risk (the sanctioned bypass for legitimate log management is

--- a/.github/scripts/test_hook_guards.py
+++ b/.github/scripts/test_hook_guards.py
@@ -203,14 +203,21 @@ def main():
                     "echo x > .codearbiter/sprint-log.md",
                     "echo x >| .codearbiter/sprint-log.md",
                     "rm .codearbiter/sprint-log.md",
-                    "Set-Content .codearbiter/sprint-log.md 'gone'"):
+                    "Set-Content .codearbiter/sprint-log.md 'gone'",
+                    # gate-events.log (observability-001, #186) joins the append-only
+                    # set — the durable BLOCK/REMIND/WARN sink gets the same H-05
+                    # tool-call protection as the other three audit logs.
+                    "echo x > .codearbiter/gate-events.log",
+                    "rm .codearbiter/gate-events.log"):
             expect_block(fx, cmd, "H-05", f"H-05 block: {cmd}")
         for cmd in ("echo entry >> .codearbiter/overrides.log",
                     "echo entry >> .codearbiter/sprint-log.md",
+                    "echo entry >> .codearbiter/gate-events.log",
                     "cat .codearbiter/overrides.log",
                     "grep GATE .codearbiter/overrides.log",
                     "cat .codearbiter/sprint-log.md",
-                    "tail -5 .codearbiter/triage.log"):
+                    "tail -5 .codearbiter/triage.log",
+                    "cat .codearbiter/gate-events.log"):
             expect_allow(fx, cmd, f"H-05 allow: {cmd}")
 
         # ---- H-11: no shell writes into .codearbiter/decisions/ --------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Every intent routes through a gated skill or reviewer agent. Nothing commits until the gates are green. Decisions go through SMARTS. The audit trail is append-only.
 
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
-<img alt="version 2.8.10" src="https://img.shields.io/badge/version-2.8.10-2b7489">
+<img alt="version 2.8.11" src="https://img.shields.io/badge/version-2.8.11-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-39-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-22-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -53,7 +53,11 @@
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
+#   staleness_warning(root, now=None, window_minutes=30) -> list[str]
+#                                         (CONFIRM-09) active-flow audit-log staleness
+#                                         messages, WARN-only, never raises
 
+import datetime
 import hashlib
 import json
 import os
@@ -118,7 +122,15 @@ ARBITER_RE = re.compile(r"^\s*arbiter:\s*enabled\s*$", re.I)
 # and DECISIONS_PATH_RE extends it to a full ADR file path. `[\\/]+` matches the
 # norm_path'd `/` as well as a raw backslash, so both the file-path and shell
 # flanks derive from one source.
-AUDIT_LOG_NAMES = r"(?:(?:overrides|triage)\.log|sprint-log\.md)"
+#
+# gate-events.log (observability-001, #186) joins this set: it is the durable,
+# mechanical BLOCK/REMIND/WARN sink block()/remind()/warn() append to below —
+# an append-only audit artifact exactly like the other three, so it gets the
+# SAME H-05 tool-call protection (Write/Edit + shell) for free via this one
+# alternation, with no separate guard to maintain. Note this protects it only
+# from Write/Edit/Bash TOOL CALLS; the hooks' own os-level `open(..., "a")`
+# append (below) is plain file I/O, never a tool call, so H-05 never gates it.
+AUDIT_LOG_NAMES = r"(?:(?:overrides|triage|gate-events)\.log|sprint-log\.md)"
 AUDIT_LOG_RE = re.compile(r"\.codearbiter/" + AUDIT_LOG_NAMES + r"$")
 DECISIONS_DIR_RE = r"\.codearbiter[\\/]+decisions"
 DECISIONS_PATH_RE = re.compile(DECISIONS_DIR_RE + r"[\\/]+.+\.md$")
@@ -141,7 +153,8 @@ GATE_MARKER_NAMES = r"(?:security-gate-passed|migration-gate-passed)"
 
 def is_audit_log(rel):
     """True iff `rel` is one of the append-only .codearbiter audit logs
-    (overrides.log, triage.log, sprint-log.md) — the H-05 guard set."""
+    (overrides.log, triage.log, sprint-log.md, gate-events.log) — the H-05
+    guard set."""
     return bool(AUDIT_LOG_RE.search(norm_path(rel)))
 
 
@@ -625,17 +638,117 @@ def marker_fresh(path, minutes):
         return False
 
 
+def _log_gate_event(kind, tag, msg):
+    """Best-effort durable append of one gate decision to
+    .codearbiter/gate-events.log (observability-001, issue #186) — the durable
+    sink block()/remind()/warn() funnel every BLOCK/REMIND/WARN through, so a
+    decision is no longer visible ONLY in the ephemeral per-turn stderr
+    transcript.
+
+    One line per event: `[ISO-8601Z] KIND [tag] hook=<script> | msg`. `tag` may
+    be None (warn() carries no tag) — the bracket is simply omitted then.
+    `hook` is the invoking script's basename (`sys.argv[0]`), the one
+    "which hook fired this" signal available at this shared layer without
+    threading a new parameter through all 21 call sites across the 16 entry
+    hooks.
+
+    FAIL-OPEN BY CONTRACT (AC-2): this function must NEVER raise and must
+    NEVER be allowed to change the caller's exit code or suppress its stderr
+    output. A missing `.codearbiter/` dir, an unwritable/locked/missing log
+    file, or project_root() itself misbehaving are ALL swallowed silently
+    here — the ONE deliberate exception to this module's fail-loud discipline,
+    mirroring the documented fail-open exception in read_input()."""
+    try:
+        root = project_root()
+        cad = os.path.join(root, ".codearbiter")
+        if not os.path.isdir(cad):
+            return  # repo never opted in (no .codearbiter/) — nothing to append to
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        hook = os.path.basename(sys.argv[0]) if sys.argv and sys.argv[0] else "-"
+        tag_part = f"[{tag}] " if tag else ""
+        line = f"[{ts}] {kind} {tag_part}hook={hook} | {msg}\n"
+        with open(os.path.join(cad, "gate-events.log"), "a",
+                  encoding="utf-8", newline="\n") as f:
+            f.write(line)
+    except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
+        pass
+
+
 def block(tag, msg):
     """BLOCK the tool call: stderr is surfaced to Claude, exit 2."""
+    _log_gate_event("BLOCK", tag, msg)
     print(f"BLOCKED [{tag}]: {msg}", file=sys.stderr)
     sys.exit(2)
 
 
 def remind(tag, msg):
     """Non-blocking nudge to stderr."""
+    _log_gate_event("REMIND", tag, msg)
     print(f"REMINDER [{tag}]: {msg}", file=sys.stderr)
 
 
 def warn(msg):
     """Loud degradation/diagnostic breadcrumb — never silent."""
+    _log_gate_event("WARN", None, msg)
     print(f"codeArbiter hook: {msg}", file=sys.stderr)
+
+
+# --- CONFIRM-09: audit-trail completeness staleness-warn ---------------------
+# The H-05 guards above are INTEGRITY controls (a written audit line can't be
+# rewritten/deleted) — they don't compel a write in the first place. This is
+# the accepted-strategy (a) completeness half (security-controls.md § Audit
+# trail, 2026-07-02): a lightweight WARN, never a gate, surfaced when an
+# active long-running flow's marker has sat around past `window_minutes` with
+# no matching activity in its expected audit log.
+#
+# Only /dev and /sprint have a persistent "in-progress" marker today
+# (.codearbiter/.markers/dev-active and .codearbiter/sprint-active — the same
+# state _arbiterstatelib.dev_active()/arbiter_state() already read). /override
+# is a single synchronous action (announce-then-log in one turn, per
+# override.md) with no analogous "still in progress" marker anywhere in the
+# framework, so per CONFIRM-09's own "do not invent new state" constraint it
+# is not tracked here — there is no existing signal to detect it from.
+_STALE_FLOWS = (
+    # (flow name, marker path parts, expected-log path parts)
+    ("dev", (".markers", "dev-active"), ("overrides.log",)),
+    ("sprint", ("sprint-active",), ("sprint-log.md",)),
+)
+
+
+def staleness_warning(root, now=None, window_minutes=30):
+    """(CONFIRM-09) One WARN message per active flow (see _STALE_FLOWS) whose
+    marker has existed for at least `window_minutes` with no audit-log
+    activity (marker touch OR log write) inside that same window. Returns []
+    when nothing is stale (including when no flow is active at all).
+
+    WARN-ONLY BY CONTRACT: this function only computes strings — it has no
+    side effects, never calls warn()/block() itself, and can NEVER raise (any
+    per-flow stat failure just skips that flow, exactly like marker_fresh's
+    own degrade-to-False). The caller decides whether to surface the result,
+    typically via warn(), which is itself non-blocking."""
+    now = time.time() if now is None else now
+    cad = os.path.join(root, ".codearbiter")
+    messages = []
+    for name, marker_parts, log_parts in _STALE_FLOWS:
+        try:
+            marker = os.path.join(cad, *marker_parts)
+            if not os.path.isfile(marker):
+                continue
+            marker_mtime = os.path.getmtime(marker)
+            if now - marker_mtime < window_minutes * 60:
+                continue  # flow started too recently to call it stale yet
+            log_path = os.path.join(cad, *log_parts)
+            try:
+                log_mtime = os.path.getmtime(log_path)
+            except OSError:
+                log_mtime = 0  # log never written at all -> definitely stale
+            last_activity = max(marker_mtime, log_mtime)
+            if now - last_activity >= window_minutes * 60:
+                messages.append(
+                    f"/{name} has been active for over {window_minutes} min with no "
+                    f"matching {os.path.basename(log_path)} entry since — confirm the "
+                    f"expected audit line landed (CONFIRM-09)."
+                )
+        except Exception:  # noqa: BLE001 — never raise; skip this flow, not the caller
+            continue
+    return messages

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -130,7 +130,19 @@ ARBITER_RE = re.compile(r"^\s*arbiter:\s*enabled\s*$", re.I)
 # alternation, with no separate guard to maintain. Note this protects it only
 # from Write/Edit/Bash TOOL CALLS; the hooks' own os-level `open(..., "a")`
 # append (below) is plain file I/O, never a tool call, so H-05 never gates it.
-AUDIT_LOG_NAMES = r"(?:(?:overrides|triage|gate-events)\.log|sprint-log\.md)"
+#
+# AUDIT_LOG_BASENAMES is the single authoritative list of bare filenames — the
+# ONE place a new audit log gets added. pre-bash.py's H-05 shell guard needs
+# these as plain strings too (a cheap `n in cmd` substring pre-filter before
+# running the regexes below), so it imports this tuple directly instead of
+# re-deriving/hand-copying the name set (the exact drift this centralization
+# exists to prevent — a filter that silently skips a future audit log because
+# its literal name was never added to a second, hand-maintained copy).
+# AUDIT_LOG_NAMES is built FROM this tuple (re.escape'd, alternated) — behavior
+# is unchanged from the prior hand-written pattern (same four literal
+# filenames, same (?:...) grouping), only the source of truth moved.
+AUDIT_LOG_BASENAMES = ("overrides.log", "triage.log", "gate-events.log", "sprint-log.md")
+AUDIT_LOG_NAMES = "(?:" + "|".join(re.escape(n) for n in AUDIT_LOG_BASENAMES) + ")"
 AUDIT_LOG_RE = re.compile(r"\.codearbiter/" + AUDIT_LOG_NAMES + r"$")
 DECISIONS_DIR_RE = r"\.codearbiter[\\/]+decisions"
 DECISIONS_PATH_RE = re.compile(DECISIONS_DIR_RE + r"[\\/]+.+\.md$")

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -22,9 +22,10 @@ import traceback
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE, GATE_MARKER_NAMES, SECRET_RE,
-    arbiter_active, block, content_digest, is_migration_path, line_digest,
-    marker_fresh, project_root, read_input, tool_input, utf8_stdio,
+    AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
+    GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
+    is_migration_path, line_digest, marker_fresh, project_root, read_input,
+    tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -682,11 +683,12 @@ def _run(root):
     # H-05: the audit trail is append-only — block truncation/removal of the
     # audit logs via shell verbs (Write/Edit are guarded separately). The
     # substring pre-filter is a cheap short-circuit before the two regexes
-    # below (avoids running them against every command); it must name every
-    # AUDIT_LOG_NAMES member or a new log silently skips this whole check —
-    # gate-events.log (observability-001, #186) joins the other three here.
-    if ("overrides.log" in cmd or "triage.log" in cmd or "sprint-log.md" in cmd
-            or "gate-events.log" in cmd) and (
+    # below (avoids running them against every command); it is DERIVED from
+    # _hooklib.AUDIT_LOG_BASENAMES (the single authoritative name list)
+    # instead of a hand-copied literal list, so a future audit log added there
+    # can never silently skip this shell flank (the exact drift
+    # security-controls.md § Audit trail centralization exists to prevent).
+    if any(n in cmd for n in AUDIT_LOG_BASENAMES) and (
             LOG_TRUNC_RE.search(cmd) or LOG_DESTROY_RE.search(cmd)):
         block("H-05", "The .codearbiter audit logs (overrides.log, triage.log, sprint-log.md, "
                       "gate-events.log) are append-only (ORCHESTRATOR §7). Truncating, "

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -680,12 +680,18 @@ def _run(root):
                           f"per file (commit-gate skill).")
 
     # H-05: the audit trail is append-only — block truncation/removal of the
-    # audit logs via shell verbs (Write/Edit are guarded separately).
-    if ("overrides.log" in cmd or "triage.log" in cmd or "sprint-log.md" in cmd) and (
+    # audit logs via shell verbs (Write/Edit are guarded separately). The
+    # substring pre-filter is a cheap short-circuit before the two regexes
+    # below (avoids running them against every command); it must name every
+    # AUDIT_LOG_NAMES member or a new log silently skips this whole check —
+    # gate-events.log (observability-001, #186) joins the other three here.
+    if ("overrides.log" in cmd or "triage.log" in cmd or "sprint-log.md" in cmd
+            or "gate-events.log" in cmd) and (
             LOG_TRUNC_RE.search(cmd) or LOG_DESTROY_RE.search(cmd)):
-        block("H-05", "The .codearbiter audit logs (overrides.log, triage.log, sprint-log.md) "
-                      "are append-only (ORCHESTRATOR §7). Truncating, overwriting, or deleting "
-                      "the audit trail is prohibited; append with '>>' only.")
+        block("H-05", "The .codearbiter audit logs (overrides.log, triage.log, sprint-log.md, "
+                      "gate-events.log) are append-only (ORCHESTRATOR §7). Truncating, "
+                      "overwriting, or deleting the audit trail is prohibited; append with "
+                      "'>>' only.")
 
     # H-11: ADRs exist only via /adr — the Write/Edit tools are guarded by
     # pre-write/pre-edit, and this closes the shell flank (`echo > decisions/…`,

--- a/plugins/ca/hooks/prune-transcript.py
+++ b/plugins/ca/hooks/prune-transcript.py
@@ -34,6 +34,27 @@ def utf8_stdio():
             pass
 
 
+def staleness_check(payload):
+    """(CONFIRM-09) WARN, never block, when an active /dev or /sprint flow's
+    marker has sat past the staleness window with no matching audit-log
+    activity — see _hooklib.staleness_warning for the detection rule and
+    security-controls.md § Audit trail for the accepted-strategy rationale.
+
+    Only runs when the repo has opted in (arbiter_active). Best-effort: ANY
+    failure (missing _hooklib import, a broken root, an unreadable marker)
+    degrades to doing nothing — this must never affect prune-transcript.py's
+    hook-mode exit code (always 0) or block the user's prompt."""
+    try:
+        import _hooklib
+        root = payload.get("cwd") or os.getcwd()
+        if not _hooklib.arbiter_active(root):
+            return
+        for msg in _hooklib.staleness_warning(root):
+            _hooklib.warn(msg)
+    except Exception:  # noqa: BLE001 — a missed warn is acceptable; a crash is not
+        pass
+
+
 def resolve(path_or_id):
     """Accept a direct path or a bare session id (resolved under ~/.claude)."""
     if os.path.isfile(path_or_id):
@@ -120,6 +141,12 @@ def main(argv=None):
             except Exception:  # noqa: BLE001
                 payload = {}
             if isinstance(payload, dict) and payload.get("hook_event_name"):
+                # CONFIRM-09 staleness-warn: runs unconditionally on
+                # UserPromptSubmit (independent of CODEARBITER_PRUNE, which
+                # gates hook_run's own pruning logic below) — a WARN-only
+                # check must not depend on an unrelated opt-in env var.
+                if payload.get("hook_event_name") == "UserPromptSubmit":
+                    staleness_check(payload)
                 return hook_run(payload)
         print("usage: prune-transcript.py <path|session-id> [--execute] ...",
               file=sys.stderr)

--- a/plugins/ca/hooks/tests/test_gate_events.py
+++ b/plugins/ca/hooks/tests/test_gate_events.py
@@ -1,0 +1,281 @@
+"""observability-001 (#186): durable gate-events sink for block()/remind()/warn().
+
+AC-1: a repo-local run of a hook that hits block()/remind()/warn() produces a
+durable, greppable record in .codearbiter/gate-events.log, outside the live
+stderr transcript.
+
+AC-2 (load-bearing): the write path is FAIL-OPEN — a locked/missing/unwritable
+gate-events.log (or a project_root() that itself misbehaves) must NEVER change
+the caller's exit code and must NEVER raise. block() still exits 2 with its
+stderr message intact; remind()/warn() still return normally.
+
+CONFIRM-09: the paired staleness-warn (_hooklib.staleness_warning) is WARN-only
+— it never has side effects and never raises, and a stale /dev or /sprint flow
+is detected purely from the markers the framework already drops.
+
+Stdlib only. Fail-open is proven via a directory-collision on the log path and
+via a patched writer that raises — never by unsetting PATH/env (that changes
+an unrelated resolution mechanism, not writability).
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _hooklib  # noqa: E402
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
+
+
+def _read_log(cad):
+    path = os.path.join(cad, "gate-events.log")
+    if not os.path.isfile(path):
+        return ""
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+class _GateEventsFixture(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.cad = os.path.join(self.root, ".codearbiter")
+        os.makedirs(self.cad)
+        self._env_patch = mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.root})
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+        self._tmp.cleanup()
+
+
+class TestDurableRecordAC1(_GateEventsFixture):
+    def test_block_writes_greppable_record_and_still_exits_2(self):
+        with self.assertRaises(SystemExit) as cm:
+            _hooklib.block("H-01", "example block reason")
+        self.assertEqual(cm.exception.code, 2)
+        text = _read_log(self.cad)
+        self.assertIn("BLOCK", text)
+        self.assertIn("[H-01]", text)
+        self.assertIn("example block reason", text)
+        # ISO-8601 UTC timestamp, bracketed.
+        self.assertRegex(text, r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\]")
+
+    def test_remind_writes_record_and_does_not_raise(self):
+        _hooklib.remind("H-05", "example reminder")
+        text = _read_log(self.cad)
+        self.assertIn("REMIND", text)
+        self.assertIn("[H-05]", text)
+        self.assertIn("example reminder", text)
+
+    def test_warn_writes_record_and_does_not_raise(self):
+        _hooklib.warn("example degradation")
+        text = _read_log(self.cad)
+        self.assertIn("WARN", text)
+        self.assertIn("example degradation", text)
+
+    def test_multiple_events_append_rather_than_overwrite(self):
+        _hooklib.warn("first")
+        _hooklib.remind("TAG", "second")
+        text = _read_log(self.cad)
+        self.assertIn("first", text)
+        self.assertIn("second", text)
+        self.assertEqual(len(text.splitlines()), 2)
+
+    def test_record_carries_the_invoking_hook_name(self):
+        # "hook/tool if available" — sys.argv[0] is the one signal available
+        # at this shared layer without threading a new param through every
+        # call site.
+        with mock.patch.object(sys, "argv", ["/path/to/pre-bash.py"]):
+            _hooklib.warn("hook-attributed line")
+        text = _read_log(self.cad)
+        self.assertIn("hook=pre-bash.py", text)
+
+
+class TestRealHookIntegrationAC1(unittest.TestCase):
+    """AC-1, end-to-end: a REAL hook (pre-bash.py) run against a real
+    throwaway git repo, hitting an actual H-20 block, must leave a durable
+    record in that repo's .codearbiter/gate-events.log — outside the live
+    transcript (here: outside the subprocess's own stderr)."""
+
+    ARBITER = "---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\n"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "repo")
+        os.makedirs(self.root)
+        self._git(["init", "-q", "-b", "feat/work"])
+        self._git(["config", "user.email", "h@example.com"])
+        self._git(["config", "user.name", "harness"])
+        os.makedirs(os.path.join(self.root, ".codearbiter"))
+        with open(os.path.join(self.root, ".codearbiter", "CONTEXT.md"), "w",
+                  encoding="utf-8") as f:
+            f.write(self.ARBITER)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _git(self, args):
+        env = {**os.environ, "CLAUDE_PROJECT_DIR": self.root}
+        r = subprocess.run(["git"] + args, cwd=self.root, capture_output=True,
+                           text=True, encoding="utf-8", errors="replace",
+                           timeout=60, env=env)
+        if r.returncode != 0:
+            raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr}")
+        return r
+
+    def test_h20_block_leaves_durable_record_outside_the_transcript(self):
+        payload = json.dumps({"tool_name": "Bash",
+                              "tool_input": {"command": "git commit --no-verify -m x"}})
+        env = {**os.environ, "CLAUDE_PROJECT_DIR": self.root}
+        res = subprocess.run([sys.executable, PRE_BASH], cwd=self.root, input=payload,
+                             capture_output=True, text=True, encoding="utf-8",
+                             errors="replace", timeout=60, env=env)
+        self.assertEqual(res.returncode, 2)
+        self.assertIn("H-20", res.stderr)
+        log_path = os.path.join(self.root, ".codearbiter", "gate-events.log")
+        self.assertTrue(os.path.isfile(log_path), "gate-events.log was not created")
+        with open(log_path, encoding="utf-8") as f:
+            log = f.read()
+        self.assertIn("BLOCK", log)
+        self.assertIn("[H-20]", log)
+        self.assertIn("hook=pre-bash.py", log)
+
+
+class TestFailOpenAC2(_GateEventsFixture):
+    """AC-2: the sink must NEVER turn a fail-open hook fail-closed, and must
+    NEVER suppress a BLOCK. Failure is injected by making the log path
+    unwritable (a directory collision) or by making the writer itself raise
+    — never by unsetting PATH/env vars."""
+
+    def test_block_still_exits_2_when_log_path_is_a_directory(self):
+        # gate-events.log exists as a DIRECTORY, not a file -> open(path, "a")
+        # raises (IsADirectoryError / PermissionError depending on platform).
+        os.makedirs(os.path.join(self.cad, "gate-events.log"))
+        with self.assertRaises(SystemExit) as cm:
+            _hooklib.block("H-02", "must still block")
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_warn_does_not_raise_when_log_path_is_a_directory(self):
+        os.makedirs(os.path.join(self.cad, "gate-events.log"))
+        try:
+            _hooklib.warn("must not raise")
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"warn() raised despite fail-open contract: {e!r}")
+
+    def test_remind_does_not_raise_when_log_path_is_a_directory(self):
+        os.makedirs(os.path.join(self.cad, "gate-events.log"))
+        try:
+            _hooklib.remind("TAG", "must not raise")
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"remind() raised despite fail-open contract: {e!r}")
+
+    def test_block_still_exits_2_when_open_itself_raises(self):
+        with mock.patch("builtins.open", side_effect=OSError("locked")):
+            with self.assertRaises(SystemExit) as cm:
+                _hooklib.block("H-03", "must still block despite locked log")
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_block_still_exits_2_when_project_root_raises(self):
+        with mock.patch.object(_hooklib, "project_root", side_effect=RuntimeError("boom")):
+            with self.assertRaises(SystemExit) as cm:
+                _hooklib.block("H-04", "must still block despite root resolution failure")
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_warn_is_silent_no_op_when_codearbiter_dir_is_missing(self):
+        # A repo that never opted in (no .codearbiter/ at all) must not have
+        # one conjured into existence just to hold this log.
+        missing_root = os.path.join(self.root, "not-a-repo")
+        os.makedirs(missing_root)
+        with mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": missing_root}):
+            _hooklib.warn("no dir to write into")  # must not raise
+        self.assertFalse(os.path.isdir(os.path.join(missing_root, ".codearbiter")))
+
+    def test_block_exit_code_and_stderr_unchanged_by_sink_failure(self):
+        # The stderr message itself (the pre-existing contract) must be
+        # unaffected by a sink failure — capture it directly.
+        import io
+        buf = io.StringIO()
+        with mock.patch("builtins.open", side_effect=OSError("locked")):
+            with mock.patch.object(sys, "stderr", buf):
+                with self.assertRaises(SystemExit) as cm:
+                    _hooklib.block("H-06", "stderr must still say this")
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("BLOCKED [H-06]: stderr must still say this", buf.getvalue())
+
+
+class TestStalenessWarnCONFIRM09(_GateEventsFixture):
+    """CONFIRM-09: active-flow audit-log staleness is a WARN, never a gate.
+    Detected from EXISTING markers (.markers/dev-active, sprint-active) —
+    no new state invented."""
+
+    def _touch(self, path, age_seconds=0):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("x")
+        t = time.time() - age_seconds
+        os.utime(path, (t, t))
+
+    def test_no_markers_present_yields_no_warnings(self):
+        self.assertEqual(_hooklib.staleness_warning(self.root), [])
+
+    def test_fresh_dev_marker_is_not_stale(self):
+        os.makedirs(os.path.join(self.cad, ".markers"))
+        self._touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=5)
+        self.assertEqual(_hooklib.staleness_warning(self.root, window_minutes=30), [])
+
+    def test_stale_dev_marker_with_no_log_activity_warns(self):
+        os.makedirs(os.path.join(self.cad, ".markers"))
+        self._touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        msgs = _hooklib.staleness_warning(self.root, window_minutes=30)
+        self.assertEqual(len(msgs), 1)
+        self.assertIn("/dev", msgs[0])
+        self.assertIn("CONFIRM-09", msgs[0])
+
+    def test_stale_dev_marker_but_recent_log_write_is_not_stale(self):
+        os.makedirs(os.path.join(self.cad, ".markers"))
+        self._touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        # overrides.log was written recently -> the flow IS producing audit
+        # activity even though the marker itself is old.
+        self._touch(os.path.join(self.cad, "overrides.log"), age_seconds=5)
+        self.assertEqual(_hooklib.staleness_warning(self.root, window_minutes=30), [])
+
+    def test_stale_sprint_marker_with_no_log_activity_warns(self):
+        self._touch(os.path.join(self.cad, "sprint-active"), age_seconds=3600)
+        msgs = _hooklib.staleness_warning(self.root, window_minutes=30)
+        self.assertEqual(len(msgs), 1)
+        self.assertIn("/sprint", msgs[0])
+
+    def test_both_flows_stale_yields_two_warnings(self):
+        os.makedirs(os.path.join(self.cad, ".markers"))
+        self._touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        self._touch(os.path.join(self.cad, "sprint-active"), age_seconds=3600)
+        msgs = _hooklib.staleness_warning(self.root, window_minutes=30)
+        self.assertEqual(len(msgs), 2)
+
+    def test_never_raises_on_a_stat_failure(self):
+        os.makedirs(os.path.join(self.cad, ".markers"))
+        self._touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        with mock.patch("os.path.getmtime", side_effect=OSError("boom")):
+            try:
+                msgs = _hooklib.staleness_warning(self.root, window_minutes=30)
+            except Exception as e:  # noqa: BLE001
+                self.fail(f"staleness_warning raised: {e!r}")
+        self.assertEqual(msgs, [])
+
+    def test_has_no_side_effects_pure_function(self):
+        os.makedirs(os.path.join(self.cad, ".markers"))
+        self._touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        before = set(os.listdir(self.cad))
+        _hooklib.staleness_warning(self.root, window_minutes=30)
+        after = set(os.listdir(self.cad))
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_pre_edit.py
+++ b/plugins/ca/hooks/tests/test_pre_edit.py
@@ -185,6 +185,28 @@ class TestH05AppendOnly(_PreEditFixture):
         )
         self.assertAllowed(res)
 
+    def test_rewrite_of_gate_events_log_is_blocked(self):
+        # gate-events.log (observability-001, #186) is the durable
+        # BLOCK/REMIND/WARN sink — an append-only audit artifact like the rest.
+        self._write(os.path.join(self.ca, "gate-events.log"),
+                    "[2026-01-01T00:00:00Z] BLOCK [H-01] hook=pre-bash.py | seed\n")
+        res = self.run_edit(
+            os.path.join(self.ca, "gate-events.log"),
+            old_string="[2026-01-01T00:00:00Z] BLOCK [H-01] hook=pre-bash.py | seed\n",
+            new_string="[2026-01-01T00:00:00Z] BLOCK [H-01] hook=pre-bash.py | tampered\n",
+        )
+        self.assertBlocked(res, "H-05")
+
+    def test_pure_append_to_gate_events_log_is_allowed(self):
+        old = "[2026-01-01T00:00:00Z] BLOCK [H-01] hook=pre-bash.py | seed\n"
+        self._write(os.path.join(self.ca, "gate-events.log"), old)
+        res = self.run_edit(
+            os.path.join(self.ca, "gate-events.log"),
+            old_string=old,
+            new_string=old + "[2026-01-01T00:01:00Z] WARN hook=session-start.py | more\n",
+        )
+        self.assertAllowed(res)
+
     def test_empty_old_string_on_audit_log_is_blocked(self):
         # migration-003: `new.startswith("")` is ALWAYS True, so an Edit with an
         # empty old_string slipped the append-only check entirely — it could

--- a/plugins/ca/hooks/tests/test_pre_write.py
+++ b/plugins/ca/hooks/tests/test_pre_write.py
@@ -94,6 +94,11 @@ class TestH05Write(_PreWriteFixture):
         # sprint-log.md is the /sprint audit record — a Write overwrites it.
         self.assertBlocked(self.run_write(os.path.join(self.ca, "sprint-log.md")), "H-05")
 
+    def test_write_to_gate_events_log_is_blocked(self):
+        # gate-events.log (observability-001, #186) is the durable
+        # BLOCK/REMIND/WARN sink — an append-only audit artifact like the rest.
+        self.assertBlocked(self.run_write(os.path.join(self.ca, "gate-events.log")), "H-05")
+
 
 class TestH11Write(_PreWriteFixture):
     def test_write_to_numbered_adr_without_marker_is_blocked(self):

--- a/plugins/ca/hooks/tests/test_staleness_warn_entry.py
+++ b/plugins/ca/hooks/tests/test_staleness_warn_entry.py
@@ -1,0 +1,146 @@
+"""CONFIRM-09: prune-transcript.py's UserPromptSubmit entry point wires
+_hooklib.staleness_warning into a real WARN — via _hooklib.warn(), which is
+non-blocking and also writes the durable gate-events.log record
+(observability-001, #186), so the two features are proven together here.
+
+WARN-only contract: the hook-mode entry point (staleness_check / main())
+must NEVER raise and must NEVER change prune-transcript.py's hook-mode exit
+code (always 0), regardless of whether a flow is stale.
+"""
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+_HOOKS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HOOKS_DIR)
+sys.path.insert(0, _TESTS_DIR)
+
+_SCRIPT = os.path.join(_HOOKS_DIR, "prune-transcript.py")
+_spec = importlib.util.spec_from_file_location("prune_transcript", _SCRIPT)
+pt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pt)
+
+import _hooklib  # noqa: E402
+from _helpers import redirect_home, restore_home  # noqa: E402
+
+
+def _touch(path, age_seconds=0):
+    d = os.path.dirname(path)
+    if d and not os.path.isdir(d):
+        os.makedirs(d)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("x")
+    t = time.time() - age_seconds
+    os.utime(path, (t, t))
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._home = redirect_home(self._tmp.name)
+        self.root = os.path.join(self._tmp.name, "repo")
+        self.cad = os.path.join(self.root, ".codearbiter")
+        os.makedirs(self.cad)
+        with open(os.path.join(self.cad, "CONTEXT.md"), "w", encoding="utf-8") as f:
+            f.write("---\narbiter: enabled\n---\n# ctx\n")
+
+    def tearDown(self):
+        restore_home(self._home)
+        self._tmp.cleanup()
+
+    def payload(self):
+        return {"hook_event_name": "UserPromptSubmit", "cwd": self.root}
+
+
+class TestStalenessCheckFunction(_Fixture):
+    def test_stale_dev_flow_emits_a_warn_and_durable_record(self):
+        _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        buf = io.StringIO()
+        # _hooklib.warn()'s durable-sink half resolves its own root via
+        # project_root() (CLAUDE_PROJECT_DIR, else a git spawn) independently
+        # of the payload["cwd"] staleness_check reads its flow state from — as
+        # every production hook invocation does, pin it to the same repo.
+        with mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.root}):
+            with mock.patch.object(sys, "stderr", buf):
+                pt.staleness_check(self.payload())
+        self.assertIn("codeArbiter hook:", buf.getvalue())
+        self.assertIn("CONFIRM-09", buf.getvalue())
+        with open(os.path.join(self.cad, "gate-events.log"), encoding="utf-8") as f:
+            log = f.read()
+        self.assertIn("WARN", log)
+        self.assertIn("CONFIRM-09", log)
+
+    def test_fresh_dev_flow_emits_nothing(self):
+        _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=5)
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stderr", buf):
+            pt.staleness_check(self.payload())
+        self.assertEqual(buf.getvalue(), "")
+        self.assertFalse(os.path.isfile(os.path.join(self.cad, "gate-events.log")))
+
+    def test_no_active_flow_emits_nothing(self):
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stderr", buf):
+            pt.staleness_check(self.payload())
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_dormant_repo_never_warns_even_when_stale(self):
+        # arbiter NOT enabled -> the check must not fire at all.
+        with open(os.path.join(self.cad, "CONTEXT.md"), "w", encoding="utf-8") as f:
+            f.write("---\narbiter: disabled\n---\n# ctx\n")
+        _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stderr", buf):
+            pt.staleness_check(self.payload())
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_never_raises_when_hooklib_import_fails(self):
+        _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        with mock.patch.dict(sys.modules, {"_hooklib": None}):
+            try:
+                pt.staleness_check(self.payload())
+            except Exception as e:  # noqa: BLE001
+                self.fail(f"staleness_check raised: {e!r}")
+
+
+class TestHookModeNeverBlocks(_Fixture):
+    """The UserPromptSubmit entry point (main(), hook-mode branch) must always
+    return 0 — a stale-flow WARN is surfaced, never a gate."""
+
+    def _run_main(self, payload):
+        # Pin CLAUDE_PROJECT_DIR to the tmp fixture: _hooklib.warn()'s durable-
+        # sink half resolves its OWN root independently of payload["cwd"] (see
+        # test_stale_dev_flow_emits_a_warn_and_durable_record above) — every
+        # production hook invocation pins this env var, and leaving it unset
+        # here would let project_root()'s git-rev-parse fallback resolve to
+        # whatever repo happens to contain the test run, not the fixture.
+        raw = __import__("json").dumps(payload)
+        env_patch = mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.root})
+        with env_patch, mock.patch.object(sys, "stdin", io.StringIO(raw)):
+            return pt.main([])
+
+    def test_stale_flow_present_still_returns_0(self):
+        _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        rc = self._run_main(self.payload())
+        self.assertEqual(rc, 0)
+
+    def test_no_transcript_path_still_returns_0(self):
+        rc = self._run_main(self.payload())
+        self.assertEqual(rc, 0)
+
+    def test_staleness_check_exception_does_not_break_hook_mode(self):
+        # staleness_check() catches broadly internally; prove the wiring
+        # stays fail-open end-to-end by making the underlying detector raise.
+        with mock.patch.object(_hooklib, "staleness_warning", side_effect=RuntimeError("boom")):
+            rc = self._run_main(self.payload())
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lane F — the campaign's final lane. #186 (observability-001) + the CONFIRM-09 staleness-warn.

## What
- **#186 durable sink:** `_hooklib` `block()`/`remind()`/`warn()` — the three primitives all 16 entry hooks funnel every gate decision through — now best-effort append a structured line to `.codearbiter/gate-events.log` (`[ISO-8601Z] KIND [tag] hook=<script> | msg`), so BLOCK/REMIND/WARN events are durable and greppable instead of ephemeral stderr.
- **CONFIRM-09 staleness-warn:** a UserPromptSubmit check warns (via `warn()`, non-blocking) when an active `/sprint` or `/dev` flow hasn't appended its expected log line within a bounded window. `/override` isn't tracked (no in-progress marker — per CONFIRM-09's "don't invent new state").

## Fail-open discipline (the load-bearing constraint)
The sink can never turn a fail-open hook fail-closed or suppress a BLOCK: `_log_gate_event` is wrapped so no exception escapes (`project_root` failure, missing `.codearbiter`, log-as-directory, read-only, disk-full all swallowed), `block()` still `sys.exit(2)` regardless, and `remind()`/`warn()` stay non-blocking. The staleness-warn is provably WARN-only — it only computes strings and routes through `warn()`, runs only on UserPromptSubmit (never a blocking hook), and can't change any exit code.

## H-05 protection
`gate-events.log` is append-only on all three flanks (Bash shell-redirect, Write, Edit). The shell pre-filter and the regex now both derive from a single `_hooklib.AUDIT_LOG_BASENAMES` — closing a reviewer-flagged drift where the hand-copied substring list could silently skip the shell flank for a future audit-log addition. The framework's own `open(...,"a")` appends aren't tool calls, so H-05 never gates the sink itself.

## Verification
- **794 hook tests pass** (+ `test_gate_events.py` AC-1/AC-2 fail-open + `test_staleness_warn_entry.py`; new H-05 cases for gate-events.log across shell/Write/Edit); `test_hook_guards.py` (106 assertions), `test_hooks_cold_install.py` (134) green; existing block/remind/warn behavior and H-05 assertions UNMODIFIED; `py_compile` clean; LF.
- **security-reviewer: PASS** (0 critical/high) — every fail-open and WARN-only claim verified against the branch content. One MEDIUM (the substring-prefilter drift) **fixed in this branch** via `AUDIT_LOG_BASENAMES`; two no-action LOWs (bounded `project_root` git-spawn only in the no-`CLAUDE_PROJECT_DIR` edge; partial-final-line on process-kill, cosmetic).

Bumps ca 2.8.10 → 2.8.11. Updates `security-controls.md` §Audit trail.

Closes #186

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa