### PR TITLE
fix(ca-codex): apply_patch parser fails closed on unrecognized directive (#256)

### DIFF
--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -243,6 +243,38 @@ class TestApplyPatchParsing(unittest.TestCase):
         self.assertEqual(len(ops), 1)
         self.assertEqual(ops[0]["kind"], "opaque")
 
+    def test_partial_envelope_unrecognized_directive_fails_closed(self):
+        # appsec-001 / coverage-001: an envelope that decomposes into >=1
+        # recognized op but ALSO carries an unrecognized "*** " directive must
+        # NOT return the partial op list (which would silently drop the
+        # unrecognized directive's file). It aborts to a single opaque op so
+        # pre-write blocks the whole envelope (H-21) — the zero-ops backstop
+        # cannot catch this because the op list is non-empty.
+        patch = ("*** Begin Patch\n"
+                 "*** Add File: safe.txt\n+hi\n"
+                 "*** Copy File: /etc/passwd\n"  # unrecognized directive
+                 "*** End Patch\n")
+        ops = self.ops(patch)
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["kind"], "opaque")
+
+    def test_mispositioned_move_to_fails_closed(self):
+        # A "*** Move to:" with no open Update op is not a valid rename; the
+        # _MOVE branch requires an edit op, so it reaches the unrecognized-
+        # directive guard and fails closed rather than being silently skipped.
+        patch = "*** Begin Patch\n*** Move to: elsewhere.txt\n*** End Patch\n"
+        ops = self.ops(patch)
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["kind"], "opaque")
+
+    def test_malformed_add_file_missing_space_fails_closed(self):
+        # "*** Add File:x" (no trailing space) is not the canonical grammar;
+        # Codex's lenient parser may still act on it, so the mirror fails
+        # closed rather than skip it.
+        ops = self.ops("*** Begin Patch\n*** Add File:x\n+data\n*** End Patch\n")
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["kind"], "opaque")
+
     def test_empty_and_malformed_payloads(self):
         self.assertEqual(self.host.iter_file_ops({}), [])
         self.assertEqual(self.host.iter_file_ops(None), [])

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -77,9 +77,13 @@ def parse_apply_patch(text):
     any file is touched). When a marker IS present but this parse yields zero
     ops, iter_file_ops fails CLOSED with a single "opaque" op that pre-write
     blocks outright — an envelope the adapter cannot decompose must never
-    pass unguarded. Unrecognized lines INSIDE a recognized envelope are
-    skipped rather than aborting the ops already collected — under-reporting
-    a whole envelope would un-guard every file in it.
+    pass unguarded. An unrecognized "*** " DIRECTIVE inside a recognized
+    envelope (e.g. "*** Copy File:", a mis-positioned "*** Move to:") aborts
+    the parse and returns a single "opaque" op: Codex's lenient parser may
+    still apply such an envelope, so emitting the PARTIAL op list collected so
+    far would silently drop that directive's file and un-guard it (appsec-001).
+    Non-directive unrecognized lines (context " " and removal "-" hunk lines)
+    are still skipped — they carry no file operation to guard.
 
     Op mapping:
       * Add File    -> one "write" op; the + lines ARE the file's full content.
@@ -140,7 +144,26 @@ def parse_apply_patch(text):
             continue  # hunk boundary / end-of-file marker — never content
         elif cur is not None and line.startswith("+"):
             cur[2].append(line[1:])
-        # " "/"-" hunk lines and anything unrecognized: skipped (see docstring)
+        elif marker.startswith("*** "):
+            # An unrecognized "*** " directive inside a recognized envelope —
+            # e.g. "*** Copy File:", a mis-positioned "*** Move to:" (the _MOVE
+            # branch above requires an open edit op), or a malformed
+            # "*** Add File:x" (no trailing space). The recognized markers were
+            # all matched above, and a "+" content line was consumed above, so
+            # reaching here means a structural directive this mirror does not
+            # model. Codex's LENIENT parser may still APPLY such an envelope, so
+            # returning the PARTIAL op list collected so far would silently DROP
+            # this directive's file operation and un-guard it (appsec-001). The
+            # whole-envelope backstop in iter_file_ops only fires on ZERO ops,
+            # so it cannot catch a partial parse. Fail CLOSED: discard the
+            # partial ops and return the single "opaque" op, which pre-write
+            # blocks (H-21). (A hunk content line whose text begins "*** " is
+            # matched here too, exactly as the recognized markers above already
+            # match a stripped content line — this mirrors Codex's own
+            # trim-then-match leniency, so it is parity-preserving, not a new
+            # divergence; the safe resolution of that ambiguity is to block.)
+            return [_op("", "opaque", None, [])]
+        # " "/"-" hunk lines and anything else unrecognized: skipped (docstring)
     _flush()
     return ops
 


### PR DESCRIPTION
Closes #256 (appsec-001), folds coverage-001.

## Problem
`parse_apply_patch` skipped any unrecognized `*** ` directive inside a recognized envelope while still emitting the ops collected so far. Codex's lenient parser may still apply such an envelope, so the partial op list silently dropped the unrecognized directive's file and un-guarded it. The whole-envelope "opaque" backstop only fires on **zero** ops, so it could not catch a partial parse.

## Fix
An unrecognized `*** ` directive (e.g. `*** Copy File:`, a mis-positioned `*** Move to:`, a malformed `*** Add File:x`) now aborts the parse and returns a single `opaque` op, which pre-write blocks (H-21). Recognized markers and `+` content lines are matched first; non-directive context/removal lines are still skipped. The stripped-marker matching mirrors Codex's own trim-then-match leniency, so this is parity-preserving; the safe resolution of the ambiguity is to block.

## Verification
- Adapter suite: 52 pass (49 existing + 3 new partial-envelope fixtures).
- `sync-core --check`: byte-identical.

> Into `feat/codex-support-m0` only. Part of the tribunal remediation sprint.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
