### PR TITLE
docs(ca-sandbox): changelog for 0.1.2 + 0.1.3 (release prep)

### DIFF
--- a/plugins/ca-sandbox/CHANGELOG.md
+++ b/plugins/ca-sandbox/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the **ca-sandbox** plugin are recorded here. Format follo
 
 ---
 
+## [0.1.3] — 2026-07-02 — Single docker primitive + helper-container hardening
+
+Consolidation and hardening of the sandbox driver's container handling (part of the tribunal remediation).
+
+### Changed
+- **One shared docker primitive (#180).** Extracted `tools/docker.ts` as the single module every `docker` invocation flows through, replacing duplicated spawn/argv logic across build/run/exec/cp/create/registry/claude-inside — so the argv-array discipline (no `shell: true`) and the container-hardening flags cannot drift between call sites.
+
+### Fixed
+- **Helper containers are labeled and time-bound (#173).** The transient helper containers the driver spawns now carry an identifying label and a bounded lifetime, so an interrupted run cannot leak an unlabeled, unbounded container.
+
+---
+
+## [0.1.2] — 2026-07-02 — Tribunal quick-kills
+
+The ca-sandbox portion of the tribunal quick-kill fixes.
+
+### Fixed
+- **Robustness and diagnosability hardening (#197).** Atomic provenance/state writes, typed `docker` spawn options (with `shell` omitted from the typed opts), removal of dead re-binds, and fail-closed CI scripts in the sandbox tooling.
+
+---
+
 ## [0.1.1] — 2026-06-21 — Dependency bump
 
 Dev-toolchain dependency bump for the sandbox driver (`tools/`). No payload behavior change; consolidates Dependabot #112 and #114 into one synced lockfile.


### PR DESCRIPTION
The ca-sandbox manifest is at **0.1.3** but its CHANGELOG stopped at 0.1.1. Adds the missing entries:
- **0.1.2** — the ca-sandbox portion of the tribunal quick-kills (#197): atomic writes, typed spawn opts (shell omitted), dead re-bind cleanup, fail-closed CI.
- **0.1.3** — single shared `docker.ts` primitive (#180) + labeled/time-bound helper containers (#173).

Docs-only. Prepares the `ca-sandbox-v0.1.3` tag + release (ca-sandbox versions independently of ca, ADR-0007).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa