### PR TITLE
feat(hooks): attribute audit-log entries to the resolved host (#269, ADR-0012)

### DIFF
--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -713,19 +713,26 @@ def _log_gate_event(kind, tag, msg):
     decision is no longer visible ONLY in the ephemeral per-turn stderr
     transcript.
 
-    One line per event: `[ISO-8601Z] KIND [tag] hook=<script> | msg`. `tag` may
-    be None (warn() carries no tag) — the bracket is simply omitted then.
-    `hook` is the invoking script's basename (`sys.argv[0]`), the one
+    One line per event: `[ISO-8601Z] KIND [tag] host=<host> hook=<script> | msg`.
+    `tag` may be None (warn() carries no tag) — the bracket is simply omitted
+    then. `hook` is the invoking script's basename (`sys.argv[0]`), the one
     "which hook fired this" signal available at this shared layer without
     threading a new parameter through all 21 call sites across the 16 entry
-    hooks.
+    hooks. `host` is `get_host().name` ("claude"/"codex"/"unknown") — added
+    for observability-001/ADR-0012: with two hosts now sharing one
+    gate-events.log (ADR-0011), a line could not be attributed to the host
+    that wrote it. Placed BEFORE `hook=` (both are `key=value` tokens with no
+    internal whitespace, so the line stays trivially greppable/parseable by
+    either field, and existing `hook=<script>` substring matches are
+    unaffected).
 
     FAIL-OPEN BY CONTRACT (AC-2): this function must NEVER raise and must
     NEVER be allowed to change the caller's exit code or suppress its stderr
     output. A missing `.codearbiter/` dir, an unwritable/locked/missing log
-    file, or project_root() itself misbehaving are ALL swallowed silently
-    here — the ONE deliberate exception to this module's fail-loud discipline,
-    mirroring the documented fail-open exception in read_input()."""
+    file, project_root() itself misbehaving, or host resolution itself
+    misbehaving are ALL swallowed silently here — the ONE deliberate
+    exception to this module's fail-loud discipline, mirroring the documented
+    fail-open exception in read_input()."""
     try:
         root = project_root()
         cad = os.path.join(root, ".codearbiter")
@@ -733,8 +740,12 @@ def _log_gate_event(kind, tag, msg):
             return  # repo never opted in (no .codearbiter/) — nothing to append to
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         hook = os.path.basename(sys.argv[0]) if sys.argv and sys.argv[0] else "-"
+        try:
+            host = get_host().name
+        except Exception:  # noqa: BLE001 — host resolution must never break the sink
+            host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
-        line = f"[{ts}] {kind} {tag_part}hook={hook} | {msg}\n"
+        line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         with open(os.path.join(cad, "gate-events.log"), "a",
                   encoding="utf-8", newline="\n") as f:
             f.write(line)

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -443,17 +443,30 @@ def has_source(root):
     return False
 
 
-def clear_dev_marker(root):
+def clear_dev_marker(root, host_name=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
     synthetic DEV: exit line to overrides.log BEFORE removing it
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
-    or remove failure must never brick session startup."""
+    or remove failure must never brick session startup.
+
+    `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
+    ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
+    the host that wrote it now that two hosts share one overrides.log
+    (ADR-0011). Optional and defaults to resolving it here via
+    `hostapi.load_host()` — main() already holds a Host instance and passes its
+    `.name` through to avoid a second resolution, but any other caller (tests
+    included) may omit it."""
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
     if os.path.isfile(marker):
+        if host_name is None:
+            try:
+                host_name = hostapi.load_host().name
+            except Exception:  # noqa: BLE001 — must never brick session startup
+                host_name = "unknown"
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        line = (f"[{ts}] | BY: session-cleanup | DEV: exit | NOTE: cleared by "
+        line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
                 f"SessionStart (prior session ended mid-dev without /ca:arbiter)\n")
         try:
             with open(os.path.join(root, ".codearbiter", "overrides.log"),
@@ -546,7 +559,7 @@ def main():
     # /dev developer-override is per-session: clear its statusline marker on
     # startup — a new session restores orchestration. A live marker means a prior
     # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
-    clear_dev_marker(root)
+    clear_dev_marker(root, host.name)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -713,19 +713,26 @@ def _log_gate_event(kind, tag, msg):
     decision is no longer visible ONLY in the ephemeral per-turn stderr
     transcript.
 
-    One line per event: `[ISO-8601Z] KIND [tag] hook=<script> | msg`. `tag` may
-    be None (warn() carries no tag) — the bracket is simply omitted then.
-    `hook` is the invoking script's basename (`sys.argv[0]`), the one
+    One line per event: `[ISO-8601Z] KIND [tag] host=<host> hook=<script> | msg`.
+    `tag` may be None (warn() carries no tag) — the bracket is simply omitted
+    then. `hook` is the invoking script's basename (`sys.argv[0]`), the one
     "which hook fired this" signal available at this shared layer without
     threading a new parameter through all 21 call sites across the 16 entry
-    hooks.
+    hooks. `host` is `get_host().name` ("claude"/"codex"/"unknown") — added
+    for observability-001/ADR-0012: with two hosts now sharing one
+    gate-events.log (ADR-0011), a line could not be attributed to the host
+    that wrote it. Placed BEFORE `hook=` (both are `key=value` tokens with no
+    internal whitespace, so the line stays trivially greppable/parseable by
+    either field, and existing `hook=<script>` substring matches are
+    unaffected).
 
     FAIL-OPEN BY CONTRACT (AC-2): this function must NEVER raise and must
     NEVER be allowed to change the caller's exit code or suppress its stderr
     output. A missing `.codearbiter/` dir, an unwritable/locked/missing log
-    file, or project_root() itself misbehaving are ALL swallowed silently
-    here — the ONE deliberate exception to this module's fail-loud discipline,
-    mirroring the documented fail-open exception in read_input()."""
+    file, project_root() itself misbehaving, or host resolution itself
+    misbehaving are ALL swallowed silently here — the ONE deliberate
+    exception to this module's fail-loud discipline, mirroring the documented
+    fail-open exception in read_input()."""
     try:
         root = project_root()
         cad = os.path.join(root, ".codearbiter")
@@ -733,8 +740,12 @@ def _log_gate_event(kind, tag, msg):
             return  # repo never opted in (no .codearbiter/) — nothing to append to
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         hook = os.path.basename(sys.argv[0]) if sys.argv and sys.argv[0] else "-"
+        try:
+            host = get_host().name
+        except Exception:  # noqa: BLE001 — host resolution must never break the sink
+            host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
-        line = f"[{ts}] {kind} {tag_part}hook={hook} | {msg}\n"
+        line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         with open(os.path.join(cad, "gate-events.log"), "a",
                   encoding="utf-8", newline="\n") as f:
             f.write(line)

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -443,17 +443,30 @@ def has_source(root):
     return False
 
 
-def clear_dev_marker(root):
+def clear_dev_marker(root, host_name=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
     synthetic DEV: exit line to overrides.log BEFORE removing it
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
-    or remove failure must never brick session startup."""
+    or remove failure must never brick session startup.
+
+    `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
+    ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
+    the host that wrote it now that two hosts share one overrides.log
+    (ADR-0011). Optional and defaults to resolving it here via
+    `hostapi.load_host()` — main() already holds a Host instance and passes its
+    `.name` through to avoid a second resolution, but any other caller (tests
+    included) may omit it."""
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
     if os.path.isfile(marker):
+        if host_name is None:
+            try:
+                host_name = hostapi.load_host().name
+            except Exception:  # noqa: BLE001 — must never brick session startup
+                host_name = "unknown"
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        line = (f"[{ts}] | BY: session-cleanup | DEV: exit | NOTE: cleared by "
+        line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
                 f"SessionStart (prior session ended mid-dev without /ca:arbiter)\n")
         try:
             with open(os.path.join(root, ".codearbiter", "overrides.log"),
@@ -546,7 +559,7 @@ def main():
     # /dev developer-override is per-session: clear its statusline marker on
     # startup — a new session restores orchestration. A live marker means a prior
     # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
-    clear_dev_marker(root)
+    clear_dev_marker(root, host.name)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -713,19 +713,26 @@ def _log_gate_event(kind, tag, msg):
     decision is no longer visible ONLY in the ephemeral per-turn stderr
     transcript.
 
-    One line per event: `[ISO-8601Z] KIND [tag] hook=<script> | msg`. `tag` may
-    be None (warn() carries no tag) — the bracket is simply omitted then.
-    `hook` is the invoking script's basename (`sys.argv[0]`), the one
+    One line per event: `[ISO-8601Z] KIND [tag] host=<host> hook=<script> | msg`.
+    `tag` may be None (warn() carries no tag) — the bracket is simply omitted
+    then. `hook` is the invoking script's basename (`sys.argv[0]`), the one
     "which hook fired this" signal available at this shared layer without
     threading a new parameter through all 21 call sites across the 16 entry
-    hooks.
+    hooks. `host` is `get_host().name` ("claude"/"codex"/"unknown") — added
+    for observability-001/ADR-0012: with two hosts now sharing one
+    gate-events.log (ADR-0011), a line could not be attributed to the host
+    that wrote it. Placed BEFORE `hook=` (both are `key=value` tokens with no
+    internal whitespace, so the line stays trivially greppable/parseable by
+    either field, and existing `hook=<script>` substring matches are
+    unaffected).
 
     FAIL-OPEN BY CONTRACT (AC-2): this function must NEVER raise and must
     NEVER be allowed to change the caller's exit code or suppress its stderr
     output. A missing `.codearbiter/` dir, an unwritable/locked/missing log
-    file, or project_root() itself misbehaving are ALL swallowed silently
-    here — the ONE deliberate exception to this module's fail-loud discipline,
-    mirroring the documented fail-open exception in read_input()."""
+    file, project_root() itself misbehaving, or host resolution itself
+    misbehaving are ALL swallowed silently here — the ONE deliberate
+    exception to this module's fail-loud discipline, mirroring the documented
+    fail-open exception in read_input()."""
     try:
         root = project_root()
         cad = os.path.join(root, ".codearbiter")
@@ -733,8 +740,12 @@ def _log_gate_event(kind, tag, msg):
             return  # repo never opted in (no .codearbiter/) — nothing to append to
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         hook = os.path.basename(sys.argv[0]) if sys.argv and sys.argv[0] else "-"
+        try:
+            host = get_host().name
+        except Exception:  # noqa: BLE001 — host resolution must never break the sink
+            host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
-        line = f"[{ts}] {kind} {tag_part}hook={hook} | {msg}\n"
+        line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         with open(os.path.join(cad, "gate-events.log"), "a",
                   encoding="utf-8", newline="\n") as f:
             f.write(line)

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -443,17 +443,30 @@ def has_source(root):
     return False
 
 
-def clear_dev_marker(root):
+def clear_dev_marker(root, host_name=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
     synthetic DEV: exit line to overrides.log BEFORE removing it
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
-    or remove failure must never brick session startup."""
+    or remove failure must never brick session startup.
+
+    `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
+    ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
+    the host that wrote it now that two hosts share one overrides.log
+    (ADR-0011). Optional and defaults to resolving it here via
+    `hostapi.load_host()` — main() already holds a Host instance and passes its
+    `.name` through to avoid a second resolution, but any other caller (tests
+    included) may omit it."""
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
     if os.path.isfile(marker):
+        if host_name is None:
+            try:
+                host_name = hostapi.load_host().name
+            except Exception:  # noqa: BLE001 — must never brick session startup
+                host_name = "unknown"
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        line = (f"[{ts}] | BY: session-cleanup | DEV: exit | NOTE: cleared by "
+        line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
                 f"SessionStart (prior session ended mid-dev without /ca:arbiter)\n")
         try:
             with open(os.path.join(root, ".codearbiter", "overrides.log"),
@@ -546,7 +559,7 @@ def main():
     # /dev developer-override is per-session: clear its statusline marker on
     # startup — a new session restores orchestration. A live marker means a prior
     # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
-    clear_dev_marker(root)
+    clear_dev_marker(root, host.name)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/plugins/ca/hooks/tests/test_gate_events.py
+++ b/plugins/ca/hooks/tests/test_gate_events.py
@@ -97,6 +97,51 @@ class TestDurableRecordAC1(_GateEventsFixture):
         text = _read_log(self.cad)
         self.assertIn("hook=pre-bash.py", text)
 
+    def test_record_carries_the_resolved_host_name(self):
+        # ADR-0012/observability-001: two hosts (Claude, Codex) can share one
+        # gate-events.log — each line must be attributable to the host that
+        # wrote it via get_host().name. project_root() itself is threaded
+        # through get_host() too (#260), so the fake host must resolve a real
+        # root, not just carry a `.name`.
+        fake_host = mock.Mock()
+        fake_host.name = "codex"
+        fake_host.project_root.return_value = self.root
+        with mock.patch.object(_hooklib, "get_host", return_value=fake_host):
+            _hooklib.warn("host-attributed line")
+        text = _read_log(self.cad)
+        self.assertIn("host=codex", text)
+
+    def test_host_field_precedes_hook_field_and_both_present(self):
+        fake_host = mock.Mock()
+        fake_host.name = "claude"
+        fake_host.project_root.return_value = self.root
+        with mock.patch.object(_hooklib, "get_host", return_value=fake_host), \
+             mock.patch.object(sys, "argv", ["/path/to/pre-write.py"]):
+            _hooklib.remind("H-01", "ordering check")
+        text = _read_log(self.cad)
+        self.assertIn("host=claude hook=pre-write.py", text)
+
+    def test_host_resolution_failure_does_not_break_fail_open_contract(self):
+        # host resolution must never turn a BLOCK into a raised exception or
+        # change its exit code — mirrors the other AC-2 fail-open guarantees.
+        # project_root() succeeds (it needs a real host to resolve a real
+        # root, #260); only the `.name` access fails, isolating the guard
+        # this test targets from the unrelated project_root() fail-open path
+        # already covered by test_block_still_exits_2_when_project_root_raises.
+        class _BoomNameHost:
+            def project_root(self, payload=None):
+                return self.root_value
+
+        boom_host = _BoomNameHost()
+        boom_host.root_value = self.root
+        type(boom_host).name = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+        with mock.patch.object(_hooklib, "get_host", return_value=boom_host):
+            with self.assertRaises(SystemExit) as cm:
+                _hooklib.block("H-07", "must still block despite host resolution failure")
+        self.assertEqual(cm.exception.code, 2)
+        text = _read_log(self.cad)
+        self.assertIn("host=unknown", text)
+
 
 class TestRealHookIntegrationAC1(unittest.TestCase):
     """AC-1, end-to-end: a REAL hook (pre-bash.py) run against a real
@@ -145,7 +190,7 @@ class TestRealHookIntegrationAC1(unittest.TestCase):
             log = f.read()
         self.assertIn("BLOCK", log)
         self.assertIn("[H-20]", log)
-        self.assertIn("hook=pre-bash.py", log)
+        self.assertIn("host=claude hook=pre-bash.py", log)
 
 
 class TestFailOpenAC2(_GateEventsFixture):

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -419,6 +419,24 @@ class TestDevExitAudit(unittest.TestCase):
         # append-only: the prior DEV: enter line is preserved.
         self.assertIn("DEV: enter", log)
 
+    def test_live_marker_close_line_is_attributed_to_the_resolved_host(self):
+        # ADR-0012/observability-001: the synthetic close line must carry
+        # HOST: <name> so a shared overrides.log is host-attributable.
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root, "codex")
+        log = self._read_log()
+        self.assertIn("HOST: codex", log)
+
+    def test_live_marker_close_line_defaults_host_when_not_supplied(self):
+        # Callers that omit host_name (e.g. legacy call sites, this test suite's
+        # own default-arg calls) still get a HOST: field, resolved internally.
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        log = self._read_log()
+        self.assertRegex(log, r"HOST: \S+")
+
     def test_no_marker_appends_nothing(self):
         seed = "[2026-01-01T00:00:00Z] | BY: x | GATE: none | REASON: seed\n"
         self._seed_log(seed)


### PR DESCRIPTION
Closes #269 (observability-001), implements the attribution half of **ADR-0012** (dual-host concurrency parity). Does NOT add locking — that is out of scope (deferred to #271 per ADR-0012).

Two shared hosts write one `.codearbiter/` audit trail; entries could not be attributed to a host. Now:

- **gate-events.log** (`_log_gate_event`): `[ts] KIND [tag] host=<host> hook=<script> | msg`. `host=` inserted before `hook=`; the `hook=<script>` substring is unchanged so existing greps still match. Host resolution is guarded by its own try/except (falls back to `unknown`) so it can never escape into the outer fail-open catch or change an exit code — the fail-open contract is preserved.
- **overrides.log** dev-cleanup close line (`clear_dev_marker`): `... | BY: session-cleanup | HOST: <host> | DEV: exit | ...`. Uses the `Host` already resolved in `main()` (no duplicate resolution).

Tests: host field present + ordered before `hook=`; a `.name`-access failure does not break the fail-open sink (isolated from #260's `project_root`→`get_host()` dependency); overrides close line attributed / defaults when host omitted. Full suite **824** pass, hooklib 68, adapter 57, guards PASS, sync-core --check byte-identical.

Follow-up (tracked separately, not in this PR): the site docs `codearbiter-directory.md` gate-events format line is now stale (missing `host=`); a `site/` change needs its own npm-test verification so it does not ride a hooks PR.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
