### PR TITLE
fix(site): base-prefix markdown links at build time; fail link-audit on base-less hrefs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,6 +2,11 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import { readFileSync } from "node:fs";
+import { rehypeBaseLinks } from "./scripts/rehype-base-links.ts";
+
+// Served from https://arbiterforge.github.io/codeArbiter/ — shared by the
+// `base` option below and the rehype plugin that base-prefixes markdown links.
+const BASE = "/codeArbiter";
 
 // Build the reference sidebar groups from the generator's output. `predev` and
 // `prebuild` run `npm run gen` first, so sidebar.json exists before this loads.
@@ -31,32 +36,40 @@ export default defineConfig({
   // `base` also applies in local dev — the dev server serves at /codeArbiter/.
   //
   // BASE-PATH-SAFE LINK PATTERN for downstream authors:
-  //   - In Starlight MDX/Markdown, use root-relative slugs (no leading slash):
-  //       [Overview](/overview)  →  Starlight maps slugs through the base automatically.
-  //   - In Astro component href props, use import.meta.env.BASE_URL:
-  //       href={`${import.meta.env.BASE_URL}overview/`}
-  //   - Never hardcode "/codeArbiter/" in href strings. That value desynchs
+  //   - Starlight does NOT rewrite root-absolute markdown links through the
+  //     base on its own. Writing [Overview](/overview) in MDX/Markdown would
+  //     render a literal `/overview` href and 404 once served from a subpath.
+  //   - Instead, `markdown.rehypePlugins` below runs our local
+  //     `rehypeBaseLinks(BASE)` plugin (scripts/rehype-base-links.ts) over
+  //     every rendered page. It walks the HAST tree and prefixes any
+  //     root-absolute href/src ("/overview") with BASE ("/codeArbiter/overview"),
+  //     idempotently, so plain root-relative markdown links stay base-safe.
+  //   - In Astro component href props (not markdown), still use
+  //     import.meta.env.BASE_URL: href={`${import.meta.env.BASE_URL}overview/`}
+  //   - Never hardcode "/codeArbiter/" in href strings. That value desyncs
   //     when the Astro base is changed and is invisible to linting.
   site: "https://arbiterforge.github.io",
-  base: "/codeArbiter",
+  base: BASE,
   // Old `-2` skill URLs from before per-collection slug dedup (see generate.ts):
   // these six skills shared a name with a same-named command, so the combined
   // dedup pass pushed the skill page to a `-2` slug. Redirect the old URLs to
   // the now-clean ones.
   //
   // Astro matches redirect *keys* through `base` itself (base-relative, no
-  // "/codeArbiter" prefix). The *destination* value, however, is emitted
-  // verbatim as the redirect Location/meta-refresh target — it is NOT
-  // base-prefixed automatically — so destinations must carry the base
-  // explicitly to land on a real page, matching every other internal href in
-  // this site (see the BASE-PATH-SAFE LINK PATTERN note above).
+  // BASE prefix). The *destination* value, however, is emitted verbatim as the
+  // redirect Location/meta-refresh target — it is NOT base-prefixed
+  // automatically — so destinations must carry the base explicitly to land on
+  // a real page (built from the shared BASE constant above).
   redirects: {
-    "/reference/skills/context-check-2": "/codeArbiter/reference/skills/context-check",
-    "/reference/skills/debug-2": "/codeArbiter/reference/skills/debug",
-    "/reference/skills/decompose-2": "/codeArbiter/reference/skills/decompose",
-    "/reference/skills/refactor-2": "/codeArbiter/reference/skills/refactor",
-    "/reference/skills/release-2": "/codeArbiter/reference/skills/release",
-    "/reference/skills/tribunal-2": "/codeArbiter/reference/skills/tribunal",
+    "/reference/skills/context-check-2": `${BASE}/reference/skills/context-check`,
+    "/reference/skills/debug-2": `${BASE}/reference/skills/debug`,
+    "/reference/skills/decompose-2": `${BASE}/reference/skills/decompose`,
+    "/reference/skills/refactor-2": `${BASE}/reference/skills/refactor`,
+    "/reference/skills/release-2": `${BASE}/reference/skills/release`,
+    "/reference/skills/tribunal-2": `${BASE}/reference/skills/tribunal`,
+  },
+  markdown: {
+    rehypePlugins: [rehypeBaseLinks(BASE)],
   },
   integrations: [
     starlight({

--- a/site/scripts/link-audit.ts
+++ b/site/scripts/link-audit.ts
@@ -1,100 +1,15 @@
-/** link-audit.ts — post-build dangling-link gate (docs-site-polish AC-2 / AC-4).
+/** link-audit.ts — thin CLI over link-audit/lib.ts's pure functions.
  *
- * Walks every built HTML page under site/dist/ and extracts the targets of
- * `<a href>` and `<img src>`. For each INTERNAL target it resolves the URL to a
- * file on disk under dist/ and asserts that file exists. Any dangling internal
- * link makes the process exit non-zero, so a broken slug fails CI before deploy.
- *
- * Resolution rules (base path is /codeArbiter, see astro.config.mjs):
- *   - Root-absolute under the base  "/codeArbiter/x/"        -> dist/x/index.html
- *   - Root-absolute asset           "/codeArbiter/foo.svg"   -> dist/foo.svg
- *   - Page-relative directory link  "../concepts/"           -> dist/concepts/index.html
- *   - Page-relative asset           "diagrams/lane-flow.svg" -> dist/diagrams/lane-flow.svg
- *
- * Skipped (not internal-to-dist): external URLs (http:, https:, mailto:, etc.),
- * protocol-relative (//host), pure fragments (#anchor), data: URIs, and
- * root-absolute links that fall OUTSIDE the base prefix (not ours to resolve).
- *
- * Also asserts the always-present chrome assets exist: dist/favicon.svg and a
- * hashed dist/_astro/logo.*.svg.
- *
- * Uses Node built-ins + a small regex HTML scan only — no added dependency.
+ * Runs the post-build dangling-link + base-path-safety gate against
+ * site/dist/ and exits non-zero on any failure. See link-audit/lib.ts for
+ * the resolution rules and rationale.
  */
-import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
-import { join, posix, dirname, relative, sep } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import { auditDist, missingRequiredAssets, BASE } from "./link-audit/lib";
 
 const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
-const BASE = "/codeArbiter"; // must match astro.config.mjs `base`
-
-/** Recursively collect every *.html file under dir. */
-function htmlFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) out.push(...htmlFiles(full));
-    else if (entry.endsWith(".html")) out.push(full);
-  }
-  return out;
-}
-
-/** Extract href/src attribute values from one HTML string. */
-function extractTargets(html: string): string[] {
-  const targets: string[] = [];
-  const re = /\b(?:href|src)\s*=\s*"([^"]*)"/gi;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(html)) !== null) targets.push(m[1]);
-  return targets;
-}
-
-/** True for targets we do not resolve against the local dist tree. */
-function isExternalOrSkippable(target: string): boolean {
-  if (target === "") return true;
-  if (target.startsWith("#")) return true; // pure fragment
-  if (target.startsWith("//")) return true; // protocol-relative
-  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return true; // has a scheme (http:, mailto:, data:, ...)
-  return false;
-}
-
-/** Strip a query string and/or fragment from a URL path. */
-function stripQueryHash(target: string): string {
-  return target.split("#")[0].split("?")[0];
-}
-
-/**
- * Map an internal URL path to the file it must resolve to under dist/.
- * `pageUrlDir` is the page's own URL directory (posix), e.g. "/codeArbiter/overview".
- * Returns the absolute dist file path, or null if the target is out of scope.
- */
-function resolveToDistFile(target: string, pageUrlDir: string): string | null {
-  let urlPath = stripQueryHash(target);
-  if (urlPath === "") return null;
-
-  let absUrlPath: string;
-  if (urlPath.startsWith("/")) {
-    // Root-absolute. Only ours if it lives under the base prefix.
-    if (urlPath !== BASE && !urlPath.startsWith(`${BASE}/`)) return null;
-    absUrlPath = urlPath.slice(BASE.length) || "/";
-  } else {
-    // Page-relative: resolve against the page's URL directory, then drop base.
-    const joined = posix.normalize(posix.join(pageUrlDir, urlPath));
-    if (joined !== BASE && !joined.startsWith(`${BASE}/`)) return null;
-    absUrlPath = joined.slice(BASE.length) || "/";
-  }
-
-  // absUrlPath now starts at the site root (base stripped). Trailing slash or a
-  // bare directory means an index.html; otherwise it is a file path verbatim.
-  let rel: string;
-  if (absUrlPath.endsWith("/")) {
-    rel = `${absUrlPath}index.html`;
-  } else if (posix.basename(absUrlPath).includes(".")) {
-    rel = absUrlPath; // looks like a file (has an extension)
-  } else {
-    rel = `${absUrlPath}/index.html`; // extensionless route -> directory index
-  }
-
-  return join(DIST, ...rel.split("/").filter(Boolean));
-}
 
 function main(): void {
   if (!existsSync(DIST)) {
@@ -102,47 +17,20 @@ function main(): void {
     process.exit(1);
   }
 
-  const pages = htmlFiles(DIST);
-  const dangling: string[] = [];
-  let checked = 0;
+  const { failures, checked, pageCount } = auditDist(DIST, BASE);
+  const requiredAssets = missingRequiredAssets(DIST);
 
-  for (const page of pages) {
-    // The page's URL directory, base-prefixed, in posix form.
-    const relFromDist = relative(DIST, page).split(sep).join("/");
-    const pageUrlDir = posix.dirname(`${BASE}/${relFromDist}`);
-    const html = readFileSync(page, "utf8");
-
-    for (const target of extractTargets(html)) {
-      if (isExternalOrSkippable(target)) continue;
-      const distFile = resolveToDistFile(target, pageUrlDir);
-      if (distFile === null) continue; // out of scope (e.g. a non-base absolute path)
-      checked++;
-      if (!existsSync(distFile)) {
-        dangling.push(`${relFromDist}  ->  ${target}  (missing ${relative(DIST, distFile).split(sep).join("/")})`);
-      }
-    }
-  }
-
-  // Chrome assets the spec pins (AC-4).
-  const requiredAssets: string[] = [];
-  if (!existsSync(join(DIST, "favicon.svg"))) requiredAssets.push("dist/favicon.svg");
-  const astroDir = join(DIST, "_astro");
-  const hasLogo =
-    existsSync(astroDir) &&
-    readdirSync(astroDir).some((f) => /^logo\..*\.svg$/.test(f));
-  if (!hasLogo) requiredAssets.push("dist/_astro/logo.*.svg");
-
-  if (dangling.length > 0 || requiredAssets.length > 0) {
-    if (dangling.length > 0) {
-      console.error(`link-audit: ${dangling.length} dangling internal link(s):`);
-      for (const d of dangling) console.error(`  ${d}`);
+  if (failures.length > 0 || requiredAssets.length > 0) {
+    if (failures.length > 0) {
+      console.error(`link-audit: ${failures.length} link failure(s):`);
+      for (const f of failures) console.error(`  ${f.message}`);
     }
     for (const a of requiredAssets) console.error(`link-audit: required asset missing: ${a}`);
     process.exit(1);
   }
 
   console.log(
-    `link-audit: OK — ${checked} internal link(s) across ${pages.length} page(s) resolve; favicon + hashed logo present.`,
+    `link-audit: OK — ${checked} internal link(s) across ${pageCount} page(s) resolve; favicon + hashed logo present.`,
   );
 }
 

--- a/site/scripts/link-audit/lib.ts
+++ b/site/scripts/link-audit/lib.ts
@@ -1,0 +1,177 @@
+/** link-audit/lib.ts — pure functions backing the post-build dangling-link
+ * gate (docs-site-polish AC-2 / AC-4; hardened for base-path safety).
+ *
+ * Walks every built HTML page under site/dist/ and extracts the targets of
+ * `<a href>` and `<img src>`. For each target that looks internal (no URL
+ * scheme, not protocol-relative, not a pure fragment) it classifies the
+ * target and resolves it to a file on disk under dist/, asserting that file
+ * exists.
+ *
+ * Resolution rules (base path is /codeArbiter, see astro.config.mjs):
+ *   - Root-absolute under the base  "/codeArbiter/x/"        -> dist/x/index.html
+ *   - Root-absolute asset           "/codeArbiter/foo.svg"   -> dist/foo.svg
+ *   - Page-relative directory link  "../concepts/"           -> dist/concepts/index.html
+ *   - Page-relative asset           "diagrams/lane-flow.svg" -> dist/diagrams/lane-flow.svg
+ *
+ * Skipped entirely (not internal-to-dist): external URLs (http:, https:,
+ * mailto:, etc.), protocol-relative (//host), pure fragments (#anchor), and
+ * data: URIs.
+ *
+ * FAILED, not skipped: a root-absolute target that does not fall under the
+ * base prefix, or a page-relative target that normalizes outside the base.
+ * Before the local rehype-base-links build step existed, root-absolute
+ * markdown links like `](/overview)` silently rendered unprefixed and 404'd
+ * in production — this gate used to skip them as "out of scope" instead of
+ * catching that. They are now recorded as failures alongside dangling links.
+ *
+ * Uses Node built-ins + a small regex HTML scan only — no added dependency.
+ */
+import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
+import { join, posix, relative, sep } from "node:path";
+
+export const BASE = "/codeArbiter"; // must match astro.config.mjs `base`
+
+/** Recursively collect every *.html file under dir. */
+export function htmlFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...htmlFiles(full));
+    else if (entry.endsWith(".html")) out.push(full);
+  }
+  return out;
+}
+
+/** Extract href/src attribute values from one HTML string. */
+export function extractTargets(html: string): string[] {
+  const targets: string[] = [];
+  const re = /\b(?:href|src)\s*=\s*"([^"]*)"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) targets.push(m[1]);
+  return targets;
+}
+
+/** True for targets we do not evaluate at all: empty, pure fragment,
+ * protocol-relative, or carrying a URL scheme (http:, mailto:, data:, ...). */
+export function isExternalOrSkippable(target: string): boolean {
+  if (target === "") return true;
+  if (target.startsWith("#")) return true; // pure fragment
+  if (target.startsWith("//")) return true; // protocol-relative
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return true; // has a scheme (http:, mailto:, data:, ...)
+  return false;
+}
+
+/** Strip a query string and/or fragment from a URL path. */
+export function stripQueryHash(target: string): string {
+  return target.split("#")[0].split("?")[0];
+}
+
+export type Resolution =
+  | { kind: "resolved"; distFile: string }
+  | { kind: "outside-base"; normalizedPath: string };
+
+/**
+ * Classify + resolve an internal-looking URL path against the base prefix
+ * and, if in scope, map it to the file it must resolve to under dist/.
+ *
+ * `pageUrlDir` is the page's own URL directory (posix), e.g.
+ * "/codeArbiter/overview". `base` defaults to the site's configured BASE.
+ */
+export function resolveToDistFile(
+  target: string,
+  pageUrlDir: string,
+  distRoot: string,
+  base: string = BASE,
+): Resolution | null {
+  let urlPath = stripQueryHash(target);
+  if (urlPath === "") return null;
+
+  let absUrlPath: string;
+  let normalizedPath: string;
+  if (urlPath.startsWith("/")) {
+    // Root-absolute.
+    normalizedPath = urlPath;
+    if (normalizedPath !== base && !normalizedPath.startsWith(`${base}/`)) {
+      return { kind: "outside-base", normalizedPath };
+    }
+    absUrlPath = normalizedPath.slice(base.length) || "/";
+  } else {
+    // Page-relative: resolve against the page's URL directory.
+    normalizedPath = posix.normalize(posix.join(pageUrlDir, urlPath));
+    if (normalizedPath !== base && !normalizedPath.startsWith(`${base}/`)) {
+      return { kind: "outside-base", normalizedPath };
+    }
+    absUrlPath = normalizedPath.slice(base.length) || "/";
+  }
+
+  // absUrlPath now starts at the site root (base stripped). Trailing slash or
+  // a bare directory means an index.html; otherwise it is a file path
+  // verbatim.
+  let rel: string;
+  if (absUrlPath.endsWith("/")) {
+    rel = `${absUrlPath}index.html`;
+  } else if (posix.basename(absUrlPath).includes(".")) {
+    rel = absUrlPath; // looks like a file (has an extension)
+  } else {
+    rel = `${absUrlPath}/index.html`; // extensionless route -> directory index
+  }
+
+  return { kind: "resolved", distFile: join(distRoot, ...rel.split("/").filter(Boolean)) };
+}
+
+export interface AuditFailure {
+  message: string;
+}
+
+export interface AuditResult {
+  failures: AuditFailure[];
+  checked: number;
+  pageCount: number;
+}
+
+/** Run the full dangling-link + base-safety audit against a built dist/ dir. */
+export function auditDist(distRoot: string, base: string = BASE): AuditResult {
+  const pages = htmlFiles(distRoot);
+  const failures: AuditFailure[] = [];
+  let checked = 0;
+
+  for (const page of pages) {
+    // The page's URL directory, base-prefixed, in posix form.
+    const relFromDist = relative(distRoot, page).split(sep).join("/");
+    const pageUrlDir = posix.dirname(`${base}/${relFromDist}`);
+    const html = readFileSync(page, "utf8");
+
+    for (const target of extractTargets(html)) {
+      if (isExternalOrSkippable(target)) continue;
+      const resolution = resolveToDistFile(target, pageUrlDir, distRoot, base);
+      if (resolution === null) continue; // empty target, nothing to check
+      checked++;
+
+      if (resolution.kind === "outside-base") {
+        failures.push({
+          message: `${relFromDist}  ->  ${target}  (outside base path: resolves to ${resolution.normalizedPath}, not under ${base})`,
+        });
+        continue;
+      }
+
+      if (!existsSync(resolution.distFile)) {
+        failures.push({
+          message: `${relFromDist}  ->  ${target}  (missing ${relative(distRoot, resolution.distFile).split(sep).join("/")})`,
+        });
+      }
+    }
+  }
+
+  return { failures, checked, pageCount: pages.length };
+}
+
+/** Chrome assets the spec pins (AC-4): favicon.svg and a hashed logo asset. */
+export function missingRequiredAssets(distRoot: string): string[] {
+  const missing: string[] = [];
+  if (!existsSync(join(distRoot, "favicon.svg"))) missing.push("dist/favicon.svg");
+  const astroDir = join(distRoot, "_astro");
+  const hasLogo =
+    existsSync(astroDir) && readdirSync(astroDir).some((f) => /^logo\..*\.svg$/.test(f));
+  if (!hasLogo) missing.push("dist/_astro/logo.*.svg");
+  return missing;
+}

--- a/site/scripts/rehype-base-links.ts
+++ b/site/scripts/rehype-base-links.ts
@@ -1,0 +1,77 @@
+/** rehype-base-links.ts — base-path-safe link rewriting at build time.
+ *
+ * Starlight does NOT map root-absolute markdown links (`](/overview)`) through
+ * the configured `base` — that was a false claim in a prior astro.config.mjs
+ * comment. Left alone, such links render as literal `/overview` in the built
+ * HTML and 404 once the site is served from a subpath (GitHub Pages:
+ * `/codeArbiter/`).
+ *
+ * This rehype plugin walks the rendered HAST tree for every markdown/MDX page
+ * and, for each element `href`/`src` value that is root-absolute (starts with
+ * "/", not "//") and not already base-prefixed, prefixes it with the
+ * configured base. It is idempotent: running it twice never double-prefixes.
+ *
+ * Deliberately dependency-free: a plain recursive walk over `node.children`
+ * instead of pulling in `unist-util-visit`.
+ */
+
+/** Minimal shape of the HAST nodes we care about — element nodes with
+ * string-valued properties, and a `children` array for recursion. */
+interface HastNode {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+}
+
+const REWRITTEN_ATTRS = ["href", "src"] as const;
+
+/** True if `value` should be left alone: empty, a fragment-only link,
+ * protocol-relative, or carrying a URL scheme (http:, mailto:, data:, ...). */
+function isSkippable(value: string): boolean {
+  if (value === "") return true;
+  if (value.startsWith("#")) return true;
+  if (value.startsWith("//")) return true;
+  if (!value.startsWith("/")) return true; // not root-absolute — nothing to do
+  return false;
+}
+
+/** True if `value` is already prefixed with `base` (exactly, or as a
+ * directory prefix), so re-prefixing would double it up. */
+function isAlreadyBasePrefixed(value: string, base: string): boolean {
+  return value === base || value.startsWith(`${base}/`);
+}
+
+/** Prefix one attribute value with `base` if it needs it; otherwise return
+ * it unchanged. */
+function rewriteValue(value: string, base: string): string {
+  if (isSkippable(value)) return value;
+  if (isAlreadyBasePrefixed(value, base)) return value;
+  return `${base}${value}`;
+}
+
+function walk(node: HastNode, base: string): void {
+  if (node.type === "element" && node.properties) {
+    for (const attr of REWRITTEN_ATTRS) {
+      const value = node.properties[attr];
+      if (typeof value === "string") {
+        node.properties[attr] = rewriteValue(value, base);
+      }
+    }
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) walk(child, base);
+  }
+}
+
+/**
+ * Factory: returns a rehype plugin (a function returning a tree transformer)
+ * that base-prefixes root-absolute `href`/`src` values throughout the tree.
+ *
+ * Usage: `rehypeBaseLinks("/codeArbiter")` in `markdown.rehypePlugins`.
+ */
+export function rehypeBaseLinks(base: string) {
+  return () => (tree: HastNode) => {
+    walk(tree, base);
+  };
+}

--- a/site/src/content/docs/feature-forge/whats-in-the-forge.mdx
+++ b/site/src/content/docs/feature-forge/whats-in-the-forge.mdx
@@ -20,7 +20,7 @@ badge on the reference pages, so it stays in step with them automatically.
       {f.summary}<br />
       Opt in: <code>{f.optIn}</code>.{' '}
       {f.command ? (
-        <a href={`${import.meta.env.BASE_URL}reference/commands/${f.command}/`}>Reference for /ca:{f.command}</a>
+        <a href={`${import.meta.env.BASE_URL.replace(/\/$/, "")}/reference/commands/${f.command}/`}>Reference for /ca:{f.command}</a>
       ) : f.href ? (
         <a href={f.href}>Details</a>
       ) : null}

--- a/site/test/link-audit/lib.test.ts
+++ b/site/test/link-audit/lib.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  extractTargets,
+  isExternalOrSkippable,
+  resolveToDistFile,
+  auditDist,
+  BASE,
+} from "../../scripts/link-audit/lib";
+
+describe("extractTargets", () => {
+  it("pulls href and src attribute values out of raw HTML", () => {
+    const html = `<a href="/codeArbiter/overview/">x</a><img src="foo.svg">`;
+    expect(extractTargets(html)).toEqual(["/codeArbiter/overview/", "foo.svg"]);
+  });
+});
+
+describe("isExternalOrSkippable", () => {
+  it("skips protocol-relative URLs", () => {
+    expect(isExternalOrSkippable("//host/x")).toBe(true);
+  });
+
+  it("skips URLs with a scheme", () => {
+    expect(isExternalOrSkippable("https://example.com")).toBe(true);
+    expect(isExternalOrSkippable("mailto:a@b.com")).toBe(true);
+  });
+
+  it("skips pure fragments", () => {
+    expect(isExternalOrSkippable("#frag")).toBe(true);
+  });
+
+  it("skips empty targets", () => {
+    expect(isExternalOrSkippable("")).toBe(true);
+  });
+
+  it("does not skip root-absolute or page-relative internal-looking targets", () => {
+    expect(isExternalOrSkippable("/overview/")).toBe(false);
+    expect(isExternalOrSkippable("../concepts/")).toBe(false);
+  });
+});
+
+describe("resolveToDistFile", () => {
+  const distRoot = "/fake/dist";
+
+  it("resolves a base-prefixed root-absolute target to a dist file", () => {
+    const result = resolveToDistFile("/codeArbiter/overview/", "/codeArbiter/x", distRoot, BASE);
+    expect(result).toEqual({
+      kind: "resolved",
+      distFile: join(distRoot, "overview", "index.html"),
+    });
+  });
+
+  it("classifies a base-less root-absolute target as outside-base (regression: previously silently skipped)", () => {
+    const result = resolveToDistFile("/overview/", "/codeArbiter/x", distRoot, BASE);
+    expect(result).toEqual({ kind: "outside-base", normalizedPath: "/overview/" });
+  });
+
+  it("resolves a page-relative target against the page's URL directory", () => {
+    const result = resolveToDistFile(
+      "../concepts/",
+      "/codeArbiter/guides/troubleshooting",
+      distRoot,
+      BASE,
+    );
+    expect(result).toEqual({
+      kind: "resolved",
+      distFile: join(distRoot, "guides", "concepts", "index.html"),
+    });
+  });
+
+  it("classifies a page-relative target that normalizes outside the base as outside-base", () => {
+    const result = resolveToDistFile("../../overview/", "/codeArbiter/x", distRoot, BASE);
+    expect(result?.kind).toBe("outside-base");
+  });
+
+  it("maps an extensionless route to its directory index", () => {
+    const result = resolveToDistFile("/codeArbiter/overview", "/codeArbiter/x", distRoot, BASE);
+    expect(result).toEqual({
+      kind: "resolved",
+      distFile: join(distRoot, "overview", "index.html"),
+    });
+  });
+
+  it("maps a file-like target (has an extension) verbatim", () => {
+    const result = resolveToDistFile("/codeArbiter/favicon.svg", "/codeArbiter/x", distRoot, BASE);
+    expect(result).toEqual({
+      kind: "resolved",
+      distFile: join(distRoot, "favicon.svg"),
+    });
+  });
+
+  it("returns null for an empty target", () => {
+    expect(resolveToDistFile("", "/codeArbiter/x", distRoot, BASE)).toBeNull();
+  });
+});
+
+describe("auditDist", () => {
+  let dist: string;
+
+  beforeAll(() => {
+    dist = mkdtempSync(join(tmpdir(), "link-audit-test-"));
+    mkdirSync(join(dist, "overview"), { recursive: true });
+    writeFileSync(join(dist, "overview", "index.html"), "<html><body>overview</body></html>");
+    writeFileSync(
+      join(dist, "index.html"),
+      [
+        `<a href="/codeArbiter/overview/">good link</a>`,
+        `<a href="/overview/">base-less link</a>`,
+        `<a href="https://example.com">external</a>`,
+        `<a href="//host/x">protocol-relative</a>`,
+        `<a href="#frag">fragment</a>`,
+        `<a href="/codeArbiter/missing/">dangling</a>`,
+      ].join("\n"),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(dist, { recursive: true, force: true });
+  });
+
+  it("resolves base-prefixed internal links and reports base-less ones and dangling ones as failures", () => {
+    const result = auditDist(dist, BASE);
+    const messages = result.failures.map((f) => f.message);
+
+    expect(messages.some((m) => m.includes("outside base path"))).toBe(true);
+    expect(messages.some((m) => m.includes("missing"))).toBe(true);
+    // The good, external, protocol-relative, and fragment links must not fail.
+    expect(messages.some((m) => m.includes("good link"))).toBe(false);
+    expect(result.failures.length).toBe(2);
+  });
+});

--- a/site/test/rehype-base-links.test.ts
+++ b/site/test/rehype-base-links.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { rehypeBaseLinks } from "../scripts/rehype-base-links";
+
+/** Minimal HAST-shaped fixture builder. */
+function elementTree(children: Array<Record<string, unknown>>) {
+  return {
+    type: "root",
+    children: children.map((c) => ({ type: "element", ...c })),
+  };
+}
+
+function run(tree: unknown, base = "/codeArbiter") {
+  const plugin = rehypeBaseLinks(base);
+  const transformer = plugin();
+  // @ts-expect-error — test-only loose call, tree shape matches our HastNode
+  transformer(tree);
+  return tree;
+}
+
+describe("rehypeBaseLinks", () => {
+  it("prefixes a bare-root href", () => {
+    const tree = elementTree([{ tagName: "a", properties: { href: "/overview" }, children: [] }]);
+    run(tree);
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.href).toBe("/codeArbiter/overview");
+  });
+
+  it("prefixes a bare-root src", () => {
+    const tree = elementTree([{ tagName: "img", properties: { src: "/diagrams/x.svg" }, children: [] }]);
+    run(tree);
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.src).toBe("/codeArbiter/diagrams/x.svg");
+  });
+
+  it("leaves an already-prefixed href untouched, and is idempotent across repeated runs", () => {
+    const tree = elementTree([{ tagName: "a", properties: { href: "/codeArbiter/overview" }, children: [] }]);
+    run(tree);
+    run(tree); // run again — must not double-prefix
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.href).toBe("/codeArbiter/overview");
+  });
+
+  it("leaves the bare base path itself untouched", () => {
+    const tree = elementTree([{ tagName: "a", properties: { href: "/codeArbiter" }, children: [] }]);
+    run(tree);
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.href).toBe("/codeArbiter");
+  });
+
+  it("leaves external URLs untouched", () => {
+    const tree = elementTree([
+      { tagName: "a", properties: { href: "https://example.com/x" }, children: [] },
+    ]);
+    run(tree);
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.href).toBe("https://example.com/x");
+  });
+
+  it("leaves protocol-relative URLs untouched", () => {
+    const tree = elementTree([{ tagName: "a", properties: { href: "//host/x" }, children: [] }]);
+    run(tree);
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.href).toBe("//host/x");
+  });
+
+  it("leaves fragment-only anchors untouched", () => {
+    const tree = elementTree([{ tagName: "a", properties: { href: "#section" }, children: [] }]);
+    run(tree);
+    // @ts-expect-error loose test access
+    expect(tree.children[0].properties.href).toBe("#section");
+  });
+
+  it("recurses into nested children", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "div",
+          properties: {},
+          children: [{ type: "element", tagName: "a", properties: { href: "/overview" }, children: [] }],
+        },
+      ],
+    };
+    run(tree);
+    expect(tree.children[0].children[0].properties.href).toBe("/codeArbiter/overview");
+  });
+});


### PR DESCRIPTION
## Summary

PR-0.1 of the docs-site overhaul campaign (spec: `.codearbiter/specs/docs-site-overhaul.md`). The P0 fix.

Every root-absolute markdown link (74 across 18 content files) rendered without the `/codeArbiter/` base and 404'd in production — the convention comment in `astro.config.mjs` claimed Starlight base-maps `](/slug)` links, which is false, and the link-audit gate silently skipped exactly that class (resolved against `dist/` where files exist regardless of base).

- **New `scripts/rehype-base-links.ts`**: dependency-free rehype plugin that base-prefixes root-absolute `href`/`src` values in the rendered HAST, idempotently. Wired via `markdown.rehypePlugins`; shared `BASE` constant now feeds `base`, the plugin, and the #221 redirect destinations. Convention comment rewritten to describe the real mechanism.
- **Hardened link-audit**: logic extracted to `scripts/link-audit/lib.ts` (unit-testable; thin CLI kept); a root-absolute internal target outside the base is now a **failure** ("outside base path"), not a skip.
- **Bonus real bug**: `whats-in-the-forge.mdx` built hrefs as `${BASE_URL}reference/...` — `BASE_URL` has no trailing slash, so this rendered `/codeArbiterreference/commands/prune/`. The old audit missed it; the hardened one caught it. Fixed.

## Detection proof

With the rehype wiring temporarily removed and the site rebuilt, the hardened audit fails:

```
link-audit: 76 link failure(s):
  concepts/auditability/index.html  ->  /reference/  (outside base path: resolves to /reference/, not under /codeArbiter)
  concepts/index.html  ->  /concepts/gated-lanes/  (outside base path: ...)
  ...
```

With the wiring restored: `OK — 15077 internal link(s) across 124 page(s) resolve`.

## Verification

- typecheck clean; 191 vitest passing (new `rehype-base-links.test.ts`, `link-audit/lib.test.ts`); build 124 pages; link-audit green.
- Rebased onto main after #221; redirect destinations now use the shared `BASE` constant.

Closes the production-404 class site-wide. After deploy, spot-check quickstart body links carry the base.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
