### PR TITLE
fix(ci): version-bump first-introduction probe + stale site hook-gate line pins (#254)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,18 +347,20 @@ jobs:
           ver=$(node -p "JSON.parse(require('fs').readFileSync('plugins/ca-sandbox/.claude-plugin/plugin.json','utf8')).version")
           # First introduction of the plugin: plugin.json does not exist on base.
           # That is never a silent-staleness trap (nothing is published yet), so
-          # allow it - but only when the file is genuinely absent at $BASE. Any
-          # other git failure (transient fetch error, corrupted object store,
-          # a race on origin/$BASE) must fail the step, not be swallowed as
-          # "first introduction".
-          rc=0
-          git cat-file -e "origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json" 2>/dev/null || rc=$?
-          if [ "$rc" = 1 ]; then
+          # allow it. NOTE: `git cat-file -e` on the tree-ish:path form exits
+          # 128 (not 1) when the PATH is absent from the tree, so absence cannot
+          # be distinguished from a bad ref by exit code alone. Instead, verify
+          # the base ref resolves first; once it does, any cat-file failure on
+          # the path means the file is genuinely absent at $BASE. A ref that
+          # does not resolve (transient fetch error, a race on origin/$BASE)
+          # must fail the step, not be swallowed as "first introduction".
+          if ! git rev-parse --verify --quiet "origin/$BASE^{commit}" > /dev/null; then
+            echo "::error::origin/$BASE does not resolve to a commit - bad ref or failed fetch"
+            exit 1
+          fi
+          if ! git cat-file -e "origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json" 2>/dev/null; then
             echo "ca-sandbox is new on $BASE (no prior plugin.json) - first introduction, version bump not required"
             exit 0
-          elif [ "$rc" != 0 ]; then
-            echo "::error::git cat-file probe on origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json failed with exit $rc (not a plain absence) - bad ref or corrupt object store"
-            exit "$rc"
           fi
           base_json=$(git show "origin/$BASE:plugins/ca-sandbox/.claude-plugin/plugin.json")
           base_ver=$(printf '%s' "$base_json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
@@ -399,18 +401,20 @@ jobs:
           ver=$(node -p "JSON.parse(require('fs').readFileSync('plugins/ca-codex/.codex-plugin/plugin.json','utf8')).version")
           # First introduction of the plugin: plugin.json does not exist on base.
           # That is never a silent-staleness trap (nothing is published yet), so
-          # allow it - but only when the file is genuinely absent at $BASE. Any
-          # other git failure (transient fetch error, corrupted object store,
-          # a race on origin/$BASE) must fail the step, not be swallowed as
-          # "first introduction".
-          rc=0
-          git cat-file -e "origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json" 2>/dev/null || rc=$?
-          if [ "$rc" = 1 ]; then
+          # allow it. NOTE: `git cat-file -e` on the tree-ish:path form exits
+          # 128 (not 1) when the PATH is absent from the tree, so absence cannot
+          # be distinguished from a bad ref by exit code alone. Instead, verify
+          # the base ref resolves first; once it does, any cat-file failure on
+          # the path means the file is genuinely absent at $BASE. A ref that
+          # does not resolve (transient fetch error, a race on origin/$BASE)
+          # must fail the step, not be swallowed as "first introduction".
+          if ! git rev-parse --verify --quiet "origin/$BASE^{commit}" > /dev/null; then
+            echo "::error::origin/$BASE does not resolve to a commit - bad ref or failed fetch"
+            exit 1
+          fi
+          if ! git cat-file -e "origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json" 2>/dev/null; then
             echo "ca-codex is new on $BASE (no prior plugin.json) - first introduction, version bump not required"
             exit 0
-          elif [ "$rc" != 0 ]; then
-            echo "::error::git cat-file probe on origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json failed with exit $rc (not a plain absence) - bad ref or corrupt object store"
-            exit "$rc"
           fi
           base_json=$(git show "origin/$BASE:plugins/ca-codex/.codex-plugin/plugin.json")
           base_ver=$(printf '%s' "$base_json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")

--- a/site/test/generator/extract-hook-gates.test.ts
+++ b/site/test/generator/extract-hook-gates.test.ts
@@ -83,7 +83,7 @@ describe("extractHookGates — real plugin hooks (count-floor snapshot)", () => 
   //   grep -c 'block("H-\|remind("H-' plugins/ca/hooks/*.py
   // as of this writing: git-enforce.py=8, post-write-edit.py=8, pre-bash.py=20,
   // pre-edit.py=10, pre-write.py=6 -> 52 literal-tag call sites. On top of
-  // those, 4 variable-tag sites (git-enforce.py:219/224, pre-bash.py:762/774)
+  // those, 4 variable-tag sites (git-enforce.py:219/224, pre-bash.py:771/783)
   // resolve through the bounded conditional-assignment pattern
   // (`tag = "H-09b" if … else "H-10b"`), each attributed to BOTH tags -> +8
   // entries -> 60. (pre-edit.py:84 is a loop unpack — genuinely unresolvable,
@@ -101,7 +101,7 @@ describe("extractHookGates — real plugin hooks (count-floor snapshot)", () => 
   it("attributes at least one H-10b entry (the conditional-assignment split) with its real message", () => {
     const h10b = callSites.filter((c) => c.tag === "H-10b");
     expect(h10b.length).toBeGreaterThanOrEqual(1);
-    const noPass = h10b.find((c) => c.file === "pre-bash.py" && c.line === 762);
+    const noPass = h10b.find((c) => c.file === "pre-bash.py" && c.line === 771);
     expect(noPass).toBeDefined();
     expect(noPass!.message).toBe(
       "This commit introduces {kind} changes, but no security-gate pass is recorded (.codearbiter/.markers/security-gate-passed). Run the {skill} gate (it records the pass), then commit. To bypass a security gate, /override requires its heavier security-acknowledgement path.",
@@ -114,7 +114,7 @@ describe("extractHookGates — real plugin hooks (count-floor snapshot)", () => 
 
   it("extracts H-01's protected-branch commit message from pre-bash.py verbatim", () => {
     const site = callSites.find(
-      (c) => c.tag === "H-01" && c.file === "pre-bash.py" && c.line === 623,
+      (c) => c.tag === "H-01" && c.file === "pre-bash.py" && c.line === 632,
     );
     expect(site).toBeDefined();
     expect(site!.message).toBe(


### PR DESCRIPTION
Unblocks the feat→main PR (#254). Two real, branch-introduced CI failures that only surface on a main-targeted PR:

- **version-bump-codex / -sandbox**: 'first introduction' detection assumed `git cat-file -e ref:path` returns exit 1 for a missing path — it returns **128** for the tree-ish:path form. ca-codex's manifest is absent on main, so it false-errored. Now: verify the base ref resolves (real bad-ref → hard error), then treat any cat-file failure as absence → first introduction. Live-verified exit codes; staleness protection intact for the future-present case. Same latent bug fixed in the sandbox twin.
- **site generator test**: pinned H-01/H-10b gate messages to exact `pre-bash.py` lines that the branch's hook edits shifted (+9). Updated the pins (623→632, 762→771); message text unchanged, assertion intent unchanged. `npm test` in site/: 2 failed→**0 failed (389 passed)**.

> Into `feat/codex-support-m0` only.

https://claude.ai/code/session_015btHFrmt5xPS5SGvnmVAKG