### PR TITLE
docs(site): voice guide + overview rewritten to address the reader

### DIFF
--- a/site/VOICE.md
+++ b/site/VOICE.md
@@ -1,0 +1,66 @@
+# Voice guide
+
+A working checklist for anyone writing or editing pages under `site/src/content/docs/`.
+
+## The principle
+
+In docs, **"you" is always the reader** — the developer using codeArbiter — never the
+model or the orchestrator persona. codeArbiter (or "the plugin") is the thing being
+described; the reader is the one being addressed.
+
+The plugin ships an orchestrator persona (`plugins/ca/ORCHESTRATOR.md`) written in a
+different register: it addresses the *model*, in second person, as an operating
+instruction ("You orchestrate; you do not freelance. You hold the gates; the user holds
+the decisions."). That persona-register text is source material, not doc prose. It may
+appear in docs only as clearly quoted or embedded source (fenced, attributed, or inside a
+source-embed block per the spec's curated-content model) — never rewritten as if it were
+addressing the reader, and never left to stand as unmarked page prose.
+
+If a passage reads naturally with "the model" substituted for "you," it is in the wrong
+register for a docs page. Rewrite it so "you" resolves only to the reader.
+
+## Register table
+
+| Register | Where | Rules |
+|---|---|---|
+| **Landing** | `index`, section intros | Punchy allowed. Show, don't claim — back an assertion with a concrete mechanism, example, or link, not adjectives. Max **one** aphorism or negation-triad per page. |
+| **Instructional** | Getting Started, Guides | Second person to the reader, imperative mood ("run", "open", "check"). Every step is verifiable — state what the reader should see or get back. No aphorisms. |
+| **Explanatory** | Concepts, Enforcement | Plain declarative. Define each term on first use, or link the glossary. Examples are mandatory, not optional color. |
+| **Reference** | Generated pages + curated framing | Neutral, front-loaded (lead with the fact, not the setup), template-conformant across all entries in a collection. No personality, no aphorisms. |
+
+## Aphorism budget
+
+Repeated parallel negation triads ("It does not X. It does not Y. It stops; it does not
+Z.") are a persona-register cadence. They are budgeted to **landing page and section
+intros only, once per page, maximum**. Everywhere else, say the positive rule plainly:
+what the gate does, not a list of what it refuses to do.
+
+## Terminology anchors
+
+One meaning each, locked to `plugins/ca/ORCHESTRATOR.md` §0.1. Do not drift or invent a
+synonym:
+
+- **gate** — a phase exit condition (STOP/BLOCK). Not "checkpoint," not "guardrail."
+- **lane** — a sanctioned path through the system (implementation, commit & ship,
+  decisions, project & meta). Not "workflow," not "track."
+- **STOP / BLOCK** — gate actions. STOP surfaces a decision and waits; BLOCK refuses to
+  proceed until fixed.
+- **override** — the sanctioned, logged bypass (`/override`). Never "workaround" or
+  "skip."
+- **Feature Forge** — the two-axis preview-features system. In navigation and
+  reader-facing copy it is labeled "Preview Features"; "Feature Forge" is the internal
+  name and may appear in explanatory prose once introduced.
+- **tribunal** — the deep, rarely-convened whole-codebase audit (`/ca:tribunal`). Not a
+  synonym for the routine `/ca:checkpoint` sweep.
+
+## Self-review checklist
+
+Before shipping a page, confirm:
+
+- [ ] Every "you" resolves to the reader, never to the model.
+- [ ] No persona-register passage stands as unmarked page prose.
+- [ ] At most one aphorism/negation-triad, and only if this is a landing page or section
+      intro.
+- [ ] Register matches the table above for this page's Diátaxis category.
+- [ ] Terminology matches the anchors list — no synonyms substituted.
+- [ ] Every instructional step states what the reader should observe.

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -4,18 +4,19 @@ description: How codeArbiter orchestrates gated software-engineering workflows i
 ---
 
 codeArbiter is a Claude Code plugin. When you enable it in a repository, it installs a
-single orchestrator persona that mediates every request. It orchestrates. It does not
-freelance. Every user intent flows through a slash command, routes to the one skill or
-agent that owns it, and clears its gates before it ships.
+single orchestrator persona that mediates every request. Every request you make flows
+through a slash command, which routes to the one skill or agent that owns it, and clears
+its gates before it ships.
 
-## You Hold the Gates; the User Holds the Decisions
+## codeArbiter Holds the Gates; You Hold the Decisions
 
-This is the organizing principle. codeArbiter is decisive about process and deferential
-about choices. It holds the gates: the test-first rule, the review chain, the secret and
-crypto checks, the commit and merge boundaries. It will not wave work through them. But
-the decisions those gates surface belong to the user. Which design? Which trade-off?
-Whether to merge? Those are yours. The plugin states; it does not hedge. It stops; it does
-not silently reconcile.
+This is the organizing principle. codeArbiter enforces process; you make the calls. It
+holds the gates: the test-first rule, the review chain, the secret and crypto checks, the
+commit and merge boundaries. Work does not pass a gate without clearing it. But the
+decisions those gates surface belong to you. Which design? Which trade-off? Whether to
+merge? Those are yours to make. When a gate finds something worth your attention, it
+reports the finding plainly and waits for your call — it does not resolve the question on
+your behalf.
 
 ## How a Request Flows
 
@@ -41,8 +42,8 @@ not silently reconcile.
 <div class="ca-callout ca-callout--gate">
   <p class="ca-callout__label">Gate</p>
   A gate is not advice you can wave off. It is the only path that kind of change takes to
-  ship. When a gate trips, codeArbiter surfaces the decision and waits; it does not invent
-  an answer and push past.
+  ship. When a gate trips, codeArbiter surfaces the decision and waits for you to resolve
+  it.
 </div>
 
 ## Context Minimization


### PR DESCRIPTION
## Summary

PR-1.1 of the docs-site overhaul campaign (spec: `.codearbiter/specs/docs-site-overhaul.md`). Phase 1 (voice), part 1 of 3.

- **New `site/VOICE.md`** — the campaign's voice standard: "you" is always the reader (persona-register text appears only as quoted/embedded source), a four-register table (Landing / Instructional / Explanatory / Reference), an aphorism budget (one per page, landing + section intros only), terminology anchors locked to ORCHESTRATOR.md §0.1, and a self-review checklist.
- **`overview.md` rewritten to address the reader.** The central heading flips addressee: "You Hold the Gates; the User Holds the Decisions" → "codeArbiter Holds the Gates; You Hold the Decisions". Persona-voice prose ("It orchestrates. It does not freelance.") rewritten as plain explanatory statements of what happens to the reader's request. Information content, structure, diagram, and links preserved.

Sibling PRs handle quickstart's worked example (1.2) and the enforcement split + remaining aphorism pages (1.3); this PR touches only the two files above.

## Verification

- typecheck clean; 216 vitest passing; build 118 pages; link-audit 15,077 links OK.
- Self-review against VOICE.md checklist: every "you" resolves to the reader (grep-verified); one aphorism on the page, within budget; terminology matches anchors.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
