### PR TITLE
feat(ci): wire ca-codex into CI/release/packaging gates (#258)

### DIFF
--- a/.github/scripts/check_license_consistency.py
+++ b/.github/scripts/check_license_consistency.py
@@ -38,6 +38,7 @@ CANONICAL_MANIFEST = "plugins/ca/.claude-plugin/plugin.json"
 MANIFESTS = [
     "plugins/ca/.claude-plugin/plugin.json",
     "plugins/ca-sandbox/.claude-plugin/plugin.json",
+    "plugins/ca-codex/.codex-plugin/plugin.json",
 ]
 LICENSE_FILE = "LICENSE"
 README_FILE = "README.md"

--- a/.github/scripts/test_hooks_cold_install.py
+++ b/.github/scripts/test_hooks_cold_install.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
-"""codeArbiter MR-10 — cold-install interpreter matrix for the hook layer.
+"""codeArbiter MR-10 / ADR-0011 infra-002 — cold-install interpreter matrix
+for the hook layer, exercised against BOTH host plugins: `ca` (Claude Code)
+and `ca-codex` (OpenAI Codex CLI).
 
 Every enforcement hook in plugins/ca/hooks/hooks.json is registered TWICE:
 
     primary :  python3 "<script>"
     fallback:  python3 -c "" || python "<script>"
 
-(rationale in plugins/ca/hooks/_hooklib.py — stock Windows ships a Microsoft
-Store `python3` alias stub that exits 9009, which would make every gate fail
-OPEN and SILENT; the fallback probes python3 and runs `python` only when the
-probe fails; separate entries each get fresh stdin so a blocking exit 2 is
-never swallowed by a rerun against drained stdin).
+`plugins/ca-codex/hooks/hooks.json` carries the same primary+fallback
+duplication (reliability-008), but in Codex's native per-entry
+`command`/`commandWindows` shape rather than one platform-neutral `command`
+string:
 
-This harness executes every hook command string VERBATIM, the way Claude Code
+    primary :  command="python3 <script>"          commandWindows="python <script>"
+    fallback:  command="python3 -c \"\" || python <script>"
+               commandWindows="python -c \"\" || python3 <script>"
+
+(rationale in core/pysrc/_hooklib.py; stock Windows ships a Microsoft Store
+`python3` alias stub that exits 9009, which would make every gate fail OPEN
+and SILENT; the fallback probes the primary interpreter and runs the OTHER
+one only when the probe fails; separate entries each get fresh stdin so a
+blocking exit 2 is never swallowed by a rerun against drained stdin).
+
+This harness executes every hook command string VERBATIM, the way each host
 does (`cmd /d /s /c "<command>"` on Windows, `/bin/sh -c '<command>'` on
 POSIX, hook-input JSON piped to stdin, one process per entry with fresh
 stdin), under three PATH scenarios:
@@ -46,6 +57,15 @@ repos, and is exactly the loud breadcrumb the design wants. Dormancy is
 therefore asserted as: no entry exits 2, no entry produces stdout, and any
 entry that actually reaches the script exits 0 silently.
 
+The ca-codex campaign exercises the SAME interpreter-resolution matrix
+against Codex-native payload shapes (Bash tool_input.command; apply_patch
+envelopes for writes) and the guard tags that payload shape is expected to
+trip (H-20 no-verify-commit block, H-05 audit-log-overwrite block) — the
+guard-decision CONTENT is exhaustively covered by
+.github/scripts/test_codex_adapter.py; this harness's job is proving the
+interpreter plumbing carries those verdicts through unchanged, on Codex's
+per-OS command/commandWindows entries, exactly as it does for `ca`.
+
 Stdlib only. Exit 0 = all assertions pass; exit 1 = failures (each printed
 with the verbatim command string and captured streams).
 """
@@ -65,8 +85,10 @@ os.environ.pop("CLAUDE_PROJECT_DIR", None)
 WIN = os.name == "nt"
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
-PLUGIN_ROOT = os.path.join(REPO, "plugins", "ca")
-HOOKS_JSON = os.path.join(PLUGIN_ROOT, "hooks", "hooks.json")
+CA_PLUGIN_ROOT = os.path.join(REPO, "plugins", "ca")
+CA_HOOKS_JSON = os.path.join(CA_PLUGIN_ROOT, "hooks", "hooks.json")
+CODEX_PLUGIN_ROOT = os.path.join(REPO, "plugins", "ca-codex")
+CODEX_HOOKS_JSON = os.path.join(CODEX_PLUGIN_ROOT, "hooks", "hooks.json")
 
 PERSONA_MARK = "=== codeArbiter startup state ==="
 STORE_STUB_MSG = "Python was not found"
@@ -94,6 +116,8 @@ def make_fixture(base, name, enabled):
         with open(os.path.join(ca, "CONTEXT.md"), "w", encoding="utf-8") as f:
             f.write("---\narbiter: enabled\nstage: 2\n---\n"
                     "<!--INITIALIZED-->\nCold-install harness fixture.\n")
+        with open(os.path.join(ca, "overrides.log"), "w", encoding="utf-8") as f:
+            f.write("seed\n")
     return root
 
 
@@ -190,7 +214,7 @@ def scenario_env(path_value, fixture):
            if k.upper() not in ("PATH", "PYTHONHOME", "PYTHONPATH", "VIRTUAL_ENV",
                                  "HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH")}
     env["PATH"] = path_value
-    env["CLAUDE_PLUGIN_ROOT"] = PLUGIN_ROOT
+    env["CLAUDE_PLUGIN_ROOT"] = _CURRENT_PLUGIN_ROOT[0]
     env["CLAUDE_PROJECT_DIR"] = fixture
     # Sandbox the home dir. Hooks resolve ~/.claude/settings.json via
     # expanduser("~") — notably session-start.py's statusLine self-heal, which
@@ -206,8 +230,15 @@ def scenario_env(path_value, fixture):
     return env
 
 
+# scenario_env needs to know which plugin's CLAUDE_PLUGIN_ROOT to export for
+# the command string currently being resolved — a 1-slot mutable cell rather
+# than a parameter, so the function signature stays identical for both
+# campaigns' call sites below.
+_CURRENT_PLUGIN_ROOT = [CA_PLUGIN_ROOT]
+
+
 def run_entry(command, hook_input, fixture, env):
-    """One hook entry, one process, fresh stdin — exactly how Claude Code
+    """One hook entry, one process, fresh stdin — exactly how each host
     invokes hook commands (cmd /d /s /c on Windows, sh -c on POSIX)."""
     stdin = json.dumps(hook_input).encode("utf-8")
     if WIN:
@@ -278,7 +309,398 @@ def assert_stub_primary(e):
     check(e.out == "", e, "stub primary must not produce stdout")
 
 
+# ------------------------------------------------------------- hooks.json map
+
+def build_hooks_map(hooks_json_path, plugin_root, field_of, expected_scripts,
+                     label):
+    """Parse `hooks_json_path`; return {script basename -> {"primary": cmd,
+    "fallback": cmd}} with ${CLAUDE_PLUGIN_ROOT} substituted. `field_of(h)`
+    extracts the OS-appropriate command string from one hook object — for
+    `ca` that is always `h["command"]`; for `ca-codex` it is
+    `h["commandWindows"]` on Windows and `h["command"]` on POSIX (Codex's
+    native per-OS shape). Structural invariant: every matcher group registers
+    exactly one primary and one fallback, and every referenced script exists
+    on disk."""
+    with open(hooks_json_path, encoding="utf-8") as f:
+        config = json.load(f)
+
+    hooks = {}
+    for event, groups in config["hooks"].items():
+        for group in groups:
+            cmds = [field_of(h) for h in group["hooks"]]
+            if len(cmds) != 2:
+                sys.exit(f"FATAL: {label} {event} group must register exactly 2 "
+                         f"entries (primary + fallback), found {len(cmds)}: {cmds}")
+            primary = [c for c in cmds if '-c ""' not in c and "-c \\\"\\\"" not in c]
+            fallback = [c for c in cmds if c not in primary]
+            if len(primary) != 1 or len(fallback) != 1:
+                sys.exit(f"FATAL: {label} {event} group lacks a primary/fallback "
+                         f"pair: {cmds}")
+            script = primary[0].split("/")[-1].rstrip('"')
+            script_path = os.path.join(plugin_root, "hooks", script)
+            if not os.path.isfile(script_path):
+                sys.exit(f"FATAL: {label} hooks.json references a missing script: "
+                         f"{script_path}")
+            hooks[script] = {
+                "primary": primary[0].replace("${CLAUDE_PLUGIN_ROOT}", plugin_root),
+                "fallback": fallback[0].replace("${CLAUDE_PLUGIN_ROOT}", plugin_root),
+            }
+    if set(hooks) != expected_scripts:
+        sys.exit(f"FATAL: {label} hook set drifted — update this harness. "
+                 f"found {sorted(hooks)}, expected {sorted(expected_scripts)}")
+    print(f"{label} hooks.json: {len(hooks)} hooks x 2 entries, all scripts present")
+    return hooks
+
+
+def ca_field(h):
+    return h["command"]
+
+
+def codex_field(h):
+    return h["commandWindows"] if WIN else h["command"]
+
+
 # ------------------------------------------------------------------- the runs
+
+def make_runner(hooks, plugin_root, paths, stub_log):
+    """Return a `run(script, kind, scenario, fixture, hook_input)` closure
+    bound to one plugin's hooks map, PATH scenarios, and stub-invocation log."""
+    def run(script, kind, scenario, fixture, hook_input):
+        cmd = hooks[script][kind]
+        _CURRENT_PLUGIN_ROOT[0] = plugin_root
+        env = scenario_env(paths[scenario], fixture)
+        if os.path.exists(stub_log):
+            os.remove(stub_log)
+        rc, out, err = run_entry(cmd, hook_input, fixture, env)
+        label = f"{script}/{kind}/{scenario}"
+        return Entry(label, cmd, rc, out, err, os.path.exists(stub_log))
+    return run
+
+
+def run_ca_campaign(hooks, paths, stub_log, enabled, dormant, base):
+    """The original `ca` (Claude Code) cold-install campaign."""
+    run = make_runner(hooks, CA_PLUGIN_ROOT, paths, stub_log)
+
+    SESSION_IN = {"hook_event_name": "SessionStart", "source": "startup"}
+    ADD_A_IN = {"tool_name": "Bash", "tool_input": {"command": "git add -A"}}
+    BENIGN_BASH_IN = {"tool_name": "Bash", "tool_input": {"command": "git status"}}
+
+    # ---- 0. harness isolation: scenario_env MUST sandbox the home dir.
+    # session-start.py self-heals the statusLine on every SessionStart by
+    # writing ~/.claude/settings.json (resolved via expanduser("~")). If the
+    # scenario env leaves HOME/USERPROFILE pointed at the developer's real
+    # home, that write escapes the harness and pins the user's statusLine to
+    # THIS run's throwaway venv interpreter — which teardown then deletes,
+    # blanking the bar. The env must redirect the home dir into the temp base.
+    real_home = os.path.realpath(os.path.expanduser("~"))
+    iso_env = scenario_env(paths["REAL"], dormant)
+    iso = Entry("ca/scenario_env/home-isolation", "scenario_env(REAL, fixture)",
+                0, "", "", False)
+    child_home = iso_env.get("USERPROFILE") if WIN else iso_env.get("HOME")
+    check(bool(child_home), iso,
+          "scenario_env must set a sandbox home (USERPROFILE on Windows, HOME on POSIX)")
+    rp = os.path.realpath(child_home) if child_home else ""
+    check(rp != real_home, iso,
+          "scenario_env must redirect the home dir AWAY from the real user home — "
+          "else a hook's ~/.claude write escapes into the developer's real settings")
+    check(rp.startswith(os.path.realpath(base)), iso,
+          "the sandbox home must live under the harness temp dir")
+
+    # ---- 1. SessionStart, enabled repo: persona exactly once, never twice
+    for scen in ("REAL", "STUB"):
+        p = run("session-start.py", "primary", scen, enabled, SESSION_IN)
+        fb = run("session-start.py", "fallback", scen, enabled, SESSION_IN)
+        total = p.out.count(PERSONA_MARK) + fb.out.count(PERSONA_MARK)
+        check(total == 1, p if scen == "REAL" else fb,
+              f"persona must inject exactly once across both entries, got {total}")
+        if scen == "REAL":
+            check(p.rc == 0 and PERSONA_MARK in p.out, p,
+                  "REAL primary must inject the persona and exit 0")
+            assert_noop_allow(fb)
+        else:
+            assert_stub_primary(p)
+            check(fb.rc == 0 and PERSONA_MARK in fb.out, fb,
+                  "STUB fallback must inject the persona via `python` and exit 0")
+            check(fb.stub_invoked, fb, "fallback probe must have hit the stub")
+    for kind in ("primary", "fallback"):
+        assert_loud_failure(run("session-start.py", kind, "NONE", enabled, SESSION_IN))
+
+    # ---- 2. SessionStart, dormant repo: no injection anywhere
+    for scen in ("REAL", "STUB", "NONE"):
+        for kind in ("primary", "fallback"):
+            e = run("session-start.py", kind, scen, dormant, SESSION_IN)
+            check(PERSONA_MARK not in e.out and e.out == "", e,
+                  "dormant repo must never receive an injection")
+            check(e.rc != 2, e, "dormant repo must never block")
+            if scen == "REAL" or (scen == "STUB" and kind == "fallback"):
+                assert_noop_allow(e, stub_ok=(scen == "STUB"))
+
+    # ---- 3. pre-bash `git add -A`, enabled repo: the H-03 block survives
+    p = run("pre-bash.py", "primary", "REAL", enabled, ADD_A_IN)
+    check(p.rc == 2 and "H-03" in p.err, p,
+          "REAL primary must BLOCK `git add -A` (exit 2, H-03)")
+    fb = run("pre-bash.py", "fallback", "REAL", enabled, ADD_A_IN)
+    assert_noop_allow(fb)  # fresh-stdin no-op; must not emit a conflicting pass
+
+    p = run("pre-bash.py", "primary", "STUB", enabled, ADD_A_IN)
+    assert_stub_primary(p)
+    fb = run("pre-bash.py", "fallback", "STUB", enabled, ADD_A_IN)
+    check(fb.rc == 2 and "H-03" in fb.err, fb,
+          "STUB fallback must BLOCK `git add -A` via `python` (exit 2, H-03)")
+    check(fb.stub_invoked, fb, "fallback probe must have hit the stub")
+
+    for kind in ("primary", "fallback"):
+        e = run("pre-bash.py", kind, "NONE", enabled, ADD_A_IN)
+        assert_loud_failure(e)
+        check("H-03" not in e.err, e, "no interpreter, so no H-03 verdict possible")
+
+    # ---- 4. pre-bash benign command, enabled repo: no false block
+    for scen, kind in (("REAL", "primary"), ("REAL", "fallback"), ("STUB", "fallback")):
+        assert_noop_allow(run("pre-bash.py", kind, scen, enabled, BENIGN_BASH_IN),
+                          stub_ok=(scen == "STUB"))
+
+    # ---- 5. pre-bash `git add -A`, dormant repo: dormancy means no block
+    for scen in ("REAL", "STUB", "NONE"):
+        for kind in ("primary", "fallback"):
+            e = run("pre-bash.py", kind, scen, dormant, ADD_A_IN)
+            check(e.rc != 2 and "H-03" not in e.err and "BLOCKED" not in e.err, e,
+                  "dormant repo must never block")
+            check(e.out == "", e, "dormant repo must produce no stdout")
+            if scen == "REAL" or (scen == "STUB" and kind == "fallback"):
+                assert_noop_allow(e, stub_ok=(scen == "STUB"))
+
+    # ---- 6. pre-write H-05 (audit log overwrite), enabled: block survives STUB
+    write_in = {"tool_name": "Write", "tool_input": {
+        "file_path": os.path.join(enabled, ".codearbiter", "overrides.log"),
+        "content": "rewritten history"}}
+    p = run("pre-write.py", "primary", "REAL", enabled, write_in)
+    check(p.rc == 2 and "H-05" in p.err, p, "REAL primary must BLOCK the audit-log Write")
+    assert_noop_allow(run("pre-write.py", "fallback", "REAL", enabled, write_in))
+    fb = run("pre-write.py", "fallback", "STUB", enabled, write_in)
+    check(fb.rc == 2 and "H-05" in fb.err, fb,
+          "STUB fallback must BLOCK the audit-log Write via `python`")
+
+    # ---- 7. pre-edit benign, enabled: allow in both interpreter routes
+    edit_in = {"tool_name": "Edit", "tool_input": {
+        "file_path": os.path.join(enabled, "notes.txt"),
+        "old_string": "a", "new_string": "b"}}
+    for scen, kind in (("REAL", "primary"), ("REAL", "fallback"), ("STUB", "fallback")):
+        assert_noop_allow(run("pre-edit.py", kind, scen, enabled, edit_in),
+                          stub_ok=(scen == "STUB"))
+
+    # ---- 8. post-write-edit crypto reminder, enabled: advisory fires, exit 0
+    post_in = {"tool_name": "Write", "tool_input": {
+        "file_path": os.path.join(enabled, "x.js"),
+        "content": "const h = createHash('md5')"}}
+    p = run("post-write-edit.py", "primary", "REAL", enabled, post_in)
+    check(p.rc == 0 and "H-09" in p.err, p,
+          "REAL primary must emit the H-09 reminder and exit 0")
+    assert_noop_allow(run("post-write-edit.py", "fallback", "REAL", enabled, post_in))
+    fb = run("post-write-edit.py", "fallback", "STUB", enabled, post_in)
+    check(fb.rc == 0 and "H-09" in fb.err, fb,
+          "STUB fallback must emit the H-09 reminder via `python` and exit 0")
+
+    # ---- 9. prune-transcript: CODEARBITER_PRUNE unset → always a no-op
+    prune_in = {"hook_event_name": "UserPromptSubmit",
+                "session_id": "test-session",
+                "transcript_path": "/nonexistent/path.jsonl"}
+    assert_noop_allow(run("prune-transcript.py", "primary", "REAL", enabled, prune_in))
+    assert_noop_allow(run("prune-transcript.py", "fallback", "REAL", enabled, prune_in))
+    assert_stub_primary(run("prune-transcript.py", "primary", "STUB", enabled, prune_in))
+    assert_noop_allow(run("prune-transcript.py", "fallback", "STUB", enabled, prune_in),
+                      stub_ok=True)
+    for kind in ("primary", "fallback"):
+        assert_loud_failure(run("prune-transcript.py", kind, "NONE", enabled, prune_in))
+
+
+def _patch(body):
+    return "*** Begin Patch\n" + body + "*** End Patch\n"
+
+
+# Codex's Windows PRIMARY entry runs `python` directly (not `python3`) —
+# already sidestepping the classic Store-alias-`python3` stub by
+# construction. The STUB fixture built by make_stub_dir() models exactly
+# THAT stub (a fake `python3`; `python` is real in the STUB scenario's
+# py-only dir). So on Windows, under THIS fixture, the codex primary entry
+# never touches the stub at all and behaves identically to REAL — and its
+# fallback's left-hand probe (`python -c ""`) succeeds too, so `||` never
+# invokes the right-hand `python3`, making the fallback a true no-op just
+# like REAL. On POSIX the primary is `python3` and IS the fixture's stub, so
+# STUB behaves the same way it does for `ca`. This flag selects which shape
+# the STUB scenario's assertions below take.
+CODEX_STUB_IS_REAL_LIKE = WIN
+
+
+def run_ca_codex_campaign(hooks, paths, stub_log, enabled, dormant):
+    """The `ca-codex` (OpenAI Codex CLI) cold-install campaign — same
+    interpreter-resolution matrix, driven through Codex's native per-OS
+    command/commandWindows entries and payload shapes (Bash tool_input, the
+    apply_patch envelope). Guard-decision CONTENT is exhaustively covered by
+    test_codex_adapter.py; here the SAME verdict-bearing scenarios (H-20
+    no-verify-commit, H-05 audit-log overwrite) prove the interpreter
+    plumbing carries the verdict through unchanged under REAL/STUB/NONE."""
+    run = make_runner(hooks, CODEX_PLUGIN_ROOT, paths, stub_log)
+
+    def session_in():
+        return {"hook_event_name": "SessionStart", "source": "startup"}
+
+    def bash_in(cmd, fixture):
+        return {"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                "cwd": fixture, "tool_input": {"command": cmd}}
+
+    def patch_in(patch, fixture, tool_name="apply_patch"):
+        return {"hook_event_name": "PreToolUse", "tool_name": tool_name,
+                "cwd": fixture, "tool_input": {"command": patch}}
+
+    def allow_pairs():
+        """(scen, kind, stub_ok) triples an ordinary allow is expected over.
+        STUB is included for BOTH entries when CODEX_STUB_IS_REAL_LIKE
+        (Windows: the stub is untouched); otherwise (POSIX) only the
+        fallback is exercised under STUB, same as `ca`."""
+        pairs = [("REAL", "primary", False), ("REAL", "fallback", False)]
+        if CODEX_STUB_IS_REAL_LIKE:
+            pairs += [("STUB", "primary", False), ("STUB", "fallback", False)]
+        else:
+            pairs += [("STUB", "fallback", True)]
+        return pairs
+
+    NOVERIFY_PATCH = 'git commit --no-verify -m "x"'
+    AUDIT_PATCH = _patch("*** Update File: .codearbiter/overrides.log\n"
+                         "@@\n-seed\n+rewritten\n")
+    ORDINARY_PATCH = _patch("*** Add File: src/util.py\n+x = 1\n")
+    PRUNE_IN = {"hook_event_name": "UserPromptSubmit", "prompt": "x"}
+
+    # ---- 1. SessionStart, enabled repo: persona exactly once, never twice
+    for scen in ("REAL", "STUB"):
+        p = run("session-start.py", "primary", scen, enabled, session_in())
+        fb = run("session-start.py", "fallback", scen, enabled, session_in())
+        total = p.out.count(PERSONA_MARK) + fb.out.count(PERSONA_MARK)
+        check(total == 1, p if scen == "REAL" else fb,
+              f"persona must inject exactly once across both entries, got {total}")
+        if scen == "REAL" or CODEX_STUB_IS_REAL_LIKE:
+            check(p.rc == 0 and PERSONA_MARK in p.out, p,
+                  "primary must inject the persona and exit 0")
+            assert_noop_allow(fb)
+        else:
+            assert_stub_primary(p)
+            check(fb.rc == 0 and PERSONA_MARK in fb.out, fb,
+                  "STUB fallback must inject the persona via the other interpreter and exit 0")
+            check(fb.stub_invoked, fb, "fallback probe must have hit the stub")
+    for kind in ("primary", "fallback"):
+        assert_loud_failure(run("session-start.py", kind, "NONE", enabled, session_in()))
+
+    # ---- 2. SessionStart, dormant repo: no injection anywhere
+    for scen in ("REAL", "STUB", "NONE"):
+        for kind in ("primary", "fallback"):
+            e = run("session-start.py", kind, scen, dormant, session_in())
+            check(PERSONA_MARK not in e.out and e.out == "", e,
+                  "dormant repo must never receive an injection")
+            check(e.rc != 2, e, "dormant repo must never block")
+            include = scen == "REAL" or (
+                scen == "STUB" and (kind == "fallback" or CODEX_STUB_IS_REAL_LIKE))
+            if include:
+                stub_ok = (scen == "STUB") and not CODEX_STUB_IS_REAL_LIKE
+                assert_noop_allow(e, stub_ok=stub_ok)
+
+    # ---- 3. pre-bash `git commit --no-verify`, enabled: the H-20 block survives
+    p = run("pre-bash.py", "primary", "REAL", enabled, bash_in(NOVERIFY_PATCH, enabled))
+    check(p.rc == 2 and "H-20" in p.err, p,
+          "REAL primary must BLOCK `git commit --no-verify` (exit 2, H-20)")
+    fb = run("pre-bash.py", "fallback", "REAL", enabled, bash_in(NOVERIFY_PATCH, enabled))
+    assert_noop_allow(fb)  # fresh-stdin no-op; must not emit a conflicting pass
+
+    if CODEX_STUB_IS_REAL_LIKE:
+        p = run("pre-bash.py", "primary", "STUB", enabled, bash_in(NOVERIFY_PATCH, enabled))
+        check(p.rc == 2 and "H-20" in p.err, p,
+              "STUB primary (python, untouched by this python3-only stub) must still BLOCK")
+        fb = run("pre-bash.py", "fallback", "STUB", enabled, bash_in(NOVERIFY_PATCH, enabled))
+        assert_noop_allow(fb)
+    else:
+        p = run("pre-bash.py", "primary", "STUB", enabled, bash_in(NOVERIFY_PATCH, enabled))
+        assert_stub_primary(p)
+        fb = run("pre-bash.py", "fallback", "STUB", enabled, bash_in(NOVERIFY_PATCH, enabled))
+        check(fb.rc == 2 and "H-20" in fb.err, fb,
+              "STUB fallback must BLOCK `git commit --no-verify` via the other interpreter (exit 2, H-20)")
+        check(fb.stub_invoked, fb, "fallback probe must have hit the stub")
+
+    for kind in ("primary", "fallback"):
+        e = run("pre-bash.py", kind, "NONE", enabled, bash_in(NOVERIFY_PATCH, enabled))
+        assert_loud_failure(e)
+        check("H-20" not in e.err, e, "no interpreter, so no H-20 verdict possible")
+
+    # ---- 4. pre-bash benign command, enabled: no false block
+    for scen, kind, stub_ok in allow_pairs():
+        assert_noop_allow(run("pre-bash.py", kind, scen, enabled, bash_in("ls -la", enabled)),
+                          stub_ok=stub_ok)
+
+    # ---- 5. pre-write H-05 (audit log overwrite via apply_patch), enabled
+    p = run("pre-write.py", "primary", "REAL", enabled, patch_in(AUDIT_PATCH, enabled))
+    check(p.rc == 2 and "H-05" in p.err, p,
+          "REAL primary must BLOCK the audit-log apply_patch")
+    assert_noop_allow(run("pre-write.py", "fallback", "REAL", enabled,
+                          patch_in(AUDIT_PATCH, enabled)))
+
+    if CODEX_STUB_IS_REAL_LIKE:
+        p = run("pre-write.py", "primary", "STUB", enabled, patch_in(AUDIT_PATCH, enabled))
+        check(p.rc == 2 and "H-05" in p.err, p,
+              "STUB primary (python, untouched by this python3-only stub) must still BLOCK")
+        assert_noop_allow(run("pre-write.py", "fallback", "STUB", enabled,
+                              patch_in(AUDIT_PATCH, enabled)))
+    else:
+        assert_stub_primary(run("pre-write.py", "primary", "STUB", enabled,
+                                patch_in(AUDIT_PATCH, enabled)))
+        fb = run("pre-write.py", "fallback", "STUB", enabled, patch_in(AUDIT_PATCH, enabled))
+        check(fb.rc == 2 and "H-05" in fb.err, fb,
+              "STUB fallback must BLOCK the audit-log apply_patch via the other interpreter")
+
+    for kind in ("primary", "fallback"):
+        e = run("pre-write.py", kind, "NONE", enabled, patch_in(AUDIT_PATCH, enabled))
+        assert_loud_failure(e)
+        check("H-05" not in e.err, e, "no interpreter, so no H-05 verdict possible")
+
+    # ---- 6. pre-write ordinary write, enabled: allow in both interpreter routes
+    for scen, kind, stub_ok in allow_pairs():
+        assert_noop_allow(run("pre-write.py", kind, scen, enabled,
+                              patch_in(ORDINARY_PATCH, enabled)),
+                          stub_ok=stub_ok)
+
+    # ---- 7. post-write-edit, enabled: an ungoverned path is a silent allow
+    post_in = patch_in(ORDINARY_PATCH, enabled)
+    for scen, kind, stub_ok in allow_pairs():
+        assert_noop_allow(run("post-write-edit.py", kind, scen, enabled, post_in),
+                          stub_ok=stub_ok)
+    for kind in ("primary", "fallback"):
+        assert_loud_failure(run("post-write-edit.py", kind, "NONE", enabled, post_in))
+
+    # ---- 8. prune-transcript audit staleness-warn: host-neutral, non-blocking
+    for kind in ("primary", "fallback"):
+        e = run("prune-transcript.py", kind, "REAL", enabled, PRUNE_IN)
+        check(e.rc == 0, e, "the audit staleness-warn must never block (exit 0)")
+        check(e.out == "", e, "the staleness-warn produces no stdout")
+
+    if CODEX_STUB_IS_REAL_LIKE:
+        for kind in ("primary", "fallback"):
+            e = run("prune-transcript.py", kind, "STUB", enabled, PRUNE_IN)
+            check(e.rc == 0, e, "the audit staleness-warn must never block (exit 0)")
+            check(e.out == "", e, "the staleness-warn produces no stdout")
+    else:
+        assert_stub_primary(run("prune-transcript.py", "primary", "STUB", enabled, PRUNE_IN))
+        fb = run("prune-transcript.py", "fallback", "STUB", enabled, PRUNE_IN)
+        check(fb.rc == 0, fb, "the audit staleness-warn must never block (exit 0)")
+        check(fb.out == "", fb, "the staleness-warn produces no stdout")
+
+    for kind in ("primary", "fallback"):
+        assert_loud_failure(run("prune-transcript.py", kind, "NONE", enabled, PRUNE_IN))
+
+
+# ------------------------------------------------------------------------- main
+
+CA_EXPECTED = {"session-start.py", "pre-bash.py", "pre-write.py",
+               "pre-edit.py", "post-write-edit.py", "prune-transcript.py",
+               "pre-read.py"}
+CODEX_EXPECTED = {"session-start.py", "pre-bash.py", "pre-write.py",
+                  "post-write-edit.py", "prune-transcript.py"}
+
 
 def main():
     for s in (sys.stdout, sys.stderr):  # Windows consoles default to cp1252
@@ -286,47 +708,18 @@ def main():
             s.reconfigure(encoding="utf-8", errors="replace")
         except Exception:  # noqa: BLE001
             pass
-    with open(HOOKS_JSON, encoding="utf-8") as f:
-        config = json.load(f)
 
-    # Structural invariant: every matcher group registers exactly one primary
-    # and one fallback, and every referenced script exists on disk.
-    hooks = {}  # script basename -> {"primary": cmd, "fallback": cmd}
-    for event, groups in config["hooks"].items():
-        for group in groups:
-            cmds = [h["command"] for h in group["hooks"]]
-            if len(cmds) != 2:
-                sys.exit(f"FATAL: {event} group must register exactly 2 entries "
-                         f"(primary + fallback), found {len(cmds)}: {cmds}")
-            primary = [c for c in cmds if '-c ""' not in c and "-c \\\"\\\"" not in c]
-            fallback = [c for c in cmds if c not in primary]
-            if len(primary) != 1 or len(fallback) != 1:
-                sys.exit(f"FATAL: {event} group lacks a primary/fallback pair: {cmds}")
-            script = primary[0].split("/")[-1].rstrip('"')
-            script_path = os.path.join(PLUGIN_ROOT, "hooks", script)
-            if not os.path.isfile(script_path):
-                sys.exit(f"FATAL: hooks.json references a missing script: {script_path}")
-            hooks[script] = {
-                "primary": primary[0].replace("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT),
-                "fallback": fallback[0].replace("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT),
-            }
-    expected = {"session-start.py", "pre-bash.py", "pre-write.py",
-                "pre-edit.py", "post-write-edit.py", "prune-transcript.py",
-                "pre-read.py"}
-    if set(hooks) != expected:
-        sys.exit(f"FATAL: hook set drifted — update this harness. "
-                 f"found {sorted(hooks)}, expected {sorted(expected)}")
-    print(f"hooks.json: {len(hooks)} hooks x 2 entries, all scripts present")
+    ca_hooks = build_hooks_map(CA_HOOKS_JSON, CA_PLUGIN_ROOT, ca_field,
+                               CA_EXPECTED, "ca")
 
-    # ---- AC-02 Read-matcher wiring assertion -----------------------------------
-    # Focused structural check: PreToolUse must have a matcher=="Read" group,
-    # both entries must reference pre-read.py, and the pair must carry the
-    # dual-interpreter shape (primary: `python3 "<script>"`, fallback:
-    # `python3 -c "" || python "<script>"`).
-    pretooluse_groups = config["hooks"].get("PreToolUse", [])
+    # ---- AC-02 Read-matcher wiring assertion (ca only — ca-codex has no
+    # read tool and registers no pre-read.py entry, per docs/parity.md). ----
+    with open(CA_HOOKS_JSON, encoding="utf-8") as f:
+        ca_config = json.load(f)
+    pretooluse_groups = ca_config["hooks"].get("PreToolUse", [])
     read_groups = [g for g in pretooluse_groups if g.get("matcher") == "Read"]
     if not read_groups:
-        sys.exit("FATAL: hooks.json has no PreToolUse entry with matcher == 'Read'")
+        sys.exit("FATAL: ca hooks.json has no PreToolUse entry with matcher == 'Read'")
     rg = read_groups[0]
     read_cmds = [h["command"] for h in rg["hooks"]]
     if not all("pre-read.py" in c for c in read_cmds):
@@ -340,6 +733,9 @@ def main():
         sys.exit(f"FATAL: Read matcher fallback lacks python3 || python dual-interpreter "
                  f"shape: {fallback_cmds[0]}")
     print("Read matcher wiring: OK (matcher='Read', pre-read.py, primary+fallback dual-interpreter)")
+
+    codex_hooks = build_hooks_map(CODEX_HOOKS_JSON, CODEX_PLUGIN_ROOT, codex_field,
+                                  CODEX_EXPECTED, "ca-codex")
 
     base = tempfile.mkdtemp(prefix="ca-coldinstall-")
     try:
@@ -358,148 +754,8 @@ def main():
             "NONE": none_path,
         }
 
-        def run(script, kind, scenario, fixture, hook_input):
-            cmd = hooks[script][kind]
-            env = scenario_env(paths[scenario], fixture)
-            if os.path.exists(stub_log):
-                os.remove(stub_log)
-            rc, out, err = run_entry(cmd, hook_input, fixture, env)
-            label = f"{script}/{kind}/{scenario}"
-            return Entry(label, cmd, rc, out, err, os.path.exists(stub_log))
-
-        SESSION_IN = {"hook_event_name": "SessionStart", "source": "startup"}
-        ADD_A_IN = {"tool_name": "Bash", "tool_input": {"command": "git add -A"}}
-        BENIGN_BASH_IN = {"tool_name": "Bash", "tool_input": {"command": "git status"}}
-
-        # ---- 0. harness isolation: scenario_env MUST sandbox the home dir.
-        # session-start.py self-heals the statusLine on every SessionStart by
-        # writing ~/.claude/settings.json (resolved via expanduser("~")). If the
-        # scenario env leaves HOME/USERPROFILE pointed at the developer's real
-        # home, that write escapes the harness and pins the user's statusLine to
-        # THIS run's throwaway venv interpreter — which teardown then deletes,
-        # blanking the bar. The env must redirect the home dir into the temp base.
-        real_home = os.path.realpath(os.path.expanduser("~"))
-        iso_env = scenario_env(paths["REAL"], dormant)
-        iso = Entry("scenario_env/home-isolation", "scenario_env(REAL, fixture)",
-                    0, "", "", False)
-        child_home = iso_env.get("USERPROFILE") if WIN else iso_env.get("HOME")
-        check(bool(child_home), iso,
-              "scenario_env must set a sandbox home (USERPROFILE on Windows, HOME on POSIX)")
-        rp = os.path.realpath(child_home) if child_home else ""
-        check(rp != real_home, iso,
-              "scenario_env must redirect the home dir AWAY from the real user home — "
-              "else a hook's ~/.claude write escapes into the developer's real settings")
-        check(rp.startswith(os.path.realpath(base)), iso,
-              "the sandbox home must live under the harness temp dir")
-
-        # ---- 1. SessionStart, enabled repo: persona exactly once, never twice
-        for scen in ("REAL", "STUB"):
-            p = run("session-start.py", "primary", scen, enabled, SESSION_IN)
-            fb = run("session-start.py", "fallback", scen, enabled, SESSION_IN)
-            total = p.out.count(PERSONA_MARK) + fb.out.count(PERSONA_MARK)
-            check(total == 1, p if scen == "REAL" else fb,
-                  f"persona must inject exactly once across both entries, got {total}")
-            if scen == "REAL":
-                check(p.rc == 0 and PERSONA_MARK in p.out, p,
-                      "REAL primary must inject the persona and exit 0")
-                assert_noop_allow(fb)
-            else:
-                assert_stub_primary(p)
-                check(fb.rc == 0 and PERSONA_MARK in fb.out, fb,
-                      "STUB fallback must inject the persona via `python` and exit 0")
-                check(fb.stub_invoked, fb, "fallback probe must have hit the stub")
-        for kind in ("primary", "fallback"):
-            assert_loud_failure(run("session-start.py", kind, "NONE", enabled, SESSION_IN))
-
-        # ---- 2. SessionStart, dormant repo: no injection anywhere
-        for scen in ("REAL", "STUB", "NONE"):
-            for kind in ("primary", "fallback"):
-                e = run("session-start.py", kind, scen, dormant, SESSION_IN)
-                check(PERSONA_MARK not in e.out and e.out == "", e,
-                      "dormant repo must never receive an injection")
-                check(e.rc != 2, e, "dormant repo must never block")
-                if scen == "REAL" or (scen == "STUB" and kind == "fallback"):
-                    assert_noop_allow(e, stub_ok=(scen == "STUB"))
-
-        # ---- 3. pre-bash `git add -A`, enabled repo: the H-03 block survives
-        p = run("pre-bash.py", "primary", "REAL", enabled, ADD_A_IN)
-        check(p.rc == 2 and "H-03" in p.err, p,
-              "REAL primary must BLOCK `git add -A` (exit 2, H-03)")
-        fb = run("pre-bash.py", "fallback", "REAL", enabled, ADD_A_IN)
-        assert_noop_allow(fb)  # fresh-stdin no-op; must not emit a conflicting pass
-
-        p = run("pre-bash.py", "primary", "STUB", enabled, ADD_A_IN)
-        assert_stub_primary(p)
-        fb = run("pre-bash.py", "fallback", "STUB", enabled, ADD_A_IN)
-        check(fb.rc == 2 and "H-03" in fb.err, fb,
-              "STUB fallback must BLOCK `git add -A` via `python` (exit 2, H-03)")
-        check(fb.stub_invoked, fb, "fallback probe must have hit the stub")
-
-        for kind in ("primary", "fallback"):
-            e = run("pre-bash.py", kind, "NONE", enabled, ADD_A_IN)
-            assert_loud_failure(e)
-            check("H-03" not in e.err, e, "no interpreter, so no H-03 verdict possible")
-
-        # ---- 4. pre-bash benign command, enabled repo: no false block
-        for scen, kind in (("REAL", "primary"), ("REAL", "fallback"), ("STUB", "fallback")):
-            assert_noop_allow(run("pre-bash.py", kind, scen, enabled, BENIGN_BASH_IN),
-                              stub_ok=(scen == "STUB"))
-
-        # ---- 5. pre-bash `git add -A`, dormant repo: dormancy means no block
-        for scen in ("REAL", "STUB", "NONE"):
-            for kind in ("primary", "fallback"):
-                e = run("pre-bash.py", kind, scen, dormant, ADD_A_IN)
-                check(e.rc != 2 and "H-03" not in e.err and "BLOCKED" not in e.err, e,
-                      "dormant repo must never block")
-                check(e.out == "", e, "dormant repo must produce no stdout")
-                if scen == "REAL" or (scen == "STUB" and kind == "fallback"):
-                    assert_noop_allow(e, stub_ok=(scen == "STUB"))
-
-        # ---- 6. pre-write H-05 (audit log overwrite), enabled: block survives STUB
-        write_in = {"tool_name": "Write", "tool_input": {
-            "file_path": os.path.join(enabled, ".codearbiter", "overrides.log"),
-            "content": "rewritten history"}}
-        p = run("pre-write.py", "primary", "REAL", enabled, write_in)
-        check(p.rc == 2 and "H-05" in p.err, p, "REAL primary must BLOCK the audit-log Write")
-        assert_noop_allow(run("pre-write.py", "fallback", "REAL", enabled, write_in))
-        fb = run("pre-write.py", "fallback", "STUB", enabled, write_in)
-        check(fb.rc == 2 and "H-05" in fb.err, fb,
-              "STUB fallback must BLOCK the audit-log Write via `python`")
-
-        # ---- 7. pre-edit benign, enabled: allow in both interpreter routes
-        edit_in = {"tool_name": "Edit", "tool_input": {
-            "file_path": os.path.join(enabled, "notes.txt"),
-            "old_string": "a", "new_string": "b"}}
-        for scen, kind in (("REAL", "primary"), ("REAL", "fallback"), ("STUB", "fallback")):
-            assert_noop_allow(run("pre-edit.py", kind, scen, enabled, edit_in),
-                              stub_ok=(scen == "STUB"))
-
-        # ---- 8. post-write-edit crypto reminder, enabled: advisory fires, exit 0
-        post_in = {"tool_name": "Write", "tool_input": {
-            "file_path": os.path.join(enabled, "x.js"),
-            "content": "const h = createHash('md5')"}}
-        p = run("post-write-edit.py", "primary", "REAL", enabled, post_in)
-        check(p.rc == 0 and "H-09" in p.err, p,
-              "REAL primary must emit the H-09 reminder and exit 0")
-        assert_noop_allow(run("post-write-edit.py", "fallback", "REAL", enabled, post_in))
-        fb = run("post-write-edit.py", "fallback", "STUB", enabled, post_in)
-        check(fb.rc == 0 and "H-09" in fb.err, fb,
-              "STUB fallback must emit the H-09 reminder via `python` and exit 0")
-
-        # ---- 9. prune-transcript: CODEARBITER_PRUNE unset → always a no-op
-        # The pruner exits 0 immediately when CODEARBITER_PRUNE is off/unset, so
-        # REAL/STUB behave identically to a dormant-repo hook (no output, exit 0);
-        # NONE still fails loud because the interpreter itself is missing.
-        prune_in = {"hook_event_name": "UserPromptSubmit",
-                    "session_id": "test-session",
-                    "transcript_path": "/nonexistent/path.jsonl"}
-        assert_noop_allow(run("prune-transcript.py", "primary", "REAL", enabled, prune_in))
-        assert_noop_allow(run("prune-transcript.py", "fallback", "REAL", enabled, prune_in))
-        assert_stub_primary(run("prune-transcript.py", "primary", "STUB", enabled, prune_in))
-        assert_noop_allow(run("prune-transcript.py", "fallback", "STUB", enabled, prune_in),
-                          stub_ok=True)
-        for kind in ("primary", "fallback"):
-            assert_loud_failure(run("prune-transcript.py", kind, "NONE", enabled, prune_in))
+        run_ca_campaign(ca_hooks, paths, stub_log, enabled, dormant, base)
+        run_ca_codex_campaign(codex_hooks, paths, stub_log, enabled, dormant)
     finally:
         shutil.rmtree(base, ignore_errors=True)
 
@@ -509,7 +765,7 @@ def main():
         print("\nRELEASE BLOCKER: a cold-install scenario failed. Do not weaken the "
               "hook — the failing command strings are above.")
         sys.exit(1)
-    print("cold-install matrix: PASS (REAL / STUB / NONE)")
+    print("cold-install matrix: PASS (ca + ca-codex, REAL / STUB / NONE)")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,19 @@ name: ci
 
 on:
   pull_request:
-    branches: [main]
+    # Campaign-branch coverage (issue #258): feat/codex-support-m0 integrates
+    # every ca-codex fix PR before it lands on main, so PRs targeting it need
+    # the same CI gate PRs targeting main get - otherwise the whole codex
+    # campaign merges with zero CI. Drop this once the campaign branch is
+    # closed out and merged to main.
+    branches: [main, feat/codex-support-m0]
   push:
     branches: [main]
     paths:
       - "plugins/ca/**"
       - "plugins/ca-sandbox/**"
+      - "plugins/ca-codex/**"
+      - "core/**"
       - "**/*.json"
       - "README.md"
       - "LICENSE"
@@ -38,6 +45,7 @@ jobs:
     outputs:
       ca: ${{ steps.filter.outputs.ca }}
       ca-sandbox: ${{ steps.filter.outputs.ca-sandbox }}
+      ca-codex: ${{ steps.filter.outputs.ca-codex }}
       hooks: ${{ steps.filter.outputs.hooks }}
       manifests: ${{ steps.filter.outputs.manifests }}
     steps:
@@ -48,9 +56,15 @@ jobs:
           # A change to shared CI infra (.github/) flags BOTH plugins so the
           # full mechanical surface re-runs. A plugin-only change flags just
           # that plugin - this is the path-scoping ADR-0007 requires.
+          #
+          # core/** is the canonical-copy source every host-neutral hook file
+          # is vendored FROM (tools/sync-core.py, ADR-0011 M1) into BOTH
+          # plugins/ca/hooks/ and plugins/ca-codex/hooks/ - a core/** edit can
+          # drift either vendored copy, so it flags ca, ca-codex, AND hooks.
           filters: |
             ca:
               - 'plugins/ca/**'
+              - 'core/**'
               - 'README.md'
               - '.github/workflows/ci.yml'
               - '.github/scripts/check-plugin-refs.py'
@@ -59,8 +73,14 @@ jobs:
               - 'plugins/ca-sandbox/**'
               - '.github/workflows/ci.yml'
               - '.github/scripts/check-plugin-refs.py'
+            ca-codex:
+              - 'plugins/ca-codex/**'
+              - 'core/**'
+              - '.github/workflows/ci.yml'
             hooks:
               - 'plugins/ca/hooks/**'
+              - 'plugins/ca-codex/hooks/**'
+              - 'core/**'
               - '.github/scripts/**'
               - '.github/workflows/ci.yml'
             manifests:
@@ -164,8 +184,21 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
+      - name: Sync-core drift gate (ADR-0011 M1)
+        # core/pysrc/ is the canonical copy of every host-neutral hook file;
+        # plugins/ca/hooks/ and plugins/ca-codex/hooks/ each vendor a
+        # byte-identical copy (tools/sync-core.py). A vendored copy that
+        # drifts from core silently forks the enforcement logic between the
+        # two hosts - fail the build before that ships.
+        run: python tools/sync-core.py --check
       - name: Run cold-install interpreter matrix
         run: python .github/scripts/test_hooks_cold_install.py
+      - name: Run ca-codex host-adapter parity suite
+        # ADR-0011 M2: Codex payload normalization, apply_patch envelope
+        # parsing, project_root resolution, and cross-host blocked-verdict
+        # parity (H-05/H-11/H-18/H-19/H-20/H-21) via real subprocess
+        # invocations of each plugin's vendored pre-write.py/pre-bash.py.
+        run: python .github/scripts/test_codex_adapter.py
       - name: Run guard-logic matrix
         # The cold-install matrix proves the interpreter plumbing; this proves
         # the guard decisions themselves - every blocked spelling of
@@ -339,6 +372,58 @@ jobs:
           fi
           echo "payload changed on unpublished version $ver (no tag ca-sandbox-v$ver) - allowed"
 
+  version-bump-codex:
+    name: CA-Codex | [Gate] - Version Bump on Payload Change
+    # Per-plugin twin of the ca / ca-sandbox version-bump guards (ADR-0007
+    # path-scoping, ADR-0011 Codex host): ca-codex versions independently, so
+    # a changed ca-codex payload on an already-published ca-codex version
+    # (tag ca-codex-v<version>) is the same silent-staleness trap and is
+    # failed here. Namespaced tags (ca-codex-v*) never collide with ca's bare
+    # v* series or ca-sandbox's ca-sandbox-v* series.
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.ca-codex == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Fail if a published version ships a changed payload
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          git fetch -q origin "$BASE" --tags
+          if git diff --quiet "origin/$BASE"...HEAD -- plugins/ca-codex; then
+            echo "no payload change - version bump not required"
+            exit 0
+          fi
+          ver=$(node -p "JSON.parse(require('fs').readFileSync('plugins/ca-codex/.codex-plugin/plugin.json','utf8')).version")
+          # First introduction of the plugin: plugin.json does not exist on base.
+          # That is never a silent-staleness trap (nothing is published yet), so
+          # allow it - but only when the file is genuinely absent at $BASE. Any
+          # other git failure (transient fetch error, corrupted object store,
+          # a race on origin/$BASE) must fail the step, not be swallowed as
+          # "first introduction".
+          rc=0
+          git cat-file -e "origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json" 2>/dev/null || rc=$?
+          if [ "$rc" = 1 ]; then
+            echo "ca-codex is new on $BASE (no prior plugin.json) - first introduction, version bump not required"
+            exit 0
+          elif [ "$rc" != 0 ]; then
+            echo "::error::git cat-file probe on origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json failed with exit $rc (not a plain absence) - bad ref or corrupt object store"
+            exit "$rc"
+          fi
+          base_json=$(git show "origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json")
+          base_ver=$(printf '%s' "$base_json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          if [ "$ver" != "$base_ver" ]; then
+            echo "payload changed and version bumped: $base_ver -> $ver"
+            exit 0
+          fi
+          if git rev-parse -q --verify "refs/tags/ca-codex-v$ver" > /dev/null; then
+            echo "::error file=plugins/ca-codex/.codex-plugin/plugin.json::plugins/ca-codex/** changed but version is still $ver, which is already published (tag ca-codex-v$ver exists). 'claude plugin update' no-ops on an unchanged version, so installed users would silently keep the old payload. Bump the version."
+            exit 1
+          fi
+          echo "payload changed on unpublished version $ver (no tag ca-codex-v$ver) - allowed"
+
   prose:
     name: CA | [Check] - Reference Graph
     needs: changes
@@ -432,6 +517,7 @@ jobs:
       - hooks
       - version-bump
       - version-bump-sandbox
+      - version-bump-codex
       - prose
       - badge-consistency
       - prose-sandbox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,33 @@ name: release
 # extracts the matching CHANGELOG section as the notes, and is idempotent — a
 # re-run when the tag/Release already exists is a no-op, not a failure.
 
+# ca-codex (the OpenAI Codex CLI sibling, ADR-0011) versions and releases
+# independently — its own tag namespace (ca-codex-v*), its own manifest
+# (plugins/ca-codex/.codex-plugin/plugin.json), its own CHANGELOG
+# (plugins/ca-codex/CHANGELOG.md). Both plugins share this one dispatched
+# workflow; each job is gated on its own confirm input being non-empty, so a
+# single dispatch releases exactly one plugin (never both, never neither) —
+# an empty `confirm` skips the `release` job entirely, an empty
+# `codex_confirm` skips `release-codex` entirely, and providing neither is an
+# explicit no-op the workflow does not need to special-case.
+
 on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "ca version to release (must equal plugins/ca/.claude-plugin/plugin.json), e.g. 2.6.1"
-        required: true
+        description: "ca version to release (must equal plugins/ca/.claude-plugin/plugin.json), e.g. 2.6.1 — leave blank to release ca-codex instead"
+        required: false
+        default: ""
       summary:
         description: "Optional release-title summary (appended after the version)"
+        required: false
+        default: ""
+      codex_confirm:
+        description: "ca-codex version to release (must equal plugins/ca-codex/.codex-plugin/plugin.json), e.g. 0.1.0 — leave blank to release ca instead"
+        required: false
+        default: ""
+      codex_summary:
+        description: "Optional release-title summary for the ca-codex release"
         required: false
         default: ""
 
@@ -26,8 +45,10 @@ permissions:
 
 jobs:
   release:
-    # Publish only from the default branch, where the merged CHANGELOG section lives.
-    if: github.ref == 'refs/heads/main'
+    name: CA | [Release] - Publish
+    # Publish only from the default branch, where the merged CHANGELOG section
+    # lives, and only when this dispatch requested a ca release.
+    if: github.ref == 'refs/heads/main' && github.event.inputs.confirm != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -100,6 +121,96 @@ jobs:
               --notes-file notes.md \
               --target "$GITHUB_SHA" \
               --latest --verify-tag
+          fi
+
+          # Verify publication rather than assume it (a create can partially succeed).
+          gh release view "$TAG" --json url,isDraft,tagName
+          DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)
+          [ "$DRAFT" = "false" ] || { echo "::error::release $TAG is draft/unpublished"; exit 1; }
+
+  release-codex:
+    name: CA-Codex | [Release] - Publish
+    # Sibling twin of the `release` job (ADR-0007-style per-plugin
+    # independence, ADR-0011 for the Codex host). Publish only from the
+    # default branch, and only when this dispatch requested a ca-codex
+    # release. The tag is namespaced (ca-codex-v*) so it never collides with
+    # ca's bare v* series, and this job never passes --latest to
+    # `gh release create` — ca-codex is a BETA sibling plugin, not the
+    # repo's primary release, and must not steal the "Latest" badge from ca.
+    if: github.ref == 'refs/heads/main' && github.event.inputs.codex_confirm != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and verify version against the manifest
+        id: v
+        env:
+          CONFIRM: ${{ github.event.inputs.codex_confirm }}
+        run: |
+          set -euo pipefail
+          MANIFEST=$(node -p "require('./plugins/ca-codex/.codex-plugin/plugin.json').version")
+          REQ="$CONFIRM"
+          if [ "$REQ" != "$MANIFEST" ]; then
+            echo "::error::requested '$REQ' does not equal plugin.json version '$MANIFEST' — bump/align first"
+            exit 1
+          fi
+          echo "version=$MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "tag=ca-codex-v$MANIFEST" >> "$GITHUB_OUTPUT"
+
+      - name: Extract the CHANGELOG section as release notes
+        env:
+          VER: ${{ steps.v.outputs.version }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Capture from "## [VER]" up to (not including) the next "## [" section heading.
+          awk -v v="## [$VER]" 'index($0,v)==1{f=1;print;next} f&&/^## \[/{exit} f{print}' plugins/ca-codex/CHANGELOG.md > notes.md
+          # Trim a trailing Keep-a-Changelog "---" separator and blank lines.
+          python3 - <<'PY'
+          import re
+          t = open("notes.md").read().rstrip()
+          open("notes.md", "w").write(re.sub(r"\n+---$", "", t).rstrip() + "\n")
+          PY
+          test -s notes.md || { echo "::error::no CHANGELOG section found for $VER in plugins/ca-codex/CHANGELOG.md"; exit 1; }
+          # The notes' first heading must match the tag (the same guard /ca:release Phase 3 runs).
+          python3 .github/scripts/_releaselib.py notes-match "$TAG" notes.md
+          echo "---- notes.md ----"; head -1 notes.md
+
+      - name: Create the tag and GitHub Release (idempotent)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SUMMARY: ${{ github.event.inputs.codex_summary }}
+          TAG: ${{ steps.v.outputs.tag }}
+          VER: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+          SUM="$SUMMARY"
+          if [ -n "$SUM" ]; then TITLE="ca-codex $VER: $SUM"; else TITLE="ca-codex $VER"; fi
+
+          # An annotated tag needs a committer identity; the runner has none by default.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "tag $TAG already on remote — skipping tag creation"
+          else
+            printf '%s\n\nReleased-at: %s\n' "$(cat notes.md)" "$(date +%F)" > tagmsg.txt
+            git tag -a "$TAG" -F tagmsg.txt "$GITHUB_SHA"
+            git push origin "refs/tags/$TAG"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists — nothing to publish"
+          else
+            # Not --latest: ca-codex is a BETA sibling plugin, not the repo's
+            # primary release; it must never displace ca's "Latest" badge.
+            gh release create "$TAG" \
+              --title "$TITLE" \
+              --notes-file notes.md \
+              --target "$GITHUB_SHA" \
+              --verify-tag
           fi
 
           # Verify publication rather than assume it (a create can partially succeed).

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — ca-codex
+
+All notable changes to the **ca-codex** plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/). ca-codex is the OpenAI Codex CLI sibling to `ca`; the two version and release independently (ADR-0011), sharing one `.codearbiter/` store via the host-abstraction seam in `core/pysrc/`.
+
+---
+
+## [0.1.0] — 2026-07-09 — Initial beta release
+
+The second host: OpenAI Codex CLI enforcement core (ADR-0011 M0–M2).
+
+### Added
+- **Codex host adapter (`hostapi.py` / `_host.py`).** Normalizes Codex's native tool payloads (`Bash`, `apply_patch`/`Write`/`Edit`, `mcp__*`) to the same canonical per-file-op shape the shared `core/pysrc/` entries consume, including full `apply_patch` envelope parsing (Add/Update/Delete/Move, added-line extraction, CRLF-lenient, fail-closed opaque fallback).
+- **Shared-core enforcement.** SessionStart persona injection, the PreToolUse exec gate (`pre-bash.py`, H-20 no-verify-commit block), the PreToolUse write gate (`pre-write.py`, H-05/H-11/H-18/H-19/H-21), and the PostToolUse scope-touch review (`post-write-edit.py`) run byte-identically to the vendored `core/pysrc/` copies via `tools/sync-core.py`.
+- **Host-neutral audit staleness-warn.** The `UserPromptSubmit` audit-staleness check (CONFIRM-09) is registered on Codex; the Claude-format-only prune ENGINE is gated off via `has_prunable_transcript` (parity ledger: `docs/parity.md`).
+- **Dual interpreter registration.** `hooks.json` registers every hook twice (primary `python3`/`python` per `command`/`commandWindows`, plus a probe-and-fallback entry), mirroring `ca`'s STUB-fallback design so a Store-alias stub or a missing `python3`/`python` on either platform cannot silently disable every Codex gate.
+
+BETA until live-Codex verification (plan: `.codearbiter/plans/codex-support.md`).

--- a/plugins/ca-codex/hooks/hooks.json
+++ b/plugins/ca-codex/hooks/hooks.json
@@ -9,6 +9,13 @@
             "commandWindows": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.py\"",
             "timeout": 60,
             "statusMessage": "codeArbiter: activating governance"
+          },
+          {
+            "type": "command",
+            "command": "python3 -c \"\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.py\"",
+            "commandWindows": "python -c \"\" || python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.py\"",
+            "timeout": 60,
+            "statusMessage": "codeArbiter: activating governance"
           }
         ]
       }
@@ -23,6 +30,13 @@
             "commandWindows": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash.py\"",
             "timeout": 30,
             "statusMessage": "codeArbiter: exec gate"
+          },
+          {
+            "type": "command",
+            "command": "python3 -c \"\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash.py\"",
+            "commandWindows": "python -c \"\" || python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash.py\"",
+            "timeout": 30,
+            "statusMessage": "codeArbiter: exec gate"
           }
         ]
       },
@@ -33,6 +47,13 @@
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-write.py\"",
             "commandWindows": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-write.py\"",
+            "timeout": 30,
+            "statusMessage": "codeArbiter: write gate"
+          },
+          {
+            "type": "command",
+            "command": "python3 -c \"\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-write.py\"",
+            "commandWindows": "python -c \"\" || python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-write.py\"",
             "timeout": 30,
             "statusMessage": "codeArbiter: write gate"
           }
@@ -49,6 +70,13 @@
             "commandWindows": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/post-write-edit.py\"",
             "timeout": 30,
             "statusMessage": "codeArbiter: scope-touch review"
+          },
+          {
+            "type": "command",
+            "command": "python3 -c \"\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/post-write-edit.py\"",
+            "commandWindows": "python -c \"\" || python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/post-write-edit.py\"",
+            "timeout": 30,
+            "statusMessage": "codeArbiter: scope-touch review"
           }
         ]
       }
@@ -60,6 +88,13 @@
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py\"",
             "commandWindows": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py\"",
+            "timeout": 30,
+            "statusMessage": "codeArbiter: audit staleness check"
+          },
+          {
+            "type": "command",
+            "command": "python3 -c \"\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py\"",
+            "commandWindows": "python -c \"\" || python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/prune-transcript.py\"",
             "timeout": 30,
             "statusMessage": "codeArbiter: audit staleness check"
           }


### PR DESCRIPTION
Closes #258. Folds architecture-002/003, infra-001/002/003, reliability-008.

Wires the ca-codex sibling plugin into the CI/release/packaging machinery ADR-0011 calls load-bearing but that never existed:

- **CI triggers + filters:** `core/**` and `plugins/ca-codex/**` added to path filters; a new `ca-codex` change-filter; `feat/codex-support-m0` added to `pull_request.branches` so campaign PRs are gated (commented for removal once merged to main).
- **sync-core drift gate:** `python tools/sync-core.py --check` step in the hooks job.
- **Adapter parity suite wired:** `test_codex_adapter.py` now runs in CI (was orphaned).
- **version-bump-codex** job, twin of version-bump-sandbox, scoped to `ca-codex-v*`.
- **release-codex** job in release.yml, twin of the ca release job; namespaced `ca-codex-v*` tag, never `--latest` (BETA sibling). `confirm` inputs made optional so one dispatch releases exactly one plugin. Adds `plugins/ca-codex/CHANGELOG.md`.
- **Cold-install matrix** extended to ca-codex (per-plugin campaigns, REAL/STUB/NONE).
- **Dual interpreter registration** in ca-codex `hooks.json` (primary + `python3 -c "" || python` fallback), fixing the STUB-python3 silent fail-open (reliability-008).
- **License check** now covers the ca-codex manifest.

Verified locally (no CI on this bootstrap PR — it is the PR that turns CI on): sync-core --check OK, license consistent, adapter 49/49, cold-install 272 assertions (ca + ca-codex), ci.yml + release.yml parse.

Reviewer notes from the author, confirmed: no ca-sandbox *release* job existed to mirror, so the ca release job was mirrored and a ca-codex CHANGELOG seeded; STUB==REAL on Windows for ca-codex by construction (it runs `python` directly), documented inline.

> Bootstrap merge on local verification. Merges into `feat/codex-support-m0` only; nothing to main until live-Codex verification.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG