### PR TITLE
fix(hooks): load_host fails closed on a broken _host.py (#255)

### DIFF
--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -29,6 +29,7 @@
 
 import os
 import subprocess
+import sys
 
 
 class Host:
@@ -173,19 +174,67 @@ class Host:
                  "added_text": added, "added_lines": added.splitlines()}]
 
 
-def load_host():
+class FailClosedHost(Host):
+    """The host returned when a `_host.py` is PRESENT but fails to load.
+
+    A broken `_host.py` means the plugin declared a host we could not
+    construct, so we do NOT know whether this install is Claude, Codex, or a
+    future host. Silently substituting the Claude-default `Host()` (as
+    load_host once did on ANY failure) is unsafe: on a Codex install the base
+    `iter_file_ops` cannot decompose an apply_patch envelope, so it yields an
+    empty-path "write" op and every pre-write guard skips — the write gate
+    silently fails OPEN (tribunal architecture-004 / typesafety-001, both
+    reproduced). This host fails CLOSED instead: every write-batching payload
+    resolves to a single "opaque" op, which pre-write.py blocks (H-21), and the
+    capability flags are the conservative (absent-surface) values. load_host()
+    emits a stderr breadcrumb when it returns this, so a broken host is never
+    silent (observability-002)."""
+
+    name = "unknown"
+    has_statusline = False
+    has_read_tool = False
+    has_prunable_transcript = False
+
+    def iter_file_ops(self, payload):
+        # Host identity is unknown, so no payload can be safely mapped to
+        # per-file ops. Force the fail-closed "opaque" op unconditionally;
+        # pre-write blocks it (H-21) rather than guessing a host's semantics.
+        return [{"file_path": "", "kind": "opaque", "content": None,
+                 "added_text": "", "added_lines": []}]
+
+
+def load_host(hooks_dir=None):
     """The Host instance for this plugin: `HOST` from the `_host.py` sitting
-    beside this file, loaded by explicit file path (each plugin ships its own
-    `_host.py`; the shared core deliberately does not). Falls back to the
-    built-in Claude defaults (a bare Host()) when `_host.py` is absent or
-    fails to load, so a partial install degrades to today's behavior instead
-    of breaking."""
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_host.py")
+    beside this file (or in `hooks_dir`, an override for tests), loaded by
+    explicit file path (each plugin ships its own `_host.py`; the shared core
+    deliberately does not). The failure semantics distinguish two cases so a
+    broken host can never silently degrade to the WRONG host's guards:
+
+      * `_host.py` ABSENT -> the bare-core / partial-install fallback: return
+        the built-in Claude default `Host()`, exactly as before. No plugin
+        declared a host, so Claude defaults are the only meaningful answer and
+        "degrade to today's behavior" is safe.
+      * `_host.py` PRESENT but fails to load (syntax error, import error,
+        unreadable, or no `HOST` symbol) -> a declared host we could not
+        construct. Emit a stderr breadcrumb and return `FailClosedHost()`,
+        which blocks every write rather than assuming Claude semantics
+        (architecture-004 / observability-002 / typesafety-001). The old
+        blanket fallback was only safe when the intended host IS Claude."""
+    base = hooks_dir or os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(base, "_host.py")
+    if not os.path.isfile(path):
+        return Host()
     try:
         import importlib.util
         spec = importlib.util.spec_from_file_location("_host", path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         return mod.HOST
-    except Exception:  # noqa: BLE001 — no/broken _host.py -> Claude defaults
-        return Host()
+    except Exception as e:  # noqa: BLE001 — declared-but-broken host -> fail closed
+        sys.stderr.write(
+            "codeArbiter: _host.py is present but failed to load "
+            "(%s: %s) — failing closed (writes blocked) rather than assuming "
+            "the default host. Reinstall or fix the plugin's _host.py.\n"
+            % (type(e).__name__, e)
+        )
+        return FailClosedHost()

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -29,6 +29,7 @@
 
 import os
 import subprocess
+import sys
 
 
 class Host:
@@ -173,19 +174,67 @@ class Host:
                  "added_text": added, "added_lines": added.splitlines()}]
 
 
-def load_host():
+class FailClosedHost(Host):
+    """The host returned when a `_host.py` is PRESENT but fails to load.
+
+    A broken `_host.py` means the plugin declared a host we could not
+    construct, so we do NOT know whether this install is Claude, Codex, or a
+    future host. Silently substituting the Claude-default `Host()` (as
+    load_host once did on ANY failure) is unsafe: on a Codex install the base
+    `iter_file_ops` cannot decompose an apply_patch envelope, so it yields an
+    empty-path "write" op and every pre-write guard skips — the write gate
+    silently fails OPEN (tribunal architecture-004 / typesafety-001, both
+    reproduced). This host fails CLOSED instead: every write-batching payload
+    resolves to a single "opaque" op, which pre-write.py blocks (H-21), and the
+    capability flags are the conservative (absent-surface) values. load_host()
+    emits a stderr breadcrumb when it returns this, so a broken host is never
+    silent (observability-002)."""
+
+    name = "unknown"
+    has_statusline = False
+    has_read_tool = False
+    has_prunable_transcript = False
+
+    def iter_file_ops(self, payload):
+        # Host identity is unknown, so no payload can be safely mapped to
+        # per-file ops. Force the fail-closed "opaque" op unconditionally;
+        # pre-write blocks it (H-21) rather than guessing a host's semantics.
+        return [{"file_path": "", "kind": "opaque", "content": None,
+                 "added_text": "", "added_lines": []}]
+
+
+def load_host(hooks_dir=None):
     """The Host instance for this plugin: `HOST` from the `_host.py` sitting
-    beside this file, loaded by explicit file path (each plugin ships its own
-    `_host.py`; the shared core deliberately does not). Falls back to the
-    built-in Claude defaults (a bare Host()) when `_host.py` is absent or
-    fails to load, so a partial install degrades to today's behavior instead
-    of breaking."""
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_host.py")
+    beside this file (or in `hooks_dir`, an override for tests), loaded by
+    explicit file path (each plugin ships its own `_host.py`; the shared core
+    deliberately does not). The failure semantics distinguish two cases so a
+    broken host can never silently degrade to the WRONG host's guards:
+
+      * `_host.py` ABSENT -> the bare-core / partial-install fallback: return
+        the built-in Claude default `Host()`, exactly as before. No plugin
+        declared a host, so Claude defaults are the only meaningful answer and
+        "degrade to today's behavior" is safe.
+      * `_host.py` PRESENT but fails to load (syntax error, import error,
+        unreadable, or no `HOST` symbol) -> a declared host we could not
+        construct. Emit a stderr breadcrumb and return `FailClosedHost()`,
+        which blocks every write rather than assuming Claude semantics
+        (architecture-004 / observability-002 / typesafety-001). The old
+        blanket fallback was only safe when the intended host IS Claude."""
+    base = hooks_dir or os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(base, "_host.py")
+    if not os.path.isfile(path):
+        return Host()
     try:
         import importlib.util
         spec = importlib.util.spec_from_file_location("_host", path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         return mod.HOST
-    except Exception:  # noqa: BLE001 — no/broken _host.py -> Claude defaults
-        return Host()
+    except Exception as e:  # noqa: BLE001 — declared-but-broken host -> fail closed
+        sys.stderr.write(
+            "codeArbiter: _host.py is present but failed to load "
+            "(%s: %s) — failing closed (writes blocked) rather than assuming "
+            "the default host. Reinstall or fix the plugin's _host.py.\n"
+            % (type(e).__name__, e)
+        )
+        return FailClosedHost()

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -29,6 +29,7 @@
 
 import os
 import subprocess
+import sys
 
 
 class Host:
@@ -173,19 +174,67 @@ class Host:
                  "added_text": added, "added_lines": added.splitlines()}]
 
 
-def load_host():
+class FailClosedHost(Host):
+    """The host returned when a `_host.py` is PRESENT but fails to load.
+
+    A broken `_host.py` means the plugin declared a host we could not
+    construct, so we do NOT know whether this install is Claude, Codex, or a
+    future host. Silently substituting the Claude-default `Host()` (as
+    load_host once did on ANY failure) is unsafe: on a Codex install the base
+    `iter_file_ops` cannot decompose an apply_patch envelope, so it yields an
+    empty-path "write" op and every pre-write guard skips — the write gate
+    silently fails OPEN (tribunal architecture-004 / typesafety-001, both
+    reproduced). This host fails CLOSED instead: every write-batching payload
+    resolves to a single "opaque" op, which pre-write.py blocks (H-21), and the
+    capability flags are the conservative (absent-surface) values. load_host()
+    emits a stderr breadcrumb when it returns this, so a broken host is never
+    silent (observability-002)."""
+
+    name = "unknown"
+    has_statusline = False
+    has_read_tool = False
+    has_prunable_transcript = False
+
+    def iter_file_ops(self, payload):
+        # Host identity is unknown, so no payload can be safely mapped to
+        # per-file ops. Force the fail-closed "opaque" op unconditionally;
+        # pre-write blocks it (H-21) rather than guessing a host's semantics.
+        return [{"file_path": "", "kind": "opaque", "content": None,
+                 "added_text": "", "added_lines": []}]
+
+
+def load_host(hooks_dir=None):
     """The Host instance for this plugin: `HOST` from the `_host.py` sitting
-    beside this file, loaded by explicit file path (each plugin ships its own
-    `_host.py`; the shared core deliberately does not). Falls back to the
-    built-in Claude defaults (a bare Host()) when `_host.py` is absent or
-    fails to load, so a partial install degrades to today's behavior instead
-    of breaking."""
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_host.py")
+    beside this file (or in `hooks_dir`, an override for tests), loaded by
+    explicit file path (each plugin ships its own `_host.py`; the shared core
+    deliberately does not). The failure semantics distinguish two cases so a
+    broken host can never silently degrade to the WRONG host's guards:
+
+      * `_host.py` ABSENT -> the bare-core / partial-install fallback: return
+        the built-in Claude default `Host()`, exactly as before. No plugin
+        declared a host, so Claude defaults are the only meaningful answer and
+        "degrade to today's behavior" is safe.
+      * `_host.py` PRESENT but fails to load (syntax error, import error,
+        unreadable, or no `HOST` symbol) -> a declared host we could not
+        construct. Emit a stderr breadcrumb and return `FailClosedHost()`,
+        which blocks every write rather than assuming Claude semantics
+        (architecture-004 / observability-002 / typesafety-001). The old
+        blanket fallback was only safe when the intended host IS Claude."""
+    base = hooks_dir or os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(base, "_host.py")
+    if not os.path.isfile(path):
+        return Host()
     try:
         import importlib.util
         spec = importlib.util.spec_from_file_location("_host", path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         return mod.HOST
-    except Exception:  # noqa: BLE001 — no/broken _host.py -> Claude defaults
-        return Host()
+    except Exception as e:  # noqa: BLE001 — declared-but-broken host -> fail closed
+        sys.stderr.write(
+            "codeArbiter: _host.py is present but failed to load "
+            "(%s: %s) — failing closed (writes blocked) rather than assuming "
+            "the default host. Reinstall or fix the plugin's _host.py.\n"
+            % (type(e).__name__, e)
+        )
+        return FailClosedHost()

--- a/plugins/ca/hooks/tests/test_hostapi_loadhost.py
+++ b/plugins/ca/hooks/tests/test_hostapi_loadhost.py
@@ -1,0 +1,83 @@
+"""Tests for hostapi.load_host() fail-closed semantics (tribunal #255).
+
+A `_host.py` that is PRESENT but fails to load must NOT silently degrade to the
+Claude-default Host() — on a Codex install that un-guards every apply_patch
+write (architecture-004 / typesafety-001). load_host() must instead return a
+FailClosedHost (writes blocked) and leave a breadcrumb. An ABSENT `_host.py`
+(the bare-core case) still returns the Claude default.
+
+stdlib unittest only; no subprocess.
+"""
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+
+_HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+import hostapi
+
+
+def _dir_with_host(body):
+    d = tempfile.mkdtemp()
+    with open(os.path.join(d, "_host.py"), "w", encoding="utf-8") as f:
+        f.write(body)
+    return d
+
+
+class LoadHostFailClosedTests(unittest.TestCase):
+    def test_absent_host_returns_claude_default(self):
+        d = tempfile.mkdtemp()  # no _host.py written
+        host = hostapi.load_host(d)
+        self.assertIsInstance(host, hostapi.Host)
+        self.assertNotIsInstance(host, hostapi.FailClosedHost)
+        self.assertEqual(host.name, "claude")
+
+    def test_valid_host_is_returned(self):
+        d = _dir_with_host(
+            "import hostapi\n"
+            "class _Probe(hostapi.Host):\n"
+            "    name = 'probe'\n"
+            "HOST = _Probe()\n"
+        )
+        host = hostapi.load_host(d)
+        self.assertEqual(host.name, "probe")
+        self.assertNotIsInstance(host, hostapi.FailClosedHost)
+
+    def test_broken_host_fails_closed_with_opaque_op(self):
+        d = _dir_with_host("raise RuntimeError('boom')\n")
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            host = hostapi.load_host(d)
+        self.assertIsInstance(host, hostapi.FailClosedHost)
+        # The write gate must see an opaque op regardless of payload shape, so
+        # pre-write.py blocks (H-21) instead of assuming a host's semantics.
+        ops = host.iter_file_ops({
+            "tool_name": "apply_patch",
+            "tool_input": {"command": "*** Begin Patch\n*** Add File: x\n+y\n*** End Patch\n"},
+        })
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["kind"], "opaque")
+        # And a breadcrumb was emitted — a broken host is never silent.
+        self.assertIn("_host.py is present but failed to load", buf.getvalue())
+
+    def test_missing_HOST_symbol_fails_closed(self):
+        d = _dir_with_host("X = 1\n")  # loads fine but declares no HOST
+        with contextlib.redirect_stderr(io.StringIO()):
+            host = hostapi.load_host(d)
+        self.assertIsInstance(host, hostapi.FailClosedHost)
+
+    def test_failclosed_capabilities_are_conservative(self):
+        h = hostapi.FailClosedHost()
+        self.assertFalse(h.has_statusline)
+        self.assertFalse(h.has_read_tool)
+        self.assertFalse(h.has_prunable_transcript)
+        self.assertEqual(h.name, "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #255. Folds observability-002 (breadcrumb) and typesafety-001 (reproduced bypass), plus coverage-003 (test).

## Problem
`hostapi.load_host()` caught **any** failure loading `_host.py` and returned the base `Host()` (Claude defaults). On a Codex install a broken/partial `_host.py` degraded silently to Claude semantics — whose `iter_file_ops` cannot decompose an apply_patch envelope — so a Codex write produced an empty-path op and every pre-write guard (H-18/H-19/H-05/H-11) skipped. The write gate failed **open** with no signal.

## Fix
`load_host()` now distinguishes:
- `_host.py` **absent** → Claude default `Host()` (bare-core fallback, unchanged).
- `_host.py` **present but fails to load** → stderr breadcrumb + new `FailClosedHost`, whose `iter_file_ops` always yields an `opaque` op so pre-write blocks (H-21) rather than assuming a host.

Adds a `hooks_dir` override for testability and `plugins/ca/hooks/tests/test_hostapi_loadhost.py`.

## Verification
- New suite: 5/5 pass.
- `python -m unittest discover -s plugins/ca/hooks/tests`: 799 pass.
- `test_codex_adapter.py`: 49 pass · `test_hook_guards.py`: 106 assertions · `test_hooks_cold_install.py`: PASS (REAL/STUB/NONE).
- `sync-core.py --check`: byte-identical across both plugins.

> Merges into `feat/codex-support-m0` only. The codex branch does not go to `main` until live-Codex verification. Part of ADR-0011 / the tribunal remediation sprint.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG