### PR TITLE
docs(site): split enforcement into user layer + hardening-history design notes; cap aphorisms

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -165,6 +165,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: "Enforcement & Security", slug: "enforcement" },
+            { label: "Hardening History", slug: "concepts/hardening-history" },
             { label: "Hooks Reference", slug: "hooks" },
           ],
         },

--- a/site/src/content/docs/concepts/gated-lanes.md
+++ b/site/src/content/docs/concepts/gated-lanes.md
@@ -3,18 +3,18 @@ title: The Gated-Lane Model
 description: "How codeArbiter assigns every kind of work to a sanctioned path with gates scaled to its risk, and what distinguishes soft gates from hard gates."
 ---
 
-Every kind of work has a **lane**: a sanctioned path with gates scaled to its risk. A lane
-is not a suggestion. It is the only way that kind of change ships. `/ca:fix` and
-`/ca:feature` run test-first through the `tdd` gate. `/ca:refactor` must prove behavioral
-parity through *unmodified* pre-existing tests. `/ca:chore` carries lighter gates, because
-prose edits and dependency bumps don't demand TDD.
+Every kind of work has a **lane**: a sanctioned path with gates scaled to its risk, and the
+only way that kind of change ships. `/ca:fix` and `/ca:feature` run test-first through the
+`tdd` gate. `/ca:refactor` must prove behavioral parity through *unmodified* pre-existing
+tests. `/ca:chore` carries lighter gates, because prose edits and dependency bumps don't
+demand TDD.
 
 Gates come in two strengths. **Soft gates** surface a decision and wait for the user.
 **Hard gates** are true stops, never auto-decided, even under autonomous execution:
 anything in the security controls, auth/crypto/secret changes, irreversible operations, a
 gate bypass, an unresolved decision, or a merge to the default branch. Hard gates are rare
-by design. When they trip often, that's a signal the spec was too thin, not an obstacle to
-grind past.
+by design; a hard gate that trips often is a signal the spec was too thin, and worth fixing
+at the spec rather than working around at the gate.
 
 <figure class="ca-diagram">
   <img src="/codeArbiter/diagrams/gate-model.svg" alt="Gate model. A soft gate surfaces a decision bubble and waits for the user. A hard gate is a closed cross-bar that is never auto-decided." loading="lazy" />

--- a/site/src/content/docs/concepts/hardening-history.md
+++ b/site/src/content/docs/concepts/hardening-history.md
@@ -1,0 +1,45 @@
+---
+title: Hardening History
+description: "Design notes on why codeArbiter's enforcement gates are built the way they are, plus a dated log of hardening work as it shipped."
+---
+
+[Enforcement & Security](/enforcement/) states what is enforced. This page explains why some of those gates are built the way they are, and records the hardening work that shaped them over time.
+
+## Why the Crypto/Secret Gate Is Digest-Bound (H-09b / H-10b)
+
+The crypto/secret gate does not just check freshness. The crypto-compliance and secret-handling skills record a `security-gate-passed` marker holding the **digest of every sensitive line the gate approved**. At commit time, `pre-bash.py` requires both:
+
+- **freshness** (the marker is under 30 minutes old), and
+- **coverage** (every sensitive line in the diff being committed hashes to a line in the approved set).
+
+Coverage is what closes the time-of-check / time-of-use window: a pass minted for one diff cannot launder a *different* diff committed inside the freshness window. The scan reads the staged diff, plus the worktree diff when the commit uses `-a`/`--all`, stages files in the same command, or names a `git commit <pathspec>` (whose worktree content the `--cached` scan would miss).
+
+The gate fails closed when the diff cannot be read. If git is unavailable or times out, `added_lines()` returns `None` (distinct from an empty diff), and codeArbiter treats that as a reason to block the commit rather than wave it through. H-14's file-list read follows the same fail-closed rule.
+
+The detection corpus is shared: `CRYPTO_RE` and `SECRET_RE` live once in `_hooklib.py`, so the redactor and the gate stay aligned on what counts as crypto or a secret — there is exactly one place either pattern set can be edited, and both consumers pick up the change together.
+
+## Why the Board Has One Writer (ADR-0008)
+
+`open-tasks.md` has one sanctioned writer: `/ca:task`. No other agent, hook, or workflow modifies that file directly. The three mutations it performs are a queued add (a new task in `[ ]` state), the start-flip (`[ ]` to `[~]` with a stamped date), and the done-flip (`[~]` to `[x]`).
+
+The commit gate is the single board-sync chokepoint. Phase 6 of the commit-gate skill identifies a schema-valid board transition and exempts it from the scope-creep check; Phase 7 stages it alongside the work. The board flip lands atomically with the code it describes: an abandoned PR abandons the flip with it, and there is no window where the board reads done while the corresponding work is not yet merged.
+
+This design replaced an earlier pattern of a separate, lagging `chore(board)` PR that could drift from the code it described. Cross-session board drift — a task left open after its work lands — is now eliminated by construction rather than by process discipline. See ADR-0008 for the full design rationale.
+
+`/ca:standup` and `/ca:doctor` each run a read-only reconciliation sweep and surface any merged-but-not-flipped task; they report findings without writing to the board themselves.
+
+## Hardening Log
+
+Dated record of enforcement hardening as it shipped, newest first. Versions correspond to `CHANGELOG.md` entries in the repository root.
+
+- **v2.5.2 (2026-06-25)** — Broadened crypto detection: `CRYPTO_RE` now flags `rc2` and `blowfish` alongside MD5, SHA-1, DES, 3DES, and RC4, plus TLS-disable forms (`rejectUnauthorized: false`, `NODE_TLS_REJECT_UNAUTHORIZED`, `verify=False`, `InsecureSkipVerify`).
+- **v2.5.2 (2026-06-25)** — Compound-name secret detection: `SECRET_RE` now matches compound keys (`aws_secret_access_key`, `client_secret`, `private_key`) and known token shapes (`AKIA…`, `ghp_…`, `sk-ant-…`).
+- **v2.5.2 (2026-06-25)** — Gate-pass markers became atomic and digest-bound, so an unrelated edit inside the freshness window no longer inherits an unrelated approval.
+- **v2.5.2 (2026-06-25)** — Audit-path sets centralized: `AUDIT_LOG_NAMES` and the decisions-path tokens live once in `_hooklib`, so the shell, Write, and Edit flanks can no longer disagree on which files are append-only.
+- **v2.5.2 (2026-06-25)** — `ca-sandbox` isolation hardened for untrusted repositories: non-root (`--user 1000:1000`), `--read-only` root, `--cap-drop ALL`, `--security-opt no-new-privileges`, and a fail-closed network policy (default `--network none`; an unknown policy is a hard error rather than a silent pass-through). No host bind mounts; the docker socket is never mounted.
+
+## Related
+
+- [Enforcement & Security](/enforcement/) — the user-facing statement of what is enforced.
+- [ADRs and the Decision Log](/concepts/adrs/)
+- [Hooks reference](/hooks/)

--- a/site/src/content/docs/concepts/provenance-drift.md
+++ b/site/src/content/docs/concepts/provenance-drift.md
@@ -7,7 +7,7 @@ Every derived document under `.codearbiter/` traces its claims to source files i
 
 Drift is surfaced once, passively, as a single line at SessionStart. It does not interrupt work. `.codearbiter/code-map.md` provides a coarse orientation map: it names the main source files and the docs that depend on them. `/ca:context-check` runs the same detection on demand, as a manual audit.
 
-When a commit lands, the **commit-gate auto-heal** step checks whether any staged source files have drifted their dependent docs. If they have, it re-baselines the provenance in the same commit or proposes a doc update to accompany the work. A drifted claim is suppressed rather than surfaced as if fresh. A stale assertion cannot appear as current fact.
+When a commit lands, the **commit-gate auto-heal** step checks whether any staged source files have drifted their dependent docs. If they have, it re-baselines the provenance in the same commit or proposes a doc update to accompany the work, so a stale claim gets flagged and corrected before it can be read as current.
 
 <figure class="ca-diagram">
   <img src="/codeArbiter/diagrams/provenance-drift-flow.svg" alt="Context-drift provenance flow: a tracked source change is detected by a git hash-object mismatch, surfaced at SessionStart, and healed by commit-gate which re-baselines or proposes a doc update with the work commit." loading="lazy" />

--- a/site/src/content/docs/enforcement.md
+++ b/site/src/content/docs/enforcement.md
@@ -29,28 +29,7 @@ These run in `pre-bash.py` on `PreToolUse(Bash|PowerShell)` (plus the Write/Edit
 | **H-11** | ADRs are authored only via `/ca:adr`. Both the shell flank (redirects, `cp`, `rm`, `sed -i` into `decisions/`) and the Write/Edit flank are guarded; the skill drops a fresh authoring marker first. |
 | **H-14** | Migration review. A commit staging a database migration is blocked unless a migration-review pass is recorded for that file's current content. |
 
-### H-09b/H-10b: A Digest-Bound Gate That Closes TOCTOU
-
-The crypto/secret gate does not just check freshness. The crypto-compliance and secret-handling skills record a `security-gate-passed` marker holding the **digest of every sensitive line the gate approved**. At commit time, `pre-bash.py` requires both:
-
-- **freshness** (the marker is under 30 minutes old), and
-- **coverage** (every sensitive line in the diff being committed hashes to a line in the approved set).
-
-Coverage is what closes the time-of-check / time-of-use window: a pass minted for one diff cannot launder a *different* diff committed inside the freshness window. The scan reads the staged diff, plus the worktree diff when the commit uses `-a`/`--all`, stages files in the same command, or names a `git commit <pathspec>` (whose worktree content the `--cached` scan would miss).
-
-The gate **fails closed when the diff cannot be read.** If git is unavailable or times out, `added_lines()` returns `None` (distinct from an empty diff) and the commit is blocked rather than waved through. The same fail-closed rule governs H-14's file-list read.
-
-The detection corpus is shared. `CRYPTO_RE` and `SECRET_RE` live once in `_hooklib.py`, so the redactor and the gate cannot drift on what counts as crypto or a secret.
-
-## Commit-Gate Board Transitions (ADR-0008)
-
-`open-tasks.md` has one sanctioned writer: `/ca:task`. No other agent, hook, or workflow is permitted to modify that file directly. The three mutations it performs are a queued add (a new task in `[ ]` state), the start-flip (`[ ]` to `[~]` with a stamped date), and the done-flip (`[~]` to `[x]`).
-
-The commit gate is the single board-sync chokepoint. Phase 6 of the commit-gate skill identifies a schema-valid board transition and exempts it from the scope-creep check; Phase 7 stages it alongside the work. The board flip therefore lands atomically with the code it describes: an abandoned PR abandons the flip with it, and there is no window where the board reads done while the corresponding work is not yet merged.
-
-This replaces the old pattern of a separate, lagging `chore(board)` PR. Cross-session board drift (a task left open after its work lands) is eliminated by construction rather than by process discipline. See ADR-0008 for the full design rationale.
-
-`/ca:standup` and `/ca:doctor` each run a read-only reconciliation sweep and surface any merged-but-not-flipped task. They report; they do not write.
+H-09b/H-10b is digest-bound: a recorded pass covers only the exact sensitive lines it approved, which closes a time-of-check / time-of-use gap between approval and commit. The board-sync behavior implied by the commit gate (only `/ca:task` writes `open-tasks.md`) follows from ADR-0008. For the design rationale behind both, see [Hardening History](/concepts/hardening-history/).
 
 ## Advisory, Non-Blocking Reminders
 
@@ -65,13 +44,9 @@ This replaces the old pattern of a separate, lagging `chore(board)` PR. Cross-se
 
 These are advisory **because they bite at a later boundary, not at commit.** A bad CI workflow, IaC manifest, or auth change does damage only once merged or applied, and `security-reviewer` is the real enforcement point at the PR. The dangerous crypto and secret primitives, which land the moment code ships, stay hard-blocked by H-09b/H-10b.
 
-## 2.5.2 Hardening
+## Sandbox Isolation for Untrusted Repositories
 
-- **Broader crypto detection.** `CRYPTO_RE` flags `rc2` and `blowfish` alongside MD5, SHA-1, DES, 3DES, and RC4, and TLS-disable forms (`rejectUnauthorized: false`, `NODE_TLS_REJECT_UNAUTHORIZED`, `verify=False`, `InsecureSkipVerify`).
-- **Compound-name secret detection.** `SECRET_RE` matches compound keys (`aws_secret_access_key`, `client_secret`, `private_key`) and known token shapes (`AKIA…`, `ghp_…`, `sk-ant-…`).
-- **Atomic, digest-bound gate-pass markers.** Passes are bound to line digests, so an unrelated edit inside the freshness window does not inherit the approval.
-- **Centralized audit-path sets.** `AUDIT_LOG_NAMES` and the decisions-path tokens live once in `_hooklib`, so the shell, Write, and Edit flanks never disagree on which files are append-only.
-- **ca-sandbox isolation.** The sandbox that runs untrusted repositories is non-root (`--user 1000:1000`), `--read-only` root, `--cap-drop ALL`, `--security-opt no-new-privileges`, with a **fail-closed network policy** (default `--network none`; an unknown policy is a hard error, never a silent pass-through). No host bind mounts; the docker socket is never mounted.
+codeArbiter runs untrusted repositories inside `ca-sandbox`, isolated as non-root (`--user 1000:1000`), with a `--read-only` root, `--cap-drop ALL`, `--security-opt no-new-privileges`, and a fail-closed network policy (default `--network none`; an unknown policy is a hard error, not a silent pass-through). No host bind mounts; the docker socket is never mounted. For how this posture evolved release over release, see [Hardening History](/concepts/hardening-history/).
 
 ## Fail-Loud, Never Silently Dormant
 

--- a/site/src/content/docs/guides/overriding-a-gate.md
+++ b/site/src/content/docs/guides/overriding-a-gate.md
@@ -3,7 +3,7 @@ title: "Override a Gate Safely"
 description: "Bypass a blocked gate with /ca:override, the only sanctioned path: one audit line is appended to overrides.log, your identity comes from git config user.email, and the bypass is permanent in the trail."
 ---
 
-A gate blocked your command and the action is genuinely justified. Use `/ca:override "reason"` to bypass it. That is the only sanctioned path. Every other bypass is unsanctioned and leaves no record.
+A gate blocked your command and the action is genuinely justified. Use `/ca:override "reason"` to bypass it — the only sanctioned path, since any other bypass leaves no record in the audit trail.
 
 Before running it, identify which kind of gate you are facing. The two paths are different.
 
@@ -29,7 +29,7 @@ Do not use `/ca:override` when:
 - Routine work passed all gates. The command is not needed and running it creates a permanent log entry for no reason.
 - Two sources conflict rather than one blocking the other. Use `/ca:conflict` instead.
 
-The bypass is scoped to the immediate action only. It creates no standing exception for future commands.
+The bypass applies only to the immediate action; future commands still hit the gate.
 
 ## Run the Command
 
@@ -50,7 +50,7 @@ The reason must name the gate and justify the action. A vague reason such as "ju
 
 3. The blocked action proceeds. The response confirms that the override is logged.
 
-The override covers the immediate action only. Nothing else is changed.
+The override covers only the immediate action.
 
 ## Security-Critical Stops
 


### PR DESCRIPTION
## Summary

PR-1.3 of the docs-site overhaul campaign (spec: `.codearbiter/specs/docs-site-overhaul.md`). Phase 1 (voice), part 3 of 3.

- **`enforcement.md` split into two layers.** The user layer keeps the activation contract, the blocking-gates table (H-IDs stay — they're the strings users see in their terminal), advisory reminders, and the fail-loud posture. The version-fossil `## 2.5.2 Hardening` section, the H-09b/H-10b digest-binding (TOCTOU-closure) design essay, and the ADR-0008 single-board-writer rationale move to a new **`concepts/hardening-history.md`** — framed as "why the gates are built this way," with a dated hardening log (date-led entries, no version-headed sections). Cross-linked both directions; sidebar entry added under Security (IA moves come in Phase 3).
- **Aphorism cap** per `site/VOICE.md` on `concepts/gated-lanes.md`, `guides/overriding-a-gate.md`, `concepts/provenance-drift.md` — negation-triad/staccato cadences rewritten as plain declarative sentences carrying the same content.
- Grep confirmed no `enforcement#` fragment links existed, so the moved anchors dangle nowhere.

## Verification

- typecheck clean; 216 vitest passing; build green; link-audit green.
- `enforcement.md` contains no version-headed section; the hardening log renders dated entries in built HTML.

## Note

The implementing agent hit the #223 hook/worktree gap in a second form (the `-C` workaround for H-01 doesn't propagate to H-09b's marker lookup, which reads the pinned project root) — and correctly **refused** to hand-plant the marker, reporting back instead. The work was landed from the main checkout where the gates resolve properly; the crypto-compliance review passed (flagged lines are prose naming detection-corpus patterns, not crypto code). Second facet noted on #223.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
