### PR TITLE
refactor(hooks): wire run(host) as live dependency injection, remove double host load (#257)

### DIFF
--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -112,6 +112,18 @@ def set_host(host):
     _HOST = host
 
 
+def reset_host():
+    """Test-only: clear the injected/cached `_HOST` so the next `get_host()`
+    lazy-loads afresh. Production hook processes are single-shot and never need
+    this; but `set_host()` makes `_HOST` a process-lifetime singleton, so a test
+    that calls `run(fake_host)` must reset it in tearDown — otherwise the fake
+    leaks into any later in-process test that calls `get_host()` without its own
+    patch, silently running against the wrong host and masking a gate
+    regression (security review #257, LOW)."""
+    global _HOST
+    _HOST = None
+
+
 # project_root() memoization (performance-001/003, #260). A hook is a
 # single-shot process, so CLAUDE_PROJECT_DIR and the process cwd cannot
 # change mid-process — but the resolved VALUE is cached keyed on those two

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -24,6 +24,13 @@
 # entries each receive their own stdin, so the block survives.
 #
 # Public API:
+#   get_host() -> Host                   the process's Host instance (hostapi.load_host(), cached)
+#   set_host(host) -> None               DI seam (#257): prime the process-cached Host that
+#                                         get_host() returns. Every entry script's run(host) calls
+#                                         this BEFORE main(), so the Host the __main__ guard already
+#                                         loaded is the one get_host() serves — main() no longer
+#                                         triggers a second hostapi.load_host(), and a test calling
+#                                         run(fake_host) genuinely runs against fake_host.
 #   utf8_stdio() -> None                 force UTF-8 on stdout/stderr
 #   norm_path(p) -> str                  normalize path separators to forward-slash
 #   frontmatter_enabled(ctx_path) -> tuple[bool, bool]   (enabled, malformed)
@@ -84,6 +91,25 @@ def get_host():
     if _HOST is None:
         _HOST = hostapi.load_host()
     return _HOST
+
+
+def set_host(host):
+    """Dependency-injection seam (#257 architecture-001/performance-002).
+
+    Primes the module-cached `_HOST` that `get_host()` reads. Every entry
+    script's `run(host, argv=None)` calls this BEFORE `main()`, so the Host
+    instance the `__main__` guard already resolved via `hostapi.load_host()`
+    is the SAME object `get_host()` serves inside `main()` — closing two
+    defects at once: (1) `main()` no longer triggers its own redundant
+    `hostapi.load_host()` (a second `_host.py` load per invocation), and
+    (2) `run(host)` stops silently ignoring its `host` argument — a test that
+    calls `run(fake_host)` now genuinely exercises `fake_host`, not whatever
+    `load_host()` resolves from disk. In production the injected host IS the
+    `load_host()` result the guard already computed, so this changes no
+    behavior — it only removes the redundant second load and makes the
+    existing `run(host)` parameter live."""
+    global _HOST
+    _HOST = host
 
 
 # project_root() memoization (performance-001/003, #260). A hook is a

--- a/core/pysrc/_updatelib.py
+++ b/core/pysrc/_updatelib.py
@@ -30,7 +30,7 @@
 #   plugin_root(explicit=None) -> str        the running plugin's own root directory
 #   installed_version(root=None, host=None) -> str|None  the version in
 #                                             <root>/<host.manifest_relpath()>
-#                                             (host defaults to hostapi.load_host())
+#                                             (host defaults to _hooklib.get_host())
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
@@ -54,8 +54,10 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import write_text_atomic  # noqa: E402 — needs the sys.path mount above
-import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
+from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+# hostapi is not imported directly here (#257): plugin_root()/installed_version()
+# resolve the Host via _hooklib.get_host() (the DI seam every entry script's
+# run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
@@ -78,23 +80,28 @@ def plugin_root(explicit=None):
     """The running plugin's own root directory (parent of hooks/). `explicit` wins
     (tests); else CLAUDE_PLUGIN_ROOT; else derived from this file's own location —
     always resolves to the ACTUAL running install, not a stale env pin. The env
-    + file-relative resolution lives on the host seam (hostapi, ADR-0011)."""
-    return explicit or hostapi.load_host().plugin_root()
+    + file-relative resolution lives on the host seam (hostapi, ADR-0011).
+    Resolves via get_host() (#257), not a direct hostapi.load_host(), so a
+    caller reached from an entry script's run(host) sees the SAME injected
+    Host instead of triggering a second disk load."""
+    return explicit or get_host().plugin_root()
 
 
 def installed_version(root=None, host=None):
     """The `version` field from <root>/<host.manifest_relpath()>, or None on any
     failure (missing file, corrupt JSON, missing/blank field). `host` defaults to
-    hostapi.load_host() (#263, reliability-002/observability-003): under Claude
-    Code that resolves to `.claude-plugin/plugin.json` exactly as before; a
-    plugin whose manifest ships elsewhere (e.g. ca-codex's `.codex-plugin/`)
-    resolves the CORRECT path instead of silently reading nothing and
-    suppressing the update-available notice forever. No caller in this repo
-    threads a host through today (session-start.py calls installed_version(plugin)
-    positionally), so resolving it here — rather than plumbing it through every
-    call site — keeps the fix local to this seam."""
+    get_host() (#263, reliability-002/observability-003; #257 — get_host(), not
+    a direct hostapi.load_host(), so this resolves the SAME injected instance):
+    under Claude Code that resolves to `.claude-plugin/plugin.json` exactly as
+    before; a plugin whose manifest ships elsewhere (e.g. ca-codex's
+    `.codex-plugin/`) resolves the CORRECT path instead of silently reading
+    nothing and suppressing the update-available notice forever. No caller in
+    this repo threads a host through today (session-start.py calls
+    installed_version(plugin) positionally), so resolving it here — rather
+    than plumbing it through every call site — keeps the fix local to this
+    seam."""
     root = root or plugin_root()
-    host = host or hostapi.load_host()
+    host = host or get_host()
     try:
         with open(os.path.join(root, host.manifest_relpath()),
                   encoding="utf-8") as f:

--- a/core/pysrc/babysit.py
+++ b/core/pysrc/babysit.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _babysitlib  # noqa: E402
 
 
@@ -30,7 +31,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/core/pysrc/boardsync.py
+++ b/core/pysrc/boardsync.py
@@ -26,6 +26,7 @@ import sys
 # regardless of cwd or how Python was invoked.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _taskboardlib as tb  # noqa: E402
 
 
@@ -112,7 +113,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/core/pysrc/doctor.py
+++ b/core/pysrc/doctor.py
@@ -21,7 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
-from _hooklib import frontmatter_enabled, utf8_stdio  # noqa: E402
+from _hooklib import frontmatter_enabled, get_host, set_host, utf8_stdio  # noqa: E402
 
 HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
@@ -51,7 +51,9 @@ def _run_cmd(args, **kw):
 def plugin_root():
     # Host seam (ADR-0011): CLAUDE_PLUGIN_ROOT then file-relative, exactly the
     # prior inline lookup; abspath preserved from the pre-seam behavior here.
-    return os.path.abspath(hostapi.load_host().plugin_root())
+    # get_host() (#257), not a direct hostapi.load_host(): resolves the SAME
+    # Host run(host) injected instead of triggering a second disk load.
+    return os.path.abspath(get_host().plugin_root())
 
 
 def check_interpreters():
@@ -83,12 +85,13 @@ def check_interpreters():
 
 
 def check_payload(root, host=None):
-    # host-aware manifest path (#263): defaults to hostapi.load_host() so
-    # every pre-seam call site (main() below, and every existing test that
+    # host-aware manifest path (#263): defaults to get_host() (#257 — not a
+    # direct hostapi.load_host(), so this stays the SAME injected instance)
+    # so every pre-seam call site (main() below, and every existing test that
     # calls check_payload(root) positionally) keeps resolving the manifest
     # for whichever host is actually running, without threading a host
     # through every caller.
-    host = host or hostapi.load_host()
+    host = host or get_host()
     manifest = os.path.join(root, host.manifest_relpath())
     version = None
     try:
@@ -200,7 +203,9 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
-    host = hostapi.load_host()
+    # get_host() (#257): resolves the SAME Host run(host) already primed via
+    # set_host(), instead of a second hostapi.load_host() disk/probe.
+    host = get_host()
     check_host(host)
     check_interpreters()
     check_payload(root, host)
@@ -225,7 +230,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so `plugin_root()`/`main()`'s `get_host()`
+    calls resolve to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/git-enforce.py
+++ b/core/pysrc/git-enforce.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, utf8_stdio,
+    line_digest, marker_fresh, set_host, utf8_stdio,
 )
 
 
@@ -295,7 +295,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/init-codearbiter.py
+++ b/core/pysrc/init-codearbiter.py
@@ -19,6 +19,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 # NOTE: this stub deliberately does NOT contain the initialization sentinel
 # (an HTML comment wrapping the word INITIALIZED). The SessionStart hook greps
@@ -178,7 +179,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/core/pysrc/metrics.py
+++ b/core/pysrc/metrics.py
@@ -25,6 +25,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _metricslib  # noqa: E402
 
 
@@ -45,7 +46,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/core/pysrc/migration-pass.py
+++ b/core/pysrc/migration-pass.py
@@ -28,8 +28,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, utf8_stdio, warn,
-    write_text_atomic,
+    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
+    warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -102,7 +102,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/post-write-edit.py
+++ b/core/pysrc/post-write-edit.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, get_host, is_ci_path, is_deploy_path,
-    project_root, read_input, remind, repo_rel, utf8_stdio,
+    project_root, read_input, remind, repo_rel, set_host, utf8_stdio,
 )
 from _sloplib import find_prose_separator_dashes, in_antislop_doc_scope  # noqa: E402
 
@@ -187,7 +187,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/pre-bash.py
+++ b/core/pysrc/pre-bash.py
@@ -26,7 +26,7 @@ from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
     GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
     get_host, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, tool_input, utf8_stdio,
+    read_input, set_host, tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -877,7 +877,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/pre-edit.py
+++ b/core/pysrc/pre-edit.py
@@ -35,7 +35,7 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
     get_host, is_tail_append, marker_fresh, project_root, read_input,
-    utf8_stdio,
+    set_host, utf8_stdio,
 )
 
 
@@ -237,7 +237,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/pre-read.py
+++ b/core/pysrc/pre-read.py
@@ -34,7 +34,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    arbiter_active, project_root, read_input, repo_rel, tool_input, utf8_stdio,
+    arbiter_active, project_root, read_input, repo_rel, set_host, tool_input,
+    utf8_stdio,
 )
 from _readinjectlib import allow_output, compute_injection  # noqa: E402
 
@@ -64,7 +65,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/pre-write.py
+++ b/core/pysrc/pre-write.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
-    get_host, marker_fresh, project_root, read_input, utf8_stdio,
+    get_host, marker_fresh, project_root, read_input, set_host, utf8_stdio,
 )
 
 
@@ -155,7 +155,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/preview.py
+++ b/core/pysrc/preview.py
@@ -23,6 +23,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _previewlib  # noqa: E402
 
 
@@ -50,7 +51,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/core/pysrc/prune-transcript.py
+++ b/core/pysrc/prune-transcript.py
@@ -160,7 +160,8 @@ def main(argv=None):
                 # parity ledger) has nothing to prune. The staleness-warn
                 # above already ran — it reads the .codearbiter audit logs,
                 # not the transcript, so it is host-neutral (ADR-0011).
-                if not hostapi.load_host().has_prunable_transcript:
+                import _hooklib
+                if not _hooklib.get_host().has_prunable_transcript:
                     return 0
                 return hook_run(payload)
         print("usage: prune-transcript.py <path|session-id> [--execute] ...",
@@ -209,7 +210,17 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `_hooklib.get_host()` call
+    (hook-mode path) resolves to the SAME instance the caller passed here —
+    no second `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`. Local import mirrors this module's existing lazy `_hooklib`
+    import convention (staleness_check) — the CLI (argv) paths never touch
+    _hooklib, so it stays off that path's import surface."""
+    import _hooklib
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/core/pysrc/security-pass.py
+++ b/core/pysrc/security-pass.py
@@ -24,8 +24,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, line_digest, project_root, utf8_stdio, warn,
-    write_text_atomic,
+    CRYPTO_RE, SECRET_RE, line_digest, project_root, set_host, utf8_stdio,
+    warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -96,7 +96,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -29,7 +29,9 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
-from _hooklib import frontmatter_enabled, project_root, utf8_stdio  # noqa: E402
+from _hooklib import (  # noqa: E402
+    frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
+)
 from _standuplib import (  # noqa: E402
     any_actionable,
     ff_pull_eligible,
@@ -454,15 +456,17 @@ def clear_dev_marker(root, host_name=None):
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
     the host that wrote it now that two hosts share one overrides.log
-    (ADR-0011). Optional and defaults to resolving it here via
-    `hostapi.load_host()` — main() already holds a Host instance and passes its
-    `.name` through to avoid a second resolution, but any other caller (tests
+    (ADR-0011). Optional and defaults to resolving it here via `get_host()`
+    (#257) — main() already holds a Host instance and passes its `.name`
+    through to avoid a second resolution, but any other caller (tests
     included) may omit it."""
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
     if os.path.isfile(marker):
         if host_name is None:
             try:
-                host_name = hostapi.load_host().name
+                # get_host() (#257), not a direct hostapi.load_host(): resolves
+                # the SAME Host run(host) injected instead of a second load.
+                host_name = get_host().name
             except Exception:  # noqa: BLE001 — must never brick session startup
                 host_name = "unknown"
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -551,7 +555,9 @@ def spawn_background_update_refresh(plugin, spawner=None):
 
 def main():
     utf8_stdio()
-    host = hostapi.load_host()
+    # get_host() (#257): resolves the SAME Host run(host) already primed via
+    # set_host(), instead of a second hostapi.load_host() disk/probe.
+    host = get_host()
     root = project_root()
     plugin = host.plugin_root()
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
@@ -709,7 +715,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/core/pysrc/statusline.py
+++ b/core/pysrc/statusline.py
@@ -68,6 +68,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 # Shared task-board logic so the "tasks" segment counts in-flight items the same
 # way the SessionStart hook does (excludes done). Guarded: a failed import must
@@ -651,7 +652,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main()
     return 0
 

--- a/core/pysrc/taskwrite.py
+++ b/core/pysrc/taskwrite.py
@@ -27,7 +27,7 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import project_root, utf8_stdio  # noqa: E402
+from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
 
 # reliability-007 (#190): project_root() is now _hooklib.project_root —
 # imported above, not a local copy. The prior local copy ran `git rev-parse
@@ -125,7 +125,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     return main(argv)
 
 

--- a/core/pysrc/update-refresh.py
+++ b/core/pysrc/update-refresh.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 
 def main():
@@ -34,7 +35,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main() unchanged — the refresh stays fail-silent
     and the process still exits 0 either way, exactly as the prior module-level
-    try/except did."""
+    try/except did.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `_updatelib` call that resolves a
+    host via `_hooklib.get_host()` gets the SAME instance the caller passed
+    here — no second `hostapi.load_host()`, and `run(fake_host)` genuinely
+    exercises `fake_host`."""
+    _hooklib.set_host(host)
     main()
     return 0
 

--- a/core/pysrc/wire-statusline.py
+++ b/core/pysrc/wire-statusline.py
@@ -66,8 +66,10 @@ def plugin_root(opt):
         return os.path.abspath(opt)
     # Host seam (ADR-0011): CLAUDE_PLUGIN_ROOT then this script's parent —
     # exactly the prior inline lookup (hostapi.py lives in the same hooks/ dir,
-    # so its file-relative fallback names the same root).
-    return os.path.abspath(hostapi.load_host().plugin_root())
+    # so its file-relative fallback names the same root). get_host() (#257),
+    # not a direct hostapi.load_host(): resolves the SAME Host run(host)
+    # injected instead of triggering a second disk load.
+    return os.path.abspath(_hooklib.get_host().plugin_root())
 
 
 def settings_path(opt):
@@ -290,7 +292,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so `plugin_root()`'s `get_host()` call
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -112,6 +112,18 @@ def set_host(host):
     _HOST = host
 
 
+def reset_host():
+    """Test-only: clear the injected/cached `_HOST` so the next `get_host()`
+    lazy-loads afresh. Production hook processes are single-shot and never need
+    this; but `set_host()` makes `_HOST` a process-lifetime singleton, so a test
+    that calls `run(fake_host)` must reset it in tearDown — otherwise the fake
+    leaks into any later in-process test that calls `get_host()` without its own
+    patch, silently running against the wrong host and masking a gate
+    regression (security review #257, LOW)."""
+    global _HOST
+    _HOST = None
+
+
 # project_root() memoization (performance-001/003, #260). A hook is a
 # single-shot process, so CLAUDE_PROJECT_DIR and the process cwd cannot
 # change mid-process — but the resolved VALUE is cached keyed on those two

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -24,6 +24,13 @@
 # entries each receive their own stdin, so the block survives.
 #
 # Public API:
+#   get_host() -> Host                   the process's Host instance (hostapi.load_host(), cached)
+#   set_host(host) -> None               DI seam (#257): prime the process-cached Host that
+#                                         get_host() returns. Every entry script's run(host) calls
+#                                         this BEFORE main(), so the Host the __main__ guard already
+#                                         loaded is the one get_host() serves — main() no longer
+#                                         triggers a second hostapi.load_host(), and a test calling
+#                                         run(fake_host) genuinely runs against fake_host.
 #   utf8_stdio() -> None                 force UTF-8 on stdout/stderr
 #   norm_path(p) -> str                  normalize path separators to forward-slash
 #   frontmatter_enabled(ctx_path) -> tuple[bool, bool]   (enabled, malformed)
@@ -84,6 +91,25 @@ def get_host():
     if _HOST is None:
         _HOST = hostapi.load_host()
     return _HOST
+
+
+def set_host(host):
+    """Dependency-injection seam (#257 architecture-001/performance-002).
+
+    Primes the module-cached `_HOST` that `get_host()` reads. Every entry
+    script's `run(host, argv=None)` calls this BEFORE `main()`, so the Host
+    instance the `__main__` guard already resolved via `hostapi.load_host()`
+    is the SAME object `get_host()` serves inside `main()` — closing two
+    defects at once: (1) `main()` no longer triggers its own redundant
+    `hostapi.load_host()` (a second `_host.py` load per invocation), and
+    (2) `run(host)` stops silently ignoring its `host` argument — a test that
+    calls `run(fake_host)` now genuinely exercises `fake_host`, not whatever
+    `load_host()` resolves from disk. In production the injected host IS the
+    `load_host()` result the guard already computed, so this changes no
+    behavior — it only removes the redundant second load and makes the
+    existing `run(host)` parameter live."""
+    global _HOST
+    _HOST = host
 
 
 # project_root() memoization (performance-001/003, #260). A hook is a

--- a/plugins/ca-codex/hooks/_updatelib.py
+++ b/plugins/ca-codex/hooks/_updatelib.py
@@ -30,7 +30,7 @@
 #   plugin_root(explicit=None) -> str        the running plugin's own root directory
 #   installed_version(root=None, host=None) -> str|None  the version in
 #                                             <root>/<host.manifest_relpath()>
-#                                             (host defaults to hostapi.load_host())
+#                                             (host defaults to _hooklib.get_host())
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
@@ -54,8 +54,10 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import write_text_atomic  # noqa: E402 — needs the sys.path mount above
-import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
+from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+# hostapi is not imported directly here (#257): plugin_root()/installed_version()
+# resolve the Host via _hooklib.get_host() (the DI seam every entry script's
+# run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
@@ -78,23 +80,28 @@ def plugin_root(explicit=None):
     """The running plugin's own root directory (parent of hooks/). `explicit` wins
     (tests); else CLAUDE_PLUGIN_ROOT; else derived from this file's own location —
     always resolves to the ACTUAL running install, not a stale env pin. The env
-    + file-relative resolution lives on the host seam (hostapi, ADR-0011)."""
-    return explicit or hostapi.load_host().plugin_root()
+    + file-relative resolution lives on the host seam (hostapi, ADR-0011).
+    Resolves via get_host() (#257), not a direct hostapi.load_host(), so a
+    caller reached from an entry script's run(host) sees the SAME injected
+    Host instead of triggering a second disk load."""
+    return explicit or get_host().plugin_root()
 
 
 def installed_version(root=None, host=None):
     """The `version` field from <root>/<host.manifest_relpath()>, or None on any
     failure (missing file, corrupt JSON, missing/blank field). `host` defaults to
-    hostapi.load_host() (#263, reliability-002/observability-003): under Claude
-    Code that resolves to `.claude-plugin/plugin.json` exactly as before; a
-    plugin whose manifest ships elsewhere (e.g. ca-codex's `.codex-plugin/`)
-    resolves the CORRECT path instead of silently reading nothing and
-    suppressing the update-available notice forever. No caller in this repo
-    threads a host through today (session-start.py calls installed_version(plugin)
-    positionally), so resolving it here — rather than plumbing it through every
-    call site — keeps the fix local to this seam."""
+    get_host() (#263, reliability-002/observability-003; #257 — get_host(), not
+    a direct hostapi.load_host(), so this resolves the SAME injected instance):
+    under Claude Code that resolves to `.claude-plugin/plugin.json` exactly as
+    before; a plugin whose manifest ships elsewhere (e.g. ca-codex's
+    `.codex-plugin/`) resolves the CORRECT path instead of silently reading
+    nothing and suppressing the update-available notice forever. No caller in
+    this repo threads a host through today (session-start.py calls
+    installed_version(plugin) positionally), so resolving it here — rather
+    than plumbing it through every call site — keeps the fix local to this
+    seam."""
     root = root or plugin_root()
-    host = host or hostapi.load_host()
+    host = host or get_host()
     try:
         with open(os.path.join(root, host.manifest_relpath()),
                   encoding="utf-8") as f:

--- a/plugins/ca-codex/hooks/babysit.py
+++ b/plugins/ca-codex/hooks/babysit.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _babysitlib  # noqa: E402
 
 
@@ -30,7 +31,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca-codex/hooks/boardsync.py
+++ b/plugins/ca-codex/hooks/boardsync.py
@@ -26,6 +26,7 @@ import sys
 # regardless of cwd or how Python was invoked.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _taskboardlib as tb  # noqa: E402
 
 
@@ -112,7 +113,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/plugins/ca-codex/hooks/doctor.py
+++ b/plugins/ca-codex/hooks/doctor.py
@@ -21,7 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
-from _hooklib import frontmatter_enabled, utf8_stdio  # noqa: E402
+from _hooklib import frontmatter_enabled, get_host, set_host, utf8_stdio  # noqa: E402
 
 HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
@@ -51,7 +51,9 @@ def _run_cmd(args, **kw):
 def plugin_root():
     # Host seam (ADR-0011): CLAUDE_PLUGIN_ROOT then file-relative, exactly the
     # prior inline lookup; abspath preserved from the pre-seam behavior here.
-    return os.path.abspath(hostapi.load_host().plugin_root())
+    # get_host() (#257), not a direct hostapi.load_host(): resolves the SAME
+    # Host run(host) injected instead of triggering a second disk load.
+    return os.path.abspath(get_host().plugin_root())
 
 
 def check_interpreters():
@@ -83,12 +85,13 @@ def check_interpreters():
 
 
 def check_payload(root, host=None):
-    # host-aware manifest path (#263): defaults to hostapi.load_host() so
-    # every pre-seam call site (main() below, and every existing test that
+    # host-aware manifest path (#263): defaults to get_host() (#257 — not a
+    # direct hostapi.load_host(), so this stays the SAME injected instance)
+    # so every pre-seam call site (main() below, and every existing test that
     # calls check_payload(root) positionally) keeps resolving the manifest
     # for whichever host is actually running, without threading a host
     # through every caller.
-    host = host or hostapi.load_host()
+    host = host or get_host()
     manifest = os.path.join(root, host.manifest_relpath())
     version = None
     try:
@@ -200,7 +203,9 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
-    host = hostapi.load_host()
+    # get_host() (#257): resolves the SAME Host run(host) already primed via
+    # set_host(), instead of a second hostapi.load_host() disk/probe.
+    host = get_host()
     check_host(host)
     check_interpreters()
     check_payload(root, host)
@@ -225,7 +230,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so `plugin_root()`/`main()`'s `get_host()`
+    calls resolve to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/git-enforce.py
+++ b/plugins/ca-codex/hooks/git-enforce.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, utf8_stdio,
+    line_digest, marker_fresh, set_host, utf8_stdio,
 )
 
 
@@ -295,7 +295,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/init-codearbiter.py
+++ b/plugins/ca-codex/hooks/init-codearbiter.py
@@ -19,6 +19,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 # NOTE: this stub deliberately does NOT contain the initialization sentinel
 # (an HTML comment wrapping the word INITIALIZED). The SessionStart hook greps
@@ -178,7 +179,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/plugins/ca-codex/hooks/metrics.py
+++ b/plugins/ca-codex/hooks/metrics.py
@@ -25,6 +25,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _metricslib  # noqa: E402
 
 
@@ -45,7 +46,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca-codex/hooks/migration-pass.py
+++ b/plugins/ca-codex/hooks/migration-pass.py
@@ -28,8 +28,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, utf8_stdio, warn,
-    write_text_atomic,
+    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
+    warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -102,7 +102,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/post-write-edit.py
+++ b/plugins/ca-codex/hooks/post-write-edit.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, get_host, is_ci_path, is_deploy_path,
-    project_root, read_input, remind, repo_rel, utf8_stdio,
+    project_root, read_input, remind, repo_rel, set_host, utf8_stdio,
 )
 from _sloplib import find_prose_separator_dashes, in_antislop_doc_scope  # noqa: E402
 
@@ -187,7 +187,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/pre-bash.py
+++ b/plugins/ca-codex/hooks/pre-bash.py
@@ -26,7 +26,7 @@ from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
     GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
     get_host, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, tool_input, utf8_stdio,
+    read_input, set_host, tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -877,7 +877,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/pre-edit.py
+++ b/plugins/ca-codex/hooks/pre-edit.py
@@ -35,7 +35,7 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
     get_host, is_tail_append, marker_fresh, project_root, read_input,
-    utf8_stdio,
+    set_host, utf8_stdio,
 )
 
 
@@ -237,7 +237,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/pre-read.py
+++ b/plugins/ca-codex/hooks/pre-read.py
@@ -34,7 +34,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    arbiter_active, project_root, read_input, repo_rel, tool_input, utf8_stdio,
+    arbiter_active, project_root, read_input, repo_rel, set_host, tool_input,
+    utf8_stdio,
 )
 from _readinjectlib import allow_output, compute_injection  # noqa: E402
 
@@ -64,7 +65,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/pre-write.py
+++ b/plugins/ca-codex/hooks/pre-write.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
-    get_host, marker_fresh, project_root, read_input, utf8_stdio,
+    get_host, marker_fresh, project_root, read_input, set_host, utf8_stdio,
 )
 
 
@@ -155,7 +155,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/preview.py
+++ b/plugins/ca-codex/hooks/preview.py
@@ -23,6 +23,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _previewlib  # noqa: E402
 
 
@@ -50,7 +51,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca-codex/hooks/prune-transcript.py
+++ b/plugins/ca-codex/hooks/prune-transcript.py
@@ -160,7 +160,8 @@ def main(argv=None):
                 # parity ledger) has nothing to prune. The staleness-warn
                 # above already ran — it reads the .codearbiter audit logs,
                 # not the transcript, so it is host-neutral (ADR-0011).
-                if not hostapi.load_host().has_prunable_transcript:
+                import _hooklib
+                if not _hooklib.get_host().has_prunable_transcript:
                     return 0
                 return hook_run(payload)
         print("usage: prune-transcript.py <path|session-id> [--execute] ...",
@@ -209,7 +210,17 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `_hooklib.get_host()` call
+    (hook-mode path) resolves to the SAME instance the caller passed here —
+    no second `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`. Local import mirrors this module's existing lazy `_hooklib`
+    import convention (staleness_check) — the CLI (argv) paths never touch
+    _hooklib, so it stays off that path's import surface."""
+    import _hooklib
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca-codex/hooks/security-pass.py
+++ b/plugins/ca-codex/hooks/security-pass.py
@@ -24,8 +24,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, line_digest, project_root, utf8_stdio, warn,
-    write_text_atomic,
+    CRYPTO_RE, SECRET_RE, line_digest, project_root, set_host, utf8_stdio,
+    warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -96,7 +96,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -29,7 +29,9 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
-from _hooklib import frontmatter_enabled, project_root, utf8_stdio  # noqa: E402
+from _hooklib import (  # noqa: E402
+    frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
+)
 from _standuplib import (  # noqa: E402
     any_actionable,
     ff_pull_eligible,
@@ -454,15 +456,17 @@ def clear_dev_marker(root, host_name=None):
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
     the host that wrote it now that two hosts share one overrides.log
-    (ADR-0011). Optional and defaults to resolving it here via
-    `hostapi.load_host()` — main() already holds a Host instance and passes its
-    `.name` through to avoid a second resolution, but any other caller (tests
+    (ADR-0011). Optional and defaults to resolving it here via `get_host()`
+    (#257) — main() already holds a Host instance and passes its `.name`
+    through to avoid a second resolution, but any other caller (tests
     included) may omit it."""
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
     if os.path.isfile(marker):
         if host_name is None:
             try:
-                host_name = hostapi.load_host().name
+                # get_host() (#257), not a direct hostapi.load_host(): resolves
+                # the SAME Host run(host) injected instead of a second load.
+                host_name = get_host().name
             except Exception:  # noqa: BLE001 — must never brick session startup
                 host_name = "unknown"
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -551,7 +555,9 @@ def spawn_background_update_refresh(plugin, spawner=None):
 
 def main():
     utf8_stdio()
-    host = hostapi.load_host()
+    # get_host() (#257): resolves the SAME Host run(host) already primed via
+    # set_host(), instead of a second hostapi.load_host() disk/probe.
+    host = get_host()
     root = project_root()
     plugin = host.plugin_root()
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
@@ -709,7 +715,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/statusline.py
+++ b/plugins/ca-codex/hooks/statusline.py
@@ -68,6 +68,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 # Shared task-board logic so the "tasks" segment counts in-flight items the same
 # way the SessionStart hook does (excludes done). Guarded: a failed import must
@@ -651,7 +652,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/taskwrite.py
+++ b/plugins/ca-codex/hooks/taskwrite.py
@@ -27,7 +27,7 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import project_root, utf8_stdio  # noqa: E402
+from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
 
 # reliability-007 (#190): project_root() is now _hooklib.project_root —
 # imported above, not a local copy. The prior local copy ran `git rev-parse
@@ -125,7 +125,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     return main(argv)
 
 

--- a/plugins/ca-codex/hooks/update-refresh.py
+++ b/plugins/ca-codex/hooks/update-refresh.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 
 def main():
@@ -34,7 +35,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main() unchanged — the refresh stays fail-silent
     and the process still exits 0 either way, exactly as the prior module-level
-    try/except did."""
+    try/except did.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `_updatelib` call that resolves a
+    host via `_hooklib.get_host()` gets the SAME instance the caller passed
+    here — no second `hostapi.load_host()`, and `run(fake_host)` genuinely
+    exercises `fake_host`."""
+    _hooklib.set_host(host)
     main()
     return 0
 

--- a/plugins/ca-codex/hooks/wire-statusline.py
+++ b/plugins/ca-codex/hooks/wire-statusline.py
@@ -66,8 +66,10 @@ def plugin_root(opt):
         return os.path.abspath(opt)
     # Host seam (ADR-0011): CLAUDE_PLUGIN_ROOT then this script's parent —
     # exactly the prior inline lookup (hostapi.py lives in the same hooks/ dir,
-    # so its file-relative fallback names the same root).
-    return os.path.abspath(hostapi.load_host().plugin_root())
+    # so its file-relative fallback names the same root). get_host() (#257),
+    # not a direct hostapi.load_host(): resolves the SAME Host run(host)
+    # injected instead of triggering a second disk load.
+    return os.path.abspath(_hooklib.get_host().plugin_root())
 
 
 def settings_path(opt):
@@ -290,7 +292,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so `plugin_root()`'s `get_host()` call
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -112,6 +112,18 @@ def set_host(host):
     _HOST = host
 
 
+def reset_host():
+    """Test-only: clear the injected/cached `_HOST` so the next `get_host()`
+    lazy-loads afresh. Production hook processes are single-shot and never need
+    this; but `set_host()` makes `_HOST` a process-lifetime singleton, so a test
+    that calls `run(fake_host)` must reset it in tearDown — otherwise the fake
+    leaks into any later in-process test that calls `get_host()` without its own
+    patch, silently running against the wrong host and masking a gate
+    regression (security review #257, LOW)."""
+    global _HOST
+    _HOST = None
+
+
 # project_root() memoization (performance-001/003, #260). A hook is a
 # single-shot process, so CLAUDE_PROJECT_DIR and the process cwd cannot
 # change mid-process — but the resolved VALUE is cached keyed on those two

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -24,6 +24,13 @@
 # entries each receive their own stdin, so the block survives.
 #
 # Public API:
+#   get_host() -> Host                   the process's Host instance (hostapi.load_host(), cached)
+#   set_host(host) -> None               DI seam (#257): prime the process-cached Host that
+#                                         get_host() returns. Every entry script's run(host) calls
+#                                         this BEFORE main(), so the Host the __main__ guard already
+#                                         loaded is the one get_host() serves — main() no longer
+#                                         triggers a second hostapi.load_host(), and a test calling
+#                                         run(fake_host) genuinely runs against fake_host.
 #   utf8_stdio() -> None                 force UTF-8 on stdout/stderr
 #   norm_path(p) -> str                  normalize path separators to forward-slash
 #   frontmatter_enabled(ctx_path) -> tuple[bool, bool]   (enabled, malformed)
@@ -84,6 +91,25 @@ def get_host():
     if _HOST is None:
         _HOST = hostapi.load_host()
     return _HOST
+
+
+def set_host(host):
+    """Dependency-injection seam (#257 architecture-001/performance-002).
+
+    Primes the module-cached `_HOST` that `get_host()` reads. Every entry
+    script's `run(host, argv=None)` calls this BEFORE `main()`, so the Host
+    instance the `__main__` guard already resolved via `hostapi.load_host()`
+    is the SAME object `get_host()` serves inside `main()` — closing two
+    defects at once: (1) `main()` no longer triggers its own redundant
+    `hostapi.load_host()` (a second `_host.py` load per invocation), and
+    (2) `run(host)` stops silently ignoring its `host` argument — a test that
+    calls `run(fake_host)` now genuinely exercises `fake_host`, not whatever
+    `load_host()` resolves from disk. In production the injected host IS the
+    `load_host()` result the guard already computed, so this changes no
+    behavior — it only removes the redundant second load and makes the
+    existing `run(host)` parameter live."""
+    global _HOST
+    _HOST = host
 
 
 # project_root() memoization (performance-001/003, #260). A hook is a

--- a/plugins/ca/hooks/_updatelib.py
+++ b/plugins/ca/hooks/_updatelib.py
@@ -30,7 +30,7 @@
 #   plugin_root(explicit=None) -> str        the running plugin's own root directory
 #   installed_version(root=None, host=None) -> str|None  the version in
 #                                             <root>/<host.manifest_relpath()>
-#                                             (host defaults to hostapi.load_host())
+#                                             (host defaults to _hooklib.get_host())
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
@@ -54,8 +54,10 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import write_text_atomic  # noqa: E402 — needs the sys.path mount above
-import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
+from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+# hostapi is not imported directly here (#257): plugin_root()/installed_version()
+# resolve the Host via _hooklib.get_host() (the DI seam every entry script's
+# run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
@@ -78,23 +80,28 @@ def plugin_root(explicit=None):
     """The running plugin's own root directory (parent of hooks/). `explicit` wins
     (tests); else CLAUDE_PLUGIN_ROOT; else derived from this file's own location —
     always resolves to the ACTUAL running install, not a stale env pin. The env
-    + file-relative resolution lives on the host seam (hostapi, ADR-0011)."""
-    return explicit or hostapi.load_host().plugin_root()
+    + file-relative resolution lives on the host seam (hostapi, ADR-0011).
+    Resolves via get_host() (#257), not a direct hostapi.load_host(), so a
+    caller reached from an entry script's run(host) sees the SAME injected
+    Host instead of triggering a second disk load."""
+    return explicit or get_host().plugin_root()
 
 
 def installed_version(root=None, host=None):
     """The `version` field from <root>/<host.manifest_relpath()>, or None on any
     failure (missing file, corrupt JSON, missing/blank field). `host` defaults to
-    hostapi.load_host() (#263, reliability-002/observability-003): under Claude
-    Code that resolves to `.claude-plugin/plugin.json` exactly as before; a
-    plugin whose manifest ships elsewhere (e.g. ca-codex's `.codex-plugin/`)
-    resolves the CORRECT path instead of silently reading nothing and
-    suppressing the update-available notice forever. No caller in this repo
-    threads a host through today (session-start.py calls installed_version(plugin)
-    positionally), so resolving it here — rather than plumbing it through every
-    call site — keeps the fix local to this seam."""
+    get_host() (#263, reliability-002/observability-003; #257 — get_host(), not
+    a direct hostapi.load_host(), so this resolves the SAME injected instance):
+    under Claude Code that resolves to `.claude-plugin/plugin.json` exactly as
+    before; a plugin whose manifest ships elsewhere (e.g. ca-codex's
+    `.codex-plugin/`) resolves the CORRECT path instead of silently reading
+    nothing and suppressing the update-available notice forever. No caller in
+    this repo threads a host through today (session-start.py calls
+    installed_version(plugin) positionally), so resolving it here — rather
+    than plumbing it through every call site — keeps the fix local to this
+    seam."""
     root = root or plugin_root()
-    host = host or hostapi.load_host()
+    host = host or get_host()
     try:
         with open(os.path.join(root, host.manifest_relpath()),
                   encoding="utf-8") as f:

--- a/plugins/ca/hooks/babysit.py
+++ b/plugins/ca/hooks/babysit.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _babysitlib  # noqa: E402
 
 
@@ -30,7 +31,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca/hooks/boardsync.py
+++ b/plugins/ca/hooks/boardsync.py
@@ -26,6 +26,7 @@ import sys
 # regardless of cwd or how Python was invoked.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _taskboardlib as tb  # noqa: E402
 
 
@@ -112,7 +113,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/plugins/ca/hooks/doctor.py
+++ b/plugins/ca/hooks/doctor.py
@@ -21,7 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
-from _hooklib import frontmatter_enabled, utf8_stdio  # noqa: E402
+from _hooklib import frontmatter_enabled, get_host, set_host, utf8_stdio  # noqa: E402
 
 HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
@@ -51,7 +51,9 @@ def _run_cmd(args, **kw):
 def plugin_root():
     # Host seam (ADR-0011): CLAUDE_PLUGIN_ROOT then file-relative, exactly the
     # prior inline lookup; abspath preserved from the pre-seam behavior here.
-    return os.path.abspath(hostapi.load_host().plugin_root())
+    # get_host() (#257), not a direct hostapi.load_host(): resolves the SAME
+    # Host run(host) injected instead of triggering a second disk load.
+    return os.path.abspath(get_host().plugin_root())
 
 
 def check_interpreters():
@@ -83,12 +85,13 @@ def check_interpreters():
 
 
 def check_payload(root, host=None):
-    # host-aware manifest path (#263): defaults to hostapi.load_host() so
-    # every pre-seam call site (main() below, and every existing test that
+    # host-aware manifest path (#263): defaults to get_host() (#257 — not a
+    # direct hostapi.load_host(), so this stays the SAME injected instance)
+    # so every pre-seam call site (main() below, and every existing test that
     # calls check_payload(root) positionally) keeps resolving the manifest
     # for whichever host is actually running, without threading a host
     # through every caller.
-    host = host or hostapi.load_host()
+    host = host or get_host()
     manifest = os.path.join(root, host.manifest_relpath())
     version = None
     try:
@@ -200,7 +203,9 @@ def check_statusline(root):
 def main():
     utf8_stdio()
     root = plugin_root()
-    host = hostapi.load_host()
+    # get_host() (#257): resolves the SAME Host run(host) already primed via
+    # set_host(), instead of a second hostapi.load_host() disk/probe.
+    host = get_host()
     check_host(host)
     check_interpreters()
     check_payload(root, host)
@@ -225,7 +230,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so `plugin_root()`/`main()`'s `get_host()`
+    calls resolve to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/git-enforce.py
+++ b/plugins/ca/hooks/git-enforce.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, utf8_stdio,
+    line_digest, marker_fresh, set_host, utf8_stdio,
 )
 
 
@@ -295,7 +295,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/init-codearbiter.py
+++ b/plugins/ca/hooks/init-codearbiter.py
@@ -19,6 +19,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 # NOTE: this stub deliberately does NOT contain the initialization sentinel
 # (an HTML comment wrapping the word INITIALIZED). The SessionStart hook greps
@@ -178,7 +179,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 

--- a/plugins/ca/hooks/metrics.py
+++ b/plugins/ca/hooks/metrics.py
@@ -25,6 +25,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _metricslib  # noqa: E402
 
 
@@ -45,7 +46,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca/hooks/migration-pass.py
+++ b/plugins/ca/hooks/migration-pass.py
@@ -28,8 +28,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, utf8_stdio, warn,
-    write_text_atomic,
+    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
+    warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -102,7 +102,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/post-write-edit.py
+++ b/plugins/ca/hooks/post-write-edit.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, arbiter_active, get_host, is_ci_path, is_deploy_path,
-    project_root, read_input, remind, repo_rel, utf8_stdio,
+    project_root, read_input, remind, repo_rel, set_host, utf8_stdio,
 )
 from _sloplib import find_prose_separator_dashes, in_antislop_doc_scope  # noqa: E402
 
@@ -187,7 +187,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -26,7 +26,7 @@ from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
     GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
     get_host, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, tool_input, utf8_stdio,
+    read_input, set_host, tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -877,7 +877,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/pre-edit.py
+++ b/plugins/ca/hooks/pre-edit.py
@@ -35,7 +35,7 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
     get_host, is_tail_append, marker_fresh, project_root, read_input,
-    utf8_stdio,
+    set_host, utf8_stdio,
 )
 
 
@@ -237,7 +237,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/pre-read.py
+++ b/plugins/ca/hooks/pre-read.py
@@ -34,7 +34,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    arbiter_active, project_root, read_input, repo_rel, tool_input, utf8_stdio,
+    arbiter_active, project_root, read_input, repo_rel, set_host, tool_input,
+    utf8_stdio,
 )
 from _readinjectlib import allow_output, compute_injection  # noqa: E402
 
@@ -64,7 +65,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/pre-write.py
+++ b/plugins/ca/hooks/pre-write.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
     arbiter_active, block, classify_protected, frontmatter_enabled_text,
-    get_host, marker_fresh, project_root, read_input, utf8_stdio,
+    get_host, marker_fresh, project_root, read_input, set_host, utf8_stdio,
 )
 
 
@@ -155,7 +155,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/preview.py
+++ b/plugins/ca/hooks/preview.py
@@ -23,6 +23,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _previewlib  # noqa: E402
 
 
@@ -50,7 +51,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca/hooks/prune-transcript.py
+++ b/plugins/ca/hooks/prune-transcript.py
@@ -160,7 +160,8 @@ def main(argv=None):
                 # parity ledger) has nothing to prune. The staleness-warn
                 # above already ran — it reads the .codearbiter audit logs,
                 # not the transcript, so it is host-neutral (ADR-0011).
-                if not hostapi.load_host().has_prunable_transcript:
+                import _hooklib
+                if not _hooklib.get_host().has_prunable_transcript:
                     return 0
                 return hook_run(payload)
         print("usage: prune-transcript.py <path|session-id> [--execute] ...",
@@ -209,7 +210,17 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `_hooklib.get_host()` call
+    (hook-mode path) resolves to the SAME instance the caller passed here —
+    no second `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`. Local import mirrors this module's existing lazy `_hooklib`
+    import convention (staleness_check) — the CLI (argv) paths never touch
+    _hooklib, so it stays off that path's import surface."""
+    import _hooklib
+    _hooklib.set_host(host)
     return main(argv)
 
 

--- a/plugins/ca/hooks/security-pass.py
+++ b/plugins/ca/hooks/security-pass.py
@@ -24,8 +24,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, line_digest, project_root, utf8_stdio, warn,
-    write_text_atomic,
+    CRYPTO_RE, SECRET_RE, line_digest, project_root, set_host, utf8_stdio,
+    warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -96,7 +96,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -29,7 +29,9 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
-from _hooklib import frontmatter_enabled, project_root, utf8_stdio  # noqa: E402
+from _hooklib import (  # noqa: E402
+    frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
+)
 from _standuplib import (  # noqa: E402
     any_actionable,
     ff_pull_eligible,
@@ -454,15 +456,17 @@ def clear_dev_marker(root, host_name=None):
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
     the host that wrote it now that two hosts share one overrides.log
-    (ADR-0011). Optional and defaults to resolving it here via
-    `hostapi.load_host()` — main() already holds a Host instance and passes its
-    `.name` through to avoid a second resolution, but any other caller (tests
+    (ADR-0011). Optional and defaults to resolving it here via `get_host()`
+    (#257) — main() already holds a Host instance and passes its `.name`
+    through to avoid a second resolution, but any other caller (tests
     included) may omit it."""
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
     if os.path.isfile(marker):
         if host_name is None:
             try:
-                host_name = hostapi.load_host().name
+                # get_host() (#257), not a direct hostapi.load_host(): resolves
+                # the SAME Host run(host) injected instead of a second load.
+                host_name = get_host().name
             except Exception:  # noqa: BLE001 — must never brick session startup
                 host_name = "unknown"
         ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -551,7 +555,9 @@ def spawn_background_update_refresh(plugin, spawner=None):
 
 def main():
     utf8_stdio()
-    host = hostapi.load_host()
+    # get_host() (#257): resolves the SAME Host run(host) already primed via
+    # set_host(), instead of a second hostapi.load_host() disk/probe.
+    host = get_host()
     root = project_root()
     plugin = host.plugin_root()
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
@@ -709,7 +715,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so main()'s `get_host()` call resolves
+    to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/statusline.py
+++ b/plugins/ca/hooks/statusline.py
@@ -68,6 +68,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 # Shared task-board logic so the "tasks" segment counts in-flight items the same
 # way the SessionStart hook does (excludes done). Guarded: a failed import must
@@ -651,7 +652,14 @@ def run(host, argv=None):
     plugin's loaded Host. Wraps main() unchanged — main() still communicates
     via sys.exit/stdout/stderr, and its return value stays discarded exactly
     as the old bare `main()` guard discarded it (so the process still exits 0
-    on a normal fall-through)."""
+    on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/taskwrite.py
+++ b/plugins/ca/hooks/taskwrite.py
@@ -27,7 +27,7 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import project_root, utf8_stdio  # noqa: E402
+from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
 
 # reliability-007 (#190): project_root() is now _hooklib.project_root —
 # imported above, not a local copy. The prior local copy ran `git rev-parse
@@ -125,7 +125,14 @@ def main(argv=None):
 def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Delegates to main(argv) and returns its exit code,
-    exactly as the old `sys.exit(main())` guard propagated it."""
+    exactly as the old `sys.exit(main())` guard propagated it.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `get_host()` call downstream
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    set_host(host)
     return main(argv)
 
 

--- a/plugins/ca/hooks/tests/test_doctor.py
+++ b/plugins/ca/hooks/tests/test_doctor.py
@@ -370,11 +370,11 @@ class TestRunHostDISeam(unittest.TestCase):
 
     def setUp(self):
         _reset()
-        _hooklib._HOST = None  # isolate from any other test's set_host()
+        _hooklib.reset_host()  # isolate from any other test's set_host()
 
     def tearDown(self):
         _reset()
-        _hooklib._HOST = None
+        _hooklib.reset_host()  # do not leak the injected fake into later tests
 
     class _FakeInjectedHost:
         """A host observably different from the real disk-loaded default

--- a/plugins/ca/hooks/tests/test_doctor.py
+++ b/plugins/ca/hooks/tests/test_doctor.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import json
 import os
 import sys
@@ -11,6 +13,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # doctor.py uses a module-level `results` list that accumulates (level, line)
 # tuples. We import doctor and reset that list between tests to isolate them.
 import doctor  # noqa: E402
+import _hooklib  # noqa: E402
 
 
 def _reset():
@@ -353,6 +356,65 @@ class TestCheckRepoOutputFormat(unittest.TestCase):
             self.assertIsInstance(lvl, str)
             self.assertIsInstance(line, str)
             self.assertGreater(len(line), 0)
+
+
+class TestRunHostDISeam(unittest.TestCase):
+    """#257 (architecture-001/performance-002): run(host) must WIRE the host it
+    is given, not silently discard it. Before this fix, main() re-resolved the
+    host itself via a fresh hostapi.load_host() call, so run(fake_host) ran
+    against whatever load_host() found on disk (real "claude" in this bare
+    checkout) — never the injected fake_host. Drives the REAL run(host) entry
+    point (not check_host()/main() directly) and asserts the injected host's
+    distinguishing `.name` reaches doctor's printed output, proving run(host)
+    is now a live dependency-injection seam."""
+
+    def setUp(self):
+        _reset()
+        _hooklib._HOST = None  # isolate from any other test's set_host()
+
+    def tearDown(self):
+        _reset()
+        _hooklib._HOST = None
+
+    class _FakeInjectedHost:
+        """A host observably different from the real disk-loaded default
+        (name="claude") — if run(host) actually wires it, this name (never
+        "claude") is what doctor's output must carry."""
+        name = "fake-injected-host-257"
+
+        def manifest_relpath(self):
+            return os.path.join(".claude-plugin", "plugin.json")
+
+        def plugin_root(self):
+            return os.getcwd()
+
+    def test_run_host_wires_the_injected_host_not_the_disk_default(self):
+        fake = self._FakeInjectedHost()
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            try:
+                doctor.run(fake)
+            except SystemExit:
+                # main() exits 1 when any check FAILs (expected here — no real
+                # plugin payload exists at cwd) — the printed lines above the
+                # exit are what this test cares about, so tolerate it.
+                pass
+        out = buf.getvalue()
+        self.assertIn("resolved host: fake-injected-host-257", out)
+        self.assertNotIn("resolved host: claude", out)
+
+    def test_run_host_primes_get_host_before_main_runs(self):
+        # Direct proof of the DI seam itself: after run(host) starts, the
+        # process-cached Host _hooklib.get_host() serves is the SAME object
+        # identity as the one passed to run() — not a second hostapi.load_host()
+        # result.
+        fake = self._FakeInjectedHost()
+        with contextlib.redirect_stdout(io.StringIO()):
+            try:
+                doctor.run(fake)
+            except SystemExit:
+                pass
+        self.assertIs(_hooklib.get_host(), fake)
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -277,7 +277,8 @@ class TestMainSkipsHealUnderNoStatuslineHost(unittest.TestCase):
     (ADR-0011) must actually be exercised end-to-end under a host with no
     statusline surface (Codex), not merely asserted as a flag value. Drives the
     REAL main() entry — mirrors TestMainHealsBeforeDormantGate's harness
-    exactly, except hostapi.load_host() is patched to return a
+    exactly, except get_host() is patched (#257: main() now resolves via
+    _hooklib.get_host(), not a direct hostapi.load_host()) to return a
     has_statusline=False host — and asserts the stale ca-owned pin is left
     UNTOUCHED (the heal never runs) while the rest of startup (the dormant
     early-exit) still completes normally."""
@@ -316,7 +317,7 @@ class TestMainSkipsHealUnderNoStatuslineHost(unittest.TestCase):
             # statusline.py exists (proving a skip, not a load-time failure).
             with mock.patch.object(os.path, "expanduser", return_value=self.home), \
                  mock.patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": self.plugin}), \
-                 mock.patch.object(_mod.hostapi, "load_host",
+                 mock.patch.object(_mod, "get_host",
                                     return_value=no_statusline_host), \
                  contextlib.redirect_stdout(io.StringIO()), \
                  contextlib.redirect_stderr(io.StringIO()):
@@ -353,7 +354,9 @@ class TestStartupStateHostLine(unittest.TestCase):
         cwd = os.getcwd()
         os.chdir(self.repo)
         try:
-            with mock.patch.object(_mod.hostapi, "load_host", return_value=host), \
+            # get_host() (#257: main() resolves the Host via _hooklib.get_host(),
+            # not a direct hostapi.load_host(), so that is the mock target).
+            with mock.patch.object(_mod, "get_host", return_value=host), \
                  mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.repo}), \
                  contextlib.redirect_stdout(buf), \
                  contextlib.redirect_stderr(io.StringIO()):

--- a/plugins/ca/hooks/update-refresh.py
+++ b/plugins/ca/hooks/update-refresh.py
@@ -20,6 +20,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _hooklib  # noqa: E402 — set_host DI seam (#257)
 
 
 def main():
@@ -34,7 +35,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main() unchanged — the refresh stays fail-silent
     and the process still exits 0 either way, exactly as the prior module-level
-    try/except did."""
+    try/except did.
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so any `_updatelib` call that resolves a
+    host via `_hooklib.get_host()` gets the SAME instance the caller passed
+    here — no second `hostapi.load_host()`, and `run(fake_host)` genuinely
+    exercises `fake_host`."""
+    _hooklib.set_host(host)
     main()
     return 0
 

--- a/plugins/ca/hooks/wire-statusline.py
+++ b/plugins/ca/hooks/wire-statusline.py
@@ -66,8 +66,10 @@ def plugin_root(opt):
         return os.path.abspath(opt)
     # Host seam (ADR-0011): CLAUDE_PLUGIN_ROOT then this script's parent —
     # exactly the prior inline lookup (hostapi.py lives in the same hooks/ dir,
-    # so its file-relative fallback names the same root).
-    return os.path.abspath(hostapi.load_host().plugin_root())
+    # so its file-relative fallback names the same root). get_host() (#257),
+    # not a direct hostapi.load_host(): resolves the SAME Host run(host)
+    # injected instead of triggering a second disk load.
+    return os.path.abspath(_hooklib.get_host().plugin_root())
 
 
 def settings_path(opt):
@@ -290,7 +292,14 @@ def run(host, argv=None):
     """Host-seam entry point (ADR-0011): the __main__ guard calls this with the
     plugin's loaded Host. Wraps main(argv) unchanged — main()'s return value
     stays discarded exactly as the old bare `main()` guard discarded it (so
-    the process still exits 0 on a normal fall-through)."""
+    the process still exits 0 on a normal fall-through).
+
+    Wires `host` live (#257): primes `_hooklib`'s process-cached Host via
+    `set_host()` BEFORE main() runs, so `plugin_root()`'s `get_host()` call
+    resolves to the SAME instance the caller passed here — no second
+    `hostapi.load_host()`, and `run(fake_host)` genuinely exercises
+    `fake_host`."""
+    _hooklib.set_host(host)
     main(argv)
     return 0
 


### PR DESCRIPTION
Closes #257, folds performance-002. Behavior-preserving.

`run(host, argv=None)` ignored its `host` argument in all 20 entries — `main()` re-resolved the host via `get_host()`, so `hostapi.load_host()` ran twice per process (once in the `__main__` guard, discarded; once in `get_host()`), and `run(fake_host)` in a test silently ran against the disk host.

Fix — wire the ADR-0011 `run(host)` seam **live** (not removed — that would contradict ADR-0011):
- New `_hooklib.set_host(host)` primes the process-cached `_HOST` that `get_host()` reads.
- Every entry's `run(host)` calls `set_host(host)` before `main()`, so `main()`'s `get_host()` returns the injected instance — no second load, and DI is real.
- Converted the stray direct `hostapi.load_host()` sites in `main()`/helpers (doctor.py — which had **two** redundant loads — session-start.py, wire-statusline.py, prune-transcript.py, _updatelib.py) to `get_host()` so the injected host is actually used.

Zero behavior change: in production the injected host **is** the `load_host()` result the guard already computed; only the redundant second load is removed. Proven by the unchanged guard-decision matrix and a new DI-proof test (`run(fake_host)` now observably uses `fake_host`).

Full suite **836** (834 + 2 DI-proof) · adapter 60 · guard matrix 106 · cold-install 272 · sync-core --check byte-identical · plugin-refs intact. Two stale `test_session_start` mocks repointed from `load_host` to `get_host` (test-harness only).

**Enforcement-chain note:** touches pre-bash/pre-edit/pre-write/git-enforce/security-pass (host-resolution timing/caching only, no gate logic). A `security-reviewer` pass is running before merge.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG
