### PR TITLE
docs(site): governance concretization — ADR mechanics, audit sources, lane phase counts

### DIFF
--- a/site/src/content/docs/concepts/adrs.md
+++ b/site/src/content/docs/concepts/adrs.md
@@ -9,3 +9,40 @@ decision log. codeArbiter never authors an ADR as its own judgment; every record
 explicit user attribution. The decision-lifecycle skill maintains supersede chains, so a
 newer ADR can replace an older one, and it can report decision health: which records are
 aging, unchallenged, or in conflict.
+
+## Where a decision lives
+
+Each ADR is a file at `.codearbiter/decisions/NNNN-<slug>.md`, numbered gap-free. The two
+entry points are [`/ca:adr "<title>"`](/reference/commands/adr/) to write one and
+[`/ca:adr-status [--adr N]`](/reference/commands/adr-status/) to report on the set. Both
+route through the [decision-lifecycle skill](/reference/skills/decision-lifecycle/).
+
+An ADR's status follows a fixed vocabulary: `proposed → accepted → superseded | rejected`.
+A status change happens only on explicit user instruction, never inferred. A supersede
+chain runs forward-only through a `supersedes:` field on the newer record; the prior ADR
+file itself is never edited.
+
+Every ADR shares its directory with an append-only companion, `decision-log.md`, that
+records the same decisions as a running ledger.
+
+## What makes a decision live
+
+An ADR's `governs:` field is a set of path globs. Once a decision is accepted, those globs
+do two things: the post-write hook surfaces "governed by ADR-NNNN" on a matching edit, and
+an accepted ADR's globs feed tier 2 of the JIT read-injection priority map (see
+[Just-in-Time Context Injection](/concepts/jit-context-injection/)).
+
+Some questions in a draft ADR can only be answered by the user. Those are marked with a
+`[CONFIRM-NN]` placeholder and never resolved by guessing.
+
+## Enforcement, not convention
+
+"ADRs only get written through `/ca:adr`" is not a house rule that relies on discipline.
+Pre-write and pre-edit hooks block any write to `decisions/NNNN-*.md` unless a fresh
+`.codearbiter/.markers/adr-authoring-active` marker exists, minted by the command and
+valid for a 30-minute window. See the [hooks and gates reference](/reference/hooks-gates/)
+for the full gate catalog.
+
+`/ca:adr-status` MAY additionally dispatch
+[`decision-challenger`](/reference/agents/decision-challenger/), an optional adversarial
+reviewer that red-teams each decision and assigns it a confidence score from 1 to 5.

--- a/site/src/content/docs/concepts/auditability.md
+++ b/site/src/content/docs/concepts/auditability.md
@@ -10,3 +10,28 @@ governance record can be assembled for any range of work on demand.
 
 For the concrete catalog of what runs in each lane, see the auto-generated
 [Reference](/reference/).
+
+## The assembler
+
+[`/ca:audit`](/reference/commands/audit/) is the command that synthesizes the record. It
+pulls together, by exact source:
+
+| Source | What it contributes |
+|---|---|
+| `overrides.log` | every sanctioned bypass |
+| `triage.log` | checkpoint findings |
+| `decisions/` + `decision-log.md` | ADRs and the decision ledger |
+| `sprint-log.md` | autonomous auto-decisions and their confidence |
+| `checkpoints/*.md` | dated sweep reports |
+| `[CONFIRM-NN]` items | unresolved open questions |
+| commits | grouped by Conventional-Commit type |
+
+## Window and output
+
+The range can be given as `<from-ref> <to-ref>`, `--since-checkpoint`, or `--since <date>`;
+with no arguments it defaults to the last tag through `HEAD`.
+
+The result is written to `.codearbiter/audits/<YYYY-MM-DD>.md` and is never overwritten: a
+second audit on the same day gets a `-2` suffix, a third `-3`. Override lines and
+low-confidence sprint entries are quoted verbatim rather than summarized, and a section with
+nothing to report says so explicitly instead of being omitted.

--- a/site/src/content/docs/concepts/gated-lanes.md
+++ b/site/src/content/docs/concepts/gated-lanes.md
@@ -20,3 +20,36 @@ at the spec rather than working around at the gate.
   <img src="/codeArbiter/diagrams/gate-model.svg" alt="Gate model. A soft gate surfaces a decision bubble and waits for the user. A hard gate is a closed cross-bar that is never auto-decided." loading="lazy" />
   <figcaption>Soft gates surface and wait. Hard gates stop, and only the user can clear them.</figcaption>
 </figure>
+
+## How many gates, concretely
+
+Lane depth is scaled to risk. The [`tdd` skill](/reference/skills/tdd/) runs 6 gated phases:
+obligation scan, red, green, obligation verify, coverage, lint. The
+[`commit-gate` skill](/reference/skills/commit-gate/) runs 9: permission, branch,
+classification, verification, behavioral proof, diff review, selective stage, message,
+commit. It's the only path to a commit. [`refactor`](/reference/skills/refactor/) runs 6
+phases, all built around proving behavioral parity through unmodified pre-existing tests.
+
+## Mandatory routing at commit time
+
+A change that touches certain surfaces pulls a specialist reviewer into the lane
+automatically, not by request:
+
+- Crypto-compliance and secret-handling changes must mint a digest-bound
+  `security-gate-passed` marker before commit-gate lets the commit through; hooks H-09b and
+  H-10b block it otherwise.
+- A database migration must mint `migration-gate-passed`, enforced by H-14.
+- A CI or deploy-path change dispatches `security-reviewer`, enforced by H-15/H-16, though
+  advisory rather than blocking.
+
+See the [hooks and gates reference](/reference/hooks-gates/) for the full gate catalog.
+
+## The terminal lane
+
+Every change lands through a PR, via
+[finishing-a-development-branch](/reference/skills/finishing-a-development-branch/). Direct
+merge to the default branch is forbidden, with no exceptions.
+
+The one sanctioned way around any of this is [`/ca:override`](/reference/commands/override/):
+a deliberate bypass that appends one line to `overrides.log` and proceeds. It is logged, not
+silent.

--- a/site/src/content/docs/concepts/gated-lanes.md
+++ b/site/src/content/docs/concepts/gated-lanes.md
@@ -48,7 +48,7 @@ See the [hooks and gates reference](/reference/hooks-gates/) for the full gate c
 
 Every change lands through a PR, via
 [finishing-a-development-branch](/reference/skills/finishing-a-development-branch/). Direct
-merge to the default branch is forbidden, with no exceptions.
+merge to the default branch is forbidden.
 
 The one sanctioned way around any of this is [`/ca:override`](/reference/commands/override/):
 a deliberate bypass that appends one line to `overrides.log` and proceeds. It is logged, not

--- a/site/src/content/docs/concepts/jit-context-injection.md
+++ b/site/src/content/docs/concepts/jit-context-injection.md
@@ -14,6 +14,8 @@ The check follows a four-tier priority map. Each tier is evaluated in order; the
 
 A file that matches none of these tiers is non-governed. The hook injects nothing and makes no git call. Injection is deduplicated once per session and file, so repeated reads of the same file do not accumulate pointer tokens.
 
+The hook is implemented as `pre-read.py`, backed by `_readinjectlib.py`; see the [hooks and gates reference](/reference/hooks-gates/) for the full gate catalog.
+
 <figure class="ca-diagram">
   <img src="/codeArbiter/diagrams/four-tier-map.svg" alt="The four-tier file-to-knowledge map: a Read is matched against security-controls.md, accepted ADRs, approved specs, and provenance in priority order, and the highest-priority match's pointer is injected within a 150-token budget." loading="lazy" />
   <figcaption>Four tiers, evaluated in priority order. The highest match governs; a non-governed Read injects nothing.</figcaption>

--- a/site/src/content/docs/concepts/provenance-drift.md
+++ b/site/src/content/docs/concepts/provenance-drift.md
@@ -7,7 +7,9 @@ Every derived document under `.codearbiter/` traces its claims to source files i
 
 Drift is surfaced once, passively, as a single line at SessionStart. It does not interrupt work. `.codearbiter/code-map.md` provides a coarse orientation map: it names the main source files and the docs that depend on them. `/ca:context-check` runs the same detection on demand, as a manual audit.
 
-When a commit lands, the **commit-gate auto-heal** step checks whether any staged source files have drifted their dependent docs. If they have, it re-baselines the provenance in the same commit or proposes a doc update to accompany the work, so a stale claim gets flagged and corrected before it can be read as current.
+When a commit lands, the **commit-gate auto-heal** step checks whether any staged source files have drifted their dependent docs. If they have, it re-baselines the provenance in the same commit or proposes a doc update to accompany the work, so a stale claim gets flagged and corrected before it can be read as current. Auto-heal is commit-gate's Phase 5.5, per the [commit-gate skill](/reference/skills/commit-gate/); on an ordinary commit with an empty worklist, it costs nothing.
+
+Per-document provenance records live under `.codearbiter/.provenance/`. [`/ca:context-check`](/reference/commands/context-check/) runs the same drift detection as a manual, on-demand audit, and offers three dispositions per stale doc: re-scout it from the current source, re-baseline the stored hash without re-scouting, or defer.
 
 <figure class="ca-diagram">
   <img src="/codeArbiter/diagrams/provenance-drift-flow.svg" alt="Context-drift provenance flow: a tracked source change is detected by a git hash-object mismatch, surfaced at SessionStart, and healed by commit-gate which re-baselines or proposes a doc update with the work commit." loading="lazy" />

--- a/site/src/content/docs/concepts/smarts.md
+++ b/site/src/content/docs/concepts/smarts.md
@@ -37,3 +37,16 @@ rather than a forced pick.
 SMARTS deliberately does not score cost, time-to-market, team-skill fit, or vendor lock-in. When
 those matter, they are surfaced as non-SMARTS considerations alongside the table; they supplement the
 analysis, never replace it.
+
+## Where it runs
+
+The canonical rubric ships at `plugins/ca/includes/smarts/core.md`. The
+[`grader` agent](/reference/agents/grader/) produces one SMARTS analysis per
+artifact-position and scaffold-evidence pair, dispatched by the
+[decision-variance skill](/reference/skills/decision-variance/) through
+[`/ca:reconcile`](/reference/commands/reconcile/).
+
+Auto-decisions made during an autonomous [`/ca:sprint`](/reference/commands/sprint/) run
+append to `.codearbiter/sprint-log.md`. Arbitrated decisions land in `decision-log.md`,
+each carrying a SHA-256 hash of its own section, which lets a later reconcile pass detect
+when a decision has gone stale against the code it once described.


### PR DESCRIPTION
PR 2 of 2 remediating the concept-page specificity gap (PR 1 was #242). Five governance concept pages gain the concrete machinery they describe; every fact verified against plugins/ca/ by the audit pass, all named components linked to their reference pages.

## What

- **adrs.md**: decision file path/shape and gap-free numbering, status vocabulary with forward-only supersede chains, the decision-log ledger, `governs:` glob mechanics (post-write surfacing + JIT tier 2), and the marker-enforced authoring rule — pre-write/pre-edit hooks block ADR writes without a fresh `adr-authoring-active` marker, so the rule is mechanical, not conventional. Optional decision-challenger dispatch.
- **auditability.md**: `/ca:audit`'s exact source set (overrides.log, triage.log, decisions + ledger, sprint-log, checkpoints, CONFIRM-NN, typed commits), window forms, and never-overwritten dated output.
- **gated-lanes.md**: real phase counts (tdd 6, commit-gate 9 as the only path to a commit, refactor 6), the mandatory commit-time routings with their gate IDs (H-09b/H-10b digest-bound markers, H-14, H-15/H-16 advisory), the PR-only terminal lane, and the logged `/ca:override` bypass. One review fix: removed a "no exceptions" claim that contradicted the override paragraph two lines later.
- **smarts.md**: a grounding section — canonical rubric path, the grader agent via decision-variance, sprint-log appends, SHA-256-hashed decision-log entries.
- **provenance-drift.md**: `.codearbiter/.provenance/` storage, commit-gate Phase 5.5 auto-heal, context-check's three dispositions.
- **jit-context-injection.md**: one sentence naming the implementing hook.

## Verification

cd site && npm run typecheck && npm test && npm run build && npm run link-audit — all green (389/389, 126 pages, 17,627 links). site/** only; no plugins/ changes → no version bump.

https://claude.ai/code/session_01GZSeNaMhsr7fAHMci17Uts