### PR TITLE
feat(hooks): surface resolved host name in session-start banner and doctor (#268)

### DIFF
--- a/core/pysrc/doctor.py
+++ b/core/pysrc/doctor.py
@@ -160,6 +160,24 @@ def check_repo():
                  "set it before gated work")
 
 
+def check_host(host):
+    """observability-004 (#268): surface which host was resolved — a dormant
+    Codex install (or any broken `_host.py`) was previously indistinguishable
+    from a working one, since nothing in doctor's output named the host at
+    all. `host.name` is "claude" / "codex" under a working install, or
+    "unknown" for the FailClosedHost hostapi.load_host() returns when a
+    declared `_host.py` is present but failed to load (#255) — that "unknown"
+    case is exactly the dormant install this check exists to surface, so it
+    WARNs (not OKs) with an actionable pointer rather than reporting green."""
+    name = getattr(host, "name", "unknown")
+    if name == "unknown":
+        warn("host resolution failed — enforcing as 'unknown' (a declared "
+             "_host.py was present but failed to load); writes fail closed. "
+             "Reinstall or fix the plugin's _host.py.")
+    else:
+        ok(f"resolved host: {name}")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -176,6 +194,7 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
+    check_host(hostapi.load_host())
     check_interpreters()
     check_payload(root)
     check_repo()

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -587,6 +587,10 @@ def main():
 
     # --- Inject live startup state ---
     print("=== codeArbiter startup state ===")
+    # observability-004 (#268): name the RESOLVED host so a dormant/broken
+    # host (FailClosedHost -> name "unknown", #255) is visible right in the
+    # banner instead of being indistinguishable from a working install.
+    print(f"host: {getattr(host, 'name', 'unknown')}")
 
     ctx_text = read_text(ctx) or ""
     if not INITIALIZED_RE.search(ctx_text):

--- a/plugins/ca-codex/hooks/doctor.py
+++ b/plugins/ca-codex/hooks/doctor.py
@@ -160,6 +160,24 @@ def check_repo():
                  "set it before gated work")
 
 
+def check_host(host):
+    """observability-004 (#268): surface which host was resolved — a dormant
+    Codex install (or any broken `_host.py`) was previously indistinguishable
+    from a working one, since nothing in doctor's output named the host at
+    all. `host.name` is "claude" / "codex" under a working install, or
+    "unknown" for the FailClosedHost hostapi.load_host() returns when a
+    declared `_host.py` is present but failed to load (#255) — that "unknown"
+    case is exactly the dormant install this check exists to surface, so it
+    WARNs (not OKs) with an actionable pointer rather than reporting green."""
+    name = getattr(host, "name", "unknown")
+    if name == "unknown":
+        warn("host resolution failed — enforcing as 'unknown' (a declared "
+             "_host.py was present but failed to load); writes fail closed. "
+             "Reinstall or fix the plugin's _host.py.")
+    else:
+        ok(f"resolved host: {name}")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -176,6 +194,7 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
+    check_host(hostapi.load_host())
     check_interpreters()
     check_payload(root)
     check_repo()

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -587,6 +587,10 @@ def main():
 
     # --- Inject live startup state ---
     print("=== codeArbiter startup state ===")
+    # observability-004 (#268): name the RESOLVED host so a dormant/broken
+    # host (FailClosedHost -> name "unknown", #255) is visible right in the
+    # banner instead of being indistinguishable from a working install.
+    print(f"host: {getattr(host, 'name', 'unknown')}")
 
     ctx_text = read_text(ctx) or ""
     if not INITIALIZED_RE.search(ctx_text):

--- a/plugins/ca/hooks/doctor.py
+++ b/plugins/ca/hooks/doctor.py
@@ -160,6 +160,24 @@ def check_repo():
                  "set it before gated work")
 
 
+def check_host(host):
+    """observability-004 (#268): surface which host was resolved — a dormant
+    Codex install (or any broken `_host.py`) was previously indistinguishable
+    from a working one, since nothing in doctor's output named the host at
+    all. `host.name` is "claude" / "codex" under a working install, or
+    "unknown" for the FailClosedHost hostapi.load_host() returns when a
+    declared `_host.py` is present but failed to load (#255) — that "unknown"
+    case is exactly the dormant install this check exists to surface, so it
+    WARNs (not OKs) with an actionable pointer rather than reporting green."""
+    name = getattr(host, "name", "unknown")
+    if name == "unknown":
+        warn("host resolution failed — enforcing as 'unknown' (a declared "
+             "_host.py was present but failed to load); writes fail closed. "
+             "Reinstall or fix the plugin's _host.py.")
+    else:
+        ok(f"resolved host: {name}")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -176,6 +194,7 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
+    check_host(hostapi.load_host())
     check_interpreters()
     check_payload(root)
     check_repo()

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -587,6 +587,10 @@ def main():
 
     # --- Inject live startup state ---
     print("=== codeArbiter startup state ===")
+    # observability-004 (#268): name the RESOLVED host so a dormant/broken
+    # host (FailClosedHost -> name "unknown", #255) is visible right in the
+    # banner instead of being indistinguishable from a working install.
+    print(f"host: {getattr(host, 'name', 'unknown')}")
 
     ctx_text = read_text(ctx) or ""
     if not INITIALIZED_RE.search(ctx_text):

--- a/plugins/ca/hooks/tests/test_doctor.py
+++ b/plugins/ca/hooks/tests/test_doctor.py
@@ -31,6 +31,36 @@ def _has(keyword):
     return any(keyword in line for _, line in doctor.results)
 
 
+class TestCheckHost(unittest.TestCase):
+    """observability-004 (#268): check_host() surfaces the resolved host name
+    (or a WARN when hostapi.load_host() failed closed to "unknown", #255)."""
+
+    def setUp(self):
+        _reset()
+
+    def tearDown(self):
+        _reset()
+
+    def test_named_host_is_ok(self):
+        class FakeHost:
+            name = "codex"
+
+        doctor.check_host(FakeHost())
+        ok_lines = [line for lvl, line in doctor.results if lvl == "OK"]
+        self.assertTrue(any("codex" in line for line in ok_lines))
+        self.assertNotIn("WARN", _levels())
+
+    def test_claude_host_is_ok(self):
+        doctor.check_host(doctor.hostapi.Host())
+        ok_lines = [line for lvl, line in doctor.results if lvl == "OK"]
+        self.assertTrue(any("claude" in line for line in ok_lines))
+
+    def test_unknown_host_is_warn(self):
+        doctor.check_host(doctor.hostapi.FailClosedHost())
+        self.assertEqual(_levels(), ["WARN"])
+        self.assertIn("unknown", _lines()[0])
+
+
 class TestCheckPayloadMissingScript(unittest.TestCase):
     """check_payload: missing hook scripts → FAIL."""
 

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -330,6 +330,53 @@ class TestMainSkipsHealUnderNoStatuslineHost(unittest.TestCase):
         self.assertEqual(cmd, self.stale_command)
 
 
+class TestStartupStateHostLine(unittest.TestCase):
+    """observability-004 (#268): the startup-state banner names the RESOLVED
+    host (`host.name`) so a dormant/broken host (FailClosedHost -> "unknown",
+    #255) is visible right in the banner instead of looking identical to a
+    working install. The line prints for ANY arbiter-enabled repo, even one
+    not yet initialized (it sits before the INITIALIZED check in main())."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = self._tmp.name
+        cad = os.path.join(self.repo, ".codearbiter")
+        os.makedirs(cad)
+        with open(os.path.join(cad, "CONTEXT.md"), "w", encoding="utf-8") as f:
+            f.write("---\narbiter: enabled\n---\n\n_stub, not initialized_\n")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run_main(self, host):
+        buf = io.StringIO()
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            with mock.patch.object(_mod.hostapi, "load_host", return_value=host), \
+                 mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.repo}), \
+                 contextlib.redirect_stdout(buf), \
+                 contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit):
+                    _mod.main()
+        finally:
+            os.chdir(cwd)
+        return buf.getvalue()
+
+    def test_named_host_appears_in_banner(self):
+        class CodexHost(_mod.hostapi.Host):
+            name = "codex"
+
+        out = self._run_main(CodexHost())
+        self.assertIn("host: codex", out)
+
+    def test_unknown_host_appears_in_banner(self):
+        # FailClosedHost (#255) — the dormant/broken-install case this
+        # feature exists to surface.
+        out = self._run_main(_mod.hostapi.FailClosedHost())
+        self.assertIn("host: unknown", out)
+
+
 class TestDevExitAudit(unittest.TestCase):
     """observability-001: when SessionStart clears a LIVE dev-active marker (a
     prior session entered /ca:dev and ended without /ca:arbiter), it must append


### PR DESCRIPTION
Closes #268 (observability-004).

Surfaces the resolved host name where a maintainer looks, so a dormant/broken Codex install is distinguishable from a working one:

- **session-start.py** startup banner: adds `host: <name>` (claude / codex / unknown) right after the banner header, before the INITIALIZED check. Uses the already-resolved `host`; no new resolution.
- **doctor.py**: new `check_host()` — `OK  resolved host: <name>` for a working host, or **WARN** `host resolution failed — enforcing as 'unknown'` for the `FailClosedHost` case (from #255). Deliberately a WARN, since that state is exactly the broken install this exists to catch.

Purely additive display; no seam logic touched (`hostapi.py`/`_hooklib.py` unchanged).

Tests: `TestCheckHost` (named/claude/FailClosedHost) and `TestStartupStateHostLine` (drives real `main()`, asserts `host: codex` / `host: unknown` in stdout). Full suite 806 pass, adapter 55, sync-core --check byte-identical.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
