### PR TITLE
fix(ca-codex): correct manifest activation description (#259)

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -328,6 +328,24 @@ friction and audit trail it adds on the cooperative path. Reopens (→ non-fabri
 reviewer-signed binding) only if the threat model expands to untrusted agents. See
 ADR-0010 (resolves appsec-003 / #196).
 
+**MCP file-write tools out of scope (both hosts).** The write-path guards
+(`pre-write.py` / `post-write-edit.py`) are wired to each host's *native* write
+tools — Claude's `Write`/`Edit`/`MultiEdit`/`NotebookEdit`, and Codex's
+`apply_patch` (plus its `Write`/`Edit` matcher aliases). A file write performed
+through an **MCP server tool** (`mcp__<server>__<tool>`) is not covered: on Claude
+such tools escape the `Write`/`Edit` matchers, and on Codex `mcp__*` normalizes to
+the `OTHER` category (no `TOOL_MAP` entry) and matches neither the
+`apply_patch|Write|Edit` write hooks nor the `Bash` exec hook. An agent that adds
+an MCP filesystem/write server can therefore write `.codearbiter/CONTEXT.md`, a
+`.markers/` token, or an audit log without a guard firing, on either host. This is
+**accepted residual risk** under the same cooperative-agent trust model as the
+`--no-verify`, shell-indirection, and self-minted-marker gaps above (ADR-0010) — a
+cooperating orchestrator does not route protected writes through an out-of-band MCP
+tool, and a non-cooperating Bash-capable agent already has stronger bypasses.
+Bringing MCP writes under the write gate on both hosts is tracked as **near-term
+hardening (issue #270 / tribunal appsec-002)**, not a codex-branch blocker; it
+reopens if the threat model expands to untrusted agents.
+
 ---
 
 ## Boundary crossings (declared exceptions)

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "displayName": "codeArbiter for Codex",
-  "description": "Beta governance kernel for OpenAI Codex CLI: the codeArbiter enforcement hooks (persona injection at SessionStart, blocking pre-exec and pre-write gates, append-only audit trail) sharing one .codearbiter/ store with the Claude Code sibling plugin. Requires Python 3 on PATH and Codex >= 0.134.0. Dormant until you opt a repo in via /ca-init.",
+  "description": "Beta governance kernel for OpenAI Codex CLI: the codeArbiter enforcement hooks (persona injection at SessionStart, blocking pre-exec and pre-write gates, append-only audit trail) sharing one .codearbiter/ store with the Claude Code sibling plugin. Requires Python 3 on PATH and Codex >= 0.134.0. Dormant until the repo is opted in: it activates when the shared .codearbiter/CONTEXT.md carries 'arbiter: enabled' (the same store the Claude Code sibling scaffolds via /ca:init).",
   "version": "0.1.0",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Fixes the broken first-run pointer in architecture-005: the manifest promised `/ca-init` (a command that does not exist — the Claude command is `/ca:init`, and ca-codex ships no commands). Now states the accurate activation condition (shared CONTEXT.md with `arbiter: enabled`).

Does NOT close #259 — the dead-vendored-entries concern is re-scoped (full vendoring is the self-contained-payload contract; unregistered entries are inert on Codex), and the Codex-only initialization UX is surfaced separately. See issue comments.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG