### PR TITLE
docs(site): uninstall guide, compatibility matrix, generated on-site changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ site/*.log
 site/src/content/docs/reference/
 site/src/generated/
 
+# On-site changelog — regenerated from the repo-root CHANGELOG.md by `npm run gen`
+# (render-changelog.ts). Same never-committed discipline as reference/ above.
+site/src/content/docs/changelog.md
+
 # Farm dispatcher runtime artifacts — worktrees, reports, integration branch staging.
 # Written per-run in any project using codeArbiter. Never committed to the plugin repo.
 .farm/

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig({
             { label: "Install", slug: "getting-started/install" },
             { label: "Quickstart", slug: "getting-started/quickstart" },
             { label: "What Is codeArbiter", slug: "overview" },
+            { label: "Compatibility", slug: "getting-started/compatibility" },
           ],
         },
         {
@@ -134,6 +135,7 @@ export default defineConfig({
             { label: "Override a Gate Safely", slug: "guides/overriding-a-gate" },
             { label: "Cut a Release", slug: "guides/releasing-a-version" },
             { label: "Troubleshooting", slug: "guides/troubleshooting" },
+            { label: "Uninstall & Disable", slug: "guides/uninstalling" },
           ],
         },
         {
@@ -175,6 +177,7 @@ export default defineConfig({
           items: [
             { label: "All Reference", slug: "reference" },
             { label: "Hook Gates", slug: "reference/hooks-gates" },
+            { label: "Changelog", slug: "changelog" },
             ...referenceGroups,
           ],
         },

--- a/site/scripts/gen.ts
+++ b/site/scripts/gen.ts
@@ -6,6 +6,7 @@ import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { generate } from "./generator/generate";
 import { extractHookGates } from "./generator/extract-hook-gates";
 import { renderHooksReference, buildEventMap, type HooksJson } from "./generator/render-hooks-reference";
+import { renderChangelog } from "./generator/render-changelog";
 
 const here = dirname(fileURLToPath(import.meta.url)); // site/scripts
 const repoRoot = resolve(here, "..", ".."); // -> repo root
@@ -54,4 +55,18 @@ if (skipped.length > 0) {
   for (const s of skipped) {
     console.log(`  skipped (non-literal tag): ${s.file}:${s.line}`);
   }
+}
+
+// On-site changelog (docs-site-overhaul spec, decision f): the repo-root
+// CHANGELOG.md is the single source of truth for release history — this emits
+// a Starlight-ready copy rather than duplicating it by hand. Gitignored output,
+// same discipline as reference/.
+const changelogSourcePath = join(repoRoot, "CHANGELOG.md");
+const changelogOutPath = join(here, "..", "src", "content", "docs", "changelog.md");
+if (existsSync(changelogSourcePath)) {
+  const changelogSource = readFileSync(changelogSourcePath, "utf-8");
+  writeFileSync(changelogOutPath, renderChangelog(changelogSource));
+  console.log(`Generated changelog -> ${changelogOutPath}`);
+} else {
+  console.log(`Skipped changelog generation: ${changelogSourcePath} not found`);
 }

--- a/site/scripts/generator/render-changelog.ts
+++ b/site/scripts/generator/render-changelog.ts
@@ -1,0 +1,62 @@
+/** render-changelog.ts — renders the repo-root `CHANGELOG.md` into the
+ * gitignored `site/src/content/docs/changelog.md` at gen time (docs-site-overhaul
+ * spec, decision f).
+ *
+ * The source file carries its own `# Changelog` H1 and a short preamble above
+ * the first version heading; Starlight pages get their title from frontmatter,
+ * so both are stripped here to avoid a duplicate `<h1>`. Every `## [X.Y.Z]`
+ * version heading and its body is passed through unchanged — this is a
+ * generated verbatim layer, not a rewrite.
+ */
+import { yamlDescriptionLine } from "./yaml-quote";
+
+const DESCRIPTION =
+  "Every released version of codeArbiter, generated from the repository's own CHANGELOG.md.";
+
+const REPO_URL = "https://github.com/arbiterForge/codeArbiter";
+
+/** CHANGELOG.md links to PRs with a repo-root-relative `../../pull/NN` path — correct
+ * when GitHub renders the file at the repo root, but meaningless once the same
+ * markdown is rendered as a site page at `/changelog/` (it resolves relative to
+ * the page URL, lands outside the site's base path, and fails the link audit).
+ * Rewrite every such link to the absolute GitHub PR URL. */
+function absolutizePullLinks(source: string): string {
+  return source.replace(/\]\(\.\.\/\.\.\/pull\/(\d+)\)/g, `](${REPO_URL}/pull/$1)`);
+}
+
+/** The first `## [` version heading marks the start of real changelog content;
+ * everything above it (the `# Changelog` H1 and any preamble prose) is
+ * Starlight-page scaffolding this renderer replaces with frontmatter, so it is
+ * dropped. Returns the H1/preamble-free remainder unchanged. */
+function stripHeadingAndPreamble(source: string): string {
+  const match = /^##\s*\[/m.exec(source);
+  if (!match) return source.trim();
+  return source.slice(match.index).trimEnd();
+}
+
+/**
+ * Render `site/src/content/docs/changelog.md` from the raw contents of the
+ * repo-root `CHANGELOG.md`.
+ *
+ * Idempotent: rendering the same `changelogSource` twice produces byte-identical
+ * output, since this is a pure function of its input with no mutable state.
+ */
+export function renderChangelog(changelogSource: string): string {
+  const body = absolutizePullLinks(stripHeadingAndPreamble(changelogSource));
+  const frontmatterLines = [
+    "---",
+    "title: Changelog",
+    yamlDescriptionLine(DESCRIPTION),
+    "---",
+  ].filter((line) => line !== "");
+
+  return (
+    frontmatterLines.join("\n") +
+    "\n\n" +
+    "Every released version of codeArbiter. See the " +
+    "[GitHub Releases page](https://github.com/arbiterForge/codeArbiter/releases) " +
+    "for the same history with release assets.\n\n" +
+    body +
+    "\n"
+  );
+}

--- a/site/src/content/docs/getting-started/compatibility.md
+++ b/site/src/content/docs/getting-started/compatibility.md
@@ -1,0 +1,65 @@
+---
+title: Compatibility
+description: "Platform, interpreter, and dependency requirements for codeArbiter: what the plugin itself needs, versus what's only required to develop the docs site."
+---
+
+codeArbiter's requirements are deliberately narrow: Claude Code, and a Python interpreter on `PATH`.
+Nothing else.
+
+## Requirements Matrix
+
+| Requirement | What's needed | Notes |
+|---|---|---|
+| **Claude Code** | Any version with plugin support | `plugin.json` states no explicit minimum version; the plugin uses standard hook events (`SessionStart`, `PreToolUse`, `PostToolUse`) and the plugin/marketplace install commands documented in [Install](/getting-started/install/). |
+| **Python** | Python 3, stdlib only, resolvable as `python3` **or** `python` on `PATH` | Every hook is registered twice in `hooks.json` — once under `python3`, once under a `python3 -c "" \|\| python` fallback — so it runs on a machine where only `python` resolves. No third-party Python packages are ever installed or imported (ADR-0004: database-free, stdlib-only architecture). |
+| **Operating system** | Windows, macOS, or Linux | Hooks are pure Python stdlib and carry no OS-specific code path beyond the interpreter-name fallback above. The `.git/hooks` backstop shim is a POSIX `sh` script; on Windows this runs under Git for Windows' bundled `sh.exe`, which ships with every standard Git install. |
+| **git** | Any reasonably current git | Required regardless of codeArbiter — the plugin reads repo state (`git config user.email`, branch, diff) via subprocess calls to your existing `git` binary, and installs the `.git/hooks` backstop through it. |
+| **Node.js** | Not required for the plugin | Node is only needed to build or develop **this documentation site** (`site/`) and the optional pluggable-execution-farm TypeScript dispatcher (`plugins/ca/tools/`) if you use `/ca:sprint --farm`. Neither is a runtime dependency of the enforcement hooks themselves. |
+| **Network access** | Not required for enforcement | See [Network Calls](#network-calls) below — the gate-enforcement hook chain makes zero network calls; two clearly-scoped, opt-in-by-default exceptions exist outside that chain. |
+
+## Prerequisites Checklist
+
+Confirm both before installing, per [Install](/getting-started/install/):
+
+- **Python 3 on `PATH`.** Without it, the gates and the session-startup injection silently do not
+  run — <kbd>/ca:doctor</kbd> catches this as an interpreter-resolution failure.
+- **`git config user.email` set.** Overrides and ADRs are attributed to this identity; an unset email
+  is asked for once, interactively, rather than silently defaulting.
+
+## Network Calls
+
+Grepping every file under `plugins/ca/hooks/` for network-capable stdlib usage (`urllib`, `http.client`,
+`socket`) turns up exactly one file that actually opens a connection: `_updatelib.py`. (`_ledgerlib.py`
+matches a naive text search only because it uses the English word "requests" to mean tool-call
+records — it imports nothing network-capable.)
+
+- **The gate-enforcement hooks** — `pre-bash.py`, `pre-write.py`, `pre-edit.py`, `pre-read.py`,
+  `post-write-edit.py`, and `session-start.py`'s activation/briefing logic — make **zero** network
+  calls. Every check is a local file read, a local `git` subprocess call against your own repo, or an
+  in-process regex/parse. This is the enforcement chain compatibility and security actually depend on.
+- **The update-available notifier** (`_updatelib.py`) is a separate, non-blocking mechanism: a
+  best-effort, once-a-day, fail-silent, unauthenticated HTTPS `GET` against GitHub's public Releases
+  API (`api.github.com`), run as a **detached background process** off the `SessionStart` hot path so
+  a slow or unreachable network never delays a session. It only ever displays a one-line notice; it
+  never applies an update. This ships on by default but is easy to make fully offline — see
+  [Staying up to date](https://github.com/arbiterForge/codeArbiter#staying-up-to-date) in the project
+  README for the opt-out.
+- **The pluggable execution farm** (`/ca:sprint --farm`, opt-in, requires `FARM_API_KEY`) sends
+  byte-capped, secret-redacted task context to an OpenAI-compatible HTTP provider you configure. This
+  is a separate, explicitly opt-in feature, not part of the gate chain, and inert unless you pass
+  `--farm`.
+
+No hook writes anything off your machine as a side effect of enforcement. `docs/hooks.md` documents the
+same invariant per-hook, plus the one local, read-only `git fetch` `session-start.py` runs in the
+background against your own configured remote (the repo-hygiene briefing).
+
+## Third-Party Dependencies
+
+Zero, for the plugin itself. `plugins/ca/hooks/*.py` import only the Python standard library — no
+`pip install`, no `requirements.txt`, no compiled binaries (ADR-0004). The one TypeScript toolchain in
+the repo, `plugins/ca/tools/` (the farm dispatcher), carries its own `devDependencies` for its own
+build and test — those are irrelevant to whether the enforcement hooks run, since the hooks never
+import from that package.
+
+The docs site (`site/`) has its own, larger `package.json` (Astro, Starlight, vitest) — that's a
+dependency surface for **building this website**, never for using the plugin.

--- a/site/src/content/docs/guides/uninstalling.md
+++ b/site/src/content/docs/guides/uninstalling.md
@@ -1,0 +1,165 @@
+---
+title: "Uninstall & Disable"
+description: "How to turn codeArbiter off in one repository, or remove it entirely: the activation flag, the plugin uninstall command, the statusline, and the git-hooks backstop."
+---
+
+codeArbiter's pitch is enforcement, so it documents the exit. This page covers three levels: turning
+it off in one repository, removing it globally, and what to check before uninstalling mid-feature.
+
+## Disable in One Repository
+
+Enforcement in a repository is controlled by a single flag: `arbiter: enabled` in `.codearbiter/CONTEXT.md`
+frontmatter. Every enforcement hook checks that flag through `arbiter_active()` and exits immediately,
+without running any gate logic, when it is absent or set to anything other than `enabled`. Turning it
+off makes the plugin genuinely dormant in that repository — the orchestrator persona never loads, and
+every `PreToolUse`/`PreToolUse`-guarded hook returns before doing anything.
+
+The flag is deliberately hard to flip from inside a session, by design. **H-18** blocks a shell
+redirect, `Write`, or `Edit` that would change `arbiter: enabled` to `arbiter: disabled` (or otherwise
+corrupt the frontmatter) through `.codearbiter/CONTEXT.md` — the gates cannot silence themselves from
+inside the repo they govern. Reads (`cat`, `grep`) still pass through untouched.
+
+Unlike the crypto/secret and migration gates (H-09b/H-10b, H-14), H-18 has no marker-based bypass that
+`/ca:override` can unlock. Its block calls in `pre-bash.py`, `pre-write.py`, and `pre-edit.py` are
+unconditional — there is no override flag the hook code checks. Running `/ca:override` first does not
+make the block go away; the hook still fires on the next Bash/Write/Edit call that touches
+`CONTEXT.md`. That's deliberate: the block exists precisely so a session cannot talk itself past it.
+
+The honest, sanctioned path is to make the edit through a channel H-18 doesn't intercept, because it
+only subscribes to Claude Code's own `PreToolUse` hook on the Bash, Write, and Edit tools:
+
+1. Close or step outside the active Claude Code session for that repo (or use a different terminal /
+   editor entirely — a plain text editor, `vim`, VS Code, a shell outside Claude Code's Bash tool).
+2. Edit `.codearbiter/CONTEXT.md` directly and change the frontmatter line to:
+
+   ```yaml
+   ---
+   arbiter: disabled
+   ---
+   ```
+
+3. Log the change for the audit trail, the same way any other gate exception is recorded, by running
+   `/ca:override "disabling codeArbiter for this repository"` in a session **after** the edit (or
+   before — the log entry and the edit are independent; only the edit itself needs to happen outside
+   the tool-mediated path). This keeps `.codearbiter/overrides.log` an honest record of the change even
+   though the hook itself never granted permission.
+4. Verify: open a new Claude Code session in the repo. No orchestrator persona loads, the statusline's
+   arbiter row (stage · tasks · questions · overrides) does not render, and any tool call proceeds
+   without a gate check.
+
+There is no hidden bypass inside a session, and this page will not pretend there is one — H-18 guards
+exactly the tool flanks Claude Code mediates, and an edit outside those tools was never something it
+could stop.
+
+Re-enabling is the same edit in reverse (`arbiter: disabled` → `arbiter: enabled`), no override
+required — H-18 only blocks disabling the switch, not re-enabling it.
+
+## Full Uninstall
+
+Removing codeArbiter entirely has four independent pieces. Do them in this order.
+
+### 1. Uninstall the Plugin
+
+```sh
+claude plugin uninstall ca
+```
+
+This removes the plugin payload (hooks, commands, agents, skills) from Claude Code's plugin cache.
+Hooks, commands, and the statusline wiring stop loading from the next session onward. `claude plugin
+update` is **not** sufficient for a full removal — it can leave a stale cached payload behind when the
+marketplace version string hasn't changed; `uninstall` is the clean path.
+
+You can also manage the marketplace entry (`codearbiter`) itself — added at install time with
+`/plugin marketplace add arbiterForge/codeArbiter` — through the `/plugin` command's interactive
+marketplace management screen in any Claude Code session, if you want it gone too.
+
+### 2. Decide What Happens to `.codearbiter/`
+
+Uninstalling the plugin does **not** touch `.codearbiter/` in any repository. That directory is your
+repo's state — specs, plans, ADRs, the decision log, tribunal reports, and the append-only overrides
+audit trail — and it survives the plugin by design, the same way it's meant to survive a plugin update.
+Deleting it is a separate, deliberate act:
+
+```text
+rm -rf .codearbiter/
+```
+
+Consider whether the audit trail in `.codearbiter/overrides.log` and `.codearbiter/decisions/` has
+value to keep even after you stop using the plugin day to day — it's a plain-file record, readable
+without codeArbiter installed.
+
+### 3. Remove the Statusline
+
+If you wired the statusline with <kbd>/ca:statusline</kbd>, remove it **before** uninstalling the
+plugin (the command needs the plugin's `wire-statusline.py` to run):
+
+```text
+/ca:statusline uninstall
+```
+
+This restores whatever `statusLine.command` was in `~/.claude/settings.json` before you wired
+codeArbiter in — or removes the key entirely if there was none — and restores any prior `spinnerVerbs`
+the same way. See [Set Up the Statusline](/guides/the-statusline/#remove-the-statusline) for the full
+behavior.
+
+If you already uninstalled the plugin first, `/ca:statusline uninstall` is no longer available — edit
+`~/.claude/settings.json` by hand and remove the `statusLine` entry that points at
+`hooks/statusline.py` under the plugin's cache path.
+
+### 4. Remove the `.git/hooks` Backstop
+
+Every session, codeArbiter installs a small POSIX-shell shim into each repo's `.git/hooks/pre-commit`
+and `.git/hooks/pre-push` (or wherever `core.hooksPath` points), which calls `git-enforce.py` at the
+git operation itself. This closes the gap where a shell command constructed to dodge the `PreToolUse`
+Bash hook's literal-string match (`g=git; c=commit; $g $c`) would otherwise slip past enforcement
+entirely.
+
+These shims are managed only in repositories you opened with the plugin active, and only removed
+automatically the next time codeArbiter runs there — which won't happen once the plugin is
+uninstalled. Remove them by hand, per repository:
+
+```sh
+python plugins/ca/hooks/_githooks.py uninstall .
+```
+
+(Run this from a checkout that still has the plugin's hook files present — for example, before you
+uninstall the plugin, or from a fresh clone of the codeArbiter repo pointed at your target repo's path
+as the second argument.) `_githooks.py uninstall` removes only shims that carry codeArbiter's sentinel
+comment; a pre-existing hook from another tool (husky, pre-commit-framework) is left untouched.
+
+If that script isn't available, remove the files directly — they only exist if codeArbiter installed
+them (check for the sentinel comment `# codeArbiter-managed git hook (#161)` at the top):
+
+```sh
+rm .git/hooks/pre-commit .git/hooks/pre-push
+```
+
+Only do this for a hook file that carries that sentinel; a hook without it belongs to something else.
+
+## Mid-Feature Uninstall
+
+If you uninstall while a `/ca:feature` or `/ca:sprint` run is in progress, here's what survives and
+what to check first.
+
+**Survives uninstall, because it lives in the repo, not the plugin:**
+
+- The feature branch and every commit on it.
+- The spec and plan files under `.codearbiter/specs/` and `.codearbiter/plans/`.
+- The task board (`.codearbiter/open-tasks.md`) and its in-progress/done state.
+- The decision log and any ADRs the feature recorded.
+- The overrides and gate-events audit logs.
+
+**Does not survive, because it's session/tool state, not repo state:**
+
+- Any in-flight gate context held only in the current Claude Code session (a half-finished TDD Phase,
+  an open `/ca:commit` gate walk). Nothing was committed to `.codearbiter/` for that step, so there's
+  nothing to lose except needing to redo that step by hand or with a different tool.
+
+**Before you uninstall mid-feature, check:**
+
+1. Run <kbd>/ca:status</kbd> to see the current stage, open tasks, and any unresolved `CONFIRM-NN`
+   questions — resolve or note anything open before losing the orchestrator's view of it.
+2. Confirm the branch is pushed or otherwise backed up if you're also about to remove local state.
+3. If a commit is staged but hasn't cleared `commit-gate`, either finish the commit through the plugin
+   first or be aware you're now committing without the gate's verification, secret-scan, and
+   behavioral-proof checks — nothing enforces those once the plugin is gone.

--- a/site/test/generator/render-changelog.test.ts
+++ b/site/test/generator/render-changelog.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { renderChangelog } from "../../scripts/generator/render-changelog";
+
+const SOURCE = `# Changelog
+
+All notable changes to codeArbiter are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
+
+The plugin is the contents of \`plugins/ca/\`. Project state under a consumer's \`.codearbiter/\` is consumer-owned and out of scope for this log.
+
+---
+
+## [2.8.11] — 2026-07-02
+
+### Added
+- **Durable gate-events sink (#186).** Some detail here.
+
+## [2.8.10] — 2026-07-02
+
+### Changed
+- **Cut SessionStart blocking work (#194).** Some other detail.
+`;
+
+describe("renderChangelog", () => {
+  it("strips the source H1 and preamble above the first version heading", () => {
+    const out = renderChangelog(SOURCE);
+    expect(out).not.toMatch(/^#\s+Changelog/m);
+    expect(out).not.toContain("Format follows [Keep a Changelog]");
+    expect(out).not.toContain("---\n\n## [2.8.11]");
+  });
+
+  it("emits Starlight frontmatter with title and description", () => {
+    const out = renderChangelog(SOURCE);
+    expect(out.startsWith("---\n")).toBe(true);
+    expect(out).toContain("title: Changelog");
+    expect(out).toMatch(/description: ".+"/);
+  });
+
+  it("preserves every `## [X.Y.Z]` version heading and its body", () => {
+    const out = renderChangelog(SOURCE);
+    expect(out).toContain("## [2.8.11] — 2026-07-02");
+    expect(out).toContain("Durable gate-events sink (#186).");
+    expect(out).toContain("## [2.8.10] — 2026-07-02");
+    expect(out).toContain("Cut SessionStart blocking work (#194).");
+  });
+
+  it("links the GitHub releases page", () => {
+    const out = renderChangelog(SOURCE);
+    expect(out).toContain("https://github.com/arbiterForge/codeArbiter/releases");
+  });
+
+  it("is idempotent: rendering the same source twice yields byte-identical output", () => {
+    const first = renderChangelog(SOURCE);
+    const second = renderChangelog(SOURCE);
+    expect(second).toBe(first);
+  });
+
+  it("rewrites repo-root-relative ../../pull/NN links to absolute GitHub PR URLs", () => {
+    const withPr = SOURCE.replace(
+      "Some detail here.",
+      "Some detail ([#11](../../pull/11)).",
+    );
+    const out = renderChangelog(withPr);
+    expect(out).toContain("(https://github.com/arbiterForge/codeArbiter/pull/11)");
+    expect(out).not.toContain("../../pull/11");
+  });
+
+  it("quote-escapes a description containing double quotes via yaml-quote", () => {
+    // The static DESCRIPTION has no quotes today, but this guards the frontmatter
+    // line stays well-formed YAML regardless — a change to DESCRIPTION that adds
+    // a `"` must not break the emitted frontmatter block.
+    const out = renderChangelog(SOURCE);
+    const descLine = out.split("\n").find((l) => l.startsWith("description:"));
+    expect(descLine).toBeDefined();
+    expect(descLine).toMatch(/^description: "[^\n]*"$/);
+  });
+});


### PR DESCRIPTION
PR-3.2 of the docs-site overhaul campaign.

- **Uninstall & Disable** (guides/): the trust-signal page. Documents per-repo disable honestly — H-18's block calls are unconditional (no marker bypass /ca:override can unlock), so the sanctioned path is an edit outside Claude Code's tool flanks, with /ca:override run afterward purely to log the change into overrides.log. Full uninstall covered in four independent pieces (plugin payload, .git/hooks backstop, statusline, the .codearbiter/ state that deliberately survives). Mid-feature uninstall: what survives, what to check first.
- **Compatibility** (getting-started/): matrix verified against source — Python 3 stdlib-only hooks with the python3||python fallback (all 8 registrations), cross-platform notes, Node needed only for site dev, and the precise network posture (enforcement chain: zero network; _updatelib.py: once-daily fail-silent release check).
- **On-site Changelog**: render-changelog.ts emits a gitignored page from repo-root CHANGELOG.md at gen time. The hardened link-audit caught that CHANGELOG's GitHub-relative ../../pull/NN links break when rendered on-site — rewritten to absolute URLs with a regression test.

Author verification: 381 vitest passing (34 files, +7 changelog tests), build 123 pages, link-audit 16,740 links OK, dist/changelog shows 2.8.11 at top. Landed from the main checkout (author correctly stopped at the #223 H-01 worktree misfire).

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa