### PR TITLE
docs(site): IA restructure — orientation-first ordering, plain-language groups, init dedupe

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -116,12 +116,10 @@ export default defineConfig({
           label: "Getting Started",
           collapsed: true,
           items: [
+            { label: "What Is codeArbiter", slug: "overview" },
             { label: "Install", slug: "getting-started/install" },
             { label: "Quickstart", slug: "getting-started/quickstart" },
-            { label: "What Is codeArbiter", slug: "overview" },
             { label: "Compatibility", slug: "getting-started/compatibility" },
-            // Temporary placement — both belong in a restructured IA (PR-3.3).
-            { label: "Glossary", slug: "glossary" },
             { label: "FAQ", slug: "faq" },
           ],
         },
@@ -142,7 +140,7 @@ export default defineConfig({
           ],
         },
         {
-          label: "Feature Forge",
+          label: "Preview Features",
           collapsed: true,
           items: [
             { label: "What Is the Feature Forge", slug: "feature-forge/overview" },
@@ -160,18 +158,11 @@ export default defineConfig({
             { label: "ADRs and the Decision Log", slug: "concepts/adrs" },
             { label: "Just-in-Time Context Injection", slug: "concepts/jit-context-injection" },
             { label: "The Gated-Lane Model", slug: "concepts/gated-lanes" },
+            { label: "Enforcement & Security", slug: "enforcement" },
+            { label: "Hardening History", slug: "concepts/hardening-history" },
             { label: "Checkpoints", slug: "concepts/checkpoints" },
             { label: "The Persona-Register Split", slug: "concepts/persona-and-context" },
             { label: "Auditability", slug: "concepts/auditability" },
-          ],
-        },
-        {
-          label: "Security",
-          collapsed: true,
-          items: [
-            { label: "Enforcement & Security", slug: "enforcement" },
-            { label: "Hardening History", slug: "concepts/hardening-history" },
-            { label: "Hooks Reference", slug: "hooks" },
           ],
         },
         {
@@ -179,7 +170,9 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: "The .codearbiter/ Directory", slug: "codearbiter-directory" },
+            { label: "Glossary", slug: "glossary" },
             { label: "All Reference", slug: "reference" },
+            { label: "Hooks Reference", slug: "hooks" },
             { label: "Hook Gates", slug: "reference/hooks-gates" },
             { label: "Changelog", slug: "changelog" },
             ...referenceGroups,

--- a/site/src/content/docs/getting-started/install.md
+++ b/site/src/content/docs/getting-started/install.md
@@ -23,7 +23,7 @@ codeArbiter self-hosts a single-plugin marketplace from its GitHub repo. In any 
 
 Hooks, commands, and agents load automatically. All commands resolve under the `/ca:` namespace.
 
-## 2. Scaffold the Repo State Store
+## 2. Scaffold and Activate the Repo
 
 Installing the plugin enforces nothing. To activate codeArbiter for a repository, open that repo in Claude Code and run:
 
@@ -31,25 +31,8 @@ Installing the plugin enforces nothing. To activate codeArbiter for a repository
 /ca:init
 ```
 
-`/ca:init` scaffolds `.codearbiter/` at the repo root and routes to the right context populator for your situation:
+`/ca:init` scaffolds `.codearbiter/` at the repo root, routes to the right context populator, and — once that populator finishes — writes the `arbiter: enabled` activation flag that turns enforcement on. See [Opt a Repository In](/guides/opt-in-a-repo/) for the full walkthrough, including the two populator paths and how to confirm the flag is set correctly.
 
-| You have | Routed to | What it does |
-|---|---|---|
-| An existing codebase | `/ca:create-context` | Back-fills `.codearbiter/` from the source already there |
-| A new project, no code yet | `/ca:decompose` | A layered interview that scaffolds `.codearbiter/` from scratch |
-
-## 3. Confirm the Activation Flag
-
-`/ca:init` writes `arbiter: enabled` into `.codearbiter/CONTEXT.md` frontmatter. This is the single activation mechanism. Enforcement is off until this flag is present; the plugin install alone changes nothing.
-
-```yaml
----
-arbiter: enabled
----
-```
-
-To verify, open `.codearbiter/CONTEXT.md` and confirm `arbiter: enabled` appears in a properly closed YAML frontmatter block (opening `---` on line 1, followed by a closing `---`). A file with no frontmatter at all is silently dormant. A frontmatter block that opens but never closes surfaces a malformed-state error.
-
-Once the flag is set, the next session opens with the orchestrator active.
+Once the flag is present, the next session opens with the orchestrator active.
 
 The [Enforcement & Security](/enforcement/) page covers which gates are blocking versus advisory and how the fail-loud posture works.

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -15,23 +15,7 @@ Open the target repository in Claude Code and run:
 /ca:init
 ```
 
-`/ca:init` scaffolds `.codearbiter/` at the repo root and routes to the right context populator for your situation:
-
-| You have | Routed to | What it produces |
-|---|---|---|
-| An existing codebase | `/ca:create-context` | Fills `.codearbiter/` from the source already there |
-| A new project, no code yet | `/ca:decompose` | A layered interview that builds `.codearbiter/` from scratch |
-
-When it finishes, confirm the activation flag:
-
-```text
-# .codearbiter/CONTEXT.md — first three lines
----
-arbiter: enabled
----
-```
-
-With `arbiter: enabled` in a properly closed frontmatter block, the next session opens with the orchestrator active and every gate armed. A file missing that flag loads nothing and blocks nothing.
+`/ca:init` scaffolds `.codearbiter/` at the repo root and routes to a context populator for your situation. See [Opt a Repository In](/guides/opt-in-a-repo/) for the two routing paths and how to confirm the `arbiter: enabled` activation flag. With that flag set in a properly closed frontmatter block, the next session opens with the orchestrator active and every gate armed.
 
 ## 2. Run a First Command
 


### PR DESCRIPTION
PR-3.3 of the docs-site overhaul campaign — completes Phase 3.

- Getting Started reordered orientation-first: What Is → Install → Quickstart → Compatibility → FAQ.
- 'Feature Forge' nav group → 'Preview Features' (labels only, slugs unchanged; the branded term stays in page prose per VOICE.md).
- Security group dissolved: Enforcement & Security + Hardening History join Concepts; Hooks Reference + Hook Gates join Reference. Sidebar moves only — no URL changes, no redirects.
- Glossary placed adjacent to The .codearbiter/ Directory at the top of Reference.
- The three /ca:init tellings deduped: guides/opt-in-a-repo is canonical (wording verified fullest against the command source); install/quickstart keep the happy path + a link.

381 vitest passing; build 126 pages; link-audit 17,556 links OK; every content page still sidebar-reachable.

https://claude.ai/code/session_01PVTCDji6bEuf9SifQ8tfsa