### PR TITLE
fix(hooks): host-aware plugin manifest path for doctor + update notifier (#263)

### DIFF
--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -426,6 +426,30 @@ class TestCodexProjectRoot(unittest.TestCase):
             self.assertEqual(os.path.realpath(got), os.path.realpath(payload_dir))
 
 
+class TestManifestRelpath(unittest.TestCase):
+    """#263 (reliability-001/002/observability-003): CodexHost.manifest_relpath
+    must point at `.codex-plugin/plugin.json` (ca-codex's ONLY manifest
+    location, per the module header in plugins/ca-codex/hooks/_host.py), and
+    the Claude host must stay at `.claude-plugin/plugin.json` unchanged —
+    doctor.py's check_payload and _updatelib.installed_version both derive
+    the manifest path from this seam now instead of a hard-coded string."""
+
+    def test_codex_host_manifest_relpath(self):
+        self.assertEqual(codex_host().manifest_relpath(),
+                          os.path.join(".codex-plugin", "plugin.json"))
+
+    def test_claude_host_manifest_relpath_unchanged(self):
+        self.assertEqual(claude_host().manifest_relpath(),
+                          os.path.join(".claude-plugin", "plugin.json"))
+
+    def test_real_ca_codex_manifest_exists_at_resolved_path(self):
+        # The actual shipped install: root/.codex-plugin/plugin.json must
+        # exist, and NOT root/.claude-plugin/plugin.json.
+        manifest = os.path.join(CODEX_PLUGIN, codex_host().manifest_relpath())
+        self.assertTrue(os.path.isfile(manifest), manifest)
+        self.assertFalse(os.path.isdir(os.path.join(CODEX_PLUGIN, ".claude-plugin")))
+
+
 class TestClaudeIterFileOps(unittest.TestCase):
     """The Claude side of the seam: Write/Edit payloads -> the SAME canonical
     op shape the shared entries consume (Claude behavior stays identical)."""

--- a/core/pysrc/_updatelib.py
+++ b/core/pysrc/_updatelib.py
@@ -28,7 +28,9 @@
 #   UPDATE_API_URL                           GitHub Releases API endpoint (module constant)
 #   state_path() -> str                      resolved cache file path (env-overridable)
 #   plugin_root(explicit=None) -> str        the running plugin's own root directory
-#   installed_version(root=None) -> str|None the version in <root>/.claude-plugin/plugin.json
+#   installed_version(root=None, host=None) -> str|None  the version in
+#                                             <root>/<host.manifest_relpath()>
+#                                             (host defaults to hostapi.load_host())
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
@@ -80,12 +82,21 @@ def plugin_root(explicit=None):
     return explicit or hostapi.load_host().plugin_root()
 
 
-def installed_version(root=None):
-    """The `version` field from <root>/.claude-plugin/plugin.json, or None on any
-    failure (missing file, corrupt JSON, missing/blank field)."""
+def installed_version(root=None, host=None):
+    """The `version` field from <root>/<host.manifest_relpath()>, or None on any
+    failure (missing file, corrupt JSON, missing/blank field). `host` defaults to
+    hostapi.load_host() (#263, reliability-002/observability-003): under Claude
+    Code that resolves to `.claude-plugin/plugin.json` exactly as before; a
+    plugin whose manifest ships elsewhere (e.g. ca-codex's `.codex-plugin/`)
+    resolves the CORRECT path instead of silently reading nothing and
+    suppressing the update-available notice forever. No caller in this repo
+    threads a host through today (session-start.py calls installed_version(plugin)
+    positionally), so resolving it here — rather than plumbing it through every
+    call site — keeps the fix local to this seam."""
     root = root or plugin_root()
+    host = host or hostapi.load_host()
     try:
-        with open(os.path.join(root, ".claude-plugin", "plugin.json"),
+        with open(os.path.join(root, host.manifest_relpath()),
                   encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, ValueError):

--- a/core/pysrc/doctor.py
+++ b/core/pysrc/doctor.py
@@ -82,8 +82,14 @@ def check_interpreters():
         ok(f"python resolves ({p})")
 
 
-def check_payload(root):
-    manifest = os.path.join(root, ".claude-plugin", "plugin.json")
+def check_payload(root, host=None):
+    # host-aware manifest path (#263): defaults to hostapi.load_host() so
+    # every pre-seam call site (main() below, and every existing test that
+    # calls check_payload(root) positionally) keeps resolving the manifest
+    # for whichever host is actually running, without threading a host
+    # through every caller.
+    host = host or hostapi.load_host()
+    manifest = os.path.join(root, host.manifest_relpath())
     version = None
     try:
         with open(manifest, encoding="utf-8") as f:
@@ -194,9 +200,10 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
-    check_host(hostapi.load_host())
+    host = hostapi.load_host()
+    check_host(host)
     check_interpreters()
-    check_payload(root)
+    check_payload(root, host)
     check_repo()
     check_statusline(root)
     width = max(len(lvl) for lvl, _ in results)

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -131,6 +131,18 @@ class Host:
             return env
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+    def manifest_relpath(self):
+        """The plugin manifest's path, relative to plugin_root() (#263,
+        reliability-001/002 + observability-003): Claude Code's marketplace
+        convention is `.claude-plugin/plugin.json` — the ONLY location this
+        host ever reads or writes. A host whose manifest ships elsewhere
+        (e.g. Codex's `.codex-plugin/`) overrides this so doctor.py's
+        check_payload and _updatelib.installed_version resolve the manifest
+        that ACTUALLY exists for the running host, instead of hard-coding the
+        Claude path and reporting a healthy Codex install as UNHEALTHY /
+        silently never firing the update-available notice."""
+        return os.path.join(".claude-plugin", "plugin.json")
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -228,6 +228,12 @@ class CodexHost(hostapi.Host):
                 return env
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+    def manifest_relpath(self):
+        """ca-codex ships its manifest at `.codex-plugin/plugin.json` ONLY
+        (module header above) — never `.claude-plugin/`, so doctor.py and
+        _updatelib.py must resolve THIS path under Codex (#263)."""
+        return os.path.join(".codex-plugin", "plugin.json")
+
     def normalize_tool_input(self, tool_name, tool_input):
         """Codex's exec payload ({command}) already IS the canonical EXEC
         shape, and the apply_patch envelope cannot be represented as ONE

--- a/plugins/ca-codex/hooks/_updatelib.py
+++ b/plugins/ca-codex/hooks/_updatelib.py
@@ -28,7 +28,9 @@
 #   UPDATE_API_URL                           GitHub Releases API endpoint (module constant)
 #   state_path() -> str                      resolved cache file path (env-overridable)
 #   plugin_root(explicit=None) -> str        the running plugin's own root directory
-#   installed_version(root=None) -> str|None the version in <root>/.claude-plugin/plugin.json
+#   installed_version(root=None, host=None) -> str|None  the version in
+#                                             <root>/<host.manifest_relpath()>
+#                                             (host defaults to hostapi.load_host())
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
@@ -80,12 +82,21 @@ def plugin_root(explicit=None):
     return explicit or hostapi.load_host().plugin_root()
 
 
-def installed_version(root=None):
-    """The `version` field from <root>/.claude-plugin/plugin.json, or None on any
-    failure (missing file, corrupt JSON, missing/blank field)."""
+def installed_version(root=None, host=None):
+    """The `version` field from <root>/<host.manifest_relpath()>, or None on any
+    failure (missing file, corrupt JSON, missing/blank field). `host` defaults to
+    hostapi.load_host() (#263, reliability-002/observability-003): under Claude
+    Code that resolves to `.claude-plugin/plugin.json` exactly as before; a
+    plugin whose manifest ships elsewhere (e.g. ca-codex's `.codex-plugin/`)
+    resolves the CORRECT path instead of silently reading nothing and
+    suppressing the update-available notice forever. No caller in this repo
+    threads a host through today (session-start.py calls installed_version(plugin)
+    positionally), so resolving it here — rather than plumbing it through every
+    call site — keeps the fix local to this seam."""
     root = root or plugin_root()
+    host = host or hostapi.load_host()
     try:
-        with open(os.path.join(root, ".claude-plugin", "plugin.json"),
+        with open(os.path.join(root, host.manifest_relpath()),
                   encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, ValueError):

--- a/plugins/ca-codex/hooks/doctor.py
+++ b/plugins/ca-codex/hooks/doctor.py
@@ -82,8 +82,14 @@ def check_interpreters():
         ok(f"python resolves ({p})")
 
 
-def check_payload(root):
-    manifest = os.path.join(root, ".claude-plugin", "plugin.json")
+def check_payload(root, host=None):
+    # host-aware manifest path (#263): defaults to hostapi.load_host() so
+    # every pre-seam call site (main() below, and every existing test that
+    # calls check_payload(root) positionally) keeps resolving the manifest
+    # for whichever host is actually running, without threading a host
+    # through every caller.
+    host = host or hostapi.load_host()
+    manifest = os.path.join(root, host.manifest_relpath())
     version = None
     try:
         with open(manifest, encoding="utf-8") as f:
@@ -194,9 +200,10 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
-    check_host(hostapi.load_host())
+    host = hostapi.load_host()
+    check_host(host)
     check_interpreters()
-    check_payload(root)
+    check_payload(root, host)
     check_repo()
     check_statusline(root)
     width = max(len(lvl) for lvl, _ in results)

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -131,6 +131,18 @@ class Host:
             return env
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+    def manifest_relpath(self):
+        """The plugin manifest's path, relative to plugin_root() (#263,
+        reliability-001/002 + observability-003): Claude Code's marketplace
+        convention is `.claude-plugin/plugin.json` — the ONLY location this
+        host ever reads or writes. A host whose manifest ships elsewhere
+        (e.g. Codex's `.codex-plugin/`) overrides this so doctor.py's
+        check_payload and _updatelib.installed_version resolve the manifest
+        that ACTUALLY exists for the running host, instead of hard-coding the
+        Claude path and reporting a healthy Codex install as UNHEALTHY /
+        silently never firing the update-available notice."""
+        return os.path.join(".claude-plugin", "plugin.json")
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""

--- a/plugins/ca/hooks/_updatelib.py
+++ b/plugins/ca/hooks/_updatelib.py
@@ -28,7 +28,9 @@
 #   UPDATE_API_URL                           GitHub Releases API endpoint (module constant)
 #   state_path() -> str                      resolved cache file path (env-overridable)
 #   plugin_root(explicit=None) -> str        the running plugin's own root directory
-#   installed_version(root=None) -> str|None the version in <root>/.claude-plugin/plugin.json
+#   installed_version(root=None, host=None) -> str|None  the version in
+#                                             <root>/<host.manifest_relpath()>
+#                                             (host defaults to hostapi.load_host())
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
@@ -80,12 +82,21 @@ def plugin_root(explicit=None):
     return explicit or hostapi.load_host().plugin_root()
 
 
-def installed_version(root=None):
-    """The `version` field from <root>/.claude-plugin/plugin.json, or None on any
-    failure (missing file, corrupt JSON, missing/blank field)."""
+def installed_version(root=None, host=None):
+    """The `version` field from <root>/<host.manifest_relpath()>, or None on any
+    failure (missing file, corrupt JSON, missing/blank field). `host` defaults to
+    hostapi.load_host() (#263, reliability-002/observability-003): under Claude
+    Code that resolves to `.claude-plugin/plugin.json` exactly as before; a
+    plugin whose manifest ships elsewhere (e.g. ca-codex's `.codex-plugin/`)
+    resolves the CORRECT path instead of silently reading nothing and
+    suppressing the update-available notice forever. No caller in this repo
+    threads a host through today (session-start.py calls installed_version(plugin)
+    positionally), so resolving it here — rather than plumbing it through every
+    call site — keeps the fix local to this seam."""
     root = root or plugin_root()
+    host = host or hostapi.load_host()
     try:
-        with open(os.path.join(root, ".claude-plugin", "plugin.json"),
+        with open(os.path.join(root, host.manifest_relpath()),
                   encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, ValueError):

--- a/plugins/ca/hooks/doctor.py
+++ b/plugins/ca/hooks/doctor.py
@@ -82,8 +82,14 @@ def check_interpreters():
         ok(f"python resolves ({p})")
 
 
-def check_payload(root):
-    manifest = os.path.join(root, ".claude-plugin", "plugin.json")
+def check_payload(root, host=None):
+    # host-aware manifest path (#263): defaults to hostapi.load_host() so
+    # every pre-seam call site (main() below, and every existing test that
+    # calls check_payload(root) positionally) keeps resolving the manifest
+    # for whichever host is actually running, without threading a host
+    # through every caller.
+    host = host or hostapi.load_host()
+    manifest = os.path.join(root, host.manifest_relpath())
     version = None
     try:
         with open(manifest, encoding="utf-8") as f:
@@ -194,9 +200,10 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
-    check_host(hostapi.load_host())
+    host = hostapi.load_host()
+    check_host(host)
     check_interpreters()
-    check_payload(root)
+    check_payload(root, host)
     check_repo()
     check_statusline(root)
     width = max(len(lvl) for lvl, _ in results)

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -131,6 +131,18 @@ class Host:
             return env
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+    def manifest_relpath(self):
+        """The plugin manifest's path, relative to plugin_root() (#263,
+        reliability-001/002 + observability-003): Claude Code's marketplace
+        convention is `.claude-plugin/plugin.json` — the ONLY location this
+        host ever reads or writes. A host whose manifest ships elsewhere
+        (e.g. Codex's `.codex-plugin/`) overrides this so doctor.py's
+        check_payload and _updatelib.installed_version resolve the manifest
+        that ACTUALLY exists for the running host, instead of hard-coding the
+        Claude path and reporting a healthy Codex install as UNHEALTHY /
+        silently never firing the update-available notice."""
+        return os.path.join(".claude-plugin", "plugin.json")
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""

--- a/plugins/ca/hooks/tests/test_doctor.py
+++ b/plugins/ca/hooks/tests/test_doctor.py
@@ -180,6 +180,78 @@ class TestCheckPayloadStaleSibling(unittest.TestCase):
         self.assertTrue(any("2.0.0" in line or "1.9.0" in line for line in warn_lines))
 
 
+class TestCheckPayloadHostAware(unittest.TestCase):
+    """#263 (reliability-001): check_payload must resolve the manifest via
+    host.manifest_relpath(), not a hard-coded `.claude-plugin/plugin.json` —
+    a ca-codex-shaped install (manifest at `.codex-plugin/plugin.json` ONLY,
+    no `.claude-plugin/` at all) was previously reported UNHEALTHY (FAIL) on
+    every healthy install."""
+
+    class _FakeCodexHost:
+        def manifest_relpath(self):
+            return os.path.join(".codex-plugin", "plugin.json")
+
+    def setUp(self):
+        _reset()
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        _reset()
+        self.tmp.cleanup()
+
+    def _build_codex_shaped_root(self, version="1.2.3"):
+        root = self.tmp.name
+        plugin_dir = os.path.join(root, ".codex-plugin")
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, "plugin.json"), "w") as f:
+            json.dump({"version": version}, f)
+        hooks_dir = os.path.join(root, "hooks")
+        os.makedirs(hooks_dir)
+        hooks_config = {"hooks": {"UserPromptSubmit": [{"hooks": ["a"]}]}}
+        with open(os.path.join(hooks_dir, "hooks.json"), "w") as f:
+            json.dump(hooks_config, f)
+        for script in doctor.HOOK_SCRIPTS:
+            open(os.path.join(hooks_dir, script), "w").close()
+        return root
+
+    def test_codex_shaped_install_is_healthy_under_codex_host(self):
+        root = self._build_codex_shaped_root()
+        doctor.check_payload(root, self._FakeCodexHost())
+        self.assertNotIn("FAIL", _levels())
+
+    def test_codex_shaped_install_version_reported(self):
+        root = self._build_codex_shaped_root("1.2.3")
+        doctor.check_payload(root, self._FakeCodexHost())
+        ok_lines = [line for lvl, line in doctor.results if lvl == "OK"]
+        self.assertTrue(any("1.2.3" in line for line in ok_lines))
+
+    def test_codex_shaped_install_fails_under_default_claude_host(self):
+        # Same root, but resolved via the default (Claude) host — no
+        # .claude-plugin/ exists here, so this must still FAIL. Confirms the
+        # fix is host-SELECTIVE, not a blanket "try both paths" workaround.
+        root = self._build_codex_shaped_root()
+        doctor.check_payload(root, doctor.hostapi.Host())
+        self.assertIn("FAIL", _levels())
+
+    def test_claude_shaped_install_still_healthy_under_default_host(self):
+        # No host arg passed at all — resolves via hostapi.load_host(), the
+        # pre-#263 default path, and must stay byte-identical for Claude.
+        root = self.tmp.name
+        plugin_dir = os.path.join(root, ".claude-plugin")
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, "plugin.json"), "w") as f:
+            json.dump({"version": "2.1.0"}, f)
+        hooks_dir = os.path.join(root, "hooks")
+        os.makedirs(hooks_dir)
+        hooks_config = {"hooks": {"UserPromptSubmit": [{"hooks": ["a"]}]}}
+        with open(os.path.join(hooks_dir, "hooks.json"), "w") as f:
+            json.dump(hooks_config, f)
+        for script in doctor.HOOK_SCRIPTS:
+            open(os.path.join(hooks_dir, script), "w").close()
+        doctor.check_payload(root)
+        self.assertNotIn("FAIL", _levels())
+
+
 class TestCheckRepoEnabled(unittest.TestCase):
     """check_repo: arbiter-enabled CONTEXT.md → OK."""
 

--- a/plugins/ca/hooks/tests/test_hostapi_loadhost.py
+++ b/plugins/ca/hooks/tests/test_hostapi_loadhost.py
@@ -79,5 +79,22 @@ class LoadHostFailClosedTests(unittest.TestCase):
         self.assertEqual(h.name, "unknown")
 
 
+class ManifestRelpathTests(unittest.TestCase):
+    """#263 (reliability-001/002): the base Host's manifest_relpath() default
+    must stay exactly `.claude-plugin/plugin.json` — the pre-#263 hard-coded
+    path both doctor.py and _updatelib.py now derive from this seam instead."""
+
+    def test_default_host_manifest_relpath_is_claude_plugin(self):
+        self.assertEqual(hostapi.Host().manifest_relpath(),
+                          os.path.join(".claude-plugin", "plugin.json"))
+
+    def test_failclosed_host_inherits_claude_manifest_relpath(self):
+        # FailClosedHost overrides no manifest-related behavior — it inherits
+        # the base Host's path (doctor's own check_host WARNs separately on
+        # "unknown"; manifest resolution is not part of that fail-closed guard).
+        self.assertEqual(hostapi.FailClosedHost().manifest_relpath(),
+                          os.path.join(".claude-plugin", "plugin.json"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/tests/test_updatelib.py
+++ b/plugins/ca/hooks/tests/test_updatelib.py
@@ -412,6 +412,69 @@ class TestInstalledVersion(unittest.TestCase):
         self.assertIsNotNone(U.parse_version(v))
 
 
+class TestInstalledVersionHostAware(unittest.TestCase):
+    """#263 (reliability-002/observability-003): installed_version() must
+    resolve the manifest via host.manifest_relpath(), not a hard-coded
+    `.claude-plugin/plugin.json` — a ca-codex install ships its manifest at
+    `.codex-plugin/plugin.json` ONLY, so the hard-coded path silently
+    returned None and the update-available notice never fired on Codex."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    class _FakeCodexHost:
+        def manifest_relpath(self):
+            return os.path.join(".codex-plugin", "plugin.json")
+
+    def _write_manifest(self, subdir, version):
+        d = os.path.join(self.root, subdir)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "plugin.json"), "w", encoding="utf-8") as f:
+            json.dump({"name": "x", "version": version}, f)
+
+    def test_codex_shaped_install_reads_codex_plugin_dir(self):
+        # No .claude-plugin/ at all — a ca-codex-shaped install.
+        self._write_manifest(".codex-plugin", "3.1.0")
+        self.assertEqual(
+            U.installed_version(self.root, host=self._FakeCodexHost()), "3.1.0")
+
+    def test_codex_host_ignores_claude_plugin_dir(self):
+        # Only .claude-plugin/ present (no .codex-plugin/) — must still miss,
+        # never accidentally fall back to the wrong host's manifest.
+        self._write_manifest(".claude-plugin", "9.9.9")
+        self.assertIsNone(U.installed_version(self.root, host=self._FakeCodexHost()))
+
+    def test_default_host_still_reads_claude_plugin_dir(self):
+        # No host arg passed at all — resolves via hostapi.load_host(), which
+        # in this bare-core checkout (no _host.py beside _updatelib.py) is the
+        # Claude default Host(); behavior must stay byte-identical to before.
+        self._write_manifest(".claude-plugin", "2.8.2")
+        self.assertEqual(U.installed_version(self.root), "2.8.2")
+
+    def test_real_ca_codex_manifest_resolves_via_codex_host(self):
+        # The actual shipped ca-codex install: root is plugins/ca-codex, its
+        # manifest lives at .codex-plugin/plugin.json ONLY. _HOOKS_DIR is
+        # .../plugins/ca/hooks, so climb two levels to plugins/ and sideways
+        # into ca-codex/ rather than string-replacing (avoids any risk of a
+        # false substring match elsewhere in the path).
+        plugins_dir = os.path.dirname(os.path.dirname(_HOOKS_DIR))
+        codex_root = os.path.join(plugins_dir, "ca-codex")
+        codex_hooks = os.path.join(codex_root, "hooks")
+        sys.path.insert(0, codex_hooks)
+        try:
+            import _host as _codex_host_mod
+            v = U.installed_version(codex_root, host=_codex_host_mod.HOST)
+        finally:
+            sys.path.remove(codex_hooks)
+            sys.modules.pop("_host", None)
+        self.assertIsNotNone(v)
+        self.assertIsNotNone(U.parse_version(v))
+
+
 class TestStatePath(unittest.TestCase):
     """The cache is user-global (~/.codearbiter/...), NOT under project .codearbiter/."""
 


### PR DESCRIPTION
Closes #263, folds reliability-001 + reliability-002 + observability-003.

`doctor.py::check_payload` and `_updatelib.py::installed_version` hard-coded `.claude-plugin/plugin.json`, so on a ca-codex install (manifest at `.codex-plugin/plugin.json`) doctor reported every healthy install UNHEALTHY and the update notice silently never fired.

Fix — host-aware manifest path via the seam:
- New `Host.manifest_relpath()` → `.claude-plugin/plugin.json` (Claude default); `CodexHost` override → `.codex-plugin/plugin.json`.
- `check_payload(root, host=None)` and `installed_version(root=None, host=None)` build the path from `get_host()/load_host().manifest_relpath()`; `doctor.main()` resolves the host once and passes it to both `check_host` and `check_payload`.

Claude byte-identity: the default (no-host-arg) path still resolves `.claude-plugin/plugin.json` exactly as before — verified by the unchanged existing tests plus explicit new ones. Tests prove **selectivity** (a codex-shaped install FAILs under the Claude host — not a blanket try-both) and a real-file test loads the actual ca-codex `_host.py` and resolves the real `.codex-plugin/plugin.json`.

Out of scope (noted, not done): the per-host version *stream* concern (comparing ca-codex's version against the ca release tag) — this fixes only which manifest PATH is read.

Full suite **829** pass · adapter **60** · sync-core --check byte-identical · plugin-refs intact.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
