### PR TITLE
docs(site): curated skill framing (all 22)

### DIFF
--- a/site/src/curated/skills/brainstorming.md
+++ b/site/src/curated/skills/brainstorming.md
@@ -1,0 +1,37 @@
+---
+entity: skills/brainstorming
+related: [commands/feature, commands/sprint, writing-plans]
+gates:
+  - gate: frame the problem
+    when: at the start of a new feature idea
+    effect: the one-line idea must resolve to a stated problem, caller, and out-of-scope boundary before questioning begins
+  - gate: spec approval
+    when: after the spec is drafted
+    effect: hard stop until you (or, under an autonomous sprint, a logged auto-approval) sign off; no code and no handoff to test-first work happens before that
+---
+
+## What it does
+
+This is where a feature starts before any code exists. `/feature` opens here, and `/sprint`'s
+planning stage runs the same interview. Given a one-line idea, it drives a Socratic
+back-and-forth — one question at a time — until the idea is concrete enough to build from: a
+named problem, a named caller, an explicit boundary of what the feature does not do, and a set
+of acceptance criteria specific enough that each one maps to a single test. Anything genuinely
+unresolved becomes a numbered open question on record rather than a guess.
+
+## Phases
+
+1. The problem, its caller, and the out-of-scope boundary are pinned down and checked against
+   the project's existing context for a contradiction.
+2. A question-at-a-time refinement loop closes every vague term, surfaces hidden complexity, and
+   forces any real trade-off to a resolution or a recorded open question.
+3. The agreed spec — problem, scope, testable acceptance criteria, open questions — is written to
+   disk.
+4. The spec is approved (by you directly, or by a logged automatic approval under an autonomous
+   sprint) before anything moves on to test-first implementation.
+
+## Exits
+
+Approval hands the spec to the test-first gate, where each acceptance criterion becomes one
+obligation to prove. A spec carrying an unresolved blocking question never reaches that handoff —
+it stops for your decision instead.

--- a/site/src/curated/skills/commit-gate.md
+++ b/site/src/curated/skills/commit-gate.md
@@ -1,0 +1,46 @@
+---
+entity: skills/commit-gate
+related: [commands/commit, tdd]
+gates:
+  - gate: permission
+    when: every invocation
+    effect: an explicit instruction to commit must be on record; "looks good" does not count
+  - gate: verification
+    when: after classification
+    effect: tests, lint, and a secrets scan must all come back clean, plus crypto/secret/migration/CI review where the diff touches those areas, before anything else runs
+  - gate: behavioral proof
+    when: after verification passes
+    effect: a freshly run command must demonstrate the change does what the spec claims — a self-report is not accepted
+  - gate: diff review
+    when: before staging
+    effect: the full staged diff is read for stray files, secrets, incomplete work, and scope creep; any finding unstages the offending files and stops
+---
+
+## What it does
+
+This is the only door into version control — nothing else in the project runs `git commit`.
+Invoking it (via the commit command) hands control to a sequence of checks that read the
+repository's actual state rather than taking your word for it: what's staged, what changed,
+whether the suite is green. It walks from confirming you actually asked for a commit through
+classification, verification, a behavioral proof, and a full diff review before anything lands.
+
+## Phases
+
+1. Confirm explicit authorization to commit.
+2. Confirm the branch is not a protected one.
+3. Classify the staged change into a single commit type and flag any database migration.
+4. Run tests, lint, and a secrets scan; route through the crypto, secret, migration, or CI/deploy
+   review gates when the diff touches those areas.
+5. Prove the change's claimed behavior with a fresh command run, not a self-report.
+5.5. When a tracked source file drifted, re-scout just that slice and either silently
+   re-baseline or route a changed claim into diff review.
+6. Read the complete staged diff for stray files, secrets, unfinished work, or scope creep.
+7. Run the follow-up harvest, then stage exactly the intended files by explicit path.
+8. Compose a Conventional Commits message with a body explaining why.
+9. Commit, capturing the resulting SHA, and confirm the tree is clean afterward.
+
+## Exits
+
+A clean run ends in a commit SHA, a clean working tree, and a report of what each gate found. A
+BLOCK at any gate halts the commit entirely and surfaces exactly what needs fixing before the
+sequence can be re-run.

--- a/site/src/curated/skills/context-check.md
+++ b/site/src/curated/skills/context-check.md
@@ -1,0 +1,26 @@
+---
+entity: skills/context-check
+related: [commands/context-check]
+---
+
+## What it does
+
+This is an optional, on-demand check for a specific bypass case: a merge or a hand edit changed a
+tracked source file outside of a normal commit, so the routine auto-heal inside the commit gate
+never had a chance to fire. It is not part of the everyday loop — the commit gate's own drift
+detection covers that. Invoke this only when you know drift happened outside a commit.
+
+## Phases
+
+1. Compute drift by comparing every tracked document's recorded source hashes against the
+   current ones, and report "no stale docs" if nothing has drifted.
+2. Report each stale document and the paths that changed under it.
+3. For each stale document, offer a per-document choice — re-scout the drifted paths and update or
+   propose changes, re-baseline without re-scouting when the underlying change was cosmetic, or
+   defer it to reappear later — then summarize what was done.
+
+## Exits
+
+Whatever a re-scout or re-baseline produces rides your next commit through the normal commit gate
+— this skill never stages or commits anything itself. A deferred document simply resurfaces at
+the next session start.

--- a/site/src/curated/skills/context-creation.md
+++ b/site/src/curated/skills/context-creation.md
@@ -1,0 +1,40 @@
+---
+entity: skills/context-creation
+related: [commands/create-context, decompose]
+gates:
+  - gate: pre-flight confirmation
+    when: before any scout is dispatched
+    effect: the project must be an uninitialized brownfield codebase with real source present; if there is no source it routes to decompose instead
+  - gate: gap interview
+    when: after synthesis
+    effect: every low-confidence inference must be resolved with you or explicitly deferred before project docs are written
+  - gate: initialization lock
+    when: at the end
+    effect: the project is not marked initialized until every required document exists and is non-empty
+---
+
+## What it does
+
+This is the brownfield back-fill: it wraps an existing codebase in project state without
+guessing at it. Invoked by the create-context command, or automatically at startup when the
+project has real source code but no initialized project state yet, it reads the codebase through
+several parallel scouts, drafts the project's foundational documents from what they find, and
+resolves anything uncertain with you before locking the project as initialized.
+
+## Phases
+
+1. Confirm the project is a genuine, uninitialized brownfield case with meaningful source present.
+2. Dispatch six parallel scouts — tech stack, infrastructure, architecture, security posture,
+   testing, and data model — each reporting file paths, line numbers, and named values only.
+3. Synthesize every surviving project document from the scout reports, tagging each claim high,
+   medium, or low confidence and turning any low-confidence gap into a numbered open question.
+4. Resolve every open question with you, one targeted question at a time.
+5. Write the finished documents to disk, along with a provenance record and a coarse concern map.
+6. Lock the project as initialized and hand back to normal operation.
+
+## Exits
+
+A completed run leaves every foundational project document populated and the project marked
+initialized, ready for feature work. It never proceeds past the interview with an unresolved gap,
+and it refuses to run at all if the project is already initialized or has no real source to
+extract from.

--- a/site/src/curated/skills/crypto-compliance.md
+++ b/site/src/curated/skills/crypto-compliance.md
@@ -1,0 +1,28 @@
+---
+entity: skills/crypto-compliance
+related: [secret-handling, commit-gate]
+gates:
+  - gate: banned-primitive scan
+    when: any change touches hashing, signing, encryption, key derivation, security-relevant randomness, or TLS configuration
+    effect: broken algorithms, disabled certificate verification, home-rolled crypto, or anything off the project's approved list blocks the change
+---
+
+## What it does
+
+This is the check that stands between the codebase and a weak cryptographic choice. It runs
+whenever changed code hashes, signs, encrypts, derives keys, generates security-relevant random
+values, configures TLS, or pulls in a crypto library — most often dispatched from inside the
+commit gate or the test-first gate rather than invoked directly. A dedicated reviewer agent
+confirms every finding against the project's documented security controls.
+
+## Phases
+
+1. Scan every cryptographic operation in the change against the project's approved-primitive
+   policy, rejecting broken algorithms, disabled certificate verification, and hand-built crypto
+   outright, and dispatching a reviewer to confirm the findings.
+
+## Exits
+
+A clean pass records a gate marker that the commit gate later checks for before it will let a
+crypto-touching change through. Any finding blocks the change outright — there is no partial
+pass, and the marker is never recorded on a failing scan.

--- a/site/src/curated/skills/debug.md
+++ b/site/src/curated/skills/debug.md
@@ -1,0 +1,38 @@
+---
+entity: skills/debug
+related: [commands/debug, tdd]
+gates:
+  - gate: symptom capture
+    when: at the start of an investigation
+    effect: a minimal reproduction, or a documented intermittent trigger, must exist before anything else proceeds
+  - gate: hypothesis breadth
+    when: before evidence gathering begins
+    effect: at least three distinct candidate causes are required, one of them a boring environmental or configuration explanation
+  - gate: root-cause decision
+    when: after evidence is gathered
+    effect: exactly one exit must be chosen — a confirmed bug, a design ambiguity, or a no-action close; "needs more investigation" alone is not an exit
+---
+
+## What it does
+
+This is where an unknown defect gets investigated before anyone touches code. Invoked as its own
+command, it runs one closed loop: capture a reproducible symptom, generate several distinct
+candidate causes, gather cited evidence against each one, then commit to exactly one disposition.
+No code changes here — a confirmed cause routes to the fix path, a design ambiguity routes to a
+decision record, and a resolved-elsewhere symptom closes with a rationale on file.
+
+## Phases
+
+1. Capture the symptom with a minimal reproduction or a documented intermittent-trigger profile.
+2. Generate at least three distinct hypotheses, including one boring, non-exotic explanation.
+3. Gather cited evidence for and against each hypothesis without touching any code.
+4. Choose exactly one root-cause exit: a confirmed bug carrying a named regression-test
+   obligation, a behavior/design ambiguity headed for a decision record, or a no-action close.
+5. Emit a summary and route to the chosen exit.
+
+## Exits
+
+A confirmed bug hands the fix path a regression-test obligation tied to the reproduction, so the
+fix must first prove it fails before it can prove it's fixed. A design ambiguity surfaces the
+question for a decision record with your attribution. A no-action close is logged as a queued
+item rather than silently dropped.

--- a/site/src/curated/skills/decision-lifecycle.md
+++ b/site/src/curated/skills/decision-lifecycle.md
@@ -1,0 +1,30 @@
+---
+entity: skills/decision-lifecycle
+related: [commands/adr, commands/adr-status, decision-variance]
+gates:
+  - gate: authoring
+    when: recording a new decision
+    effect: the decision content must come from you, not inference, and the record is never authored as the disposition of a routine finding
+---
+
+## What it does
+
+This is where architecture decisions get written down and tracked. The adr command routes here to
+author a new, numbered, dated decision record with your explicit attribution; the status command
+routes here to list every decision's health, read-only. It shares its scoring reference and log
+format with the arbitration skill but owns a different half of the job: recording a decision you
+have already made, not helping you make one.
+
+## Phases
+
+1. Index existing decision records and fix the next sequential number.
+2. Author a new decision record from content you confirm — never inferred — and append a matching
+   entry to the decision log, with your name as decider.
+3. (Status mode) Report every indexed record's number, title, status, date, and whether a later
+   record supersedes it, plus any unresolved open question found inside one.
+
+## Exits
+
+Authoring leaves a new decision record on disk in `proposed` status with a matching log entry;
+status reporting changes nothing. A decision with no clear user attribution, or one proposed as
+the outcome of an ordinary finding rather than your explicit call, never gets recorded.

--- a/site/src/curated/skills/decision-variance.md
+++ b/site/src/curated/skills/decision-variance.md
@@ -1,0 +1,37 @@
+---
+entity: skills/decision-variance
+related: [commands/reconcile, decision-lifecycle]
+gates:
+  - gate: stale-decision surfacing
+    when: a decision log exists
+    effect: any prior decision whose cited artifact section has since changed is flagged for you to re-evaluate, keep, or supersede before new variances are generated
+  - gate: user-attributed resolution
+    when: presenting each variance
+    effect: nothing is recorded to the decision log without your explicit choice; the skill only recommends
+---
+
+## What it does
+
+This is the arbitration pass over the project's architectural artifacts — invoked by the reconcile
+command when the written plan and the actual codebase disagree, or an existing decision record
+conflicts with either. It builds an evidence index comparing what the plans say against what the
+code shows, scores each disagreement through a shared six-lens framework, and presents every one
+to you for a decision, one area at a time, logging your choice as it's made.
+
+## Phases
+
+1. Locate the project's three architectural artifacts and the decision log, and surface any prior
+   decision whose cited section has since changed for you to dispose of.
+2. Build an evidence index classifying every architectural decision as agreeing, disagreeing,
+   silent on one side, or silent on both.
+3. Generate a scored report for every disagreement, each carrying a recommendation and citing
+   relevant precedent from the existing log.
+4. Present the variances area by area and record your resolution to the decision log immediately,
+   never batched in memory; you may pause and resume at any point.
+5. Report which downstream documents the current decision state is ready to support.
+
+## Exits
+
+Each resolved variance lands as a user-attributed entry in the append-only decision log. The skill
+never edits the artifacts, the scaffold, or the codebase to fix a variance itself, and it never
+produces a downstream document without your explicit direction to do so.

--- a/site/src/curated/skills/decompose.md
+++ b/site/src/curated/skills/decompose.md
@@ -1,0 +1,42 @@
+---
+entity: skills/decompose
+related: [commands/decompose, context-creation]
+gates:
+  - gate: layer completion
+    when: within the six-layer interview
+    effect: a layer never advances while an unresolved "later" item stands outside a recorded open question, and each completed layer is written to disk before the next one starts
+  - gate: artifact approval
+    when: after synthesis
+    effect: you must explicitly approve all three architecture artifacts before any project document is populated
+  - gate: initialization lock
+    when: at the end
+    effect: the project is not marked initialized while any draft decision record remains, or while the working draft directory still exists
+---
+
+## What it does
+
+This is the greenfield counterpart to the brownfield back-fill: a structured interview for a
+project with no source code yet. Invoked at startup on an empty project, or directly by the
+decompose command, it walks you through six layers — vision, users and flows, functional scope,
+technical shape, integrations, and risks — persisting every layer to disk as it closes so a lost
+session never erases the earlier work, then turns the finished interview into the project's
+foundational documents.
+
+## Phases
+
+1. Adopt the interview persona and state its rules of engagement.
+2. Create or resume a durable draft directory that survives a session interruption.
+3. Run the six-layer interview in order, writing each completed layer to disk immediately and
+   drafting a decision record for every forced architectural trade-off as it's made.
+4. Re-read every layer from disk and synthesize three architecture artifacts, then get your
+   explicit approval on all three.
+5. Re-read the approved artifacts and layers from disk, promote every draft decision to accepted,
+   and populate the project's foundational documents.
+6. Lock the project as initialized, remove the draft directory, and hand back to normal operation.
+
+## Exits
+
+A completed run leaves the project initialized with populated foundational documents, no draft
+decision records outstanding, and the working draft directory removed — ready for feature work.
+It never writes a project document before all six layers are solid on disk, and it never closes
+while a draft directory or an unpromoted decision record remains.

--- a/site/src/curated/skills/dispatching-parallel-agents.md
+++ b/site/src/curated/skills/dispatching-parallel-agents.md
@@ -1,0 +1,38 @@
+---
+entity: skills/dispatching-parallel-agents
+related: [subagent-driven-development, commands/review, commands/checkpoint]
+gates:
+  - gate: partition
+    when: before any agent is dispatched
+    effect: two units that would mutate the same file cannot share a batch — the collision is isolated or serialized first
+  - gate: funnel
+    when: after results are deduped
+    effect: the caller only ever sees the aggregated verdict from triage plus aggregation; raw or merely-deduped agent output never reaches it directly
+---
+
+## What it does
+
+This is the shared fan-out mechanism other parts of the system dispatch through whenever work
+splits across independent units, each handled by its own agent — used inside the implementation
+engine, an autonomous sprint, and a parallel code review. It owns the mechanics of dispatching
+safely, not the judgment about what the units are: bound the concurrency, isolate each unit's
+scope, collect every result even when one errors, remove duplicate findings, and only then let
+the results reach whoever asked for the work.
+
+## Phases
+
+1. Partition the work into units with disjoint file paths, routing any unavoidable overlap
+   through worktree isolation or serialization.
+2. Dispatch one agent per unit in bounded waves, each agent seeing only its own unit's scope.
+3. Collect every unit's terminal state — completed, errored, or halted — without letting one
+   failure discard the rest of the batch.
+4. Merge duplicate findings, surface contradictions instead of silently picking one, and verify
+   any completion claim with a fresh proving run rather than trusting a self-report.
+5. Route the deduped results through severity triage and then aggregation, and hand the caller
+   only the resulting verdict.
+
+## Exits
+
+The caller receives one aggregated verdict — a pass, or a list of blocking findings — never the
+raw agent output. Every dispatched unit terminates with a recorded state, so nothing dispatched
+ever silently disappears from the batch.

--- a/site/src/curated/skills/executing-plans.md
+++ b/site/src/curated/skills/executing-plans.md
@@ -1,0 +1,31 @@
+---
+entity: skills/executing-plans
+related: [commands/feature, subagent-driven-development, writing-plans]
+gates:
+  - gate: batch checkpoint
+    when: after every batch completes
+    effect: the next batch does not start until you acknowledge what landed, what's next, and what's still open
+---
+
+## What it does
+
+This is the checkpointed coordinator behind the feature command, taking over once an approved
+plan exists. It groups the plan's tasks into small batches, hands each batch to the implementation
+engine for the actual test-first work and review, and stops for your acknowledgment between
+batches. It never implements anything itself — only schedules and checkpoints.
+
+## Phases
+
+1. Group the plan's non-accepted tasks into small batches, respecting dependency order, and
+   present the breakdown as information rather than a question.
+2. Hand the current batch's task IDs to the implementation engine, which runs the test-first work,
+   review, and verification for each task.
+3. Stop and report what landed, what's next, and what's still open, and wait for your
+   acknowledgment before starting the next batch.
+
+## Exits
+
+Once the final batch is acknowledged and every plan task is accepted, the branch moves on to the
+commit gate — this skill never commits on its own. A halt inside the implementation engine, such
+as a failed test-first gate or an unresolved open question, surfaces to you rather than being
+worked around.

--- a/site/src/curated/skills/finishing-a-development-branch.md
+++ b/site/src/curated/skills/finishing-a-development-branch.md
@@ -1,0 +1,35 @@
+---
+entity: skills/finishing-a-development-branch
+related: [commands/feature, commands/sprint, commands/pr]
+gates:
+  - gate: terminal choice
+    when: after the commit gate clears
+    effect: you choose exactly one of open a PR, merge via PR, or discard — direct merge to the default branch is never an option
+  - gate: pushed-work confirmation
+    when: discarding a branch
+    effect: any commit that isn't pushed yet is reported as a loss before the discard is confirmed, never deleted silently
+---
+
+## What it does
+
+This is the last step of a feature or a sprint, reached only once the commit gate has cleared.
+It gathers the branch's state — what changed, what the gates found, what a plan still leaves
+open — then presents exactly three ways to end the branch: open a pull request and stop, open one
+and merge it once checks are green, or discard it. Under an autonomous sprint, "open a PR" is
+chosen automatically and the merge decision is left to you.
+
+## Phases
+
+1. Assemble the branch, diff, gate-result, and plan-delta facts the decision needs.
+2. Present the three terminal options and stop for your choice — or, under an autonomous sprint,
+   auto-select opening a PR and surface the merge decision separately.
+3. Carry out exactly the chosen option: open the PR, merge through it once green, or discard after
+   confirming any unpushed work you'd lose.
+4. Emit a short receipt — obligations covered, gates that caught something, decisions you made,
+   secrets or regressions prevented, suite time — drawn only from what's already in hand.
+
+## Exits
+
+Opening or merging a PR lands the work through GitHub, never by a direct push to the default
+branch. A discard only proceeds after you've confirmed it against a stated summary of anything
+unpushed that would be lost.

--- a/site/src/curated/skills/refactor.md
+++ b/site/src/curated/skills/refactor.md
@@ -1,0 +1,38 @@
+---
+entity: skills/refactor
+related: [commands/refactor, tdd]
+gates:
+  - gate: surface sign-off
+    when: before any coverage work begins
+    effect: the exact files, symbols, and signatures being restructured must be named precisely and confirmed with you — a vague description does not pass
+  - gate: parity coverage
+    when: before implementation
+    effect: every public method in the named surface needs at least one direct pre-existing test, backfilled via the test-first gate if missing
+  - gate: parity verification
+    when: after implementation
+    effect: the full suite must pass with zero modifications to any pre-existing test — a changed test is treated as evidence the behavior itself changed
+---
+
+## What it does
+
+This is the behavior-preserving restructure path, invoked by the refactor command for a rename,
+extract, inline, move, dedup, or internal-implementation swap. It proves — through unmodified
+pre-existing tests, not inspection — that the code's externally observable behavior is identical
+before and after. Anything that turns out to add behavior gets redirected to the test-first gate
+as a feature or fix instead of proceeding as a refactor.
+
+## Phases
+
+1. Name the exact files, symbols, and signatures the refactor will touch, and get it confirmed.
+2. Prove pre-existing tests already cover that surface well enough to catch a behavior change,
+   backfilling through the test-first gate if they don't.
+3. Where the refactor exposes a genuinely new seam, pin its contract with a failing test first.
+4. Apply the restructure, confined strictly to the named surface, with no added behavior.
+5. Run the full suite and confirm zero pre-existing tests were modified to make it pass.
+6. Run lint, type-checking, and coverage, confirming no regression on the touched surface.
+
+## Exits
+
+A clean run clears the path to the commit gate with behavioral parity proven, not asserted. Any
+diff that turns out to add a behavior, branch, or side effect is redirected to the test-first gate
+instead of continuing as a refactor.

--- a/site/src/curated/skills/release.md
+++ b/site/src/curated/skills/release.md
@@ -1,0 +1,34 @@
+---
+entity: skills/release
+related: [commands/release, commit-gate]
+gates:
+  - gate: version derivation
+    when: before tagging
+    effect: the version bump is derived mechanically from the commit log, not guessed, and must match the manifest's version field before anything is tagged
+  - gate: publication authorization
+    when: after the local tag is composed
+    effect: pushing the tag and creating the public release both wait for your explicit go-ahead — nothing about the tag composition authorizes publishing it
+---
+
+## What it does
+
+This is the only sanctioned path to a version tag, invoked by the release command on a
+non-default branch with a green suite. It derives the version bump from the Conventional Commits
+history since the last tag, rolls the relevant commits into the changelog, composes an annotated
+tag locally, and — only once you authorize it — pushes the tag and publishes it as a public
+release using that same changelog section as its notes.
+
+## Phases
+
+1. Derive the version bump mechanically from the commit log, confirm it against the manifest, and
+   roll the qualifying commits into a new changelog section.
+2. Compose the annotated tag locally from that changelog section and report the version, the
+   bump rationale, and the tag — without publishing anything yet.
+3. On your explicit authorization, push the tag, create the public release from the same
+   changelog section, and read the result back to confirm it actually published.
+
+## Exits
+
+A completed run leaves a pushed tag and a confirmed, non-draft public release whose notes are
+exactly the changelog section composed in the first phase. Without your authorization, the tag
+and changelog stay staged locally and nothing leaves the repository.

--- a/site/src/curated/skills/secret-handling.md
+++ b/site/src/curated/skills/secret-handling.md
@@ -1,0 +1,32 @@
+---
+entity: skills/secret-handling
+related: [crypto-compliance, commit-gate]
+gates:
+  - gate: approved source
+    when: any secret-bearing value is introduced
+    effect: it must originate from the project's approved secret store; a hardcoded literal, a plain environment variable, or an unlisted store all block
+  - gate: sink and persistence check
+    when: after sourcing
+    effect: a secret reaching a logger, an error response, telemetry, an LLM prompt, or any storage outside the approved reference format blocks, as does one that outlives its request
+---
+
+## What it does
+
+This is the check for any changed code that reads, writes, generates, stores, or passes a secret
+— an API key, token, password, connection string, signing key, or certificate. It is dispatched
+rather than invoked directly, most often from inside the commit gate, and treats anything of
+uncertain secret status as a secret. A dedicated reviewer agent confirms every finding against the
+project's documented security controls.
+
+## Phases
+
+1. Identify every secret-bearing candidate in the changed code and record where it comes from and
+   everywhere it flows.
+2. Confirm each one originates from the approved store through the approved access method, and
+   dispatch a reviewer to confirm the sink findings.
+
+## Exits
+
+A clean pass records a gate marker the commit gate checks for before allowing a secret-touching
+change through. Any BLOCK — an unapproved source, a prohibited sink, or a secret persisting past
+its request — stops the change outright, and the marker is never recorded on that failing run.

--- a/site/src/curated/skills/security-architecture.md
+++ b/site/src/curated/skills/security-architecture.md
@@ -1,0 +1,32 @@
+---
+entity: skills/security-architecture
+related: [commands/threat-model]
+gates:
+  - gate: critical unmitigated threat
+    when: during the structured threat pass
+    effect: the only condition that stops the pass outright — an exploitable, high-impact gap with no mitigation; lesser gaps are reported as constraints instead
+---
+
+## What it does
+
+This is an opt-in threat-modeling pass over a design, invoked deliberately through the
+threat-model command for a sensitive feature — never forced on an ordinary change. It maps what
+the change exposes, walks that surface through a structured set of threat categories, and reports
+a verdict. It reviews architectural intent before code exists; once code is written, a security
+reviewer covers that ground instead.
+
+## Phases
+
+1. Map the attack surface — new entry points, new outbound calls, security boundaries crossed,
+   and the sensitivity of the data involved.
+2. Walk that surface through six threat categories, marking each relevant one's mitigation as
+   present, planned, or a gap, and optionally dispatching a specialist reviewer for auth, crypto,
+   or broader boundary concerns.
+3. Report the surface, the threats found — gaps first — and a verdict: proceed, proceed with
+   named constraints, or stop.
+
+## Exits
+
+The report hands any decision-worthy gap to you or to a decision record — this skill never
+authors one itself. It only halts the design outright on a genuinely critical, exploitable,
+unmitigated threat; everything short of that is surfaced as a constraint to carry forward.

--- a/site/src/curated/skills/skill-author.md
+++ b/site/src/curated/skills/skill-author.md
@@ -1,0 +1,40 @@
+---
+entity: skills/skill-author
+related: [commands/new-skill]
+gates:
+  - gate: gap evidence
+    when: before any authoring begins
+    effect: the gap must be proven not already covered by an existing skill, and backed by either three concrete blocked cases or one high-impact traceable one — a hypothetical case does not count
+  - gate: scope agreement
+    when: before any prose is written
+    effect: you must explicitly agree on whether the gap is a routed skill or a dispatched agent, whether it's command-invoked or internal, and its one-sentence single responsibility
+  - gate: routing integration
+    when: at the end
+    effect: a new skill is not finished until it has a catalog entry and a routing-table entry — a skill nothing routes to is dead code
+---
+
+## What it does
+
+This is the only sanctioned way a new skill gets written, invoked through the new-skill command
+with a stated gap. It first proves the gap isn't already covered, settles the new skill's exact
+scope with you, writes it to the house format, self-reviews it against that format, and wires it
+into the catalog and routing table so it's actually reachable.
+
+## Phases
+
+1. Restate the gap, check it against the existing skill catalog for overlap, and demand concrete
+   evidence — either three specific blocked cases or one high-impact traceable one.
+2. Settle scope with you: routed skill or dispatched agent, command-invoked or internal, and a
+   single stated responsibility.
+3. Write the skill to the house format — frontmatter, an opening description, a pre-flight list,
+   numbered gated phases, and hard rules.
+4. Re-read the authored skill against the house quality bar, fix every defect found, and present
+   the corrected version along with the findings list.
+5. Add the skill's catalog entry and routing-table entry, verify every reference it cites
+   resolves, and hand the change to the commit gate.
+
+## Exits
+
+A finished skill has a catalog row, a routing entry, and lands only through the commit gate — it
+is never committed directly from here. Insufficient evidence in the first phase ends the request
+outright rather than producing a speculative skill.

--- a/site/src/curated/skills/subagent-driven-development.md
+++ b/site/src/curated/skills/subagent-driven-development.md
@@ -1,0 +1,41 @@
+---
+entity: skills/subagent-driven-development
+related: [commands/sprint, executing-plans, tdd, dispatching-parallel-agents]
+gates:
+  - gate: fresh-run verification
+    when: before any task is accepted
+    effect: a task's own verification command must be re-run fresh and read directly — a subagent's self-reported success is never accepted as evidence
+  - gate: quality review
+    when: once per scope, after every task in it clears
+    effect: no task in the scope is accepted until the combined diff clears review with no critical or high finding
+---
+
+## What it does
+
+This is the engine that actually writes implementation code, invoked by an autonomous sprint over
+a full plan and by the checkpointed batch coordinator over one batch at a time. Each task gets its
+own fresh agent working test-first, so no single context accumulates drift across tasks, followed
+by a compliance check against the task's obligation, a shared quality review over the whole
+batch's combined diff, and a fresh verification run before anything is marked done.
+
+## Phases
+
+1. Select the next unblocked task in dependency order, confirming its dependencies are already
+   accepted and it carries no unresolved open question.
+2. Dispatch one fresh agent for that task, working test-first through the test-first gate — no
+   implementation code exists before that gate's first phase clears.
+3. Check the result against the task's specific obligation — nothing more, nothing less than what
+   was asked.
+4. Once every task in the current scope clears that check, run one quality review over the
+   combined diff, dispatching only the reviewers the diff's content calls for.
+5. Re-run the task's verification command fresh and confirm its output actually demonstrates the
+   obligation.
+6. Mark the task accepted, recording it directly in the plan file, and either move to the next
+   task or hand the finished scope back to the caller.
+
+## Exits
+
+A scoped batch returns "all tasks accepted" to the checkpoint coordinator without ever reaching
+the commit gate itself. A full, uncoped run instead hands the whole branch to the commit gate once
+every task is accepted. A failed test-first gate, a critical security finding, or an unresolved
+open question halts the loop and surfaces to you rather than being worked around.

--- a/site/src/curated/skills/tdd.md
+++ b/site/src/curated/skills/tdd.md
@@ -1,0 +1,40 @@
+---
+entity: skills/tdd
+related: [commands/feature, commands/fix, commands/refactor, commit-gate]
+gates:
+  - gate: obligation scan
+    when: before any code is written
+    effect: every verifiable claim about the change — spec, contract, or security — must be listed with a source and status before implementation starts
+  - gate: red
+    when: before implementation
+    effect: a failing test must exist for every obligation, failing for the right reason, with every pre-existing test still green
+  - gate: obligation verify
+    when: after the implementation is green
+    effect: every obligation must move to a genuinely covered state backed by a real passing test, or the workflow loops back to write one
+---
+
+## What it does
+
+This is the test-first gate — no feature code exists before it clears its first phase. The
+feature command routes here after your spec is approved, and the fix and refactor commands route
+here directly. It turns the spec (or the fix's regression obligation) into a list of concrete,
+verifiable claims, forces a failing test for each one before any implementation, then verifies
+coverage and cleanliness before the change is eligible for the commit gate.
+
+## Phases
+
+1. Derive every obligation the change must satisfy from the spec, the contract, and — where
+   relevant — the security boundary, before any code is written.
+2. Write a failing test for each obligation, confirming it fails for the right reason and that
+   every pre-existing test still passes.
+3. Write the minimum implementation that satisfies those tests, without weakening any assertion.
+4. Walk the obligation list again, moving each to genuinely covered by a real passing test, or
+   looping back to write one for anything missing.
+5. Confirm coverage meets the project's current maturity-scaled threshold.
+6. Run lint and type-checking with zero errors outstanding.
+
+## Exits
+
+A clean run leaves every obligation covered, coverage at threshold, and lint clean — clearing the
+path to the commit gate. Any obligation that cannot be tied to a real test, or any test whose
+assertion had to be weakened to pass, keeps the change from moving forward.

--- a/site/src/curated/skills/tribunal.md
+++ b/site/src/curated/skills/tribunal.md
@@ -1,0 +1,43 @@
+---
+entity: skills/tribunal
+related: [commands/tribunal]
+gates:
+  - gate: cost acknowledgment
+    when: before anything is dispatched
+    effect: you must acknowledge the estimated token cost and confirm the model before the run proceeds — an unacknowledged run does not start
+  - gate: approval and filing
+    when: after the report is presented
+    effect: findings become tracked issues only on your explicit selection; silence or a vague "looks good" files nothing
+---
+
+## What it does
+
+This is the deepest, most expensive review the project offers — convened rarely, on demand,
+invoked through the tribunal command, and never required as a gate on ordinary work. Eleven
+specialist reviewers each judge one lens of the codebase in parallel, every finding persisted to
+its own file as it's found so the run survives an interruption and resumes from disk rather than
+restarting.
+
+## Phases
+
+1. Check for a resumable prior run, size the job, and get your explicit acknowledgment of the
+   estimated cost and confirmed model before dispatching anything.
+2. Build an inventory of the codebase and a risk overlay that decides which areas get closer
+   scrutiny, then fix the set of active specialist lenses.
+3. Dispatch the active lenses in bounded waves, each one writing its findings straight to disk as
+   they're found.
+4. Triage every finding from disk as each wave finishes, independently recalibrating severity and
+   confidence rather than trusting the lens's own numbers.
+5. Regenerate the report from the triage record — never hand-authored — grouped by calibrated
+   severity.
+6. On your explicit selection, file the approved findings as tracked issues, skipping anything
+   already filed or already tracked elsewhere.
+7. Optionally, and only on your per-run authorization, send a scrubbed, aggregate-only telemetry
+   payload.
+
+## Exits
+
+The run leaves a regenerated report and, only on your explicit approval, a set of filed tracked
+issues — nothing is filed on silence. It never edits, refactors, or commits project code itself,
+and it never blocks a commit or a merge; a critical finding here is a recommendation to fix, not a
+pipeline stop.

--- a/site/src/curated/skills/using-git-worktrees.md
+++ b/site/src/curated/skills/using-git-worktrees.md
@@ -1,0 +1,36 @@
+---
+entity: skills/using-git-worktrees
+related: [subagent-driven-development, dispatching-parallel-agents]
+gates:
+  - gate: provisioning
+    when: setting up isolated units
+    effect: every parallel unit must land on its own distinct worktree and branch off the same clean base, recorded in a manifest, before any isolated work begins
+  - gate: teardown
+    when: after fold-back
+    effect: every worktree this skill created must be removed and the manifest cleared before the skill returns — an orphaned worktree counts as a failure
+---
+
+## What it does
+
+This is optional, per-task filesystem isolation for parallel agent work — it only runs when the
+implementation engine or the parallel-dispatch primitive explicitly opts into it, never by
+default. It gives concurrent units their own working tree each so they can edit files without
+colliding, then folds every accepted unit's work back onto the caller's single working branch,
+which still takes exactly one pass through the commit gate and the branch-finishing step.
+
+## Phases
+
+1. Stand up one worktree and one branch per parallel unit, all rooted at the same clean base, and
+   record each in a manifest.
+2. Let each unit do its work entirely inside its own worktree, still routed through the test-first
+   gate — isolation changes nothing about that requirement.
+3. Integrate every accepted unit's branch back onto the caller's single working branch, resolving
+   any conflict in the open rather than force-merging.
+4. Remove every worktree this skill created and clear the manifest.
+
+## Exits
+
+The consolidated working branch goes through the caller's usual single exit path — a single pass
+through the commit gate followed by a single branch-finishing decision, never one of either per
+unit. This skill never opens a pull request or finishes a branch on its own; it only provisions,
+folds back, and tears down.

--- a/site/src/curated/skills/writing-plans.md
+++ b/site/src/curated/skills/writing-plans.md
@@ -1,0 +1,32 @@
+---
+entity: skills/writing-plans
+related: [commands/feature, commands/sprint, brainstorming, executing-plans]
+gates:
+  - gate: bijective coverage
+    when: before the plan is written to disk
+    effect: every acceptance criterion must map to at least one task, and every task must advance at least one criterion — a task covering nothing is scope creep and is cut
+---
+
+## What it does
+
+This is the bridge between an approved spec and something the implementation engine can actually
+execute. The feature command routes here once a spec is approved, and an autonomous sprint routes
+here before execution begins. It breaks the spec into small, individually verifiable tasks — each
+with an exact file path and a concrete verification step — orders them by dependency, and proves
+every acceptance criterion is covered before the plan is written.
+
+## Phases
+
+1. Pull each acceptance criterion out of the spec word for word and give it a stable ID.
+2. Break the work into small tasks, each carrying an exact path, a concrete verification step, the
+   test-first obligation it maps to, and the criteria it advances.
+3. Order the tasks by dependency and mark the minimal shippable slice within them.
+4. Cross-check coverage both ways so nothing goes untested and nothing is added for no reason,
+   then write the finished plan to disk with every task's status initialized as pending.
+
+## Exits
+
+A finished plan clears the path to either the checkpointed batch coordinator or the autonomous
+implementation engine, which route every task through the test-first gate — this skill never hands
+off to that gate directly. An uncovered criterion, or a task with no path or verification step,
+keeps the plan from being written at all.


### PR DESCRIPTION
PR-2.5 of the docs-site overhaul campaign — curated framing for all 22 skills (what routes to it / phases in outcome language / exits), with gates tables for skills that own hard stops and correctly omitted for pure coordinators. Phase counts verified against each SKILL.md (e.g. commit-gate 9, tdd 6, tribunal 7). Addressee discipline per VOICE.md: skill bodies address the model; these pages address the reader about the skill. 271 vitest passing incl. 22 new paraphrase-lint cases (2 shingle overlaps caught and reworded); build + link-audit green (15,561 links).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa