### PR TITLE
docs(site): curated agent framing (all 28) + roster index tables

### DIFF
--- a/site/scripts/generator/build-index.ts
+++ b/site/scripts/generator/build-index.ts
@@ -1,4 +1,6 @@
 import type { RenderedPage, IndexResult, SidebarGroup, SidebarEntry } from "./types";
+import { modelTier } from "./model-tier";
+import { truncateDescription } from "./truncate-description";
 
 const FIXED_ORDER = ["command", "skill", "agent"] as const;
 
@@ -34,6 +36,9 @@ export function buildIndex(pages: RenderedPage[]): IndexResult {
       const items: SidebarEntry[] = sorted.map((p) => ({
         label: p.title,
         slug: p.slug,
+        description: p.description ? truncateDescription(p.description) : undefined,
+        tier: type === "agent" ? modelTier(p.model) : undefined,
+        preview: type === "command" ? p.forgeStatus != null : undefined,
       }));
       sidebar.push({ type, label: type, items });
     }

--- a/site/scripts/generator/generate.ts
+++ b/site/scripts/generator/generate.ts
@@ -193,6 +193,9 @@ export function generate(
       slug: slugs[i],
       title: name,
       markdown: renderPage(source.type, input),
+      description: doc.fields.description,
+      model: doc.fields.model,
+      forgeStatus,
     };
   });
 
@@ -212,16 +215,31 @@ export function generate(
     writeFileSync(join(dir, `${page.slug}.md`), page.markdown);
   }
 
-  // Index + sidebar. buildIndex gives the grouped, sorted structure; we render a
-  // Starlight-valid index page (frontmatter title + linked groups) from it.
+  // Index + sidebar. buildIndex gives the grouped, sorted structure (each item
+  // already carrying its truncated description, and — per collection — a
+  // model tier or preview flag); we render a Starlight-valid index page
+  // (frontmatter title + one table per collection) from it.
   const { sidebar } = buildIndex(pages);
+  // Column headers per collection: agents carry a model-tier column the other
+  // two collections don't have.
+  const TABLE_HEADER: Record<SourceType, string> = {
+    command: "| Command | Description |\n|---|---|",
+    skill: "| Skill | Description |\n|---|---|",
+    agent: "| Agent | Model tier | Description |\n|---|---|---|",
+  };
   const indexBody = sidebar
     .map((group) => {
       const heading = `## ${group.type.charAt(0).toUpperCase()}${group.type.slice(1)}s`;
-      const links = group.items
-        .map((it) => `- [${it.label}](./${TYPE_DIR[group.type]}/${it.slug}/)`)
-        .join("\n");
-      return `${heading}\n\n${links}`;
+      const rows = group.items.map((it) => {
+        const nameCell =
+          `[${it.label}](./${TYPE_DIR[group.type]}/${it.slug}/)` +
+          (it.preview ? " (preview)" : "");
+        const description = it.description ?? "";
+        return group.type === "agent"
+          ? `| ${nameCell} | ${it.tier ?? "default"} | ${description} |`
+          : `| ${nameCell} | ${description} |`;
+      });
+      return `${heading}\n\n${TABLE_HEADER[group.type]}\n${rows.join("\n")}`;
     })
     .join("\n\n");
   const indexContent = `---\ntitle: Reference\ndescription: Auto-generated reference for codeArbiter commands, skills, and agents.\n---\n\nThis section is generated from the plugin's own frontmatter and regenerates on every build, so it can never drift from the source.\n\n${indexBody}\n`;

--- a/site/scripts/generator/truncate-description.ts
+++ b/site/scripts/generator/truncate-description.ts
@@ -1,0 +1,13 @@
+/**
+ * Truncate a description to its first sentence for a compact table cell.
+ *
+ * Cuts at the first ". " (period + space) and keeps the leading period, so a
+ * multi-sentence frontmatter `description` collapses to one line in the
+ * roster tables. A description with no ". " (already one sentence, or ending
+ * in a bare period with nothing after it) is returned unchanged.
+ */
+export function truncateDescription(text: string): string {
+  const idx = text.indexOf(". ");
+  if (idx === -1) return text;
+  return text.slice(0, idx + 1);
+}

--- a/site/scripts/generator/types.ts
+++ b/site/scripts/generator/types.ts
@@ -81,12 +81,24 @@ export interface RenderedPage {
   slug: string;
   title: string;
   markdown: string;
+  /** First-sentence-truncated description, for the reference index table. */
+  description?: string;
+  /** Raw `model:` frontmatter value (agents only), for the index's tier column. */
+  model?: string;
+  /** Feature Forge preview status (commands only), for the index's preview marker. */
+  forgeStatus?: ForgeStatus | null;
 }
 
 /** One entry in a sidebar group. */
 export interface SidebarEntry {
   label: string;
   slug: string;
+  /** First-sentence-truncated description, for the reference index table. */
+  description?: string;
+  /** Model tier display label (agents only), via {@link modelTier}. */
+  tier?: string;
+  /** Whether this entry carries a Feature Forge preview badge (commands only). */
+  preview?: boolean;
 }
 
 /** A sidebar group (one per source type). */

--- a/site/src/curated/agents/architecture-drift-reviewer.md
+++ b/site/src/curated/agents/architecture-drift-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/architecture-drift-reviewer
+related: [commands/checkpoint, commands/review, finding-triage]
+---
+
+## Role
+
+Read-only checkpoint reviewer: for every ADR marked `accepted` in `.codearbiter/decisions/`, it scans
+the codebase for evidence the decision is being followed or contradicted. It is dispatched as part of
+the reviewer fleet by `/ca:checkpoint` and `/ca:review`, and its output feeds `finding-triage` on the
+way to `checkpoint-aggregator`. It never edits code — this review is informational, pairing with the
+`decision-variance` skill's append-only decision record rather than gating a change.
+
+## Why this model tier
+
+Ships `model: haiku`. Matching a known ADR against grep/glob evidence in the codebase is a high-volume,
+pattern-matching check rather than open-ended judgment, which fits a fast, low-cost tier.
+
+## What it emits
+
+A CONFIRMED / PARTIAL DRIFT / DRIFT / INSUFFICIENT EVIDENCE classification per ADR, plus a
+CRITICAL–LOW severity finding with file:line for every drift or partial-drift case. All output is
+informational — it never blocks a change.

--- a/site/src/curated/agents/auth-crypto-reviewer.md
+++ b/site/src/curated/agents/auth-crypto-reviewer.md
@@ -1,0 +1,26 @@
+---
+entity: agents/auth-crypto-reviewer
+related: [skills/crypto-compliance, skills/secret-handling, skills/security-architecture, skills/subagent-driven-development]
+---
+
+## Role
+
+Read-only reviewer of authentication, cryptography, key handling, and secrets, enforcing whatever
+`.codearbiter/security-controls.md` specifies as the sole authority — including the approved-primitive
+list — rather than a hardcoded compliance framework. It is dispatched by the `crypto-compliance` and
+`secret-handling` gates whenever changed code hashes, signs, encrypts, or reads a secret, by
+`security-architecture` on a threat-model pass, and by the author agents (`backend-author`,
+`frontend-author`, `infra-author`) whenever a diff touches an auth or crypto boundary.
+
+## Why this model tier
+
+Ships `model: inherit`, running at whatever tier dispatched it rather than a pinned floor — the
+calling lane (an author agent, or a dedicated crypto/secret gate) already commits the reasoning budget
+this review needs.
+
+## What it emits
+
+CRITICAL/HIGH/MEDIUM/LOW findings, each with a file:line, the specific algorithm or value involved,
+the `security-controls.md` control it violates, and a remediation. Hard-blocks the PR on any CRITICAL
+or HIGH finding — a banned primitive, home-rolled crypto, disabled TLS verification, a secret outside
+the approved store, or a shell-injection vector.

--- a/site/src/curated/agents/backend-author.md
+++ b/site/src/curated/agents/backend-author.md
@@ -1,0 +1,23 @@
+---
+entity: agents/backend-author
+related: [skills/subagent-driven-development, skills/tdd, frontend-author, infra-author]
+---
+
+## Role
+
+Writes backend and server-side code — the implementation executor for the `tdd` skill's Phase 1 test
+obligations. It never writes implementation code before a failing-test checklist exists, and it
+dispatches `security-reviewer`, `auth-crypto-reviewer`, `migration-reviewer`, or `dependency-reviewer`
+itself when the diff crosses their triggers. Dispatched fresh per task by `subagent-driven-development`
+(and by `dispatching-parallel-agents` for a batch of independent backend tasks).
+
+## Why this model tier
+
+Ships `model: sonnet`. Writing correct server-side code test-first — input validation, ORM usage,
+framework conventions — needs implementation-grade reasoning, not just fact-gathering, which is why it
+sits above the haiku-tier read-only reviewers.
+
+## What it emits
+
+Not findings — it writes source and test files directly (`Edit`/`Write`), plus the security-boundary
+dispatch calls its own rules require. It hands the result back for the review chain that follows it.

--- a/site/src/curated/agents/checkpoint-aggregator.md
+++ b/site/src/curated/agents/checkpoint-aggregator.md
@@ -1,0 +1,22 @@
+---
+entity: agents/checkpoint-aggregator
+related: [skills/dispatching-parallel-agents, finding-triage, commands/checkpoint]
+---
+
+## Role
+
+Final stage of the checkpoint pipeline: reads the `finding-triage` report, ensures
+`.codearbiter/checkpoints/` exists, and writes the dated checkpoint document. It composes rather than
+judges — dispatched by `dispatching-parallel-agents` after `finding-triage` completes, once every
+reviewer in the sweep has reported in.
+
+## Why this model tier
+
+Ships `model: haiku`. Assembling a templated document from an already-classified triage report is
+composition, not judgment, so a fast, low-cost tier is sufficient.
+
+## What it emits
+
+Writes `.codearbiter/checkpoints/YYYY-MM-DD.md` directly (never overwriting an existing one — it
+suffixes `-2`, `-3` on same-day reruns), reports the path back, and lists the report's DEFERRABLE
+findings as harvest candidates for the orchestrator to route to `open-tasks.md`.

--- a/site/src/curated/agents/coverage-auditor.md
+++ b/site/src/curated/agents/coverage-auditor.md
@@ -1,0 +1,21 @@
+---
+entity: agents/coverage-auditor
+related: [skills/tdd, skills/subagent-driven-development]
+---
+
+## Role
+
+Read-only auditor of test coverage against TDD obligations: checks the coverage percentage against the
+project's maturity threshold, flags untested source files, and flags logical gaps (missing
+boundary/negative-path tests). Dispatched by the `tdd` skill's Phase 4 and by
+`subagent-driven-development` as part of fresh-run verification after an author agent finishes.
+
+## Why this model tier
+
+Ships `model: haiku`. Comparing a coverage number against a threshold table and checking for the
+presence of a test file is a mechanical, high-volume check rather than novel reasoning.
+
+## What it emits
+
+CRITICAL–LOW findings with the source/test path and the specific gap, a coverage-vs-threshold status
+line, and a PASS/BLOCK gate status — HIGH or above blocks the change at the commit gate.

--- a/site/src/curated/agents/decision-challenger.md
+++ b/site/src/curated/agents/decision-challenger.md
@@ -1,0 +1,24 @@
+---
+entity: agents/decision-challenger
+related: [skills/decision-lifecycle, skills/decision-variance, grader]
+---
+
+## Role
+
+Adversarial red-team reviewer of Architecture Decision Records: builds the strongest case against each
+decision under review, names its load-bearing assumptions, and rates confidence 1–5 rather than
+rubber-stamping. Read-only and decides nothing itself — dispatched by `decision-lifecycle` (via
+`/ca:adr-status`) and optionally by `decision-variance` when a variance warrants adversarial scrutiny;
+the user makes the actual call.
+
+## Why this model tier
+
+Ships `model: inherit`, matching whatever reasoning budget the dispatching lane already carries.
+Building the strongest case against a decision — not just describing it — is the kind of adversarial
+reasoning that benefits from staying at the calling context's tier rather than a fixed cap.
+
+## What it emits
+
+One block per ADR: a confidence rating (1–5), the load-bearing assumptions, the strongest case against
+the decision, the evidence that would disprove it, and an UPHOLD / REVISIT / ESCALATE recommendation —
+never a decision, only the argument for the user to weigh.

--- a/site/src/curated/agents/dependency-reviewer.md
+++ b/site/src/curated/agents/dependency-reviewer.md
@@ -1,0 +1,24 @@
+---
+entity: agents/dependency-reviewer
+related: [commands/add-dep, skills/subagent-driven-development]
+---
+
+## Role
+
+Read-only reviewer of third-party dependencies and container base images: checks license, provenance,
+maintenance signal, known CVEs, and supply-chain posture before any install runs. It never installs
+anything itself. `/ca:add-dep` dispatches it as the sole gate before a new dependency is added;
+`subagent-driven-development` dispatches it when an author agent's diff touches a manifest or lock
+file.
+
+## Why this model tier
+
+Ships `model: sonnet`. Judging license compatibility, provenance, and supply-chain risk from an
+external registry (it holds `WebFetch`) is closer to research-grade reasoning than a fixed-pattern
+scan, which is why it sits above the haiku-tier checks.
+
+## What it emits
+
+A per-check verdict (license, provenance, maintenance signal, CVEs, supply-chain posture, each
+PASS/BLOCK/FLAG) plus CRITICAL–LOW findings with the package name and remediation. Blocks the install
+on a denied license, an unapproved source, or a known CRITICAL CVE with no documented justification.

--- a/site/src/curated/agents/design-quality-reviewer.md
+++ b/site/src/curated/agents/design-quality-reviewer.md
@@ -1,0 +1,24 @@
+---
+entity: agents/design-quality-reviewer
+related: [frontend-author, skills/subagent-driven-development]
+---
+
+## Role
+
+Read-only reviewer of generated, user-facing output — UI, reports, slides, charts, diagrams, CLI
+output — against the `anti-slop-design` reference. It checks that a deliverable made deliberate,
+brief-driven design choices instead of defaulting to the statistical center; it never reviews
+codeArbiter's own internal framework docs. `frontend-author` dispatches it on any change that produces
+or alters user-facing UI, the same way it dispatches `security-reviewer` for a security-sensitive one.
+
+## Why this model tier
+
+Ships `model: sonnet`. Judging whether a design choice was deliberate versus a reflex default (a
+generic three-card layout, a fabricated chart number) is a nuanced call against a reference document,
+not a fixed-pattern scan.
+
+## What it emits
+
+CRITICAL/HIGH/MEDIUM/LOW findings, each naming the artifact location, the violated `anti-slop-design`
+rule, and a concrete fix. Blocks only on a data-integrity violation (a fabricated or unmarked number)
+or a prose em-dash used as a sentence separator; everything else surfaces without blocking.

--- a/site/src/curated/agents/finding-triage.md
+++ b/site/src/curated/agents/finding-triage.md
@@ -1,0 +1,23 @@
+---
+entity: agents/finding-triage
+related: [skills/dispatching-parallel-agents, checkpoint-aggregator]
+---
+
+## Role
+
+Post-processes every reviewer report from a checkpoint or review run: consolidates all findings and
+classifies each as BLOCKS, DEFERRABLE, or NON_BLOCKING. It generates no findings of its own — it
+unifies and classifies what the reviewer fleet already found. Runs sequentially after every reviewer
+in the batch has reported, dispatched by `dispatching-parallel-agents`, and its output feeds
+`checkpoint-aggregator`.
+
+## Why this model tier
+
+Ships `model: haiku`. Classifying an already-produced finding by severity and blocking status against
+a fixed rule set is mechanical triage, not open-ended judgment.
+
+## What it emits
+
+A single unified triage report: one table row per finding under BLOCKS / DEFERRABLE / NON_BLOCKING,
+with source reviewer, severity, description, and disposition, plus summary counts. Nothing is dropped
+— every finding from every reviewer must appear.

--- a/site/src/curated/agents/frontend-author.md
+++ b/site/src/curated/agents/frontend-author.md
@@ -1,0 +1,22 @@
+---
+entity: agents/frontend-author
+related: [skills/subagent-driven-development, skills/tdd, backend-author, design-quality-reviewer]
+---
+
+## Role
+
+Writes frontend and UI code — the implementation executor for the `tdd` skill's Phase 1 test
+obligations, mirroring `backend-author` on the client side. It never writes implementation code before
+a failing-test checklist exists, and it dispatches `security-reviewer`, `auth-crypto-reviewer`, or
+`design-quality-reviewer` itself when the diff crosses their triggers. Dispatched fresh per task by
+`subagent-driven-development`.
+
+## Why this model tier
+
+Ships `model: sonnet`. Component logic, state management, and accessibility all need
+implementation-grade reasoning under TDD, the same rationale that puts `backend-author` at this tier.
+
+## What it emits
+
+Not findings — it writes component and test files directly, plus the security- and design-review
+dispatch calls its own rules require, before handing the result to the review chain that follows it.

--- a/site/src/curated/agents/grader.md
+++ b/site/src/curated/agents/grader.md
@@ -1,0 +1,24 @@
+---
+entity: agents/grader
+related: [skills/decision-variance, decision-challenger]
+---
+
+## Role
+
+Internal SMARTS analyst dispatched only by the `decision-variance` skill: takes one
+artifact-position-versus-scaffold-evidence pair and produces a scored SMARTS analysis (Scalable,
+Maintainable, Available, Reliable, Testable, Securable) with a recommendation strength. It never
+decides — `decision-variance` dispatches a grader for a variance detailed or borderline enough to
+warrant a structured second-pass evaluation, and analyzes obvious cases inline instead.
+
+## Why this model tier
+
+Ships `model: inherit`, matching whatever tier `decision-variance` is running at. A SMARTS analysis
+quality-caps at the reasoning available, so inheriting keeps the grader as capable as the arbitration
+it's supporting.
+
+## What it emits
+
+A structured SMARTS table (one row per lens, verdict-first, ≤25 words per cell), a preferred option
+with a strong/moderate/tied recommendation strength, and a self-conformance checklist against the
+format's hard constraints — never the arbitration decision itself.

--- a/site/src/curated/agents/infra-author.md
+++ b/site/src/curated/agents/infra-author.md
@@ -1,0 +1,22 @@
+---
+entity: agents/infra-author
+related: [skills/subagent-driven-development, backend-author]
+---
+
+## Role
+
+Writes infrastructure-as-code, containers, CI/CD manifests, and deployment configuration, mirroring
+`backend-author` and `frontend-author` for the infra surface. It reads tech stack and security
+boundaries from `.codearbiter/` before writing, and dispatches `security-reviewer` (mandatory before
+staging) whenever a change touches network policy, IAM, or a container security context. Dispatched by
+`subagent-driven-development` once the relevant planning phase has completed.
+
+## Why this model tier
+
+Ships `model: sonnet`. IaC idempotency, least-privilege IAM, and network-policy correctness are
+implementation-grade judgment calls, the same tier rationale as the other author agents.
+
+## What it emits
+
+Not findings — it writes IaC, container, and CI/CD configuration files directly, plus the mandatory
+`security-reviewer` dispatch its own rules require before anything with elevated permissions ships.

--- a/site/src/curated/agents/map-deps.md
+++ b/site/src/curated/agents/map-deps.md
@@ -1,0 +1,25 @@
+---
+entity: agents/map-deps
+related: [skills/tribunal, map-structure]
+---
+
+## Role
+
+Read-only extractor of a repository's dependency and integration-surface inventory — manifests,
+lockfiles, outbound service calls, and where environment/secret-shaped identifiers are read (names
+only, never values). It reports facts, never findings; judging license or security risk is out of
+scope, left to `dependency-reviewer` and the tribunal secrets-supply lens. Dispatched only by the
+`tribunal` skill's Phase 1, and only on a large or sprawling repo, to keep raw file-reading out of the
+orchestrator's retained context.
+
+## Why this model tier
+
+Ships `model: inherit`, but the `tribunal` skill's own dispatch-time model guidance recommends Haiku
+for this role — it is bulk fact extraction, not judgment, so a cheap tier is the right fit even though
+the frontmatter leaves the choice to the dispatcher.
+
+## What it emits
+
+A terse structured summary — manifest list, dependency highlights, integration-surface list, and
+env/secret-usage-surface list — sized to fold directly into the tribunal run's `inventory.md`, never a
+file-by-file narrative.

--- a/site/src/curated/agents/map-structure.md
+++ b/site/src/curated/agents/map-structure.md
@@ -1,0 +1,23 @@
+---
+entity: agents/map-structure
+related: [skills/tribunal, map-deps]
+---
+
+## Role
+
+Read-only extractor of a repository's structural inventory — file-tree shape, language breakdown,
+entry points, core-logic locations, and churn via git history. It reports facts, never findings;
+risk-ranking and trust-boundary marking are the orchestrator's Phase 1 judgment overlay, applied after
+this report returns. Dispatched only by the `tribunal` skill's Phase 1, and only on a large or
+sprawling repo, alongside `map-deps`.
+
+## Why this model tier
+
+Ships `model: inherit`, but the `tribunal` skill's own dispatch-time model guidance recommends Haiku
+for this role, the same rationale as `map-deps` — high-volume extraction, not judgment.
+
+## What it emits
+
+A terse structured summary sized to fold directly into the tribunal run's `inventory.md`: a condensed
+directory tree, a per-language breakdown, where the routes and entry files live, and a
+most-active-files list, never raw file contents.

--- a/site/src/curated/agents/migration-reviewer.md
+++ b/site/src/curated/agents/migration-reviewer.md
@@ -1,0 +1,22 @@
+---
+entity: agents/migration-reviewer
+related: [skills/commit-gate, skills/subagent-driven-development]
+---
+
+## Role
+
+Read-only reviewer of database migration files: checks reversibility, data-classification annotation
+on sensitive tables, and immutability of already-committed migrations. Dispatched whenever a diff
+contains a new or modified migration file — by the `commit-gate` skill's verification phase, and by
+`subagent-driven-development` when `backend-author`'s diff touches a migration.
+
+## Why this model tier
+
+Ships `model: inherit`, running at whatever tier the calling gate or author agent already committed —
+migration safety review rides on the same reasoning budget as the change it's checking.
+
+## What it emits
+
+CRITICAL–LOW findings with the migration file path, the specific safety or classification gap, and a
+remediation. Blocks on an irreversible destructive operation without a linked ADR, a missing
+classification annotation on sensitive data, or an edit to an already-merged migration.

--- a/site/src/curated/agents/scout.md
+++ b/site/src/curated/agents/scout.md
@@ -1,0 +1,23 @@
+---
+entity: agents/scout
+related: [skills/decision-variance, skills/context-creation, skills/commit-gate]
+---
+
+## Role
+
+Internal evidence-gatherer: scans an assigned code scope and reports file-path-and-line-number
+evidence of architectural decisions, with no excerpts and no variance judgment — that stays with the
+dispatching skill. Dispatched by `decision-variance` and `context-creation` when a single inline scan
+would consume significant context, and by `subagent-driven-development`/`commit-gate` for scoped
+evidence gathering elsewhere. Never dispatched directly by the orchestrator.
+
+## Why this model tier
+
+Ships `model: haiku`. High-volume, file:line evidence gathering with an explicit "no judgment, no
+excerpts" mandate is exactly the workload a fast, cheap tier is built for.
+
+## What it emits
+
+A structured scout report: evidence locations (file, lines, git hash, a ≤20-word note) per decision
+category, a strong/moderate/weak confidence rating per category, and an unlabeled anomalies section for
+evidence that doesn't map to any passed category.

--- a/site/src/curated/agents/security-reviewer.md
+++ b/site/src/curated/agents/security-reviewer.md
@@ -1,0 +1,24 @@
+---
+entity: agents/security-reviewer
+related: [commands/review, commands/checkpoint, skills/commit-gate, skills/subagent-driven-development]
+---
+
+## Role
+
+Read-only reviewer of authentication, authorization, secrets, deployment manifests, network policy, and
+CI workflows against `.codearbiter/security-controls.md`. It is the broadest of the security reviewers
+— dispatched proactively whenever a diff touches any of those surfaces, by `/ca:review`,
+`/ca:checkpoint`, the `commit-gate` skill, and every author agent (`backend-author`, `frontend-author`,
+`infra-author`) that crosses a security boundary.
+
+## Why this model tier
+
+Ships `model: inherit`, running at whatever tier the calling lane already committed. Because it is
+dispatched from so many different contexts — a fast checkpoint sweep or a careful pre-commit gate — a
+pinned tier would either overpay on the common case or underpower the sensitive one.
+
+## What it emits
+
+CRITICAL/HIGH/MEDIUM/LOW findings, each with a file:line, description, the violated `security-controls.md`
+control, and a remediation. Blocks the PR on any CRITICAL or HIGH finding — an exploitable
+vulnerability, an exposed secret, a banned primitive, or an undeclared security-boundary crossing.

--- a/site/src/curated/agents/tribunal-appsec-reviewer.md
+++ b/site/src/curated/agents/tribunal-appsec-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-appsec-reviewer
+related: [skills/tribunal, tribunal-architecture-reviewer, tribunal-reliability-reviewer]
+---
+
+## Role
+
+Read-only application-security lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope
+for injection, resource-level authorization/IDOR, input validation, JWT handling, CORS, and SSRF.
+Dispatched only by `tribunal`'s Phase 2 roster dispatch, against the checklist and exposure
+denominator in its own lens reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends the highest-reasoning
+tier (Opus, high effort) for this lens — appsec is one of three lenses the skill treats as needing the
+deepest adversarial reasoning, alongside architecture and reliability.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/appsec/` — never a batched
+write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-architecture-reviewer.md
+++ b/site/src/curated/agents/tribunal-architecture-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-architecture-reviewer
+related: [skills/tribunal, tribunal-appsec-reviewer, tribunal-reliability-reviewer]
+---
+
+## Role
+
+Read-only architecture lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for
+dead or orphan modules, pattern drift, cosmetic abstractions, dead code paths, god modules, and
+monolith accretion. Distinct from `architecture-drift-reviewer`, which checks conformance to accepted
+ADRs rather than structural health. Dispatched only by `tribunal`'s Phase 2 roster dispatch.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends the highest-reasoning
+tier (Opus, high effort) for this lens — spotting structural drift and cosmetic abstractions across a
+whole codebase is one of the three lenses the skill treats as needing the deepest reasoning.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/architecture/` — never a
+batched write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-coverage-reviewer.md
+++ b/site/src/curated/agents/tribunal-coverage-reviewer.md
@@ -1,0 +1,24 @@
+---
+entity: agents/tribunal-coverage-reviewer
+related: [skills/tribunal, tribunal-infra-reviewer, coverage-auditor]
+---
+
+## Role
+
+Read-only coverage lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for
+risk-path coverage gaps, edge/property gaps, and implementation-coupled tests across the whole
+codebase. Distinct from the routine `coverage-auditor`, which checks a single change against its TDD
+obligations rather than the codebase's risk paths at large. Dispatched only by `tribunal`'s Phase 2
+roster dispatch.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at medium effort
+for this lens — one of the five Tier-2 lenses the skill scopes to a lighter reasoning budget than the
+adversarial-security and reliability lenses, and the first offered up for trimming under cost pressure.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/coverage/` — never a batched
+write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-infra-reviewer.md
+++ b/site/src/curated/agents/tribunal-infra-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-infra-reviewer
+related: [skills/tribunal, tribunal-coverage-reviewer, tribunal-performance-reviewer]
+---
+
+## Role
+
+Read-only infra lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for CI/CD
+workflow correctness and security, container posture, IaC/deploy manifests, and release automation.
+Dispatched only by `tribunal`'s Phase 2 roster dispatch, against the checklist and exposure denominator
+in its own lens reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at medium effort
+for this lens — one of the five Tier-2 lenses the skill scopes to a lighter reasoning budget than the
+adversarial-security and reliability lenses, and the first offered up for trimming under cost pressure.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/infra/` — never a batched
+write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-migration-reviewer.md
+++ b/site/src/curated/agents/tribunal-migration-reviewer.md
@@ -1,0 +1,24 @@
+---
+entity: agents/tribunal-migration-reviewer
+related: [skills/tribunal, tribunal-secrets-supply-reviewer, tribunal-test-fidelity-reviewer]
+---
+
+## Role
+
+Read-only migration lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for
+migration safety, data-classification tagging, immutability, and schema-to-code drift across the whole
+codebase. Distinct from the routine `migration-reviewer`, which checks a single new or modified
+migration file rather than the whole migration history. Dispatched only by `tribunal`'s Phase 2 roster
+dispatch.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at high effort
+for this lens — one of three lenses the skill treats as needing careful, high-effort reasoning just
+below the top tier, given the cost of missing a schema-integrity gap.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/migration/` — never a batched
+write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-observability-reviewer.md
+++ b/site/src/curated/agents/tribunal-observability-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-observability-reviewer
+related: [skills/tribunal, tribunal-performance-reviewer, tribunal-typesafety-reviewer]
+---
+
+## Role
+
+Read-only observability lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for
+structured logging, tracing/correlation IDs, metrics on critical paths, and audit gaps. Dispatched only
+by `tribunal`'s Phase 2 roster dispatch, against the checklist and exposure denominator in its own lens
+reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at medium effort
+for this lens — one of the five Tier-2 lenses the skill scopes to a lighter reasoning budget than the
+adversarial-security and reliability lenses, and the first offered up for trimming under cost pressure.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/observability/` — never a
+batched write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-performance-reviewer.md
+++ b/site/src/curated/agents/tribunal-performance-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-performance-reviewer
+related: [skills/tribunal, tribunal-observability-reviewer, tribunal-typesafety-reviewer]
+---
+
+## Role
+
+Read-only performance lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for N+1
+queries, redundant hot-path work, query/index shape, caching gaps, and blocking IO. Dispatched only by
+`tribunal`'s Phase 2 roster dispatch, against the checklist and exposure denominator in its own lens
+reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at medium effort
+for this lens — one of the five Tier-2 lenses the skill scopes to a lighter reasoning budget than the
+adversarial-security and reliability lenses, and the first offered up for trimming under cost pressure.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/performance/` — never a
+batched write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-reliability-reviewer.md
+++ b/site/src/curated/agents/tribunal-reliability-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-reliability-reviewer
+related: [skills/tribunal, tribunal-appsec-reviewer, tribunal-architecture-reviewer]
+---
+
+## Role
+
+Read-only reliability lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for async
+correctness, error propagation, races, resource lifecycle, boundary conditions, and orphan state.
+Dispatched only by `tribunal`'s Phase 2 roster dispatch, against the checklist and exposure
+denominator in its own lens reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends the highest-reasoning
+tier (Opus, high effort) for this lens — tracing races and resource-lifecycle bugs is one of the three
+lenses the skill treats as needing the deepest reasoning.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/reliability/` — never a
+batched write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-secrets-supply-reviewer.md
+++ b/site/src/curated/agents/tribunal-secrets-supply-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-secrets-supply-reviewer
+related: [skills/tribunal, tribunal-migration-reviewer, tribunal-test-fidelity-reviewer]
+---
+
+## Role
+
+Read-only secrets/supply-chain lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope
+for hardcoded secrets, weak crypto, cleartext data, secrets in logs, and dependency/supply-chain
+hygiene. Dispatched only by `tribunal`'s Phase 2 roster dispatch, against the checklist and exposure
+denominator in its own lens reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at high effort
+for this lens — one of three lenses the skill treats as needing careful, high-effort reasoning just
+below the top tier, given the cost of missing a real secret exposure.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/secrets-supply/` — never a
+batched write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-test-fidelity-reviewer.md
+++ b/site/src/curated/agents/tribunal-test-fidelity-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-test-fidelity-reviewer
+related: [skills/tribunal, tribunal-secrets-supply-reviewer, tribunal-migration-reviewer]
+---
+
+## Role
+
+Read-only test-fidelity lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for
+tests that validate fiction — a mock, stub, or fixture that has drifted from a now-existing real
+producer. Dispatched only by `tribunal`'s Phase 2 roster dispatch, against the recipe, severity rule,
+and exposure denominator in its own lens reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at high effort
+for this lens — one of three lenses the skill treats as needing careful, high-effort reasoning just
+below the top tier, given how easily a fixture-drift bug hides behind a passing suite.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/test-fidelity/` — never a
+batched write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/src/curated/agents/tribunal-typesafety-reviewer.md
+++ b/site/src/curated/agents/tribunal-typesafety-reviewer.md
@@ -1,0 +1,23 @@
+---
+entity: agents/tribunal-typesafety-reviewer
+related: [skills/tribunal, tribunal-performance-reviewer, tribunal-observability-reviewer]
+---
+
+## Role
+
+Read-only type-safety lens for the `/ca:tribunal` deep-audit lane: reviews the assigned scope for
+footgun interfaces, weak typing, escape hatches, unhelpful errors, and undocumented invariants.
+Dispatched only by `tribunal`'s Phase 2 roster dispatch, against the checklist and exposure denominator
+in its own lens reference.
+
+## Why this model tier
+
+Ships `model: inherit`, but `tribunal`'s own dispatch-time guidance recommends Sonnet at medium effort
+for this lens — one of the five Tier-2 lenses the skill scopes to a lighter reasoning budget than the
+adversarial-security and reliability lenses, and the first offered up for trimming under cost pressure.
+
+## What it emits
+
+One `finding/v1` JSON file per finding, written immediately to `findings/typesafety/` — never a batched
+write — with severity, confidence, file:line locations, evidence, and a remediation shape. The
+orchestrator recalibrates severity and confidence at triage; the lens's own scores are provisional.

--- a/site/test/generator/build-index.test.ts
+++ b/site/test/generator/build-index.test.ts
@@ -32,3 +32,63 @@ describe("buildIndex", () => {
     expect(buildIndex([]).sidebar).toEqual([]);
   });
 });
+
+describe("buildIndex — roster metadata (description/tier/preview)", () => {
+  it("truncates a multi-sentence description to its first sentence per item", () => {
+    const { sidebar } = buildIndex([
+      {
+        type: "command",
+        slug: "commit",
+        title: "commit",
+        markdown: "",
+        description: "Run the commit gate. Nothing lands without it.",
+      },
+    ]);
+    const commands = sidebar.find((g) => g.type === "command");
+    expect(commands?.items[0].description).toBe("Run the commit gate.");
+  });
+
+  it("attaches a model tier to agent items only", () => {
+    const { sidebar } = buildIndex([
+      { type: "agent", slug: "scout", title: "scout", markdown: "", model: "haiku" },
+      { type: "command", slug: "commit", title: "commit", markdown: "" },
+    ]);
+    const agents = sidebar.find((g) => g.type === "agent");
+    const commands = sidebar.find((g) => g.type === "command");
+    expect(agents?.items[0].tier).toBe("Haiku");
+    expect(commands?.items[0].tier).toBeUndefined();
+  });
+
+  it("defaults an agent with no model field to the 'default' tier", () => {
+    const { sidebar } = buildIndex([
+      { type: "agent", slug: "scout", title: "scout", markdown: "" },
+    ]);
+    const agents = sidebar.find((g) => g.type === "agent");
+    expect(agents?.items[0].tier).toBe("default");
+  });
+
+  it("marks a command with a forgeStatus as preview; leaves others unmarked", () => {
+    const { sidebar } = buildIndex([
+      {
+        type: "command",
+        slug: "prune",
+        title: "prune",
+        markdown: "",
+        forgeStatus: { kind: "preview-command" },
+      },
+      { type: "command", slug: "commit", title: "commit", markdown: "" },
+    ]);
+    const commands = sidebar.find((g) => g.type === "command");
+    const bySlug = Object.fromEntries(commands!.items.map((it) => [it.slug, it]));
+    expect(bySlug.prune.preview).toBe(true);
+    expect(bySlug.commit.preview).toBe(false);
+  });
+
+  it("leaves preview undefined for non-command collections", () => {
+    const { sidebar } = buildIndex([
+      { type: "skill", slug: "tdd", title: "tdd", markdown: "" },
+    ]);
+    const skills = sidebar.find((g) => g.type === "skill");
+    expect(skills?.items[0].preview).toBeUndefined();
+  });
+});

--- a/site/test/generator/generate.test.ts
+++ b/site/test/generator/generate.test.ts
@@ -183,4 +183,47 @@ describe("generate", () => {
       );
     });
   });
+
+  describe("reference index — roster tables", () => {
+    it("renders one markdown table per non-empty collection, headers matching the collection", () => {
+      generate(pluginDir, outDir);
+      const indexContent = readFileSync(join(outDir, "index.md"), "utf8");
+      expect(indexContent).toContain("| Command | Description |");
+      expect(indexContent).toContain("| Skill | Description |");
+      expect(indexContent).toContain("| Agent | Model tier | Description |");
+    });
+
+    it("links the name cell to the entity's page", () => {
+      const result = generate(pluginDir, outDir);
+      const indexContent = readFileSync(join(outDir, "index.md"), "utf8");
+      const anyCommand = result.pages.find((p) => p.type === "command");
+      expect(anyCommand).toBeDefined();
+      expect(indexContent).toContain(
+        `[${anyCommand!.title}](./commands/${anyCommand!.slug}/)`,
+      );
+    });
+
+    it("marks a preview command with a (preview) suffix after its name", () => {
+      const result = generate(collisionsPluginDir, collisionsOutDir);
+      const indexContent = readFileSync(join(collisionsOutDir, "index.md"), "utf8");
+      const prunePage = result.pages.find(
+        (p) => p.type === "command" && p.slug === "prune",
+      );
+      expect(prunePage).toBeDefined();
+      expect(indexContent).toContain(
+        `[${prunePage!.title}](./commands/${prunePage!.slug}/) (preview)`,
+      );
+    });
+
+    it("carries a model-tier column value for an agent row", () => {
+      const result = generate(pluginDir, outDir);
+      const indexContent = readFileSync(join(outDir, "index.md"), "utf8");
+      const anyAgent = result.pages.find((p) => p.type === "agent");
+      expect(anyAgent).toBeDefined();
+      const rowRegex = new RegExp(
+        `\\[${anyAgent!.title}\\]\\(\\./agents/${anyAgent!.slug}/\\) \\| \\S+ \\|`,
+      );
+      expect(indexContent).toMatch(rowRegex);
+    });
+  });
 });

--- a/site/test/generator/truncate-description.test.ts
+++ b/site/test/generator/truncate-description.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { truncateDescription } from "../../scripts/generator/truncate-description";
+
+describe("truncateDescription", () => {
+  it("cuts a multi-sentence description at the first '. '", () => {
+    expect(truncateDescription("Foo bar. Baz qux.")).toBe("Foo bar.");
+  });
+
+  it("returns a single-sentence description unchanged", () => {
+    expect(truncateDescription("Foo bar")).toBe("Foo bar");
+  });
+
+  it("returns an already-short description ending in a period unchanged", () => {
+    expect(truncateDescription("Foo bar.")).toBe("Foo bar.");
+  });
+
+  it("cuts at the first occurrence when there are several", () => {
+    expect(truncateDescription("One. Two. Three.")).toBe("One.");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(truncateDescription("")).toBe("");
+  });
+});


### PR DESCRIPTION
PR-2.4 of the docs-site overhaul campaign — curated framing for all 28 agents (Role / Why this model tier / What it emits; the 11 tribunal reviewers deliberately parallel, with dispatch-time tier guidance from the tribunal cost-model reference since they ship model: inherit), plus the reference index reworked into roster tables per collection (agents carry a Model tier column; preview commands carry a marker). New truncate-description helper; RenderedPage/SidebarEntry extended to carry description/model/forge status. 291 vitest passing; build + link-audit green (15,589 links).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa