### PR TITLE
docs(site): curated reference for lanes & lifecycle commands (batch a)

### DIFF
--- a/site/src/curated/commands/chore.md
+++ b/site/src/curated/commands/chore.md
@@ -1,0 +1,50 @@
+---
+entity: commands/chore
+related: [feature, add-dep, skills/commit-gate]
+gates:
+  - gate: type classification
+    when: before any gate runs
+    effect: the request must sort cleanly into docs, deps, or revert; a behavioral change beyond that scope redirects to feature or fix
+  - gate: type-scaled checks
+    when: after classification
+    effect: docs gets a copy pass and a secrets scan; deps gets a dependency review and a full green suite; revert gets a clean git revert and a full green suite
+  - gate: commit-gate
+    when: after the type's checks pass
+    effect: the change still exits through the standard commit gate and lands via branch and PR
+---
+
+## What it does
+
+This is the lane for changes with no behavior to test-drive — prose edits, a version bump on an
+existing dependency, or backing out a named commit. Each of the three types gets exactly the checks
+it needs and nothing more: a docs edit gets a secrets scan and a copy pass instead of a demand for
+failing tests that would never exist for prose; a dependency bump gets the same vetting `/ca:add-dep`
+applies plus a full suite run; a revert has to be a real `git revert`, never a hand-edited backout,
+and also needs the suite green afterward. Anything that smuggles in a behavioral code change gets
+redirected — this lane exists precisely to keep TDD ceremony off changes that have nothing to test.
+
+## Usage
+
+```
+/ca:chore <docs|deps|revert> <description or SHA>
+```
+
+Name the type first, then the docs description, the dependency to bump, or the commit SHA to revert.
+
+## Example
+
+```text
+> /ca:chore deps bump lodash to 4.17.21
+
+Classified: deps.
+Dispatching dependency-reviewer... license MIT (unchanged), no new transitive risk, changelog reviewed.
+Manifest and lockfile updated together.
+Running full suite... 412 passed, 0 failed.
+Routing to commit-gate (classification: chore)...
+```
+
+## When to reach for it
+
+Reach for `/ca:chore` for docs-only edits, an existing dependency's version bump, or reverting a
+named commit. A brand-new dependency goes through `/ca:add-dep` first; any behavioral change goes
+through `/ca:feature` or `/ca:fix`.

--- a/site/src/curated/commands/commit.md
+++ b/site/src/curated/commands/commit.md
@@ -1,6 +1,6 @@
 ---
 entity: commands/commit
-related: [sprint, skills/tdd]
+related: [sprint, pr, skills/commit-gate]
 gates:
   - gate: verification
     when: every invocation
@@ -25,3 +25,29 @@ diff review before anything is written to history.
 ```
 
 Takes no arguments — everything it needs comes from the current git state.
+
+## Example
+
+```text
+> commit this
+
+Branch: feat/export-csv (not protected — OK).
+Classification: feat, scope export.
+Running tests... 214 passed. Running lint... clean. Scanning staged files for secrets... clean.
+Behavioral proof: re-running the export endpoint against the spec's acceptance criterion — a saved
+search with zero results returns a header-only CSV. Confirmed by fresh output.
+Reviewing the staged diff... no unexpected files, no TODO markers, nothing out of scope.
+Staged set matches intended files exactly.
+Commit message drafted:
+
+  feat(export): add CSV export for saved searches
+
+  CHANGELOG: Saved searches can now be exported as CSV from the search list.
+
+Committed a1b2c3d. git status: clean.
+```
+
+## When to reach for it
+
+Reach for `/ca:commit` once staged work is ready to persist. `/ca:pr` builds on the same gate to
+check PR readiness, dispatching additional reviewers the diff's path demands.

--- a/site/src/curated/commands/create-context.md
+++ b/site/src/curated/commands/create-context.md
@@ -1,0 +1,57 @@
+---
+entity: commands/create-context
+related: [decompose, init, skills/context-creation]
+gates:
+  - gate: brownfield check
+    when: before scouts are dispatched
+    effect: meaningful source code must already exist; a project with none redirects to decompose instead
+  - gate: parallel scout dispatch
+    when: after the pre-flight check
+    effect: several read-only scouts each cover one slice of the codebase, returning file paths, line numbers, and named values only — never raw code or secret values
+  - gate: initialization lock
+    when: after the gap interview
+    effect: the completion marker is written only once every gap is either resolved or explicitly deferred
+---
+
+## What it does
+
+This is the populator for a project that already has code to read. Instead of interviewing you about
+architecture that's already decided, it dispatches several scouts in parallel to read different
+slices of the repository — dependencies, infrastructure, and so on — and each one reports back
+structured findings rather than raw excerpts. Those findings get synthesized into a draft of the
+project's state documents, and whatever the scouts couldn't determine on their own becomes a short,
+targeted set of questions instead of a full interview. Once every gap is answered or explicitly
+deferred, the documents are finalized and the project is marked initialized.
+
+## Usage
+
+```
+/ca:create-context
+```
+
+No arguments — the skill reads the repository itself and only asks about what it can't determine
+from the code.
+
+## Example
+
+```text
+> /ca:create-context
+
+Existing source detected (Express API + React frontend). Beginning scout-based extraction.
+Dispatching 6 scouts in parallel: tech stack, infrastructure, domain vocabulary, testing conventions,
+security surface, existing conventions...
+[scouts report back: file paths, line numbers, named values]
+
+Synthesis complete. Two gaps the scouts couldn't resolve from code alone:
+  1. Is there a staging environment, or just local and prod?
+  2. Who are the two user roles referenced in permissions.ts — admin and... ?
+> staging exists at staging.example.com; the second role is "billing-admin"
+
+Writing tech-stack.md, security-controls.md, coding-standards.md, CONTEXT.md...
+CONTEXT.md marked initialized.
+```
+
+## When to reach for it
+
+Reach for `/ca:create-context` on an existing codebase with `.codearbiter/` already scaffolded by
+`/ca:init`. For a project with no meaningful source yet, `/ca:decompose` is the right populator.

--- a/site/src/curated/commands/debug.md
+++ b/site/src/curated/commands/debug.md
@@ -1,0 +1,59 @@
+---
+entity: commands/debug
+related: [fix, adr, skills/debug]
+gates:
+  - gate: minimal repro
+    when: before a hypothesis is formed
+    effect: a defect with no reliable reproduction (or a documented intermittent-trigger profile) cannot proceed
+  - gate: three hypotheses, one boring
+    when: before evidence is gathered
+    effect: at least three distinct candidate causes are required, including one environmental or configuration explanation, before anything is checked against evidence
+  - gate: no code changes
+    when: for the entire investigation
+    effect: every phase is read-only; a fix is never attempted mid-investigation
+  - gate: single named exit
+    when: at the end of the investigation
+    effect: the session must close as exactly one of a confirmed bug, a design ambiguity, or a no-action close — never left open
+---
+
+## What it does
+
+This is where an unexplained defect goes before anyone touches code. The investigation is
+deliberately separated from the fix: describing the symptom, forming multiple candidate causes, and
+checking each against logs, traces, and recent commits all happen without editing anything. The
+requirement for at least three distinct hypotheses — with one of them a boring explanation like a
+stale cache or a config mismatch — exists because locking onto the first plausible story is the most
+common way a diagnosis goes wrong. Whatever the investigation lands on, it has to close as exactly one
+outcome: a confirmed bug handed to `/ca:fix` with a named regression-test obligation, a design
+ambiguity handed to `/ca:adr`, or a documented decision that no action is needed.
+
+## Usage
+
+```
+/ca:debug <observed symptom>
+```
+
+Describe what happened with enough detail that someone else could reproduce it — a vague description
+like "it's flaky" gets a request for more detail before routing begins.
+
+## Example
+
+```text
+> /ca:debug the nightly export job sometimes finishes with a zero-byte file, maybe once a week
+
+Symptom captured. Repro: intermittent, ~1-in-7 nightly runs, no clear trigger yet identified.
+Hypotheses:
+  H1 (likely): export writer is not flushed before the process exits
+  H2: source query times out silently under load and returns nothing
+  H3 (boring): the export volume mount is occasionally unmounted before the job starts
+Gathering evidence... H1 CONFIRMED (log shows process exit 0.2s after last write, no flush call in
+the writer's shutdown path). H2 and H3 REFUTED (query duration and mount logs are clean on affected runs).
+
+Exit: (a) confirmed bug. Regression test obligation: kill the writer immediately after the last write
+call and assert the output file is complete. Routing to /ca:fix.
+```
+
+## When to reach for it
+
+Reach for `/ca:debug` when the cause isn't known yet. If the cause and a reproduction are already
+in hand, go straight to `/ca:fix`.

--- a/site/src/curated/commands/decompose.md
+++ b/site/src/curated/commands/decompose.md
@@ -1,0 +1,59 @@
+---
+entity: commands/decompose
+related: [create-context, init, skills/decompose]
+gates:
+  - gate: greenfield check
+    when: before the interview starts
+    effect: any meaningful source code already in the repo redirects to create-context instead
+  - gate: layer-by-layer persistence
+    when: throughout the interview
+    effect: each of the six layers writes to disk as it's answered, so closing the session mid-interview loses nothing
+  - gate: initialization lock
+    when: at the end of the interview
+    effect: the completion marker is written only once every required doc is present and non-empty
+---
+
+## What it does
+
+This is the populator for a project that has no code yet to read. Rather than guessing at
+architecture, it runs a long, structured interview — six layers covering purpose, scope, users,
+vocabulary, and constraints — pushing back on vague answers and naming the complexity a quick answer
+tends to hide. Because a real interview like this can span multiple sessions, every layer is saved as
+it's completed rather than held in memory until the end, so a context reset or a closed terminal
+doesn't cost you the earlier answers. Once all six layers are solid, the surviving documents get
+written to the project's state directory and the project is marked initialized — only then does
+normal operation resume.
+
+## Usage
+
+```
+/ca:decompose
+```
+
+No arguments — the interview itself elicits everything it needs; you can hand it a summary at any
+point if you already have one written down.
+
+## Example
+
+```text
+> /ca:decompose
+
+Switching to decomposition mode. Six layers, one question at a time — typically 60-110 questions
+total, all persisted so you can pick this back up later.
+
+Layer 1 — Purpose. What problem does this project solve, in one sentence?
+> a scheduling tool for community garden plot signups
+
+"Scheduling tool" is broad — walk me through one signup, start to finish: who initiates it, what do
+they choose, what confirms it?
+...
+[layers 2-6 continue across the session; each answer lands on disk as it's given]
+
+All six layers complete. Writing tech-stack.md, coding-standards.md, security-controls.md, and the
+rest of the doc set... CONTEXT.md marked initialized.
+```
+
+## When to reach for it
+
+Reach for `/ca:decompose` on a genuinely greenfield project with `.codearbiter/` already scaffolded
+by `/ca:init`. If source code already exists, `/ca:create-context` is the right populator instead.

--- a/site/src/curated/commands/feature.md
+++ b/site/src/curated/commands/feature.md
@@ -1,0 +1,64 @@
+---
+entity: commands/feature
+related: [fix, refactor, skills/brainstorming, skills/writing-plans, skills/tdd]
+gates:
+  - gate: triage
+    when: before any routing decision
+    effect: the request is classified small-lane or full-lane against fixed criteria; an uncertain case always falls to the full lane
+  - gate: spec approval
+    when: after the Socratic refinement conversation
+    effect: hard stop; a plan is not written until you sign off on the spec
+  - gate: tdd obligation
+    when: before implementation begins
+    effect: each accepted criterion becomes a failing test the author must watch fail before writing code
+  - gate: batch checkpoint
+    when: between groups of tasks during execution
+    effect: work pauses for your acknowledgement before the next batch starts
+---
+
+## What it does
+
+This is the standard entry point for new work with a human in the loop at every step. A short
+description of what you want gets classified first: a narrow change touching a couple of files with
+no security, dependency, or schema surface can take a trimmed path that skips the full interview,
+while anything broader goes through a Socratic conversation that turns a one-line idea into a spec
+with testable criteria. From there the request becomes a task-by-task plan, and each task is
+implemented test-first, reviewed, and checked in small groups — you're asked to confirm before the
+next group starts. Nothing gets built without an approved plan behind it, and the pipeline can always
+be resumed later from wherever it left off rather than starting over.
+
+## Usage
+
+```
+/ca:feature <what you want to build>
+```
+
+A short description of the desired capability opens the classification step and, for the full path,
+seeds the spec conversation.
+
+## Example
+
+```text
+> /ca:feature let people export their saved searches as a CSV
+
+This touches one new endpoint and a small UI control — no auth, schema, or dependency surface.
+Proposed small-lane scope:
+  1. GET /api/searches/export returns the current user's saved searches as CSV
+  2. an "Export" button on the saved-searches page triggers the download
+  3. an empty saved-search list returns a header-only CSV, not an error
+
+Proceed on this scope? (y/n)
+> y
+
+Logged to triage.log. Routing to test-first implementation...
+[failing test written for criterion 1 — red]
+[failing test written for criterion 2 — red]
+[failing test written for criterion 3 — red]
+...implementation, review, and commit-gate follow before a PR opens.
+```
+
+## When to reach for it
+
+Reach for `/ca:feature` for new, human-checkpointed capability work. For a fully autonomous run
+across the whole plan, use `/ca:sprint` instead — the same spec-and-plan front, but without pausing
+between batches.

--- a/site/src/curated/commands/fix.md
+++ b/site/src/curated/commands/fix.md
@@ -1,0 +1,47 @@
+---
+entity: commands/fix
+related: [feature, refactor, skills/tdd]
+gates:
+  - gate: regression test first
+    when: before any fix code is written
+    effect: a test reproducing the defect must exist and fail for the right reason
+  - gate: root cause named
+    when: before the failing test is written
+    effect: the exact code path producing the wrong behavior must be located, not guessed at
+---
+
+## What it does
+
+This is the entry point for a defect that already has a known cause, or one you can describe
+precisely — what's happening versus what should happen, ideally with a stack trace or a way to
+reproduce it. The work routes into the standard test-first pipeline, but the first obligation is
+framed around proving the bug rather than building something new: a test has to fail, and fail for
+the specific reason the defect causes, before any correction is written. Only after that red test is
+confirmed does the minimal fix land, followed by the same review and verification steps every other
+change goes through.
+
+## Usage
+
+```
+/ca:fix <what's happening vs. what should happen>
+```
+
+Describe the observed behavior and the expected behavior; a stack trace or reliable reproduction
+sharpens the diagnosis.
+
+## Example
+
+```text
+> /ca:fix search results page shows a blank page instead of "no results" when a query matches nothing
+
+Reproducing... confirmed: empty result set triggers an unhandled render path in SearchResults.
+Root cause: the component assumes results.length > 0 and never checks the empty case.
+Writing regression test: renders SearchResults with an empty array, expects "no matches" text.
+Running... FAIL (expected reason: TypeError reading results[0], matches the observed defect)
+Test is red for the right reason. Proceeding to the minimal fix.
+```
+
+## When to reach for it
+
+Reach for `/ca:fix` once the cause is known or you can name a precise repro. If the cause is unknown,
+`/ca:debug` investigates first and hands off a confirmed bug statement `/ca:fix` can act on.

--- a/site/src/curated/commands/init.md
+++ b/site/src/curated/commands/init.md
@@ -1,0 +1,47 @@
+---
+entity: commands/init
+related: [create-context, decompose]
+gates:
+  - gate: no overwrite
+    when: every invocation
+    effect: the scaffolder refuses to run if .codearbiter/CONTEXT.md already exists — it never overwrites existing state
+  - gate: mandatory populator handoff
+    when: right after scaffolding
+    effect: the stub it creates is not usable on its own; it routes straight to create-context or decompose to actually fill it in
+---
+
+## What it does
+
+This is how a repository opts into codeArbiter for the first time. It writes the root-level state
+directory with the activation flag and a set of empty tracking files — nothing more. The `CONTEXT.md`
+it creates is deliberately a stub, not a finished project doc, so the very next thing that has to
+happen is populating it: an existing codebase routes to the brownfield scout that reads the code and
+drafts the real docs, while a from-scratch project routes to the layered architect interview instead.
+Until that populator runs and writes its own completion marker, the rest of the pipeline stays
+blocked — `/ca:feature` and the other lanes need `tech-stack.md` and `security-controls.md` to exist
+before they'll proceed.
+
+## Usage
+
+```
+/ca:init | --stage N | --check
+```
+
+No arguments runs the scaffold at its default maturity stage; `--stage N` sets an initial maturity
+value other than the default; `--check` reports the current state without writing anything.
+
+## Example
+
+```text
+> /ca:init
+
+Running the scaffolder against the repo root...
+Created .codearbiter/CONTEXT.md (arbiter: enabled, stage: 1, stub body)
+Created open-tasks.md, open-questions.md, overrides.log, last-checkpoint
+Source code detected in this repo — routing to /ca:create-context to populate the stub.
+```
+
+## When to reach for it
+
+Reach for `/ca:init` exactly once, on a repository that hasn't opted in yet. If `.codearbiter/`
+already exists, this refuses and `/ca:status` shows the current state instead.

--- a/site/src/curated/commands/pr.md
+++ b/site/src/curated/commands/pr.md
@@ -1,0 +1,55 @@
+---
+entity: commands/pr
+related: [commit, watch, skills/finishing-a-development-branch]
+gates:
+  - gate: commit gate cleared
+    when: before a PR is drafted
+    effect: the commit gate must have already passed this session; a PR is not the place to catch up on skipped verification
+  - gate: path-matrix review dispatch
+    when: after the commit gate check
+    effect: the diff decides which reviewers run — auth/crypto paths, migrations, dependency manifests each pull in a dedicated reviewer, and a coverage check always runs
+  - gate: BLOCK check
+    when: after reviewers report
+    effect: any CRITICAL or HIGH finding stops the PR from being drafted until you resolve it
+---
+
+## What it does
+
+This is the only path to opening a pull request — there's no direct push or force-push to the
+default branch anywhere in the system. Before anything gets drafted, it confirms the commit gate
+already ran clean this session, then looks at what actually changed to decide which reviewers need
+to weigh in: touching authentication or crypto code pulls in a security-focused pass, a migration
+file pulls in a migration reviewer, a changed dependency manifest pulls in a supply-chain check, and
+a coverage check runs on every PR regardless. Any finding at CRITICAL or HIGH severity stops the
+draft cold until it's addressed. Once everything clears, the PR itself gets written with a real
+summary, a test plan, and links to any decision record it touches — then, if you've opted into CI
+babysitting, a watcher attaches to follow the checks through to green.
+
+## Usage
+
+```
+/ca:pr
+```
+
+Takes no arguments — it reads the current branch, its diff against the default branch, and the
+commit history to determine what changed.
+
+## Example
+
+```text
+> /ca:pr
+
+commit-gate: confirmed clean this session.
+Diff touches: src/auth/session.ts, src/auth/session.test.ts.
+Path matrix: auth path detected — dispatching auth-crypto-reviewer and security-reviewer.
+Dispatching coverage-auditor (all paths).
+Reviewers report: 0 CRITICAL, 0 HIGH, 1 LOW (naming suggestion, non-blocking).
+Drafting PR: "fix(auth): rotate session token on privilege change"...
+PR opened: https://github.com/org/repo/pull/482
+CODEARBITER_BABYSIT is off — no CI watcher attached. Run /ca:watch to follow it manually.
+```
+
+## When to reach for it
+
+Reach for `/ca:pr` once work is committed and you're ready to open it for review. If changes are
+still only staged, run `/ca:commit` first; to review a diff without opening a PR, use `/ca:review`.

--- a/site/src/curated/commands/refactor.md
+++ b/site/src/curated/commands/refactor.md
@@ -1,0 +1,52 @@
+---
+entity: commands/refactor
+related: [feature, fix, skills/refactor]
+gates:
+  - gate: named surface
+    when: before the restructure starts
+    effect: the exact files, functions, or methods in scope must be stated; a vague target like "the auth module" is rejected
+  - gate: parity coverage
+    when: before any code moves
+    effect: pre-existing tests must already cover the named surface, with at least one direct test per public method — an under-covered surface halts and backfills first
+  - gate: parity verification
+    when: after the restructure
+    effect: the full pre-existing suite passes with zero edits to any pre-existing test file
+---
+
+## What it does
+
+This is the lane for moving or reshaping code without changing what it does — a rename, an extract,
+an inline, a dedup, or swapping an internal implementation for another one that behaves identically.
+The proof that nothing changed comes from tests that already existed before the restructure started;
+editing one of those tests to make it pass again is treated as a behavior change in disguise, not
+valid proof. If the surface isn't covered well enough to prove parity, the work pauses to add tests
+first. And if what comes out the other end would actually classify as new behavior, the whole thing
+reroutes to feature work instead of finishing as a refactor.
+
+## Usage
+
+```
+/ca:refactor <surface and motivation>
+```
+
+State the exact surface being restructured and why it's worth doing — both parts are required.
+
+## Example
+
+```text
+> /ca:refactor extract the retry logic in OrderClient.submit() into a shared withRetry() helper — three other clients duplicate it
+
+Surface locked: OrderClient.submit(), PaymentClient.submit(), InventoryClient.reserve().
+Parity coverage: each has a direct test; PaymentClient's covers only the success path — backfilling
+a failure-path test before continuing.
+[backfill test added, suite green]
+Applying the extraction... no new branches, no new error paths.
+Running full suite unmodified: 187 passed, 0 failed, zero test files touched.
+Coverage on the named surface: unchanged. Parity proven.
+```
+
+## When to reach for it
+
+Reach for `/ca:refactor` when the behavior is staying the same and only the shape of the code is
+changing. If the motivation is "the current behavior is wrong," that's `/ca:fix`; if it adds new
+behavior, that's `/ca:feature`.

--- a/site/src/curated/commands/release.md
+++ b/site/src/curated/commands/release.md
@@ -1,0 +1,54 @@
+---
+entity: commands/release
+related: [commit, pr, skills/release]
+gates:
+  - gate: version derivation
+    when: before a tag is composed
+    effect: the SemVer bump is computed mechanically from Conventional Commits since the last tag — an explicit version that disagrees with that classification blocks rather than being silently adjusted
+  - gate: changelog completeness
+    when: same phase as version derivation
+    effect: every feat/fix/perf commit in the release window must carry its own changelog note; a missing one blocks rather than being auto-filled
+  - gate: publish authorization
+    when: after the tag is composed locally
+    effect: the tag and the GitHub Release publish together, and only once you explicitly say to
+---
+
+## What it does
+
+This is the only sanctioned way a version tag gets created. It never invents a version number — it
+walks every commit since the last tag, classifies each by its Conventional Commits type, and applies
+whichever bump that history actually earns (a breaking change beats a feature, a feature beats a
+fix). The changelog section is assembled the same mechanical way, pulled from the commit footers
+rather than freehand summary, and a commit that should have carried one but didn't is a hard stop
+rather than a gap silently papered over. Composing the tag locally and publishing it are two separate
+moments: nothing pushes to the remote or shows up as a GitHub Release until you explicitly authorize
+that second step.
+
+## Usage
+
+```
+/ca:release ["<version>"] | --auto | --dry-run
+```
+
+An explicit version still gets checked against the derived classification; `--auto` derives it
+outright (the default when no version is given); `--dry-run` runs every check and reports readiness
+without composing anything.
+
+## Example
+
+```text
+> /ca:release --dry-run
+
+Working tree clean. Branch: release/prep (not the default branch — OK).
+Last tag: v2.4.1. Scanning 14 commits since...
+Classification: 3 feat, 6 fix, 5 chore -> minor bump.
+Derived version: v2.5.0. Matches plugin manifest? no — manifest still reads 2.4.1, would need updating.
+Changelog: all 9 feat/fix commits carry a CHANGELOG: footer.
+Dry run complete — no tag composed. Update the manifest version, then re-run without --dry-run.
+```
+
+## When to reach for it
+
+Reach for `/ca:release` once the target branch is clean and its suite is green and you're ready to
+cut a version. Work still in progress lands through `/ca:feature` or `/ca:fix` first — a release
+aggregates what already passed, it doesn't chase down anything new.

--- a/site/src/curated/commands/spike.md
+++ b/site/src/curated/commands/spike.md
@@ -1,0 +1,56 @@
+---
+entity: commands/spike
+related: [feature, debug, skills/using-git-worktrees]
+gates:
+  - gate: named question
+    when: before the branch is created
+    effect: a spike must restate the request as a falsifiable question plus a timebox, and you confirm it before any code is written
+  - gate: no merge, ever
+    when: for the lifetime of the spike branch
+    effect: the branch can only end in a findings file and deletion — it is never PR'd or merged
+  - gate: security floor
+    when: throughout exploration
+    effect: no secret leaves the approved store and no irreversible operation runs, even on disposable code
+---
+
+## What it does
+
+This is the outlet for "I need to write code to find out" rather than "I know what to build." The
+work happens on a disposable branch with none of the usual process overhead — no plan, no test-first
+discipline, no review fleet — because the code itself is never meant to survive. What survives is the
+answer: once the question is settled (or the timebox runs out without one), the finding gets written
+down as a short note and the branch is deleted. If the answer turns out to justify building the real
+thing, that's a fresh `/ca:feature` request that treats the spike as reference material, not as a
+starting diff.
+
+## Usage
+
+```
+/ca:spike <question to answer> [timebox]
+```
+
+State the question the exploration needs to answer; an optional timebox overrides the one-session
+default.
+
+## Example
+
+```text
+> /ca:spike can we stream large CSV exports without loading the whole file into memory? 2 hours
+
+Question: can a 500MB export stream to the client without a full in-memory buffer?
+Timebox: 2 hours. Confirm? (y/n)
+> y
+
+Branch spike/streaming-csv-export created.
+[exploration — no plan, no tdd, no review]
+
+Timebox reached. Answer: yes, a Node stream + res.write() loop holds memory flat at ~40MB regardless
+of file size; the current buffer-then-send path is the only blocker.
+Findings written to .codearbiter/spikes/streaming-csv-export.md.
+Branch spike/streaming-csv-export deleted.
+```
+
+## When to reach for it
+
+Reach for `/ca:spike` when you don't yet know if an approach works. Once you do, hand the findings to
+`/ca:feature` — the implementation is written fresh, test-first, never copied from the spike branch.

--- a/site/src/curated/commands/sprint.md
+++ b/site/src/curated/commands/sprint.md
@@ -1,6 +1,6 @@
 ---
 entity: commands/sprint
-related: [commit, skills/tdd]
+related: [feature, commit, skills/subagent-driven-development]
 gates:
   - gate: spec + plan approval
     when: before autonomous execution starts
@@ -28,3 +28,31 @@ to approve it in the moment.
 A short goal seeds the spec conversation that opens the sprint. Add `--farm` to send
 implementation work to lower-cost worker agents while the same spec-authoring, test-writing, and
 review responsibilities stay put.
+
+## Example
+
+```text
+> /ca:sprint add rate limiting to the public webhook endpoint
+
+Opening the sprint spec conversation...
+[Socratic refinement — per-IP limit, window, response on exceed]
+Spec written to .codearbiter/specs/webhook-rate-limit.md. Plan written with 5 tasks.
+Approve spec and plan to begin autonomous execution? (y/n)
+> y
+
+Executing task 1/5... task 2/5... task 3/5 touches security-controls.md scope — this is a hard gate,
+halting for your decision rather than choosing on your behalf.
+
+Task 3 adds a Redis-backed limiter key derived from client IP. Confirm this fits the approved
+security posture before I continue? (y/n)
+> y
+
+...task 4/5... task 5/5 complete. Every auto-decision logged to sprint-log.md (1 low-confidence entry).
+Routing to commit-gate, then finishing-a-development-branch (opening a PR — sprint never merges).
+```
+
+## When to reach for it
+
+Reach for `/ca:sprint` when the spec can be made concrete up front and you want the whole plan to run
+without per-batch checkpoints. `/ca:feature` is the better fit when you want to review progress
+between batches.


### PR DESCRIPTION
PR-2.3a of the docs-site overhaul campaign — curated full-anatomy reference (what/usage/gates/example/related) for the 13 lanes & lifecycle commands: feature, fix, chore, refactor, commit, sprint, pr, release, spike, debug, init, decompose, create-context. Seeds commit.md/sprint.md extended with transcripts and corrected related: refs (commit now points at skills/commit-gate). Transcripts grounded in the owning skills' real phases. 260 vitest passing incl. paraphrase lint; build + link-audit green (15,546 links).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa