### PR TITLE
docs(site): curated reference for utility & meta commands (batch c)

### DIFF
--- a/site/src/curated/commands/add-dep.md
+++ b/site/src/curated/commands/add-dep.md
@@ -1,0 +1,53 @@
+---
+entity: commands/add-dep
+related: [agents/dependency-reviewer, review]
+gates:
+  - gate: dependency review
+    when: before any install runs
+    effect: the dependency-reviewer agent must clear the package first — a denied license or unresolved supply-chain concern blocks the install
+---
+
+## What it does
+
+Gates a new or changed third-party dependency through review before anything installs. Naming the
+package here — with a version if you have one, or without one to have the reviewer evaluate the
+latest available — hands the decision to the `dependency-reviewer` agent, which reads
+`.codearbiter/security-controls.md` for the allowed/denied license list and supply-chain policy,
+and `.codearbiter/tech-stack.md` for stack fit and the project's dependency manager.
+
+Once the agent clears the package, the install command is surfaced for confirmation rather than
+run silently, and the resulting lock-file update ships in the same commit as the manifest edit,
+so the two never drift apart.
+
+This gate is orchestrator-enforced, not hook-enforced: there's no pre-bash rule blocking a bare
+install command run outside this channel the way the crypto/secret gate blocks a raw shell
+command. The discipline depends on actually routing installs through here.
+
+## Usage
+
+```
+/ca:add-dep <package[@version]>
+```
+
+Version is optional; omitting it evaluates the latest available release.
+
+## Example
+
+```text
+> /ca:add-dep left-pad@1.3.0
+
+dependency-reviewer: left-pad@1.3.0
+  license: MIT (allowed)
+  provenance: npm registry, 6M+ weekly downloads, maintained
+  supply-chain: no known advisories
+
+Cleared. Install command ready:
+  npm install left-pad@1.3.0
+Run it? (lock-file change will be committed alongside package.json)
+```
+
+## When to reach for it
+
+Removing a dependency, or a code change that happens to bump one, goes through `/ca:fix` or
+`/ca:feature` instead (the manifest change is reviewed at `/ca:pr`); asking about a package
+without installing it is `/ca:btw`'s job.

--- a/site/src/curated/commands/arbiter.md
+++ b/site/src/curated/commands/arbiter.md
@@ -1,0 +1,41 @@
+---
+entity: commands/arbiter
+related: [dev]
+gates:
+  - gate: append-only audit
+    when: exiting dev mode
+    effect: an exit line is appended to overrides.log and the dev-active marker is removed before orchestration resumes
+---
+
+## What it does
+
+The exit door for `/ca:dev`: it ends the maintainer override and restores normal orchestration.
+It writes the exit line to `.codearbiter/overrides.log` before anything else, removes the
+gitignored dev-active marker so the statusline drops out of alarm-red, then re-presents the
+startup state — current stage, any blocking `[CONFIRM-NN]`, in-flight tasks — and waits for a
+slash command with routing, gates, and skills all back in force. If dev mode wasn't active, this
+command is a no-op.
+
+If a prior session ended mid-dev, SessionStart already appended a synthetic close line
+(`BY: session-cleanup | DEV: exit`) and cleared the marker for that orphaned entry; this command
+does not write a second exit line for it.
+
+## Usage
+
+```
+/ca:arbiter
+```
+
+Takes no arguments.
+
+## Example
+
+```text
+> /ca:arbiter
+
+[2026-07-02T14:41:03Z] | BY: dev@example.com | DEV: exit
+dev-active marker removed; statusline back to normal.
+
+stage: implementation · tasks: 2 open · q: 0 · overrides: 1 since last checkpoint
+Orchestration restored. Awaiting a command.
+```

--- a/site/src/curated/commands/btw.md
+++ b/site/src/curated/commands/btw.md
@@ -1,0 +1,42 @@
+---
+entity: commands/btw
+related: [commands, feature]
+---
+
+## What it does
+
+The one exception to codeArbiter's slash-command pipeline: a lightweight question-and-answer
+channel that reads project context and answers, then returns control. No skill is routed to, no
+agent is dispatched, no file changes. It is always safe to invoke, even mid-gate or mid-override,
+because it never touches state.
+
+Ask it anything about the repo's current shape — what stage a spec is in, what a hook does, why a
+prior decision was made — and it answers directly from `.codearbiter/` (`CONTEXT.md`,
+`tech-stack.md`, `coding-standards.md`, `security-controls.md`, decisions, specs, plans) instead of
+guessing. If the answer to the question isn't in that context, it says so rather than
+fabricating one.
+
+## Usage
+
+```
+/ca:btw <question>
+```
+
+The question is free text; there is no other argument shape.
+
+## Example
+
+```text
+> /ca:btw why does commit-gate block a wildcard git add?
+
+H-03 in pre-bash.py blocks `git add -A` / `.` / `--all` / `-u` and any pathspec
+that stages a non-explicit file set. The rule exists so a commit only ever
+contains what was reviewed — a wildcard stage can silently pull in an
+unrelated in-progress edit. Stage files explicitly, one path per file
+(see the commit-gate skill).
+```
+
+## When to reach for it
+
+A request to build or fix something is out of scope here — `/ca:btw` names the
+question-only boundary and points to `/ca:feature` or `/ca:fix` instead of starting work.

--- a/site/src/curated/commands/commands.md
+++ b/site/src/curated/commands/commands.md
@@ -1,0 +1,40 @@
+---
+entity: commands/commands
+related: [btw]
+---
+
+## What it does
+
+Prints the public command catalog straight from `COMMANDS.md` — the plugin's own single source
+of truth for what each `/ca:*` command takes and where it routes. There is no second, hand-copied
+table maintained anywhere else in the prompt set, so this command can't drift out of sync with
+the real routing table: it renders the file itself, not a memory of it.
+
+Reach for it when you know you want *something* codeArbiter does but not the exact command name
+or argument shape.
+
+## Usage
+
+```
+/ca:commands
+```
+
+Takes no arguments — it always renders the full catalog.
+
+## Example
+
+```text
+> /ca:commands
+
+Implementation
+  /ca:feature   "description"         Spec-driven feature: brainstorm -> plan -> build -> commit -> finish
+  /ca:sprint    ["goal"] [--farm]     Autonomous sprint; every auto-decision SMARTS-scored and logged
+  /ca:fix       "bug description"    Fix a defect via tdd, regression-test-first
+  ...
+
+Commit & ship
+  /ca:commit    (none)                The only path to a commit
+  /ca:pr        ["title"]             Finish a branch: open-PR / merge-via-PR / discard
+  /ca:watch     <PR number|url|branch> Babysit a PR's CI; never auto-merges
+  ...
+```

--- a/site/src/curated/commands/context-check.md
+++ b/site/src/curated/commands/context-check.md
@@ -1,0 +1,42 @@
+---
+entity: commands/context-check
+related: [skills/context-check, create-context, status]
+---
+
+## What it does
+
+An optional, on-demand drift audit for the bypass case: a merge, a direct push, or a manual edit
+outside a normal commit changed a tracked source file, so commit-gate's auto-heal never got a
+chance to fire (that heal runs automatically on every commit that touches a `drift_trigger`
+source — this command is not that routine path). It reports every stale provenance-tracked doc,
+then for each one offers a choice: re-scout (a partial scout run), re-baseline (accept the new
+hash into `.codearbiter/.provenance/`), or defer.
+
+It's read-only until you pick one of those actions — nothing is modified or committed on its own.
+The SessionStart drift line is the usual signal that this check is worth running.
+
+## Usage
+
+```
+/ca:context-check
+```
+
+Takes no arguments.
+
+## Example
+
+```text
+> /ca:context-check
+
+Stale provenance-tracked docs (2):
+  tech-stack.md       drift_trigger: package.json  (hash changed 3 commits ago)
+  security-controls.md drift_trigger: auth/**       (hash changed 1 commit ago)
+
+For tech-stack.md: re-scout / re-baseline / defer?
+```
+
+## When to reach for it
+
+Skip it for routine maintenance — commit-gate's auto-heal already covers the common case with no
+manual step. A full brownfield re-scan from scratch is `/ca:create-context`'s job; a project-state
+snapshot without a drift focus is `/ca:status`'s.

--- a/site/src/curated/commands/dev.md
+++ b/site/src/curated/commands/dev.md
@@ -1,0 +1,48 @@
+---
+entity: commands/dev
+related: [arbiter, override]
+gates:
+  - gate: env gate
+    when: CODEARBITER_DEV is not set to 1
+    effect: refuses in one line and orchestration stays in force — dev mode is never a casual bypass
+  - gate: append-only audit
+    when: entering dev mode
+    effect: an entry line is appended to overrides.log before orchestration is suspended, and the statusline turns alarm-red for the duration
+---
+
+## What it does
+
+Suspends codeArbiter's orchestration so you can edit codeArbiter itself — skill, agent, command,
+and hook bodies, `ORCHESTRATOR.md`, settings. It is not for project work; `/ca:override` covers a
+single-gate bypass on ordinary project code, and this command declines that use.
+
+Entry is gated behind the `CODEARBITER_DEV=1` environment variable specifically so it's a
+deliberate maintainer posture, never a one-line accidental bypass. Once entered, an append-only
+log line records who and when in `.codearbiter/overrides.log`, a gitignored marker file turns the
+statusline alarm-red so the mode is unmistakable, and the session becomes a plain, direct coding
+assistant — no routing, no skills, no gates, no `[CONFIRM-NN]` surfacing — until `/ca:arbiter` or a
+new session.
+
+## Usage
+
+```
+/ca:dev [note]
+```
+
+An optional free-text note is recorded alongside the entry log line.
+
+## Example
+
+```text
+$ export CODEARBITER_DEV=1
+> /ca:dev "fixing pre-bash H-03 regex"
+
+[2026-07-02T14:02:11Z] | BY: dev@example.com | DEV: enter | NOTE: fixing pre-bash H-03 regex
+dev-active marker written; statusline is now red.
+Orchestration suspended — plain coding assistant mode until /ca:arbiter.
+```
+
+## When to reach for it
+
+A single gate bypass on ordinary project work is `/ca:override "reason"`'s job, not this one's;
+a plain question is `/ca:btw`'s.

--- a/site/src/curated/commands/doctor.md
+++ b/site/src/curated/commands/doctor.md
@@ -1,0 +1,57 @@
+---
+entity: commands/doctor
+related: [statusline, preview]
+---
+
+## What it does
+
+Proves the install is actually enforcing, rather than just present. codeArbiter's worst failure
+shape is silent dormancy: a plugin cache surviving `claude plugin update` unchanged, hooks that
+look wired but never fire, and nothing that says so. This command checks in two parts. First a
+static pass — interpreter resolution, plugin payload integrity, stale cached versions, repo
+activation state, git identity, statusline wiring — reported one `OK`/`WARN`/`FAIL` line per
+check. Then, in an arbiter-enabled repo, a live-fire probe: it actually attempts a real,
+gate-tripping command (a dry-run `git add --all`) and checks whether the hook layer blocks it. A
+healthy install blocks the probe; if the probe instead executes, that is reported as CRITICAL —
+the static checks alone cannot catch a hook that's registered but not actually firing.
+
+It is read-only end to end. Because the probe uses `--dry-run`, getting blocked is the outcome it
+wants to see — that block is the passing verdict, not a failure to route around.
+
+## Usage
+
+```
+/ca:doctor
+```
+
+Takes no arguments.
+
+## Example
+
+```text
+> /ca:doctor
+
+OK      python3 resolves and runs (/usr/bin/python3)
+OK      plugin payload at /home/x/.claude/plugins/ca (version 2.8.11)
+OK      hooks.json parses: 6 events, 11 entries
+OK      all 6 hook scripts present
+OK      single cached plugin version (no stale siblings)
+OK      repo is arbiter-enabled (CONTEXT.md frontmatter)
+OK      project is initialized (<!--INITIALIZED--> marker present)
+OK      git identity for audit attribution: dev@example.com
+OK      statusline wired in ~/.claude/settings.json
+
+doctor: 0 FAIL, 0 WARN, 9 OK
+verdict: healthy (static checks) — the live-fire probe in /ca:doctor proves hooks actually fire
+
+live-fire probe: git add --all --dry-run
+BLOCKED [H-03]: 'git add -A' / 'git add .' / 'git add --all' / 'git add -u' are
+prohibited. Stage files explicitly (commit-gate skill).
+
+verdict: healthy — hooks firing
+```
+
+## When to reach for it
+
+Statusline wiring only is a narrower question answered by `/ca:statusline status`; scaffold state
+alone by `/ca:init --check`; project progress (not install health) by `/ca:status`.

--- a/site/src/curated/commands/new-skill.md
+++ b/site/src/curated/commands/new-skill.md
@@ -1,0 +1,53 @@
+---
+entity: commands/new-skill
+related: [skills/skill-author, feature]
+gates:
+  - gate: gap evidence
+    when: before any skill content is written
+    effect: the gap must be proven uncovered by an existing skill or agent — nothing is authored speculatively
+  - gate: spec approval
+    when: before authoring begins
+    effect: the user must sign off on the skill's spec first
+---
+
+## What it does
+
+The only permitted entry to creating a new codeArbiter skill. It hands off to the `skill-author`
+skill, which drives the whole job through five gated stages: proving the gap, scoping it,
+authoring the content, a self-review pass, and finally wiring in the routing entry — the
+`INDEX.md` line that actually makes the new skill reachable. Nothing gets written before an
+existing skill or agent is shown not to already handle the need, and nothing is considered done
+until the result has its own gates, hard rules, and a route pointing to it.
+
+Name the skill in verb-noun form (`"dependency-review"`), not as a loose description
+(`"the thing that checks packages"`) — that shape is what the authoring phase expects.
+
+## Usage
+
+```
+/ca:new-skill <verb-noun skill name>
+```
+
+The name argument seeds the gap-evidence phase; the spec that phase produces is what gets
+approved before any file is written.
+
+## Example
+
+```text
+> /ca:new-skill "release-notes-linter"
+
+Phase 1 (gap evidence): checked existing skills/agents — no coverage found for
+release-notes format linting.
+Phase 2 (scope): drafting spec for approval...
+
+Spec: release-notes-linter
+  Routes from: /ca:release (post-changelog-render)
+  Gates: 2 (format check, broken-link check)
+Approve this spec? y
+```
+
+## When to reach for it
+
+A one-time action belongs in `/ca:feature` or a plain command definition, not a new skill; if an
+existing skill nearly covers the need, extend it via `/ca:feature` instead. "Do we even need a
+skill here?" is a question for `/ca:btw`.

--- a/site/src/curated/commands/preview.md
+++ b/site/src/curated/commands/preview.md
@@ -1,0 +1,53 @@
+---
+entity: commands/preview
+related: [doctor, review]
+---
+
+## What it does
+
+A zero-onboarding, read-only dry-run of the reviewer fleet against whatever is currently
+uncommitted — no `/ca:init`, no `.codearbiter/` directory, no decompose or create-context
+interview required first. It exists so someone evaluating codeArbiter can see it react to their
+real, in-progress code before paying any setup cost. `git status` is unchanged by a run: nothing
+is written, not the worktree, not the index, not `.codearbiter/`.
+
+It does three things: collects the current diff (unstaged, staged, and untracked changes,
+unioned); predicts which reviewers *would* dispatch by matching changed paths against the same
+reviewer-to-path matrix `/ca:review` uses; and actually runs the one check that needs no project
+rules at all — a state-free secret scan — reporting any finding by `path:line_no` with the
+credential value already redacted to `****`. The reviewer predictions are exactly that,
+predictions; only the secret scan is a real result.
+
+## Usage
+
+```
+/ca:preview
+```
+
+Takes no arguments — it always inspects the current uncommitted diff.
+
+## Example
+
+```text
+> /ca:preview
+
+Changed files
+  src/auth/session.ts     (unstaged)
+  src/auth/login.test.ts  (untracked)
+
+Predicted reviewers
+  security-reviewer       -> src/auth/session.ts (auth path)
+  auth-crypto-reviewer    -> src/auth/session.ts (crypto/key handling path)
+  coverage-auditor        -> src/auth/login.test.ts (source change)
+
+Secret findings
+  none found
+
+Full gated review needs /ca:init, then /ca:review.
+```
+
+## When to reach for it
+
+An onboarded repo wanting the full gated verdict wants `/ca:init` then `/ca:review`; proving the
+install's hooks actually fire (not just predicting reviewers) is `/ca:doctor`'s job, not this
+one's — the two make distinct claims and are never blended.

--- a/site/src/curated/commands/prune.md
+++ b/site/src/curated/commands/prune.md
@@ -1,0 +1,62 @@
+---
+entity: commands/prune
+related: [status]
+gates:
+  - gate: live-transcript refusal
+    when: run <path> targets the current session's live transcript
+    effect: refused by construction — a recently-modified file can't be pruned with --execute; only a copy or an inactive session can
+  - gate: opt-in enable
+    when: turning the after-each-turn service on (CODEARBITER_PRUNE=on)
+    effect: never set on the user's behalf — explained, then left to the user's explicit choice
+---
+
+This is a Feature Forge preview command — the after-each-turn service ships **off** by default and
+is promoted from `dry` to `on` only once the collected dry-run evidence shows a clean record.
+
+## What it does
+
+A long Claude Code session can exhaust its context window on pure bulk long before real content
+does the damage: tool-result sidecars, oversized outputs, thinking blocks, MCP/shell noise, stale
+file reads. This
+command trims that bulk at safe quiescence boundaries — it always preserves the `uuid`/`parentUuid`
+chain, every line type (including ones it doesn't recognize), and the K most recent tool-bearing
+turns verbatim. The gain lands at the next `claude --resume`/restart or compaction, never on the
+turn that ran the command, because the running CLI already sent its in-memory history to the API.
+
+It has five modes, chosen by the first argument: `status` (default) reports cumulative reduction
+and service state; `dry` copies the live transcript and analyzes the copy without touching the
+original; `run <path>` prunes a target for real, but only a copy or an inactive session — a file that was
+touched recently is rejected outright; `audit <path>` is a read-only integrity report;
+`on`/`off` explain how to toggle the always-safe after-each-turn service.
+
+## Usage
+
+```
+/ca:prune status | dry | run <path> | audit <path> | on | off
+```
+
+`status` is the default with no argument. `run` and `audit` take a transcript path.
+
+## Example
+
+```text
+> /ca:prune status
+
+service: off  (CODEARBITER_PRUNE unset)
+this session: 0 prunes recorded
+
+> /ca:prune dry
+
+strategy                  lines      before       after  est. saved
+sidecar-strip                214     412,880     301,440     111,440
+oversize-clamp                31     301,440     288,110      13,330
+reasoning-fold                 9     288,110     279,900       8,210
+
+total: 403KB -> 273KB  (32% reduction)
+verdict: dry-run — gains land at next --resume or compaction
+```
+
+## When to reach for it
+
+Skip it when the context bar is nowhere near compaction — the most recent turns are protected
+regardless. Install health is `/ca:doctor`'s job; project progress is `/ca:status`'s.

--- a/site/src/curated/commands/review.md
+++ b/site/src/curated/commands/review.md
@@ -1,0 +1,54 @@
+---
+entity: commands/review
+related: [skills/dispatching-parallel-agents, pr, preview]
+gates:
+  - gate: severity block
+    when: any CRITICAL or HIGH finding surfaces
+    effect: must be resolved before /ca:pr — the aggregated verdict is not advisory at that severity
+---
+
+## What it does
+
+A read-only review of the current change, dispatched by path against a reviewer-to-path matrix:
+`security-reviewer` for auth/middleware/secrets/deploy paths, `auth-crypto-reviewer` for
+authn/crypto/key handling, `dependency-reviewer` for manifest/lockfile changes,
+`migration-reviewer` for DB migrations, `coverage-auditor` for any source change, and
+`architecture-drift-reviewer` for code that may diverge from an accepted ADR. Each matched
+reviewer runs as one read-only unit through `dispatching-parallel-agents`; the results are
+deduped, then funneled through `finding-triage` (severity plus an inline `[NEEDS-TRIAGE]` marker
+on anything out of scope) and `checkpoint-aggregator` down to a single verdict. No file is
+modified by a run.
+
+Findings are surfaced by severity (CRITICAL/HIGH/MEDIUM/LOW), file:line, remediation, and — for
+security findings — the specific control in `.codearbiter/security-controls.md` they map to. Raw
+per-reviewer output is never consumed directly; only the triaged, aggregated verdict is.
+
+## Usage
+
+```
+/ca:review [path]
+```
+
+Defaults to the current uncommitted diff when no path is given.
+
+## Example
+
+```text
+> /ca:review
+
+Dispatched: security-reviewer, auth-crypto-reviewer (src/auth/session.ts)
+            coverage-auditor (src/auth/session.ts, src/auth/login.test.ts)
+
+HIGH   src/auth/session.ts:41  Session token generated with Math.random(),
+       not a CSPRNG. Control: security-controls.md §Randomness.
+LOW    src/auth/login.test.ts  No test for expired-token rejection path.
+
+Verdict: 1 HIGH, 1 LOW — HIGH must be resolved before /ca:pr.
+```
+
+## When to reach for it
+
+`/ca:pr` already dispatches this automatically when opening a PR, so a manual run is for checking
+before that point; a periodic full-codebase sweep is `/ca:checkpoint`'s job, and a
+pre-implementation threat model is `/ca:threat-model`'s. A read-only look before onboarding at all
+is `/ca:preview`.

--- a/site/src/curated/commands/statusline.md
+++ b/site/src/curated/commands/statusline.md
@@ -1,0 +1,48 @@
+---
+entity: commands/statusline
+related: [doctor]
+---
+
+## What it does
+
+Wires codeArbiter's renderer into `~/.claude/settings.json`, or removes it. A plugin can't own a
+`statusLine` directly and `${CLAUDE_PLUGIN_ROOT}` isn't expanded inside `settings.json`, so this
+command resolves the renderer's absolute path and writes it in. It's the only sanctioned way to
+make that edit: the backing script backs up any existing `statusLine` before overwriting it
+(so `uninstall` can restore it later), and it never clobbers a settings file it can't parse.
+
+The renderer itself is global — folder, git, model, rate limits, context, cumulative tokens, and
+an estimated API-equivalent cost render in every repo. The arbiter-specific segments (stage,
+tasks, open questions, overrides) show up only in a repo that has opted in via CONTEXT.md
+frontmatter. Token and cost figures are read from the session transcript's real per-model
+usage — the cost is an estimated pay-as-you-go equivalent, not a bill.
+
+## Usage
+
+```
+/ca:statusline install | uninstall | status
+```
+
+`install` is the default. Before running `install`, the resolved command and the prior line it
+will back up are shown for confirmation — editing global settings is the user's call.
+
+## Example
+
+```text
+> /ca:statusline install
+
+About to set statusLine.command to:
+  python "/home/x/.claude/plugins/ca/hooks/statusline.py"
+No prior statusLine to back up.
+Proceed? y
+
+WIRED codeArbiter statusline -> python ".../hooks/statusline.py"
+no prior statusLine existed; uninstall will simply remove ours.
+
+Takes effect on the next render (new prompt or session).
+```
+
+## When to reach for it
+
+Confirming the wiring took effect, or diagnosing whether something else owns the statusline, is
+`/ca:doctor`'s broader install-health check as well as this command's own `status` action.

--- a/site/src/curated/commands/watch.md
+++ b/site/src/curated/commands/watch.md
@@ -1,0 +1,52 @@
+---
+entity: commands/watch
+related: [pr, review]
+gates:
+  - gate: no auto-merge
+    when: CI turns green
+    effect: notifies and offers the ready-to-run merge command; never runs it itself
+  - gate: default-branch merge
+    when: the offered merge targets the default branch
+    effect: routes through the merge-to-default hard gate — the offer cannot bypass it
+---
+
+## What it does
+
+Watches a pull request's CI checks to completion without polling by hand. The wait is a real
+server-side block (`gh pr checks <PR> --watch`), so it costs nothing while checks run — arbiter is
+re-invoked exactly once, when that process exits, not on a timer. On red, it retrieves the failing
+job's logs and acts at a configured depth: `propose` names the likely cause and proposes a fix
+without touching any tracked file (the fix itself routes through `/ca:fix` or `/ca:feature`);
+`branch` additionally opens an unmergeable `spike/fix-*` branch carrying the proposed change for
+review, leaving the default branch untouched. On green, it notifies and presents the merge command
+as an offer — it never runs `gh pr merge` itself.
+
+`CODEARBITER_BABYSIT` (default off) governs whether `/ca:pr` auto-attaches a watcher to the PR it
+opens; `/ca:watch <PR>` itself works ad-hoc regardless of that flag.
+
+## Usage
+
+```
+/ca:watch <PR number | url | branch>
+```
+
+Defaults to the current branch's PR when the argument names none of those.
+
+## Example
+
+```text
+> /ca:watch 231
+
+watching PR #231 checks... (gh pr checks 231 --watch)
+[blocks server-side until every check finishes]
+
+All checks passed.
+Ready to merge:
+  gh pr merge 231 --squash --delete-branch
+Run it? (this command will not run it for you)
+```
+
+## When to reach for it
+
+Open the PR first with `/ca:pr`; apply a fix for a diagnosed red with `/ca:fix` or `/ca:feature`;
+review a diff without watching CI with `/ca:review`.


### PR DESCRIPTION
## Summary

PR-2.3c of the docs-site overhaul campaign — curated reference for the 13 utility & meta commands: btw, commands, doctor, preview, prune, statusline, watch, context-check, add-dep, dev, arbiter, new-skill, review.

Full anatomy per file; transcripts grounded in real behavior — doctor's live-fire probe quotes the actual `BLOCKED [H-03]` message from `pre-bash.py` (verified against source), `dev`'s gates table documents the `CODEARBITER_DEV=1` refusal and append-only logging, `prune` notes its Feature Forge preview status (its page carries the badge). No-gate commands omit `gates:` rather than inventing any.

The paraphrase lint caught 5 verbatim-shingle violations during authoring; reworded.

## Verification

- 262 vitest passing; typecheck clean; build 119 pages; link-audit 15,534 links OK.
- Spot-checked dist: doctor + prune pages (one h1, per-page meta description, preview badge on prune).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa
