### PR TITLE
feat(site): two-layer source-visible reference pages (curated merge + verbatim embeds)

### DIFF
--- a/site/scripts/gen.ts
+++ b/site/scripts/gen.ts
@@ -9,8 +9,9 @@ const repoRoot = resolve(here, "..", ".."); // -> repo root
 const srcDir = join(repoRoot, "plugins", "ca");
 const outDir = join(here, "..", "src", "content", "docs", "reference");
 const sidebarPath = join(here, "..", "src", "generated", "sidebar.json");
+const curatedDir = join(here, "..", "src", "curated");
 
-const result = generate(srcDir, outDir, sidebarPath);
+const result = generate(srcDir, outDir, sidebarPath, curatedDir);
 const counts = result.pages.reduce<Record<string, number>>((acc, p) => {
   acc[p.type] = (acc[p.type] ?? 0) + 1;
   return acc;

--- a/site/scripts/generator/generate.ts
+++ b/site/scripts/generator/generate.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { collectSources } from "./collect-sources";
 import { parseDoc } from "./parse-doc";
@@ -9,7 +9,14 @@ import { renderCommandPage } from "./render-command-page";
 import { renderSkillPage } from "./render-skill-page";
 import { buildIndex } from "./build-index";
 import { getCommandForgeStatus } from "./forge-status";
-import type { GenerateResult, PageInput, RenderedPage, SourceType } from "./types";
+import { loadCurated } from "./load-curated";
+import type {
+  GenerateResult,
+  PageInput,
+  RelatedLink,
+  RenderedPage,
+  SourceType,
+} from "./types";
 
 /** Output subdirectory for each source type. */
 const TYPE_DIR: Record<SourceType, string> = {
@@ -42,18 +49,46 @@ function normalize(raw: string): string {
 }
 
 /**
- * Generate the full reference: collect → parse → render → write.
+ * Read the plugin's version from `<srcDir>/.claude-plugin/plugin.json`.
+ *
+ * Falls back to `"0.0.0-dev"` when the file is absent or unreadable (e.g. a
+ * synthetic test fixture with no plugin manifest) rather than throwing — the
+ * version only pins the source-embed's "View in repo" link.
+ */
+function readPluginVersion(srcDir: string): string {
+  const manifestPath = join(srcDir, ".claude-plugin", "plugin.json");
+  if (!existsSync(manifestPath)) return "0.0.0-dev";
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    return typeof manifest.version === "string" ? manifest.version : "0.0.0-dev";
+  } catch {
+    return "0.0.0-dev";
+  }
+}
+
+/**
+ * Generate the full reference: collect → parse → curate → render → write.
  *
  * Reads plugin sources under `srcDir`, emits one markdown page per source file
  * under `outDir/{commands,skills,agents}/<slug>.md` (slugs deduplicated so there
  * are no collisions), writes an `index.md`, and writes the sidebar JSON to
  * `sidebarPath` (default `outDir/sidebar.json`). Idempotent: running twice over
- * the same sources produces byte-identical output. Returns a summary.
+ * the same sources produces byte-identical output.
+ *
+ * Every page carries a verbatim source embed (see `render-source-embed.ts`).
+ * When `curatedDir` is given and contains a companion file for a source, its
+ * curated framing (body, gates, related links) is merged in — see
+ * `load-curated.ts` for the divergence-check rules. Before writing, the
+ * output's `{commands,skills,agents}` dirs and `index.md` are deleted so a
+ * stale file from a prior run (e.g. an old `-2` slug) cannot survive.
+ *
+ * Returns a summary.
  */
 export function generate(
   srcDir: string,
   outDir: string,
   sidebarPath?: string,
+  curatedDir?: string,
 ): GenerateResult {
   const resolvedSidebarPath = sidebarPath ?? join(outDir, "sidebar.json");
   // `INDEX.md` files are the plugin's internal catalog / surface-scan tables
@@ -91,6 +126,25 @@ export function generate(
     });
   }
 
+  // Curated companion files key off the plugin source file's basename (a
+  // skill's basename is its directory name), not the display name — the same
+  // filename-stable discipline forge-status.ts uses. Compute it by calling
+  // deriveName with no frontmatter fields, so a `name:` override in the
+  // source can never change the curated lookup key.
+  const basenameKeys = parsed.map((p) => deriveName(p.source.path, {}));
+  const entityKeys = parsed.map(
+    (p, i) => `${TYPE_DIR[p.source.type]}/${basenameKeys[i]}`,
+  );
+  const entityKeyToIndex = new Map<string, number>(
+    entityKeys.map((key, i) => [key, i]),
+  );
+  const collectedKeys = new Set(entityKeys);
+  const curatedMap = curatedDir
+    ? loadCurated(curatedDir, collectedKeys)
+    : new Map();
+
+  const pluginVersion = readPluginVersion(srcDir);
+
   const pages: RenderedPage[] = parsed.map(({ source, doc }, i) => {
     const name = names[i];
     // Derive forge status for command pages only. The slug at this point is the
@@ -100,12 +154,39 @@ export function generate(
       source.type === "command"
         ? getCommandForgeStatus(slugs[i])
         : null;
+    const curated = curatedMap.get(entityKeys[i]);
+
+    let relatedLinks: RelatedLink[] | undefined;
+    if (curated?.related && curated.related.length > 0) {
+      relatedLinks = curated.related.map((ref: string) => {
+        const resolvedKey = ref.includes("/")
+          ? ref
+          : `${TYPE_DIR[source.type]}/${ref}`;
+        const targetIndex = entityKeyToIndex.get(resolvedKey);
+        if (targetIndex === undefined) {
+          throw new Error(
+            `Curated file for "${entityKeys[i]}" has an unresolvable related ref "${ref}"`,
+          );
+        }
+        const targetType = parsed[targetIndex].source.type;
+        return {
+          label: names[targetIndex],
+          href: `/reference/${TYPE_DIR[targetType]}/${slugs[targetIndex]}/`,
+        };
+      });
+    }
+
     const input: PageInput = {
       name,
       description: doc.fields.description ?? "",
       model: doc.fields.model,
       tools: doc.fields.tools,
       forgeStatus,
+      curated,
+      relatedLinks,
+      sourceRaw: source.raw,
+      sourceRelPath: `plugins/ca/${source.path}`,
+      pluginVersion,
     };
     return {
       type: source.type,
@@ -114,6 +195,15 @@ export function generate(
       markdown: renderPage(source.type, input),
     };
   });
+
+  // Clean prior output before writing: a stale file from a previous run (an
+  // old `-2` slug, a since-removed entity) must not survive a re-generate.
+  // Only the generated subtrees + index are removed — never the whole
+  // outDir, which may hold other content-collection files.
+  for (const typeDir of Object.values(TYPE_DIR)) {
+    rmSync(join(outDir, typeDir), { recursive: true, force: true });
+  }
+  rmSync(join(outDir, "index.md"), { force: true });
 
   // Write one page per source under its type directory.
   for (const page of pages) {

--- a/site/scripts/generator/load-curated.ts
+++ b/site/scripts/generator/load-curated.ts
@@ -1,0 +1,186 @@
+/** load-curated.ts — codeArbiter's curated-companion-file loader.
+ *
+ * Discovers and parses every curated framing file under
+ * `site/src/curated/{commands,agents,skills}/<basename>.md`, keyed by the
+ * plugin source file's basename (the same filename-stable discipline
+ * `forge-status.ts` uses) — the skill "basename" is its containing
+ * directory name, matching `deriveName`'s SKILL.md fallback.
+ *
+ * Enforces the divergence check both directions:
+ *   - a curated file whose `entity` has no matching collected source is an
+ *     orphan and THROWS (lists every orphan file found, not just the first);
+ *   - two curated files declaring the same `entity` THROWS;
+ *   - a collected source with no curated file is fine — the caller falls
+ *     back to an uncurated (generated-only) page.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { splitFrontmatter } from "./split-frontmatter";
+import { parseFields } from "./parse-fields";
+import type { CuratedDoc, GateSpec, SourceType } from "./types";
+
+const TYPE_DIR_NAME: Record<SourceType, string> = {
+  command: "commands",
+  skill: "skills",
+  agent: "agents",
+};
+const TYPES: SourceType[] = ["command", "skill", "agent"];
+
+/** Strip a leading BOM and normalize CRLF to LF, matching generate.ts's read boundary. */
+function normalize(raw: string): string {
+  const noBom = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  return noBom.replace(/\r\n/g, "\n");
+}
+
+/**
+ * Parse a `related:` frontmatter field.
+ *
+ * Accepted syntax: a single flow-style list on one line —
+ * `related: [commit, skills/tdd]`. An empty `related: []` yields `[]`.
+ * Absent field yields `undefined`. This is deliberately minimal (no
+ * block-list form, no quoting) — refs are bare identifiers.
+ */
+function parseRelated(frontmatter: string): string[] | undefined {
+  const match = frontmatter.match(/^related:\s*\[(.*)\]\s*$/m);
+  if (!match) return undefined;
+  const inner = match[1].trim();
+  if (inner === "") return [];
+  return inner
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function finalizeGate(partial: Partial<GateSpec>, filePath: string): GateSpec {
+  if (!partial.gate || !partial.when || !partial.effect) {
+    throw new Error(
+      `Curated file ${filePath}: a "gates:" entry is missing gate/when/effect`,
+    );
+  }
+  return { gate: partial.gate, when: partial.when, effect: partial.effect };
+}
+
+/**
+ * Parse a `gates:` frontmatter field — a block list of `{gate, when, effect}` maps.
+ *
+ * Accepted syntax (a deliberately minimal, line-based YAML subset — no
+ * external YAML dependency, consistent with the rest of the generator):
+ *
+ * ```yaml
+ * gates:
+ *   - gate: commit-gate
+ *     when: staged changes exist
+ *     effect: blocks commit until tests/lint/secrets scan pass
+ *   - gate: another gate
+ *     when: ...
+ *     effect: ...
+ * ```
+ *
+ * Each entry starts with a `- gate: <value>` line; the following `when:` and
+ * `effect:` lines (any indentation, in either order) belong to that entry
+ * until the next `- gate:` line or a line that dedents back to column 0
+ * (the next top-level frontmatter key). No nested lists, no flow-style
+ * `{...}` maps, no multi-line scalars.
+ */
+function parseGates(frontmatter: string, filePath: string): GateSpec[] | undefined {
+  const lines = frontmatter.split("\n");
+  const startIdx = lines.findIndex((l) => /^gates:\s*$/.test(l));
+  if (startIdx === -1) return undefined;
+
+  const gates: GateSpec[] = [];
+  let current: Partial<GateSpec> | null = null;
+
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    // A line starting at column 0 is the next top-level frontmatter key.
+    if (!/^\s/.test(line)) break;
+
+    const item = line.match(/^\s*-\s*gate:\s*(.+)$/);
+    if (item) {
+      if (current) gates.push(finalizeGate(current, filePath));
+      current = { gate: item[1].trim() };
+      continue;
+    }
+    const kv = line.match(/^\s*(when|effect):\s*(.*)$/);
+    if (kv && current) {
+      current[kv[1] as "when" | "effect"] = kv[2].trim();
+    }
+  }
+  if (current) gates.push(finalizeGate(current, filePath));
+  return gates;
+}
+
+function parseCurated(raw: string, filePath: string): CuratedDoc {
+  const { frontmatter, body } = splitFrontmatter(normalize(raw));
+  if (frontmatter === null) {
+    throw new Error(`Curated file ${filePath} has no frontmatter block`);
+  }
+  const fields = parseFields(frontmatter);
+  const entity = fields.entity;
+  if (!entity) {
+    throw new Error(`Curated file ${filePath} is missing the required "entity" field`);
+  }
+  return {
+    entity,
+    related: parseRelated(frontmatter),
+    gates: parseGates(frontmatter, filePath),
+    body: body.trim(),
+  };
+}
+
+/**
+ * Discover and parse every curated companion file under `curatedDir`.
+ *
+ * `collectedKeys` is the set of `<type-dir>/<basename>` keys for every
+ * collected plugin source (built by `generate.ts` from the same collection
+ * pass, so this check reads exactly the sources a given `npm run gen`
+ * invocation saw). Returns a Map keyed by `entity` (`<type-dir>/<basename>`).
+ * A missing `curatedDir` returns an empty Map (curated content is entirely
+ * optional).
+ */
+export function loadCurated(
+  curatedDir: string,
+  collectedKeys: Set<string>,
+): Map<string, CuratedDoc> {
+  const result = new Map<string, CuratedDoc>();
+  if (!existsSync(curatedDir)) return result;
+
+  const orphans: string[] = [];
+  const seenBy = new Map<string, string>();
+
+  for (const type of TYPES) {
+    const dirName = TYPE_DIR_NAME[type];
+    const dir = join(curatedDir, dirName);
+    if (!existsSync(dir)) continue;
+
+    for (const entry of readdirSync(dir)) {
+      if (!entry.endsWith(".md")) continue;
+      const filePath = join(dir, entry);
+      const raw = readFileSync(filePath, "utf-8");
+      const doc = parseCurated(raw, filePath);
+
+      const existing = seenBy.get(doc.entity);
+      if (existing) {
+        throw new Error(
+          `Duplicate curated file for entity "${doc.entity}": ${existing} and ${filePath}`,
+        );
+      }
+      seenBy.set(doc.entity, filePath);
+
+      if (!collectedKeys.has(doc.entity)) {
+        orphans.push(filePath);
+        continue;
+      }
+      result.set(doc.entity, doc);
+    }
+  }
+
+  if (orphans.length > 0) {
+    throw new Error(
+      `Orphan curated file(s) with no matching collected source: ${orphans.join(", ")}`,
+    );
+  }
+
+  return result;
+}

--- a/site/scripts/generator/render-agent-page.ts
+++ b/site/scripts/generator/render-agent-page.ts
@@ -2,19 +2,24 @@ import { modelTier } from "./model-tier";
 import { formatToolsList } from "./format-tools-list";
 import type { PageInput } from "./types";
 import { yamlDescriptionLine } from "./yaml-quote";
+import { renderSourceEmbed } from "./render-source-embed";
+import { renderGatesTable } from "./render-gates-table";
+import { renderRelatedLinks } from "./render-related-links";
 
 /**
  * Render an agent reference page as Starlight-compatible markdown.
  *
- * Includes a `title:` frontmatter line and, when a description is present, a
- * quoted `description:` frontmatter line (used for the page's meta
- * description). Starlight renders the frontmatter `title` as the page's only
- * H1, so the body carries no `# <name>` heading — it opens with the
- * description, followed by a `**Model tier:**` line (via {@link modelTier},
- * so a missing model shows `default`), and a `**Tools:**` line (via
- * {@link formatToolsList}).
+ * Anatomy, in order: frontmatter (`title` + quoted `description`) →
+ * description paragraph → `Model tier`/`Tools` lines (via {@link modelTier}
+ * and {@link formatToolsList}) → curated body (verbatim, when `curated` is
+ * present) → gates table (when `curated.gates` is present) → `## Related`
+ * (when `relatedLinks` is present) → `## Source` verbatim embed (always).
+ *
+ * Starlight renders the frontmatter `title` as the page's only H1, so the
+ * body carries no `# <name>` heading.
  */
 export function renderAgentPage(input: PageInput): string {
+  const { curated, relatedLinks } = input;
   const description = input.description ?? "";
   const descriptionLine = yamlDescriptionLine(description);
   const frontMatterFields = descriptionLine
@@ -24,5 +29,29 @@ export function renderAgentPage(input: PageInput): string {
   const modelLine = `- **Model tier:** ${modelTier(input.model)}`;
   const toolsLine = `- **Tools:** ${formatToolsList(input.tools)}`;
 
-  return `${frontMatter}\n\n${description}\n\n${modelLine}\n${toolsLine}\n`;
+  const sections: string[] = [`${description}\n\n${modelLine}\n${toolsLine}`];
+
+  if (curated?.body) {
+    sections.push(curated.body.trim());
+  }
+
+  const gatesTable = renderGatesTable(curated?.gates);
+  if (gatesTable) {
+    sections.push(`## Gates\n\n${gatesTable}`);
+  }
+
+  const related = renderRelatedLinks(relatedLinks);
+  if (related) {
+    sections.push(related);
+  }
+
+  sections.push(
+    `## Source\n\n${renderSourceEmbed(
+      input.sourceRaw,
+      input.sourceRelPath,
+      input.pluginVersion,
+    )}`,
+  );
+
+  return `${frontMatter}\n\n${sections.join("\n\n")}\n`;
 }

--- a/site/scripts/generator/render-command-page.ts
+++ b/site/scripts/generator/render-command-page.ts
@@ -1,27 +1,25 @@
 /** render-command-page.ts — codeArbiter's command reference page renderer. */
 import type { PageInput } from "./types";
 import { yamlDescriptionLine } from "./yaml-quote";
+import { renderSourceEmbed } from "./render-source-embed";
+import { renderGatesTable } from "./render-gates-table";
+import { renderRelatedLinks } from "./render-related-links";
 
 /**
  * Render a command reference page as Starlight-compatible markdown.
  *
- * Includes a `title:` frontmatter line and, when a description is present, a
- * quoted `description:` frontmatter line (used for the page's meta
- * description). Starlight renders the frontmatter `title` as the page's only
- * H1, so the body carries no `# <name>` heading. Commands have no model or
- * tools, so the page renders neither a `Model tier` nor a `Tools` section.
+ * Anatomy, in order: frontmatter (`title` + quoted `description`) → forge
+ * preview badge/callout (when `forgeStatus` is set) → description paragraph
+ * → curated body (verbatim, when `curated` is present) → gates table (when
+ * `curated.gates` is present) → `## Related` (when `relatedLinks` is
+ * present) → `## Source` verbatim embed (always).
  *
- * When `forgeStatus` is provided on the input the renderer decorates the page:
- * - `preview-command` — a preview badge (`<span class="ca-badge" data-kind="preview">`)
- *   is injected as the first body element, before the description paragraph.
- * - `preview-flag` — a preview callout (`<div class="ca-callout ca-callout--preview">`)
- *   naming the preview flag is injected as the first body element, before the
- *   description paragraph.
- * - null / undefined — no decoration; the description paragraph is the only
- *   body content.
+ * Starlight renders the frontmatter `title` as the page's only H1, so the
+ * body carries no `# <name>` heading. Commands have no model or tools, so
+ * the page renders neither a `Model tier` nor a `Tools` line.
  */
 export function renderCommandPage(input: PageInput): string {
-  const { name, description, forgeStatus } = input;
+  const { name, description, forgeStatus, curated, relatedLinks } = input;
   const desc = description ?? "";
 
   let decoration = "";
@@ -42,10 +40,34 @@ export function renderCommandPage(input: PageInput): string {
     ? `title: ${name}\n${descriptionLine}`
     : `title: ${name}`;
 
+  const sections: string[] = [`${decoration}${desc}`.trimEnd()];
+
+  if (curated?.body) {
+    sections.push(curated.body.trim());
+  }
+
+  const gatesTable = renderGatesTable(curated?.gates);
+  if (gatesTable) {
+    sections.push(`## Gates\n\n${gatesTable}`);
+  }
+
+  const related = renderRelatedLinks(relatedLinks);
+  if (related) {
+    sections.push(related);
+  }
+
+  sections.push(
+    `## Source\n\n${renderSourceEmbed(
+      input.sourceRaw,
+      input.sourceRelPath,
+      input.pluginVersion,
+    )}`,
+  );
+
   return `---
 ${frontMatter}
 ---
 
-${decoration}${desc}
+${sections.join("\n\n")}
 `;
 }

--- a/site/scripts/generator/render-gates-table.ts
+++ b/site/scripts/generator/render-gates-table.ts
@@ -1,0 +1,20 @@
+/** render-gates-table.ts — codeArbiter's curated `gates:` table renderer. */
+import type { GateSpec } from "./types";
+
+/**
+ * Render a list of {@link GateSpec} entries as a markdown table.
+ *
+ * Returns an empty string for an empty/absent list, so callers can splice
+ * the result in unconditionally and get nothing when there is nothing to
+ * show. Column order is fixed: Gate, When, Effect.
+ */
+export function renderGatesTable(gates: GateSpec[] | undefined): string {
+  if (!gates || gates.length === 0) return "";
+
+  const header = "| Gate | When | Effect |\n| --- | --- | --- |";
+  const rows = gates
+    .map((g) => `| ${g.gate} | ${g.when} | ${g.effect} |`)
+    .join("\n");
+
+  return `${header}\n${rows}`;
+}

--- a/site/scripts/generator/render-related-links.ts
+++ b/site/scripts/generator/render-related-links.ts
@@ -1,0 +1,15 @@
+/** render-related-links.ts — codeArbiter's `## Related` section renderer. */
+import type { RelatedLink } from "./types";
+
+/**
+ * Render the `## Related` section for a page's resolved related links.
+ *
+ * Returns an empty string for an empty/absent list. Links are rendered in
+ * the order given (the order `curated.related` was written in).
+ */
+export function renderRelatedLinks(related: RelatedLink[] | undefined): string {
+  if (!related || related.length === 0) return "";
+
+  const links = related.map((r) => `- [${r.label}](${r.href})`).join("\n");
+  return `## Related\n\n${links}`;
+}

--- a/site/scripts/generator/render-skill-page.ts
+++ b/site/scripts/generator/render-skill-page.ts
@@ -1,25 +1,56 @@
 import type { PageInput } from "./types";
 import { yamlDescriptionLine } from "./yaml-quote";
+import { renderSourceEmbed } from "./render-source-embed";
+import { renderGatesTable } from "./render-gates-table";
+import { renderRelatedLinks } from "./render-related-links";
 
 /**
  * Render a skill reference page as Starlight-compatible markdown.
  *
- * Includes a `title:` frontmatter line and, when a description is present, a
- * quoted `description:` frontmatter line (used for the page's meta
- * description). Starlight renders the frontmatter `title` as the page's only
- * H1, so the body carries no `# <name>` heading — it opens with the
- * description.
+ * Anatomy, in order: frontmatter (`title` + quoted `description`) →
+ * description paragraph → curated body (verbatim, when `curated` is
+ * present) → gates table (when `curated.gates` is present) → `## Related`
+ * (when `relatedLinks` is present) → `## Source` verbatim embed (always).
+ *
+ * Starlight renders the frontmatter `title` as the page's only H1, so the
+ * body carries no `# <name>` heading.
  */
 export function renderSkillPage(input: PageInput): string {
+  const { curated, relatedLinks } = input;
   const description = input.description ?? "";
   const descriptionLine = yamlDescriptionLine(description);
   const frontMatterFields = descriptionLine
     ? `title: ${input.name}\n${descriptionLine}`
     : `title: ${input.name}`;
 
+  const sections: string[] = [description];
+
+  if (curated?.body) {
+    sections.push(curated.body.trim());
+  }
+
+  const gatesTable = renderGatesTable(curated?.gates);
+  if (gatesTable) {
+    sections.push(`## Gates\n\n${gatesTable}`);
+  }
+
+  const related = renderRelatedLinks(relatedLinks);
+  if (related) {
+    sections.push(related);
+  }
+
+  sections.push(
+    `## Source\n\n${renderSourceEmbed(
+      input.sourceRaw,
+      input.sourceRelPath,
+      input.pluginVersion,
+    )}`,
+  );
+
   return `---
 ${frontMatterFields}
 ---
-${description}
+
+${sections.join("\n\n")}
 `;
 }

--- a/site/scripts/generator/render-source-embed.ts
+++ b/site/scripts/generator/render-source-embed.ts
@@ -1,0 +1,53 @@
+/** render-source-embed.ts — codeArbiter's verbatim source-embed renderer.
+ *
+ * The "source-visible" half of every reference page: a collapsible `<details>`
+ * wrapping the plugin source file's raw contents, unmodified, plus a
+ * tag-pinned link to view the exact file in the repo at the version it was
+ * generated from.
+ */
+
+/**
+ * Choose a fenced-code-block delimiter long enough to safely wrap `content`.
+ *
+ * Plugin sources routinely contain triple-backtick fences of their own (code
+ * examples inside a command/skill body), so a fixed 3-backtick fence would
+ * terminate early. The fence is the longest run of backticks found in
+ * `content`, plus one, with a floor of 4 (so short/fence-free content still
+ * gets a visually distinct fence from an ordinary ``` block).
+ */
+function chooseFence(content: string): string {
+  const runs = content.match(/`+/g) ?? [];
+  const longest = runs.reduce((max, run) => Math.max(max, run.length), 0);
+  const length = Math.max(longest + 1, 4);
+  return "`".repeat(length);
+}
+
+/**
+ * Render a verbatim source embed for one plugin source file.
+ *
+ * Produces a `<details class="ca-source">` block: a summary line naming the
+ * repo-relative path and the pinned plugin version, a dynamically-fenced
+ * ```` ```md ```` block containing `sourceRaw` unmodified (see
+ * {@link chooseFence}), and a "View in repo" link pinned to the `v<version>`
+ * tag. `pluginVersion` is passed without a leading `v` — the `v` is added
+ * here, once, for both the summary and the URL.
+ */
+export function renderSourceEmbed(
+  sourceRaw: string,
+  sourceRelPath: string,
+  pluginVersion: string,
+): string {
+  const fence = chooseFence(sourceRaw);
+  const tag = `v${pluginVersion}`;
+  const repoUrl = `https://github.com/arbiterForge/codeArbiter/blob/${tag}/${sourceRelPath}`;
+
+  return `<details class="ca-source">
+<summary>Source — <code>${sourceRelPath}</code> (${tag})</summary>
+
+${fence}md
+${sourceRaw}
+${fence}
+
+<a href="${repoUrl}">View in repo</a>
+</details>`;
+}

--- a/site/scripts/generator/types.ts
+++ b/site/scripts/generator/types.ts
@@ -27,6 +27,34 @@ export interface SourceFile {
   type: SourceType;
 }
 
+/** One row of a curated `gates:` table — a gate the entity participates in. */
+export interface GateSpec {
+  gate: string;
+  when: string;
+  effect: string;
+}
+
+/**
+ * A parsed curated companion file (`site/src/curated/{commands,agents,skills}/<basename>.md`).
+ *
+ * `entity` is the `<type-dir>/<basename>` key the file declares itself under (must match its
+ * location and a collected source — validated by `load-curated.ts`). `related` holds raw entity
+ * refs as written in frontmatter (bare basename or `type/basename`); resolution to a slug/link
+ * happens at generation time. `body` is the verbatim markdown body, inserted as-is.
+ */
+export interface CuratedDoc {
+  entity: string;
+  related?: string[];
+  gates?: GateSpec[];
+  body: string;
+}
+
+/** A related-entity link, already resolved to its collection + slug by `generate.ts`. */
+export interface RelatedLink {
+  label: string;
+  href: string;
+}
+
 /** Input to a page renderer. Fields are optional because source frontmatter is heterogeneous. */
 export interface PageInput {
   name: string;
@@ -35,6 +63,16 @@ export interface PageInput {
   tools?: string;
   /** Feature Forge preview status for this page, or null/undefined for stable features. */
   forgeStatus?: ForgeStatus | null;
+  /** The curated framing layer for this entity, or undefined when uncurated. */
+  curated?: CuratedDoc;
+  /** Resolved `related:` links, or undefined when there are none. */
+  relatedLinks?: RelatedLink[];
+  /** Verbatim raw contents of the plugin source file, for the source embed. */
+  sourceRaw: string;
+  /** Repo-relative path to the plugin source file, e.g. `plugins/ca/commands/sprint.md`. */
+  sourceRelPath: string;
+  /** The plugin's version (from `plugin.json`), for the tag-pinned view-in-repo link. */
+  pluginVersion: string;
 }
 
 /** A rendered reference page ready to write to disk. */

--- a/site/src/curated/commands/commit.md
+++ b/site/src/curated/commands/commit.md
@@ -1,0 +1,27 @@
+---
+entity: commands/commit
+related: [sprint, skills/tdd]
+gates:
+  - gate: verification
+    when: every invocation
+    effect: test, lint, and secret-scan results must all come back clean before anything else runs
+  - gate: behavioral proof + diff review
+    when: after verification passes
+    effect: the change must demonstrate the behavior it claims, and the diff is reviewed line by line before staging
+---
+
+## What it does
+
+This is the single entry point for turning staged work into a commit — nothing in codeArbiter
+calls `git commit` any other way. Invoking it hands control to a multi-phase check that reads the
+repository's current state itself (what's staged, what changed, whether the test suite is green)
+rather than taking your word for it, then walks through verification, a behavioral check, and a
+diff review before anything is written to history.
+
+## Usage
+
+```
+/ca:commit
+```
+
+Takes no arguments — everything it needs comes from the current git state.

--- a/site/src/curated/commands/sprint.md
+++ b/site/src/curated/commands/sprint.md
@@ -1,0 +1,30 @@
+---
+entity: commands/sprint
+related: [commit, skills/tdd]
+gates:
+  - gate: spec + plan approval
+    when: before autonomous execution starts
+    effect: hard stop; both the sprint spec and the resulting plan need your explicit sign-off
+  - gate: hard gates
+    when: a security boundary, crypto/secret handling, an irreversible operation, an override request, an unresolved confirmation point, or a merge to the default branch comes up mid-run
+    effect: execution halts and surfaces the decision to you instead of choosing on your behalf
+---
+
+## What it does
+
+This is codeArbiter's autonomy mode. It collapses the usual spec-plan-execute cycle into one
+interactive checkpoint up front, then runs the rest of the arc — task selection, test-first
+implementation, review, and landing the branch — without stopping between batches. Every call it
+makes on your behalf along the way is scored and appended to a running log with a confidence
+rating, so a low-confidence choice is easy to find and revisit later even though nobody was there
+to approve it in the moment.
+
+## Usage
+
+```
+/ca:sprint [goal] [--farm]
+```
+
+A short goal seeds the spec conversation that opens the sprint. Add `--farm` to send
+implementation work to lower-cost worker agents while the same spec-authoring, test-writing, and
+review responsibilities stay put.

--- a/site/test/generator/generate.test.ts
+++ b/site/test/generator/generate.test.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   readdirSync,
   mkdirSync,
+  writeFileSync,
 } from "node:fs";
 import { generate } from "../../scripts/generator/generate";
 
@@ -108,6 +109,78 @@ describe("generate", () => {
       // its rendered page must still carry the preview badge/markup after
       // switching slug assignment to per-collection.
       expect(prunePage!.markdown).toMatch(/preview/i);
+    });
+  });
+
+  describe("source embed + output-dir cleaning", () => {
+    it("always renders a source embed, even with no curated dir", () => {
+      const result = generate(pluginDir, outDir);
+      const anyPage = result.pages[0];
+      expect(anyPage.markdown).toContain("## Source");
+      expect(anyPage.markdown).toContain('<details class="ca-source">');
+    });
+
+    it("cleans stale files out of outDir before writing", () => {
+      mkdirSync(join(outDir, "commands"), { recursive: true });
+      writeFileSync(join(outDir, "commands", "stale-2.md"), "stale content");
+      writeFileSync(join(outDir, "index.md"), "stale index");
+      generate(pluginDir, outDir);
+      expect(existsSync(join(outDir, "commands", "stale-2.md"))).toBe(false);
+      const indexContent = readFileSync(join(outDir, "index.md"), "utf8");
+      expect(indexContent).not.toBe("stale index");
+    });
+  });
+
+  describe("curated merge", () => {
+    const curatedOutDir = join(tmpdir(), "ca-gen-test-out-curated");
+    const curatedDir = join(tmpdir(), "ca-gen-test-curated-src");
+
+    beforeEach(() => {
+      rmSync(curatedOutDir, { recursive: true, force: true });
+      rmSync(curatedDir, { recursive: true, force: true });
+      mkdirSync(curatedOutDir, { recursive: true });
+    });
+    afterEach(() => {
+      rmSync(curatedOutDir, { recursive: true, force: true });
+      rmSync(curatedDir, { recursive: true, force: true });
+    });
+
+    it("merges a curated body/gates/related for a matching source", () => {
+      mkdirSync(join(curatedDir, "commands"), { recursive: true });
+      writeFileSync(
+        join(curatedDir, "commands", "sample.md"),
+        `---\nentity: commands/sample\nrelated: [another]\ngates:\n  - gate: g1\n    when: w1\n    effect: e1\n---\n\nCurated prose for sample.\n`,
+      );
+      const result = generate(pluginDir, curatedOutDir, undefined, curatedDir);
+      const samplePage = result.pages.find(
+        (p) => p.type === "command" && p.slug === "sample",
+      );
+      expect(samplePage).toBeDefined();
+      expect(samplePage!.markdown).toContain("Curated prose for sample.");
+      expect(samplePage!.markdown).toContain("| g1 | w1 | e1 |");
+      expect(samplePage!.markdown).toContain("## Related");
+    });
+
+    it("throws when a curated file's entity has no matching collected source (orphan)", () => {
+      mkdirSync(join(curatedDir, "commands"), { recursive: true });
+      writeFileSync(
+        join(curatedDir, "commands", "ghost.md"),
+        `---\nentity: commands/ghost\n---\n\nBody.\n`,
+      );
+      expect(() => generate(pluginDir, curatedOutDir, undefined, curatedDir)).toThrow(
+        /ghost/,
+      );
+    });
+
+    it("throws when a curated related ref cannot be resolved", () => {
+      mkdirSync(join(curatedDir, "commands"), { recursive: true });
+      writeFileSync(
+        join(curatedDir, "commands", "sample.md"),
+        `---\nentity: commands/sample\nrelated: [does-not-exist]\n---\n\nBody.\n`,
+      );
+      expect(() => generate(pluginDir, curatedOutDir, undefined, curatedDir)).toThrow(
+        /unresolvable/,
+      );
     });
   });
 });

--- a/site/test/generator/load-curated.test.ts
+++ b/site/test/generator/load-curated.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { loadCurated } from "../../scripts/generator/load-curated";
+
+const base = join(tmpdir(), "ca-load-curated-test");
+
+function writeCurated(relPath: string, content: string) {
+  const full = join(base, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content);
+}
+
+describe("loadCurated", () => {
+  beforeEach(() => {
+    rmSync(base, { recursive: true, force: true });
+    mkdirSync(base, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it("returns an empty map when the curated dir does not exist", () => {
+    const result = loadCurated(join(base, "does-not-exist"), new Set(["commands/sprint"]));
+    expect(result.size).toBe(0);
+  });
+
+  it("parses a curated file's entity, body, related, and gates", () => {
+    writeCurated(
+      "commands/sprint.md",
+      `---
+entity: commands/sprint
+related: [commit, skills/tdd]
+gates:
+  - gate: spec approval
+    when: before execution
+    effect: hard stop
+---
+
+## What it does
+
+Curated prose about sprint.
+`,
+    );
+    const result = loadCurated(base, new Set(["commands/sprint"]));
+    const doc = result.get("commands/sprint");
+    expect(doc).toBeDefined();
+    expect(doc!.entity).toBe("commands/sprint");
+    expect(doc!.related).toEqual(["commit", "skills/tdd"]);
+    expect(doc!.gates).toEqual([
+      { gate: "spec approval", when: "before execution", effect: "hard stop" },
+    ]);
+    expect(doc!.body).toContain("Curated prose about sprint.");
+  });
+
+  it("returns undefined (falls back) for a collected source with no curated file", () => {
+    writeCurated(
+      "commands/sprint.md",
+      `---\nentity: commands/sprint\n---\n\nBody.\n`,
+    );
+    const result = loadCurated(base, new Set(["commands/sprint", "commands/commit"]));
+    expect(result.get("commands/commit")).toBeUndefined();
+    expect(result.get("commands/sprint")).toBeDefined();
+  });
+
+  it("throws on an orphan curated file (entity has no matching collected source), naming the filename", () => {
+    writeCurated(
+      "commands/ghost.md",
+      `---\nentity: commands/ghost\n---\n\nBody.\n`,
+    );
+    expect(() => loadCurated(base, new Set(["commands/sprint"]))).toThrow(/ghost\.md/);
+  });
+
+  it("throws on duplicate curated files declaring the same entity", () => {
+    writeCurated(
+      "commands/sprint.md",
+      `---\nentity: commands/sprint\n---\n\nBody A.\n`,
+    );
+    // A second, differently-named file that (mistakenly) declares the same
+    // entity — a genuine duplicate, not merely a filename collision.
+    writeCurated(
+      "commands/sprint-old.md",
+      `---\nentity: commands/sprint\n---\n\nBody B.\n`,
+    );
+    expect(() =>
+      loadCurated(base, new Set(["commands/sprint"])),
+    ).toThrow(/[Dd]uplicate/);
+  });
+});

--- a/site/test/generator/paraphrase-lint.test.ts
+++ b/site/test/generator/paraphrase-lint.test.ts
@@ -1,0 +1,88 @@
+/** paraphrase-lint.test.ts — structural enforcement of the spec's paraphrase ban.
+ *
+ * For every curated companion file under `site/src/curated/`, assert that no
+ * 12-word shingle (whitespace/case normalized) appears verbatim in both the
+ * curated body and its entity's plugin source body. The embed already carries
+ * the source verbatim — curated prose must describe it, not restate it.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { splitFrontmatter } from "../../scripts/generator/split-frontmatter";
+import { parseFields } from "../../scripts/generator/parse-fields";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(here, "..", ".."); // site/
+const repoRoot = join(siteRoot, ".."); // repo root
+const curatedRoot = join(siteRoot, "src", "curated");
+
+const TYPE_DIRS = ["commands", "skills", "agents"] as const;
+const SHINGLE_SIZE = 12;
+
+function normalizeWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[`*_#>|[\](){}]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function shingles(words: string[], n: number): Set<string> {
+  const set = new Set<string>();
+  for (let i = 0; i + n <= words.length; i++) {
+    set.add(words.slice(i, i + n).join(" "));
+  }
+  return set;
+}
+
+/** Resolve a curated `entity` (`<type-dir>/<basename>`) to its plugin source path. */
+function resolveSourcePath(entity: string): string {
+  const [typeDir, basename] = entity.split("/");
+  if (typeDir === "skills") {
+    return join(repoRoot, "plugins", "ca", "skills", basename, "SKILL.md");
+  }
+  return join(repoRoot, "plugins", "ca", typeDir, `${basename}.md`);
+}
+
+function findCuratedFiles(): string[] {
+  const files: string[] = [];
+  for (const dir of TYPE_DIRS) {
+    const full = join(curatedRoot, dir);
+    if (!existsSync(full)) continue;
+    for (const entry of readdirSync(full)) {
+      if (entry.endsWith(".md")) files.push(join(full, entry));
+    }
+  }
+  return files;
+}
+
+describe("paraphrase lint — curated content never quotes its own source verbatim", () => {
+  const files = findCuratedFiles();
+
+  it("found at least one curated file to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const filePath of files) {
+    it(`${filePath} carries no ${SHINGLE_SIZE}-word shingle from its source`, () => {
+      const raw = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n");
+      const { frontmatter, body } = splitFrontmatter(raw);
+      expect(frontmatter).not.toBeNull();
+      const fields = parseFields(frontmatter as string);
+      const entity = fields.entity;
+      expect(entity).toBeTruthy();
+
+      const sourcePath = resolveSourcePath(entity);
+      expect(existsSync(sourcePath)).toBe(true);
+      const sourceRaw = readFileSync(sourcePath, "utf-8").replace(/\r\n/g, "\n");
+      const { body: sourceBody } = splitFrontmatter(sourceRaw);
+
+      const sourceShingles = shingles(normalizeWords(sourceBody), SHINGLE_SIZE);
+      const curatedShingles = shingles(normalizeWords(body), SHINGLE_SIZE);
+
+      const overlap = [...curatedShingles].filter((s) => sourceShingles.has(s));
+      expect(overlap).toEqual([]);
+    });
+  }
+});

--- a/site/test/generator/render-agent-page.test.ts
+++ b/site/test/generator/render-agent-page.test.ts
@@ -1,14 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { renderAgentPage } from "../../scripts/generator/render-agent-page";
+import type { PageInput } from "../../scripts/generator/types";
+
+const sourceFields = {
+  sourceRaw: "---\nname: myagent\n---\n\nBody.\n",
+  sourceRelPath: "plugins/ca/agents/myagent.md",
+  pluginVersion: "2.8.11",
+};
+
+function input(overrides: Partial<PageInput> & { name: string }): PageInput {
+  return { ...sourceFields, ...overrides };
+}
 
 describe("renderAgentPage", () => {
   it("renders title, description, model tier, and tools, with no body H1", () => {
-    const md = renderAgentPage({
-      name: "myagent",
-      description: "reviews a thing",
-      model: "sonnet",
-      tools: "Read, Grep",
-    });
+    const md = renderAgentPage(
+      input({
+        name: "myagent",
+        description: "reviews a thing",
+        model: "sonnet",
+        tools: "Read, Grep",
+      }),
+    );
     expect(md).toContain("title: myagent");
     expect(md).not.toMatch(/^# /m);
     expect(md).toContain("reviews a thing");
@@ -17,42 +30,89 @@ describe("renderAgentPage", () => {
   });
 
   it("shows the default tier when model is missing", () => {
-    const md = renderAgentPage({
-      name: "nomodel",
-      description: "no model here",
-      tools: "Read",
-    });
+    const md = renderAgentPage(
+      input({ name: "nomodel", description: "no model here", tools: "Read" }),
+    );
     expect(md).toContain("default");
     expect(md).toContain("`Read`");
   });
 
   it("emits a quoted description frontmatter line", () => {
-    const md = renderAgentPage({
-      name: "myagent",
-      description: "reviews a thing",
-      tools: "Read",
-    });
+    const md = renderAgentPage(
+      input({ name: "myagent", description: "reviews a thing", tools: "Read" }),
+    );
     expect(md).toContain('description: "reviews a thing"');
   });
 
   it("escapes double quotes and colons in the description frontmatter line", () => {
-    const md = renderAgentPage({
-      name: "myagent",
-      description: 'Reviews "the" thing: end-to-end — nothing skipped.',
-      tools: "Read",
-    });
+    const md = renderAgentPage(
+      input({
+        name: "myagent",
+        description: 'Reviews "the" thing: end-to-end — nothing skipped.',
+        tools: "Read",
+      }),
+    );
     expect(md).toContain(
       'description: "Reviews \\"the\\" thing: end-to-end — nothing skipped."',
     );
   });
 
   it("omits the description frontmatter line when description is empty", () => {
-    const md = renderAgentPage({ name: "myagent", description: "", tools: "Read" });
+    const md = renderAgentPage(input({ name: "myagent", description: "", tools: "Read" }));
     expect(md).not.toContain("description:");
   });
 
   it("omits the description frontmatter line when description is absent", () => {
-    const md = renderAgentPage({ name: "myagent", tools: "Read" });
+    const md = renderAgentPage(input({ name: "myagent", tools: "Read" }));
     expect(md).not.toContain("description:");
+  });
+
+  it("always renders a source embed, even with no curated content", () => {
+    const md = renderAgentPage(input({ name: "myagent", tools: "Read" }));
+    expect(md).toContain("## Source");
+    expect(md).toContain('<details class="ca-source">');
+  });
+
+  it("places Model tier / Tools before the curated body", () => {
+    const md = renderAgentPage(
+      input({
+        name: "myagent",
+        description: "d",
+        tools: "Read",
+        curated: { entity: "agents/myagent", body: "## What it does\n\nCurated prose." },
+      }),
+    );
+    expect(md.indexOf("Tools")).toBeLessThan(md.indexOf("Curated prose."));
+    expect(md.indexOf("Curated prose.")).toBeLessThan(md.indexOf("## Source"));
+  });
+
+  it("renders a gates table when curated.gates is present", () => {
+    const md = renderAgentPage(
+      input({
+        name: "myagent",
+        description: "d",
+        tools: "Read",
+        curated: {
+          entity: "agents/myagent",
+          body: "",
+          gates: [{ gate: "review", when: "dispatched", effect: "blocks on findings" }],
+        },
+      }),
+    );
+    expect(md).toContain("## Gates");
+    expect(md).toContain("| review | dispatched | blocks on findings |");
+  });
+
+  it("renders a Related section when relatedLinks is present", () => {
+    const md = renderAgentPage(
+      input({
+        name: "myagent",
+        description: "d",
+        tools: "Read",
+        relatedLinks: [{ label: "commit", href: "/reference/commands/commit/" }],
+      }),
+    );
+    expect(md).toContain("## Related");
+    expect(md).toContain("[commit](/reference/commands/commit/)");
   });
 });

--- a/site/test/generator/render-command-page-forge.test.ts
+++ b/site/test/generator/render-command-page-forge.test.ts
@@ -1,14 +1,27 @@
 /** render-command-page-forge.test.ts — codeArbiter's preview badge/callout rendering tests. */
 import { describe, it, expect } from "vitest";
 import { renderCommandPage } from "../../scripts/generator/render-command-page";
+import type { PageInput } from "../../scripts/generator/types";
+
+const sourceFields = {
+  sourceRaw: "---\ndescription: d\n---\n\nBody.\n",
+  sourceRelPath: "plugins/ca/commands/x.md",
+  pluginVersion: "2.8.11",
+};
+
+function input(overrides: Partial<PageInput> & { name: string }): PageInput {
+  return { ...sourceFields, ...overrides };
+}
 
 describe("renderCommandPage — forge status badges and callouts", () => {
   it("renders a preview badge for a preview-command (prune)", () => {
-    const md = renderCommandPage({
-      name: "/ca:prune",
-      description: "Trim transcript clutter.",
-      forgeStatus: { kind: "preview-command" },
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:prune",
+        description: "Trim transcript clutter.",
+        forgeStatus: { kind: "preview-command" },
+      }),
+    );
     // Must contain the badge with data-kind="preview"
     expect(md).toContain('class="ca-badge"');
     expect(md).toContain('data-kind="preview"');
@@ -16,11 +29,13 @@ describe("renderCommandPage — forge status badges and callouts", () => {
   });
 
   it("renders a --farm preview callout for a preview-flag (sprint)", () => {
-    const md = renderCommandPage({
-      name: "/ca:sprint",
-      description: "Autonomous sprint.",
-      forgeStatus: { kind: "preview-flag", flag: "--farm" },
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:sprint",
+        description: "Autonomous sprint.",
+        forgeStatus: { kind: "preview-flag", flag: "--farm" },
+      }),
+    );
     // Must contain the preview callout with the flag name
     expect(md).toContain("ca-callout--preview");
     expect(md).toContain("--farm");
@@ -28,51 +43,61 @@ describe("renderCommandPage — forge status badges and callouts", () => {
   });
 
   it("does NOT render a badge or callout for a stable command (commit)", () => {
-    const md = renderCommandPage({
-      name: "/ca:commit",
-      description: "Run the full commit gate.",
-      forgeStatus: null,
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:commit",
+        description: "Run the full commit gate.",
+        forgeStatus: null,
+      }),
+    );
     expect(md).not.toContain("ca-badge");
     expect(md).not.toContain("ca-callout--preview");
   });
 
   it("does NOT render a badge or callout when forgeStatus is omitted", () => {
-    const md = renderCommandPage({
-      name: "/ca:commit",
-      description: "Run the full commit gate.",
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:commit",
+        description: "Run the full commit gate.",
+      }),
+    );
     expect(md).not.toContain("ca-badge");
     expect(md).not.toContain("ca-callout--preview");
   });
 
   it("preview-flag callout uses the contract callout classes", () => {
-    const md = renderCommandPage({
-      name: "/ca:sprint",
-      description: "Autonomous sprint.",
-      forgeStatus: { kind: "preview-flag", flag: "--farm" },
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:sprint",
+        description: "Autonomous sprint.",
+        forgeStatus: { kind: "preview-flag", flag: "--farm" },
+      }),
+    );
     // Must carry both base class and variant modifier
     expect(md).toContain("ca-callout");
     expect(md).toContain("ca-callout--preview");
   });
 
   it("preview-command badge uses the contract badge class and data-kind attribute", () => {
-    const md = renderCommandPage({
-      name: "/ca:prune",
-      description: "Trim transcript clutter.",
-      forgeStatus: { kind: "preview-command" },
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:prune",
+        description: "Trim transcript clutter.",
+        forgeStatus: { kind: "preview-command" },
+      }),
+    );
     expect(md).toContain('class="ca-badge"');
     expect(md).toContain('data-kind="preview"');
   });
 
   it("preview-command badge is the first body element, before the description", () => {
-    const md = renderCommandPage({
-      name: "/ca:prune",
-      description: "Trim transcript clutter.",
-      forgeStatus: { kind: "preview-command" },
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:prune",
+        description: "Trim transcript clutter.",
+        forgeStatus: { kind: "preview-command" },
+      }),
+    );
     // Body starts after the closing frontmatter `---` fence.
     const body = md.slice(md.indexOf("---", 3) + 3);
     const badgeIndex = body.indexOf('class="ca-badge"');
@@ -82,11 +107,13 @@ describe("renderCommandPage — forge status badges and callouts", () => {
   });
 
   it("preview-flag callout is the first body element, before the description", () => {
-    const md = renderCommandPage({
-      name: "/ca:sprint",
-      description: "Autonomous sprint.",
-      forgeStatus: { kind: "preview-flag", flag: "--farm" },
-    });
+    const md = renderCommandPage(
+      input({
+        name: "/ca:sprint",
+        description: "Autonomous sprint.",
+        forgeStatus: { kind: "preview-flag", flag: "--farm" },
+      }),
+    );
     // Body starts after the closing frontmatter `---` fence.
     const body = md.slice(md.indexOf("---", 3) + 3);
     const calloutIndex = body.indexOf("ca-callout--preview");

--- a/site/test/generator/render-command-page.test.ts
+++ b/site/test/generator/render-command-page.test.ts
@@ -1,48 +1,117 @@
 import { describe, it, expect } from "vitest";
 import { renderCommandPage } from "../../scripts/generator/render-command-page";
+import type { PageInput } from "../../scripts/generator/types";
+
+/** Minimal required fields every PageInput now carries. */
+const sourceFields = {
+  sourceRaw: "Plain command body, no frontmatter markers.\n",
+  sourceRelPath: "plugins/ca/commands/commit.md",
+  pluginVersion: "2.8.11",
+};
+
+function input(overrides: Partial<PageInput> & { name: string }): PageInput {
+  return { ...sourceFields, ...overrides };
+}
 
 describe("renderCommandPage", () => {
   it("renders title and description, and no body H1", () => {
-    const md = renderCommandPage({
-      name: "commit",
-      description: "the only path to a commit",
-    });
+    const md = renderCommandPage(
+      input({ name: "commit", description: "the only path to a commit" }),
+    );
     expect(md).toContain("title: commit");
     expect(md).not.toMatch(/^# /m);
     expect(md).toContain("the only path to a commit");
   });
 
   it("omits model and tools sections", () => {
-    const md = renderCommandPage({ name: "commit", description: "d" });
+    const md = renderCommandPage(input({ name: "commit", description: "d" }));
     expect(md).not.toContain("Model tier");
     expect(md).not.toContain("Tools");
   });
 
   it("emits a quoted description frontmatter line", () => {
-    const md = renderCommandPage({
-      name: "commit",
-      description: "the only path to a commit",
-    });
+    const md = renderCommandPage(
+      input({ name: "commit", description: "the only path to a commit" }),
+    );
     expect(md).toContain('description: "the only path to a commit"');
   });
 
   it("escapes double quotes and colons in the description frontmatter line", () => {
-    const md = renderCommandPage({
-      name: "commit",
-      description: 'The "only" path: a commit — never a direct write.',
-    });
+    const md = renderCommandPage(
+      input({
+        name: "commit",
+        description: 'The "only" path: a commit — never a direct write.',
+      }),
+    );
     expect(md).toContain(
       'description: "The \\"only\\" path: a commit — never a direct write."',
     );
   });
 
   it("omits the description frontmatter line when description is empty", () => {
-    const md = renderCommandPage({ name: "commit", description: "" });
+    const md = renderCommandPage(input({ name: "commit", description: "" }));
     expect(md).not.toContain("description:");
   });
 
   it("omits the description frontmatter line when description is absent", () => {
-    const md = renderCommandPage({ name: "commit" });
+    const md = renderCommandPage(input({ name: "commit" }));
     expect(md).not.toContain("description:");
+  });
+
+  it("always renders a source embed, even with no curated content", () => {
+    const md = renderCommandPage(input({ name: "commit", description: "d" }));
+    expect(md).toContain("## Source");
+    expect(md).toContain('<details class="ca-source">');
+    expect(md).toContain("plugins/ca/commands/commit.md");
+    expect(md).toContain("v2.8.11");
+  });
+
+  it("merges curated body verbatim after the description", () => {
+    const md = renderCommandPage(
+      input({
+        name: "commit",
+        description: "d",
+        curated: { entity: "commands/commit", body: "## What it does\n\nCurated prose." },
+      }),
+    );
+    expect(md).toContain("## What it does");
+    expect(md).toContain("Curated prose.");
+    // curated body must land before the source embed
+    expect(md.indexOf("Curated prose.")).toBeLessThan(md.indexOf("## Source"));
+  });
+
+  it("renders a gates table when curated.gates is present", () => {
+    const md = renderCommandPage(
+      input({
+        name: "commit",
+        description: "d",
+        curated: {
+          entity: "commands/commit",
+          body: "",
+          gates: [{ gate: "verification", when: "every run", effect: "must be clean" }],
+        },
+      }),
+    );
+    expect(md).toContain("## Gates");
+    expect(md).toContain("| Gate | When | Effect |");
+    expect(md).toContain("| verification | every run | must be clean |");
+  });
+
+  it("renders a Related section when relatedLinks is present", () => {
+    const md = renderCommandPage(
+      input({
+        name: "commit",
+        description: "d",
+        relatedLinks: [{ label: "sprint", href: "/reference/commands/sprint/" }],
+      }),
+    );
+    expect(md).toContain("## Related");
+    expect(md).toContain("[sprint](/reference/commands/sprint/)");
+  });
+
+  it("omits Gates and Related sections when absent", () => {
+    const md = renderCommandPage(input({ name: "commit", description: "d" }));
+    expect(md).not.toContain("## Gates");
+    expect(md).not.toContain("## Related");
   });
 });

--- a/site/test/generator/render-gates-table.test.ts
+++ b/site/test/generator/render-gates-table.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { renderGatesTable } from "../../scripts/generator/render-gates-table";
+
+describe("renderGatesTable", () => {
+  it("returns an empty string for an empty list", () => {
+    expect(renderGatesTable([])).toBe("");
+  });
+
+  it("returns an empty string for undefined", () => {
+    expect(renderGatesTable(undefined)).toBe("");
+  });
+
+  it("renders a markdown table with the fixed header", () => {
+    const md = renderGatesTable([
+      { gate: "verification", when: "every run", effect: "must be clean" },
+    ]);
+    expect(md).toContain("| Gate | When | Effect |");
+    expect(md).toContain("| --- | --- | --- |");
+    expect(md).toContain("| verification | every run | must be clean |");
+  });
+
+  it("renders one row per gate, in order", () => {
+    const md = renderGatesTable([
+      { gate: "a", when: "w1", effect: "e1" },
+      { gate: "b", when: "w2", effect: "e2" },
+    ]);
+    const rows = md.split("\n");
+    expect(rows[2]).toBe("| a | w1 | e1 |");
+    expect(rows[3]).toBe("| b | w2 | e2 |");
+  });
+});

--- a/site/test/generator/render-skill-page.test.ts
+++ b/site/test/generator/render-skill-page.test.ts
@@ -1,48 +1,79 @@
 import { describe, it, expect } from "vitest";
 import { renderSkillPage } from "../../scripts/generator/render-skill-page";
+import type { PageInput } from "../../scripts/generator/types";
+
+const sourceFields = {
+  sourceRaw: "---\nname: tdd\n---\n\nBody.\n",
+  sourceRelPath: "plugins/ca/skills/tdd/SKILL.md",
+  pluginVersion: "2.8.11",
+};
+
+function input(overrides: Partial<PageInput> & { name: string }): PageInput {
+  return { ...sourceFields, ...overrides };
+}
 
 describe("renderSkillPage", () => {
   it("renders title and description, and no body H1", () => {
-    const md = renderSkillPage({
-      name: "tdd",
-      description: "the test-first gate",
-    });
+    const md = renderSkillPage(input({ name: "tdd", description: "the test-first gate" }));
     expect(md).toContain("title: tdd");
     expect(md).not.toMatch(/^# /m);
     expect(md).toContain("the test-first gate");
   });
 
   it("omits model and tools sections", () => {
-    const md = renderSkillPage({ name: "tdd", description: "d" });
+    const md = renderSkillPage(input({ name: "tdd", description: "d" }));
     expect(md).not.toContain("Model tier");
     expect(md).not.toContain("Tools");
   });
 
   it("emits a quoted description frontmatter line", () => {
-    const md = renderSkillPage({
-      name: "tdd",
-      description: "the test-first gate",
-    });
+    const md = renderSkillPage(input({ name: "tdd", description: "the test-first gate" }));
     expect(md).toContain('description: "the test-first gate"');
   });
 
   it("escapes double quotes and colons in the description frontmatter line", () => {
-    const md = renderSkillPage({
-      name: "tdd",
-      description: 'The "test-first" gate: red, green — refactor.',
-    });
+    const md = renderSkillPage(
+      input({ name: "tdd", description: 'The "test-first" gate: red, green — refactor.' }),
+    );
     expect(md).toContain(
       'description: "The \\"test-first\\" gate: red, green — refactor."',
     );
   });
 
   it("omits the description frontmatter line when description is empty", () => {
-    const md = renderSkillPage({ name: "tdd", description: "" });
+    const md = renderSkillPage(input({ name: "tdd", description: "" }));
     expect(md).not.toContain("description:");
   });
 
   it("omits the description frontmatter line when description is absent", () => {
-    const md = renderSkillPage({ name: "tdd" });
+    const md = renderSkillPage(input({ name: "tdd" }));
     expect(md).not.toContain("description:");
+  });
+
+  it("always renders a source embed, even with no curated content", () => {
+    const md = renderSkillPage(input({ name: "tdd", description: "d" }));
+    expect(md).toContain("## Source");
+    expect(md).toContain('<details class="ca-source">');
+  });
+
+  it("merges curated body, gates table, and related links", () => {
+    const md = renderSkillPage(
+      input({
+        name: "tdd",
+        description: "d",
+        curated: {
+          entity: "skills/tdd",
+          body: "## What it does\n\nCurated prose.",
+          gates: [{ gate: "red", when: "phase 2", effect: "test must fail first" }],
+        },
+        relatedLinks: [{ label: "sprint", href: "/reference/commands/sprint/" }],
+      }),
+    );
+    expect(md).toContain("Curated prose.");
+    expect(md).toContain("## Gates");
+    expect(md).toContain("## Related");
+    expect(md.indexOf("Curated prose.")).toBeLessThan(md.indexOf("## Gates"));
+    expect(md.indexOf("## Gates")).toBeLessThan(md.indexOf("## Related"));
+    expect(md.indexOf("## Related")).toBeLessThan(md.indexOf("## Source"));
   });
 });

--- a/site/test/generator/render-source-embed.test.ts
+++ b/site/test/generator/render-source-embed.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { renderSourceEmbed } from "../../scripts/generator/render-source-embed";
+
+describe("renderSourceEmbed", () => {
+  it("wraps content with no backticks in a minimum 4-backtick fence", () => {
+    const md = renderSourceEmbed("plain content, no fences", "plugins/ca/commands/x.md", "2.8.11");
+    expect(md).toContain("````md");
+    expect(md).toContain("plain content, no fences");
+  });
+
+  it("escalates the fence past a 3-backtick run in the content", () => {
+    const content = "Some prose.\n```\ncode block\n```\nMore prose.";
+    const md = renderSourceEmbed(content, "plugins/ca/commands/x.md", "2.8.11");
+    // longest run in content is 3, so fence must be 4.
+    expect(md).toContain("````md");
+    expect(md).toContain(content);
+    // The fence appears exactly twice: opening (with "md") and closing.
+    const lines = md.split("\n");
+    const fenceLines = lines.filter((l) => l === "````md" || l === "````");
+    expect(fenceLines).toHaveLength(2);
+  });
+
+  it("escalates past a 4-backtick run in the content to a 5-backtick fence", () => {
+    const content = "Nested example:\n````\nsome fenced text\n````\nend.";
+    const md = renderSourceEmbed(content, "plugins/ca/commands/x.md", "2.8.11");
+    expect(md).toContain("`````md");
+  });
+
+  it("pins the View in repo link to the given version tag", () => {
+    const md = renderSourceEmbed("x", "plugins/ca/commands/sprint.md", "2.8.11");
+    expect(md).toContain(
+      '<a href="https://github.com/arbiterForge/codeArbiter/blob/v2.8.11/plugins/ca/commands/sprint.md">View in repo</a>',
+    );
+  });
+
+  it("renders the details/summary structure with the repo-relative path and version", () => {
+    const md = renderSourceEmbed("x", "plugins/ca/commands/sprint.md", "2.8.11");
+    expect(md).toContain('<details class="ca-source">');
+    expect(md).toContain(
+      "<summary>Source — <code>plugins/ca/commands/sprint.md</code> (v2.8.11)</summary>",
+    );
+    expect(md).toContain("</details>");
+  });
+});


### PR DESCRIPTION
## Summary

PR-2.1 of the docs-site overhaul campaign (spec: `.codearbiter/specs/docs-site-overhaul.md`) — the Phase 2 generator infrastructure implementing the **source-visible documentation** principle: every reference page becomes curated framing (optional, hand-written) + a verbatim build-time source embed (always).

**New generator modules:** `load-curated.ts` (discovers `site/src/curated/{commands,agents,skills}/<basename>.md`, validates entities against collected sources — an orphan curated file **fails the build**, the divergence check), `render-source-embed.ts` (collapsible `<details>` with dynamic fence escalation — longest backtick run + 1, floor 4 — and a "View in repo" link pinned to `v<version>` from plugin.json), `render-gates-table.ts`, `render-related-links.ts` (refs resolve to per-collection slugs; unresolvable refs throw at gen time).

**Page anatomy** (all three renderers): frontmatter → forge badge → description → model/tools (agents) → curated body → gates table → Related → Source embed. Uncurated entities render the fallback (description + embed) — full coverage arrives in the batch PRs.

**Also:** the generator now cleans its output dirs before writing (stale files from prior runs — e.g. old `-2` slug pages — can no longer survive locally), and a **paraphrase-lint test** enforces the spec's ban structurally: no 12-word shingle from an entity's source may appear in its curated file.

Two seed curated files (`commands/sprint`, `commands/commit`) exercise the merge path in CI and document the authoring format for the batch PRs.

## Verification

- 249 vitest passing (30 files; new suites for load-curated, source-embed, gates-table, paraphrase-lint); typecheck clean; build 89 reference pages; link-audit 15,510 links across 125 pages.
- Dist inspection: curated page (sprint) renders full anatomy with v2.8.11-pinned source link; uncurated page (adr) renders fallback + embed; planted stale file removed by gen.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
