### PR TITLE
docs(hooks): document the dual-host git-hook shim residual (#265, accept-risk)

### DIFF
--- a/core/pysrc/_githooks.py
+++ b/core/pysrc/_githooks.py
@@ -21,6 +21,29 @@
 #     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
 #     our OWN staleness only — never brick a user's commits because our path
 #     drifted; the pre-bash + Claude layers still apply).
+#
+#     Accepted residual, dual-host widening (reliability-009 / #265, LOW,
+#     ACCEPT-RISK): with BOTH `ca` and `ca-codex` installed against one repo,
+#     each SessionStart (whichever host ran last) rewrites the shim to point at
+#     THAT plugin's own `_enforcer_path()` — the two hosts manage entirely
+#     separate, independently versioned plugin caches (e.g. Claude Code's
+#     `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`; Codex's
+#     cache root and layout are not fixed by anything in this repo), so the
+#     sibling plugin's absolute enforcer path is NOT reliably derivable from
+#     this file's own path at write time — no path-substitution or fixed
+#     sibling-directory guess survives an independent version bump on either
+#     side. Multiple-candidate embedding (try both known paths) and a runtime
+#     filesystem search (glob likely cache roots from inside the POSIX `sh`
+#     shim) were both considered and rejected: the former requires knowing a
+#     path this file cannot derive, and the latter would mean an unverified,
+#     host-layout-guessing filesystem search on every commit/push under
+#     Windows Git-Bash `sh` — a fragile git-level backstop is worse than the
+#     accepted trade. Net effect: uninstalling whichever plugin most recently
+#     ran SessionStart leaves the shim fail-open until the SURVIVING host's
+#     next SessionStart rewrites it (single-plugin behavior — install()
+#     writing its own current path — is unchanged and unaffected by this
+#     residual). Revisit only if a host-neutral, version-independent enforcer
+#     location becomes available (e.g. a shared non-versioned shim target).
 #   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale

--- a/plugins/ca-codex/hooks/_githooks.py
+++ b/plugins/ca-codex/hooks/_githooks.py
@@ -21,6 +21,29 @@
 #     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
 #     our OWN staleness only — never brick a user's commits because our path
 #     drifted; the pre-bash + Claude layers still apply).
+#
+#     Accepted residual, dual-host widening (reliability-009 / #265, LOW,
+#     ACCEPT-RISK): with BOTH `ca` and `ca-codex` installed against one repo,
+#     each SessionStart (whichever host ran last) rewrites the shim to point at
+#     THAT plugin's own `_enforcer_path()` — the two hosts manage entirely
+#     separate, independently versioned plugin caches (e.g. Claude Code's
+#     `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`; Codex's
+#     cache root and layout are not fixed by anything in this repo), so the
+#     sibling plugin's absolute enforcer path is NOT reliably derivable from
+#     this file's own path at write time — no path-substitution or fixed
+#     sibling-directory guess survives an independent version bump on either
+#     side. Multiple-candidate embedding (try both known paths) and a runtime
+#     filesystem search (glob likely cache roots from inside the POSIX `sh`
+#     shim) were both considered and rejected: the former requires knowing a
+#     path this file cannot derive, and the latter would mean an unverified,
+#     host-layout-guessing filesystem search on every commit/push under
+#     Windows Git-Bash `sh` — a fragile git-level backstop is worse than the
+#     accepted trade. Net effect: uninstalling whichever plugin most recently
+#     ran SessionStart leaves the shim fail-open until the SURVIVING host's
+#     next SessionStart rewrites it (single-plugin behavior — install()
+#     writing its own current path — is unchanged and unaffected by this
+#     residual). Revisit only if a host-neutral, version-independent enforcer
+#     location becomes available (e.g. a shared non-versioned shim target).
 #   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -21,6 +21,29 @@
 #     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
 #     our OWN staleness only — never brick a user's commits because our path
 #     drifted; the pre-bash + Claude layers still apply).
+#
+#     Accepted residual, dual-host widening (reliability-009 / #265, LOW,
+#     ACCEPT-RISK): with BOTH `ca` and `ca-codex` installed against one repo,
+#     each SessionStart (whichever host ran last) rewrites the shim to point at
+#     THAT plugin's own `_enforcer_path()` — the two hosts manage entirely
+#     separate, independently versioned plugin caches (e.g. Claude Code's
+#     `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`; Codex's
+#     cache root and layout are not fixed by anything in this repo), so the
+#     sibling plugin's absolute enforcer path is NOT reliably derivable from
+#     this file's own path at write time — no path-substitution or fixed
+#     sibling-directory guess survives an independent version bump on either
+#     side. Multiple-candidate embedding (try both known paths) and a runtime
+#     filesystem search (glob likely cache roots from inside the POSIX `sh`
+#     shim) were both considered and rejected: the former requires knowing a
+#     path this file cannot derive, and the latter would mean an unverified,
+#     host-layout-guessing filesystem search on every commit/push under
+#     Windows Git-Bash `sh` — a fragile git-level backstop is worse than the
+#     accepted trade. Net effect: uninstalling whichever plugin most recently
+#     ran SessionStart leaves the shim fail-open until the SURVIVING host's
+#     next SessionStart rewrites it (single-plugin behavior — install()
+#     writing its own current path — is unchanged and unaffected by this
+#     residual). Revisit only if a host-neutral, version-independent enforcer
+#     location becomes available (e.g. a shared non-versioned shim target).
 #   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale


### PR DESCRIPTION
Re: #265 (reliability-009, LOW). **Accept-risk, no logic change** — documents the residual in `_githooks.py`.

The clean fix (shim resolves either plugin's enforcer) is not safely achievable: ca and ca-codex are managed by separate host plugin managers with independent, per-plugin versioned cache roots, so the sibling's absolute enforcer path can't be derived at write time; and a runtime filesystem search inside the POSIX-`sh` git shim (incl. Windows Git-Bash) would be a fragile git-level backstop — not worth it for a LOW finding. Added a module-header note explaining the residual and why both fix approaches were rejected.

Preserved: single-plugin case byte-identical; dormant fail-open untouched. test_git_hooks 33/33, full suite 834, guard matrix 106 — all pass.

Residual (accepted): after uninstalling one of two installed plugins, the git-level backstop stays dark for the surviving plugin until that host's next SessionStart rewrites the shim. Revisit if Codex's cache layout becomes stable/documented.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG