### PR TITLE
fix(hooks): git-toplevel climb + memoize project_root seam (#260)

### DIFF
--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -331,7 +331,10 @@ class TestApplyPatchParsing(unittest.TestCase):
 
 
 class TestCodexProjectRoot(unittest.TestCase):
-    """CodexHost.project_root: payload cwd -> git rev-parse -> cwd; NO env leg."""
+    """CodexHost.project_root: payload cwd -> git rev-parse -> cwd; NO env leg.
+    The payload-cwd leg itself climbs to the git TOPLEVEL from that cwd
+    (reliability-005/#260) rather than returning it verbatim, falling back to
+    the cwd only when the climb fails (not a repo)."""
 
     def setUp(self):
         self.host = codex_host()
@@ -391,6 +394,36 @@ class TestCodexProjectRoot(unittest.TestCase):
             finally:
                 os.chdir(self._cwd)
             self.assertEqual(os.path.realpath(got), os.path.realpath(plain))
+
+    def test_payload_cwd_in_repo_subdir_resolves_repo_root(self):
+        # reliability-005 (#260): a Codex session started in a repo
+        # SUBDIRECTORY must resolve the repo ROOT from the payload cwd leg,
+        # not that subdirectory verbatim — .codearbiter/ state lives at the
+        # root, so a wrong (subdir) root silently reads/writes nothing there.
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            repo = os.path.join(top, "repo")
+            sub = os.path.join(repo, "pkg", "sub")
+            os.makedirs(sub)
+            r = subprocess.run(["git", "init", "-q"], cwd=repo,
+                               capture_output=True, timeout=30)
+            if r.returncode != 0:
+                self.skipTest("git unavailable")
+            # cwd stays OUTSIDE the repo; only the payload cwd names the
+            # subdirectory, isolating the payload leg from the process-cwd leg.
+            got = self.host.project_root({"cwd": sub})
+            self.assertEqual(os.path.realpath(got), os.path.realpath(repo))
+            self.assertNotEqual(os.path.realpath(got), os.path.realpath(sub))
+
+    def test_payload_cwd_non_repo_dir_falls_back_to_cwd_verbatim(self):
+        # The payload cwd IS an existing directory but not a git repo (or
+        # git itself is unavailable from there) — git_toplevel climb fails,
+        # so the leg falls back to the cwd itself (not a hard failure to the
+        # process-cwd leg), matching the pre-#260 behavior for a non-repo cwd.
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory() as payload_dir:
+            got = self.host.project_root({"cwd": payload_dir})
+            self.assertEqual(os.path.realpath(got), os.path.realpath(payload_dir))
 
 
 class TestClaudeIterFileOps(unittest.TestCase):

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -31,7 +31,9 @@
 #   arbiter_active(root) -> bool         True iff repo opted in via CONTEXT.md frontmatter
 #   read_input() -> dict                 parse hook JSON from stdin; fail-open on error
 #   tool_input(data) -> dict             extract tool_input sub-dict from hook payload
-#   project_root() -> str                CLAUDE_PROJECT_DIR, else git repo root, else cwd
+#   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
+#                                         (memoized per process, keyed on the
+#                                         inputs that could change it — #260)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -82,6 +84,42 @@ def get_host():
     if _HOST is None:
         _HOST = hostapi.load_host()
     return _HOST
+
+
+# project_root() memoization (performance-001/003, #260). A hook is a
+# single-shot process, so CLAUDE_PROJECT_DIR and the process cwd cannot
+# change mid-process — but the resolved VALUE is cached keyed on those two
+# inputs (not unconditionally) rather than as one bare value, so an env/cwd
+# change is a cache MISS, never a stale hit. This keeps the production
+# single-shot contract (the same hook process always sees an unchanging
+# env/cwd, so it resolves at most once) while staying correct for the
+# in-process integration-test harnesses that legitimately re-target
+# project_root() across many fixtures/envs within one Python process
+# (`python -m unittest discover` runs the whole suite in ONE interpreter —
+# an unconditional single-value cache would leak the FIRST test's resolved
+# root into every later test that calls project_root() or warn()/block()/
+# remind() in-process). A payload's `cwd` is deliberately NOT part of the
+# cache key: within one real hook process the payload is parsed at most once
+# and never changes, so a payload-bearing call and a later no-payload call in
+# the SAME (env, cwd) context are the SAME logical resolution and must return
+# the SAME value — exactly the "payload-bearing first call, later no-arg
+# calls stay consistent" contract. (A payload-only scenario — Codex, no
+# CLAUDE_PROJECT_DIR — still resolves once: the first call's payload wins and
+# is cached against the current (env, cwd); env/cwd don't change either.)
+_ROOT_CACHE = {}
+
+
+def _root_cache_key():
+    return (os.environ.get("CLAUDE_PROJECT_DIR"), os.getcwd())
+
+
+def _reset_root_cache():
+    """Test-only: drop every memoized project_root() resolution. Production
+    hook processes never need this (each is single-shot); integration tests
+    that simulate MANY logical hook invocations in one Python process and
+    need a resolution to be genuinely re-computed (rather than served from an
+    still-valid (env, cwd) cache entry) call this between scenarios."""
+    _ROOT_CACHE.clear()
 
 # Crypto/TLS and secret patterns — shared by the post-write reminder (H-09/H-10)
 # and the blocking pre-commit gate (H-09b/H-10b) so the two never drift.
@@ -338,7 +376,7 @@ def tool_input(data):
     return (data or {}).get("tool_input", {}) or {}
 
 
-def project_root():
+def project_root(payload=None):
     """The project root. `CLAUDE_PROJECT_DIR` is the harness's own authoritative
     signal and is trusted first: a hook subprocess is not guaranteed to start
     with the project directory as its cwd, and a `git rev-parse` from elsewhere
@@ -347,10 +385,21 @@ def project_root():
     Test harnesses that spawn hooks into fixture repos must pin the variable to
     the fixture, as the production harness pins it to the project.
 
-    The resolution itself now lives on the Host seam (hostapi.Host.project_root,
-    ADR-0011) — this function keeps its public signature and delegates, so every
-    existing caller/import keeps working unchanged."""
-    return get_host().project_root()
+    The resolution itself lives on the Host seam (hostapi.Host.project_root,
+    ADR-0011) — this function keeps its public signature (now accepting an
+    optional `payload`, architecture-006/#260, so a caller that already has
+    the parsed hook payload can hand it through to the payload-cwd leg) and
+    delegates, so every existing no-arg caller/import keeps working unchanged.
+
+    Memoized per (CLAUDE_PROJECT_DIR, process cwd) — see _ROOT_CACHE above for
+    the full contract (performance-001/003, #260): at most one resolution
+    (and at most one git spawn) per that key, so the repeated project_root()
+    reads inside block()/remind()/warn()'s gate-event logging don't each pay
+    a fresh subprocess."""
+    key = _root_cache_key()
+    if key not in _ROOT_CACHE:
+        _ROOT_CACHE[key] = get_host().project_root(payload)
+    return _ROOT_CACHE[key]
 
 
 def repo_rel(fpath, root):

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -32,6 +32,35 @@ import subprocess
 import sys
 
 
+def git_toplevel(cwd=None):
+    """`git rev-parse --show-toplevel`, run FROM `cwd` when given (`git -C
+    cwd ...`) rather than the process's own cwd. Returns the resolved
+    toplevel path, or None on any failure (not a repo, git missing, timeout,
+    empty output) — callers decide the fallback.
+
+    Shared by every Host.project_root payload-cwd leg (base Host and
+    CodexHost, #260/reliability-005): a hook payload's `cwd` can be a repo
+    SUBDIRECTORY (e.g. a Codex session started below the repo root), and the
+    project root must be the repo TOPLEVEL, not that subdirectory verbatim —
+    `.codearbiter/` state lives at the root."""
+    args = ["git"]
+    if cwd:
+        args += ["-C", cwd]
+    args += ["rev-parse", "--show-toplevel"]
+    try:
+        out = subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=5,
+        )
+        if out.returncode == 0:
+            top = out.stdout.strip()
+            if top:
+                return top
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -71,9 +100,12 @@ class Host:
           1. CLAUDE_PROJECT_DIR, when set and an existing directory — the
              harness's own authoritative signal, trusted first.
           2. the hook payload's `cwd`, when a payload is given and its cwd is
-             an existing directory (no Claude call site passes a payload
-             today, so this leg is inert under Claude Code; it exists for
-             hosts with no project-dir env var).
+             an existing directory — climbed to the git TOPLEVEL from that
+             cwd (git_toplevel), falling back to the cwd itself when that
+             climb fails (not a git repo). No Claude call site passes a
+             payload today (architecture-006, #260), so this leg is inert
+             under Claude Code; it exists for hosts with no project-dir env
+             var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
         """
@@ -83,17 +115,10 @@ class Host:
         if payload:
             cwd = payload.get("cwd") if isinstance(payload, dict) else None
             if cwd and os.path.isdir(cwd):
-                return cwd
-        try:
-            out = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace",
-                timeout=5,
-            )
-            if out.returncode == 0:
-                return out.stdout.strip()
-        except Exception:  # noqa: BLE001
-            pass
+                return git_toplevel(cwd) or cwd
+        top = git_toplevel()
+        if top:
+            return top
         return os.getcwd()
 
     def plugin_root(self):

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -31,7 +31,9 @@
 #   arbiter_active(root) -> bool         True iff repo opted in via CONTEXT.md frontmatter
 #   read_input() -> dict                 parse hook JSON from stdin; fail-open on error
 #   tool_input(data) -> dict             extract tool_input sub-dict from hook payload
-#   project_root() -> str                CLAUDE_PROJECT_DIR, else git repo root, else cwd
+#   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
+#                                         (memoized per process, keyed on the
+#                                         inputs that could change it — #260)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -82,6 +84,42 @@ def get_host():
     if _HOST is None:
         _HOST = hostapi.load_host()
     return _HOST
+
+
+# project_root() memoization (performance-001/003, #260). A hook is a
+# single-shot process, so CLAUDE_PROJECT_DIR and the process cwd cannot
+# change mid-process — but the resolved VALUE is cached keyed on those two
+# inputs (not unconditionally) rather than as one bare value, so an env/cwd
+# change is a cache MISS, never a stale hit. This keeps the production
+# single-shot contract (the same hook process always sees an unchanging
+# env/cwd, so it resolves at most once) while staying correct for the
+# in-process integration-test harnesses that legitimately re-target
+# project_root() across many fixtures/envs within one Python process
+# (`python -m unittest discover` runs the whole suite in ONE interpreter —
+# an unconditional single-value cache would leak the FIRST test's resolved
+# root into every later test that calls project_root() or warn()/block()/
+# remind() in-process). A payload's `cwd` is deliberately NOT part of the
+# cache key: within one real hook process the payload is parsed at most once
+# and never changes, so a payload-bearing call and a later no-payload call in
+# the SAME (env, cwd) context are the SAME logical resolution and must return
+# the SAME value — exactly the "payload-bearing first call, later no-arg
+# calls stay consistent" contract. (A payload-only scenario — Codex, no
+# CLAUDE_PROJECT_DIR — still resolves once: the first call's payload wins and
+# is cached against the current (env, cwd); env/cwd don't change either.)
+_ROOT_CACHE = {}
+
+
+def _root_cache_key():
+    return (os.environ.get("CLAUDE_PROJECT_DIR"), os.getcwd())
+
+
+def _reset_root_cache():
+    """Test-only: drop every memoized project_root() resolution. Production
+    hook processes never need this (each is single-shot); integration tests
+    that simulate MANY logical hook invocations in one Python process and
+    need a resolution to be genuinely re-computed (rather than served from an
+    still-valid (env, cwd) cache entry) call this between scenarios."""
+    _ROOT_CACHE.clear()
 
 # Crypto/TLS and secret patterns — shared by the post-write reminder (H-09/H-10)
 # and the blocking pre-commit gate (H-09b/H-10b) so the two never drift.
@@ -338,7 +376,7 @@ def tool_input(data):
     return (data or {}).get("tool_input", {}) or {}
 
 
-def project_root():
+def project_root(payload=None):
     """The project root. `CLAUDE_PROJECT_DIR` is the harness's own authoritative
     signal and is trusted first: a hook subprocess is not guaranteed to start
     with the project directory as its cwd, and a `git rev-parse` from elsewhere
@@ -347,10 +385,21 @@ def project_root():
     Test harnesses that spawn hooks into fixture repos must pin the variable to
     the fixture, as the production harness pins it to the project.
 
-    The resolution itself now lives on the Host seam (hostapi.Host.project_root,
-    ADR-0011) — this function keeps its public signature and delegates, so every
-    existing caller/import keeps working unchanged."""
-    return get_host().project_root()
+    The resolution itself lives on the Host seam (hostapi.Host.project_root,
+    ADR-0011) — this function keeps its public signature (now accepting an
+    optional `payload`, architecture-006/#260, so a caller that already has
+    the parsed hook payload can hand it through to the payload-cwd leg) and
+    delegates, so every existing no-arg caller/import keeps working unchanged.
+
+    Memoized per (CLAUDE_PROJECT_DIR, process cwd) — see _ROOT_CACHE above for
+    the full contract (performance-001/003, #260): at most one resolution
+    (and at most one git spawn) per that key, so the repeated project_root()
+    reads inside block()/remind()/warn()'s gate-event logging don't each pay
+    a fresh subprocess."""
+    key = _root_cache_key()
+    if key not in _ROOT_CACHE:
+        _ROOT_CACHE[key] = get_host().project_root(payload)
+    return _ROOT_CACHE[key]
 
 
 def repo_rel(fpath, root):

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -25,7 +25,6 @@
 #     (e.g. a nested/adjacent Claude session), it names the WRONG project.
 
 import os
-import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -200,24 +199,23 @@ class CodexHost(hostapi.Host):
 
           1. the hook payload's `cwd`, when given and an existing directory —
              the harness's own signal (Codex runs hooks in the session cwd
-             and repeats that cwd in every hook payload).
+             and repeats that cwd in every hook payload) — climbed to the git
+             TOPLEVEL from that cwd (hostapi.git_toplevel), falling back to
+             the cwd itself when that climb fails. A session started in a
+             repo SUBDIRECTORY must still resolve the repo ROOT, not that
+             subdirectory verbatim (reliability-005, #260) — `.codearbiter/`
+             state lives at the root, not wherever the session happened to
+             start.
           2. `git rev-parse --show-toplevel` from the process cwd.
           3. the process cwd.
         """
         if payload and isinstance(payload, dict):
             cwd = payload.get("cwd")
             if cwd and os.path.isdir(cwd):
-                return cwd
-        try:
-            out = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace",
-                timeout=5,
-            )
-            if out.returncode == 0:
-                return out.stdout.strip()
-        except Exception:  # noqa: BLE001
-            pass
+                return hostapi.git_toplevel(cwd) or cwd
+        top = hostapi.git_toplevel()
+        if top:
+            return top
         return os.getcwd()
 
     def plugin_root(self):

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -32,6 +32,35 @@ import subprocess
 import sys
 
 
+def git_toplevel(cwd=None):
+    """`git rev-parse --show-toplevel`, run FROM `cwd` when given (`git -C
+    cwd ...`) rather than the process's own cwd. Returns the resolved
+    toplevel path, or None on any failure (not a repo, git missing, timeout,
+    empty output) — callers decide the fallback.
+
+    Shared by every Host.project_root payload-cwd leg (base Host and
+    CodexHost, #260/reliability-005): a hook payload's `cwd` can be a repo
+    SUBDIRECTORY (e.g. a Codex session started below the repo root), and the
+    project root must be the repo TOPLEVEL, not that subdirectory verbatim —
+    `.codearbiter/` state lives at the root."""
+    args = ["git"]
+    if cwd:
+        args += ["-C", cwd]
+    args += ["rev-parse", "--show-toplevel"]
+    try:
+        out = subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=5,
+        )
+        if out.returncode == 0:
+            top = out.stdout.strip()
+            if top:
+                return top
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -71,9 +100,12 @@ class Host:
           1. CLAUDE_PROJECT_DIR, when set and an existing directory — the
              harness's own authoritative signal, trusted first.
           2. the hook payload's `cwd`, when a payload is given and its cwd is
-             an existing directory (no Claude call site passes a payload
-             today, so this leg is inert under Claude Code; it exists for
-             hosts with no project-dir env var).
+             an existing directory — climbed to the git TOPLEVEL from that
+             cwd (git_toplevel), falling back to the cwd itself when that
+             climb fails (not a git repo). No Claude call site passes a
+             payload today (architecture-006, #260), so this leg is inert
+             under Claude Code; it exists for hosts with no project-dir env
+             var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
         """
@@ -83,17 +115,10 @@ class Host:
         if payload:
             cwd = payload.get("cwd") if isinstance(payload, dict) else None
             if cwd and os.path.isdir(cwd):
-                return cwd
-        try:
-            out = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace",
-                timeout=5,
-            )
-            if out.returncode == 0:
-                return out.stdout.strip()
-        except Exception:  # noqa: BLE001
-            pass
+                return git_toplevel(cwd) or cwd
+        top = git_toplevel()
+        if top:
+            return top
         return os.getcwd()
 
     def plugin_root(self):

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -31,7 +31,9 @@
 #   arbiter_active(root) -> bool         True iff repo opted in via CONTEXT.md frontmatter
 #   read_input() -> dict                 parse hook JSON from stdin; fail-open on error
 #   tool_input(data) -> dict             extract tool_input sub-dict from hook payload
-#   project_root() -> str                CLAUDE_PROJECT_DIR, else git repo root, else cwd
+#   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
+#                                         (memoized per process, keyed on the
+#                                         inputs that could change it — #260)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -82,6 +84,42 @@ def get_host():
     if _HOST is None:
         _HOST = hostapi.load_host()
     return _HOST
+
+
+# project_root() memoization (performance-001/003, #260). A hook is a
+# single-shot process, so CLAUDE_PROJECT_DIR and the process cwd cannot
+# change mid-process — but the resolved VALUE is cached keyed on those two
+# inputs (not unconditionally) rather than as one bare value, so an env/cwd
+# change is a cache MISS, never a stale hit. This keeps the production
+# single-shot contract (the same hook process always sees an unchanging
+# env/cwd, so it resolves at most once) while staying correct for the
+# in-process integration-test harnesses that legitimately re-target
+# project_root() across many fixtures/envs within one Python process
+# (`python -m unittest discover` runs the whole suite in ONE interpreter —
+# an unconditional single-value cache would leak the FIRST test's resolved
+# root into every later test that calls project_root() or warn()/block()/
+# remind() in-process). A payload's `cwd` is deliberately NOT part of the
+# cache key: within one real hook process the payload is parsed at most once
+# and never changes, so a payload-bearing call and a later no-payload call in
+# the SAME (env, cwd) context are the SAME logical resolution and must return
+# the SAME value — exactly the "payload-bearing first call, later no-arg
+# calls stay consistent" contract. (A payload-only scenario — Codex, no
+# CLAUDE_PROJECT_DIR — still resolves once: the first call's payload wins and
+# is cached against the current (env, cwd); env/cwd don't change either.)
+_ROOT_CACHE = {}
+
+
+def _root_cache_key():
+    return (os.environ.get("CLAUDE_PROJECT_DIR"), os.getcwd())
+
+
+def _reset_root_cache():
+    """Test-only: drop every memoized project_root() resolution. Production
+    hook processes never need this (each is single-shot); integration tests
+    that simulate MANY logical hook invocations in one Python process and
+    need a resolution to be genuinely re-computed (rather than served from an
+    still-valid (env, cwd) cache entry) call this between scenarios."""
+    _ROOT_CACHE.clear()
 
 # Crypto/TLS and secret patterns — shared by the post-write reminder (H-09/H-10)
 # and the blocking pre-commit gate (H-09b/H-10b) so the two never drift.
@@ -338,7 +376,7 @@ def tool_input(data):
     return (data or {}).get("tool_input", {}) or {}
 
 
-def project_root():
+def project_root(payload=None):
     """The project root. `CLAUDE_PROJECT_DIR` is the harness's own authoritative
     signal and is trusted first: a hook subprocess is not guaranteed to start
     with the project directory as its cwd, and a `git rev-parse` from elsewhere
@@ -347,10 +385,21 @@ def project_root():
     Test harnesses that spawn hooks into fixture repos must pin the variable to
     the fixture, as the production harness pins it to the project.
 
-    The resolution itself now lives on the Host seam (hostapi.Host.project_root,
-    ADR-0011) — this function keeps its public signature and delegates, so every
-    existing caller/import keeps working unchanged."""
-    return get_host().project_root()
+    The resolution itself lives on the Host seam (hostapi.Host.project_root,
+    ADR-0011) — this function keeps its public signature (now accepting an
+    optional `payload`, architecture-006/#260, so a caller that already has
+    the parsed hook payload can hand it through to the payload-cwd leg) and
+    delegates, so every existing no-arg caller/import keeps working unchanged.
+
+    Memoized per (CLAUDE_PROJECT_DIR, process cwd) — see _ROOT_CACHE above for
+    the full contract (performance-001/003, #260): at most one resolution
+    (and at most one git spawn) per that key, so the repeated project_root()
+    reads inside block()/remind()/warn()'s gate-event logging don't each pay
+    a fresh subprocess."""
+    key = _root_cache_key()
+    if key not in _ROOT_CACHE:
+        _ROOT_CACHE[key] = get_host().project_root(payload)
+    return _ROOT_CACHE[key]
 
 
 def repo_rel(fpath, root):

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -32,6 +32,35 @@ import subprocess
 import sys
 
 
+def git_toplevel(cwd=None):
+    """`git rev-parse --show-toplevel`, run FROM `cwd` when given (`git -C
+    cwd ...`) rather than the process's own cwd. Returns the resolved
+    toplevel path, or None on any failure (not a repo, git missing, timeout,
+    empty output) — callers decide the fallback.
+
+    Shared by every Host.project_root payload-cwd leg (base Host and
+    CodexHost, #260/reliability-005): a hook payload's `cwd` can be a repo
+    SUBDIRECTORY (e.g. a Codex session started below the repo root), and the
+    project root must be the repo TOPLEVEL, not that subdirectory verbatim —
+    `.codearbiter/` state lives at the root."""
+    args = ["git"]
+    if cwd:
+        args += ["-C", cwd]
+    args += ["rev-parse", "--show-toplevel"]
+    try:
+        out = subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=5,
+        )
+        if out.returncode == 0:
+            top = out.stdout.strip()
+            if top:
+                return top
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -71,9 +100,12 @@ class Host:
           1. CLAUDE_PROJECT_DIR, when set and an existing directory — the
              harness's own authoritative signal, trusted first.
           2. the hook payload's `cwd`, when a payload is given and its cwd is
-             an existing directory (no Claude call site passes a payload
-             today, so this leg is inert under Claude Code; it exists for
-             hosts with no project-dir env var).
+             an existing directory — climbed to the git TOPLEVEL from that
+             cwd (git_toplevel), falling back to the cwd itself when that
+             climb fails (not a git repo). No Claude call site passes a
+             payload today (architecture-006, #260), so this leg is inert
+             under Claude Code; it exists for hosts with no project-dir env
+             var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
         """
@@ -83,17 +115,10 @@ class Host:
         if payload:
             cwd = payload.get("cwd") if isinstance(payload, dict) else None
             if cwd and os.path.isdir(cwd):
-                return cwd
-        try:
-            out = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace",
-                timeout=5,
-            )
-            if out.returncode == 0:
-                return out.stdout.strip()
-        except Exception:  # noqa: BLE001
-            pass
+                return git_toplevel(cwd) or cwd
+        top = git_toplevel()
+        if top:
+            return top
         return os.getcwd()
 
     def plugin_root(self):

--- a/plugins/ca/hooks/tests/test_hooklib.py
+++ b/plugins/ca/hooks/tests/test_hooklib.py
@@ -2,9 +2,11 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _hooklib import frontmatter_enabled  # noqa: E402
+import _hooklib  # noqa: E402
+from _hooklib import frontmatter_enabled, project_root  # noqa: E402
 
 
 def _write_ctx(tmp, content):
@@ -86,6 +88,111 @@ class TestFrontmatterEnabled(unittest.TestCase):
         enabled, malformed = frontmatter_enabled(path)
         self.assertFalse(enabled)
         self.assertFalse(malformed)
+
+
+class TestProjectRootMemoization(unittest.TestCase):
+    """#260 (performance-001/003): project_root() resolves at most once per
+    (CLAUDE_PROJECT_DIR, process cwd) — repeated calls within that same
+    context must not re-spawn git — while a genuine env/cwd change (as
+    integration tests simulate across scenarios) must still get a FRESH
+    resolution, never a stale cached one."""
+
+    def setUp(self):
+        _hooklib._reset_root_cache()
+        self._env = os.environ.get("CLAUDE_PROJECT_DIR")
+        self._cwd = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        if self._env is None:
+            os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        else:
+            os.environ["CLAUDE_PROJECT_DIR"] = self._env
+        _hooklib._reset_root_cache()
+
+    def test_repeated_calls_resolve_the_host_only_once(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.environ["CLAUDE_PROJECT_DIR"] = d
+            calls = []
+            real = _hooklib.get_host()
+
+            def _spy(payload=None):
+                calls.append(payload)
+                return d
+
+            with mock.patch.object(real, "project_root", side_effect=_spy):
+                self.assertEqual(project_root(), d)
+                self.assertEqual(project_root(), d)
+                self.assertEqual(project_root(), d)
+            self.assertEqual(len(calls), 1,
+                              "project_root() must resolve the Host only once "
+                              "per (env, cwd) context")
+
+    def test_payload_bearing_first_call_and_later_no_arg_calls_stay_consistent(self):
+        # A first call WITH a payload, then later no-arg calls (the
+        # block()/remind()/warn() gate-logging pattern) in the SAME (env,
+        # cwd) context must return the SAME cached value, never re-resolve.
+        with tempfile.TemporaryDirectory() as d:
+            os.environ["CLAUDE_PROJECT_DIR"] = d
+            calls = []
+            real = _hooklib.get_host()
+
+            def _spy(payload=None):
+                calls.append(payload)
+                return d
+
+            with mock.patch.object(real, "project_root", side_effect=_spy):
+                first = project_root({"cwd": "/somewhere/irrelevant"})
+                second = project_root()
+                third = project_root()
+            self.assertEqual(first, d)
+            self.assertEqual(second, d)
+            self.assertEqual(third, d)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0], {"cwd": "/somewhere/irrelevant"})
+
+    def test_env_change_busts_the_cache(self):
+        with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+            os.environ["CLAUDE_PROJECT_DIR"] = d1
+            self.assertEqual(os.path.realpath(project_root()), os.path.realpath(d1))
+            os.environ["CLAUDE_PROJECT_DIR"] = d2
+            self.assertEqual(os.path.realpath(project_root()), os.path.realpath(d2))
+
+    def test_cwd_change_busts_the_cache(self):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+            try:
+                os.chdir(d1)
+                r1 = project_root()
+                os.chdir(d2)
+                r2 = project_root()
+            finally:
+                # Release both dirs before the `with` blocks try to remove
+                # them — a Windows process cwd inside a TemporaryDirectory
+                # blocks its own cleanup (WinError 32).
+                os.chdir(self._cwd)
+            # Neither d1 nor d2 is a git repo, so both resolve to the
+            # respective cwd itself (final fallback) — proving the second
+            # call re-resolved rather than replaying the first cwd's answer.
+            self.assertEqual(os.path.realpath(r1), os.path.realpath(d1))
+            self.assertEqual(os.path.realpath(r2), os.path.realpath(d2))
+            self.assertNotEqual(os.path.realpath(r1), os.path.realpath(r2))
+
+    def test_reset_helper_forces_a_fresh_resolution(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.environ["CLAUDE_PROJECT_DIR"] = d
+            calls = []
+            real = _hooklib.get_host()
+
+            def _spy(payload=None):
+                calls.append(payload)
+                return d
+
+            with mock.patch.object(real, "project_root", side_effect=_spy):
+                project_root()
+                _hooklib._reset_root_cache()
+                project_root()
+            self.assertEqual(len(calls), 2)
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/tests/test_host_project_root.py
+++ b/plugins/ca/hooks/tests/test_host_project_root.py
@@ -1,0 +1,148 @@
+"""Tests for hostapi.Host.project_root (base/Claude host) — #260.
+
+Covers:
+  * CLAUDE_PROJECT_DIR still wins first, byte-identical to pre-#260 behavior
+    (the base host backs the `ca` plugin — Claude Code — so this is the
+    byte-identity guarantee the #260 remediation must not regress).
+  * The payload-cwd leg (reachable only when CLAUDE_PROJECT_DIR is unset) now
+    climbs to the git TOPLEVEL from that cwd rather than returning it
+    verbatim (reliability-005's base-host half — CodexHost is covered
+    separately in .github/scripts/test_codex_adapter.py::TestCodexProjectRoot).
+  * hostapi.git_toplevel() itself: repo -> toplevel, subdir -> toplevel,
+    non-repo -> None.
+
+stdlib unittest only; no subprocess for the Host method itself (git_toplevel
+shells out internally, so a real git init is used where the climb matters).
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+import hostapi  # noqa: E402
+
+
+def _git_available():
+    try:
+        r = subprocess.run(["git", "--version"], capture_output=True, timeout=10)
+        return r.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class GitToplevelTests(unittest.TestCase):
+    """hostapi.git_toplevel(cwd) — the shared climb helper both Host.project_root
+    implementations route their payload-cwd leg through."""
+
+    def setUp(self):
+        if not _git_available():
+            self.skipTest("git unavailable")
+
+    def test_repo_root_resolves_itself(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            repo = os.path.join(top, "repo")
+            os.makedirs(repo)
+            r = subprocess.run(["git", "init", "-q"], cwd=repo,
+                               capture_output=True, timeout=30)
+            if r.returncode != 0:
+                self.skipTest("git init failed")
+            got = hostapi.git_toplevel(repo)
+            self.assertEqual(os.path.realpath(got), os.path.realpath(repo))
+
+    def test_subdir_climbs_to_toplevel(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            repo = os.path.join(top, "repo")
+            sub = os.path.join(repo, "a", "b")
+            os.makedirs(sub)
+            r = subprocess.run(["git", "init", "-q"], cwd=repo,
+                               capture_output=True, timeout=30)
+            if r.returncode != 0:
+                self.skipTest("git init failed")
+            got = hostapi.git_toplevel(sub)
+            self.assertEqual(os.path.realpath(got), os.path.realpath(repo))
+
+    def test_non_repo_returns_none(self):
+        with tempfile.TemporaryDirectory() as plain:
+            self.assertIsNone(hostapi.git_toplevel(plain))
+
+    def test_no_cwd_arg_uses_process_cwd(self):
+        cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+                repo = os.path.join(top, "repo")
+                os.makedirs(repo)
+                r = subprocess.run(["git", "init", "-q"], cwd=repo,
+                                   capture_output=True, timeout=30)
+                if r.returncode != 0:
+                    self.skipTest("git init failed")
+                os.chdir(repo)
+                got = hostapi.git_toplevel()
+                self.assertEqual(os.path.realpath(got), os.path.realpath(repo))
+        finally:
+            os.chdir(cwd)
+
+
+class BaseHostProjectRootTests(unittest.TestCase):
+    """hostapi.Host.project_root — CLAUDE_PROJECT_DIR-first, then the
+    (now climbing) payload-cwd leg, then git-toplevel-from-cwd, then cwd."""
+
+    def setUp(self):
+        self.host = hostapi.Host()
+        self._env = os.environ.get("CLAUDE_PROJECT_DIR")
+        self._cwd = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        if self._env is None:
+            os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        else:
+            os.environ["CLAUDE_PROJECT_DIR"] = self._env
+
+    def test_claude_project_dir_wins_over_a_payload_cwd(self):
+        # Byte-identity guarantee (#260): CLAUDE_PROJECT_DIR must still win
+        # first even when a payload IS given — no Claude call site passes one
+        # today, but the seam must not silently invert precedence the moment
+        # one does.
+        with tempfile.TemporaryDirectory() as env_dir, \
+                tempfile.TemporaryDirectory() as payload_dir:
+            os.environ["CLAUDE_PROJECT_DIR"] = env_dir
+            got = self.host.project_root({"cwd": payload_dir})
+            self.assertEqual(os.path.realpath(got), os.path.realpath(env_dir))
+
+    def test_claude_project_dir_wins_with_no_payload(self):
+        with tempfile.TemporaryDirectory() as env_dir:
+            os.environ["CLAUDE_PROJECT_DIR"] = env_dir
+            self.assertEqual(os.path.realpath(self.host.project_root()),
+                             os.path.realpath(env_dir))
+
+    def test_payload_cwd_subdir_climbs_to_repo_root_when_env_unset(self):
+        # reliability-005 (#260): even on the base Host, a payload cwd naming
+        # a repo SUBDIRECTORY resolves the repo root, not the subdir verbatim.
+        if not _git_available():
+            self.skipTest("git unavailable")
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            repo = os.path.join(top, "repo")
+            sub = os.path.join(repo, "sub")
+            os.makedirs(sub)
+            r = subprocess.run(["git", "init", "-q"], cwd=repo,
+                               capture_output=True, timeout=30)
+            if r.returncode != 0:
+                self.skipTest("git init failed")
+            got = self.host.project_root({"cwd": sub})
+            self.assertEqual(os.path.realpath(got), os.path.realpath(repo))
+
+    def test_payload_cwd_non_repo_falls_back_to_cwd_verbatim(self):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory() as payload_dir:
+            got = self.host.project_root({"cwd": payload_dir})
+            self.assertEqual(os.path.realpath(got), os.path.realpath(payload_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #260. Folds reliability-005, performance-001, performance-003, and structurally enables architecture-006.

## Changes
- **`git_toplevel(cwd=None)`** (hostapi.py): shared helper — `git -C <cwd> rev-parse --show-toplevel`, `None` on any failure.
- **`Host.project_root` payload leg**: now climbs to the git toplevel from the payload cwd (`git_toplevel(cwd) or cwd`) instead of returning the cwd verbatim — a subdir session resolves the **repo root** (reliability-005). Base and CodexHost share the helper.
- **`_hooklib.project_root(payload=None)`**: accepts/forwards a payload, and is **memoized** per `(CLAUDE_PROJECT_DIR, cwd)` so repeated resolutions inside `block()/remind()/warn()` gate-logging don't each spawn git (performance-003, and caps Codex's git spawn at once/process — performance-001).

## Deliberate, conservative scoping (flagged for review)
- **Memoization is keyed on `(env, cwd)`, not a bare single value.** A bare "resolve once forever" global would leak the first test's root into every later in-process call under `unittest discover`. Keying on the two inputs that determine the answer gives identical single-shot behavior in a real hook process while staying correct under the test harness. Payload cwd is intentionally not in the key (one payload per process; a payload-first call and later no-arg calls in the same context are the same logical resolution).
- **architecture-006 is structurally fixed but production-dormant.** The payload leg is now reachable, tested, and forwarding-capable, but no entry passes a payload yet: every gate entry resolves root *before* `read_input()` (and before the arbiter-active gate), and threading a payload would require reading stdin before that gate — the risky reorder I was told to avoid. session-start never reads stdin at all; adding a first-ever stdin read there is a hang risk, not just a stale-value risk. So the phantom "dead leg with a lying docstring" is gone (it's real + tested now), but no behavior changes today.

## Claude byte-identity
`CLAUDE_PROJECT_DIR` still wins first, unconditionally, before any payload — verified by tests (env beats a different payload cwd). Memoization changes *when* a resolution happens, never *what* it resolves to for a fixed input (cache busts on env/cwd change, tested).

## Verification
Full hook suite **814** pass · adapter **57** · guards + cold-install (ca + ca-codex, REAL/STUB/NONE) PASS · sync-core --check byte-identical · new tests: `TestCodexProjectRoot` subdir-climb, `test_host_project_root.py` (git_toplevel + base-host byte-identity), `TestProjectRootMemoization`.

> Into `feat/codex-support-m0` only. Part of the tribunal remediation sprint.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
