### PR TITLE
feat(ci): guard against ORCHESTRATOR.md drift between plugins (#262)

### DIFF
--- a/.github/scripts/check_orchestrator_parity.py
+++ b/.github/scripts/check_orchestrator_parity.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# codeArbiter — ORCHESTRATOR.md drift guard (issue #262, architecture-010).
+#
+# plugins/ca/ORCHESTRATOR.md and plugins/ca-codex/ORCHESTRATOR.md are
+# hand-duplicated (ADR-0011 named a core/surface/ + tools/build-surface.py
+# generator that would let the two controllably diverge, but that generator
+# does not exist yet). Until it does, the correct contract is that the two
+# files stay BYTE-IDENTICAL — an edit to one that forgets its twin silently
+# ships divergent governance between the two hosts, with nothing to catch it.
+# This is a drift GUARD, not the generator: it only asserts today's identity
+# invariant. If a deliberate host-specific divergence is ever needed, that is
+# a future change to this script (and ideally the real generator), not a
+# reason to skip the guard now.
+#
+# Design invariants (mirror check_license_consistency.py / tools/sync-core.py):
+#   - Stdlib only; zero side effects at import.
+#   - Pure comparison function over already-read text; filesystem access
+#     isolated to the named reader (read_text).
+#   - Never raise on malformed/missing input — degrade to a surfaced finding.
+#
+# Public API:
+#   first_diff_line(a, b) -> int | None
+#   differs(a, b) -> bool
+#   read_text(path) -> str | None
+#   run_all(repo_root) -> list[str]
+#   main(argv) -> int
+
+import os
+import sys
+
+CA_ORCHESTRATOR = os.path.join("plugins", "ca", "ORCHESTRATOR.md")
+CA_CODEX_ORCHESTRATOR = os.path.join("plugins", "ca-codex", "ORCHESTRATOR.md")
+
+
+def differs(a, b):
+    """True if the two texts are not identical."""
+    return a != b
+
+
+def first_diff_line(a, b):
+    """1-based line number of the first line at which `a` and `b` diverge, or
+    None if the texts are identical. A length mismatch (one text has fewer
+    lines) reports the first line past the shorter text's end."""
+    if a == b:
+        return None
+    a_lines = a.splitlines()
+    b_lines = b.splitlines()
+    for i, (la, lb) in enumerate(zip(a_lines, b_lines)):
+        if la != lb:
+            return i + 1
+    return min(len(a_lines), len(b_lines)) + 1
+
+
+def read_text(path):
+    """File text, or None if missing / unreadable."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def run_all(repo_root):
+    """Read both ORCHESTRATOR.md surfaces under `repo_root` and return all
+    findings (empty = the two files are byte-identical). A missing surface is
+    itself a finding, never an exception."""
+    ca_path = os.path.join(repo_root, CA_ORCHESTRATOR)
+    codex_path = os.path.join(repo_root, CA_CODEX_ORCHESTRATOR)
+    ca_text = read_text(ca_path)
+    codex_text = read_text(codex_path)
+
+    findings = []
+    if ca_text is None:
+        findings.append(f"{CA_ORCHESTRATOR}: missing or unreadable")
+    if codex_text is None:
+        findings.append(f"{CA_CODEX_ORCHESTRATOR}: missing or unreadable")
+    if findings:
+        return findings
+
+    if differs(ca_text, codex_text):
+        line = first_diff_line(ca_text, codex_text)
+        findings.append(
+            f"{CA_ORCHESTRATOR} and {CA_CODEX_ORCHESTRATOR} have diverged "
+            f"(first differing line: {line}). These two files are "
+            f"hand-duplicated (no generator yet, ADR-0011) and must stay "
+            f"byte-identical — sync the edit to both, or if a deliberate "
+            f"per-host divergence is intended, update this guard "
+            f"(.github/scripts/check_orchestrator_parity.py) to reflect the "
+            f"new contract.")
+    return findings
+
+
+def main(argv):
+    """CLI: `check_orchestrator_parity.py [repo_root]`. Prints findings; exit 1 if any."""
+    repo_root = argv[0] if argv else "."
+    findings = run_all(repo_root)
+    if findings:
+        sys.stderr.write("orchestrator-parity check FAILED:\n")
+        for f in findings:
+            sys.stderr.write(f"  - {f}\n")
+        return 1
+    print("ORCHESTRATOR.md is byte-identical across plugins/ca and plugins/ca-codex")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/test_orchestrator_parity.py
+++ b/.github/scripts/test_orchestrator_parity.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Unit tests for check_orchestrator_parity — the ORCHESTRATOR.md drift guard.
+
+Run: python .github/scripts/test_orchestrator_parity.py
+
+Covers the pure comparison helpers against literal strings (so drift detection
+is provable without mutating real files) AND the live repo (the guard must
+pass on HEAD: plugins/ca/ORCHESTRATOR.md and plugins/ca-codex/ORCHESTRATOR.md
+are byte-identical today).
+"""
+import unittest
+from pathlib import Path
+
+import check_orchestrator_parity as G
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class DiffersTest(unittest.TestCase):
+    def test_identical_texts(self):
+        self.assertFalse(G.differs("same\ntext\n", "same\ntext\n"))
+
+    def test_diverged_texts(self):
+        self.assertTrue(G.differs("a\nb\n", "a\nc\n"))
+
+
+class FirstDiffLineTest(unittest.TestCase):
+    def test_identical_returns_none(self):
+        self.assertIsNone(G.first_diff_line("a\nb\nc\n", "a\nb\nc\n"))
+
+    def test_reports_first_diverging_line(self):
+        self.assertEqual(G.first_diff_line("a\nb\nc\n", "a\nX\nc\n"), 2)
+
+    def test_reports_line_past_shorter_text(self):
+        self.assertEqual(G.first_diff_line("a\nb\n", "a\nb\nc\n"), 3)
+
+
+class ReadTextTest(unittest.TestCase):
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(G.read_text(str(REPO_ROOT / "no-such-file-262.md")))
+
+
+class RunAllTest(unittest.TestCase):
+    def test_missing_surfaces_are_findings_not_exceptions(self):
+        findings = G.run_all(str(REPO_ROOT / "no-such-dir-262"))
+        self.assertTrue(any("ca" in f and "missing or unreadable" in f for f in findings))
+        self.assertTrue(any("ca-codex" in f and "missing or unreadable" in f for f in findings))
+
+    def test_diverged_pair_is_a_finding(self):
+        ca_text = G.read_text(str(REPO_ROOT / G.CA_ORCHESTRATOR))
+        self.assertIsNotNone(ca_text, "plugins/ca/ORCHESTRATOR.md must exist for this test")
+        self.assertTrue(G.differs(ca_text, ca_text + "\nDRIFTED\n"))
+
+    def test_live_repo_is_currently_in_parity(self):
+        # The guard's own contract: on HEAD, the two files are byte-identical.
+        findings = G.run_all(str(REPO_ROOT))
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,26 @@ jobs:
       - name: Check license declarations agree across surfaces
         run: python3 .github/scripts/check_license_consistency.py .
 
+  orchestrator-parity:
+    name: Repo | [Check] - ORCHESTRATOR.md Parity
+    # Shared infra - plugins/ca/ORCHESTRATOR.md and plugins/ca-codex/ORCHESTRATOR.md
+    # are hand-duplicated (issue #262, architecture-010): ADR-0011 named a
+    # core/surface/ + tools/build-surface.py generator that would let the two
+    # controllably diverge, but that generator does not exist yet. Until it
+    # does, an edit to one file that forgets its twin silently ships divergent
+    # governance between the two hosts with nothing to catch it. This is a
+    # drift GUARD (byte-identity today), not the generator. Repo-wide and
+    # always-on, like license-consistency: an ORCHESTRATOR.md edit can ride
+    # any PR, not just a plugins/**-path-filtered one.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - name: Check ORCHESTRATOR.md is byte-identical across plugins/ca and plugins/ca-codex
+        run: python3 .github/scripts/check_orchestrator_parity.py .
+
   ci-passed:
     name: Repo | [Gate] - CI Passed
     if: always()
@@ -523,6 +543,7 @@ jobs:
       - prose-sandbox
       - manifests
       - license-consistency
+      - orchestrator-parity
     runs-on: ubuntu-latest
     steps:
       - name: Require every job to have succeeded or been skipped


### PR DESCRIPTION
Closes #262 (architecture-010). Adds `.github/scripts/check_orchestrator_parity.py` (stdlib, byte-identity check reporting the first differing line) + a `orchestrator-parity` CI job (repo-wide, always-on, in `ci-passed` needs) + unit tests. The two ORCHESTRATOR.md files are byte-identical today; this guards against silent drift.

Honest scope: this is a drift GUARD, not the ADR-0011 templating generator — it enforces today's byte-identity invariant; controlled per-host divergence (core/surface + build-surface.py) remains future work if ever needed.

Verified: exits 0 now; exits 1 with a clear message on an injected diff; ci.yml parses; 9 tests pass.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG