### PR TITLE
docs(site): curated reference for governance & audit commands (batch b)

### DIFF
--- a/site/src/curated/commands/adr-status.md
+++ b/site/src/curated/commands/adr-status.md
@@ -1,0 +1,45 @@
+---
+entity: commands/adr-status
+related: [adr, reconcile, skills/decision-lifecycle]
+---
+
+## What it does
+
+A read-only health scan of every recorded ADR under `.codearbiter/decisions/`. For each one it
+reports number, title, status, and date, then flags what needs attention: aged decisions,
+`proposed` ADRs that were never challenged, supersession candidates where a newer ADR or code
+pattern contradicts an older one, and any unresolved `[CONFIRM-NN]` placeholder left inside an ADR
+body. Nothing is modified, and no `[CONFIRM-NN]` found during the scan is resolved here — it's
+surfaced and left for you.
+
+## Usage
+
+```
+/ca:adr-status [--adr N]
+```
+
+With no argument it scans every ADR; `--adr N` narrows the scan to a single ADR.
+
+## Example
+
+```text
+> /ca:adr-status
+
+## ADR Status — 2026-07-02
+
+### Active
+- ADR-0005 — Split the persona register — accepted (2026-06-18)
+- ADR-0006 — Decline a commercial vertical — accepted (2026-06-20)
+- ADR-0007 — Use PostgreSQL as the primary database — proposed (2026-07-01)
+
+### Superseded
+- ADR-0003 — Original watch-strangers onboarding — superseded by ADR-0006
+
+### Unresolved CONFIRM-NN
+- ADR-0007 — [CONFIRM-08]: connection-pool sizing not yet decided
+```
+
+## When to reach for it
+
+A quick health check across all ADRs. To record a new decision, use `/ca:adr`; to challenge or
+reconcile a specific ADR in depth, use `/ca:reconcile`.

--- a/site/src/curated/commands/adr.md
+++ b/site/src/curated/commands/adr.md
@@ -1,0 +1,51 @@
+---
+entity: commands/adr
+related: [adr-status, reconcile, skills/decision-lifecycle]
+gates:
+  - gate: user attribution
+    when: authoring the ADR content
+    effect: context, decision, alternatives, and consequences are confirmed with you directly — an unknown becomes an inline `[CONFIRM-NN]`, never a guess
+  - gate: numbering + marker
+    when: writing the file
+    effect: the next ADR number is fixed with no gap, and a short-lived authoring marker is armed so the write hooks allow the file — `/adr` is the only path that can arm it
+---
+
+## What it does
+
+Records an architectural decision as a numbered, dated ADR under `.codearbiter/decisions/`. This is
+the only sanctioned way an ADR gets written: the underlying skill drops a 30-minute authoring marker
+immediately before the write, and the repo's pre-write/pre-edit hooks refuse to touch a
+`.codearbiter/decisions/NNNN-*.md` file without one. Status transitions
+(`proposed → accepted → superseded | rejected`) always require your explicit instruction — the
+decision never advances on its own.
+
+## Usage
+
+```
+/ca:adr "<decision title>"
+```
+
+Title the decision as what was decided, not what was considered — `"Use PostgreSQL as the primary
+database"`, not `"Database selection"`.
+
+## Example
+
+```text
+> /ca:adr "Use PostgreSQL as the primary database"
+
+Indexed 6 existing ADRs under .codearbiter/decisions/ — next number is 0007.
+
+Confirm before I write:
+  Context: <you supply/confirm>
+  Decision: Use PostgreSQL as the primary database
+  Alternatives considered: <you supply/confirm>
+  Consequences: <you supply/confirm>
+
+Written: .codearbiter/decisions/0007-use-postgresql-as-the-primary-database.md (status: proposed)
+Decision log entry appended — Decided by: dev@example.com
+```
+
+## When to reach for it
+
+Recording a decision you've already made. If the question is which option to pick, that's
+`/ca:reconcile`; if you just want to know an ADR's health, that's `/ca:adr-status`.

--- a/site/src/curated/commands/audit.md
+++ b/site/src/curated/commands/audit.md
@@ -1,0 +1,44 @@
+---
+entity: commands/audit
+related: [status, metrics, checkpoint]
+---
+
+## What it does
+
+Assembles everything codeArbiter logs — `overrides.log`, `triage.log`, `decisions/`,
+`sprint-log.md`, `checkpoints/` — into a single dated record: what happened during a window, who
+signed off on it, and what's still outstanding. It's read-only over every source; its only write is
+the packet itself, saved to
+`.codearbiter/audits/<YYYY-MM-DD>.md` (a second run the same day appends `-2`, never overwriting).
+Every override and low-confidence sprint entry is quoted verbatim, never paraphrased, and an empty
+section is stated as empty — "no overrides in window" is itself part of the record.
+
+## Usage
+
+```
+/ca:audit "[<from-ref> <to-ref> | --since-checkpoint | --since <date>]"
+```
+
+Two tags/SHAs bound an explicit range; `--since-checkpoint` runs from the last recorded checkpoint
+to HEAD; `--since <date>` runs from an ISO date to HEAD; no argument defaults to the most recent
+tag (or last checkpoint, or a hard stop asking for an explicit window if neither exists).
+
+## Example
+
+```text
+> /ca:audit v2.4.0 v2.5.0
+
+Window: v2.4.0..v2.5.0 (2026-06-15 to 2026-07-02)
+Packet written: .codearbiter/audits/2026-07-02.md
+
+Summary:
+  Commits: 41 (12 feat, 9 fix, 6 docs, ...)
+  Overrides: 2 (both routine, 0 SECURITY-OVERRIDE)
+  Open items: 1 unresolved [CONFIRM-11], 3 checkpoint findings still open
+```
+
+## When to reach for it
+
+You want an evidentiary packet for a range, not a live snapshot — for that, use `/ca:status`. This
+command only reports what reviews already found; to trigger a fresh review sweep, use
+`/ca:checkpoint`.

--- a/site/src/curated/commands/checkpoint.md
+++ b/site/src/curated/commands/checkpoint.md
@@ -1,0 +1,52 @@
+---
+entity: commands/checkpoint
+related: [tribunal, audit, status]
+gates:
+  - gate: reviewer fleet, funneled
+    when: every invocation
+    effect: security-reviewer, auth-crypto-reviewer, dependency-reviewer, migration-reviewer, coverage-auditor, and architecture-drift-reviewer run read-only over the whole codebase, then funnel through finding-triage and checkpoint-aggregator — the orchestrator never consumes raw reviewer output directly
+---
+
+## What it does
+
+A periodic sweep of the entire codebase with the same reviewer fleet `/ca:review` uses per-diff,
+scoped instead to everything against the `.codearbiter/` docs. Every reviewer's output passes
+through `finding-triage` then `checkpoint-aggregator`, which writes a dated report to
+`.codearbiter/checkpoints/YYYY-MM-DD.md` with findings grouped by severity and file:line. It also
+re-zeros the `over:N` overrides-since-checkpoint counter the statusline shows, by writing the
+current `overrides.log` line count to `.codearbiter/last-checkpoint`. This is a report, not a
+promotion gate — it surfaces findings and enforces no sign-off.
+
+## Usage
+
+```
+/ca:checkpoint
+```
+
+Takes no arguments — it sweeps the whole codebase every time.
+
+## Example
+
+```text
+> /ca:checkpoint
+
+Dispatching reviewer fleet (6 reviewers, read-only)...
+Triaging findings...
+
+Checkpoint document written to .codearbiter/checkpoints/2026-07-02.md.
+
+| Reviewer | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| security-reviewer | 0 | 1 | 2 | 0 |
+| coverage-auditor | 0 | 0 | 3 | 1 |
+| architecture-drift-reviewer | 0 | 0 | 1 | 0 |
+| **Total** | **0** | **1** | **6** | **1** |
+
+1 DEFERRABLE finding surfaced for follow-up harvest.
+last-checkpoint updated: 4 (override count reset)
+```
+
+## When to reach for it
+
+The routine, cheap, whole-codebase sweep — not the current diff (`/ca:review`), not the rare
+expensive deep audit (`/ca:tribunal`), and not ADR health alone (`/ca:adr-status`).

--- a/site/src/curated/commands/conflict.md
+++ b/site/src/curated/commands/conflict.md
@@ -1,0 +1,59 @@
+---
+entity: commands/conflict
+related: [override, reconcile]
+gates:
+  - gate: halt on detection
+    when: the persona, a .codearbiter/ document, and code contradict each other — or two docs contradict each other
+    effect: all other work stops, both sides are quoted side by side and classified against the conflict-resolution hierarchy, and work resumes only after you resolve it explicitly
+---
+
+## What it does
+
+The protocol for a rule conflict — not a skill route, an orchestrator-level halt. When two sources
+disagree (the persona vs. a `.codearbiter/` document, a doc vs. code, or two docs against each
+other), everything in progress stops, both passages are quoted exactly, and the tension is
+classified against the conflict-resolution hierarchy so you can see which level it sits at. The
+orchestrator never picks a side, and recency alone never decides it — a more-recently-updated
+source is noted as informational, not determinative. It also fires automatically whenever the
+orchestrator detects this class of contradiction on its own, not just when invoked directly.
+
+## Usage
+
+```
+/ca:conflict
+```
+
+Takes no arguments — it presents whatever conflict triggered it (or the most recent one it detected).
+
+## Example
+
+```text
+> /ca:conflict
+
+## Conflict detected — work halted
+
+### Source A
+File: plugins/ca/ORCHESTRATOR.md · Last updated: 2026-06-10
+> Direct commit to a protected branch is prohibited.
+
+### Source B
+File: .codearbiter/decisions/0004-fast-forward-hotfix-branch.md · Last updated: 2026-07-01
+> Hotfix commits may land directly on main under the fast-forward exception.
+
+### Nature of conflict
+ADR-0004 appears to carve an exception into a hard rule the persona states as absolute.
+
+### Conflict-hierarchy level
+Level 1 — a hard rule vs. an accepted ADR.
+
+### To resolve
+Update ADR-0004 to route through commit-gate, or supersede the hard rule via a new ADR.
+
+---
+Work is halted. Resolve before the orchestrator proceeds.
+```
+
+## When to reach for it
+
+You rarely invoke this directly — it's usually the orchestrator surfacing a contradiction it found.
+For a gate you've decided to bypass rather than a contradiction to resolve, that's `/ca:override`.

--- a/site/src/curated/commands/metrics.md
+++ b/site/src/curated/commands/metrics.md
@@ -1,0 +1,38 @@
+---
+entity: commands/metrics
+related: [status, audit]
+---
+
+## What it does
+
+A bare-numbers governance glance — three metrics, each with a trend arrow against the prior
+20-commit window: override rate, small-lane rate, and sprint low-confidence ratio. It calls a thin
+Python helper and prints only the numbers and arrows, never a verbatim override line, a commit
+list, or any other log content, and it writes nothing to disk. It's meant for a glance, not
+evidence — reach for `/ca:audit` when you need the full packet with quoted log lines.
+
+## Usage
+
+```
+/ca:metrics [--window N]
+```
+
+`--window N` changes the commit-window size from the default of 20.
+
+## Example
+
+```text
+> /ca:metrics
+
+override rate:          0.05  →  (prior: 0.05)
+small-lane rate:        0.30  ↓  (prior: 0.42)
+sprint low-conf ratio:  n/a   →  (prior: n/a)
+
+An upward arrow on override rate or sprint low-conf ratio is a worsening signal.
+Window: 20 commits (default)
+```
+
+## When to reach for it
+
+A fast trend check without leaving the terminal. For the full evidentiary packet with verbatim
+overrides and a commit list, use `/ca:audit`; for live project state right now, use `/ca:status`.

--- a/site/src/curated/commands/override.md
+++ b/site/src/curated/commands/override.md
@@ -1,0 +1,48 @@
+---
+entity: commands/override
+related: [conflict, audit]
+gates:
+  - gate: single-confirm log
+    when: a routine gate is bypassed (lint, style, a non-security review finding)
+    effect: one append-only line is written to overrides.log — timestamp, operator identity, gate name, reason — before the action proceeds
+  - gate: security ceiling
+    when: a security CRITICAL finding, the crypto/secret commit gate (H-09b/H-10b), or an irreversible operation is at stake
+    effect: the single-confirm path is refused; the finding must be surfaced verbatim, acknowledged in your own words, and logged as a heavier SECURITY-OVERRIDE line before anything proceeds
+---
+
+## What it does
+
+The sanctioned, logged escape hatch. A routine gate — a lint rule, a style check, a non-security
+review finding — can be bypassed with a one-line confirm: the reason is validated, your identity is
+read from `git config user.email`, and a permanent line is appended to
+`.codearbiter/overrides.log` before the action proceeds. A security-critical stop takes a heavier
+path instead: the specific finding is named verbatim, you acknowledge that finding in your own
+words (a bare "yes" is declined), and a `SECURITY-OVERRIDE`-tagged line is logged before the bypass
+is recorded. Under `/ca:sprint`, a security-critical override is always a hard-gate stop — never
+auto-decided, even in autonomous mode.
+
+## Usage
+
+```
+/ca:override "<reason>"
+```
+
+The reason must name the gate being bypassed and a real justification — a vague reason like
+"just skip it" is rejected.
+
+## Example
+
+```text
+> /ca:override "skip the coverage-auditor finding on the new formatter, it's test-only tooling"
+
+Identity: dev@example.com (from git config user.email)
+Logged:
+  [2026-07-02T14:03:11Z] | BY: dev@example.com | GATE: coverage-auditor | REASON: skip the coverage-auditor finding on the new formatter, it's test-only tooling
+Proceeding — override recorded in .codearbiter/overrides.log.
+```
+
+## When to reach for it
+
+Only when a gate is actually standing in the way of a change you've decided is correct. Never
+needed for work that clears every gate on its own. For a rule conflict between two sources rather
+than a gate to bypass, that's `/ca:conflict`.

--- a/site/src/curated/commands/reconcile.md
+++ b/site/src/curated/commands/reconcile.md
@@ -1,0 +1,52 @@
+---
+entity: commands/reconcile
+related: [adr, adr-status, conflict, skills/decision-variance]
+gates:
+  - gate: explicit choice per variance
+    when: every variance presented
+    effect: "you pick ratify, supersede, or surface as [CONFIRM-NN] — \"you decide\" or \"use your best judgment\" is declined; only your verbatim acceptance of the recommendation counts as a decision"
+---
+
+## What it does
+
+Arbitrates variances between the project's three architectural artifacts
+(`01-architecture-breakdown.md`, `02-phased-build-plan.md`, `03-task-backlog.md`) and what the
+scaffold or prior ADRs actually show. Every divergent, scaffold-silent, or artifact-silent case
+gets a SMARTS analysis of its resolution options and a strength-labeled recommendation — but the
+skill never arbitrates on its own. Each variance ends in exactly one of three user-chosen outcomes:
+ratify the existing decision, supersede it (appending a new decision log entry and, if warranted, a
+replacement ADR via `/ca:adr`), or surface it as an unresolved `[CONFIRM-NN]`. Called bare it runs
+the full reconciliation pass; give it a target and it narrows to just that ADR, conflict, or
+artifact.
+
+## Usage
+
+```
+/ca:reconcile [<ADR-id | artifact | scope>]
+```
+
+Leave it bare for a full reconciliation pass; pass an ADR ID, artifact name, or other scope to
+narrow it to one variance.
+
+## Example
+
+```text
+> /ca:reconcile ADR-0004
+
+Variance: ADR-0004 (fast-forward hotfix branch) vs. scaffold — divergent.
+Artifact position: hotfixes may fast-forward directly to main.
+Scaffold evidence: git-enforce.py H-01 blocks any direct commit to main, no hotfix carve-out found.
+
+SMARTS analysis... recommendation: supersede (moderate).
+Your call — ratify, supersede, or surface as [CONFIRM-NN]?
+> supersede
+
+Decision log entry appended, Decided by: dev@example.com.
+Route to /ca:adr to author the replacement ADR? (y/n)
+```
+
+## When to reach for it
+
+A variance already exists between artifacts, code, or prior decisions and needs a user-attributed
+resolution. For a brand-new decision with no prior conflict, use `/ca:adr`; for ADR health alone,
+use `/ca:adr-status`.

--- a/site/src/curated/commands/standup.md
+++ b/site/src/curated/commands/standup.md
@@ -1,0 +1,51 @@
+---
+entity: commands/standup
+related: [status, task]
+gates:
+  - gate: per-action confirmation
+    when: pruning a merged branch or removing a stale worktree
+    effect: each candidate is confirmed individually before it's deleted — declining leaves it in place, and nothing is batched into one implied yes
+  - gate: fast-forward-only pull
+    when: the working tree is clean and the branch is behind upstream
+    effect: a --ff-only pull is offered; a dirty tree withholds the pull and reports the dirty state instead, and a diverged branch is refused rather than merged
+---
+
+## What it does
+
+The daily hygiene checklist, made routine and gated: fetch and offer a fast-forward pull, list
+locally-merged branches and stale worktrees for individual confirm-and-delete, surface stashes,
+uncommitted changes, and un-pushed commits with a suggested next step, and run an advisory
+board-drift sweep comparing recent merge history against `open-tasks.md`. Nothing destructive
+happens without an explicit per-item yes, and the task board is never auto-flipped — a drifted task
+is resolved only through `/ca:task done <id>`.
+
+## Usage
+
+```
+/ca:standup
+```
+
+Takes no arguments.
+
+## Example
+
+```text
+> /ca:standup
+
+Fetched. Branch is 2 commits behind origin/main, tree clean — fast-forward pull? (y/n)
+> y
+Pulled 2 commits.
+
+Locally-merged branches:
+  fix/typo-in-readme — delete? (y/n)
+> y
+Deleted fix/typo-in-readme.
+
+Board-drift sweep: 1 DRIFTED task (2.3a merged but not marked [x] in open-tasks.md).
+Resolve with /ca:task done 2.3a — not auto-flipped here.
+```
+
+## When to reach for it
+
+The daily cleanup pass with your yes on each destructive step. For a read-only snapshot without
+acting, use `/ca:status`; to actually flip the drifted task, use `/ca:task`.

--- a/site/src/curated/commands/status.md
+++ b/site/src/curated/commands/status.md
@@ -1,0 +1,42 @@
+---
+entity: commands/status
+related: [metrics, audit, task]
+---
+
+## What it does
+
+A read-only snapshot of `.codearbiter/` state: the project's `stage:` maturity value, every
+in-flight pipeline under `specs/` and `plans/` with how far each got (spec awaiting approval, spec
+approved with no plan, a plan in progress with its `ACCEPTED` task count, or complete), the open
+task and open-question counts, overrides logged since the last checkpoint, and the current git
+branch. No skill is routed to and no file is modified — if `[CONFIRM-NN]` placeholders are open, it
+surfaces them without resolving them.
+
+## Usage
+
+```
+/ca:status
+```
+
+Takes no arguments.
+
+## Example
+
+```text
+> /ca:status
+
+## Project status — 2026-07-02
+
+Stage:            3
+Branch:           docs/site-curated-commands-b
+Pipelines:
+  docs-site-overhaul   plan 4/12 ACCEPTED — resume with /ca:feature "docs-site-overhaul"
+Open tasks:       2
+Open questions:   1 ([CONFIRM-11] unresolved)
+Overrides since last checkpoint: 2
+```
+
+## When to reach for it
+
+A quick glance at where things stand right now. For a full cross-cutting review, use
+`/ca:checkpoint`; for a specific question about the project, use `/ca:btw`.

--- a/site/src/curated/commands/task.md
+++ b/site/src/curated/commands/task.md
@@ -1,0 +1,42 @@
+---
+entity: commands/task
+related: [status, standup]
+gates:
+  - gate: writer-only mutation
+    when: any add, start, or done invocation
+    effect: the write goes through the taskwrite.py transforms only, never a free-hand edit — a malformed target, an already-matching state, or a bad --date is reported and writes nothing
+---
+
+## What it does
+
+The only blessed way to mutate `.codearbiter/open-tasks.md`. It runs a thin writer over pure
+board-transform logic, which keeps every entry schema-conformant and every transition dated —
+`start` always stamps a started date so a task can never sit as a dateless in-progress item.
+Board-only PRs filed just to flip a task's state are the anti-pattern this command eliminates: a
+task's done-flip, start-flip, or new-task add is meant to ride the same commit as the work it
+tracks.
+
+## Usage
+
+```
+/ca:task add "<desc>" | start <id|"title"> | done <id|"title">
+```
+
+`add` appends a queued task (optionally minting a dotted ID with `--id`); `start` flips a task to
+in-progress and stamps today's date (or mints an ID at pick-up with `--as`); `done` flips a task to
+done and stamps the done date. Targeting by title is best-effort — prefer the dotted ID once one
+exists.
+
+## Example
+
+```text
+> /ca:task done 2.3a
+
+Flipped 2.3a to done, dated 2026-07-02.
+open-tasks.md updated via taskwrite.py.
+```
+
+## When to reach for it
+
+Any board write — adding, starting, or completing a task. To just read the board and its counts,
+use `/ca:status` instead; it's read-only.

--- a/site/src/curated/commands/threat-model.md
+++ b/site/src/curated/commands/threat-model.md
@@ -1,0 +1,53 @@
+---
+entity: commands/threat-model
+related: [checkpoint, skills/security-architecture]
+gates:
+  - gate: critical-gap stop
+    when: a STRIDE category comes back GAP — exploitable now, high impact
+    effect: the pass halts with a stated verdict of STOP naming the specific unmitigated threat; a lesser gap is surfaced as a constraint, not a halt
+---
+
+## What it does
+
+An opt-in, lightweight STRIDE pass over a design before it's built — invoked deliberately, never
+forced on an ordinary change. It maps the attack surface (new entry points, new egress, security
+boundaries crossed against `.codearbiter/security-controls.md`, the data handled), then walks each
+of the six STRIDE categories — spoofing, tampering, repudiation, information disclosure, denial of
+service, elevation of privilege — marking each threat's mitigation `PRESENT`, `PLANNED`, or `GAP`.
+It reads no code changes to review after the fact; for code already written, `/ca:review` or
+`/ca:checkpoint` cover that ground instead.
+
+## Usage
+
+```
+/ca:threat-model "<scope description>"
+```
+
+Name the feature or component, its data sensitivity, and the actors that reach it — that framing
+becomes the scope of the STRIDE pass.
+
+## Example
+
+```text
+> /ca:threat-model "new public webhook endpoint that receives partner payment notifications"
+
+## Scope
+Public webhook receiving partner payment notifications; no prior auth boundary here.
+
+## STRIDE findings
+| Threat | Category | Likelihood | Impact | Control |
+|---|---|---|---|---|
+| Unsigned payload accepted as genuine | Spoofing | H | H | GAP — no signature verification planned |
+| Payload replay | Repudiation | M | M | PLANNED — nonce + timestamp window |
+
+## Recommended controls before implementation
+- HMAC signature verification on the webhook payload before any processing.
+
+## Clearance
+BLOCKED — resolve findings first
+```
+
+## When to reach for it
+
+Before writing a sensitive feature — new external endpoints, new secrets-handling paths, new
+auth/authz flows. Not a routine gate; skip it for ordinary changes.

--- a/site/src/curated/commands/tribunal.md
+++ b/site/src/curated/commands/tribunal.md
@@ -1,0 +1,57 @@
+---
+entity: commands/tribunal
+related: [checkpoint, audit, skills/tribunal]
+gates:
+  - gate: cost acknowledgement
+    when: before Phase 0 finishes, every run
+    effect: the job is sized, a token-cost band and model recommendation are printed, and nothing dispatches until you explicitly acknowledge the estimate and confirm the model
+  - gate: approval before filing
+    when: after the report is generated
+    effect: findings become GitHub issues only on your explicit selection — silence or "looks good" files nothing
+---
+
+## What it does
+
+codeArbiter's deepest, most expensive review, convened rarely and never as a required gate. Eleven
+specialist lenses judge the whole codebase in priority waves; each finding is written to its own
+file under `.codearbiter/reports/<run-id>/`, so an interrupted run resumes from disk instead of
+losing progress. Because this lane routinely costs millions of tokens on a large repo, Phase 0
+always stops first: it sizes the codebase, prints the cost band, recommends the highest-reasoning
+model, and waits for you to say go. Critical and high findings are blocking-severity in the report
+— meaning they're work that should block shipping the affected code — but the tribunal run itself
+never halts a merge or commit.
+
+## Usage
+
+```
+/ca:tribunal "[scope-path] [--tag <label>]"
+```
+
+An optional `scope-path` narrows which subtree gets scrutiny (the full eleven-lens roster still
+runs); `--tag <label>` records a freeform label if you opt in to KPI telemetry at the end.
+
+## Example
+
+```text
+> /ca:tribunal
+
+Sizing codebase... 340 files, ~2.1M tokens estimated.
+Recommended model: highest-reasoning available, high effort.
+Estimated cost band: $180-$260.
+
+Proceed with this model and cost? (y/n)
+> y
+
+RUN_ID: 2026-07-02-full
+Phase 1: mapping... inventory.md written, 11 lenses active.
+Phase 2: dispatching lenses (wave 1/3, ≤5 in flight)...
+...
+Phase 4: report.md regenerated — 3 CRITICAL, 9 HIGH, 21 MEDIUM findings.
+
+Phase 5: file findings as GitHub issues? Select which, or "none".
+```
+
+## When to reach for it
+
+Rare, deliberate, whole-codebase depth — not the routine sweep (`/ca:checkpoint`), not a diff review
+(`/ca:review`), and never wired into a hot loop or schedule.


### PR DESCRIPTION
## Summary

PR-2.3b of the docs-site overhaul campaign — curated reference for the 13 governance & audit commands: adr, adr-status, override, conflict, audit, checkpoint, tribunal, metrics, status, standup, task, reconcile, threat-model.

Each file carries the full anatomy (what it does / usage / gates table / example transcript / related), grounded in the actual command + skill sources: real `overrides.log` line format, real `.codearbiter/` paths, tribunal's cost-band STOP, `/ca:task`'s three board mutations. Read-only commands (adr-status, audit, metrics, status) correctly carry no gates. Example identities use a neutral `dev@example.com` (review swapped out a real address).

The paraphrase lint caught 3 files with 12-word verbatim runs from their sources during authoring; reworded — the structural ban works.

## Verification

- 262 vitest passing (paraphrase lint + divergence checks included); typecheck clean; build 119 pages; link-audit 15,544 links OK.
- Spot-checked dist: adr + tribunal pages render curated body, gates, related, and the v-pinned source embed.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
