### PR TITLE
fix(site): scope reference slug dedup per collection; redirect old -2 skill URLs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -39,6 +39,25 @@ export default defineConfig({
   //     when the Astro base is changed and is invisible to linting.
   site: "https://arbiterforge.github.io",
   base: "/codeArbiter",
+  // Old `-2` skill URLs from before per-collection slug dedup (see generate.ts):
+  // these six skills shared a name with a same-named command, so the combined
+  // dedup pass pushed the skill page to a `-2` slug. Redirect the old URLs to
+  // the now-clean ones.
+  //
+  // Astro matches redirect *keys* through `base` itself (base-relative, no
+  // "/codeArbiter" prefix). The *destination* value, however, is emitted
+  // verbatim as the redirect Location/meta-refresh target — it is NOT
+  // base-prefixed automatically — so destinations must carry the base
+  // explicitly to land on a real page, matching every other internal href in
+  // this site (see the BASE-PATH-SAFE LINK PATTERN note above).
+  redirects: {
+    "/reference/skills/context-check-2": "/codeArbiter/reference/skills/context-check",
+    "/reference/skills/debug-2": "/codeArbiter/reference/skills/debug",
+    "/reference/skills/decompose-2": "/codeArbiter/reference/skills/decompose",
+    "/reference/skills/refactor-2": "/codeArbiter/reference/skills/refactor",
+    "/reference/skills/release-2": "/codeArbiter/reference/skills/release",
+    "/reference/skills/tribunal-2": "/codeArbiter/reference/skills/tribunal",
+  },
   integrations: [
     starlight({
       title: "codeArbiter",

--- a/site/scripts/generator/generate.ts
+++ b/site/scripts/generator/generate.ts
@@ -70,7 +70,26 @@ export function generate(
     doc: parseDoc(normalize(source.raw)),
   }));
   const names = parsed.map((p) => deriveName(p.source.path, p.doc.fields));
-  const slugs = assignSlugs(names);
+
+  // Slugs are deduplicated per collection (command/skill/agent), not across the
+  // whole combined set — each collection writes to its own output directory, so
+  // a skill sharing a name with a command must not be pushed to a `-2` slug.
+  // Group indices by type (preserving relative order), assign slugs within each
+  // group, then scatter the results back into a single array aligned with
+  // `parsed`/`names` so the rest of generation is unaffected.
+  const slugs: string[] = new Array(parsed.length);
+  const indicesByType = new Map<SourceType, number[]>();
+  parsed.forEach(({ source }, i) => {
+    const list = indicesByType.get(source.type) ?? [];
+    list.push(i);
+    indicesByType.set(source.type, list);
+  });
+  for (const indices of indicesByType.values()) {
+    const groupSlugs = assignSlugs(indices.map((i) => names[i]));
+    indices.forEach((i, j) => {
+      slugs[i] = groupSlugs[j];
+    });
+  }
 
   const pages: RenderedPage[] = parsed.map(({ source, doc }, i) => {
     const name = names[i];

--- a/site/test/fixtures/plugin-collisions/agents/debug.md
+++ b/site/test/fixtures/plugin-collisions/agents/debug.md
@@ -1,0 +1,10 @@
+---
+name: debug
+description: A fixture agent named debug, colliding with the debug command/skill.
+tools: Read, Grep
+model: sonnet
+---
+
+# Debug Agent
+
+Agent body content for the debug fixture.

--- a/site/test/fixtures/plugin-collisions/commands/debug.md
+++ b/site/test/fixtures/plugin-collisions/commands/debug.md
@@ -1,0 +1,7 @@
+---
+description: A fixture command named debug, colliding with the debug skill/agent.
+---
+
+# /ca:debug — debug command fixture
+
+Body content for the debug command fixture.

--- a/site/test/fixtures/plugin-collisions/commands/prune.md
+++ b/site/test/fixtures/plugin-collisions/commands/prune.md
@@ -1,0 +1,7 @@
+---
+description: A fixture command named prune, used to regression-test forge badges.
+---
+
+# /ca:prune — prune command fixture
+
+Body content for the prune command fixture.

--- a/site/test/fixtures/plugin-collisions/skills/debug/SKILL.md
+++ b/site/test/fixtures/plugin-collisions/skills/debug/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: debug
+description: A fixture skill named debug, colliding with the debug command/agent.
+---
+
+# debug
+
+Skill body content for the debug fixture.

--- a/site/test/fixtures/plugin-collisions/skills/dupskill-a/SKILL.md
+++ b/site/test/fixtures/plugin-collisions/skills/dupskill-a/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: dup
+description: First of two same-named skills, used to prove within-collection dedup still works.
+---
+
+# dup
+
+Skill body content for the first dup fixture.

--- a/site/test/fixtures/plugin-collisions/skills/dupskill-b/SKILL.md
+++ b/site/test/fixtures/plugin-collisions/skills/dupskill-b/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: dup
+description: Second of two same-named skills, used to prove within-collection dedup still works.
+---
+
+# dup
+
+Skill body content for the second dup fixture.

--- a/site/test/generator/generate.test.ts
+++ b/site/test/generator/generate.test.ts
@@ -13,7 +13,9 @@ import { generate } from "../../scripts/generator/generate";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pluginDir = join(here, "..", "fixtures", "plugin");
+const collisionsPluginDir = join(here, "..", "fixtures", "plugin-collisions");
 const outDir = join(tmpdir(), "ca-gen-test-out");
+const collisionsOutDir = join(tmpdir(), "ca-gen-test-out-collisions");
 
 /** Recursively read every file under a dir into a path->contents map. */
 function snapshot(dir: string): Record<string, string> {
@@ -34,9 +36,12 @@ describe("generate", () => {
   beforeEach(() => {
     rmSync(outDir, { recursive: true, force: true });
     mkdirSync(outDir, { recursive: true });
+    rmSync(collisionsOutDir, { recursive: true, force: true });
+    mkdirSync(collisionsOutDir, { recursive: true });
   });
   afterEach(() => {
     rmSync(outDir, { recursive: true, force: true });
+    rmSync(collisionsOutDir, { recursive: true, force: true });
   });
 
   it("emits exactly one page per source file", () => {
@@ -65,5 +70,44 @@ describe("generate", () => {
     generate(pluginDir, outDir);
     const second = snapshot(outDir);
     expect(second).toEqual(first);
+  });
+
+  describe("per-collection slug dedup", () => {
+    it("gives a same-named command, skill, and agent all the clean slug in their own collection — no -2 anywhere", () => {
+      const result = generate(collisionsPluginDir, collisionsOutDir);
+      const debugPages = result.pages.filter((p) => p.title === "debug");
+      expect(debugPages).toHaveLength(3);
+      const byType = Object.fromEntries(debugPages.map((p) => [p.type, p.slug]));
+      expect(byType.command).toBe("debug");
+      expect(byType.skill).toBe("debug");
+      expect(byType.agent).toBe("debug");
+      // None of the three "debug" pages themselves got pushed to a -2 slug.
+      // (A separate, deliberately-colliding "dup" skill pair in this fixture
+      // set is expected to produce a -2 — that's covered by the next test.)
+      expect(debugPages.some((p) => p.slug.endsWith("-2"))).toBe(false);
+      expect(existsSync(join(collisionsOutDir, "commands", "debug.md"))).toBe(true);
+      expect(existsSync(join(collisionsOutDir, "skills", "debug.md"))).toBe(true);
+      expect(existsSync(join(collisionsOutDir, "agents", "debug.md"))).toBe(true);
+    });
+
+    it("still dedupes two same-named files WITHIN one collection to a -2 slug", () => {
+      const result = generate(collisionsPluginDir, collisionsOutDir);
+      const dupPages = result.pages.filter((p) => p.type === "skill" && p.title === "dup");
+      expect(dupPages).toHaveLength(2);
+      const slugs = dupPages.map((p) => p.slug).sort();
+      expect(slugs).toEqual(["dup", "dup-2"]);
+    });
+
+    it("resolves the forge preview badge for a command after per-collection slugging (regression)", () => {
+      const result = generate(collisionsPluginDir, collisionsOutDir);
+      const prunePage = result.pages.find(
+        (p) => p.type === "command" && p.slug === "prune",
+      );
+      expect(prunePage).toBeDefined();
+      // prune is a preview-command in the forge allowlist (forge-status.ts) —
+      // its rendered page must still carry the preview badge/markup after
+      // switching slug assignment to per-collection.
+      expect(prunePage!.markdown).toMatch(/preview/i);
+    });
   });
 });


### PR DESCRIPTION
## Summary

PR-0.3 of the docs-site overhaul campaign (spec: `.codearbiter/specs/docs-site-overhaul.md`).

`generate.ts` deduplicated slugs across ONE combined commands+skills+agents array, so six skills sharing a name with a command shipped `-2` URLs (`context-check-2`, `debug-2`, `decompose-2`, `refactor-2`, `release-2`, `tribunal-2`). Slug dedup is now scoped per collection; the six old URLs get Astro `redirects` (meta-refresh stubs verified in dist).

**Deviation from plan, verified against Astro source:** redirect *destinations* are emitted verbatim (not base-prefixed) — only redirect *keys* are base-matched — so destinations carry `/codeArbiter` explicitly; comment in config explains.

Forge-status command keys unaffected (commands never collided; regression test added).

## Verification
- 172 vitest passing (+3 new: cross-collection clean slugs, within-collection dedup intact, forge badge regression), typecheck clean.
- Build: `dist/reference/skills/debug/` real page; `debug-2/` = 477-byte meta-refresh stub to `/codeArbiter/reference/skills/debug`; no `-2` hrefs in index/sidebar.
- link-audit: 14,999 internal links resolve.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa