### PR TITLE
docs(site): landing content blocks — why-gates, audience split, trust row, three doors

### DIFF
--- a/site/scripts/generator/landing-stats.ts
+++ b/site/scripts/generator/landing-stats.ts
@@ -1,0 +1,64 @@
+/** landing-stats.ts — build-time counters for the landing page's trust row.
+ *
+ * The landing page's stat tiles (gate IDs, commands, agents, skills) are
+ * computed here from the plugin source, never hand-typed, so they cannot
+ * drift from what actually ships. `TrustRow.astro` calls
+ * `computeLandingStats()` at build time; `test/landing/trust-row.test.ts`
+ * asserts the result against an independent filesystem count.
+ */
+import { readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { extractHookGates } from "./extract-hook-gates";
+
+// Deliberately NOT `import.meta.url`-relative: this module is imported by
+// TrustRow.astro, which Vite bundles for the static build into
+// dist/.prerender/chunks/ at a different relative depth than the source
+// tree, so an import.meta.url-derived path resolves to the wrong directory
+// once bundled (it works fine unbundled, e.g. under vitest or tsx, which is
+// what made this easy to miss). `process.cwd()` is stable across every entry
+// point that matters here (`npm test`, `npm run build`, `astro dev`), all of
+// which run from `site/`.
+/** Repo root — one level up from the `site/` working directory every build
+ *  and test entry point runs from. */
+export const REPO_ROOT = resolve(process.cwd(), "..");
+
+/** `plugins/ca/` — the payload directory the counts are drawn from. */
+export const DEFAULT_PLUGIN_ROOT = join(REPO_ROOT, "plugins", "ca");
+
+export interface LandingStats {
+  /** Distinct `H-xx` gate IDs found across `block()`/`remind()` call sites. */
+  gateCount: number;
+  /** Slash-command markdown files under `commands/`. */
+  commandCount: number;
+  /** Specialist agent markdown files under `agents/`, excluding `INDEX.md`
+   *  (the internal catalog is not a published roster entry). */
+  agentCount: number;
+  /** Skill directories under `skills/` (each a published skill). */
+  skillCount: number;
+}
+
+/** Counts `.md` files directly under `dir`, optionally excluding `INDEX.md`
+ *  (the generator's own published-roster rule; see `generate.ts`). */
+function countMarkdownFiles(dir: string, excludeIndex: boolean): number {
+  return readdirSync(dir, { withFileTypes: true }).filter((entry) => {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) return false;
+    if (excludeIndex && /^index\.md$/i.test(entry.name)) return false;
+    return true;
+  }).length;
+}
+
+/** Counts directories directly under `dir`. */
+function countDirectories(dir: string): number {
+  return readdirSync(dir, { withFileTypes: true }).filter((entry) => entry.isDirectory()).length;
+}
+
+/** Computes the landing page's trust-row numbers from the plugin source at
+ *  `pluginRoot` (defaults to the real `plugins/ca/`). */
+export function computeLandingStats(pluginRoot: string = DEFAULT_PLUGIN_ROOT): LandingStats {
+  const { callSites } = extractHookGates(join(pluginRoot, "hooks"));
+  const gateCount = new Set(callSites.map((site) => site.tag)).size;
+  const commandCount = countMarkdownFiles(join(pluginRoot, "commands"), false);
+  const agentCount = countMarkdownFiles(join(pluginRoot, "agents"), true);
+  const skillCount = countDirectories(join(pluginRoot, "skills"));
+  return { gateCount, commandCount, agentCount, skillCount };
+}

--- a/site/src/components/TrustRow.astro
+++ b/site/src/components/TrustRow.astro
@@ -1,0 +1,59 @@
+---
+/**
+ * TrustRow.astro — the landing page's trust-signal row.
+ *
+ * Four numeric tiles (gate IDs, commands, agents, skills) computed at build
+ * time from `plugins/ca/` via `computeLandingStats()`, plus one qualitative
+ * tile. The numbers are never hand-typed here, so a payload change (a new
+ * hook gate, a new command) shows up on the next build without an edit to
+ * this file.
+ */
+import { computeLandingStats } from "../../scripts/generator/landing-stats";
+
+const stats = computeLandingStats();
+// BASE_URL is not guaranteed to carry a trailing slash — normalize before
+// joining a path onto it (same pattern as Search.astro's `base` constant).
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+const tiles = [
+  {
+    value: String(stats.gateCount),
+    label: stats.gateCount === 1 ? "gate ID enforced" : "gate IDs enforced",
+    href: `${base}/reference/hooks-gates/`,
+  },
+  {
+    value: String(stats.commandCount),
+    label: "slash commands",
+    href: `${base}/reference/`,
+  },
+  {
+    value: String(stats.agentCount),
+    label: "specialist agents",
+    href: `${base}/reference/`,
+  },
+  {
+    value: String(stats.skillCount),
+    label: "skills",
+    href: `${base}/reference/`,
+  },
+];
+---
+
+<div class="ca-trust">
+  <ul class="ca-trust__row" role="list">
+    {
+      tiles.map((tile) => (
+        <li class="ca-trust__tile">
+          <a class="ca-trust__link" href={tile.href}>
+            <span class="ca-trust__num">{tile.value}</span>
+            <span class="ca-trust__label">{tile.label}</span>
+          </a>
+        </li>
+      ))
+    }
+    <li class="ca-trust__tile ca-trust__tile--qual">
+      <span class="ca-trust__num ca-trust__num--qual">stdlib-only</span>
+      <span class="ca-trust__label">every hook is stdlib-only Python, no third-party dependencies</span>
+    </li>
+  </ul>
+</div>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -10,6 +10,7 @@ next: false
 
 import GateCatchTerminal from '../../components/GateCatchTerminal.astro';
 import InstallTerminal from '../../components/InstallTerminal.astro';
+import TrustRow from '../../components/TrustRow.astro';
 
 <div class="ca-landing">
 
@@ -73,6 +74,100 @@ import InstallTerminal from '../../components/InstallTerminal.astro';
     />
     <figcaption>The statusline you get, live in every session.</figcaption>
   </figure>
+</div>
+
+<div class="ca-why-gates">
+  <div class="ca-why-gates__copy">
+    <h2>Gates are hooks, not suggestions</h2>
+    <p>
+      Every gate in codeArbiter is a Claude Code <a href="./glossary/#hook">hook</a>: a
+      deterministic Python script that runs at the tool-call boundary, before the tool
+      call happens. A blocking gate exits non-zero and the tool call is refused. Nothing
+      about that depends on the model choosing to comply.
+    </p>
+    <p>
+      Prompt-layer rules still matter. They are the model's judgment for everything a
+      hook does not reach. Hooks are the backstop for the moment that judgment slips: a
+      blocking gate does not ask the model to agree, it stops the call.
+    </p>
+    <p>
+      Every block names the gate that caught it. A <code>BLOCKED [H-09b]</code> line in
+      your terminal points at an entry in the hook gates reference, with the exact
+      condition and the exact message the hook prints.
+    </p>
+  </div>
+
+  <div class="ca-why-gates__mechanics">
+    <h3>How a gate fires</h3>
+    <ol>
+      <li>A tool call (Bash, Write, Edit) reaches Claude Code's <code>PreToolUse</code> boundary.</li>
+      <li>The matching hook runs first, against the repository's current state.</li>
+      <li>It exits 0 (allowed) or blocks with a non-zero exit and a <code>BLOCKED [H-xx]</code> message.</li>
+    </ol>
+    <p class="ca-why-gates__links">
+      <a href="./enforcement/">Read the enforcement guide</a>
+      <span aria-hidden="true">·</span>
+      <a href="./reference/hooks-gates/">Look up a gate ID</a>
+    </p>
+  </div>
+</div>
+
+<div class="ca-audience">
+  <h2>Who this is for</h2>
+  <div class="ca-audience__cols">
+    <div class="ca-audience__col ca-audience__col--for">
+      <h3>Built for</h3>
+      <ul>
+        <li>Teams and solo developers who want an audit trail, not a changelog written after the fact.</li>
+        <li>Compliance-minded adopters who need to show a control actually ran.</li>
+        <li>Anyone who has watched an agent commit untested code and wants that failure mode closed.</li>
+        <li>Brownfield repos that need governance layered on, not a rewrite.</li>
+      </ul>
+    </div>
+    <div class="ca-audience__col ca-audience__col--not">
+      <h3>Not built for</h3>
+      <ul>
+        <li>A quick throwaway script you plan to delete in an hour.</li>
+        <li>Anyone who finds any gate friction unacceptable, even a fixable one.</li>
+        <li>A repo where you do not want a <code>.codearbiter/</code> state directory checked in.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<TrustRow />
+
+<div class="ca-doors">
+  <h2>Three ways in</h2>
+  <div class="ca-doors__grid">
+    <div class="ca-doors__card">
+      <p class="ca-doors__label">Learn</p>
+      <p class="ca-doors__promise">Understand what a gate is and why the lane model exists before you touch a command.</p>
+      <ul>
+        <li><a href="./concepts/">Concepts overview</a></li>
+        <li><a href="./concepts/gated-lanes/">The gated-lane model</a></li>
+        <li><a href="./enforcement/">Enforcement &amp; security</a></li>
+      </ul>
+    </div>
+    <div class="ca-doors__card">
+      <p class="ca-doors__label">Use</p>
+      <p class="ca-doors__promise">Get codeArbiter installed and take your first change through a gated lane.</p>
+      <ul>
+        <li><a href="./getting-started/install/">Install</a></li>
+        <li><a href="./getting-started/quickstart/">Quickstart</a></li>
+        <li><a href="./guides/feature-lane/">Build a feature end to end</a></li>
+      </ul>
+    </div>
+    <div class="ca-doors__card">
+      <p class="ca-doors__label">Look up</p>
+      <p class="ca-doors__promise">Find the exact command, gate ID, or hook behavior you are checking against.</p>
+      <ul>
+        <li><a href="./reference/">All reference</a></li>
+        <li><a href="./reference/hooks-gates/">Hook gates</a></li>
+        <li><a href="./glossary/">Glossary</a></li>
+      </ul>
+    </div>
+  </div>
 </div>
 
 </div>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -250,6 +250,285 @@
 }
 
 /* =========================================================
+   WHY GATES
+   Two-column split: prose explaining the hook mechanism (left) and a compact
+   numbered "how it fires" list plus reference links (right). Collapses to a
+   single column on narrow viewports, matching the hero/install pattern.
+   ========================================================= */
+
+.ca-why-gates {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 4fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  margin-block: 3rem 2rem;
+  padding-block-start: 2rem;
+  border-block-start: 1px solid var(--ca-slate-border);
+}
+
+@media (max-width: 50rem) {
+  .ca-why-gates {
+    grid-template-columns: 1fr;
+    gap: 1.75rem;
+  }
+}
+
+.ca-why-gates h2 {
+  margin-block-end: 1rem;
+  color: var(--ca-gold-text);
+  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+  font-weight: 700;
+}
+
+.ca-why-gates__copy p {
+  max-width: 60ch;
+  margin: 0 0 1rem;
+  color: var(--ca-text-muted);
+  line-height: 1.65;
+}
+
+.ca-why-gates__copy p:last-child {
+  margin-block-end: 0;
+}
+
+.ca-why-gates__copy code,
+.ca-why-gates__mechanics code {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.9em;
+}
+
+.ca-why-gates__mechanics {
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--ca-slate-border);
+  border-radius: 0.6rem;
+  background: var(--ca-slate-mid);
+}
+
+.ca-why-gates__mechanics h3 {
+  margin: 0 0 0.85rem;
+  color: var(--sl-color-white);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.ca-why-gates__mechanics ol {
+  margin: 0 0 1.1rem;
+  padding-inline-start: 1.2rem;
+  color: var(--ca-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.ca-why-gates__mechanics li + li {
+  margin-block-start: 0.5rem;
+}
+
+.ca-why-gates__links {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.88rem;
+}
+
+.ca-why-gates__links span {
+  color: var(--ca-text-muted);
+}
+
+/* =========================================================
+   AUDIENCE SPLIT
+   Two-column honest "who this is for / who it isn't" grid. Stacks on mobile.
+   ========================================================= */
+
+.ca-audience {
+  margin-block: 2rem;
+  padding-block-start: 2rem;
+  border-block-start: 1px solid var(--ca-slate-border);
+}
+
+.ca-audience h2 {
+  margin-block-end: 1.25rem;
+  color: var(--ca-gold-text);
+  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+  font-weight: 700;
+}
+
+.ca-audience__cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(1.5rem, 4vw, 3rem);
+}
+
+@media (max-width: 50rem) {
+  .ca-audience__cols {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+.ca-audience__col h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.ca-audience__col--for h3 {
+  color: var(--ca-term-pass);
+}
+
+.ca-audience__col--not h3 {
+  color: var(--ca-text-muted);
+}
+
+.ca-audience__col ul {
+  margin: 0;
+  padding-inline-start: 1.2rem;
+  color: var(--ca-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.ca-audience__col li + li {
+  margin-block-start: 0.6rem;
+}
+
+.ca-audience__col code {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.9em;
+}
+
+/* =========================================================
+   TRUST ROW
+   A compact strip of build-time-computed stat tiles plus one qualitative
+   tile. Wraps to two columns, then one, on narrow viewports.
+   ========================================================= */
+
+.ca-trust {
+  margin-block: 2rem;
+  padding-block-start: 2rem;
+  border-block-start: 1px solid var(--ca-slate-border);
+}
+
+.ca-trust__row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (max-width: 62rem) {
+  .ca-trust__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 30rem) {
+  .ca-trust__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ca-trust__tile {
+  padding: 1rem;
+  border: 1px solid var(--ca-slate-border);
+  border-radius: 0.6rem;
+  background: var(--ca-slate-mid);
+}
+
+.ca-trust__link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.ca-trust__link:focus-visible {
+  outline: 2px solid var(--ca-gold);
+  outline-offset: 2px;
+}
+
+.ca-trust__num {
+  display: block;
+  color: var(--ca-gold-text);
+  font-size: clamp(1.4rem, 3vw, 1.9rem);
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.ca-trust__tile--qual .ca-trust__num--qual {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
+.ca-trust__label {
+  display: block;
+  margin-block-start: 0.3rem;
+  color: var(--ca-text-muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+/* =========================================================
+   THREE DOORS
+   Learn / Use / Look up: three intent-routed cards.
+   ========================================================= */
+
+.ca-doors {
+  margin-block: 2rem 3rem;
+  padding-block-start: 2rem;
+  border-block-start: 1px solid var(--ca-slate-border);
+}
+
+.ca-doors h2 {
+  margin-block-end: 1.25rem;
+  color: var(--ca-gold-text);
+  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+  font-weight: 700;
+}
+
+.ca-doors__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+@media (max-width: 50rem) {
+  .ca-doors__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ca-doors__card {
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--ca-slate-border);
+  border-radius: 0.6rem;
+  background: var(--ca-slate-mid);
+}
+
+.ca-doors__label {
+  margin: 0 0 0.5rem;
+  color: var(--ca-gold-text);
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ca-doors__promise {
+  margin: 0 0 1rem;
+  color: var(--ca-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.ca-doors__card ul {
+  margin: 0;
+  padding-inline-start: 1.1rem;
+  font-size: 0.92rem;
+  line-height: 1.7;
+}
+
+/* =========================================================
    REDUCED-MOTION OVERRIDE (landing-specific)
    ========================================================= */
 

--- a/site/test/landing/trust-row.test.ts
+++ b/site/test/landing/trust-row.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Landing trust-row obligation — the stat-tile numbers TrustRow.astro renders
+ * must equal an independent filesystem count over plugins/ca/, not drift from
+ * it. This guards against the counting helper silently under/over-collecting
+ * (e.g. an INDEX.md-exclusion rule that stops matching after a rename).
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { computeLandingStats, DEFAULT_PLUGIN_ROOT } from "../../scripts/generator/landing-stats";
+
+const stats = computeLandingStats();
+
+function independentGateCount(): number {
+  // Scans every quoted "H-xx" literal in the hooks source (not just calls
+  // whose first argument is the literal) — some tags (e.g. H-10b) only ever
+  // appear as a literal inside a conditional variable assignment
+  // (`tag = "H-09b" if touches_crypto else "H-10b"`), resolved to a call site
+  // by extractHookGates's variable-tag logic rather than matched directly at
+  // the call. A literal-anywhere scan still finds every tag that exists,
+  // without re-implementing that resolution logic here.
+  const hooksDir = join(DEFAULT_PLUGIN_ROOT, "hooks");
+  const files = readdirSync(hooksDir).filter((f) => f.endsWith(".py"));
+  const tags = new Set<string>();
+  for (const file of files) {
+    const content = readFileSync(join(hooksDir, file), "utf8");
+    const matches = content.matchAll(/"(H-\d+[a-z]?)"/g);
+    for (const m of matches) tags.add(m[1]);
+  }
+  return tags.size;
+}
+
+function independentMarkdownCount(dir: string, excludeIndex: boolean): number {
+  return readdirSync(dir, { withFileTypes: true }).filter((entry) => {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) return false;
+    if (excludeIndex && /^index\.md$/i.test(entry.name)) return false;
+    return true;
+  }).length;
+}
+
+function independentDirCount(dir: string): number {
+  return readdirSync(dir, { withFileTypes: true }).filter((e) => e.isDirectory()).length;
+}
+
+describe("computeLandingStats matches an independent filesystem count", () => {
+  it("gate count matches a literal-tag regex scan of plugins/ca/hooks/*.py", () => {
+    expect(stats.gateCount).toBe(independentGateCount());
+  });
+
+  it("command count matches the .md file count in plugins/ca/commands/", () => {
+    const expected = independentMarkdownCount(join(DEFAULT_PLUGIN_ROOT, "commands"), false);
+    expect(stats.commandCount).toBe(expected);
+  });
+
+  it("agent count matches the .md file count in plugins/ca/agents/, excluding INDEX.md", () => {
+    const expected = independentMarkdownCount(join(DEFAULT_PLUGIN_ROOT, "agents"), true);
+    expect(stats.agentCount).toBe(expected);
+  });
+
+  it("skill count matches the directory count in plugins/ca/skills/", () => {
+    const expected = independentDirCount(join(DEFAULT_PLUGIN_ROOT, "skills"));
+    expect(stats.skillCount).toBe(expected);
+  });
+});
+
+describe("computeLandingStats — floor guard (catches silent under-collection)", () => {
+  // Snapshot as of this writing (2026-07-03): 20 distinct gate IDs, 39
+  // commands, 28 agents (29 files minus INDEX.md), 22 skills. Floors, not
+  // exact pins, so a legitimate payload addition does not fail this test.
+  it("finds at least 15 distinct gate IDs", () => {
+    expect(stats.gateCount).toBeGreaterThanOrEqual(15);
+  });
+
+  it("finds at least 30 commands", () => {
+    expect(stats.commandCount).toBeGreaterThanOrEqual(30);
+  });
+
+  it("finds at least 20 agents", () => {
+    expect(stats.agentCount).toBeGreaterThanOrEqual(20);
+  });
+
+  it("finds at least 15 skills", () => {
+    expect(stats.skillCount).toBeGreaterThanOrEqual(15);
+  });
+});


### PR DESCRIPTION
PR-4.1 of the docs-site overhaul campaign (spec: .codearbiter/specs/docs-site-overhaul.md). Phase 4 — landing/sell.

## What

Four new landing-page blocks after the existing hero/install sections:

- **Gates are hooks, not suggestions** — the tool-call-boundary enforcement story, with a how-a-gate-fires mechanics panel and links into the enforcement guide and the hooks-gates reference.
- **Who this is for / not built for** — honest two-column audience split.
- **Trust row** — 4 numeric tiles (gate IDs, commands, agents, skills) **computed at build time** from plugins/ca/ via a new `landing-stats.ts` that reuses the real `extractHookGates()`, plus one qualitative "stdlib-only Python hooks" tile. Numbers can't drift from the payload.
- **Three ways in** — Learn / Use / Look up intent cards with real post-#238 IA links.

## Notes

- "Zero network calls" tile was **dropped** as a claim: hooks' imports are stdlib-only (kept), but `session-start.py` invokes the update-available check which makes a real HTTPS call, so a blanket no-network claim would be false. `enforcement.md`'s narrower gate-function no-network claim is untouched and remains accurate.
- Gate count is 20 (the extractor resolves variable-assigned tags like the H-09b/H-10b conditional), not the 18 a naive literal-call-site grep finds.
- New vitest suite `test/landing/trust-row.test.ts`: exact-match against an independent fs scan + floor guards against silent under-collection.
- site/** only; zero plugins/ca/ changes → no version bump (payload-scoped rule).

## Verification

`cd site && npm run typecheck && npm test && npm run build && npm run link-audit` — all green locally (389/389 tests, 126 pages, 17,572 internal links OK). CI (docs.yml) re-runs all four.

Conflict-hierarchy note: trust-row numbers computed at build time over hand-typed prose = level 1 (correctness of the audit trail / no drifting claims) over level 5 (velocity).

https://claude.ai/code/session_01GZSeNaMhsr7fAHMci17Uts