### PR TITLE
fix(site): drop duplicate reference-page H1; emit per-page meta descriptions

### DIFF
--- a/site/scripts/generator/render-agent-page.ts
+++ b/site/scripts/generator/render-agent-page.ts
@@ -1,19 +1,28 @@
 import { modelTier } from "./model-tier";
 import { formatToolsList } from "./format-tools-list";
 import type { PageInput } from "./types";
+import { yamlDescriptionLine } from "./yaml-quote";
 
 /**
  * Render an agent reference page as Starlight-compatible markdown.
  *
- * Includes a `title:` frontmatter line, an `# <name>` heading, the description,
- * a `**Model tier:**` line (via {@link modelTier}, so a missing model shows
- * `default`), and a `**Tools:**` line (via {@link formatToolsList}).
+ * Includes a `title:` frontmatter line and, when a description is present, a
+ * quoted `description:` frontmatter line (used for the page's meta
+ * description). Starlight renders the frontmatter `title` as the page's only
+ * H1, so the body carries no `# <name>` heading — it opens with the
+ * description, followed by a `**Model tier:**` line (via {@link modelTier},
+ * so a missing model shows `default`), and a `**Tools:**` line (via
+ * {@link formatToolsList}).
  */
 export function renderAgentPage(input: PageInput): string {
-  const frontMatter = `---\ntitle: ${input.name}\n---`;
-  const heading = `# ${input.name}`;
+  const description = input.description ?? "";
+  const descriptionLine = yamlDescriptionLine(description);
+  const frontMatterFields = descriptionLine
+    ? `title: ${input.name}\n${descriptionLine}`
+    : `title: ${input.name}`;
+  const frontMatter = `---\n${frontMatterFields}\n---`;
   const modelLine = `- **Model tier:** ${modelTier(input.model)}`;
   const toolsLine = `- **Tools:** ${formatToolsList(input.tools)}`;
 
-  return `${frontMatter}\n\n${heading}\n\n${input.description}\n\n${modelLine}\n${toolsLine}\n`;
+  return `${frontMatter}\n\n${description}\n\n${modelLine}\n${toolsLine}\n`;
 }

--- a/site/scripts/generator/render-command-page.ts
+++ b/site/scripts/generator/render-command-page.ts
@@ -1,19 +1,24 @@
 /** render-command-page.ts — codeArbiter's command reference page renderer. */
 import type { PageInput } from "./types";
+import { yamlDescriptionLine } from "./yaml-quote";
 
 /**
  * Render a command reference page as Starlight-compatible markdown.
  *
- * Includes a `title:` frontmatter line, an `# <name>` heading, and the
- * description. Commands have no model or tools, so the page renders neither a
- * `Model tier` nor a `Tools` section.
+ * Includes a `title:` frontmatter line and, when a description is present, a
+ * quoted `description:` frontmatter line (used for the page's meta
+ * description). Starlight renders the frontmatter `title` as the page's only
+ * H1, so the body carries no `# <name>` heading. Commands have no model or
+ * tools, so the page renders neither a `Model tier` nor a `Tools` section.
  *
  * When `forgeStatus` is provided on the input the renderer decorates the page:
  * - `preview-command` — a preview badge (`<span class="ca-badge" data-kind="preview">`)
- *   is injected immediately after the H1 heading.
+ *   is injected as the first body element, before the description paragraph.
  * - `preview-flag` — a preview callout (`<div class="ca-callout ca-callout--preview">`)
- *   naming the preview flag is injected immediately after the H1 heading.
- * - null / undefined — no decoration; stable command renders unchanged.
+ *   naming the preview flag is injected as the first body element, before the
+ *   description paragraph.
+ * - null / undefined — no decoration; the description paragraph is the only
+ *   body content.
  */
 export function renderCommandPage(input: PageInput): string {
   const { name, description, forgeStatus } = input;
@@ -22,22 +27,25 @@ export function renderCommandPage(input: PageInput): string {
   let decoration = "";
   if (forgeStatus?.kind === "preview-command") {
     decoration =
-      '\n\n<span class="ca-badge" data-kind="preview">preview</span>';
+      '<span class="ca-badge" data-kind="preview">preview</span>\n\n';
   } else if (forgeStatus?.kind === "preview-flag") {
     const flag = forgeStatus.flag;
     decoration =
-      `\n\n<div class="ca-callout ca-callout--preview">` +
+      `<div class="ca-callout ca-callout--preview">` +
       `<p class="ca-callout__label">Feature Forge — preview</p>` +
       `<p><code>${flag}</code> — preview. This flag is part of the Feature Forge and ships dormant by default. Promotion to stable is driven by real-world evidence.</p>` +
-      `</div>`;
+      `</div>\n\n`;
   }
 
+  const descriptionLine = yamlDescriptionLine(desc);
+  const frontMatter = descriptionLine
+    ? `title: ${name}\n${descriptionLine}`
+    : `title: ${name}`;
+
   return `---
-title: ${name}
+${frontMatter}
 ---
 
-# ${name}${decoration}
-
-${desc}
+${decoration}${desc}
 `;
 }

--- a/site/scripts/generator/render-skill-page.ts
+++ b/site/scripts/generator/render-skill-page.ts
@@ -1,10 +1,25 @@
 import type { PageInput } from "./types";
+import { yamlDescriptionLine } from "./yaml-quote";
 
+/**
+ * Render a skill reference page as Starlight-compatible markdown.
+ *
+ * Includes a `title:` frontmatter line and, when a description is present, a
+ * quoted `description:` frontmatter line (used for the page's meta
+ * description). Starlight renders the frontmatter `title` as the page's only
+ * H1, so the body carries no `# <name>` heading — it opens with the
+ * description.
+ */
 export function renderSkillPage(input: PageInput): string {
+  const description = input.description ?? "";
+  const descriptionLine = yamlDescriptionLine(description);
+  const frontMatterFields = descriptionLine
+    ? `title: ${input.name}\n${descriptionLine}`
+    : `title: ${input.name}`;
+
   return `---
-title: ${input.name}
+${frontMatterFields}
 ---
-# ${input.name}
-${input.description}
+${description}
 `;
 }

--- a/site/scripts/generator/yaml-quote.ts
+++ b/site/scripts/generator/yaml-quote.ts
@@ -1,0 +1,25 @@
+/** yaml-quote.ts — codeArbiter's shared YAML double-quoted-scalar helper. */
+
+/**
+ * Escape a string for use inside a YAML double-quoted scalar.
+ *
+ * Backslashes are escaped first (so a later `"` escape doesn't double-escape
+ * an already-inserted backslash), then double quotes are escaped as `\"`.
+ * Source descriptions routinely contain colons, em-dashes, and double quotes,
+ * all of which are safe inside a double-quoted scalar once escaped this way.
+ */
+export function yamlQuoteEscape(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Render a YAML frontmatter `description:` line for the given value.
+ *
+ * Returns an empty string when `value` is empty or absent, so callers can
+ * omit the line entirely (Starlight then falls back to the site default
+ * meta description) rather than emitting `description: ""`.
+ */
+export function yamlDescriptionLine(value: string | undefined): string {
+  if (!value) return "";
+  return `description: "${yamlQuoteEscape(value)}"`;
+}

--- a/site/test/generator/render-agent-page.test.ts
+++ b/site/test/generator/render-agent-page.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { renderAgentPage } from "../../scripts/generator/render-agent-page";
 
 describe("renderAgentPage", () => {
-  it("renders title, heading, description, model tier, and tools", () => {
+  it("renders title, description, model tier, and tools, with no body H1", () => {
     const md = renderAgentPage({
       name: "myagent",
       description: "reviews a thing",
@@ -10,7 +10,7 @@ describe("renderAgentPage", () => {
       tools: "Read, Grep",
     });
     expect(md).toContain("title: myagent");
-    expect(md).toContain("# myagent");
+    expect(md).not.toMatch(/^# /m);
     expect(md).toContain("reviews a thing");
     expect(md).toContain("Sonnet");
     expect(md).toContain("`Read`, `Grep`");
@@ -24,5 +24,35 @@ describe("renderAgentPage", () => {
     });
     expect(md).toContain("default");
     expect(md).toContain("`Read`");
+  });
+
+  it("emits a quoted description frontmatter line", () => {
+    const md = renderAgentPage({
+      name: "myagent",
+      description: "reviews a thing",
+      tools: "Read",
+    });
+    expect(md).toContain('description: "reviews a thing"');
+  });
+
+  it("escapes double quotes and colons in the description frontmatter line", () => {
+    const md = renderAgentPage({
+      name: "myagent",
+      description: 'Reviews "the" thing: end-to-end — nothing skipped.',
+      tools: "Read",
+    });
+    expect(md).toContain(
+      'description: "Reviews \\"the\\" thing: end-to-end — nothing skipped."',
+    );
+  });
+
+  it("omits the description frontmatter line when description is empty", () => {
+    const md = renderAgentPage({ name: "myagent", description: "", tools: "Read" });
+    expect(md).not.toContain("description:");
+  });
+
+  it("omits the description frontmatter line when description is absent", () => {
+    const md = renderAgentPage({ name: "myagent", tools: "Read" });
+    expect(md).not.toContain("description:");
   });
 });

--- a/site/test/generator/render-command-page-forge.test.ts
+++ b/site/test/generator/render-command-page-forge.test.ts
@@ -66,4 +66,32 @@ describe("renderCommandPage — forge status badges and callouts", () => {
     expect(md).toContain('class="ca-badge"');
     expect(md).toContain('data-kind="preview"');
   });
+
+  it("preview-command badge is the first body element, before the description", () => {
+    const md = renderCommandPage({
+      name: "/ca:prune",
+      description: "Trim transcript clutter.",
+      forgeStatus: { kind: "preview-command" },
+    });
+    // Body starts after the closing frontmatter `---` fence.
+    const body = md.slice(md.indexOf("---", 3) + 3);
+    const badgeIndex = body.indexOf('class="ca-badge"');
+    const descIndex = body.indexOf("Trim transcript clutter.");
+    expect(badgeIndex).toBeGreaterThan(-1);
+    expect(descIndex).toBeGreaterThan(badgeIndex);
+  });
+
+  it("preview-flag callout is the first body element, before the description", () => {
+    const md = renderCommandPage({
+      name: "/ca:sprint",
+      description: "Autonomous sprint.",
+      forgeStatus: { kind: "preview-flag", flag: "--farm" },
+    });
+    // Body starts after the closing frontmatter `---` fence.
+    const body = md.slice(md.indexOf("---", 3) + 3);
+    const calloutIndex = body.indexOf("ca-callout--preview");
+    const descIndex = body.indexOf("Autonomous sprint.");
+    expect(calloutIndex).toBeGreaterThan(-1);
+    expect(descIndex).toBeGreaterThan(calloutIndex);
+  });
 });

--- a/site/test/generator/render-command-page.test.ts
+++ b/site/test/generator/render-command-page.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "vitest";
 import { renderCommandPage } from "../../scripts/generator/render-command-page";
 
 describe("renderCommandPage", () => {
-  it("renders title, heading, and description", () => {
+  it("renders title and description, and no body H1", () => {
     const md = renderCommandPage({
       name: "commit",
       description: "the only path to a commit",
     });
     expect(md).toContain("title: commit");
-    expect(md).toContain("# commit");
+    expect(md).not.toMatch(/^# /m);
     expect(md).toContain("the only path to a commit");
   });
 
@@ -16,5 +16,33 @@ describe("renderCommandPage", () => {
     const md = renderCommandPage({ name: "commit", description: "d" });
     expect(md).not.toContain("Model tier");
     expect(md).not.toContain("Tools");
+  });
+
+  it("emits a quoted description frontmatter line", () => {
+    const md = renderCommandPage({
+      name: "commit",
+      description: "the only path to a commit",
+    });
+    expect(md).toContain('description: "the only path to a commit"');
+  });
+
+  it("escapes double quotes and colons in the description frontmatter line", () => {
+    const md = renderCommandPage({
+      name: "commit",
+      description: 'The "only" path: a commit — never a direct write.',
+    });
+    expect(md).toContain(
+      'description: "The \\"only\\" path: a commit — never a direct write."',
+    );
+  });
+
+  it("omits the description frontmatter line when description is empty", () => {
+    const md = renderCommandPage({ name: "commit", description: "" });
+    expect(md).not.toContain("description:");
+  });
+
+  it("omits the description frontmatter line when description is absent", () => {
+    const md = renderCommandPage({ name: "commit" });
+    expect(md).not.toContain("description:");
   });
 });

--- a/site/test/generator/render-skill-page.test.ts
+++ b/site/test/generator/render-skill-page.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "vitest";
 import { renderSkillPage } from "../../scripts/generator/render-skill-page";
 
 describe("renderSkillPage", () => {
-  it("renders title, heading, and description", () => {
+  it("renders title and description, and no body H1", () => {
     const md = renderSkillPage({
       name: "tdd",
       description: "the test-first gate",
     });
     expect(md).toContain("title: tdd");
-    expect(md).toContain("# tdd");
+    expect(md).not.toMatch(/^# /m);
     expect(md).toContain("the test-first gate");
   });
 
@@ -16,5 +16,33 @@ describe("renderSkillPage", () => {
     const md = renderSkillPage({ name: "tdd", description: "d" });
     expect(md).not.toContain("Model tier");
     expect(md).not.toContain("Tools");
+  });
+
+  it("emits a quoted description frontmatter line", () => {
+    const md = renderSkillPage({
+      name: "tdd",
+      description: "the test-first gate",
+    });
+    expect(md).toContain('description: "the test-first gate"');
+  });
+
+  it("escapes double quotes and colons in the description frontmatter line", () => {
+    const md = renderSkillPage({
+      name: "tdd",
+      description: 'The "test-first" gate: red, green — refactor.',
+    });
+    expect(md).toContain(
+      'description: "The \\"test-first\\" gate: red, green — refactor."',
+    );
+  });
+
+  it("omits the description frontmatter line when description is empty", () => {
+    const md = renderSkillPage({ name: "tdd", description: "" });
+    expect(md).not.toContain("description:");
+  });
+
+  it("omits the description frontmatter line when description is absent", () => {
+    const md = renderSkillPage({ name: "tdd" });
+    expect(md).not.toContain("description:");
   });
 });

--- a/site/test/generator/yaml-quote.test.ts
+++ b/site/test/generator/yaml-quote.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+  yamlQuoteEscape,
+  yamlDescriptionLine,
+} from "../../scripts/generator/yaml-quote";
+
+describe("yamlQuoteEscape", () => {
+  it("leaves a plain string unchanged", () => {
+    expect(yamlQuoteEscape("plain text")).toBe("plain text");
+  });
+
+  it("escapes double quotes", () => {
+    expect(yamlQuoteEscape('the "quoted" word')).toBe(
+      'the \\"quoted\\" word',
+    );
+  });
+
+  it("escapes backslashes before quotes so escaping is not doubled", () => {
+    expect(yamlQuoteEscape('a\\"b')).toBe('a\\\\\\"b');
+  });
+
+  it("leaves colons and em-dashes unescaped (safe inside a double-quoted scalar)", () => {
+    expect(yamlQuoteEscape("a: b — c")).toBe("a: b — c");
+  });
+});
+
+describe("yamlDescriptionLine", () => {
+  it("renders a quoted description line", () => {
+    expect(yamlDescriptionLine("hello world")).toBe(
+      'description: "hello world"',
+    );
+  });
+
+  it("escapes quotes and colons together", () => {
+    expect(yamlDescriptionLine('The "only" path: forward.')).toBe(
+      'description: "The \\"only\\" path: forward."',
+    );
+  });
+
+  it("returns an empty string for an empty description", () => {
+    expect(yamlDescriptionLine("")).toBe("");
+  });
+
+  it("returns an empty string for an undefined description", () => {
+    expect(yamlDescriptionLine(undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

PR-0.2 of the docs-site overhaul campaign (spec: `.codearbiter/specs/docs-site-overhaul.md`).

All three reference renderers emitted a body `# <name>` alongside the frontmatter `title:`, so every generated page rendered two identical H1s. And with `title:`-only frontmatter, every page shipped the site-default meta description.

- Body H1 dropped; Starlight's frontmatter-title H1 is now the only one (verified: `PageTitle.astro` suppresses the landing hero only).
- Source `description:` now emitted as a double-quoted YAML frontmatter scalar via a new shared `yaml-quote.ts` (escapes `\` then `"`); omitted entirely when empty so Starlight falls back to the site default.
- Forge preview badge/callout moves to first body element, ahead of the description paragraph.

## Verification

- 191 vitest passing across 24 files (new `yaml-quote.test.ts` x8, +2 badge-ordering cases), typecheck clean, build 118 pages, link-audit 14,993 links OK.
- Dist proof: `reference/commands/commit/index.html` renders one `<h1` and a populated per-page `<meta name="description">`. Spot-checked skills/tdd and agents/scout.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
