### PR TITLE
docs(site): name the machinery — checkpoint fleet, agent roster, tribunal lenses

### DIFF
--- a/site/src/content/docs/concepts/checkpoints.md
+++ b/site/src/content/docs/concepts/checkpoints.md
@@ -5,12 +5,54 @@ description: "Periodic, read-only sweeps of the whole codebase by the reviewer f
 
 A **checkpoint** is a periodic, read-only sweep of the whole codebase by the reviewer fleet.
 The findings are consolidated, classified by severity, and triaged into a single dated
-report. The ones that block the current change are called out, the rest recorded.
-Checkpoints are how drift and latent issues get caught between feature work, without
+report. Checkpoints are how drift and latent issues get caught between feature work, without
 blocking any single change.
 
-When a lean sweep isn't enough, `/ca:tribunal` convenes the deep counterpart: a rare,
-on-demand audit of the whole codebase by eleven specialist lens reviewers. Its run state
-persists under `.codearbiter/reports/`, so an interrupted run resumes from disk, and its
-findings become GitHub issues only on explicit approval. Like the checkpoint, it is
-read-only review and never a required gate.
+## The fleet
+
+A checkpoint dispatches six named reviewers, read-only and in parallel. This is the same
+fleet [`/ca:review`](/reference/commands/review/) runs per-diff; a checkpoint scopes it to the
+whole tree instead of one change.
+
+| Reviewer | Checks |
+|---|---|
+| [`security-reviewer`](/reference/agents/security-reviewer/) | Security posture against `security-controls.md` |
+| [`auth-crypto-reviewer`](/reference/agents/auth-crypto-reviewer/) | Authentication, cryptography, key, and secret paths |
+| [`dependency-reviewer`](/reference/agents/dependency-reviewer/) | License and supply-chain posture of manifests |
+| [`migration-reviewer`](/reference/agents/migration-reviewer/) | Migration safety and data classification |
+| [`coverage-auditor`](/reference/agents/coverage-auditor/) | Test coverage against TDD obligations |
+| [`architecture-drift-reviewer`](/reference/agents/architecture-drift-reviewer/) | Drift between code and accepted ADRs in `decisions/` |
+
+## The funnel
+
+The orchestrator never reads raw reviewer output. Each reviewer's findings go to
+[`finding-triage`](/reference/agents/finding-triage/), which classifies every finding by
+severity and by whether it blocks the current change. The triaged result goes to
+[`checkpoint-aggregator`](/reference/agents/checkpoint-aggregator/), which composes the dated
+report.
+
+## What gets written
+
+- `.codearbiter/checkpoints/YYYY-MM-DD.md`: findings grouped by severity with `file:line`;
+  anything out of scope for the sweep is marked `[NEEDS-TRIAGE]` inline.
+- `.codearbiter/last-checkpoint`: the current override count, re-zeroing the statusline's
+  `over:N` counter until the next `/ca:override`.
+
+A checkpoint is a report, not a promotion gate. It enforces no sign-off and blocks nothing by
+itself.
+
+## The deep counterpart
+
+[`/ca:tribunal`](/reference/commands/tribunal/) convenes the rare, on-demand version of this
+same idea, at far greater depth. Where a checkpoint runs six reviewers against the current
+tree, tribunal dispatches eleven specialist lens reviewers (roster on the
+[tribunal command](/reference/commands/tribunal/) and [tribunal skill](/reference/skills/tribunal/)
+pages) across seven gated phases. Phase 0 is a hard STOP: the user must acknowledge a
+token-cost estimate, routinely in the millions, before anything runs. Each finding is written
+to its own file the moment it's found, alongside append-only `run.jsonl` and `triage.jsonl`
+logs under `.codearbiter/reports/<run-id>/`, so an interrupted run resumes from disk instead
+of restarting. A triage pass independently recalibrates every lens's severity; every
+critical or high finding carries a counter-argument. Findings become GitHub issues only on
+explicit per-finding selection. "Looks good" files nothing.
+
+Like the checkpoint, tribunal is read-only review and never a required gate.

--- a/site/src/content/docs/concepts/persona-and-context.md
+++ b/site/src/content/docs/concepts/persona-and-context.md
@@ -9,3 +9,32 @@ each carry their own focused register and tools, scoped to their job. Splitting 
 register keeps each role sharp. The orchestrator isn't trying to also be a backend engineer,
 and a security reviewer isn't trying to also be a copywriter. Each agent loads only the
 context its role needs, which is also what keeps the standing footprint small.
+
+## The roster
+
+Every agent ships as its own file under `plugins/ca/agents/`. Each carries only the tools its
+role needs.
+
+Three agents carry write tools (`Edit`/`Write`): the authors.
+
+- [`backend-author`](/reference/agents/backend-author/)
+- [`frontend-author`](/reference/agents/frontend-author/)
+- [`infra-author`](/reference/agents/infra-author/)
+
+Every reviewer is read-only by construction. The roster splits into three families:
+
+- **The review fleet.** The six checkpoint/review reviewers ([`security-reviewer`](/reference/agents/security-reviewer/),
+  `auth-crypto-reviewer`, `dependency-reviewer`, `migration-reviewer`, `coverage-auditor`,
+  `architecture-drift-reviewer`), plus [`design-quality-reviewer`](/reference/agents/design-quality-reviewer/)
+  for generated, user-facing output.
+- **The tribunal lenses.** Eleven `tribunal-*` agents, one per lens, dispatched only by
+  [`/ca:tribunal`](/reference/commands/tribunal/). See the [tribunal command](/reference/commands/tribunal/)
+  page for the full roster, starting with [`tribunal-appsec-reviewer`](/reference/agents/tribunal-appsec-reviewer/).
+- **Internal analysts.** Never dispatched directly by a user: `scout`, `grader`,
+  `decision-challenger`, `finding-triage`, `checkpoint-aggregator`, `map-structure`,
+  `map-deps`.
+
+## Where it's decided
+
+The orchestrator persona itself lives in `plugins/ca/ORCHESTRATOR.md`. The split is a
+recorded decision, not an accident of file layout. See ADR-0005.

--- a/site/src/curated/commands/tribunal.md
+++ b/site/src/curated/commands/tribunal.md
@@ -7,7 +7,7 @@ gates:
     effect: the job is sized, a token-cost band and model recommendation are printed, and nothing dispatches until you explicitly acknowledge the estimate and confirm the model
   - gate: approval before filing
     when: after the report is generated
-    effect: findings become GitHub issues only on your explicit selection — silence or "looks good" files nothing
+    effect: findings become GitHub issues only on your explicit selection, silence or "looks good" files nothing
 ---
 
 ## What it does
@@ -17,9 +17,37 @@ specialist lenses judge the whole codebase in priority waves; each finding is wr
 file under `.codearbiter/reports/<run-id>/`, so an interrupted run resumes from disk instead of
 losing progress. Because this lane routinely costs millions of tokens on a large repo, Phase 0
 always stops first: it sizes the codebase, prints the cost band, recommends the highest-reasoning
-model, and waits for you to say go. Critical and high findings are blocking-severity in the report
-— meaning they're work that should block shipping the affected code — but the tribunal run itself
-never halts a merge or commit.
+model, and waits for you to say go. Critical and high findings are blocking-severity in the report:
+they are work that should block shipping the affected code. The tribunal run itself never halts a
+merge or commit.
+
+## The eleven lenses
+
+Each lens judges one concern, in priority waves capped at five in flight. A lens is skipped
+when its concern is absent from scope: a repo with no migrations drops the migration lens.
+
+1. [`tribunal-appsec-reviewer`](/reference/agents/tribunal-appsec-reviewer/): injection, resource-level authz/IDOR, input validation, JWT, CORS, SSRF.
+2. [`tribunal-architecture-reviewer`](/reference/agents/tribunal-architecture-reviewer/): dead/orphan modules, pattern drift, cosmetic abstractions, god modules, monolith accretion. Distinct from `architecture-drift-reviewer`, which checks conformance to accepted ADRs; this lens judges structural health on its own terms.
+3. [`tribunal-coverage-reviewer`](/reference/agents/tribunal-coverage-reviewer/): risk-path coverage gaps, edge/property gaps, implementation-coupled tests.
+4. [`tribunal-infra-reviewer`](/reference/agents/tribunal-infra-reviewer/): CI/CD correctness and security, container posture, IaC/deploy manifests, release automation.
+5. [`tribunal-migration-reviewer`](/reference/agents/tribunal-migration-reviewer/): migration safety, data-classification tagging, immutability, schema-to-code drift.
+6. [`tribunal-observability-reviewer`](/reference/agents/tribunal-observability-reviewer/): structured logging, tracing/correlation IDs, metrics on critical paths, audit gaps.
+7. [`tribunal-performance-reviewer`](/reference/agents/tribunal-performance-reviewer/): N+1 queries, redundant hot-path work, query/index shape, caching, blocking IO.
+8. [`tribunal-reliability-reviewer`](/reference/agents/tribunal-reliability-reviewer/): async correctness, error propagation, races, resource lifecycle, boundary conditions, orphan state.
+9. [`tribunal-secrets-supply-reviewer`](/reference/agents/tribunal-secrets-supply-reviewer/): hardcoded secrets, weak crypto, cleartext, secrets in logs, supply-chain hygiene.
+10. [`tribunal-test-fidelity-reviewer`](/reference/agents/tribunal-test-fidelity-reviewer/): tests validating fiction, meaning mocks, stubs, or fixtures that drifted from a producer that's since become real.
+11. [`tribunal-typesafety-reviewer`](/reference/agents/tribunal-typesafety-reviewer/): footgun interfaces, weak typing, escape hatches, unhelpful errors, undocumented invariants.
+
+On a large repo, two optional read-only mappers ([`map-structure`](/reference/agents/map-structure/)
+and [`map-deps`](/reference/agents/map-deps/)) build the codebase inventory ahead of the lenses, so
+that mapping work stays off the orchestrator's own context.
+
+A triage pass independently recalibrates every lens's own severity call rather than trusting it
+as final; every critical or high finding must carry a counter-argument. `report.md` is always a
+projection of the append-only `run.jsonl` and `triage.jsonl` logs, never hand-authored.
+
+Resuming an interrupted run is time-boxed: a run older than seven days STOPs and asks whether to
+resume anyway or start fresh, since the codebase may have drifted under the recorded findings.
 
 ## Usage
 
@@ -53,5 +81,5 @@ Phase 5: file findings as GitHub issues? Select which, or "none".
 
 ## When to reach for it
 
-Rare, deliberate, whole-codebase depth — not the routine sweep (`/ca:checkpoint`), not a diff review
+Rare, deliberate, whole-codebase depth, not the routine sweep (`/ca:checkpoint`), not a diff review
 (`/ca:review`), and never wired into a hot loop or schedule.

--- a/site/src/curated/skills/tribunal.md
+++ b/site/src/curated/skills/tribunal.md
@@ -4,7 +4,7 @@ related: [commands/tribunal]
 gates:
   - gate: cost acknowledgment
     when: before anything is dispatched
-    effect: you must acknowledge the estimated token cost and confirm the model before the run proceeds — an unacknowledged run does not start
+    effect: you must acknowledge the estimated token cost and confirm the model before the run proceeds; an unacknowledged run does not start
   - gate: approval and filing
     when: after the report is presented
     effect: findings become tracked issues only on your explicit selection; silence or a vague "looks good" files nothing
@@ -12,11 +12,32 @@ gates:
 
 ## What it does
 
-This is the deepest, most expensive review the project offers — convened rarely, on demand,
+This is the deepest, most expensive review the project offers: convened rarely, on demand,
 invoked through the tribunal command, and never required as a gate on ordinary work. Eleven
 specialist reviewers each judge one lens of the codebase in parallel, every finding persisted to
 its own file as it's found so the run survives an interruption and resumes from disk rather than
 restarting.
+
+## The lenses
+
+The eleven `tribunal-*` agents are named on the [tribunal command page](/reference/commands/tribunal/),
+which carries the full roster and each lens's concern. At most five run concurrently; a lens
+whose concern doesn't exist in scope is skipped rather than run for nothing.
+
+## On disk
+
+A run lives entirely under `.codearbiter/reports/<run-id>/`, with `RUN_ID` set to
+`<UTC-date>-<scope-slug>` on a fresh run and reused as-is on resume.
+
+- `findings/<lens>/<finding-id>.json`: one file per finding, written the instant it's found.
+- `run.jsonl` and `triage.jsonl`: append-only logs; nothing here is ever hand-edited.
+- `inventory.md`: the Phase 1 codebase map.
+- `plans/phase-<n>.md`: one plan file per wave's kept work.
+- `report.md` and `manifest.yaml`: regenerated from the two logs, never authored directly.
+- `issue-commands.sh`: the default hand-off, a ready command set executed only on explicit approval.
+
+Resuming a run older than seven days STOPs rather than continuing silently. The tree may have
+moved under the findings already on disk.
 
 ## Phases
 
@@ -28,7 +49,7 @@ restarting.
    they're found.
 4. Triage every finding from disk as each wave finishes, independently recalibrating severity and
    confidence rather than trusting the lens's own numbers.
-5. Regenerate the report from the triage record — never hand-authored — grouped by calibrated
+5. Regenerate the report from the triage record, never hand-authored, grouped by calibrated
    severity.
 6. On your explicit selection, file the approved findings as tracked issues, skipping anything
    already filed or already tracked elsewhere.
@@ -38,6 +59,7 @@ restarting.
 ## Exits
 
 The run leaves a regenerated report and, only on your explicit approval, a set of filed tracked
-issues — nothing is filed on silence. It never edits, refactors, or commits project code itself,
-and it never blocks a commit or a merge; a critical finding here is a recommendation to fix, not a
-pipeline stop.
+issues. Nothing is filed on silence. Approved findings land as GitHub issues, never as entries
+on `open-tasks.md`, so a periodic-review finding survives a PR getting abandoned. It never edits,
+refactors, or commits project code itself, and it never blocks a commit or a merge; a critical
+finding here is a recommendation to fix, not a pipeline stop.


### PR DESCRIPTION
PR 1 of 2 remediating the concept-page specificity gap: pages described machinery abstractly without naming what runs. Every fact below was verified against plugins/ca/ by an audit pass and re-verified by a design-quality review of the committed diff.

## What

- **concepts/checkpoints.md** (was 16 lines of abstraction): the six-reviewer fleet table (each linked to its reference page), the finding-triage → checkpoint-aggregator funnel, the persisted paths (checkpoints/YYYY-MM-DD.md, last-checkpoint override baseline), honest no-sign-off semantics, and a concrete "why tribunal is deeper" section (Phase-0 cost STOP, per-finding JSON + append-only logs, independent severity recalibration, per-finding filing).
- **concepts/persona-and-context.md**: the real roster shape — 28 agents, the three write-capable authors, the three reviewer families, internal analysts, ORCHESTRATOR.md + ADR-0005.
- **curated/commands/tribunal.md**: the enumerated eleven-lens roster with one-line roles, each linked to its agent reference page, plus mappers, triage recalibration, log-projection reporting, 7-day resume staleness.
- **curated/skills/tribunal.md**: lens name list (deferring roles to the command page) and the full on-disk layout of a run.

## Notes

- Paraphrase lint green — closest overlap with plugin sources is a 9-word run, under the 12-word shingle threshold.
- Author also cleared pre-existing em-dash separators in the two curated files; a follow-up design verification confirmed the committed state is em-dash-clean (the one survivor is inside a fenced transcript, exempt).
- site/** only; no plugins/ changes → no version bump.

## Verification

cd site && npm run typecheck && npm test && npm run build && npm run link-audit — all green (389/389, 126 pages, 17,607 links).

PR 2 (governance concretization: adrs, auditability, gated-lanes, smarts, provenance-drift) follows.

https://claude.ai/code/session_01GZSeNaMhsr7fAHMci17Uts