### PR TITLE
fix(hooks): resolve prune-transcript staleness root through the host seam (#264)

### DIFF
--- a/core/pysrc/prune-transcript.py
+++ b/core/pysrc/prune-transcript.py
@@ -50,7 +50,11 @@ def staleness_check(payload):
     hook-mode exit code (always 0) or block the user's prompt."""
     try:
         import _hooklib
-        root = payload.get("cwd") or os.getcwd()
+        # Resolve through the host seam (ADR-0011), not the raw payload cwd —
+        # a session whose cwd is a repo subdirectory must still resolve the
+        # repo root (CLAUDE_PROJECT_DIR -> payload cwd -> git toplevel ->
+        # process cwd), or this WARN silently never fires (#264).
+        root = _hooklib.get_host().project_root(payload)
         if not _hooklib.arbiter_active(root):
             return
         for msg in _hooklib.staleness_warning(root):

--- a/plugins/ca-codex/hooks/prune-transcript.py
+++ b/plugins/ca-codex/hooks/prune-transcript.py
@@ -50,7 +50,11 @@ def staleness_check(payload):
     hook-mode exit code (always 0) or block the user's prompt."""
     try:
         import _hooklib
-        root = payload.get("cwd") or os.getcwd()
+        # Resolve through the host seam (ADR-0011), not the raw payload cwd —
+        # a session whose cwd is a repo subdirectory must still resolve the
+        # repo root (CLAUDE_PROJECT_DIR -> payload cwd -> git toplevel ->
+        # process cwd), or this WARN silently never fires (#264).
+        root = _hooklib.get_host().project_root(payload)
         if not _hooklib.arbiter_active(root):
             return
         for msg in _hooklib.staleness_warning(root):

--- a/plugins/ca/hooks/prune-transcript.py
+++ b/plugins/ca/hooks/prune-transcript.py
@@ -50,7 +50,11 @@ def staleness_check(payload):
     hook-mode exit code (always 0) or block the user's prompt."""
     try:
         import _hooklib
-        root = payload.get("cwd") or os.getcwd()
+        # Resolve through the host seam (ADR-0011), not the raw payload cwd —
+        # a session whose cwd is a repo subdirectory must still resolve the
+        # repo root (CLAUDE_PROJECT_DIR -> payload cwd -> git toplevel ->
+        # process cwd), or this WARN silently never fires (#264).
+        root = _hooklib.get_host().project_root(payload)
         if not _hooklib.arbiter_active(root):
             return
         for msg in _hooklib.staleness_warning(root):

--- a/plugins/ca/hooks/tests/test_staleness_warn_entry.py
+++ b/plugins/ca/hooks/tests/test_staleness_warn_entry.py
@@ -100,6 +100,23 @@ class TestStalenessCheckFunction(_Fixture):
             pt.staleness_check(self.payload())
         self.assertEqual(buf.getvalue(), "")
 
+    def test_subdir_cwd_still_resolves_active_repo_via_host_seam(self):
+        # #264 (reliability-006): a session whose cwd is a repo SUBDIRECTORY
+        # must still resolve the repo root through the host seam
+        # (CLAUDE_PROJECT_DIR first) rather than reading payload["cwd"]
+        # verbatim — else `<subdir>/.codearbiter/CONTEXT.md` (which doesn't
+        # exist) reads as not-enabled and the WARN silently never fires.
+        subdir = os.path.join(self.root, "src", "nested")
+        os.makedirs(subdir)
+        _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
+        payload = {"hook_event_name": "UserPromptSubmit", "cwd": subdir}
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.root}):
+            with mock.patch.object(sys, "stderr", buf):
+                pt.staleness_check(payload)
+        self.assertIn("codeArbiter hook:", buf.getvalue())
+        self.assertIn("CONFIRM-09", buf.getvalue())
+
     def test_never_raises_when_hooklib_import_fails(self):
         _touch(os.path.join(self.cad, ".markers", "dev-active"), age_seconds=3600)
         with mock.patch.dict(sys.modules, {"_hooklib": None}):


### PR DESCRIPTION
Closes #264 (reliability-006). One-line change: `staleness_check` resolved root as `payload.get("cwd") or os.getcwd()`, the only shared-core call site bypassing the host seam. A subdir-cwd session read the wrong `.codearbiter` state, got arbiter as inactive, and the CONFIRM-09 audit-staleness WARN silently never fired.

Now `root = _hooklib.get_host().project_root(payload)` (CLAUDE_PROJECT_DIR then payload cwd then git toplevel then cwd). The `except Exception: pass` fail-safe is untouched.

Test added: `test_subdir_cwd_still_resolves_active_repo_via_host_seam` (subdir cwd, WARN still fires). Full hook suite 795 pass; sync-core --check byte-identical.

> Into `feat/codex-support-m0` only. Part of the tribunal remediation sprint.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
