### PR TITLE
feat(site): generated hook gate-ID reference from Python call sites

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -172,7 +172,11 @@ export default defineConfig({
         {
           label: "Reference",
           collapsed: true,
-          items: [{ label: "All Reference", slug: "reference" }, ...referenceGroups],
+          items: [
+            { label: "All Reference", slug: "reference" },
+            { label: "Hook Gates", slug: "reference/hooks-gates" },
+            ...referenceGroups,
+          ],
         },
       ],
     }),

--- a/site/scripts/gen.ts
+++ b/site/scripts/gen.ts
@@ -2,7 +2,10 @@
 // emits the reference pages + sidebar data. Wired into `predev`/`prebuild`.
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { generate } from "./generator/generate";
+import { extractHookGates } from "./generator/extract-hook-gates";
+import { renderHooksReference, buildEventMap, type HooksJson } from "./generator/render-hooks-reference";
 
 const here = dirname(fileURLToPath(import.meta.url)); // site/scripts
 const repoRoot = resolve(here, "..", ".."); // -> repo root
@@ -20,3 +23,35 @@ console.log(
   `Generated ${result.pages.length} reference pages ` +
     `(${Object.entries(counts).map(([t, n]) => `${n} ${t}`).join(", ")}) -> ${outDir}`,
 );
+
+// Hooks are code, not prose (docs-site-overhaul spec, decision d): the hooks
+// gate-ID reference is generated separately from `plugins/ca/hooks/*.py` call
+// sites rather than joining the command/skill/agent frontmatter pipeline above
+// — it has no source frontmatter and isn't one of `generate()`'s three
+// SourceTypes, so it is emitted here as a standalone page in the same output
+// directory instead of extending the SourceType union for a single page.
+const hooksDir = join(srcDir, "hooks");
+const hooksJsonPath = join(hooksDir, "hooks.json");
+const pluginManifestPath = join(srcDir, ".claude-plugin", "plugin.json");
+const pluginVersion = existsSync(pluginManifestPath)
+  ? (JSON.parse(readFileSync(pluginManifestPath, "utf-8")).version ?? "0.0.0-dev")
+  : "0.0.0-dev";
+
+const { callSites, skipped } = extractHookGates(hooksDir);
+const hooksJson: HooksJson = existsSync(hooksJsonPath)
+  ? JSON.parse(readFileSync(hooksJsonPath, "utf-8"))
+  : { hooks: {} };
+const eventMap = buildEventMap(hooksJson);
+const hooksGatesPage = renderHooksReference(callSites, eventMap, pluginVersion);
+writeFileSync(join(outDir, "hooks-gates.md"), hooksGatesPage);
+
+console.log(
+  `Generated hooks-gates reference (${callSites.length} call sites, ` +
+    `${new Set(callSites.map((c) => c.tag)).size} tags, ${skipped.length} skipped) -> ` +
+    join(outDir, "hooks-gates.md"),
+);
+if (skipped.length > 0) {
+  for (const s of skipped) {
+    console.log(`  skipped (non-literal tag): ${s.file}:${s.line}`);
+  }
+}

--- a/site/scripts/generator/extract-hook-gates.ts
+++ b/site/scripts/generator/extract-hook-gates.ts
@@ -1,0 +1,251 @@
+/** extract-hook-gates.ts — scans `plugins/ca/hooks/*.py` for `block()`/`remind()`
+ * call sites whose gate tag is a literal `"H-<digits><letter?>"` string, and
+ * extracts the user-visible message text those calls print.
+ *
+ * Hooks are code, not prose (see the docs-site-overhaul spec, decision d): the
+ * hooks reference page is generated from these call sites rather than
+ * hand-transcribed, so it can never drift from what a hook actually prints.
+ *
+ * `_hooklib.py` defines `block(tag, msg)` / `remind(tag, msg)` themselves —
+ * those definition sites take `tag` as a parameter, never a string literal, so
+ * the literal-tag regex below never matches them; no special-case exclusion is
+ * needed for the definition file itself.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** One `block()`/`remind()` call site with a literal `"H-xx"` tag. */
+export interface HookCallSite {
+  tag: string;
+  kind: "block" | "remind";
+  file: string;
+  line: number;
+  message: string;
+}
+
+/** A `block()`/`remind()` call whose first argument was NOT a literal tag string. */
+export interface SkippedCallSite {
+  file: string;
+  line: number;
+}
+
+export interface ExtractResult {
+  callSites: HookCallSite[];
+  skipped: SkippedCallSite[];
+}
+
+/** 1-based line number of `index` within `content`. */
+function lineOf(content: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < content.length; i++) {
+    if (content[i] === "\n") line++;
+  }
+  return line;
+}
+
+/** True iff `content[idx..]` starts a Python string literal (optional prefix
+ * letters — f/F/r/R/b/B/u/U, up to two — followed by a quote char). Returns
+ * the literal's quote-run length (1 or 3) and the index just past the opening
+ * quote(s), or null if this is not a string start. */
+function matchStringStart(
+  content: string,
+  idx: number,
+): { quote: string; quoteLen: number; contentStart: number } | null {
+  let i = idx;
+  let prefixLen = 0;
+  while (prefixLen < 2 && /[fFrRbBuU]/.test(content[i + prefixLen] ?? "")) {
+    prefixLen++;
+  }
+  const q = content[i + prefixLen];
+  if (q !== '"' && q !== "'") return null;
+  const tripleStart = i + prefixLen;
+  const isTriple =
+    content[tripleStart + 1] === q && content[tripleStart + 2] === q;
+  const quoteLen = isTriple ? 3 : 1;
+  return { quote: q, quoteLen, contentStart: tripleStart + quoteLen };
+}
+
+/** Unescape the common escape sequences inside a Python string literal body. */
+function unescapePython(raw: string): string {
+  return raw
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t")
+    .replace(/\\"/g, '"')
+    .replace(/\\'/g, "'")
+    .replace(/\\\\/g, "\\");
+}
+
+/** Consume one string literal starting at `content[idx]` (which must satisfy
+ * `matchStringStart`). Returns the literal's unescaped body and the index
+ * just past the closing quote(s). */
+function consumeString(
+  content: string,
+  idx: number,
+): { body: string; endIdx: number } {
+  const start = matchStringStart(content, idx);
+  if (!start) {
+    throw new Error(`consumeString called at non-string position ${idx}`);
+  }
+  const closer = start.quote.repeat(start.quoteLen);
+  let i = start.contentStart;
+  while (i < content.length) {
+    if (content[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (content.slice(i, i + closer.length) === closer) {
+      return {
+        body: unescapePython(content.slice(start.contentStart, i)),
+        endIdx: i + closer.length,
+      };
+    }
+    i++;
+  }
+  // Unterminated literal (malformed source) — consume to EOF rather than loop forever.
+  return {
+    body: unescapePython(content.slice(start.contentStart)),
+    endIdx: content.length,
+  };
+}
+
+/**
+ * Scan a `block(`/`remind(` call's argument list starting just after the
+ * `tag,` prefix already matched by the caller (so we are one `(` deep),
+ * concatenating every literal string segment found at that depth into the
+ * message. Non-literal glue (`+`, whitespace, a trailing function call like
+ * `_read_err_hint()`) is walked over for correct paren-depth tracking but
+ * contributes nothing to the message text.
+ */
+function scanMessage(content: string, startIdx: number): { message: string; endIdx: number } {
+  let depth = 1;
+  let i = startIdx;
+  let message = "";
+  while (i < content.length && depth > 0) {
+    const ch = content[i];
+    if (ch === '"' || ch === "'" || /[fFrRbBuU]/.test(ch)) {
+      const strStart = matchStringStart(content, i);
+      if (strStart) {
+        const { body, endIdx } = consumeString(content, i);
+        if (depth === 1) message += body;
+        i = endIdx;
+        continue;
+      }
+    }
+    if (ch === "(") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      depth--;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return { message, endIdx: i };
+}
+
+const LITERAL_TAG_CALL_RE = /\b(block|remind)\(\s*"(H-\d+[a-z]?)"\s*,/g;
+const ANY_CALL_RE = /\b(block|remind)\(/g;
+
+/**
+ * Build a per-index "is real code" mask for a whole file: `false` inside a `#`
+ * comment or any string/docstring literal, `true` everywhere else.
+ *
+ * `_hooklib.py`'s own module docstring and inline comments mention
+ * `block(tag, msg)` / `block()`/`remind()` in prose while documenting the
+ * public API — without this mask those textual mentions look like call sites
+ * with a non-literal (variable) tag and would pollute the `skipped` census.
+ */
+function computeCodeMask(content: string): boolean[] {
+  const mask = new Array<boolean>(content.length).fill(true);
+  let i = 0;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === "#") {
+      const start = i;
+      while (i < content.length && content[i] !== "\n") i++;
+      mask.fill(false, start, i);
+      continue;
+    }
+    if (ch === '"' || ch === "'" || /[fFrRbBuU]/.test(ch)) {
+      const strStart = matchStringStart(content, i);
+      if (strStart) {
+        const start = i;
+        const { endIdx } = consumeString(content, i);
+        mask.fill(false, start, endIdx);
+        i = endIdx;
+        continue;
+      }
+    }
+    i++;
+  }
+  return mask;
+}
+
+/** Extract every `block(`/`remind(` call site from one file's raw content. */
+function extractFromFile(file: string, content: string): ExtractResult {
+  const callSites: HookCallSite[] = [];
+  const claimedSpans: Array<[number, number]> = [];
+  const codeMask = computeCodeMask(content);
+
+  LITERAL_TAG_CALL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = LITERAL_TAG_CALL_RE.exec(content)) !== null) {
+    const kind = m[1] as "block" | "remind";
+    const tag = m[2];
+    const matchStart = m.index;
+    const argsStart = LITERAL_TAG_CALL_RE.lastIndex;
+    const { message, endIdx } = scanMessage(content, argsStart);
+    claimedSpans.push([matchStart, endIdx]);
+    callSites.push({
+      tag,
+      kind,
+      file,
+      line: lineOf(content, matchStart),
+      message,
+    });
+    // scanMessage may have consumed past lastIndex (multi-line call); keep the
+    // regex cursor from re-scanning inside the call we just extracted.
+    LITERAL_TAG_CALL_RE.lastIndex = Math.max(LITERAL_TAG_CALL_RE.lastIndex, endIdx);
+  }
+
+  const skipped: SkippedCallSite[] = [];
+  ANY_CALL_RE.lastIndex = 0;
+  while ((m = ANY_CALL_RE.exec(content)) !== null) {
+    const matchStart = m.index;
+    // A textual mention inside a comment or docstring (e.g. _hooklib.py's own
+    // API-listing prose) is not a call site — skip.
+    if (!codeMask[matchStart]) continue;
+    // Definition sites ("def block(tag, msg):") are not calls — skip.
+    const before = content.slice(Math.max(0, matchStart - 4), matchStart);
+    if (before === "def ") continue;
+    // Already captured as a literal-tag call site above — skip.
+    if (claimedSpans.some(([s, e]) => matchStart >= s && matchStart < e)) continue;
+    skipped.push({ file, line: lineOf(content, matchStart) });
+  }
+
+  return { callSites, skipped };
+}
+
+/**
+ * Scan every top-level `*.py` file under `hooksDir` (non-recursive — the
+ * `tests/` subdirectory is deliberately excluded) for `block()`/`remind()`
+ * call sites with a literal `"H-xx"` tag.
+ */
+export function extractHookGates(hooksDir: string): ExtractResult {
+  const files = readdirSync(hooksDir)
+    .filter((f) => f.endsWith(".py"))
+    .sort((a, b) => a.localeCompare(b));
+
+  const callSites: HookCallSite[] = [];
+  const skipped: SkippedCallSite[] = [];
+  for (const file of files) {
+    const content = readFileSync(join(hooksDir, file), "utf-8");
+    const result = extractFromFile(file, content);
+    callSites.push(...result.callSites);
+    skipped.push(...result.skipped);
+  }
+  return { callSites, skipped };
+}

--- a/site/scripts/generator/extract-hook-gates.ts
+++ b/site/scripts/generator/extract-hook-gates.ts
@@ -14,7 +14,10 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-/** One `block()`/`remind()` call site with a literal `"H-xx"` tag. */
+/** One `block()`/`remind()` call site attributed to a gate tag — either a
+ * literal `"H-xx"` first argument, or a bare identifier resolved through the
+ * bounded nearest-preceding-assignment pattern (see resolveVariableTag; a
+ * conditional assignment yields one call site per tag). */
 export interface HookCallSite {
   tag: string;
   kind: "block" | "remind";
@@ -147,7 +150,49 @@ function scanMessage(content: string, startIdx: number): { message: string; endI
 }
 
 const LITERAL_TAG_CALL_RE = /\b(block|remind)\(\s*"(H-\d+[a-z]?)"\s*,/g;
+const VARIABLE_TAG_CALL_RE = /\b(block|remind)\(\s*([A-Za-z_]\w*)\s*,/g;
 const ANY_CALL_RE = /\b(block|remind)\(/g;
+
+/** How far back (in lines) a variable-tag call looks for its assignment. */
+const VARIABLE_TAG_LOOKBACK_LINES = 30;
+
+/**
+ * Resolve a bare-identifier tag argument (`block(tag, …)`) to its literal
+ * value(s) by scanning BACKWARD for the nearest preceding assignment.
+ *
+ * BOUNDED PATTERN ONLY — this is deliberately NOT general dataflow. Exactly
+ * two single-line assignment shapes are recognized, within
+ * {@link VARIABLE_TAG_LOOKBACK_LINES} lines above the call:
+ *
+ *     tag = "H-09b" if touches_crypto else "H-10b"   -> both tags
+ *     tag = "H-09b"                                   -> the single tag
+ *
+ * These cover the real hooks' one variable-tag idiom: the crypto-vs-secret
+ * H-09b/H-10b split in git-enforce.py and pre-bash.py, whose messages would
+ * otherwise leave H-10b with ZERO entries on the generated page even though
+ * users see `BLOCKED [H-10b]` in their terminals. Anything else — a loop
+ * unpack (`for cls, tag in _CLASS_TAG:`), a function parameter, an assignment
+ * further away — resolves to null and the call site stays in `skipped`,
+ * visibly, rather than being guessed at.
+ */
+function resolveVariableTag(
+  content: string,
+  ident: string,
+  callIndex: number,
+): string[] | null {
+  const callLine = lineOf(content, callIndex);
+  const lines = content.split("\n");
+  const firstLine = Math.max(0, callLine - 1 - VARIABLE_TAG_LOOKBACK_LINES);
+  const assignRe = new RegExp(
+    `^\\s*${ident}\\s*=\\s*"(H-\\d+[a-z]?)"(?:\\s*if\\b.*\\belse\\s*"(H-\\d+[a-z]?)")?\\s*(?:#.*)?$`,
+  );
+  // Nearest preceding assignment wins: scan upward from the line above the call.
+  for (let ln = callLine - 2; ln >= firstLine; ln--) {
+    const m = assignRe.exec(lines[ln]);
+    if (m) return m[2] ? [m[1], m[2]] : [m[1]];
+  }
+  return null;
+}
 
 /**
  * Build a per-index "is real code" mask for a whole file: `false` inside a `#`
@@ -211,6 +256,35 @@ function extractFromFile(file: string, content: string): ExtractResult {
     LITERAL_TAG_CALL_RE.lastIndex = Math.max(LITERAL_TAG_CALL_RE.lastIndex, endIdx);
   }
 
+  // Second pass: variable-tag calls (`block(tag, …)`) resolvable through the
+  // bounded nearest-preceding-assignment pattern (see resolveVariableTag). A
+  // resolved conditional assignment attributes the SAME message to BOTH tags —
+  // one HookCallSite per tag, sharing the call's line pin.
+  VARIABLE_TAG_CALL_RE.lastIndex = 0;
+  while ((m = VARIABLE_TAG_CALL_RE.exec(content)) !== null) {
+    const matchStart = m.index;
+    if (!codeMask[matchStart]) continue;
+    const before = content.slice(Math.max(0, matchStart - 4), matchStart);
+    if (before === "def ") continue;
+    if (claimedSpans.some(([s, e]) => matchStart >= s && matchStart < e)) continue;
+    const tags = resolveVariableTag(content, m[2], matchStart);
+    if (tags === null) continue; // unresolvable — the skipped pass below reports it
+    const kind = m[1] as "block" | "remind";
+    const argsStart = VARIABLE_TAG_CALL_RE.lastIndex;
+    const { message, endIdx } = scanMessage(content, argsStart);
+    claimedSpans.push([matchStart, endIdx]);
+    for (const tag of tags) {
+      callSites.push({
+        tag,
+        kind,
+        file,
+        line: lineOf(content, matchStart),
+        message,
+      });
+    }
+    VARIABLE_TAG_CALL_RE.lastIndex = Math.max(VARIABLE_TAG_CALL_RE.lastIndex, endIdx);
+  }
+
   const skipped: SkippedCallSite[] = [];
   ANY_CALL_RE.lastIndex = 0;
   while ((m = ANY_CALL_RE.exec(content)) !== null) {
@@ -221,7 +295,7 @@ function extractFromFile(file: string, content: string): ExtractResult {
     // Definition sites ("def block(tag, msg):") are not calls — skip.
     const before = content.slice(Math.max(0, matchStart - 4), matchStart);
     if (before === "def ") continue;
-    // Already captured as a literal-tag call site above — skip.
+    // Already captured as a literal-tag or resolved variable-tag call site — skip.
     if (claimedSpans.some(([s, e]) => matchStart >= s && matchStart < e)) continue;
     skipped.push({ file, line: lineOf(content, matchStart) });
   }

--- a/site/scripts/generator/render-hooks-reference.ts
+++ b/site/scripts/generator/render-hooks-reference.ts
@@ -1,0 +1,162 @@
+/** render-hooks-reference.ts — renders the generated `reference/hooks-gates.md`
+ * page from the call sites `extract-hook-gates.ts` found, plus each script's
+ * registered event(s) from `hooks.json`.
+ *
+ * See the docs-site-overhaul spec, decision d: hooks are code, not prose — the
+ * page's "verbatim layer" is this generated metadata + line-pinned source
+ * permalinks, never pasted Python.
+ */
+import type { HookCallSite } from "./extract-hook-gates";
+
+/** Parsed shape of `plugins/ca/hooks/hooks.json` (only the fields this module reads). */
+export interface HooksJson {
+  hooks: Record<
+    string,
+    Array<{
+      matcher?: string;
+      hooks: Array<{ command: string }>;
+    }>
+  >;
+}
+
+/** `git-enforce.py` is the `.git/hooks` backstop shim — it is installed
+ * directly, not registered in `hooks.json`, so it gets a hand-mapped label. */
+const GIT_BACKSTOP_FILE = "git-enforce.py";
+const GIT_BACKSTOP_LABEL = "git backstop";
+
+/**
+ * Build a script-basename -> event-label list map from a parsed `hooks.json`.
+ *
+ * A label is `EventName` (no matcher registered, or the matcher is absent) or
+ * `EventName (matcher)`. A script registered under more than one event/matcher
+ * combination gets every one, in the order `hooks.json` lists them, deduplicated.
+ */
+export function buildEventMap(hooksJson: HooksJson): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  const scriptRe = /hooks\/([A-Za-z0-9_.-]+\.py)/;
+
+  for (const [event, entries] of Object.entries(hooksJson.hooks ?? {})) {
+    for (const entry of entries) {
+      const label = entry.matcher ? `${event} (${entry.matcher})` : event;
+      const scripts = new Set<string>();
+      for (const h of entry.hooks ?? []) {
+        const m = scriptRe.exec(h.command);
+        if (m) scripts.add(m[1]);
+      }
+      for (const script of scripts) {
+        const existing = map.get(script) ?? [];
+        if (!existing.includes(label)) existing.push(label);
+        map.set(script, existing);
+      }
+    }
+  }
+  return map;
+}
+
+/** Events label list for one hook source file — hand-mapped for the git backstop. */
+export function eventsFor(file: string, eventMap: Map<string, string[]>): string[] {
+  if (file === GIT_BACKSTOP_FILE) return [GIT_BACKSTOP_LABEL];
+  return eventMap.get(file) ?? [];
+}
+
+/** Parse a gate tag into (numeric part, letter suffix) for natural sort:
+ * H-00, H-01, ..., H-09, H-09b, H-10, H-10b, ..., H-20. */
+function parseTag(tag: string): { num: number; suffix: string } {
+  const m = /^H-(\d+)([a-z]?)$/.exec(tag);
+  if (!m) return { num: Number.MAX_SAFE_INTEGER, suffix: tag };
+  return { num: Number(m[1]), suffix: m[2] };
+}
+
+function compareTags(a: string, b: string): number {
+  const pa = parseTag(a);
+  const pb = parseTag(b);
+  if (pa.num !== pb.num) return pa.num - pb.num;
+  return pa.suffix.localeCompare(pb.suffix);
+}
+
+/** Wrap every `{placeholder}` run in an f-string message with backticks, so it
+ * renders as inline code rather than looking like missing/broken prose. */
+function markPlaceholders(message: string): string {
+  return message.replace(/\{[^{}]*\}/g, (m) => `\`${m}\``);
+}
+
+/** Escape a string for safe inclusion in a markdown blockquote line. */
+function toBlockquote(message: string): string {
+  return markPlaceholders(message)
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+/**
+ * Render the full `reference/hooks-gates.md` page.
+ *
+ * One `## H-xx` section per tag, sorted in natural gate-ID order. Each section
+ * carries a badge line (Blocking / Advisory — both if the tag has call sites of
+ * both kinds), the registered event(s) across every file that has a call site
+ * for that tag, and one blockquote + line-pinned permalink per call site.
+ */
+export function renderHooksReference(
+  callSites: HookCallSite[],
+  eventMap: Map<string, string[]>,
+  pluginVersion: string,
+): string {
+  const tag = `v${pluginVersion}`;
+  const byTag = new Map<string, HookCallSite[]>();
+  for (const site of callSites) {
+    const list = byTag.get(site.tag) ?? [];
+    list.push(site);
+    byTag.set(site.tag, list);
+  }
+
+  const tags = [...byTag.keys()].sort(compareTags);
+
+  const sections = tags.map((gateTag) => {
+    const sites = byTag.get(gateTag)!;
+    const kinds = new Set(sites.map((s) => s.kind));
+    const badges: string[] = [];
+    if (kinds.has("block")) badges.push("**Blocking**");
+    if (kinds.has("remind")) badges.push("**Advisory**");
+
+    const events = new Set<string>();
+    for (const site of sites) {
+      for (const label of eventsFor(site.file, eventMap)) events.add(label);
+    }
+
+    const entries = sites
+      .map((site) => {
+        const permalink = `https://github.com/arbiterForge/codeArbiter/blob/${tag}/plugins/ca/hooks/${site.file}#L${site.line}`;
+        return `${toBlockquote(site.message)}\n>\n> — [\`${site.file}:${site.line}\`](${permalink})`;
+      })
+      .join("\n\n");
+
+    return [
+      `## ${gateTag}`,
+      "",
+      badges.join(" / "),
+      "",
+      `**Event(s):** ${events.size > 0 ? [...events].map((e) => `\`${e}\``).join(", ") : "_(none registered)_"}`,
+      "",
+      entries,
+    ].join("\n");
+  });
+
+  const frontmatter = [
+    "---",
+    "title: Hook Gates",
+    'description: "Every gate ID a codeArbiter hook can print — generated from the block()/remind() call sites in plugins/ca/hooks, never hand-transcribed."',
+    "---",
+  ].join("\n");
+
+  const intro = [
+    "These gate IDs appear in terminal output as `BLOCKED [H-xx]: <message>` (a blocking",
+    "hook, exit 2) or `REMINDER [H-xx]: <message>` (an advisory hook, exit 0). This page is",
+    "generated at build time directly from the `block()`/`remind()` call sites in",
+    "`plugins/ca/hooks/*.py`, so it can never drift from what a hook actually prints.",
+    "",
+    "A `` `{placeholder}` `` shown in a message is an f-string interpolation — the hook fills",
+    "it in with a run-time value (a file path, a branch name, a count) when it actually fires.",
+  ].join("\n");
+
+  return `${frontmatter}\n\n${intro}\n\n${sections.join("\n\n---\n\n")}\n`;
+}

--- a/site/src/content/docs/hooks.md
+++ b/site/src/content/docs/hooks.md
@@ -7,6 +7,8 @@ codeArbiter enforces its gates as Claude Code hooks under `plugins/ca/hooks/`. E
 
 Every hook is registered **twice** in `hooks.json`: once under `python3`, and once under a `python3 -c "" || python` fallback. On a stock Windows box that has only the `python` interpreter, the gates still fire. The two entries each receive their own stdin, so a real block is never swallowed by the fallback.
 
+For the exact, word-for-word message text a hook prints for every gate ID — generated directly from each `block()`/`remind()` call site, so it can never drift from the narrative summaries below — see the [Hook Gates reference](/reference/hooks-gates/).
+
 ## Registered Hooks
 
 | Event | Matcher | Script |

--- a/site/test/generator/extract-hook-gates.test.ts
+++ b/site/test/generator/extract-hook-gates.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractHookGates } from "../../scripts/generator/extract-hook-gates";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = join(here, "fixtures", "hook-gates");
+// The real plugin hooks directory — scanned for the count-floor snapshot below.
+const realHooksDir = resolve(here, "..", "..", "..", "plugins", "ca", "hooks");
+
+describe("extractHookGates — fixture", () => {
+  const { callSites, skipped } = extractHookGates(fixtureDir);
+
+  it("extracts a multi-line adjacent f-string call, concatenating placeholder text verbatim", () => {
+    const site = callSites.find((c) => c.tag === "H-13");
+    expect(site).toBeDefined();
+    expect(site!.kind).toBe("remind");
+    expect(site!.message).toBe(
+      "{rel}: found {count} issue(s) on line(s) {count} (nested check) — please fix before committing.",
+    );
+  });
+
+  it("handles nested parens inside a plain string literal without truncating the call", () => {
+    const site = callSites.find((c) => c.tag === "H-05");
+    expect(site).toBeDefined();
+    expect(site!.message).toBe(
+      "The audit log (overrides.log, triage.log) is append-only (see ORCHESTRATOR §7). Truncation is prohibited.",
+    );
+  });
+
+  it("handles `+` concatenation, ignoring the non-literal trailing call but tracking its parens", () => {
+    const site = callSites.find((c) => c.tag === "H-01");
+    expect(site).toBeDefined();
+    expect(site!.message).toBe("Direct commit to main is prohibited.");
+  });
+
+  it("finds two distinct tags in the same file", () => {
+    const tags = new Set(callSites.map((c) => c.tag));
+    expect(tags.has("H-13")).toBe(true);
+    expect(tags.has("H-07")).toBe(true);
+  });
+
+  it("counts a variable-tag call into `skipped`, not silently dropped", () => {
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].file).toBe("sample-hook.py");
+  });
+
+  it("excludes the block()/remind() definition sites themselves", () => {
+    // Only the 4 literal-tag call sites should surface — never the two `def`s.
+    expect(callSites).toHaveLength(4);
+  });
+
+  it("records 1-based line numbers and the source file basename", () => {
+    const site = callSites.find((c) => c.tag === "H-07");
+    expect(site!.file).toBe("sample-hook.py");
+    expect(site!.line).toBeGreaterThan(0);
+  });
+});
+
+describe("extractHookGates — real plugin hooks (count-floor snapshot)", () => {
+  // Guards against silent under-collection. Counted directly via:
+  //   grep -c 'block("H-\|remind("H-' plugins/ca/hooks/*.py
+  // as of this writing: git-enforce.py=8, post-write-edit.py=8, pre-bash.py=20,
+  // pre-edit.py=10, pre-write.py=6 -> 52 literal-tag call sites. A future hook
+  // addition only grows this number, so the assertion is a floor (>=), not an
+  // exact match — it must fail if the extractor starts silently missing sites,
+  // not if the source genuinely grows.
+  const REAL_CALL_SITE_FLOOR = 52;
+
+  const { callSites } = extractHookGates(realHooksDir);
+
+  it(`finds at least ${REAL_CALL_SITE_FLOOR} literal-tag call sites in the real hooks`, () => {
+    expect(callSites.length).toBeGreaterThanOrEqual(REAL_CALL_SITE_FLOOR);
+  });
+
+  it("extracts H-01's protected-branch commit message from pre-bash.py verbatim", () => {
+    const site = callSites.find(
+      (c) => c.tag === "H-01" && c.file === "pre-bash.py" && c.line === 623,
+    );
+    expect(site).toBeDefined();
+    expect(site!.message).toBe(
+      "Direct commit to {target} is prohibited (ORCHESTRATOR §3). Create a feature branch.",
+    );
+  });
+
+  it("extracts an H-09b message from pre-bash.py verbatim", () => {
+    const site = callSites.find((c) => c.tag === "H-09b" && c.file === "pre-bash.py");
+    expect(site).toBeDefined();
+    expect(site!.message).toBe(
+      "the diff for the crypto/secret security scan could not be read (git unavailable or timed out) — failing closed (ORCHESTRATOR §2). Retry, or run the crypto-compliance / secret-handling gate, then commit.",
+    );
+  });
+});

--- a/site/test/generator/extract-hook-gates.test.ts
+++ b/site/test/generator/extract-hook-gates.test.ts
@@ -40,14 +40,35 @@ describe("extractHookGates — fixture", () => {
     expect(tags.has("H-07")).toBe(true);
   });
 
-  it("counts a variable-tag call into `skipped`, not silently dropped", () => {
+  it("resolves a bare-assignment variable tag to its single literal tag", () => {
+    const site = callSites.find((c) => c.tag === "H-14");
+    expect(site).toBeDefined();
+    expect(site!.kind).toBe("block");
+    expect(site!.message).toBe("migration gate pass missing.");
+  });
+
+  it("resolves a conditional-assignment variable tag to BOTH tags with the same message and line pin", () => {
+    const h09b = callSites.find((c) => c.tag === "H-09b");
+    const h10b = callSites.find((c) => c.tag === "H-10b");
+    expect(h09b).toBeDefined();
+    expect(h10b).toBeDefined();
+    const message =
+      "This commit introduces {kind} changes without a recorded security-gate pass.";
+    expect(h09b!.message).toBe(message);
+    expect(h10b!.message).toBe(message);
+    expect(h09b!.line).toBe(h10b!.line);
+    expect(h09b!.line).toBeGreaterThan(0);
+  });
+
+  it("counts an unresolvable variable-tag call (loop unpack) into `skipped`, not silently dropped", () => {
     expect(skipped).toHaveLength(1);
     expect(skipped[0].file).toBe("sample-hook.py");
   });
 
   it("excludes the block()/remind() definition sites themselves", () => {
-    // Only the 4 literal-tag call sites should surface — never the two `def`s.
-    expect(callSites).toHaveLength(4);
+    // 4 literal-tag sites + 1 bare-assignment + 2 from the conditional split
+    // should surface — never the two `def`s or the unresolvable loop-unpack call.
+    expect(callSites).toHaveLength(7);
   });
 
   it("records 1-based line numbers and the source file basename", () => {
@@ -61,16 +82,34 @@ describe("extractHookGates — real plugin hooks (count-floor snapshot)", () => 
   // Guards against silent under-collection. Counted directly via:
   //   grep -c 'block("H-\|remind("H-' plugins/ca/hooks/*.py
   // as of this writing: git-enforce.py=8, post-write-edit.py=8, pre-bash.py=20,
-  // pre-edit.py=10, pre-write.py=6 -> 52 literal-tag call sites. A future hook
-  // addition only grows this number, so the assertion is a floor (>=), not an
-  // exact match — it must fail if the extractor starts silently missing sites,
-  // not if the source genuinely grows.
-  const REAL_CALL_SITE_FLOOR = 52;
+  // pre-edit.py=10, pre-write.py=6 -> 52 literal-tag call sites. On top of
+  // those, 4 variable-tag sites (git-enforce.py:219/224, pre-bash.py:762/774)
+  // resolve through the bounded conditional-assignment pattern
+  // (`tag = "H-09b" if … else "H-10b"`), each attributed to BOTH tags -> +8
+  // entries -> 60. (pre-edit.py:84 is a loop unpack — genuinely unresolvable,
+  // stays in `skipped`.) A future hook addition only grows this number, so the
+  // assertion is a floor (>=), not an exact match — it must fail if the
+  // extractor starts silently missing sites, not if the source genuinely grows.
+  const REAL_CALL_SITE_FLOOR = 60;
 
-  const { callSites } = extractHookGates(realHooksDir);
+  const { callSites, skipped } = extractHookGates(realHooksDir);
 
-  it(`finds at least ${REAL_CALL_SITE_FLOOR} literal-tag call sites in the real hooks`, () => {
+  it(`finds at least ${REAL_CALL_SITE_FLOOR} attributed call sites in the real hooks`, () => {
     expect(callSites.length).toBeGreaterThanOrEqual(REAL_CALL_SITE_FLOOR);
+  });
+
+  it("attributes at least one H-10b entry (the conditional-assignment split) with its real message", () => {
+    const h10b = callSites.filter((c) => c.tag === "H-10b");
+    expect(h10b.length).toBeGreaterThanOrEqual(1);
+    const noPass = h10b.find((c) => c.file === "pre-bash.py" && c.line === 762);
+    expect(noPass).toBeDefined();
+    expect(noPass!.message).toBe(
+      "This commit introduces {kind} changes, but no security-gate pass is recorded (.codearbiter/.markers/security-gate-passed). Run the {skill} gate (it records the pass), then commit. To bypass a security gate, /override requires its heavier security-acknowledgement path.",
+    );
+  });
+
+  it("keeps the genuinely unresolvable loop-unpack call site in `skipped`", () => {
+    expect(skipped.some((s) => s.file === "pre-edit.py")).toBe(true);
   });
 
   it("extracts H-01's protected-branch commit message from pre-bash.py verbatim", () => {

--- a/site/test/generator/fixtures/hook-gates/sample-hook.py
+++ b/site/test/generator/fixtures/hook-gates/sample-hook.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Fixture hook exercising the extractor's real-world call shapes.
+
+
+def block(tag, msg):
+    print(f"BLOCKED [{tag}]: {msg}")
+
+
+def remind(tag, msg):
+    print(f"REMINDER [{tag}]: {msg}")
+
+
+def run():
+    # Multi-line f-string call, with a placeholder split across the args.
+    rel = "foo.md"
+    count = 3
+    remind("H-13", f"{rel}: found {count} issue(s) on line(s) "
+                   f"{count} (nested check) — please fix before "
+                   f"committing.")
+
+    # Nested parens inside a plain string literal (must not be mistaken for
+    # the call's own closing paren).
+    block("H-05", "The audit log (overrides.log, triage.log) is append-only "
+                  "(see ORCHESTRATOR §7). Truncation is prohibited.")
+
+    # Explicit `+` concatenation, including a trailing non-literal call whose
+    # own parens must be depth-tracked correctly.
+    block("H-01", "Direct commit to main is prohibited." + _hint())
+
+    # A second tag in the same file.
+    remind("H-07", "Dependency manifest changed.")
+
+    # A call whose tag is a variable, not a literal — must land in `skipped`,
+    # not silently dropped.
+    tag = "H-09b"
+    block(tag, "sensitive content detected.")
+
+
+def _hint():
+    return " Retry."

--- a/site/test/generator/fixtures/hook-gates/sample-hook.py
+++ b/site/test/generator/fixtures/hook-gates/sample-hook.py
@@ -30,10 +30,22 @@ def run():
     # A second tag in the same file.
     remind("H-07", "Dependency manifest changed.")
 
-    # A call whose tag is a variable, not a literal — must land in `skipped`,
-    # not silently dropped.
-    tag = "H-09b"
-    block(tag, "sensitive content detected.")
+    # A variable tag resolved through the bare-assignment form.
+    tag = "H-14"
+    block(tag, "migration gate pass missing.")
+
+    # A variable tag resolved through the conditional-assignment form — the
+    # message is attributed to BOTH tags (the real H-09b/H-10b split idiom).
+    touches_crypto = True
+    kind = "crypto/TLS" if touches_crypto else "secret"
+    tag = "H-09b" if touches_crypto else "H-10b"
+    block(tag, f"This commit introduces {kind} changes without a recorded "
+               f"security-gate pass.")
+
+    # A variable tag from a loop unpack — NOT the bounded assignment pattern,
+    # must land in `skipped`, not silently dropped.
+    for cls, loop_tag in (("audit", "H-05"),):
+        block(loop_tag, "protected artifact touched.")
 
 
 def _hint():

--- a/site/test/generator/render-hooks-reference.test.ts
+++ b/site/test/generator/render-hooks-reference.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderHooksReference,
+  buildEventMap,
+  eventsFor,
+  type HooksJson,
+} from "../../scripts/generator/render-hooks-reference";
+import type { HookCallSite } from "../../scripts/generator/extract-hook-gates";
+
+const hooksJson: HooksJson = {
+  hooks: {
+    PreToolUse: [
+      {
+        matcher: "Bash|PowerShell",
+        hooks: [
+          { command: 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash.py"' },
+          { command: 'python3 -c "" || python "${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash.py"' },
+        ],
+      },
+    ],
+    SessionStart: [
+      {
+        hooks: [{ command: 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.py"' }],
+      },
+    ],
+  },
+};
+
+const callSites: HookCallSite[] = [
+  { tag: "H-09", kind: "block", file: "pre-bash.py", line: 10, message: "crypto detected" },
+  { tag: "H-09b", kind: "block", file: "pre-bash.py", line: 20, message: "sensitive line" },
+  { tag: "H-10", kind: "remind", file: "pre-bash.py", line: 30, message: "possible secret" },
+  { tag: "H-10", kind: "block", file: "pre-bash.py", line: 31, message: "possible secret, blocked" },
+];
+
+describe("buildEventMap / eventsFor", () => {
+  it("maps a script to its EventName (matcher) label", () => {
+    const map = buildEventMap(hooksJson);
+    expect(map.get("pre-bash.py")).toEqual(["PreToolUse (Bash|PowerShell)"]);
+  });
+
+  it("maps a script with no matcher to a bare EventName label", () => {
+    const map = buildEventMap(hooksJson);
+    expect(map.get("session-start.py")).toEqual(["SessionStart"]);
+  });
+
+  it("hand-maps git-enforce.py to the git backstop label, bypassing hooks.json", () => {
+    const map = buildEventMap(hooksJson);
+    expect(eventsFor("git-enforce.py", map)).toEqual(["git backstop"]);
+  });
+
+  it("returns an empty list for a script registered nowhere", () => {
+    const map = buildEventMap(hooksJson);
+    expect(eventsFor("nowhere.py", map)).toEqual([]);
+  });
+});
+
+describe("renderHooksReference", () => {
+  const eventMap = buildEventMap(hooksJson);
+  const md = renderHooksReference(callSites, eventMap, "2.8.11");
+
+  it("renders frontmatter with title Hook Gates", () => {
+    expect(md).toContain("title: Hook Gates");
+  });
+
+  it("orders sections in natural gate-ID order: H-09 before H-09b before H-10", () => {
+    const iH09 = md.indexOf("## H-09\n");
+    const iH09b = md.indexOf("## H-09b");
+    const iH10 = md.indexOf("## H-10\n");
+    expect(iH09).toBeGreaterThan(-1);
+    expect(iH09b).toBeGreaterThan(iH09);
+    expect(iH10).toBeGreaterThan(iH09b);
+  });
+
+  it("shows the Blocking badge for a block-only tag", () => {
+    const section = md.slice(md.indexOf("## H-09b"), md.indexOf("## H-10\n"));
+    expect(section).toContain("**Blocking**");
+    expect(section).not.toContain("**Advisory**");
+  });
+
+  it("shows both badges when a tag has both a block and a remind call site", () => {
+    const section = md.slice(md.indexOf("## H-10\n"));
+    expect(section).toContain("**Blocking**");
+    expect(section).toContain("**Advisory**");
+  });
+
+  it("renders a line-pinned permalink in the expected format", () => {
+    expect(md).toContain(
+      "https://github.com/arbiterForge/codeArbiter/blob/v2.8.11/plugins/ca/hooks/pre-bash.py#L10",
+    );
+  });
+
+  it("wraps f-string placeholders in backticks", () => {
+    const site: HookCallSite = {
+      tag: "H-13",
+      kind: "remind",
+      file: "post-write-edit.py",
+      line: 5,
+      message: "{rel}: found an issue on line {line}.",
+    };
+    const out = renderHooksReference([site], eventMap, "2.8.11");
+    expect(out).toContain("`{rel}`");
+    expect(out).toContain("`{line}`");
+  });
+});


### PR DESCRIPTION
PR-2.2 of the docs-site overhaul campaign — the hooks half of the source-visible principle: hooks are code, so their verbatim layer is generated metadata + pinned permalinks, never pasted Python.

New extract-hook-gates.ts scans plugins/ca/hooks/*.py at docs-build time for block()/remind() call sites: literal tags plus a bounded resolver for the 'tag = "H-09b" if cond else "H-10b"' conditional-assignment pattern (review caught that H-10b had zero entries without it — users see BLOCKED [H-10b] in terminals). Census: 60 attributed call sites across 20 tags; 1 genuinely unresolvable site (pre-edit.py loop unpack) reported in the gen log, not silently dropped. Count-floor snapshot (60) + verbatim golden-message tests (H-01, H-09b, H-10b) guard against silent under-collection on future hook refactors. Events attributed from hooks.json; git-enforce.py labeled as the git backstop. Generated reference/hooks-gates.md renders per-tag sections with Blocking/Advisory badges and v-pinned line-level permalinks; hooks.md narrative links to it.

273 vitest passing; typecheck/build/link-audit green (120 pages, 15,758 links).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa