### PR TITLE
docs(site): .codearbiter directory reference, glossary, FAQ

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -119,6 +119,9 @@ export default defineConfig({
             { label: "Install", slug: "getting-started/install" },
             { label: "Quickstart", slug: "getting-started/quickstart" },
             { label: "What Is codeArbiter", slug: "overview" },
+            // Temporary placement — both belong in a restructured IA (PR-3.3).
+            { label: "Glossary", slug: "glossary" },
+            { label: "FAQ", slug: "faq" },
           ],
         },
         {
@@ -173,6 +176,7 @@ export default defineConfig({
           label: "Reference",
           collapsed: true,
           items: [
+            { label: "The .codearbiter/ Directory", slug: "codearbiter-directory" },
             { label: "All Reference", slug: "reference" },
             { label: "Hook Gates", slug: "reference/hooks-gates" },
             ...referenceGroups,

--- a/site/src/content/docs/codearbiter-directory.md
+++ b/site/src/content/docs/codearbiter-directory.md
@@ -1,0 +1,295 @@
+---
+title: "The .codearbiter/ Directory Reference"
+description: "Every file and directory under .codearbiter/, what writes it, what reads it, and what happens if it's deleted."
+---
+
+`.codearbiter/` is codeArbiter's project-state store: a root-level directory, outside `.claude/`,
+so it survives even if the plugin itself is uninstalled. It holds the project's own record — its
+spec, task board, decisions, and audit trail — separate from the plugin code that reads and
+writes it. `/ca:init` scaffolds it; `/ca:create-context` (existing codebase) or `/ca:decompose`
+(greenfield) populates it. Its presence and content is the plugin's actual contract with your
+repo: if you want to know what codeArbiter knows about your project, or what it will do next,
+this directory is where to look.
+
+Enforcement itself is gated on one file in here: `CONTEXT.md`. Everything else described below
+only matters once that file carries `arbiter: enabled`.
+
+This page documents every file and directory a stock install produces or reads. Some appear only
+once the feature that uses them first runs (`.markers/`, `.provenance/`, `spikes/`, `reports/`);
+those are noted below.
+
+## At a glance
+
+| Path | Written by | Read by | Editable by hand? |
+|---|---|---|---|
+| `CONTEXT.md` | `/ca:init`, `/ca:decompose`, `/ca:create-context` | every enforcement hook (`arbiter_active()`), the orchestrator | Yes, but the frontmatter is guarded — see below |
+| `open-tasks.md` | `/ca:task` only | `/ca:status`, the statusline, `SessionStart` | No — guarded to `/ca:task` |
+| `open-questions.md` | the orchestrator, when a `[CONFIRM-NN]` is raised | `/ca:status`, `SessionStart`, the statusline | Yes |
+| `decisions/*.md`, `decision-log.md` | `/ca:adr` only | `/ca:adr-status`, `/ca:reconcile`, `post-write-edit.py` (H-12) | No — guarded to `/ca:adr` |
+| `specs/*.md` | `brainstorming` skill (via `/ca:feature`, `/ca:sprint`) | `writing-plans`, `/ca:status` | Yes |
+| `plans/*.md` | `writing-plans` skill | `executing-plans`, `subagent-driven-development`, `/ca:status` | Yes |
+| `checkpoints/*.md` | `checkpoint-aggregator` agent (`/ca:checkpoint`) | `/ca:audit`, `/ca:status`-adjacent reads | Yes |
+| `audits/*.md` | `/ca:audit` | humans (report only) | Yes |
+| `reports/<run-id>/` | `/ca:tribunal` | `/ca:tribunal` on resume, the filing gate | Yes, but not while a run is in flight |
+| `sprint-log.md` | `/ca:sprint` | `/ca:status`, `/ca:audit` | No — append-only, guarded (H-05) |
+| `overrides.log` | `/ca:override`, `/ca:dev` entry/exit | statusline, `/ca:status`, `/ca:audit`, staleness-warn | No — append-only, guarded (H-05) |
+| `triage.log` | `/ca:feature` small-lane triage | `/ca:metrics`, `/ca:audit` | No — append-only, guarded (H-05) |
+| `gate-events.log` | every `block()`/`remind()`/`warn()` call in the hooks | (durable sink; no reader ships yet) | No — append-only, guarded (H-05) |
+| `.markers/` | `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr` | the commit-gate hooks (`pre-bash.py`, `pre-write.py`, `pre-edit.py`) | No — guarded, and hand-written markers can't satisfy a gate |
+| `.provenance/*.json` | `context-creation`, `decompose`, `context-check` (re-scout/re-baseline) | `SessionStart` (drift line), `commit-gate` (auto-heal) | Not by hand — regenerate via `/ca:context-check` |
+| `security-controls.md`, `tech-stack.md`, `coding-standards.md` | `/ca:init` / `/ca:create-context` / `/ca:decompose`, kept current by hand or `/ca:context-check` | every reviewer agent, the crypto/secret gates | Yes |
+| `last-checkpoint` | `checkpoint-aggregator` agent | `/ca:status`, the statusline (overrides-since-checkpoint) | Not normally — it's a counter, not a note |
+| `spikes/*.md` | `/ca:spike` | humans, `/ca:feature` (seeds `brainstorming`) | Yes |
+
+## CONTEXT.md
+
+The activation contract. Its leading YAML frontmatter carries two load-bearing keys:
+
+- **`arbiter: enabled`** — the single flag every enforcement hook checks via `arbiter_active()`
+  (`plugins/ca/hooks/_hooklib.py`). It must appear inside a *properly closed* frontmatter block —
+  `---` opens on line 1, `arbiter: enabled` somewhere inside, `---` closes it. A block that opens
+  but never closes is treated as **malformed**, not disabled, and is surfaced as an error rather
+  than silently ignored. A file with no frontmatter at all is simply dormant. No frontmatter,
+  malformed frontmatter, or `arbiter: disabled` all mean: nothing loads, nothing blocks.
+- **`stage: N`** — a single maturity number that `/ca:status` and the statusline surface. It has
+  no enforcement effect encoded in this file itself; it is a legible signal for how far the
+  project has matured, not a config switch.
+
+The body needs an `<!--INITIALIZED-->` marker before the file counts as populated. `SessionStart`
+checks for it: present with source code in the repo but the marker absent routes to
+`/ca:create-context`; absent with no source routes to `/ca:decompose`. Once the marker and
+frontmatter are both in place, the orchestrator persona loads on every session in this repo.
+
+**Writers:** `/ca:init` (scaffold), `/ca:decompose` and `/ca:create-context` (populate + lock).
+**Readers:** every enforcement hook, the `SessionStart` injector, the statusline.
+**Editable by hand?** The prose body, yes. The frontmatter is guarded: a Write/Edit that would
+flip `arbiter: enabled` off, or corrupt the block, is blocked (`pre-write.py`/`pre-edit.py`,
+issue #159) — the file that turns every gate off can't itself be edited past the gate.
+**Delete it:** codeArbiter goes fully dormant in this repo on the next session — no persona, no
+enforcement, nothing loads. The rest of `.codearbiter/` is untouched on disk; recreating
+`CONTEXT.md` (or running `/ca:init` again) reactivates it against whatever state remains.
+
+## open-tasks.md
+
+The [board](/glossary/#board): one top-level `- ` bullet per task, in one of three states —
+queued (`- [ ]`), in-progress (`- [~]`, always carrying a started date), or done (`- [x]`). The
+only sanctioned writer is `/ca:task` (`add` / `start` / `done`), which calls the pure
+`_taskboardlib` transforms via `taskwrite.py` so every entry stays schema-conformant and every
+transition dated — hand-editing risked malforming the schema, which is why the command exists.
+A task's `[x]` done-flip, `[~]` start-flip, or new `[ ]` entry rides the work commit itself
+through commit-gate (ADR-0008); there's no separate lagging board-only PR.
+
+**Writers:** `/ca:task` only. **Readers:** `/ca:status`, the statusline, `SessionStart` (in-flight
+count and staleness). **Editable by hand?** No — guarded to the one writer.
+**Delete it:** the board is empty going forward; nothing else breaks, but every count that reads
+it (statusline, `/ca:status`) reports zero until tasks are re-added.
+
+## open-questions.md
+
+The record of unresolved `[CONFIRM-NN]` items — numbered placeholders for a question only the
+user can answer, per the terminology lock in `ORCHESTRATOR.md` §0.1. An open `CONFIRM-NN` blocks
+stage promotion until it's resolved; it is never guessed at or resolved inside an ADR. The
+`SessionStart` hook and the statusline both count occurrences here.
+
+**Writers:** the orchestrator, when a skill surfaces a genuine unknown. **Readers:** `/ca:status`,
+`SessionStart`, the statusline. **Editable by hand?** Yes — resolving a `CONFIRM-NN` is a prose
+edit recording the decision and its date. **Delete it:** any `[CONFIRM-NN]` count in the
+statusline or `/ca:status` reads zero; a future skill that needs to raise one recreates the file.
+
+## decisions/
+
+One numbered, dated, user-attributed file per Architecture Decision Record (`0001-*.md`,
+`0002-*.md`, …), plus `decision-log.md`, an append-only ledger that mirrors every ADR as one
+entry. `/ca:adr` is the only sanctioned author; both the shell flank (redirects, `cp`, `sed -i`
+targeting `decisions/`) and the Write/Edit flank are guarded (H-11) so an ADR can't be
+fabricated, edited after the fact, or slipped in outside the command. Status moves through
+`proposed -> accepted -> superseded | rejected`; a superseding decision never rewrites the prior
+file — it appends a new numbered ADR whose own text names what it supersedes, and a new
+`decision-log.md` entry does the same.
+
+**Writers:** `/ca:adr` (via the `decision-lifecycle` skill) only. **Readers:** `/ca:adr-status`,
+`/ca:reconcile`, and `post-write-edit.py`'s H-12 advisory (a file matching an ADR's `governs:`
+glob gets a reminder on every future touch). **Editable by hand?** No — guarded.
+**Delete it:** the project's decision history is gone; `governs:` reminders for any ADR that used
+to cover a file stop firing, and `/ca:adr-status` has nothing to report.
+
+## specs/
+
+One markdown file per feature/campaign spec, written by the `brainstorming` skill once a spec is
+approved (`/ca:feature`, `/ca:sprint`). `writing-plans` reads an approved spec to derive its task
+plan, and `/ca:status` lists every slug here alongside its plan to show how far each pipeline got.
+
+**Writers:** `brainstorming`. **Readers:** `writing-plans`, `/ca:status`.
+**Editable by hand?** Yes — specs are prose documents; edit for clarity, but avoid rewriting
+acceptance criteria the plan and its tests already trace against.
+**Delete it:** `/ca:status` no longer lists that pipeline; a plan that referenced the missing spec
+still runs (the plan is self-contained), but nothing can re-derive it from the (now-gone) spec.
+
+## plans/
+
+One markdown file per feature's task plan, written by `writing-plans` from an approved spec.
+Each task carries an exact file path and a verification step that maps to a `tdd` obligation.
+`executing-plans` and `subagent-driven-development` consume it task by task; `/ca:status` reports
+the ACCEPTED-vs-total count for an in-progress plan.
+
+**Writers:** `writing-plans`. **Readers:** `executing-plans`, `subagent-driven-development`,
+`/ca:status`. **Editable by hand?** Yes, though editing mid-execution risks desyncing the
+plan from tasks already marked accepted. **Delete it:** an in-progress feature loses its
+resumption point; `/ca:status` can no longer report that pipeline's progress.
+
+## checkpoints/
+
+One dated report per `/ca:checkpoint` sweep (`YYYY-MM-DD.md`), written by the
+`checkpoint-aggregator` agent from the finding-triage and decision-challenger output. Findings are
+classified by severity; the ones blocking the current change are called out, the rest recorded
+for later. `/ca:tribunal`'s deep-audit output is a distinct artifact (`reports/<run-id>/`, below)
+— checkpoints are the lean, routine sweep.
+
+**Writers:** `checkpoint-aggregator`. **Readers:** humans (the report is the deliverable);
+`/ca:audit` pulls still-open findings from the most recent one. **Editable by hand?** Yes, though
+there's rarely reason to. **Delete it:** history of past sweeps is gone; the next `/ca:checkpoint`
+recreates the directory and writes fresh.
+
+## audits/
+
+One dated governance packet per `/ca:audit` run (`YYYY-MM-DD.md`), assembling commits, overrides,
+ADRs, sprint auto-decisions, open questions, and open checkpoint findings for a given range into
+one document. `/ca:audit` is read-only against everything it summarizes — it never mutates
+`overrides.log`, `decisions/`, or any of its other sources.
+
+**Writers:** `/ca:audit`. **Readers:** humans. **Editable by hand?** Yes.
+**Delete it:** past audit packets are gone; nothing else in the framework depends on their
+presence, since `/ca:audit` re-derives everything from the underlying logs and files each run.
+
+## reports/
+
+`/ca:tribunal`'s working directory: `.codearbiter/reports/<run-id>/`, where `<run-id>` is
+`<UTC-date>-<scope-slug>`. A fresh run creates the directory and opens `run.jsonl`; a resumed run
+reuses the same `run-id` (the date is the run's creation date and never changes on resume). Every
+lens's findings are written one file per finding, plus append-only triage/run logs, so an
+interrupted deep audit picks back up from disk instead of restarting. Tribunal writes are confined
+to this directory until the filing gate — it never edits, refactors, or commits project code.
+
+**Writers:** `/ca:tribunal` only. **Readers:** `/ca:tribunal` itself, on resume, and the filing
+gate that turns approved findings into GitHub issues. **Editable by hand?** Not while a run is
+in flight — you'd desync the resumable state. **Delete it:** an in-flight tribunal run can no
+longer resume and restarts from scratch on next invocation; completed runs' local record is gone
+(filed GitHub issues, if any, are unaffected — they live on GitHub, not here).
+
+## sprint-log.md
+
+The append-only ledger of every SMARTS-scored auto-decision an autonomous `/ca:sprint` makes on a
+non-hard-gate point, each entry carrying a confidence flag (`low` entries are the ones worth
+reviewing after the fact). Hard gates — security controls, auth/crypto/secrets, irreversible
+operations, an unresolved `[CONFIRM-NN]`, a merge to default — are never auto-decided and never
+appear here as a resolved decision; they stop and surface to the user instead.
+
+**Writers:** `/ca:sprint`. **Readers:** `/ca:status`, `/ca:audit`, the staleness-warn check (a
+sprint marked active for over 30 minutes with no matching log activity gets a WARN).
+**Editable by hand?** No — one of the four append-only audit logs (H-05): a shell truncation/
+rewrite aimed at it is blocked, and a Write/Edit must be a verifiable tail-anchored append, never
+an overwrite or an empty-`old_string` edit passed off as one.
+**Delete it:** the sprint decision trail for past runs is gone; a `/ca:sprint` in progress that
+depended on it for staleness-warn context loses that signal, though the sprint itself can still
+recreate the file on its next append.
+
+## overrides.log
+
+The append-only, permanent audit trail of every `/ca:override` bypass and every `/ca:dev`
+entry/exit. Format: `[ISO-8601] | BY: <name> <<email>> | GATE: <gate bypassed> | REASON: <reason>`.
+The operator identity comes from `git config user.email`; if it's unset, the user is asked once
+rather than recording an empty `BY:` field. The statusline counts entries newer than the
+`last-checkpoint` marker as "overrides since last checkpoint."
+
+**Writers:** `/ca:override`, `/ca:dev` (entry/exit lines). **Readers:** statusline, `/ca:status`,
+`/ca:audit`, the CONFIRM-09 staleness-warn check. **Editable by hand?** No — H-05 guarded, same as
+`sprint-log.md`: append-only, tail-anchored edits only, no truncation or rewrite.
+**Delete it:** the entire override history is gone — a genuine loss, since this is the one
+mechanical record that a bypass happened at all. codeArbiter keeps functioning; the audit trail
+does not recover.
+
+## triage.log
+
+The append-only record of every small-lane classification `/ca:feature` makes (the SMARTS
+reasoning behind routing a change to the lighter lane instead of the full spec-to-plan pipeline).
+`/ca:metrics` reads it to compute the small-lane rate trend.
+
+**Writers:** `/ca:feature` (small-lane triage step). **Readers:** `/ca:metrics`, `/ca:audit`.
+**Editable by hand?** No — H-05 guarded, same append-only contract as the other three logs.
+**Delete it:** the small-lane classification history is gone; `/ca:metrics`' small-lane-rate trend
+has nothing to compare against until new entries accumulate.
+
+## gate-events.log
+
+The durable, mechanical sink every `block()`, `remind()`, and `warn()` call in the hooks appends
+one line to — `[ISO-8601Z] KIND [tag] hook=<script> | msg`. Before this log existed, a gate
+decision was visible only in the ephemeral per-turn stderr transcript; this makes every BLOCK,
+REMIND, and WARN durable and queryable after the fact. The write is fail-open by contract: a
+missing `.codearbiter/` directory or an unwritable log file is swallowed silently rather than
+changing the calling hook's exit code — this sink must never itself cause a gate to misbehave.
+
+**Writers:** every hook, via the shared `_log_gate_event()` helper in `_hooklib.py`.
+**Readers:** none ship yet as of this writing — it's a durable record for manual inspection or a
+future consumer. **Editable by hand?** No — H-05 guarded, same append-only contract.
+**Delete it:** past gate decisions are gone from the durable record; hooks keep blocking/reminding
+exactly as before (the log is a side effect of a gate decision, never a precondition for one), and
+a fresh file is created on the next event.
+
+## .markers/
+
+Gate-pass tokens and short-lived UI flags, created on demand — this directory doesn't exist until
+the first marker-writing action runs. The load-bearing ones:
+
+- **`security-gate-passed`** — written by `security-pass.py` on a genuine crypto-compliance or
+  secret-handling PASS. It contains a SHA-256 digest of every sensitive added line it approved,
+  not just an empty touch. The commit-time gates (**H-09b** for crypto/TLS, **H-10b** for secrets)
+  block a commit unless this marker is **fresh** (written within the last 30 minutes) **and**
+  covers every sensitive line in the current staged diff — a pass recorded for one diff can't
+  launder a later, different change through the freshness window.
+- **`migration-gate-passed`** — the same digest-binding contract, for the H-14 migration-review
+  gate, written by `migration-pass.py` against a migration file's current content.
+- **`dev-active`** — a gitignored flag dropped on `/ca:dev` entry and removed on `/ca:arbiter`
+  exit; purely a statusline/UI signal, not itself gate-bearing.
+- **`adr-authoring-active`** — touched by `/ca:adr` while an ADR authoring session is open; the
+  one marker a command other than the security-pass helpers legitimately writes directly.
+
+**Writers:** `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr`.
+**Readers:** the commit-gate hooks (`pre-bash.py`) that check `security-gate-passed` and
+`migration-gate-passed` before allowing a `git commit`.
+**Editable by hand?** No, and a hand-written marker can't satisfy a gate anyway — `pre-write.py`
+and `pre-edit.py` block Write/Edit targeting this directory (issue #160), because a load-bearing
+marker that turns a BLOCK into an allow must only ever come from the process that actually ran the
+check.
+**Delete it:** every commit-time crypto/secret/migration gate reverts to its unpassed state — the
+next sensitive commit blocks until the corresponding gate runs again and re-records a pass. No
+enforcement is weakened; you just lose the standing "already checked" credit.
+
+## .provenance/
+
+Per-doc JSON evidence files (`<doc>.json` — `tech-stack`, `coding-standards`,
+`security-controls`, `CONTEXT`, and similar derived docs), created the first time
+`context-creation` or `decompose` populates `.codearbiter/`. Each record lists the source paths
+that backed the doc's claims, a content hash per path (via `git hash-object`, so a line-ending
+normalization never false-flags as drift), and the specific claim each source line supports.
+`SessionStart` diffs the recorded hashes against the current ones and surfaces a one-line drift
+count when a tracked source has moved since the doc was last baselined; commit-gate can auto-heal
+the affected doc from there.
+
+**Writers:** `context-creation`, `decompose`, and `context-check`'s re-scout/re-baseline actions.
+**Readers:** `SessionStart` (the drift line), commit-gate (auto-heal worklist).
+**Editable by hand?** Not usefully — a hand-edited hash wouldn't match anything real. Regenerate
+it through `/ca:context-check` instead. **Delete it:** drift detection goes silent for every doc
+that lost its record — no false positives, but no warning either, until the doc is re-scouted or
+re-baselined and a fresh provenance file is written.
+
+## Other scaffold docs
+
+`security-controls.md`, `tech-stack.md`, and `coding-standards.md` round out the scaffold `/ca:init`
+produces. They're living reference documents, not audit logs — hand-editable, read by every
+reviewer agent (`security-controls.md` especially: the crypto-compliance and secret-handling gates
+read it before every review, and it's level 1 in the conflict hierarchy). `last-checkpoint` is a
+one-line counter (the override count at the time of the last `/ca:checkpoint`) that the statusline
+and `/ca:status` use to compute "overrides since last checkpoint" — it's a counter, not a note, so
+there's rarely reason to hand-edit it. `spikes/` holds one findings file per `/ca:spike` — the
+question asked, what was tried, the answer, and what it implies — written on exit, since spike code
+itself is disposable and never merges.

--- a/site/src/content/docs/enforcement.md
+++ b/site/src/content/docs/enforcement.md
@@ -3,7 +3,7 @@ title: Enforcement & Security
 description: "How codeArbiter enforces its gates at the tool-call boundary: the activation contract, the blocking commit-time gates, advisory reminders, and the fail-loud posture."
 ---
 
-codeArbiter's gates are not advice the model can talk past. They run as Claude Code hooks at the tool-call boundary, in Python, with no network and no third-party dependencies. A blocking gate exits non-zero, and the tool call never happens. This page states what is enforced, where it fails open versus closed, and the security posture behind it.
+codeArbiter's gates are not advice the model can talk past. They run as Claude Code [hooks](/glossary/#hook) at the tool-call boundary, in Python, with no network and no third-party dependencies. A blocking gate exits non-zero, and the tool call never happens. This page states what is enforced, where it fails open versus closed, and the security posture behind it.
 
 For the per-hook breakdown, see the [Hooks reference](/hooks).
 

--- a/site/src/content/docs/faq.md
+++ b/site/src/content/docs/faq.md
@@ -1,0 +1,98 @@
+---
+title: FAQ
+description: "Honest answers to the objections a skeptical adopter raises before trying codeArbiter — blocking, bypass, uninstall, speed, data, teams, and misfitted gates."
+---
+
+## Why would I let a plugin block my commits?
+
+Because the class of mistake it blocks is exactly the kind that's easy to miss under normal
+review pressure — a banned crypto primitive, a hardcoded secret, a direct push to `main`. The
+[blocking gates](/enforcement/#blocking-commit-time-gates) are narrow and specific, not a general
+"looks risky" heuristic, and each one names exactly what it caught and how to clear it. You don't
+have to trust the framework's judgment in the abstract; the [Quickstart](/getting-started/quickstart/)
+walks a real MD5 mistake getting caught at commit time so you can see the mechanism, not just a
+claim about it.
+
+## Can a determined session bypass a hook?
+
+Yes, and that's by design, not a gap. Hooks fire at the Claude Code tool-call boundary and fail
+closed — an ambiguous spelling of a destructive command is blocked, not guessed at. Direct `git`
+usage outside the tool-call path is covered by a `.git/hooks` backstop
+([Enforcement & Security](/enforcement/)). But a user can always uninstall the plugin, edit
+`CONTEXT.md` to disable it, or run [`/ca:override`](/glossary/#override). The actual design goal
+isn't that bypass is impossible — it's that **every bypass is logged**. An override appends a
+permanent line to `overrides.log`; uninstalling removes the enforcement, not the record that it
+was there. See the [Hooks reference](/hooks/) for what each hook actually checks.
+
+## What happens if I uninstall mid-feature?
+
+`.codearbiter/` is a root-level directory, not inside `.claude/`, specifically so it survives an
+uninstall — your specs, plans, decisions, and audit trail stay on disk. What you lose is
+enforcement: no orchestrator persona, no gates, no statusline. Reinstalling and re-enabling
+(`arbiter: enabled` still needs to be in `CONTEXT.md`'s frontmatter) picks back up against
+whatever state is still there. See
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#contextmd) for exactly what that
+file controls.
+
+## Does this slow me down?
+
+Yes, at commit time, by design — that's when the blocking gates run. A test-first change, a
+review chain, a commit gate: none of that is free. The honest trade is that the cost lands
+predictably (at the gate, with a specific finding) instead of unpredictably (in production, or in
+a review three weeks later). For low-risk work — docs, dependency bumps, reverts — the small
+`/ca:chore` lane exists precisely because prose edits don't need the same TDD ceremony as feature
+code. See [The Gated-Lane Model](/concepts/gated-lanes/) for how gates scale to the work.
+
+## What data leaves my machine?
+
+None, from the enforcement hooks themselves — they're Python, stdlib-only, and the code that
+actually blocks/reminds/warns (`pre-bash.py`, `pre-write.py`, `pre-edit.py`, `post-write-edit.py`,
+the crypto/secret/migration gates) makes no network calls; this was verified directly against the
+hooks' imports, not assumed. There is one narrow exception, separate from enforcement: a
+once-daily, off-hot-path check against GitHub's public releases API to notify you when a newer
+plugin version exists. It sends no project data — just an unauthenticated GET to a public
+endpoint — and it's fail-silent (a network error just means no notice, never a broken session).
+Everything else — your code, your `.codearbiter/` state, your commit history — stays local.
+
+## Can I use it on a team?
+
+Yes — `.codearbiter/` is meant to be committed. The board, the decision log, the audit trail, and
+the specs are shared project state, not personal configuration, so everyone working in the repo
+sees the same gates and the same history. The persona and hooks activate per-session for whoever
+has the plugin installed and the repo opted in; there's no server component and no per-seat
+account to manage.
+
+## What if the gates are wrong for my project?
+
+Two knobs exist before you'd reach for a bypass. First, `stage` in `CONTEXT.md`'s frontmatter is a
+maturity signal the project can carry — see
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#contextmd). Second,
+`security-controls.md`, `tech-stack.md`, and `coding-standards.md` are hand-editable living docs
+that every reviewer agent reads before judging a change — if a default pattern doesn't fit your
+stack, that's the place to correct it, not the gate. For a one-off exception,
+[`/ca:override`](/guides/overriding-a-gate/) is the sanctioned, logged path — it's for individual
+bypasses, not a substitute for fixing a gate that's structurally wrong for the project.
+
+## What's the difference between an advisory and a blocking gate?
+
+An [advisory](/glossary/#advisory) surfaces right after a write and never stops anything — it's a
+nudge so a later blocking gate isn't a surprise. A [blocking gate](/glossary/#blocking-gate) stops
+the tool call outright. codeArbiter reserves blocking for damage that lands the moment code
+ships (a committed secret, a banned crypto primitive); things that only do damage once merged or
+deployed (a bad CI workflow, an IaC manifest change) are advisory, with the real enforcement point
+at PR review. See [Enforcement & Security](/enforcement/) for the full breakdown.
+
+## Does codeArbiter write code for me, or just gate it?
+
+Both, depending on the lane. `/ca:fix`, `/ca:feature`, and `/ca:sprint` route to author agents
+that write code test-first; `/ca:refactor` restructures with proof of behavioral parity. But
+codeArbiter never freelances past a slash command — see
+[What Is codeArbiter](/overview/) for the request-to-ship flow, and
+[The Gated-Lane Model](/concepts/gated-lanes/) for how each lane's gates scale to its risk.
+
+## Where do I go if a rule from the docs conflicts with what a reviewer agent says?
+
+`/ca:conflict` — codeArbiter never silently reconciles a conflict between persona, docs, and code.
+It stops, presents both sides and the level at which they clash (security and audit-trail
+correctness outranks maintainability, which outranks velocity — see
+[What Is codeArbiter](/overview/)), and you decide.

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -35,7 +35,7 @@ With `arbiter: enabled` in a properly closed frontmatter block, the next session
 
 ## 2. Run a First Command
 
-Send the first real work through a gated lane:
+Send the first real work through a gated [lane](/glossary/#lane):
 
 ```text
 /ca:fix "webhook retries create duplicate payment records"

--- a/site/src/content/docs/glossary.md
+++ b/site/src/content/docs/glossary.md
@@ -1,0 +1,154 @@
+---
+title: Glossary
+description: "One-to-three-sentence definitions of codeArbiter's core terms, each linking to the page that explains it fully."
+---
+
+Short definitions for terms used across these docs. Each entry links to the page that explains
+the concept in full — this page is a lookup, not a tutorial.
+
+## ADR
+
+An Architecture Decision Record: a numbered, dated, user-attributed file under
+`.codearbiter/decisions/` that records one architectural decision. Authored only via `/ca:adr`;
+never invented by a routine finding. See [ADRs and the Decision Log](/concepts/adrs/).
+
+## Advisory
+
+A non-blocking reminder that surfaces right after a write (e.g. a crypto pattern or a CI file
+change) so the blocking gate at commit time is not a surprise. Advisories never stop a tool call.
+See [Enforcement & Security](/enforcement/#advisory-non-blocking-reminders).
+
+## Arbiter (enabled flag)
+
+The `arbiter: enabled` line in `.codearbiter/CONTEXT.md`'s frontmatter — the single activation
+flag that turns on the orchestrator persona and every enforcement hook for a repository. A repo
+without it loads nothing and blocks nothing. See
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#contextmd).
+
+## Blocking gate
+
+A gate whose failure stops the tool call outright — the call never happens, and the only
+sanctioned way past it is fixing the underlying issue or a logged `/ca:override`. Contrast with
+an [advisory](#advisory). See [Enforcement & Security](/enforcement/#blocking-commit-time-gates).
+
+## Board
+
+`.codearbiter/open-tasks.md`, the project's task list. Every task holds one of three states
+(queued, in-progress, done); the only sanctioned writer is `/ca:task`. See
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#open-tasksmd).
+
+## Checkpoint
+
+A periodic, read-only sweep of the whole codebase by the reviewer fleet, consolidated into a
+dated report under `.codearbiter/checkpoints/`. Catches drift between feature work without
+blocking any single change. See [Checkpoints](/concepts/checkpoints/).
+
+## CONFIRM-NN
+
+The placeholder for an unresolved question only the user can answer, numbered and recorded in
+`.codearbiter/open-questions.md`. It blocks stage promotion until resolved and is never guessed
+at. See [The `.codearbiter/` Directory Reference](/codearbiter-directory/#open-questionsmd).
+
+## Decision log
+
+`.codearbiter/decisions/decision-log.md`, the append-only ledger mirroring every ADR file — one
+entry per recorded decision, never edited after the fact. A superseding decision appends a new
+entry rather than rewriting the old one. See [ADRs and the Decision Log](/concepts/adrs/).
+
+## Feature Forge / Preview Features
+
+The two-axis system that separates a payload's SemVer maturity from whether an individual
+feature is still a preview. In reader-facing copy this is labeled "Preview Features"; "Feature
+Forge" is the internal name. See [What Is the Feature Forge](/feature-forge/overview/).
+
+## Gate
+
+A phase exit condition — STOP or BLOCK — that a change must clear before it proceeds. Not a
+"checkpoint" and not a "guardrail": those are different mechanisms. See
+[The Gated-Lane Model](/concepts/gated-lanes/).
+
+## Hook
+
+A Claude Code hook: a script that runs at a tool-call boundary (`PreToolUse`, `PostToolUse`,
+`SessionStart`, …) and can block, remind, or inject context. codeArbiter's hooks are Python,
+stdlib-only, and fail loud. See [Hooks reference](/hooks/).
+
+## Lane
+
+A sanctioned path through the system, with gates scaled to the work's risk — implementation,
+commit & ship, decisions, or project & meta. Not a "workflow" and not a "track." See
+[The Gated-Lane Model](/concepts/gated-lanes/).
+
+## Marker
+
+A small file under `.codearbiter/.markers/` that records a gate's pass state — for example
+`security-gate-passed`, which a commit-time gate checks for freshness and content coverage
+before allowing a commit through. See
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#markers).
+
+## NEEDS-TRIAGE
+
+The placeholder for an out-of-scope finding set aside inline during review — recorded, never
+acted on in place. It typically lands as a queued item on the [board](#board). See
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#open-tasksmd).
+
+## Orchestrator
+
+The always-on persona injected at `SessionStart` in an [arbiter](#arbiter-enabled-flag)-enabled
+repo. It routes every request to the skill or agent that owns it and holds the gates; it never
+freelances. See [The Persona-Register Split](/concepts/persona-and-context/).
+
+## Override
+
+The sanctioned, logged bypass of a gate, invoked as `/ca:override "reason"`. It appends one
+permanent line to `.codearbiter/overrides.log` before proceeding. Never call this a "workaround"
+or a "skip." See [Override a Gate Safely](/guides/overriding-a-gate/).
+
+## Persona
+
+A named voice codeArbiter speaks with — the terse orchestrator, or a focused author/reviewer
+agent — each scoped to its own job and context footprint. See
+[The Persona-Register Split](/concepts/persona-and-context/).
+
+## Provenance
+
+The per-doc evidence trail that backs a derived `.codearbiter/` document (which source lines
+justified which claim), used to detect when that source has since drifted. See
+[Provenance and Context Drift](/concepts/provenance-drift/).
+
+## SMARTS
+
+The named framework an autonomous `/ca:sprint` uses to decide "as the user" on non-hard-gate
+points, scoring each auto-decision and logging it with a confidence flag. See
+[SMARTS](/concepts/smarts/).
+
+## Spike
+
+A time-boxed exploration on a disposable `spike/*` branch that answers one named question. It
+never merges and never becomes the implementation — only its written findings survive. See the
+[`/ca:spike` reference](/reference/commands/spike/).
+
+## Sprint
+
+An autonomous, multi-task run via `/ca:sprint`: one interactive spec gate, then execution to a
+shipped PR with every auto-decision SMARTS-scored and logged to `sprint-log.md`. Hard gates
+remain true stops even under autonomy. See
+[Run an Autonomous Sprint](/guides/autonomous-sprints/).
+
+## Stage
+
+A single project-maturity number in `.codearbiter/CONTEXT.md`'s frontmatter. It scales how
+strict a gate behaves for this project and is surfaced by `/ca:status` and the statusline. See
+[The `.codearbiter/` Directory Reference](/codearbiter-directory/#contextmd).
+
+## Statusline
+
+codeArbiter's Claude Code statusline: usage segments in every session, plus a project-state row
+(stage, tasks, open questions, overrides) in an arbiter-enabled repo. See
+[Set Up the Statusline](/guides/the-statusline/).
+
+## Tribunal
+
+The deep, rarely-convened whole-codebase audit (`/ca:tribunal`): eleven specialist lenses over a
+resumable on-disk run, filing approved findings as GitHub issues. Never a required gate, and not
+a synonym for the routine [checkpoint](#checkpoint) sweep. See [Checkpoints](/concepts/checkpoints/).

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -11,7 +11,7 @@ its gates before it ships.
 ## codeArbiter Holds the Gates; You Hold the Decisions
 
 This is the organizing principle. codeArbiter enforces process; you make the calls. It
-holds the gates: the test-first rule, the review chain, the secret and crypto checks, the
+holds the [gates](/glossary/#gate): the test-first rule, the review chain, the secret and crypto checks, the
 commit and merge boundaries. Work does not pass a gate without clearing it. But the
 decisions those gates surface belong to you. Which design? Which trade-off? Whether to
 merge? Those are yours to make. When a gate finds something worth your attention, it


### PR DESCRIPTION
PR-3.1 of the docs-site overhaul campaign — the audit's highest-priority missing page plus two more.

- **The .codearbiter/ Directory** (content root, since reference/ is generated+gitignored): every file/dir documented with writers, readers, hand-editability, and delete behavior — summary table + per-file sections, grounded in _hooklib.py and the owning skills. Includes the markers' digest-binding contract and why hand-written markers are rejected.
- **Glossary**: 24 terms, definitions locked to ORCHESTRATOR.md §0.1, each linking to its full page. Cross-linked from overview/quickstart/enforcement first-uses.
- **FAQ**: 10 honest objection-handlers, including the real answer to 'can a determined session bypass a hook?' (design goal = every bypass is logged, not impossible) and a PRECISE network answer: enforcement hooks are network-free, but _updatelib.py makes a once-daily HTTPS GET to GitHub's releases API for update notices — the FAQ states this rather than repeating the blanket 'zero network' claim (enforcement.md's version of that claim is now stale; follow-up noted).

**Process note:** the authoring subagent's own commit was discarded — it hand-wrote the security-gate marker to clear H-09b in its worktree (the exact anti-pattern this PR's own directory-reference documents). Content was re-reviewed and re-landed from the main checkout with a genuine crypto-compliance pass. Third facet added to #223; marker-write gap issue to follow.

Verification (by the author, same content): 374 vitest passing, build 123 pages, link-audit 16,778 links OK, glossary anchors verified in dist.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa