### PR TITLE
fix(hooks): pre-release enforcement-integrity sprint — close #223, #237, #271, #265

### DIFF
--- a/.codearbiter/decisions/0014-githook-shim-dropin-fail-closed.md
+++ b/.codearbiter/decisions/0014-githook-shim-dropin-fail-closed.md
@@ -1,0 +1,101 @@
+---
+status: accepted
+date: 2026-07-13
+title: The git-hook shim resolves either host's enforcer from a shared drop-in dir and fails closed
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: core/pysrc/_githooks.py, core/pysrc/session-start.py
+---
+
+# ADR-0014 — The git-hook shim resolves either host's enforcer from a shared drop-in dir and fails closed
+
+## Status
+Accepted — ratified 2026-07-13 by SUaDtL@users.noreply.github.com during the `pre-release-hardening`
+sprint (`/ca:sprint`), resolving issue #265.
+
+## Context
+The `#161` git-level backstop installs a `pre-commit` / `pre-push` shim (`core/pysrc/_githooks.py`)
+that execs the plugin's `git-enforce.py`. The shim embeds the enforcer by **absolute path**, resolved
+from the installing plugin's own location, and is deliberately **fail-open**: `[ -f "$E" ] || exit 0`.
+
+That fail-open was an accepted trade for a single plugin: `install()` re-runs every SessionStart, so a
+version-bump path drift heals on the next session, and the brief window where the enforcer path is
+stale should never brick a user's commits.
+
+ADR-0011 added a second host. With both `ca` and `ca-codex` installed against one repo, each
+SessionStart rewrites the shim to point at **whichever host ran last**. The two hosts keep separate,
+independently versioned plugin caches, so neither can derive the other's absolute enforcer path. Issue
+#265 (tribunal `reliability-009`) showed the consequence: **uninstall one plugin and the git-level
+backstop is silently unwired for BOTH hosts** until the surviving host's next SessionStart — and if the
+uninstalled plugin was the one the shim last pointed at, every commit in that window passes with no
+git-level enforcement at all.
+
+The `_githooks.py` header recorded this as accepted risk and **explicitly rejected** the two obvious
+fixes: embedding multiple candidate paths ("requires knowing a path this file cannot derive") and a
+runtime cache-glob from inside the POSIX `sh` shim ("an unverified, host-layout-guessing filesystem
+search on every commit under Windows Git-Bash — a fragile git-level backstop is worse than the accepted
+trade"). Crucially, that same header named its own exit condition: *revisit only if a host-neutral,
+version-independent enforcer location becomes available (e.g. a shared non-versioned shim target).*
+
+That target now exists. This decision does not override the header's rejection — it satisfies the
+condition the header itself set for revisiting.
+
+## Decision
+Each host's `install()` registers its own current enforcer path into a shared, non-versioned drop-in
+directory inside the repo's own `.git/`:
+
+```
+.git/codearbiter-hooksd/<plugin>.path      # e.g. ca.path, ca-codex.path
+```
+
+The shim iterates that directory and execs the **first** enforcer path that resolves:
+
+```sh
+for c in "$D"/*.path; do
+    E=$(cat "$c" 2>/dev/null) || continue
+    [ -f "$E" ] && exec "$PY" "$E" <phase>
+done
+# nothing resolved:
+```
+
+...and when nothing resolves, the shim **fails closed** — non-zero exit with a diagnostic message,
+rather than `exit 0`.
+
+This is a read of a directory **codeArbiter itself owns**, inside `.git/` (where `_githooks.py` already
+writes its hooks-dir cache), populated by each host writing its own path. It is not the rejected
+host-layout guess: no plugin has to derive a sibling's path, and there is no glob of an unknown cache
+root. Each host refreshes its own `<plugin>.path` on every SessionStart, so a live host self-heals a
+stale entry; `uninstall()` removes only its own `.path` file.
+
+## Alternatives considered
+- **Keep fail-open, ship the drop-in dir only.** Fixes the cross-plugin discovery symptom (both
+  enforcers become resolvable) while preserving "never brick a commit over our own path drift."
+  Rejected: a genuinely broken or fully-uninstalled install would still enforce nothing, silently, and
+  a release should not ship a security backstop whose failure mode is invisible. The whole point of the
+  #161 backstop is to catch the case where the higher layers are absent; a backstop that fails open in
+  exactly that case is not a backstop.
+- **Keep the accepted risk, close #265 won't-fix.** Rejected: the exit condition the original header
+  set has been met, so the trade that justified the risk no longer holds.
+- **Multiple-candidate path embedding / runtime cache glob.** Already rejected by the prior header and
+  not revived — the drop-in dir is strictly better than both.
+
+## Consequences
+- Removing one of two installed plugins leaves the git-level backstop wired to the survivor; removing
+  all of them makes the next commit **block** with a clear message rather than pass silently.
+- The `_githooks.py` header block (the ADR-of-record for the fail-open behavior) is rewritten to point
+  at this ADR and describe the drop-in dir and the fail-closed contract.
+- The behavior change has a real blast radius: a state where **no** enforcer resolves now blocks
+  commits where it previously allowed them. This is the intended direction — a security backstop should
+  fail safe — and the drop-in dir bounds it, since any one live host keeps its own entry fresh.
+
+## Risks
+- **Stale entry from an uninstalled plugin.** A removed plugin leaves its `<plugin>.path` behind; the
+  shim's `[ -f "$E" ]` test on that dead path simply fails and the loop moves on, so a stale entry is
+  inert, not a hazard. `uninstall()` drops its own entry when it runs, but plugin removal does not
+  reliably invoke it — hence the `-f` guard is the real safety, not the reaper.
+- **A repo with the drop-in dir but no live SessionStart** (e.g. a bare CI checkout that never runs the
+  hook) would find no `.path` entries and block. This is the fail-closed contract working as designed;
+  environments that must not run the backstop should not install the shim.
+- Relates to ADR-0011 (multi-host shared core) and the fail-closed posture of the `#161` backstop.
+  This decision is proven wrong if the fail-closed shim blocks legitimate commits in a common,
+  non-broken configuration that the test matrix did not anticipate.

--- a/.codearbiter/plans/pre-release-hardening.md
+++ b/.codearbiter/plans/pre-release-hardening.md
@@ -1,0 +1,107 @@
+# Plan — pre-release-hardening
+
+Spec: `.codearbiter/specs/pre-release-hardening.md`
+Branch: `feat/pre-release-hardening` (worktree @ `.claude/worktrees/pre-release-hardening`)
+Base: `origin/main` @ 32b116b
+
+## Conventions (every task)
+
+1. Edit **`core/pysrc/`** only — never a vendored `plugins/*/hooks/` copy.
+2. Run `python tools/sync-core.py` after the edit (tests import the vendored copy).
+3. Test-first (`tdd` Phase 1): the failing test exists before the implementation.
+4. Stdlib `unittest` only (ADR-0004).
+5. All git writes use `git -C <worktree>`.
+
+## File-conflict map (drives the ordering)
+
+- `core/pysrc/pre-bash.py` — Lane A **and** Lane B → **sequential**, A before B.
+- `core/pysrc/session-start.py` — Lane C **and** Lane D → **sequential**, C before D.
+- `core/pysrc/_hooklib.py` — Lane A (root helper) **and** Lane C (lock hoist) → **sequential**.
+- Lane E touches `_colorlib.py` / `statusline.py` / `test_ledgerlib.py` / docs only → **disjoint**, may
+  run parallel with Lane A.
+
+## Slice 1 — Lane A: #223 (MVP; the enabler)
+
+Unblocks correct guard behavior in this very worktree, and removes the incentive that caused #237.
+
+| # | Task | Files | Verification |
+|---|---|---|---|
+| A-1 | Failing test: worktree false-positive + false-negative. Extend `TestGitCwdEndToEnd` — build a repo with a linked worktree; assert H-01 BLOCKS a commit from a worktree sitting on `main` while the main checkout is on a feature branch (the false negative), and does NOT block a worktree on `feat/*` while main checkout is on `main` (the false positive). | `plugins/ca/hooks/tests/test_repo_resolution.py` | Test **fails** (both cases) against current code |
+| A-2 | Failing test: heredoc prose. `gh pr create --body "$(cat <<'EOF' … git commit -m x … EOF)"` must NOT trip H-01. `bash <<'EOF' … git commit … EOF` must still BLOCK. | `plugins/ca/hooks/tests/test_repo_resolution.py` | Test **fails** on case 1, passes case 2 |
+| A-3 | Add cwd-aware repo resolution. Introduce an effective-cwd resolver: derive the git root from the command's effective cwd (process cwd / payload `cwd`), preferring it over `CLAUDE_PROJECT_DIR` when the two resolve to different git roots. Reuse the linked-worktree-aware precedent in `_gitlib.head_branch` / `_gitlib.project_root` (parses the `gitdir:` pointer file). Keep gate **markers** resolving to the pinned project root per spec D-2, and comment that split as intentional. | `core/pysrc/_hooklib.py`, `core/pysrc/pre-bash.py`, `core/pysrc/hostapi.py` | A-1 passes; `sync-core.py`; full `test_repo_resolution.py` + `test_h01_failclosed.py` green |
+| A-4 | Narrow the raw-`cmd` fallback (spec D-3). Keep `X_RE.search(cmd)` fallback only when the heredoc's **consuming command is a shell** (`bash`/`sh`/`zsh`/`python -c`/…); drop it for non-shell consumers (`gh`, `curl`, …). Do not delete the fallback. | `core/pysrc/pre-bash.py` (~576-599, `_strip_heredoc_bodies` ~504-517) | A-2 passes; `test_pre_bash_no_verify.py`, `test_hook_guards.py` green (no regression) |
+| A-5 | Sync + full-suite regression. | `tools/sync-core.py` | `unittest discover -s plugins/ca/hooks/tests`; every `.github/scripts/test_*.py`; `sync-core.py --check` |
+
+**Exit:** AC-1, AC-2. From here on, `git -C` is no longer required for correctness (keep using it anyway until merged).
+
+## Slice 2 — Lane B (#237) + Lane E (harvest), parallel-safe with each other
+
+### Lane B — #237
+
+| # | Task | Files | Verification |
+|---|---|---|---|
+| B-1 | Failing test: interpreter forgery. `python -c "...write security-gate-passed..."`, `python3 -c`, `node -e`, `perl -e`, `ruby -e`, `sh -c` naming a `.markers/` gate-marker path must all BLOCK (H-19). | `.github/scripts/test_hook_guards.py` (H-19 block) | Test **fails** — the verb list omits interpreters |
+| B-2 | Extend `GATE_MARKER_WRITE_RE`'s verb set with the interpreters. Watch the `[^\|;&]*` segment bound — an interpreter one-liner's payload is a quoted string, so confirm the marker path is still reachable by the pattern within the same segment. | `core/pysrc/pre-bash.py:244-260` | B-1 passes; existing H-19 cases (`mv`/`cp`/`tee`/redirect) still block; no false positive on a benign `python -c` |
+| B-3 | Correct the docs claim (AC-4). Find and rewrite the `.codearbiter` directory reference asserting a hand-written marker "can't satisfy a gate anyway". Replace with the truth: the Write/Edit/Bash flanks add friction and an audit trail on the cooperative path (ADR-0010); a determined same-user process can still mint one. | docs (locate via grep), possibly `site/` | Claim gone; `npm test` + build if `site/` is touched (per repo rule: site changes run the vitest suite, not just build) |
+
+**Exit:** AC-3, AC-4.
+
+### Lane E — harvest (disjoint files; may also start during Slice 1)
+
+| # | Task | Files | Verification |
+|---|---|---|---|
+| E-1 | `_read_custom`: add `RecursionError` to the except tuple (deeply nested custom theme JSON). Test-first. | `core/pysrc/_colorlib.py` | New test in `plugins/ca/hooks/tests/test_colorlib.py` |
+| E-2 | Invalid-hex boundary cases (`#01020`, `#0102030`, `#0102GG`) assert the violet fallback. | `plugins/ca/hooks/tests/test_colorlib.py` | Tests pass |
+| E-3 | Strip C0/OSC control chars from `display_model` and `sub_label` before render. Test-first. | `core/pysrc/statusline.py` (+ `_colorlib.py` if the helper lands there) | New test; injected `\x1b]0;…\x07` / C0 bytes do not reach the rendered line |
+| E-4 | Restore the time-bounded negative wait (~0.2s) on `second_acquired` after `second_attempted` in the contention harness. | `plugins/ca/hooks/tests/test_ledgerlib.py` (`_serialize_transactions`, ~192-231) | Serialization is actually asserted, not assumed |
+| E-5 | Codex py2-Windows host: document out-of-support, **or** extend the PY2 cold-install scenario to assert the codex Windows entry never exits 0. | `.github/scripts/test_hooks_cold_install.py` or docs | Test or doc lands |
+
+**Exit:** AC-9.
+
+## Slice 3 — Lane C: #271
+
+| # | Task | Files | Verification |
+|---|---|---|---|
+| C-1 | Failing test: board lost-update + duplicate dotted ID under contention. Pattern-match `_serialize_transactions` (`test_ledgerlib.py:192-231`) — specifically the `while_first_holds` shape used by `test_same_session_concurrent_updates_do_not_regress_accounting`. **New file** (`taskwrite.py` has no test today). | `plugins/ca/hooks/tests/test_taskwrite.py` (new) | Test **fails**: an edit is lost and/or IDs collide |
+| C-2 | Hoist the lock. Move `_acquire_lock`/`_release_lock` (+`LOCK_WAIT`) from `_ledgerlib.py:153-201` into `_hooklib.py` as a shared `acquire_lock`/`release_lock`. Repoint `_ledgerlib`'s two call sites (`:427`, `:504`). **Import-cycle check:** `_ledgerlib` currently imports nothing from `_hooklib`; `_hooklib` imports only `hostapi`. Verify no cycle. | `core/pysrc/_hooklib.py`, `core/pysrc/_ledgerlib.py` | `test_ledgerlib.py` fully green (all lock tests, incl. fail-soft latency bound ≤0.35s) |
+| C-3 | Lock + **re-read-under-lock CAS** in `taskwrite` (spec D-4). Take the lock, **then** read the board, re-run the pure transform on the fresh text, `os.replace`, release. This is what fixes the duplicate-ID mint — `next_seq` must run on fresh text. Fail-soft on `None` lock handle: match `_ledgerlib`'s convention, but **do not silently drop a board write** — surface it. | `core/pysrc/taskwrite.py:73-120` | C-1 passes; `.github/scripts/test_taskwriter.py` green |
+| C-4 | Failing test: dev-marker clobber. Session B's `clear_dev_marker` must not remove session A's live marker nor append a synthetic `DEV: exit`. Extend `TestDevExitAudit`. | `plugins/ca/hooks/tests/test_session_start.py:383-440` | Test **fails** — the clear is unconditional (`session-start.py:487-490`) |
+| C-5 | Session-scope the dev marker. `session-start.py` must start **reading its stdin payload** (it does not today) to obtain `session_id` — precedent: `pre-read.py:51`, `statusline.py:545`, and the session-keyed marker hash in `_readinjectlib.marker_path` (`:786-812`). Carry the session id in the marker; clear only your own. **Degrade safely** when no `session_id` is available (Codex parity is unverified — fall back to today's behavior rather than never clearing). Update the three readers: `_arbiterstatelib.dev_active` (`:202`), `_hooklib._STALE_FLOWS` (`:878-882`), and the `/ca:dev` + `/ca:arbiter` prose entry/exit paths. | `core/pysrc/session-start.py:450-490`, `core/pysrc/_arbiterstatelib.py`, `core/pysrc/_hooklib.py`, `core/surface/commands/dev.md`, `core/surface/commands/arbiter.md` | C-4 passes; `test_session_start.py` green |
+
+**Exit:** AC-5, AC-6. **Note:** C-5 touches `session-start.py` — Lane D must follow, not overlap.
+
+## Slice 4 — Lane D: #265 + ADR-0014
+
+**This lane reverses a documented ACCEPT-RISK** recorded in `_githooks.py`'s own header (lines 25-46),
+which explicitly considered and rejected both multiple-candidate embedding and a runtime cache glob.
+The drop-in dir is admissible precisely because it satisfies that header's *own stated exit condition*
+("a shared, non-versioned shim target") — it reads a directory **we own** inside `.git/`, not an
+unknown host cache layout. The ADR must say so.
+
+| # | Task | Files | Verification |
+|---|---|---|---|
+| D-1 | **[HARD GATE]** Author **ADR-0014** — reversing the git-hook shim fail-open. User-attributed via `/ca:adr`. Must state: the accepted-risk being reversed, why the drop-in dir is not the rejected glob, the new fail-**closed** blast radius, and the residual (a stale entry from an uninstalled plugin). **Halt for user attribution.** | `.codearbiter/decisions/0014-*.md` | ADR exists, user-attributed. (0013 is taken by ca-pi.) |
+| D-2 | Failing test: two plugins registered, remove one → the backstop still resolves to the survivor. Zero resolvable enforcers → shim **blocks** (non-zero), not exit 0. | `plugins/ca/hooks/tests/test_git_hooks.py` (real throwaway git repo, `_GitFixture`) | Test **fails** — today's shim exits 0 |
+| D-3 | Implement the drop-in dir. `install()` registers this plugin's enforcer at `.git/codearbiter-hooksd/<plugin>.path`; `_shim()` iterates `"$D"/*.path`, execs the first that resolves, and **fails closed** with a message if none do. `uninstall()` drops only its own `.path`. Rewrite the header block (25-46) — it is the ADR-of-record today and must now point at ADR-0014. | `core/pysrc/_githooks.py:102-160, 316-414`, `core/pysrc/session-start.py:593-602` | D-2 passes; `test_git_hooks.py`, `.github/scripts/test_hooks_cold_install.py` green |
+| D-4 | Sync + validate the codex plugin manifest if hook wiring changed. | `tools/sync-core.py`, `.github/scripts/validate_codex_plugin.py` | `sync-core.py --check`; validator green |
+
+**Exit:** AC-7, AC-8.
+
+## Slice 5 — Land
+
+| # | Task | Verification |
+|---|---|---|
+| L-1 | Full fresh-run suite: `unittest discover -s plugins/ca/hooks/tests`; every `.github/scripts/test_*.py`; `tools/sync-core.py --check`. | AC-10 green |
+| L-2 | `commit-gate` → `finishing-a-development-branch` (auto-selects open-PR). Board done-flips ride **with** this PR, not a lagging chore commit. | PR open; merge decision is the user's |
+| L-3 | PR body closes #223, #237, #271, #265. Notes #270 deferred with its rationale. | — |
+
+## Ordering summary
+
+```
+Slice 1 (A: #223)  ──┬──> Slice 2 (B: #237)  ──> Slice 3 (C: #271) ──> Slice 4 (D: #265) ──> Slice 5
+                     └──> Lane E (harvest, disjoint — may start immediately)
+```
+
+MVP slice = **Slice 1**. It alone fixes the guard bug that (a) blocks correct worktree enforcement,
+(b) created the #237 incident, and (c) is currently forcing every git write in this sprint through a
+`-C` workaround.

--- a/.codearbiter/specs/pre-release-hardening.md
+++ b/.codearbiter/specs/pre-release-hardening.md
@@ -1,0 +1,124 @@
+# Sprint spec — pre-release-hardening
+
+Date: 2026-07-13
+Goal (user): "run through some more open gh issues before we do the next release"
+Slug: `pre-release-hardening`
+Branch: `feat/pre-release-hardening` (worktree, based on `origin/main` @ 32b116b)
+
+## Intent
+
+Close the open GitHub issues that mean **the gates are not actually enforcing what they claim**,
+before the next release cuts. This is an enforcement-integrity sprint, not a feature sprint. Every
+item is a bug where a guard can be sidestepped, silently unwired, or silently lost to a race.
+
+## Concurrency context
+
+A Codex CLI session is running concurrently in the main checkout on `feat/pi-support` (ca-pi host
+support, ADR-0013 — user-ratified, out of scope here). This sprint runs in an isolated worktree by
+user direction. `CLAUDE_PROJECT_DIR` remains pinned to the main checkout, so **every git write in this
+sprint passes `git -C <worktree>`**, which `git_cwd()` (`pre-bash.py:263-300`) honors — the workaround
+#223 documents, and which Lane A removes the need for.
+
+## In scope
+
+| Lane | Issue | Problem | Resolution |
+|---|---|---|---|
+| A | #223 | `pre-bash.py` resolves branch guards against `CLAUDE_PROJECT_DIR` (main checkout), not the command's effective cwd; heredoc *bodies* are pattern-matched as if they were commands | cwd/worktree-aware root resolution; narrow the raw-command fallback to shell-consuming heredocs only |
+| B | #237 | The H-19 forgery guard's verb list omits interpreters, so `python -c` can hand-write the security-gate marker; the docs claim enforcement the model cannot deliver | Extend the H-19 verb set to interpreters; correct the docs claim |
+| C | #271 | `taskwrite.py` does a lock-free RMW on `open-tasks.md` (lost updates, duplicate dotted IDs); `SessionStart` clobbers a repo-global dev marker and writes a false `DEV: exit` | Hoist the `_ledgerlib` OS lock to `_hooklib`; re-read-under-lock CAS in `taskwrite`; session-scope the dev marker |
+| D | #265 | The git-hook shim embeds the last-writing plugin's absolute enforcer path and fails **open** when it's missing — uninstall one of two plugins and both hosts silently lose the git-level backstop | `.git/codearbiter-hooksd/<plugin>.path` drop-in dir; shim iterates it; fail **closed**. Requires **ADR-0014** |
+| E | harvest | Five PR-304 review findings queued on the board | Close them alongside |
+
+## Out of scope
+
+- **#270** (Codex MCP write-gate bypass) — **deferred by user decision, 2026-07-13.** The agreed
+  path-based guard is sound in shape but rests on an `mcp__*` `tool_input` payload schema never
+  observed from a live Codex install. Its own session: capture a real payload first, build against it,
+  with its own ADR amending ADR-0010's trust model.
+- Feature ideas (#247–#253, #38, #80), GTM (#70, #71), run-metrics noise (#246, #200 — left open).
+- ADR-0013 / `feat/pi-support` — the concurrent Codex session's work. Untouched.
+
+## Load-bearing design decisions (settled at the spec gate)
+
+**D-1 — #237 is NOT fixed by consumer-side digest recomputation.** The originally-proposed direction
+(git-enforce recomputes the digest set so a hand-written marker carries no authority) is **wrong and
+was rejected at the gate**. The consumer already derives the sensitive-line set from the diff; if it
+also *recomputed* the approved set, coverage would be vacuously true by construction — the gate would
+degrade to an mtime check and the existing TOCTOU case (`test_hook_guards.py:331-339`) would pass when
+it must block. `line_digest` is a pure public function of a string the forger already holds, so **no
+consumer-side recomputation can distinguish a genuine marker from a forged one.**
+`security-controls.md:322-329` already concedes this under ADR-0010: the marker is a *cooperative
+attestation* whose value is friction and audit trail, not unforgeability. The sprint therefore closes
+the **real** hole (the missing interpreter flank in H-19) and makes the **docs stop overselling**
+enforcement the model cannot deliver.
+
+**D-2 — markers stay at the main checkout; branch and diff checks follow the worktree.** A linked
+worktree has `.codearbiter/` (tracked) but *not* `.codearbiter/.markers/` (gitignored). So H-09b/H-14
+must keep reading gate markers from the pinned project root while reading branch/diff state from the
+command's effective cwd. This makes intentional and documented what is today accidental
+(`pre-bash.py:769,828` read markers from `root`; everything else reads from `cwd`).
+
+**D-3 — the heredoc fix must narrow the fallback, not strip harder.** `pre-bash.py:588-598`
+deliberately retains a raw-`cmd` fallback matcher, because a heredoc fed *to a shell* (`bash <<EOF …
+git commit … EOF`) genuinely executes its body — ambiguity resolves closed. That fallback is exactly
+what makes `gh pr create --body "$(cat <<'EOF' … git commit … EOF)"` trip H-01. Keep the fallback for
+**shell-consuming** heredocs; drop it for non-shell consumers. Do not remove it.
+
+**D-4 — #271's lock is necessary but not sufficient; pair it with re-read-under-lock.** `taskwrite.py`
+is the only *programmatic* board mutator, but the harvest/decompose paths write `open-tasks.md` with
+the host's own Edit/Write tool and will never take a lock. Reading the board **inside** the lock and
+re-running the pure transform on fresh text makes an interleaved external edit a detected-loss rather
+than a silent clobber, and independently fixes the duplicate-ID mint (`next_seq` then runs on fresh
+text). The lock alone would not.
+
+## Build constraints (non-negotiable, from the codebase)
+
+- `core/pysrc/` is the **single source of truth**. `plugins/ca/hooks/` and `plugins/ca-codex/hooks/`
+  are byte-identical vendored copies produced by `tools/sync-core.py`. **Never edit a vendored copy** —
+  `.github/scripts/test_sync_core.py` fails if you do. Every task: edit `core/pysrc/`, then run
+  `python tools/sync-core.py`.
+- **Tests import the vendored `plugins/ca/hooks/` copy**, so a core-only edit is not exercised until
+  sync runs. Sync before verifying.
+- **Stdlib only** (ADR-0004). Tests are stdlib `unittest`. No pytest, no third-party.
+- Two test roots: `plugins/ca/hooks/tests/` (`python -m unittest discover`) and `.github/scripts/`
+  (standalone scripts). Both are CI gates (`.github/workflows/ci.yml`).
+- All git writes use `git -C <worktree>` (see Concurrency context).
+
+## Acceptance criteria
+
+- **AC-1 (#223 worktree)** — a `git commit` executed from a linked worktree on a feature branch is
+  judged against **the worktree's** branch, not the main checkout's. The false-negative closes: a
+  worktree sitting on `main`/`master` is BLOCKED by H-01 even when the main checkout is on a feature
+  branch.
+- **AC-2 (#223 heredoc)** — `gh pr create` / `gh issue create` whose heredoc body merely *contains*
+  the text `git commit` does **not** trip H-01/H-09b. A heredoc fed to a **shell** containing a real
+  `git commit` still BLOCKS.
+- **AC-3 (#237 flank)** — `python -c`, `python3 -c`, `node -e`, `perl -e`, `ruby -e`, `sh -c`
+  invocations that write a path under `.markers/` matching a gate-marker name are BLOCKED by H-19,
+  matching the existing `mv`/`cp`/`tee` flank.
+- **AC-4 (#237 docs)** — the `.codearbiter` directory reference no longer claims a hand-written marker
+  cannot satisfy a gate. It states what is true: the flanks add friction and an audit trail on the
+  cooperative path (ADR-0010); a determined same-user process can still mint one.
+- **AC-5 (#271 board)** — two concurrent `taskwrite` mutations both survive: no lost update, no
+  duplicate dotted ID. Proven by a contention test in the `_serialize_transactions` idiom
+  (`test_ledgerlib.py:192-231`).
+- **AC-6 (#271 dev marker)** — a `SessionStart` from session B does **not** clear session A's live dev
+  marker and does **not** append a synthetic `DEV: exit` for it. A session clears only its own.
+  Degrades safely when no session id is available.
+- **AC-7 (#265 shim)** — with two plugins registered, removing one leaves the git-level backstop wired
+  to the survivor. With **zero** resolvable enforcers, the shim **blocks** (non-zero), not exit 0.
+- **AC-8 (#265 ADR)** — **ADR-0014** records the reversal of the fail-open accept-risk, and the
+  `_githooks.py` header block (lines 25-46, the ADR-of-record today) is rewritten to match.
+- **AC-9 (harvest)** — the five PR-304 board items close: `_colorlib._read_custom` catches
+  `RecursionError`; invalid-hex boundary cases (`#01020`, `#0102030`, `#0102GG`) assert the violet
+  fallback; C0/OSC control chars are stripped from `display_model`/`sub_label` before render; the
+  `test_ledgerlib` `_serialize_transactions` negative wait is restored; the codex py2-Windows host
+  scenario is documented or asserted.
+- **AC-10 (suite)** — full CI suite green on the branch: `unittest discover` over
+  `plugins/ca/hooks/tests`, every `.github/scripts/test_*.py`, and `tools/sync-core.py --check`.
+
+## Hard-gate surfaces (halt, do not auto-decide)
+
+- ADR-0014 authorship — user attribution required.
+- Any change to `security-controls.md` beyond the D-1 docs correction.
+- Merge to `main` — `/sprint` opens a PR; the merge is the user's.

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -736,3 +736,237 @@ Note: the prior attempt to append SD-03 failed (shell cwd had drifted into site/
 - **Harvest D-03:** promoted queued task `(from sprint:auto-safe-open-issues)` to benchmark and revisit the 100 ms dirty-check timeout. SMARTS: reliable/secure behavior favors measurement before changing the bounded fail-soft policy; non-blocking. Confidence: high.
 - **Harvest D-05:** promoted queued task `(from sprint:auto-safe-open-issues)` to validate annotated palette evidence with users before adding unstable bitmap captures. SMARTS: useful evidence with low maintenance cost; non-blocking. Confidence: high.
 - **Harvest D-06:** promoted queued task `(from sprint:auto-safe-open-issues)` to reconfirm version classification against the final merged diff before release/tagging. SMARTS: release accuracy without blocking this feature PR; non-blocking. Confidence: high.
+
+# Sprint log — pre-release-hardening
+Started 2026-07-13. Append-only. SMARTS-scored auto-decisions; `low` = review these.
+Spec: .codearbiter/specs/pre-release-hardening.md · Plan: .codearbiter/plans/pre-release-hardening.md
+Branch: feat/pre-release-hardening (worktree, from origin/main 32b116b).
+
+Context (user-decided, not auto): scope = #223/#237/#271/#265 + 5 harvest items; #270 DEFERRED
+(rests on an unobserved mcp__* payload schema); #237 fixed via H-19 interpreter flank + honest docs,
+NOT consumer-recompute (which would make the gate vacuously pass); #265 via .git/codearbiter-hooksd
+drop-in + fail-closed, needs ADR-0014. Worktree mandated by user (concurrent Codex session on
+feat/pi-support in the main checkout, ratifying ADR-0013 — legitimate, out of scope).
+
+## SD-01 — Serialize the lanes rather than parallelize authors · confidence: high
+- **Point:** the plan's file-conflict map allows Lane E (harvest) to run parallel with Lane A (#223).
+  Should authors run concurrently in this one worktree?
+- **Options:** (a) serial lanes, one author at a time; (b) parallel authors in the same worktree;
+  (c) parallel authors in nested per-task worktrees.
+- **SMARTS:** Reliable strongly favors (a). Every lane funnels through `python tools/sync-core.py`,
+  which rewrites the whole vendored tree under plugins/ca/hooks + plugins/ca-codex/hooks — two
+  concurrent syncs race on the same output files even when the authors' *source* edits are disjoint.
+  Prior sprint SD-02 recorded exactly this class of bug (concurrent `npm run build` in one tree).
+  (c) is sound but nested worktrees + a repo-wide generator is disproportionate for a 5-task lane.
+  Velocity cost of (a) is real but bounded; correctness of the enforcement layer outranks it (§2 L2).
+- **Chosen:** (a) serial lanes; orchestrator owns sync + full-suite verification centrally, authors
+  edit + run targeted tests only. Strength: strong.
+
+## SD-02 — Lane A review BLOCK: the heredoc narrowing opened an H-01 bypass · confidence: high
+- **Point:** Lane A's A-4 narrowed the raw-`cmd` fallback by asking "is the heredoc's DIRECT CONSUMER a
+  shell?". That is the wrong question. In `bash -c "$(cat <<'EOF' … git commit … EOF)"` the consumer is
+  `cat` (classified inert), so the fallback is suppressed and the body is stripped from `git_view` —
+  COMMIT_RE never matches and the protected-branch commit is ALLOWED. `bash -c` executes the
+  substituted result regardless. Same for `eval`/`sh -c`. The subagent's suite was green (935 tests)
+  because no test covered an executor-behind-substitution.
+- **Options:** (a) accept — the false positive is fixed and the bypass is contrived; (b) require the
+  fallback to fire when the body can reach a shell by ANY route (direct consumer OR a shell executor
+  anywhere in the command), fail-closed on unknown tokens; (c) revert A-4, accept the `gh pr create`
+  false positive.
+- **SMARTS:** Secure + Reliable decisively favor (b). (a) trades a false positive (annoying) for a
+  false NEGATIVE in the protected-branch guard (dangerous) — the exact defect class the same lane's
+  worktree half exists to close; shipping it would mean #223's fix reintroduced #223's bug in another
+  spelling. (c) is safe but abandons the issue's actual, evidenced ask. (b) preserves the original
+  "ambiguity resolves CLOSED" contract while fixing the one case #223 documents. §2 L1 (security) over
+  L5 (velocity).
+- **Chosen:** (b) — `heredoc_shell_fallback = _heredoc_fed_to_shell(cmd) or _has_shell_executor(cmd)`,
+  fail-closed; three new BLOCK regression tests (`bash -c`/`eval`/`sh -c` behind `$(cat <<EOF …)`).
+  Returned to the author test-first. Strength: strong.
+- **Note:** caught by orchestrator diff review, not by the suite. The gap was a missing test, so the
+  fix carries its own regression guard.
+
+## SD-03 — Commit per slice, not one commit at the end · confidence: high
+- **Point:** the plan puts a single commit-gate at Slice 5. Four independent bug fixes in one commit?
+- **Options:** (a) one commit at the end (as planned); (b) one commit per slice/lane.
+- **SMARTS:** Maintainable + Reviewable favor (b): each lane closes a distinct issue with its own
+  conventional-commit type and its own regression tests, so a per-lane commit gives real rollback
+  points and a reviewable history; a single 4-issue commit is a reviewer-hostile blob and cannot be
+  reverted piecewise. Velocity cost is one extra gate run per lane — bounded. No security or
+  correctness argument for (a).
+- **Chosen:** (b) commit per slice; still ONE PR at the end. Amends the plan's L-2. Strength: strong.
+
+## SD-04 — Accept Lane B's H-19 interpreter over-block (reads blocked too) · confidence: high
+- **Point:** the author flagged that a dedicated interpreter regex cannot distinguish an interpreter's
+  OWN `;` statement separator from shell chaining without real tokenization, so it must scan past the
+  `[^|;&]*` bound the verb-list regex uses — which also blocks a *read* of a gate marker through an
+  interpreter, and any marker path appearing later on the same line as an interpreter name.
+- **Options:** (a) accept the over-block (fail closed); (b) keep the segment bound and accept that
+  `python -c "x=1; open(...marker...)"` slips through; (c) build a real shell/python tokenizer.
+- **SMARTS:** Secure decisively favors (a). (b) reopens the exact hole #237 filed — the bound is
+  trivially defeated by putting a `;` in the payload, so the guard would only catch the naive spelling
+  and advertise protection it does not have. (c) is disproportionate (a tokenizer per interpreter
+  language) and is itself a new bug surface. The over-block's blast radius is narrow: reading a gate
+  marker through a raw interpreter one-liner has no legitimate use (`cat`/`grep` are untouched), and
+  the sanctioned producers write the marker from INSIDE python, never by naming it on a command line —
+  so `python .../security-pass.py` is unaffected. §2 L1 over L5.
+- **Chosen:** (a) accept. Strength: strong.
+
+## SD-05 — Lane B review BLOCK: H-19 interp regex has a newline hole AND over-blocks prose · confidence: high
+- **Point:** `GATE_MARKER_INTERP_RE` used `[^\n]*`, which cannot cross a newline. It blocks
+  `python -c "open(...marker...)"` but MISSES the identical multi-line payload
+  (`python -c "\nopen(...marker...)\n"`) — ordinary Python, and a hole in the exact shape the flank
+  exists to close. But naively crossing newlines over-blocks PROSE: H-19 scans the raw `cmd`, so a
+  `gh pr create` heredoc body *describing* the #237 fix (which necessarily names `python -c` and
+  `security-gate-passed`) would BLOCK — i.e. this sprint's own PR body.
+- **Options:** (a) leave `[^\n]*` — miss the multi-line attack; (b) cross newlines and eat the prose
+  over-block; (c) cross newlines AND scan the heredoc-stripped view, with the raw fallback gated on
+  `heredoc_shell_fallback` — reusing the exact machinery Slice 1 landed for commit/push/add.
+- **SMARTS:** (c) dominates. (a) ships a guard with a trivially-reachable hole. (b) is not "fail
+  closed", it is broken — it would dead-end a real, necessary workflow (opening the PR that ships the
+  fix). (c) answers the already-answered question: a marker path in an inert heredoc body is prose, one
+  behind `bash -c "$(cat <<EOF …)"` is code. Consistency with Slice 1 also means one concept to
+  maintain, not two.
+- **Chosen:** (c). Extends to GATE_MARKER_REDIRECT_RE / GATE_MARKER_WRITE_RE, which have the same
+  prose false-positive today. Returned to the author test-first. Strength: strong.
+- **Note:** the over-block in SD-04 is accepted; this one is not. They are different — SD-04 blocks a
+  pointless action, SD-05 blocked a necessary one.
+
+## SD-06 — Accept taskwrite's fail-HARD on a null lock handle · confidence: high
+- **Point:** `_ledgerlib`'s convention is to silently no-op when `acquire_lock` returns None (a
+  statusline render is disposable). What should `taskwrite` do — it inherits the primitive but not the
+  disposability?
+- **Options:** (a) inherit fail-soft: proceed unlocked; (b) inherit fail-soft: silently skip the write;
+  (c) fail HARD — refuse to write, exit nonzero.
+- **SMARTS:** Reliable + correctness favor (c). (a) silently reintroduces the exact race #271 closes —
+  a lock you skip under contention is not a lock. (b) is worse: the caller sees success while the board
+  update vanished. A board write is the SOLE user-visible effect of the invocation, not a disposable
+  render, so a nonzero exit the caller can retry is the honest failure. Author proposed (c) unprompted
+  and justified it; concur.
+- **Chosen:** (c). Strength: strong.
+
+## SD-07 — Lane C review BLOCK: the dev-marker liveness window slides and never expires · confidence: high
+- **Point:** C-5's sidecar ownership record (`dev-session-owner.json`) is refreshed UNCONDITIONALLY on
+  every SessionStart carrying a session id — including sessions unrelated to the live dev marker. So
+  `now - prev_ts` never grows in an actively-used repo, the 6h liveness window never elapses, and a
+  dev marker orphaned by a crashed session becomes IMMORTAL: statusline stuck alarm-red, `overrides.log`
+  left with a `DEV: enter` that never closes. The window only expires in a repo nobody is using — i.e.
+  exactly where it isn't needed. The author's own comment claimed "a THIRD session after the window
+  passes" heals it; that third session refreshes the timestamp before evaluating it.
+- **Options:** (a) accept — the false-close bug (#271's actual complaint) is fixed either way;
+  (b) anchor the timestamp to the OWNER: refresh only when there is no live marker, or when the
+  refreshing session IS the recorded owner (a resume/compaction heartbeat); (c) drop session-scoping,
+  keep today's unconditional clear.
+- **SMARTS:** (b) clearly. (a) trades a FALSE audit close for a PERMANENTLY MISSING one — strictly
+  worse against §2 L1 (audit-trail integrity), and it breaks the self-heal the design claims to have.
+  (c) abandons AC-6. (b) costs one conditional and makes the residual honest and bounded: an orphaned
+  marker heals 6h after the OWNER's last activity, and a live /dev sitting idle longer than the window
+  can still be force-closed — both stateable, both acceptable.
+- **Chosen:** (b), plus two regression tests (immortal-marker sequence; owner-heartbeat) and a corrected
+  module comment. Returned to the author test-first. Strength: strong.
+
+## SD-08 — Lane E promoted a NEEDS-TRIAGE into scope: the board contention test proved nothing · confidence: high
+- **Point:** Lane E's E-4 found that Slice 3's lock hoist silently killed a test seam
+  (`mock.patch.object(_ledgerlib, "LOCK_WAIT")` became dead — the real deadline now reads
+  `_hooklib.LOCK_WAIT`). Pulling that thread exposed that the BOARD contention test (Slice 3's whole
+  proof of AC-5) used THREADS to test a bug about PROCESSES, and asserted non-acquisition with an
+  instant `is_set()` that could pass vacuously.
+- **Orchestrator error, recorded:** I inferred "the suite is green, therefore the lock is not
+  serializing in-process." That inference was WRONG — `release_first.set()` fires microseconds after
+  the assertion, well inside the second thread's 0.2s retry budget, so it acquires on retry and the
+  test passes legitimately. The author checked empirically (two handles, one process → second returns
+  None) and corrected me. The CONCLUSION survived the bad reasoning: threads are still the wrong
+  instrument for a two-process bug.
+- **Options:** (a) accept Slice 3's test — the fix reads correctly; (b) patch LOCK_WAIT until the
+  thread test is meaningfully green; (c) rebuild the proof on real subprocesses.
+- **SMARTS:** (c). (a) leaves AC-5 unproven — a green light over an unverified fix is the precise
+  failure this sprint exists to eliminate, and I had already bounced three lanes for it. (b) manufactures
+  a green over a harness that structurally cannot exercise the production risk (two `/ca:task` OS
+  processes, each with its own fail-soft clock, racing a file-level lock).
+- **Chosen:** (c). Rebuilt on real `taskwrite.py` subprocesses; proves mutual exclusion by MEASURING the
+  gap between acquisitions rather than assuming it; validated by reintroducing the pre-#271 bug and
+  confirming all three properties fail with the predicted symptoms. **Outcome: the #271 fix is correct;
+  the evidence for it was worthless. Now it isn't.** Strength: strong.
+
+## SD-09 — [HARD GATE, user-decided] the crypto gate poisons itself with its own audit log
+- **Point:** H-09b blocked a commit whose diff has ZERO sensitive lines. Cause: `candidate_lines()`
+  scans `.codearbiter/gate-events.log`, and that log echoes the detector's own message text
+  ("Crypto/TLS pattern detected") back at it. The log is append-only and nearly always dirty, so once
+  the gate has EVER fired a crypto REMIND in a repo, H-09b carries a permanent self-perpetuating false
+  positive. Compounded by #223: the installed 2.8.11 hook resolved to the MAIN checkout and scanned the
+  concurrent Codex session's diff, not mine — i.e. I was blocked by the bug this branch fixes, because
+  the fix is not the installed one.
+- **NOT auto-decided.** Security-gate scanning scope is a hard gate under /sprint (ORCHESTRATOR §3).
+  Surfaced to the user with three options.
+- **User chose:** exclude `gate-events.log` ONLY — deliberately keeping `overrides.log` / `triage.log` /
+  `sprint-log.md` in scope, since those carry human-written prose that could legitimately leak a secret
+  worth catching. And: fix the cause rather than take a logged /override, so no security-gate bypass
+  enters the audit trail for what is our own bug.
+- **Implementation note (mine):** the exclusion MUST land in the producer (`security-pass.py`) and BOTH
+  consumers (`pre-bash.py` H-09b, `git-enforce.py`) — they derive the sensitive set independently, so a
+  partial exclusion would make the producer stop covering lines the consumer still demands, blocking
+  PERMANENTLY with no marker able to satisfy it. Must be path-anchored, not a substring match on the
+  line text (excluding any line that merely NAMES the log would be a real hole).
+
+## SD-10 — [SECURITY BLOCK] the gate-events.log exemption shipped a scanner-blinding bypass (3rd of its class) · confidence: high
+- **Point:** the log-poisoning fix (SD-09) narrows the crypto/secret scan by attributing each diff line
+  to its file. First impl keyed on `+++ ` (content-forgeable) — sent back. Second impl keyed on
+  `diff --git a/X b/X` per my instruction. A dispatched security-reviewer found that header is
+  UNSPOOFABLE but PATH-AMBIGUOUS: the greedy `b/(.+)$` resolves to the LAST ` b/`, so a file named
+  `x b/.codearbiter/gate-events.log` exempts a real source file. Reproduced end-to-end: an md5 call +
+  a committed password passed the backstop with no marker, no --no-verify. Same defect class as the
+  first two bounces, via a different mechanism. My own remediation instruction created it.
+- **Also found:** MEDIUM — `diff.mnemonicPrefix`/`diff.noprefix` git config breaks the `a/`…`b/` anchor,
+  so the REAL gate-events.log stops being exempt and the self-DoS returns (consumers don't pin diff
+  format). MEDIUM — combined/merge diffs (`diff --cc`) aren't recognized as section boundaries, so a
+  `--cc` source section inherits the prior (exempt) path — reachable via git-enforce's `git diff
+  --cached` at a merge commit; fails toward EXEMPTION. LOW — producer (ls-files) and consumers (diff
+  walk) disagree on identity for the collision path.
+- **Options:** (a) accept HIGH as contrived (a file named `x b/...` is exotic); (b) redesign attribution
+  to be both unforgeable AND unambiguous, pin diff config, treat any `^diff ` as a boundary; (c) drop the
+  exemption, revert SD-09, live with the self-poisoning false positive.
+- **SMARTS:** (b). (a) is indefensible — this is the crypto/secret backstop and the bypass needs no
+  privilege; "exotic filename" is exactly how scanner-blinding vectors read until someone uses one.
+  (c) trades a false positive for the original bug. (b): attribute off `+++ b/<path>` by stripping the
+  FIXED 6-char prefix (unambiguous even for paths containing ` b/`, unlike the twice-repeated
+  `diff --git` path), accepted only in the pre-`@@` preamble (content is post-`@@`, so unforgeable);
+  pin `-c diff.mnemonicPrefix=false -c diff.noprefix=false --no-ext-diff --src-prefix=a/ --dst-prefix=b/`
+  at all three call sites; reset attribution on ANY `^diff ` line. §2 L1.
+- **Chosen:** (b). Not a new user decision — the DECISION (exempt gate-events.log only) stands; this is
+  fixing bugs in an approved change. Returned to author test-first with the reviewer's repro as the
+  failing case. Strength: strong.
+- **Note:** the security-reviewer caught what the author's full test matrix missed, and the author had
+  written the false invariant into a code comment. The review paid for itself.
+
+## SD-11 — [landing] board reconciliation deferred to post-merge; papercuts harvested to the PR body · confidence: high
+- **Point:** the 5 harvest tasks live only in the MAIN checkout's UNCOMMITTED open-tasks.md (added by a
+  prior session from pr304-review); the worktree board is the HEAD version and lacks them. The board is
+  shared mutable state the concurrent Codex session also touches.
+- **Options:** (a) flip the harvest tasks done in the worktree board + commit; (b) leave the board out of
+  this PR, reconcile against main post-merge; (c) mutate main's board directly now.
+- **SMARTS:** (b). (a) commits a board the harvest tasks aren't in, and on merge collides three ways
+  (this PR, main's uncommitted board, Codex). (c) races the Codex session on the exact file #271 is about
+  — running the anti-race fix's cleanup THROUGH the race. (b) keeps the PR to code+ADR+artifacts and does
+  the board flip once concurrent state settles. board-done-flip-rides-with-work is overridden here by the
+  concurrent-writer hazard; noted explicitly.
+- **Chosen:** (b). Post-merge: flip the 5 pr304-review tasks done; queue the papercuts below. Strength: strong.
+
+## Papercuts found in-sprint (harvest to open-tasks post-merge, NOT fixed here — out of scope)
+- **#223-family, guard vs shell variables:** `git -C "$VAR"` fails CLOSED (guard pattern-matches the raw
+  string, never sees the expansion) — forces literal paths. Safe direction, real friction.
+- **#223-family, H-03 false positive:** a quoted `git -C "<path>"` target is mis-parsed as a staging
+  pathspec (blocked my per-slice commits until I dropped `-C` from inside the worktree). And an `echo`
+  whose text contains a `$(git diff ...)` substitution trips H-03/wildcard as if it were a real add.
+- **#223 marker-root split, ADR flow:** the installed hook reads gate/authoring markers from the MAIN
+  checkout while a worktree author writes to the worktree — I had to drop `adr-authoring-active` in BOTH
+  locations to author ADR-0014. This is the exact mismatch that CAUSED #237. Worth a real fix: resolve
+  marker root the same worktree-aware way #223 now resolves branch/diff root (but markers stay pinned per
+  D-2, so this needs its own design).
+
+## SD-12 — [landing] full-suite green; per-slice commits; one PR · confidence: high
+- Final tree: 967 hook tests OK, all 25 .github/scripts suites OK, sync-core + build-surface byte-identical,
+  site 403/403. AC-1..AC-10 met. Five commits (6738581 #223, 5cfb89a #237, e50d58b #271, a97d87b harvest+
+  gate-events-self-poisoning, 9c09172 #265+ADR-0014). Crypto-gate pass for a97d87b recorded via the
+  SANCTIONED producer (security-pass.py) after an auth-crypto-reviewer PASS — never hand-written.
+- The gate-events.log self-poisoning bug (#279-shaped) was NOT on the sprint's issue list; found by using
+  the system, surfaced as a hard gate, user-scoped, fixed under two security reviews. Recorded as the
+  sprint's one genuinely new find.

--- a/.github/scripts/test_hook_guards.py
+++ b/.github/scripts/test_hook_guards.py
@@ -236,6 +236,87 @@ def main():
                     "grep -r seed .codearbiter/decisions/"):
             expect_allow(fx, cmd, f"H-11 allow: {cmd}")
 
+        # ---- H-19: interpreter one-liners forging a gate marker (#237) -------
+        # The mv/cp/tee/sed/redirect flank (below, exercised via H-05-style
+        # verbs elsewhere) misses an arbitrary interpreter invocation entirely —
+        # `python -c "..."` can hand-write the marker using the SAME public
+        # helpers the sanctioned producer uses, and no verb in the old list
+        # ever fires. Each of these must BLOCK exactly like the mv/cp forge.
+        for cmd in (
+            'python -c "open(\'.codearbiter/.markers/security-gate-passed\', '
+            '\'w\').write(\'deadbeef\')"',
+            'python3 -c "open(\'.codearbiter/.markers/security-gate-passed\', '
+            '\'w\').write(\'deadbeef\')"',
+            'node -e "require(\'fs\').writeFileSync('
+            '\'.codearbiter/.markers/security-gate-passed\', \'deadbeef\')"',
+            'perl -e \'open(my $fh, ">", ".codearbiter/.markers/'
+            'security-gate-passed"); print $fh "deadbeef"\'',
+            'ruby -e \'File.write(".codearbiter/.markers/'
+            'security-gate-passed", "deadbeef")\'',
+            'sh -c "echo deadbeef > .codearbiter/.markers/'
+            'security-gate-passed"',
+            # the segment-bound case: a `;` sits BEFORE the marker path inside
+            # the interpreter's own quoted payload. A verb-style regex whose
+            # scan stops at the first `;` (as the mv/cp flank's does, by
+            # design, to avoid reaching across an unrelated chained command)
+            # would never reach the marker here and falsely ALLOW.
+            'python -c "import sys; open(\'.codearbiter/.markers/'
+            'security-gate-passed\', \'w\').write(\'deadbeef\')"',
+            'python3 -c "d=\'deadbeef\'; open(\'.codearbiter/.markers/'
+            'migration-gate-passed\', \'w\').write(d)"',
+        ):
+            expect_block(fx, cmd, "H-19", f"H-19 block: {cmd}")
+        # must NOT over-block a benign interpreter call that never names a
+        # gate marker anywhere on the line.
+        for cmd in ('python -c "print(1)"', 'node -e "console.log(1)"',
+                    'sh -c "echo hello"'):
+            expect_allow(fx, cmd, f"H-19 allow (benign interpreter): {cmd}")
+
+        # ---- H-19 review finding: newline-crossing + heredoc/prose scoping ----
+        # Defect 1: a MULTI-LINE `-c`/`-e` payload is completely ordinary
+        # python/node/etc — the interpreter token and the marker path can sit
+        # on different physical lines of the SAME invocation. A regex whose
+        # scan cannot cross a newline (`[^\n]*`) misses this identical attack.
+        multiline_python = (
+            "python -c \"\n"
+            "open('.codearbiter/.markers/security-gate-passed', 'w')."
+            "write('deadbeef')\n\""
+        )
+        expect_block(fx, multiline_python, "H-19",
+                     f"H-19 block: multi-line python -c payload: {multiline_python!r}")
+
+        # Same attack, one level further removed: the heredoc's DIRECT consumer
+        # is `cat` (not a shell), but `bash -c` elsewhere in the command
+        # EXECUTES the substituted result — a genuine executor route
+        # (`_has_shell_executor`), so the body really runs and must still
+        # BLOCK, mirroring how commit/push/add already treat this shape.
+        bash_c_heredoc = (
+            "bash -c \"$(cat <<'EOF'\n"
+            "python -c \\\"open('.codearbiter/.markers/security-gate-passed', "
+            "'w').write('deadbeef')\\\"\n"
+            "EOF\n"
+            ")\""
+        )
+        expect_block(fx, bash_c_heredoc, "H-19",
+                     f"H-19 block: heredoc body reaching bash -c executor: {bash_c_heredoc!r}")
+
+        # Defect 2: a heredoc fed to a NON-shell consumer with no executor
+        # anywhere in the command is inert PROSE to this guard (D-3, #223) —
+        # a PR/issue body merely DESCRIBING the python-c forgery attack must
+        # not itself trip H-19, or this very sprint's own PR body would block.
+        pr_body_prose = (
+            "gh pr create --body \"$(cat <<'EOF'\n"
+            "Fixes #237: a `python -c` one-liner could write\n"
+            ".codearbiter/.markers/security-gate-passed and the gate accepted it.\n"
+            "EOF\n"
+            ")\""
+        )
+        expect_allow(fx, pr_body_prose,
+                     f"H-19 allow: PR-body prose describing the forge: {pr_body_prose!r}")
+        issue_body_prose = pr_body_prose.replace("gh pr create", "gh issue create")
+        expect_allow(fx, issue_body_prose,
+                     f"H-19 allow: issue-body prose describing the forge: {issue_body_prose!r}")
+
         # ---- H-01/H-02: protected-branch pushes ------------------------------
         for cmd in ("git push origin HEAD:main", "git push origin feat/work:main",
                     "git push origin main", "git push origin :main",

--- a/.github/scripts/test_hook_guards.py
+++ b/.github/scripts/test_hook_guards.py
@@ -430,6 +430,130 @@ def main():
         expect_allow(fx, "git commit -m 'notes only'",
                      "H-09b allow: benign commit needs no pass")
 
+        # ---- #279: gate-events.log self-poisoning exemption -------------------
+        # The gate's own audit sink echoes the detector's message text back at
+        # itself: the REAL H-09 REMIND text (post-write-edit.py) spells out
+        # "no MD5/SHA1/DES/3DES/RC2/RC4/Blowfish", and those bare words match
+        # CRYPTO_RE just as well as a genuine algorithm choice would. An
+        # uncommitted appended REMIND line in gate-events.log must NOT be
+        # treated as a sensitive line — narrowly, only for that one file.
+        shutil.rmtree(markers, ignore_errors=True)
+        crypto_remind_line = (
+            "[2026-07-12T17:12:53Z] REMIND [H-09] host=codex "
+            "hook=post-write-edit.py | Crypto/TLS pattern detected. Run the "
+            "crypto-compliance check + dispatch auth-crypto-reviewer (no "
+            "MD5/SHA1/DES/3DES/RC2/RC4/Blowfish; do not disable TLS "
+            "verification). The commit will block until the gate records a "
+            "pass.\n"
+        )
+
+        # 6e2. gate-events.log dirty with a self-referential REMIND line, diff
+        # otherwise innocuous -> ALLOW, no marker needed.
+        gate_events = os.path.join(fx, ".codearbiter", "gate-events.log")
+        with open(gate_events, "a", encoding="utf-8") as f:
+            f.write(crypto_remind_line)
+        git(["add", ".codearbiter/gate-events.log"], fx)
+        with open(os.path.join(fx, "notes.txt"), "a", encoding="utf-8") as f:
+            f.write("another benign note\n")
+        git(["add", "notes.txt"], fx)
+        expect_allow(fx, "git commit -m 'log churn only'",
+                     "#279 allow: dirty gate-events.log alone must not block H-09b")
+
+        # 6e3. still BLOCKS: a real crypto line added to a genuine source file,
+        # over-excluding must not weaken the scan for actual source changes.
+        git(["restore", "--staged", "--worktree", ".codearbiter/gate-events.log"], fx)
+        git(["restore", "--staged", "--worktree", "notes.txt"], fx)
+        with open(crypto_file, "a", encoding="utf-8") as f:
+            f.write("const h4 = createHash('sha1');\n")
+        git(["add", "src/auth.js"], fx)
+        expect_block(fx, "git commit -m 'real crypto'", "H-09b",
+                     "#279 block: a real crypto line in a source file still blocks")
+
+        # 6e4. still BLOCKS with gate-events.log ALSO dirty — proves the log is
+        # excluded, not the whole scan.
+        with open(gate_events, "a", encoding="utf-8") as f:
+            f.write(crypto_remind_line)
+        git(["add", ".codearbiter/gate-events.log"], fx)
+        expect_block(fx, "git commit -m 'real crypto plus log churn'", "H-09b",
+                     "#279 block: real crypto still blocks even with gate-events.log dirty")
+        git(["restore", "--staged", "--worktree", "src/auth.js"], fx)
+        git(["restore", "--staged", "--worktree", ".codearbiter/gate-events.log"], fx)
+
+        # 6e5. still BLOCKS: a secret added to overrides.log — the narrow scope
+        # proves only gate-events.log is exempt, not every audit log.
+        overrides_log = os.path.join(fx, ".codearbiter", "overrides.log")
+        with open(overrides_log, "a", encoding="utf-8") as f:
+            f.write('[2026-07-12T17:14:00Z] | BY: harness | GATE: none | '
+                    'REASON: api_key="abcd1234efgh"\n')
+        git(["add", ".codearbiter/overrides.log"], fx)
+        expect_block(fx, "git commit -m 'log secret'", "H-10b",
+                     "#279 block: a secret in overrides.log still blocks (narrow scope)")
+        git(["restore", "--staged", "--worktree", ".codearbiter/overrides.log"], fx)
+
+        # 6e6/6e7. THE EVASION (2026-07 review finding): the attribution used
+        # to key off "+++ b/<path>", which a genuine ADDED CONTENT line can
+        # FORGE — a source line whose text is "++ b/.codearbiter/gate-events.
+        # log" renders in `git diff` as "+++ b/.codearbiter/gate-events.log",
+        # byte-identical to the real hunk header, hijacking attribution for
+        # every added line after it. A real crypto line placed right after
+        # such a forged line must still BLOCK with no marker recorded.
+        with open(crypto_file, "a", encoding="utf-8") as f:
+            f.write("++ b/.codearbiter/gate-events.log\n"
+                    "const h5 = createHash('md5');\n")
+        git(["add", "src/auth.js"], fx)
+        expect_block(fx, "git commit -m 'forged plusplusplus header (2-plus form)'", "H-09b",
+                     "#279 block: a forged '++ b/...' content line must not evade the scan")
+        git(["restore", "--staged", "--worktree", "src/auth.js"], fx)
+
+        # Same shape with the 3-plus content form ("+++ b/<path>" as literal
+        # SOURCE text, rendering as "++++ b/<path>" once diff-prefixed) —
+        # covers the other prefix arithmetic the reviewer called out.
+        with open(crypto_file, "a", encoding="utf-8") as f:
+            f.write("+++ b/.codearbiter/gate-events.log\n"
+                    "const h6 = createHash('md5');\n")
+        git(["add", "src/auth.js"], fx)
+        expect_block(fx, "git commit -m 'forged plusplusplus header (3-plus form)'", "H-09b",
+                     "#279 block: a forged '+++ b/...' content line must not evade the scan")
+        git(["restore", "--staged", "--worktree", "src/auth.js"], fx)
+
+        # 6e8. THE AMBIGUOUS-PATH BYPASS (2026-07 security review, round 3,
+        # HIGH): a genuine repo file whose path itself contains " b/" renders
+        # its `diff --git` header as
+        #   diff --git a/x b/.codearbiter/gate-events.log b/x b/.codearbiter/gate-events.log
+        # A greedy regex parse of that line (the round-2 fix) resolves the
+        # path to ".codearbiter/gate-events.log" (the LAST " b/" split),
+        # exempting the WHOLE unrelated source file. A real crypto call and a
+        # committed secret in that file must still BLOCK with no marker.
+        odd_dir = os.path.join(fx, "x b", ".codearbiter")
+        os.makedirs(odd_dir, exist_ok=True)
+        odd_file = os.path.join(odd_dir, "gate-events.log")
+        with open(odd_file, "w", encoding="utf-8") as f:
+            f.write("const h7 = createHash('md5');\n"
+                    'const key = api_key="abcd1234efgh";\n')
+        git(["add", "x b/.codearbiter/gate-events.log"], fx)
+        expect_block(fx, "git commit -m 'ambiguous path exploit'", "H-09b",
+                     "#279 block: a real source file named 'x b/...' must not be "
+                     "misattributed to the exempt log via a greedy diff --git parse")
+        git(["restore", "--staged", "--worktree", "x b/.codearbiter/gate-events.log"], fx)
+
+        # 6e9/6e10. THE DIFF-CONFIG BYPASS (round 3, MEDIUM-1): the REAL
+        # gate-events.log, dirty, must stay exempt (commit ALLOWED) even when
+        # the repo has `diff.mnemonicPrefix=true` or `diff.noprefix=true` set
+        # — either config, left unpinned by the H-09b/H-10b readers, changes
+        # the destination-path prefix the fixed `+++ b/` strip depends on,
+        # silently un-exempting the log and reopening the exact self-DoS this
+        # whole change exists to close.
+        for cfg_name, cfg_val in (("mnemonicPrefix", "true"), ("noprefix", "true")):
+            git(["config", f"diff.{cfg_name}", cfg_val], fx)
+            with open(gate_events, "a", encoding="utf-8") as f:
+                f.write(crypto_remind_line)
+            git(["add", ".codearbiter/gate-events.log"], fx)
+            expect_allow(
+                fx, f"git commit -m 'log churn under diff.{cfg_name}={cfg_val}'",
+                f"#279 allow: gate-events.log stays exempt under diff.{cfg_name}={cfg_val}")
+            git(["restore", "--staged", "--worktree", ".codearbiter/gate-events.log"], fx)
+            git(["config", "--unset", f"diff.{cfg_name}"], fx)
+
         # ---- 6f-6j: deep-review HIGH (v2.rev.0015) — a `git commit <pathspec>`
         # records the WORKTREE content of the named paths, bypassing the index.
         # The gate scanned only --cached (unioning worktree only on -a/add), so an

--- a/.github/scripts/test_hooklib.py
+++ b/.github/scripts/test_hooklib.py
@@ -545,5 +545,198 @@ class ActivationAndMarkerHelpersTest(unittest.TestCase):
             self.assertIn("audit", hits)
 
 
+class DiffAddedLinesTest(unittest.TestCase):
+    """#279 review (three rounds): `diff_added_lines` must attribute added
+    lines to the correct file using ONLY:
+      (1) a bare `diff ` section header (`--git`/`--cc`/`--combined`) to mark
+          a NEW section and reset attribution to None (content can't forge an
+          unprefixed line at column 0) — never inheriting the PREVIOUS
+          section's path (round 3, MEDIUM-2: combined/merge diffs);
+      (2) within that section's PREAMBLE (before its first `@@`), a `+++
+          b/<path>` line, read via a FIXED 6-character prefix strip — never a
+          regex search for a separator, which is ambiguous when the path
+          itself contains " b/" (round 3, HIGH) — and never trusted once
+          INSIDE the hunk body, where an identical-looking string is content,
+          not a header (round 2)."""
+
+    def _one_file_diff(self, path, added_lines, removed_lines=()):
+        lines = [
+            f"diff --git a/{path} b/{path}",
+            "index 1111111..2222222 100644",
+            f"--- a/{path}",
+            f"+++ b/{path}",
+            "@@ -1,1 +1,2 @@",
+        ]
+        for ln in removed_lines:
+            lines.append("-" + ln)
+        for ln in added_lines:
+            lines.append("+" + ln)
+        return "\n".join(lines) + "\n"
+
+    def test_simple_single_file_diff(self):
+        diff = self._one_file_diff("src/app.py", ["print('hi')"])
+        self.assertEqual(_hooklib.diff_added_lines(diff),
+                          [("src/app.py", "print('hi')")])
+
+    def test_multi_file_diff_attributes_each_hunk(self):
+        diff = (self._one_file_diff("a.py", ["line a"]) +
+                self._one_file_diff("b.py", ["line b"]))
+        self.assertEqual(_hooklib.diff_added_lines(diff),
+                          [("a.py", "line a"), ("b.py", "line b")])
+
+    def test_forged_plusplusplus_header_does_not_hijack_attribution(self):
+        # A genuine source file adds a line whose CONTENT is the text
+        # "++ b/.codearbiter/gate-events.log" — in real `git diff` output this
+        # renders as "+++ b/.codearbiter/gate-events.log" (one '+' prefix +
+        # the two-'+' content), byte-identical to a real hunk header. Every
+        # added line must still attribute to the REAL file (src/auth.js), not
+        # get silently reassigned to gate-events.log.
+        diff = self._one_file_diff(
+            "src/auth.js",
+            [
+                "++ b/.codearbiter/gate-events.log",
+                "const h = createHash('md5');",
+            ],
+        )
+        result = _hooklib.diff_added_lines(diff)
+        self.assertEqual(len(result), 2)
+        for path, _line in result:
+            self.assertEqual(path, "src/auth.js")
+
+    def test_forged_full_plusplusplus_content_line(self):
+        # Same shape, but the forged content line is itself "+++ b/<path>"
+        # (three literal plus signs in the source) — renders in the diff as
+        # "++++ b/<path>", which must ALSO never be mistaken for the header
+        # (the header line is never `+`-prefixed at all).
+        diff = self._one_file_diff(
+            "src/auth.js",
+            [
+                "+++ b/.codearbiter/gate-events.log",
+                "const h = createHash('md5');",
+            ],
+        )
+        result = _hooklib.diff_added_lines(diff)
+        self.assertEqual(len(result), 2)
+        for path, _line in result:
+            self.assertEqual(path, "src/auth.js")
+
+    def test_ambiguous_diff_git_path_does_not_hijack_attribution(self):
+        # #279 review HIGH: a real repo file named "x b/.codearbiter/
+        # gate-events.log" renders its `diff --git` header as
+        #   diff --git a/x b/.codearbiter/gate-events.log b/x b/.codearbiter/gate-events.log
+        # A greedy regex parse of that line resolves group(1) to
+        # ".codearbiter/gate-events.log" (the LAST " b/" split), exempting the
+        # whole unrelated source file. The fix must NOT parse `diff --git` for
+        # the path at all — attribution comes only from the fixed-prefix
+        # `+++ b/<path>` strip, which is unambiguous no matter what the path
+        # contains.
+        odd_path = "x b/.codearbiter/gate-events.log"
+        diff = (
+            f"diff --git a/{odd_path} b/{odd_path}\n"
+            "index 1111111..2222222 100644\n"
+            f"--- a/{odd_path}\n"
+            f"+++ b/{odd_path}\n"
+            "@@ -1,1 +1,2 @@\n"
+            " context\n"
+            "+const h = createHash('md5');\n"
+            '+api_key="abcd1234efgh"\n'
+        )
+        result = _hooklib.diff_added_lines(diff)
+        self.assertEqual(len(result), 2, f"expected 2 added lines, got {result!r}")
+        for path, _line in result:
+            self.assertEqual(path, odd_path,
+                              f"lines must attribute to the REAL path {odd_path!r}, "
+                              f"not the exempt log; got {path!r}")
+        # And the sensitive-scan-exempt check on that real path must be False
+        # (it is a source file, not the audit log itself).
+        self.assertFalse(_hooklib.is_sensitive_scan_exempt(odd_path))
+
+    def test_combined_diff_cc_section_does_not_inherit_prior_path(self):
+        # #279 review MEDIUM-2: a merge commit's `git diff --cached` can emit
+        # `diff --cc <path>` combined-diff sections. If attribution resets
+        # only on `diff --git` (not on `diff --cc`), a `--cc` section that
+        # follows an exempt gate-events.log section would silently inherit
+        # that path and its added lines would be dropped from the scan — the
+        # dangerous (exempting) direction. Attribution must reset to None on
+        # ANY `diff ` header and pick up the `--cc` section's OWN `+++
+        # b/<path>` line.
+        diff = (
+            "diff --git a/.codearbiter/gate-events.log b/.codearbiter/gate-events.log\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/.codearbiter/gate-events.log\n"
+            "+++ b/.codearbiter/gate-events.log\n"
+            "@@ -1,0 +1,1 @@\n"
+            "+REMIND: no MD5/SHA1/DES/3DES/RC2/RC4/Blowfish\n"
+            "diff --cc src/evil.py\n"
+            "index 1111111,3333333..4444444\n"
+            "--- a/src/evil.py\n"
+            "+++ b/src/evil.py\n"
+            "@@@ -1,2 -1,2 +1,3 @@@\n"
+            "  context\n"
+            "+const h = createHash('md5');\n"
+        )
+        result = _hooklib.diff_added_lines(diff)
+        evil_lines = [ln for path, ln in result if path == "src/evil.py"]
+        self.assertTrue(any("createHash" in ln for ln in evil_lines),
+                         f"the --cc section's crypto line must attribute to "
+                         f"src/evil.py, not inherit gate-events.log; got {result!r}")
+        gate_events_lines = [ln for path, ln in result
+                             if path == ".codearbiter/gate-events.log"]
+        self.assertEqual(len(gate_events_lines), 1)
+
+    def test_unattributed_line_is_not_silently_dropped(self):
+        # A stray '+' line before any `diff --git` header (not producible by
+        # real git output) attributes to path=None, not to a guess.
+        diff = "+orphan added line\n"
+        self.assertEqual(_hooklib.diff_added_lines(diff), [(None, "orphan added line")])
+
+    def test_dev_null_destination_has_no_added_lines(self):
+        # A deleted file's diff only has removed lines; nothing to attribute.
+        diff = self._one_file_diff("gone.py", [], removed_lines=["bye"])
+        self.assertEqual(_hooklib.diff_added_lines(diff), [])
+
+
+class SensitiveScanAddedLinesTest(unittest.TestCase):
+    """#279: sensitive_scan_added_lines applies the gate-events.log exemption
+    using diff_added_lines' unspoofable attribution."""
+
+    def test_gate_events_log_lines_excluded(self):
+        diff = (
+            "diff --git a/.codearbiter/gate-events.log b/.codearbiter/gate-events.log\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/.codearbiter/gate-events.log\n"
+            "+++ b/.codearbiter/gate-events.log\n"
+            "@@ -1,0 +1,1 @@\n"
+            "+REMIND: no MD5/SHA1/DES/3DES/RC2/RC4/Blowfish\n"
+        )
+        self.assertEqual(_hooklib.sensitive_scan_added_lines(diff), [])
+
+    def test_forged_header_line_does_not_exempt_real_source(self):
+        diff = (
+            "diff --git a/src/auth.js b/src/auth.js\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/src/auth.js\n"
+            "+++ b/src/auth.js\n"
+            "@@ -1,1 +1,3 @@\n"
+            "+++ b/.codearbiter/gate-events.log\n"
+            "+const h = createHash('md5');\n"
+        )
+        result = _hooklib.sensitive_scan_added_lines(diff)
+        self.assertTrue(any("createHash" in ln for ln in result),
+                         f"the real crypto line must still be scanned, got {result!r}")
+
+    def test_other_audit_logs_stay_in_scope(self):
+        diff = (
+            "diff --git a/.codearbiter/overrides.log b/.codearbiter/overrides.log\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/.codearbiter/overrides.log\n"
+            "+++ b/.codearbiter/overrides.log\n"
+            "@@ -1,0 +1,1 @@\n"
+            '+api_key="abcd1234efgh"\n'
+        )
+        result = _hooklib.sensitive_scan_added_lines(diff)
+        self.assertEqual(len(result), 1)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/scripts/test_hooks_cold_install.py
+++ b/.github/scripts/test_hooks_cold_install.py
@@ -835,6 +835,26 @@ def run_ca_codex_campaign(hooks, paths, stub_log, enabled, dormant):
 
     assert_loud_failure(run("prune-transcript.py", "primary", "NONE", enabled, PRUNE_IN))
 
+    # ---- 9. PY2-only Windows host (E-5): Codex's PreToolUse group has no
+    # allow-valued fallback sibling (a concurrent allow could neutralize a
+    # structured block — see the module docstring), so every commandWindows
+    # entry must never exit 0 when the selected `python` is Python-2-only.
+    # A silent exit 0 here would mean the hook layer never actually ran and
+    # Codex would treat the tool call as ungated-allow. Codex's POSIX command
+    # always selects `python3`, which the PY2 fixture never touches (it only
+    # shims `python`), so this is Windows-only.
+    if WIN:
+        py2_inputs = {
+            "session-start.py": session_in(),
+            "pre-tool-adapter.py": bash_in("git status", enabled),
+            "post-write-edit.py": patch_in(ORDINARY_PATCH, enabled),
+            "prune-transcript.py": PRUNE_IN,
+        }
+        for script, hook_input in py2_inputs.items():
+            e = run(script, "primary", "PY2", enabled, hook_input)
+            check(e.rc != 0, e,
+                  f"PY2-only Windows host: {script}'s selected commandWindows "
+                  "entry must never exit 0 (ungated allow)")
 
 # ------------------------------------------------------------------------- main
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ legacy/
 # Removed when the sprint completes. Local-only, never committed.
 .codearbiter/sprint-active
 
+# OS-owned sidecar lock file for the task-board writer (#271 C-2/C-3):
+# taskwrite.py takes a cross-process file lock on open-tasks.md.lock while it
+# reads/mutates/writes the board. Never project state, never committed.
+.codearbiter/open-tasks.md.lock
+
 # Python bytecode (e.g. the statusline dev harnesses under plugins/ca/hooks/).
 __pycache__/
 

--- a/core/pysrc/_arbiterstatelib.py
+++ b/core/pysrc/_arbiterstatelib.py
@@ -198,5 +198,11 @@ def _arbiter_state_uncached(cad, count_in_flight=None, read_board=None, frontmat
 
 def dev_active(root):
     """True when /dev developer-override mode is on — signalled by a transient marker
-    the orchestrator drops on /dev and clears on /arbiter (a local UI flag, not a log)."""
+    the orchestrator drops on /dev and clears on /arbiter (a local UI flag, not a log).
+
+    Presence-only by design, unaffected by #271 C-5's session-scoped clearing:
+    the marker still means "dev mode is on for SOMEONE" regardless of which
+    session owns it. Session-scoping only changes WHEN SessionStart is willing
+    to clear a live marker (never a different, possibly still-live session's
+    own marker) — it does not change what "present" means to this reader."""
     return os.path.exists(os.path.join(root, ".codearbiter", ".markers", "dev-active"))

--- a/core/pysrc/_colorlib.py
+++ b/core/pysrc/_colorlib.py
@@ -20,6 +20,7 @@
 #   clip(s, w) -> str                         truncate to <= w visible columns (ANSI-preserving)
 #   pad(s, w) -> str                          pad/clip to exactly w visible columns
 #   gradient_h(text, width, c_from, c_to) -> str   per-character violet sheen
+#   strip_control(s) -> str                   strip C0 control bytes + OSC/CSI escape sequences
 
 import json
 import os
@@ -110,7 +111,7 @@ def _read_custom(path):
             return None
         value = json.loads(raw.decode("utf-8"))
         return value if isinstance(value, dict) else None
-    except (OSError, UnicodeError, ValueError, TypeError):
+    except (OSError, UnicodeError, ValueError, TypeError, RecursionError):
         return None
 
 
@@ -211,6 +212,26 @@ BOLT = "↯"
 SPARK = "▁▂▃▄▅▆▇█"
 
 ANSI = re.compile(r"\033\[[0-9;]*m")
+
+# Host-controlled strings (a model display name, a subagent's derived label)
+# reach the render path verbatim. Neither the host payload nor a subagent
+# transcript is a trusted source, so any C0 control byte or OSC/CSI escape
+# sequence embedded in one is terminal-escape injection into the user's
+# prompt line — strip it before the string is ever composed into a row.
+_OSC_RE = re.compile(r"\033\][^\007\033]*(?:\007|\033\\)?")
+_CSI_RE = re.compile(r"\033\[[0-?]*[ -/]*[@-~]?")
+_C0_RE = re.compile(r"[\000-\037]")
+
+
+def strip_control(s):
+    """Strip OSC/CSI escape sequences and any remaining C0 control byte
+    (0x00-0x1f) from a host- or transcript-derived string. Non-string input
+    passes through unchanged; this must never raise."""
+    if not isinstance(s, str):
+        return s
+    s = _OSC_RE.sub("", s)
+    s = _CSI_RE.sub("", s)
+    return _C0_RE.sub("", s)
 
 
 def _cw(ch):

--- a/core/pysrc/_githooks.py
+++ b/core/pysrc/_githooks.py
@@ -7,43 +7,56 @@
 # repo-level .git/hooks/pre-commit and pre-push that invoke git-enforce.py at the
 # git operation itself, where spelling no longer matters.
 #
-# Design decisions:
+# Design decisions (ADR-0014, resolves #265 / tribunal reliability-009):
 #   * The shim is a tiny POSIX `sh` script that detects the interpreter ONCE
 #     (python3 else python) and runs the enforcer EXACTLY once — never
 #     `python3 X || python X`, which would (a) swallow a BLOCK when python3 both
 #     exists and blocks, and (b) drain stdin before the fallback (pre-push feeds
 #     the ref list on stdin). Same hazard hooks.json avoids via two entries; a
 #     single hook file must guard it inline.
-#   * The shim points at the enforcer by ABSOLUTE PATH, resolved from THIS file's
-#     location (inside the plugin) at install time. install() is re-run every
-#     SessionStart, so the path is refreshed each session — if a plugin update
-#     moves the install dir, the next session rewrites the shim. During the brief
-#     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
-#     our OWN staleness only — never brick a user's commits because our path
-#     drifted; the pre-bash + Claude layers still apply).
+#   * The shim itself is HOST-NEUTRAL: it embeds no absolute enforcer path at
+#     all. It instead points at a shared, non-versioned drop-in directory
+#     inside the repo's OWN `.git/`:
 #
-#     Accepted residual, dual-host widening (reliability-009 / #265, LOW,
-#     ACCEPT-RISK): with BOTH `ca` and `ca-codex` installed against one repo,
-#     each SessionStart (whichever host ran last) rewrites the shim to point at
-#     THAT plugin's own `_enforcer_path()` — the two hosts manage entirely
-#     separate, independently versioned plugin caches (e.g. Claude Code's
-#     `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`; Codex's
-#     cache root and layout are not fixed by anything in this repo), so the
-#     sibling plugin's absolute enforcer path is NOT reliably derivable from
-#     this file's own path at write time — no path-substitution or fixed
-#     sibling-directory guess survives an independent version bump on either
-#     side. Multiple-candidate embedding (try both known paths) and a runtime
-#     filesystem search (glob likely cache roots from inside the POSIX `sh`
-#     shim) were both considered and rejected: the former requires knowing a
-#     path this file cannot derive, and the latter would mean an unverified,
-#     host-layout-guessing filesystem search on every commit/push under
-#     Windows Git-Bash `sh` — a fragile git-level backstop is worse than the
-#     accepted trade. Net effect: uninstalling whichever plugin most recently
-#     ran SessionStart leaves the shim fail-open until the SURVIVING host's
-#     next SessionStart rewrites it (single-plugin behavior — install()
-#     writing its own current path — is unchanged and unaffected by this
-#     residual). Revisit only if a host-neutral, version-independent enforcer
-#     location becomes available (e.g. a shared non-versioned shim target).
+#         .git/codearbiter-hooksd/<plugin>.path      # e.g. ca.path, ca-codex.path
+#
+#     Each installed host writes its OWN current `_enforcer_path()` into its
+#     own `<plugin>.path` file every SessionStart (install() below) — a live
+#     host self-heals a stale entry on its very next session. The shim iterates
+#     the directory and execs the FIRST enforcer path that resolves (`[ -f "$E" ]`
+#     succeeds); a dead entry from an uninstalled plugin simply fails that test
+#     and the loop moves on to the next one. `uninstall()` removes only ITS OWN
+#     `.path` file — never the shared shim, which a sibling plugin may still
+#     depend on.
+#   * FAIL CLOSED, not fail-open: if the directory is empty, absent, or every
+#     entry it contains names a file that no longer exists, the shim prints a
+#     diagnostic to stderr and exits non-zero — it BLOCKS the git operation
+#     rather than silently allowing it. This is a deliberate reversal of the
+#     single-plugin fail-open era: ADR-0014 records why. Before this drop-in dir
+#     existed, the shim embedded ONE absolute enforcer path (whichever plugin's
+#     SessionStart ran last), so uninstalling that plugin — or even the OTHER
+#     plugin, if IT never got a chance to write its own copy afterward — could
+#     silently unwire the git-level backstop for every host. The drop-in dir
+#     removes the reason fail-open existed (a plugin no longer has to derive a
+#     SIBLING's path — each writes only its own), so the residual failure mode
+#     (truly nothing resolves) can safely — and must — fail closed instead.
+#   * The drop-in directory itself is resolved via the repo's git COMMON dir
+#     (mirrors `git rev-parse --git-common-dir`, resolved without a git spawn
+#     when possible — see `_git_common_dir`), never `--git-dir` and never a
+#     per-worktree path: a linked worktree's `.git` is a FILE pointing at
+#     `<main>/.git/worktrees/<name>`, and the shared hooks/backstop must resolve
+#     to the ONE drop-in dir inside the MAIN repo's `.git/`, so every worktree
+#     and every host agree on the same directory — a per-worktree drop-in dir
+#     would defeat the entire cross-host purpose.
+#   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
+#     so an existing husky / pre-commit-framework setup is preserved.
+#   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
+#     ours-hook is refreshed. Because the shim no longer embeds any
+#     plugin-specific path, an enforcer-path change (e.g. a version bump moving
+#     the install dir) does NOT by itself require rewriting the shim file — only
+#     this plugin's own `<plugin>.path` drop-in entry, which install() refreshes
+#     unconditionally every session regardless of whether the shim itself needed
+#     a rewrite.
 #   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
@@ -146,17 +159,132 @@ def _enforcer_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-enforce.py")
 
 
-def _shim(enforcer, phase):
-    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK exit
-    # code. `exit 0` when the enforcer file is absent is deliberate fail-open on
-    # our own path staleness (see module header).
+def _plugin_name():
+    """A stable per-plugin identifier for THIS install's drop-in `.path`
+    filename (ADR-0014) — derived from THIS file's own vendored location,
+    exactly the same directory `_enforcer_path()` already anchors on:
+    `.../plugins/<plugin>/hooks/_githooks.py` -> `<plugin>` (e.g. "ca",
+    "ca-codex"). No plugin ever has to know a SIBLING's name or path — each
+    only ever writes its own `<plugin>.path` entry, using its own directory
+    name as the key. Running the unsynced `core/pysrc/_githooks.py` directly
+    (dev-only; tests always import the vendored copy) walks one level higher
+    than a real install and yields a less meaningful name, but still a stable,
+    non-empty one — never a hard failure."""
+    hooks_dir_path = os.path.dirname(os.path.abspath(__file__))
+    plugin_dir = os.path.dirname(hooks_dir_path)
+    return os.path.basename(plugin_dir) or "plugin"
+
+
+_DROPIN_DIRNAME = "codearbiter-hooksd"
+
+
+def _git_common_dir(root):
+    """The directory `git rev-parse --git-common-dir` would report for
+    `root` — resolved WITHOUT a git spawn whenever the on-disk layout is
+    cheaply readable, falling back to a real git spawn only when it isn't.
+
+    Deliberately mirrors --git-common-dir, NOT --git-dir: a linked worktree's
+    `.git` is a FILE (not a directory) holding a `gitdir: <path>` pointer into
+    `<main>/.git/worktrees/<name>`, and THAT directory in turn holds a
+    `commondir` file naming the real, SHARED main `.git`. Every worktree of a
+    repo must resolve to the SAME common dir here, or the #265 drop-in dir
+    would fork per-worktree and defeat the entire cross-host purpose (a shim
+    installed from worktree A would never see an entry written from
+    worktree B). The main-repo case (`.git` is a directory) needs no spawn at
+    all: it IS its own common dir. Returns None if nothing resolves — callers
+    must treat that as "can't place the drop-in dir right now" and never
+    invent a per-worktree fallback."""
+    git_path = os.path.join(root, ".git")
+    if os.path.isdir(git_path):
+        return os.path.abspath(git_path)
+    if os.path.isfile(git_path):
+        text = _read(git_path)
+        if text:
+            for line in text.splitlines():
+                line = line.strip()
+                if line.lower().startswith("gitdir:"):
+                    wt_gitdir = line.split(":", 1)[1].strip()
+                    if not os.path.isabs(wt_gitdir):
+                        wt_gitdir = os.path.normpath(os.path.join(root, wt_gitdir))
+                    cd_text = _read(os.path.join(wt_gitdir, "commondir"))
+                    if cd_text:
+                        cd = cd_text.strip()
+                        common = (cd if os.path.isabs(cd)
+                                  else os.path.normpath(os.path.join(wt_gitdir, cd)))
+                        return os.path.abspath(common)
+                    break
+    r = _git(["rev-parse", "--git-common-dir"], root)
+    if r is not None and r.returncode == 0 and r.stdout.strip():
+        out = r.stdout.strip()
+        return os.path.abspath(out if os.path.isabs(out) else os.path.join(root, out))
+    return None
+
+
+def _dropin_dir(root):
+    """The shared, non-versioned drop-in directory (ADR-0014) each installed
+    host writes its own `<plugin>.path` entry into. Lives inside the repo's
+    git COMMON dir (never a per-worktree one — see `_git_common_dir`) so
+    every worktree and every host share exactly ONE directory. Returns None
+    when the common dir itself can't be resolved (no git dir at all)."""
+    common = _git_common_dir(root)
+    return os.path.join(common, _DROPIN_DIRNAME) if common else None
+
+
+def _path_entry_file(dropin_dir, plugin):
+    return os.path.join(dropin_dir, f"{plugin}.path")
+
+
+def _path_entry_current(dropin_dir, plugin, enforcer):
+    """True iff this plugin's own drop-in entry already names `enforcer`."""
+    existing = _read(_path_entry_file(dropin_dir, plugin))
+    return existing is not None and existing.strip() == enforcer
+
+
+def _write_path_entry(dropin_dir, plugin, enforcer):
+    """Best-effort (never fatal) write/refresh of this plugin's OWN
+    `<plugin>.path` drop-in entry — the self-heal half of ADR-0014: a live
+    host rewrites its own entry every SessionStart regardless of whether the
+    shared shim itself needed any change, so a stale entry from a version
+    bump never outlives one session on a live install."""
+    if _path_entry_current(dropin_dir, plugin, enforcer):
+        return True
+    try:
+        os.makedirs(dropin_dir, exist_ok=True)
+        _hooklib.write_text_atomic(
+            _path_entry_file(dropin_dir, plugin), enforcer + "\n", newline="\n")
+        return True
+    except Exception as e:  # noqa: BLE001
+        _warn(f"could not write drop-in enforcer entry for '{plugin}' at {dropin_dir}: {e}")
+        return False
+
+
+def _shim(dropin_dir, phase):
+    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK
+    # exit code. The shim is HOST-NEUTRAL (ADR-0014): it embeds no plugin-
+    # specific enforcer path, only the shared drop-in directory. It iterates
+    # every "*.path" entry there and execs the FIRST enforcer that resolves
+    # (`[ -f "$E" ]`); a dead entry from an uninstalled plugin just fails that
+    # test and the loop tries the next one. An unmatched glob (dir absent or
+    # empty) leaves `c` as the literal, un-expanded "$D/*.path" string in
+    # POSIX `sh` — `[ -f "$c" ]` on that literal correctly fails too, so the
+    # loop falls straight through to the same fail-closed tail with no special
+    # case needed. When NOTHING resolves, this now FAILS CLOSED: a loud
+    # stderr diagnostic and a non-zero exit, blocking the git operation,
+    # rather than the old single-plugin era's `exit 0`.
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
-        f'E="{enforcer}"\n'
-        '[ -f "$E" ] || exit 0\n'
+        f'D="{dropin_dir}"\n'
         'if python3 -c "" 2>/dev/null; then PY=python3; else PY=python; fi\n'
-        f'exec "$PY" "$E" {phase}\n'
+        'for c in "$D"/*.path; do\n'
+        '  [ -f "$c" ] || continue\n'
+        '  E=$(cat "$c" 2>/dev/null) || continue\n'
+        f'  [ -f "$E" ] && exec "$PY" "$E" {phase}\n'
+        'done\n'
+        'echo "codeArbiter: no registered git-enforce.py could be resolved from '
+        '\\"$D\\" -- failing CLOSED (#161/#265 git backstop, ADR-0014). Reinstall '
+        'codeArbiter, or check .git/codearbiter-hooksd/*.path entries." >&2\n'
+        'exit 1\n'
     )
 
 
@@ -297,18 +425,26 @@ def _write_hooks_dir_cache(root, hd):
         pass
 
 
-def _hooks_current(hd, enforcer):
+def _hooks_current(hd, dropin_dir):
     """True iff BOTH phase shims at `hd` already match what install() would
-    write right now for `enforcer` — i.e. install() would be a complete no-op.
-    Filesystem-only (no git spawn): this is exactly the check that lets
-    install() skip the git-config/rev-parse re-probe when a prior session
-    already installed current hooks. A foreign (non-sentinel) hook, a stale
-    shim, or a missing file all correctly return False here, falling the
-    caller through to the full probe (which then re-derives the right action:
-    refresh, warn-and-preserve, or install fresh)."""
+    write right now for `dropin_dir` — i.e. install() would be a complete
+    no-op for the SHIM files themselves. Filesystem-only (no git spawn): this
+    is exactly the check that lets install() skip the git-config/rev-parse
+    re-probe when a prior session already installed current hooks. A foreign
+    (non-sentinel) hook, a stale shim, or a missing file all correctly return
+    False here, falling the caller through to the full probe (which then
+    re-derives the right action: refresh, warn-and-preserve, or install
+    fresh).
+
+    Note (ADR-0014): the shim is host-neutral — it depends only on
+    `dropin_dir` (repo-derived, stable across plugin versions), never on this
+    plugin's own enforcer path. So a plugin-version bump that only changes
+    `_enforcer_path()` does NOT make this return False; install() refreshes
+    the plugin's OWN drop-in `.path` entry unconditionally every call,
+    independent of whether this check short-circuits the shim-file rewrite."""
     for phase in PHASES:
         existing = _read(os.path.join(hd, phase))
-        if existing is None or existing != _shim(enforcer, phase):
+        if existing is None or existing != _shim(dropin_dir, phase):
             return False
     return True
 
@@ -338,21 +474,32 @@ def install(root):
          after the cache was written — e.g. adopting husky / pre-commit-
          framework — silently left the NEW hooks dir unwired while returning
          `[]`);
-      4. the shims at that dir are already current for the CURRENT enforcer
-         path (_hooks_current).
-    Any single miss/mismatch — including a genuine cold install, a moved
-    plugin path, a foreign hook, a changed core.hooksPath, or ambiguity in the
-    config read — falls through to the original git-based probe below,
-    unchanged. Fail direction is "install when unsure," never "skip when
-    unsure"."""
+      4. the shims at that dir are already current for the drop-in dir
+         (_hooks_current — ADR-0014: the shim depends only on `dropin_dir`,
+         never on this plugin's own enforcer path).
+    Any single miss/mismatch — including a genuine cold install, a foreign
+    hook, a changed core.hooksPath, or ambiguity in the config read — falls
+    through to the original git-based probe below, unchanged. Fail direction
+    is "install when unsure," never "skip when unsure".
+
+    ADR-0014: regardless of which path this function takes (fast path or full
+    probe), THIS plugin's own drop-in `<plugin>.path` entry is refreshed
+    every single call — a live host self-heals a stale entry (e.g. after a
+    version bump moved `_enforcer_path()`) every SessionStart, independent of
+    whether the shared shim FILE itself needed any rewrite."""
+    plugin = _plugin_name()
     enforcer = _enforcer_path()
+    dropin_dir = _dropin_dir(root)
+    if dropin_dir is None:
+        return []  # no resolvable git dir at all — nothing to install against
     cached_hd = _cached_hooks_dir(root)
     if cached_hd is not None:
         default_hd = os.path.normcase(os.path.abspath(_default_hooks_dir(root)))
         cached_norm = os.path.normcase(os.path.abspath(cached_hd))
         if (cached_norm == default_hd
                 and _confirmed_no_local_hooks_path(root)
-                and _hooks_current(cached_hd, enforcer)):
+                and _hooks_current(cached_hd, dropin_dir)):
+            _write_path_entry(dropin_dir, plugin, enforcer)
             return []
     hd = hooks_dir(root)
     if not hd:
@@ -365,7 +512,7 @@ def install(root):
     actions = []
     for phase in PHASES:
         dest = os.path.join(hd, phase)
-        desired = _shim(enforcer, phase)
+        desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
             if existing is not None and SENTINEL not in existing:
@@ -392,26 +539,35 @@ def install(root):
     # Cache the resolved location so the NEXT call can skip the git-config/
     # rev-parse re-probe entirely (performance-002) — best-effort, never fatal.
     _write_hooks_dir_cache(root, hd)
+    # ADR-0014: refresh THIS plugin's own drop-in entry every call, whether or
+    # not the shim files above needed a rewrite.
+    if _write_path_entry(dropin_dir, plugin, enforcer):
+        pass
     return actions
 
 
 def uninstall(root):
-    """Remove ONLY codeArbiter-managed hooks (identified by the sentinel);
-    a foreign hook is left in place. Returns the actions taken."""
-    hd = hooks_dir(root)
-    if not hd:
+    """Remove ONLY this plugin's OWN drop-in `<plugin>.path` entry (ADR-0014).
+
+    Deliberately does NOT touch the shared shim file (.git/hooks/pre-commit /
+    pre-push) — that shim is host-neutral and a sibling plugin may still
+    depend on it. Leaving a genuinely EMPTY drop-in dir behind (every plugin
+    uninstalled) is the intended fail-closed contract, not a bug: the next
+    commit finds no resolvable enforcer and blocks with a clear diagnostic
+    (see `_shim`'s tail), rather than the old single-plugin era silently
+    passing. Returns the actions taken."""
+    plugin = _plugin_name()
+    dropin_dir = _dropin_dir(root)
+    if dropin_dir is None:
         return []
-    actions = []
-    for phase in PHASES:
-        dest = os.path.join(hd, phase)
-        existing = _read(dest)
-        if existing is not None and SENTINEL in existing:
-            try:
-                os.remove(dest)
-                actions.append(f"{phase}: removed")
-            except Exception as e:  # noqa: BLE001
-                _warn(f"could not remove {dest}: {e}")
-    return actions
+    entry = _path_entry_file(dropin_dir, plugin)
+    if os.path.isfile(entry):
+        try:
+            os.remove(entry)
+            return [f"{plugin}.path: removed"]
+        except Exception as e:  # noqa: BLE001
+            _warn(f"could not remove {entry}: {e}")
+    return []
 
 
 if __name__ == "__main__":

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -57,6 +57,19 @@
 #   is_context_md(rel) -> bool            True iff rel is the CONTEXT.md activation file (#159)
 #   is_marker_path(rel) -> bool           True iff rel is under .codearbiter/.markers/ (#160)
 #   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
+#   is_sensitive_scan_exempt(rel) -> bool  True iff rel is exempt from the H-09b/H-10b
+#                                         crypto/secret scan (gate-events.log only, #279)
+#   SECURITY_DIFF_GIT_ARGS                pinned `git diff` argv suffix (fixed a/ b/
+#                                         prefixes, no external diff) every H-09b/H-10b
+#                                         sensitive-line reader MUST use (#279 review)
+#   diff_added_lines(diff_text) -> list[tuple[str|None, str]]  path-aware walk of a unified
+#                                         diff's added ('+') lines (from SECURITY_DIFF_GIT_ARGS
+#                                         output), paired with the destination path each
+#                                         belongs to, attributed from `+++ b/<path>` via a
+#                                         fixed-prefix strip within an unspoofable `diff `
+#                                         section (#279 review)
+#   sensitive_scan_added_lines(diff_text) -> list[str]  diff_added_lines() narrowed to the
+#                                         H-09b/H-10b candidate set (exempt paths dropped)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
 #   acquire_lock(path) -> handle|None     OS-owned cross-process file lock (#271 C-2);
@@ -360,6 +373,182 @@ def classify_protected(fpath, root):
         if is_marker_path(p):
             hits.add("marker")
     return hits
+
+
+# Sensitive-scan exemption (H-09b/H-10b, #279). gate-events.log is the durable
+# BLOCK/REMIND/WARN sink block()/remind()/warn() append to (observability-001,
+# #186) — it is machine-written, never source code, and structurally
+# guaranteed to echo the crypto/secret detector's OWN message text back at
+# itself the moment the gate ever fires a crypto/secret REMIND (e.g. "Crypto/
+# TLS pattern detected" itself matches CRYPTO_RE). That makes it a permanent,
+# self-perpetuating false positive with zero disclosure value: nothing
+# written there is a genuine crypto/secret USE, only a report ABOUT one.
+# Deliberately narrow — overrides.log/triage.log/sprint-log.md stay IN SCOPE:
+# they carry human-written prose (an override reason, a triage note) that
+# COULD legitimately contain a leaked secret worth catching. This set is
+# anchored on the REPO-RELATIVE PATH a line belongs to, never a substring
+# match on the line's own text — a secret cannot escape the scan by merely
+# mentioning gate-events.log on its line; only lines that actually LIVE in
+# that file are exempt.
+SENSITIVE_SCAN_EXEMPT_RELPATHS = frozenset({".codearbiter/gate-events.log"})
+
+
+def is_sensitive_scan_exempt(rel):
+    """True iff `rel` (a repo-relative path, as attributed by `diff_added_
+    lines` or as returned by a bare `git ls-files` listing) names a file
+    exempt from the H-09b/H-10b crypto/secret scan. The ONE predicate both
+    the diff walk and the untracked/unborn-branch file listings route
+    through (#279 review LOW) — deliberately strict: no case-folding, no
+    `./`/`//` collapsing. An identifier that isn't an exact, `norm_path`'d
+    match resolves toward IN SCOPE (not exempt), which is the safe
+    direction. See SENSITIVE_SCAN_EXEMPT_RELPATHS."""
+    return norm_path(rel) in SENSITIVE_SCAN_EXEMPT_RELPATHS
+
+
+# Every H-09b/H-10b sensitive-line reader (security-pass.py, pre-bash.py,
+# git-enforce.py) MUST run `git diff` through this pinned argv, never a bare
+# `["diff", ...]` (#279 review MEDIUM-1). Two independent user/global git
+# config knobs change the destination-path prefix `diff_added_lines` below
+# depends on: `diff.mnemonicPrefix=true` emits `c/`/`w/`/`i/`/`o/` instead of
+# `a/`/`b/`, and `diff.noprefix=true` emits no prefix at all. Either one, left
+# unpinned, silently un-exempts the REAL gate-events.log for any dev/CI runner
+# with that config set — bringing back the exact self-DoS this whole change
+# exists to close. `-c` overrides win over any config file (including repo,
+# global, and system config), so pinning both flags to false here forces the
+# standard `a/`/`b/` prefixes regardless of the caller's environment.
+# `--no-ext-diff` additionally blocks a configured `GIT_EXTERNAL_DIFF` /
+# `diff.external` from replacing git's own unified-diff output with something
+# this parser was never designed to read. Centralized so a call site cannot
+# forget to pin it (that was exactly how this hole would keep reopening).
+SECURITY_DIFF_GIT_ARGS = (
+    "-c", "diff.mnemonicPrefix=false", "-c", "diff.noprefix=false",
+    "diff", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/",
+)
+
+# The fixed-width destination-path prefix `diff_added_lines` strips off a
+# preamble `+++ ` line. MUST be a fixed-length slice, never a search for a
+# separator: a greedy/`.+`-based parse of "diff --git a/<path> b/<path>" (the
+# prior approach) resolves ambiguously when <path> itself contains " b/" —
+# e.g. a real repo path `x b/.codearbiter/gate-events.log` renders that
+# header as `diff --git a/x b/.codearbiter/gate-events.log b/x
+# b/.codearbiter/gate-events.log`, and a greedy match backtracks group(1) to
+# `.codearbiter/gate-events.log`, exempting the WHOLE unrelated source file
+# (#279 review HIGH — reproduced end-to-end: an md5() call and a committed
+# password both passed H-09b with no marker). Stripping a FIXED 6-character
+# prefix has no such ambiguity: `"+++ b/x b/.codearbiter/gate-events.log"[6:]`
+# is unconditionally `"x b/.codearbiter/gate-events.log"`, the correct full
+# path, no matter what the path itself contains.
+_PLUS_B_PREFIX = "+++ b/"
+_PLUS_DEV_NULL = "+++ /dev/null"
+
+
+def diff_added_lines(diff_text):
+    """Added (`+`) lines of a unified `git diff`-style text (produced via
+    SECURITY_DIFF_GIT_ARGS — pinned `a/`/`b/` prefixes, no external diff), as
+    `(path, line)` tuples — a PATH-AWARE walk so a caller can exclude lines by
+    the FILE they live in, never by matching the line's own text (which a
+    hidden secret could otherwise dodge by naming the excluded file).
+
+    Two-phase state machine per file section, `path`/`in_hunk`/`seen_section`:
+
+    1. A bare, UNPREFIXED `diff ` line (`diff --git`, `diff --cc`, `diff
+       --combined`, ...) starts a new section: `path` resets to `None` and
+       `in_hunk` resets to False. Content can NEVER forge this line at column
+       0 — every diff-body line (context/added/removed) carries a leading
+       ' '/'+'/'-'/'\\' character, so a file whose own content is literally
+       "diff --git a/x b/y" renders as "+diff --git a/x b/y" (added), never as
+       a bare match. Resetting `path` to None (not inheriting the PREVIOUS
+       section's path) on ANY `diff ` spelling matters for combined/merge
+       diffs (#279 review MEDIUM-2): git-enforce.py's `git diff --cached` at a
+       merge commit emits `diff --cc <path>` sections, which the prior
+       `diff --git`-only reset missed, letting a `--cc` section's added lines
+       silently inherit whatever path the section before it had — failing
+       toward EXEMPTION if that was gate-events.log.
+    2. While NOT yet `in_hunk` (the section's preamble, before its first `@@`
+       / `@@@` hunk header), a `+++ b/<path>` line sets `path` by stripping
+       the FIXED 6-character prefix `_PLUS_B_PREFIX` — never a regex search
+       for a separator (see `_PLUS_B_PREFIX`'s comment for the ambiguity a
+       greedy `diff --git` parse had). `+++ /dev/null` (a deleted
+       destination) sets `path` back to None explicitly — no added lines are
+       expected in a deletion's hunk body anyway. Every other preamble line
+       (`--- a/<path>`, `index ...`, `new/deleted file mode`, `rename
+       from/to`, `similarity index`, `Binary files ... differ`) is inert
+       noise. A `+++ b/...`-shaped line can ONLY be trusted here, before the
+       section's first `@@`: once `in_hunk` is True, an apparently identical
+       `+++ b/...` string is body CONTENT (it carries the hunk body's own
+       leading `+`, i.e. the underlying source line was "++ b/..." or "+++
+       b/..." before diff-prefixing) and is captured as an added line like any
+       other, never re-parsed as an attribution header (closes the #279
+       review's own earlier finding: an added content line forging `+++
+       b/<path>` used to hijack attribution for the rest of the file).
+    3. Once `in_hunk`, `+`-prefixed lines are collected as `(path, content)`;
+       `-`/` `/`\\` (no-newline-marker) lines are skipped; anything else ends
+       the hunk (not producible by well-formed `git diff` output there, but
+       handled rather than guessed at).
+
+    FAILS SAFE: a `+` line seen before ANY `diff ` section header at all (not
+    producible by real `git diff` output) is attributed to `path=None` and
+    STILL COLLECTED, never silently dropped. `sensitive_scan_added_lines`
+    treats an unattributed (`None`) path as NOT exempt — in scope for
+    scanning. Exempting, or discarding, an unattributable line would be the
+    dangerous direction; over-scanning only risks a false positive, the
+    harmless failure mode here.
+
+    The shared primitive behind the H-09b/H-10b crypto/secret gate's producer
+    (security-pass.py) and both consumers (pre-bash.py, git-enforce.py) —
+    implemented once here so the gate-events.log exemption can never drift
+    between the three independent line-collectors that used to each do their
+    own flat `[ln[1:] for ln in text.splitlines() if ln.startswith("+") ...]`
+    walk with no path information (and no forgery-resistance) at all."""
+    path = None
+    in_hunk = False
+    seen_section = False  # True once the first `diff ` section header is seen
+    out = []
+    for line in diff_text.splitlines():
+        if line.startswith("diff "):
+            path = None
+            in_hunk = False
+            seen_section = True
+            continue
+        if line.startswith("@@"):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            if not seen_section:
+                # No `diff ` section header seen yet at all: not producible
+                # by real `git diff` output. Fail SAFE (see docstring) rather
+                # than silently dropping a line that cannot be confidently
+                # classed as header noise either.
+                if line.startswith("+"):
+                    out.append((None, line[1:]))
+                continue
+            # Section preamble: only a genuine `+++ b/<path>` (or `+++
+            # /dev/null`) line here can set `path` — see point 2 above.
+            if line.startswith(_PLUS_B_PREFIX):
+                path = line[len(_PLUS_B_PREFIX):]
+            elif line == _PLUS_DEV_NULL:
+                path = None
+            continue
+        if line.startswith("+"):
+            out.append((path, line[1:]))
+        elif line.startswith(("-", " ", "\\")):
+            pass  # removed / context / "\ No newline at end of file"
+        else:
+            # Not producible by well-formed `git diff` output (a hunk body
+            # line is always one of the four prefixes above); treat it as the
+            # hunk having ended rather than guessing.
+            in_hunk = False
+    return out
+
+
+def sensitive_scan_added_lines(diff_text):
+    """`diff_added_lines(diff_text)` narrowed to the H-09b/H-10b crypto/secret
+    scan's candidate set: every added line EXCEPT those belonging to a
+    sensitive-scan-exempt path (currently only gate-events.log). Call this
+    instead of a raw `+`-line filter anywhere the crypto/secret scan reads a
+    diff, so the exemption is applied uniformly."""
+    return [ln for path, ln in diff_added_lines(diff_text)
+            if not (path and is_sensitive_scan_exempt(path))]
 
 
 def utf8_stdio():

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -59,6 +59,10 @@
 #   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
+#   acquire_lock(path) -> handle|None     OS-owned cross-process file lock (#271 C-2);
+#                                         non-blocking + bounded LOCK_WAIT retry spin,
+#                                         fail-soft None on contention/timeout/OSError
+#   release_lock(handle) -> None          release + close; None handle is a no-op
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -91,6 +95,15 @@ _GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
+
+# Bounded best-effort wait for another cross-process writer to release
+# acquire_lock()'s sidecar lock file (#271 C-2). Originally _ledgerlib-private
+# (the statusline's cost/token ledger); hoisted here so taskwrite.py's board
+# writer (a second, genuinely different caller) can share ONE lock
+# implementation instead of a second hand-rolled copy. _ledgerlib re-exports
+# this name (`from _hooklib import LOCK_WAIT`) so its own module-level
+# mock.patch.object(L, "LOCK_WAIT", ...) test seam keeps working unchanged.
+LOCK_WAIT = 0.2
 
 
 def _is_lock_contention(exc):
@@ -750,6 +763,74 @@ def write_text_atomic(path, text, newline=None):
         raise
 
 
+def acquire_lock(path):
+    """Acquire an OS-owned cross-process file lock keyed on `path`; process
+    death releases it automatically (#271 C-2 — hoisted from the
+    statusline-ledger-only `_ledgerlib._acquire_lock`, now shared with
+    taskwrite.py's board writer).
+
+    Sidecar lock file `f"{abspath(path)}.lock"`, opened `"a+b"` and seeded
+    with one byte so the OS byte-range lock has a byte to lock (an empty file
+    has no range to range-lock). Non-blocking (`msvcrt.locking(..., LK_NBLCK,
+    1)` on Windows, `fcntl.flock(..., LOCK_EX | LOCK_NB)` elsewhere) with a
+    bounded `LOCK_WAIT`-second retry spin; any `OSError` opening the lock file,
+    or exhausting the deadline still contended, is FAIL-SOFT: returns `None`
+    rather than raising or blocking indefinitely. Callers decide what
+    "fail-soft" means for them — `_ledgerlib.ledger_update`/`persist_sess_start`
+    treat `None` as a disposable no-op (a statusline render is throwaway), but
+    `taskwrite.py` treats it as a hard error (a board write is NOT disposable;
+    see its module docstring)."""
+    lock_path = f"{os.path.abspath(path)}.lock"
+    parent = os.path.dirname(lock_path)
+    try:
+        os.makedirs(parent, exist_ok=True)
+        handle = open(lock_path, "a+b")
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+    except OSError:
+        return None
+    deadline = time.monotonic() + LOCK_WAIT
+    while True:
+        try:
+            handle.seek(0)
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except (OSError, BlockingIOError):
+            if time.monotonic() >= deadline:
+                handle.close()
+                return None
+            time.sleep(0.005)
+
+
+def release_lock(handle):
+    """Release + close a handle from acquire_lock(). None is a no-op —
+    callers that never got the lock don't need to guard the release call."""
+    if handle is None:
+        return
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
 def marker_fresh(path, minutes):
     """True if the marker file exists and was touched within `minutes`."""
     try:
@@ -875,6 +956,16 @@ def warn(msg):
 # override.md) with no analogous "still in progress" marker anywhere in the
 # framework, so per CONFIRM-09's own "do not invent new state" constraint it
 # is not tracked here — there is no existing signal to detect it from.
+#
+# #271 C-5: this staleness WARN is presence + age based (marker mtime vs. an
+# audit-log write), which is unaffected by session-start.py's newer
+# session-scoped CLEARING decision for the SAME dev-active marker — the two
+# consumers ask different questions ("has this sat around too long with no
+# matching log activity?" vs. "am I sure enough this belongs to nobody live
+# right now that I should force-close it?") and neither needs to agree with
+# the other's answer. A dev marker owned by a still-live different session
+# can legitimately trip THIS warning (it really has been open a while) even
+# though session-start.py correctly declines to clobber it.
 _STALE_FLOWS = (
     # (flow name, marker path parts, expected-log path parts)
     ("dev", (".markers", "dev-active"), ("overrides.log",)),

--- a/core/pysrc/_ledgerlib.py
+++ b/core/pysrc/_ledgerlib.py
@@ -29,14 +29,26 @@
 import hashlib
 import json
 import os
+import sys
 import time
 from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
+# taskwrite.py's board writer can share ONE lock implementation instead of a
+# second hand-rolled copy. Re-exported under their ORIGINAL private names so
+# this module's own call sites (ledger_update/persist_sess_start) and the test
+# suite's `mock.patch.object(L, "_acquire_lock", ...)` / `mock.patch.object(L,
+# "LOCK_WAIT", ...)` seams keep working unchanged — no import-cycle risk:
+# _hooklib imports only hostapi, never _ledgerlib.
+from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
+from _hooklib import release_lock as _release_lock  # noqa: E402
+from _hooklib import LOCK_WAIT  # noqa: E402
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
-LOCK_WAIT = 0.2          # bounded best-effort wait for another statusline writer
 
 # API list prices, USD per 1M tokens (captured 2026-06-10 from Anthropic's
 # pricing pages). Used ONLY to estimate the pay-as-you-go API-equivalent cost of
@@ -148,57 +160,6 @@ def _atomic_json(path, value):
                 os.remove(tmp)
             except OSError:
                 pass
-
-
-def _acquire_lock(path):
-    """Acquire an OS-owned file lock; process death releases it automatically."""
-    lock_path = f"{os.path.abspath(path)}.lock"
-    parent = os.path.dirname(lock_path)
-    try:
-        os.makedirs(parent, exist_ok=True)
-        handle = open(lock_path, "a+b")
-        handle.seek(0, os.SEEK_END)
-        if handle.tell() == 0:
-            handle.write(b"\0")
-            handle.flush()
-    except OSError:
-        return None
-    deadline = time.monotonic() + LOCK_WAIT
-    while True:
-        try:
-            handle.seek(0)
-            if os.name == "nt":
-                import msvcrt
-                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-            else:
-                import fcntl
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return handle
-        except (OSError, BlockingIOError):
-            if time.monotonic() >= deadline:
-                handle.close()
-                return None
-            time.sleep(0.005)
-
-
-def _release_lock(handle):
-    if handle is None:
-        return
-    try:
-        handle.seek(0)
-        if os.name == "nt":
-            import msvcrt
-            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-    except OSError:
-        pass
-    finally:
-        try:
-            handle.close()
-        except OSError:
-            pass
 
 
 def _session_dir(path):

--- a/core/pysrc/_subagentslib.py
+++ b/core/pysrc/_subagentslib.py
@@ -23,6 +23,15 @@ import os
 import re
 import time
 
+try:
+    import _colorlib
+    strip_control = _colorlib.strip_control
+except Exception:  # pragma: no cover — never let an import break the statusline
+    _colorlib = None
+
+    def strip_control(s):
+        return s if not isinstance(s, str) else re.sub(r"[\000-\037]", "", s)
+
 ACTIVE_WINDOW = 150       # secs: a subagent file touched this recently is "active"
 SHOW_WINDOW = 600         # secs: still display recently-finished subagents
 MAX_SUB_ROWS = 4
@@ -34,7 +43,7 @@ def display_model(model_id):
     """Compact a host model ID while retaining its family and version."""
     if not isinstance(model_id, str):
         return "model:?"
-    name = model_id.strip()
+    name = strip_control(model_id).strip()
     if not name:
         return "model:?"
     if name.startswith("claude-"):
@@ -170,7 +179,7 @@ def sub_label(content):
             if isinstance(blk, str):
                 text = blk
                 break
-    raw = str(text)
+    raw = strip_control(str(text))
     # strip leading reminder/system blocks up front (multi-line safe), then a lone tag
     raw = re.sub(r"^\s*(?:<([^>\s]+)[^>]*>.*?</\1>\s*)+", "", raw, flags=re.S)
     raw = re.sub(r"^\s*<[^>]+>\s*", "", raw)

--- a/core/pysrc/git-enforce.py
+++ b/core/pysrc/git-enforce.py
@@ -11,9 +11,10 @@
 #
 # It mirrors pre-bash.py's commit/push gates and reuses the SAME detection
 # primitives from _hooklib (CRYPTO_RE / SECRET_RE / line_digest / content_digest
-# / is_migration_path / marker_fresh), so the two enforcement points can never
-# drift on what counts as sensitive or as a migration, or on how a gate-pass
-# marker binds to the lines it approved.
+# / is_migration_path / marker_fresh / sensitive_scan_added_lines), so the two
+# enforcement points can never drift on what counts as sensitive or as a
+# migration, on how a gate-pass marker binds to the lines it approved, or on
+# which path (gate-events.log, #279) is exempt from the sensitive-line scan.
 #
 # Contract: a git hook aborts its operation on ANY non-zero exit, so a BLOCK is
 # exit 1 with a loud stderr message. Exit 0 allows. The security/migration scans
@@ -27,8 +28,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, set_host, utf8_stdio,
+    CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, arbiter_active,
+    content_digest, is_migration_path, line_digest, marker_fresh,
+    sensitive_scan_added_lines, set_host, utf8_stdio,
 )
 
 
@@ -144,12 +146,23 @@ def head_on_protected_tip(cwd):
 def cached_added_lines(cwd):
     """Added (`+`) lines of the staged diff — exactly what a commit records
     (including `commit -a` sweeps, which git has already staged by pre-commit
-    time). None on a git read error → caller fails closed."""
-    r = _git(["diff", "--cached"], cwd)
+    time). None on a git read error -> caller fails closed.
+
+    Excludes gate-events.log (#279): `sensitive_scan_added_lines` walks the
+    diff path-aware, dropping lines that belong to the crypto/secret gate's
+    own machine-written audit sink, so this backstop's view of "sensitive
+    lines" never drifts from the producer (security-pass.py) or the
+    PreToolUse gate (pre-bash.py) — see the shared helper's docstring in
+    `_hooklib`. Reads the diff via SECURITY_DIFF_GIT_ARGS (pinned a/ b/
+    prefixes, no external diff) so a hostile `diff.mnemonicPrefix`/
+    `diff.noprefix`/external-diff config can never break that attribution
+    (#279 review MEDIUM-1) — a merge commit's `--cc` combined-diff sections
+    are also handled correctly (MEDIUM-2): the diff walk resets attribution on
+    ANY `diff ` section header, not just `diff --git`."""
+    r = _git([*SECURITY_DIFF_GIT_ARGS, "--cached"], cwd)
     if r is None or r.returncode != 0:
         return None
-    return [ln[1:] for ln in r.stdout.splitlines()
-            if ln.startswith("+") and not ln.startswith("+++")]
+    return sensitive_scan_added_lines(r.stdout)
 
 
 def cached_names(cwd):

--- a/core/pysrc/pre-bash.py
+++ b/core/pysrc/pre-bash.py
@@ -260,6 +260,43 @@ GATE_MARKER_WRITE_RE = re.compile(
     r"|Move-Item|Copy-Item|Clear-Content|Set-Content|Out-File|Add-Content)\b"
     r"[^|;&]*" + GATE_MARKER, re.I,
 )
+# #237: an arbitrary interpreter invocation is a flank the verb list above
+# cannot see — `python -c "open('.markers/security-gate-passed','w')..."`
+# reuses the sanctioned producer's own public helpers to self-compute valid
+# digests, and no mv/cp/tee/sed spelling ever appears on the command line.
+# Interpreter one-liners get their OWN, wider regex rather than joining the
+# verb list above: the payload is a single quoted string handed to the
+# interpreter, and that string may itself contain `;` as a statement
+# separator (`python -c "x=1; open(...security-gate-passed...)"`). The
+# `[^|;&]*` bound on GATE_MARKER_WRITE_RE exists to keep a write verb from
+# reaching across an UNRELATED shell-chained command; applying that same
+# bound here would stop scanning at the interpreter's OWN internal `;` and
+# silently reopen exactly the hole this closes. There is no reliable way to
+# tell a chained shell command from a `;`-separated statement inside an
+# opaque interpreter string without full shell/language tokenization, so
+# this guard fails CLOSED: any command line invoking one of these
+# interpreters that ALSO names a gate marker anywhere on the line is
+# blocked, whether the marker is written or merely read. A read of a gate
+# marker has no legitimate reason to go through a raw interpreter one-liner
+# either (cat/grep already pass the audit-log flanks above untouched).
+#
+# review finding (post-B-2): a `-c`/`-e` payload is ordinary multi-line
+# source — the interpreter token and the marker path can sit on different
+# physical lines of the SAME invocation (`python -c "\nopen('...security-
+# gate-passed'...)\n"`). `[^\n]*` cannot cross that newline, leaving the
+# identical attack open in its multi-line spelling. `[\s\S]*` (DOTALL-
+# equivalent) closes it. This regex is applied to the heredoc-stripped
+# `git_view` at the call site below, gated on `heredoc_shell_fallback` for
+# the raw-`cmd` leg exactly like the commit/push/add guards already are —
+# scanning the raw, unstripped `cmd` unconditionally would make crossing
+# newlines here false-trip on inert PROSE inside a heredoc body fed to a
+# non-shell consumer (`gh pr create --body "$(cat <<EOF … a python -c
+# one-liner wrote .markers/security-gate-passed … EOF)"` — a PR/issue body
+# merely DESCRIBING this very fix), the same D-3 (#223) distinction the
+# other guards already draw.
+GATE_MARKER_INTERP_RE = re.compile(
+    r"\b(python3?|node|perl|ruby|sh)\b[\s\S]*" + GATE_MARKER, re.I,
+)
 
 
 def git_cwd(cmd, root):
@@ -888,12 +925,28 @@ def _run(root):
 
     # H-19: the gate-pass markers (#160) are recorded only by the sanctioned
     # python producers — shell flank against `echo <digest> > security-gate-passed`
-    # and `cp`/`sed`/`tee` forges naming a gate marker.
-    if GATE_MARKER_REDIRECT_RE.search(cmd) or GATE_MARKER_WRITE_RE.search(cmd):
+    # and `cp`/`sed`/`tee` forges naming a gate marker, plus an interpreter
+    # one-liner (#237).
+    #
+    # review finding (post-B-2): scan `git_view` (heredoc bodies stripped),
+    # with the raw-`cmd` leg gated on `heredoc_shell_fallback` — mirroring
+    # how commit/push/add already work post-D-3 (#223). Scanning raw `cmd`
+    # unconditionally, as this used to, means a heredoc body fed to a
+    # NON-shell consumer that merely QUOTES a gate-marker path (a PR/issue
+    # body describing this very fix) false-trips H-19; scanning only
+    # `git_view` would miss the genuine case where the heredoc's body DOES
+    # reach an executor (`bash -c "$(cat <<EOF … EOF)"`).
+    def _gate_marker_hit(view):
+        return (GATE_MARKER_REDIRECT_RE.search(view)
+                or GATE_MARKER_WRITE_RE.search(view)
+                or GATE_MARKER_INTERP_RE.search(view))
+
+    if _gate_marker_hit(git_view) or (heredoc_shell_fallback and _gate_marker_hit(cmd)):
         block("H-19", "The .codearbiter/.markers/ security-gate-passed / migration-gate-passed "
                       "tokens are recorded only by the sanctioned gate producers (#160) — a shell "
-                      "redirect or write verb naming a gate marker forges a security/migration "
-                      "gate pass and is prohibited.")
+                      "redirect, write verb, or interpreter invocation (python/node/perl/ruby/sh) "
+                      "naming a gate marker forges a security/migration gate pass and is "
+                      "prohibited.")
 
     # H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     # a recorded security-gate pass. The crypto-compliance / secret-handling skills

--- a/core/pysrc/pre-bash.py
+++ b/core/pysrc/pre-bash.py
@@ -22,6 +22,8 @@ import traceback
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _gitlib  # noqa: E402 — reused for its spawn-free, worktree-aware
+                # (.git-as-a-FILE / gitdir: pointer) project_root() climb (#223)
 from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
     GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
@@ -298,6 +300,148 @@ def git_cwd(cmd, root):
         val = raw.strip("\"'")
         acc = val if os.path.isabs(val) else os.path.join(acc, val)
     return acc
+
+
+def _effective_exec_root(payload, root):
+    """The git root that a `-C`-less git command in THIS Bash call actually
+    runs against — the command's effective cwd — rather than always the
+    pinned `root` (CLAUDE_PROJECT_DIR) (#223).
+
+    #223's bug: `root` is pinned to CLAUDE_PROJECT_DIR (the MAIN checkout),
+    so a `git commit` fired from a LINKED WORKTREE was judged against the
+    main checkout's branch — both a false positive (worktree on a feature
+    branch, main checkout on main -> wrongly blocked) and a false negative
+    (worktree on main/master, main checkout on a feature branch -> H-01
+    silently sidestepped, the more serious direction).
+
+    D-2 (spec pre-release-hardening): this function governs BRANCH/DIFF
+    resolution (git_cwd's seed) ONLY. Gate MARKERS always keep reading from
+    the pinned `root` regardless of this function's answer — a linked
+    worktree has `.codearbiter/` (tracked) but not `.codearbiter/.markers/`
+    (gitignored), so marker paths must stay anchored at the main checkout.
+    This split existed accidentally before #223 (pre-bash.py:769,828 already
+    read markers from `root` while everything else read from `cwd`); this is
+    now the intentional, documented contract.
+
+    Resolution reuses `_gitlib.project_root` — the existing linked-worktree-
+    aware precedent (`_gitlib.head_branch` already parses a `.git` FILE's
+    `gitdir:` pointer for exactly this case) — rather than a fresh
+    `git rev-parse --show-toplevel` spawn. It climbs from the hook payload's
+    own `cwd` (a trusted-harness input, same footing as CLAUDE_PROJECT_DIR
+    itself — see security-controls.md's Repo resolution section) or, absent
+    one, the hook process's own cwd, stopping at the nearest ancestor with a
+    `.git` (dir OR file) or a `.codearbiter` directory — a linked worktree's
+    `.git` is a FILE, and it also carries its own `.codearbiter/`, so either
+    check alone stops the climb at the worktree root, never the main
+    checkout.
+
+    When that climb lands on the SAME root as `root`, this returns `root`
+    unchanged — the overwhelmingly common (non-worktree) case sees zero
+    behavioral difference. It returns the climbed root only when it names a
+    genuinely DIFFERENT filesystem location."""
+    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
+        return root
+    return exec_root
+
+
+# D-3 (spec pre-release-hardening, #223): the raw-`cmd` fallback below (used
+# when a heredoc is present) must fire ONLY when the heredoc body can
+# genuinely reach a shell — via EITHER of two independent routes, checked by
+# the two functions below (`_heredoc_fed_to_shell` and `_has_shell_executor`,
+# OR'd together at the call site): (1) the heredoc's DIRECT consumer is
+# itself a shell-like program whose stdin is executed as code (`bash <<EOF`),
+# or (2) some OTHER token in the command is a shell/interpreter executor that
+# runs a command-substitution result carrying the heredoc's output
+# (`bash -c "$(cat <<EOF … EOF)"` — the heredoc's direct consumer is `cat`,
+# route (1) says no, but `bash -c` EXECUTES what `cat` produced, so route (2)
+# must say yes). A heredoc handed to a non-shell consumer with NO executor
+# anywhere in the command (`gh pr create --body "$(cat <<EOF … EOF)"`) is
+# inert prose to this guard even though it is substituted into another
+# command's argument — neither route fires, so the fallback correctly stays
+# off and a PR/issue body merely QUOTING "git commit" does not false-trip.
+SHELL_HEREDOC_CONSUMERS = frozenset({
+    "bash", "sh", "zsh", "dash", "ksh",
+    "python", "python2", "python3", "perl", "ruby", "node", "nodejs",
+})
+
+
+def _heredoc_fed_to_shell(cmd):
+    """True iff at least one `<<` heredoc operator in `cmd` attaches to a
+    shell-like consumer (SHELL_HEREDOC_CONSUMERS) — a program whose stdin IS
+    executed, not merely read as inert text.
+
+    The consumer is the FIRST token of the "simple command" the heredoc
+    operator sits at the end of: scan backward from the operator to the
+    nearest unquoted `|`, `;`, `&`, or `(` (or the start of the string) —
+    that is where the current simple command began — then take its first
+    token. This correctly finds `bash` in `bash <<EOF` and `cat` (not `gh`)
+    in `gh pr create --body "$(cat <<EOF … EOF)"` (the `(` from `$(` bounds
+    the segment)."""
+    for m in re.finditer(r"<<", cmd):
+        start = m.start()
+        seg_start = 0
+        in_dq = in_sq = False
+        for i in range(start - 1, -1, -1):
+            ch = cmd[i]
+            if ch == '"' and not in_sq:
+                in_dq = not in_dq
+            elif ch == "'" and not in_dq:
+                in_sq = not in_sq
+            elif not in_dq and not in_sq and ch in "|;&(":
+                seg_start = i + 1
+                break
+        segment = cmd[seg_start:start]
+        tokens = re.findall(r'"[^"]*"|\'[^\']*\'|\S+', segment)
+        if not tokens:
+            continue
+        head = os.path.basename(tokens[0].strip("\"'"))
+        if head in SHELL_HEREDOC_CONSUMERS:
+            return True
+    return False
+
+
+# security-reviewer finding (post-A-4): `_heredoc_fed_to_shell` alone answers
+# "is the heredoc's DIRECT consumer a shell" — that is NOT the same question
+# as "does the heredoc's body reach a shell." `bash -c "$(cat <<EOF … EOF)"`
+# has `cat` as the heredoc's direct consumer (correctly classified non-shell
+# by the check above), but `bash -c` then EXECUTES the substituted result of
+# that `cat` — the body reaches a shell by a route the direct-consumer check
+# cannot see (same hole for `eval "$(cat <<EOF … EOF)"`, `sh -c "$(…)"`, and
+# any command-substitution chain ending in a shell/interpreter executor).
+# This second check asks the complementary question: does ANY token in the
+# whole command invoke something that executes a string as code, regardless
+# of where the heredoc sits relative to it. FAILS CLOSED on uncertainty —
+# `eval` and `xargs` (which can forward its input straight into an executor)
+# are treated as always-executor, no flag required.
+SHELL_C_PROGRAMS = frozenset({"bash", "sh", "zsh", "dash", "ksh"})
+INTERP_C_PROGRAMS = frozenset({"python", "python2", "python3"})
+INTERP_E_PROGRAMS = frozenset({"perl", "ruby", "node", "nodejs"})
+ALWAYS_EXECUTOR_PROGRAMS = frozenset({"eval", "xargs"})
+
+
+def _has_shell_executor(cmd):
+    """True iff `cmd` invokes ANYWHERE a program that executes a string as
+    code: `bash -c`/`sh -c`/`zsh -c`/`dash -c`/`ksh -c`, `python[23]? -c`,
+    `perl -e`/`ruby -e`/`node[js]? -e`, or a bare `eval`/`xargs` (both can
+    hand an arbitrary string straight to an executor — `xargs bash -c '...'`,
+    `eval "$var"` — so both are treated as executors unconditionally, no
+    flag needed, per the fail-closed mandate).
+
+    Scans the RAW command (heredoc bodies included) — a heredoc body that
+    happens to mention one of these tokens as prose causes a conservative
+    over-block, never an under-scan, matching this file's established
+    ambiguity-resolves-CLOSED stance (D-3)."""
+    tokens = [t.strip("\"'") for t in re.findall(r'"[^"]*"|\'[^\']*\'|\S+', cmd)]
+    basenames = [os.path.basename(t) for t in tokens]
+    if any(b in ALWAYS_EXECUTOR_PROGRAMS for b in basenames):
+        return True
+    if "-c" in tokens and any(
+            b in SHELL_C_PROGRAMS or b in INTERP_C_PROGRAMS for b in basenames):
+        return True
+    if "-e" in tokens and any(b in INTERP_E_PROGRAMS for b in basenames):
+        return True
+    return False
 
 
 def current_branch(cwd):
@@ -588,15 +732,34 @@ def _run(root):
     # a body-stripped view so message content (which may contain `;`/`|`/`&`,
     # or mention `git -C`) never truncates the args capture, poisons the cwd
     # extraction, or leaks words into the pathspec parse. The RAW command stays
-    # as a fallback matcher: a heredoc fed TO a shell (`bash <<EOF … EOF`)
-    # executes its body, so a commit/push/add visible only in the raw text must
-    # still be guarded — ambiguity resolves CLOSED, so the fallback over-blocks
-    # (e.g. a message QUOTING a force-push) rather than under-scans.
+    # as a fallback matcher, but ONLY when the heredoc's consumer is a shell
+    # (D-3, #223, `_heredoc_fed_to_shell` above): a heredoc fed TO a shell
+    # (`bash <<EOF … EOF`) genuinely executes its body, so a commit/push/add
+    # visible only in the raw text must still be guarded there — ambiguity
+    # resolves CLOSED. A heredoc fed to a non-shell consumer (`gh`, `cat`, …)
+    # is inert prose and must NOT fall back to the raw-text scan, or a PR/issue
+    # body merely QUOTING "git commit" false-trips H-01/H-09b/H-14.
     git_view = _strip_heredoc_bodies(cmd) if "<<" in cmd else cmd
+    # Both legs are OR'd: the heredoc's direct consumer being a shell
+    # (`bash <<EOF`) is one route to execution; a shell/interpreter executor
+    # appearing ANYWHERE in the command (`bash -c "$(cat <<EOF … EOF)"`,
+    # `eval "$(cat <<EOF … EOF)"`) is another that the direct-consumer check
+    # alone cannot see (security-reviewer finding, post-A-4) — either is
+    # sufficient to keep the fallback closed.
+    heredoc_shell_fallback = "<<" in cmd and (
+        _heredoc_fed_to_shell(cmd) or _has_shell_executor(cmd))
 
-    commit = COMMIT_RE.search(git_view) or COMMIT_RE.search(cmd)
-    push_probe = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
-    cwd = git_cwd(git_view, root)
+    commit = COMMIT_RE.search(git_view) or (
+        heredoc_shell_fallback and COMMIT_RE.search(cmd))
+    push_probe = PUSH_RE.search(git_view) or (
+        heredoc_shell_fallback and PUSH_RE.search(cmd))
+
+    # #223: -C-less git commands run against the command's EFFECTIVE cwd, not
+    # unconditionally CLAUDE_PROJECT_DIR — see _effective_exec_root's
+    # docstring (D-2: gate MARKERS stay pinned to `root` regardless; only
+    # branch/diff resolution follows the command's real cwd).
+    exec_root = _effective_exec_root(payload, root)
+    cwd = git_cwd(git_view, exec_root)
 
     # reliability-004 (#190): fail CLOSED for commit/push when the `-C` target
     # git_cwd() resolved does not exist as a directory — an unresolvable -C
@@ -632,7 +795,8 @@ def _run(root):
             block("H-01", f"Direct commit to {target} is prohibited (ORCHESTRATOR §3). "
                           f"Create a feature branch.")
 
-    push = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
+    push = PUSH_RE.search(git_view) or (
+        heredoc_shell_fallback and PUSH_RE.search(cmd))
     if push:
         pargs = push.group("args")
 
@@ -678,7 +842,8 @@ def _run(root):
     # flag spellings (-A/--all/-u/.) and the argument spellings (globs,
     # directories, pathspec magic) — `git add src/` stages everything beneath
     # src/ just as surely as `git add -A` does.
-    add = ADD_RE.search(git_view) or ADD_RE.search(cmd)
+    add = ADD_RE.search(git_view) or (
+        heredoc_shell_fallback and ADD_RE.search(cmd))
     if add:
         if WILDCARD_ADD_RE.search(add.group("args")):
             block("H-03", "'git add -A' / 'git add .' / 'git add --all' / 'git add -u' "

--- a/core/pysrc/pre-bash.py
+++ b/core/pysrc/pre-bash.py
@@ -26,9 +26,10 @@ import _gitlib  # noqa: E402 — reused for its spawn-free, worktree-aware
                 # (.git-as-a-FILE / gitdir: pointer) project_root() climb (#223)
 from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
-    GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
-    get_host, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, set_host, tool_input, utf8_stdio,
+    GATE_MARKER_NAMES, SECRET_RE, SECURITY_DIFF_GIT_ARGS, arbiter_active,
+    block, content_digest, get_host, is_migration_path, line_digest,
+    marker_fresh, project_root, read_input, sensitive_scan_added_lines,
+    set_host, tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -563,8 +564,15 @@ def added_lines(cwd, ref, paths=None):
     Decoded as UTF-8 with replacement: `text=True` alone uses the locale code
     page (cp1252 on stock Windows), where a non-cp1252 byte in the diff raised
     UnicodeDecodeError into the bare except below and the security gate
-    silently failed OPEN on exactly the platform this layer protects."""
-    argv = ["git", "diff", ref] + (["--", *paths] if paths else [])
+    silently failed OPEN on exactly the platform this layer protects.
+
+    Excludes gate-events.log (#279): `sensitive_scan_added_lines` walks the
+    diff path-aware, dropping lines that belong to the crypto/secret gate's
+    own machine-written audit sink — see its docstring in `_hooklib`. Reads
+    the diff via SECURITY_DIFF_GIT_ARGS (pinned a/ b/ prefixes, no external
+    diff) so a hostile `diff.mnemonicPrefix`/`diff.noprefix`/external-diff
+    config can never break that attribution (#279 review MEDIUM-1)."""
+    argv = ["git", *SECURITY_DIFF_GIT_ARGS, ref] + (["--", *paths] if paths else [])
     try:
         out = subprocess.run(
             argv, cwd=cwd,
@@ -577,10 +585,7 @@ def added_lines(cwd, ref, paths=None):
     except Exception as e:  # noqa: BLE001
         _note_read_err(argv, repr(e))
         return None
-    return "\n".join(
-        line[1:] for line in out.stdout.splitlines()
-        if line.startswith("+") and not line.startswith("+++")
-    )
+    return "\n".join(sensitive_scan_added_lines(out.stdout))
 
 
 def _names(cwd, args):

--- a/core/pysrc/security-pass.py
+++ b/core/pysrc/security-pass.py
@@ -24,8 +24,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, line_digest, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
+    line_digest, project_root, sensitive_scan_added_lines, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -53,19 +54,34 @@ def candidate_lines(root):
     """Every line the next commit could introduce: added lines of the
     worktree-vs-HEAD diff (staged and unstaged alike), plus the full content
     of untracked files — `git diff HEAD` never shows those, but they land in
-    the staged diff the moment commit-gate stages them."""
+    the staged diff the moment commit-gate stages them.
+
+    Excludes gate-events.log (#279, is_sensitive_scan_exempt): the crypto/
+    secret gate's own machine-written audit sink, which structurally echoes
+    the detector's message text back at itself. The diff branch drops those
+    lines via the shared path-aware `sensitive_scan_added_lines`; the
+    unborn-branch and untracked-file branches skip the file outright since
+    they read whole-file content rather than a diff.
+
+    The diff is read via SECURITY_DIFF_GIT_ARGS (not a bare `["diff", ...]`):
+    it pins the `a/`/`b/` prefix format `sensitive_scan_added_lines` depends
+    on for path attribution, regardless of the caller's `diff.mnemonicPrefix`
+    / `diff.noprefix` / external-diff config (#279 review MEDIUM-1)."""
     lines = []
-    diff = run_git(["diff", "HEAD"], root)
+    diff = run_git([*SECURITY_DIFF_GIT_ARGS, "HEAD"], root)
     if diff.returncode == 0:
-        lines += [ln[1:] for ln in diff.stdout.splitlines()
-                  if ln.startswith("+") and not ln.startswith("+++")]
+        lines += sensitive_scan_added_lines(diff.stdout)
     else:
         # Unborn branch (no HEAD yet): every tracked file is new content.
         ls = run_git(["ls-files"], root)
         for rel in ls.stdout.splitlines():
+            if is_sensitive_scan_exempt(rel):
+                continue
             lines += file_lines(root, rel)
     untracked = run_git(["ls-files", "--others", "--exclude-standard"], root)
     for rel in untracked.stdout.splitlines():
+        if is_sensitive_scan_exempt(rel):
+            continue
         lines += file_lines(root, rel)
     return lines
 

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -21,6 +21,7 @@
 import concurrent.futures
 import copy
 import datetime
+import json
 import os
 import re
 import subprocess
@@ -31,6 +32,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
+    write_text_atomic,
 )
 from _standuplib import (  # noqa: E402
     any_actionable,
@@ -447,7 +449,80 @@ def has_source(root):
     return False
 
 
-def clear_dev_marker(root, host_name=None):
+# #271 C-5 — session-scoping the repo-global dev marker. The marker itself
+# carries no owner: it is dropped by /dev's own prose (dev.md), which has no
+# reliable way to stamp a real session_id into its content (slash-command
+# prose never receives the hook JSON payload — only actual HOOKS do). So
+# ownership is tracked SEPARATELY, by SessionStart itself: every invocation
+# records (its OWN session_id, now) as "the last session known to have
+# started in this repo" BEFORE deciding what to do with the dev marker.
+#
+# This is a heuristic, not true liveness detection (there is no SessionEnd
+# signal this hook can rely on) — documented tradeoff, not a defect. The
+# record's timestamp is ANCHORED TO THE OWNER, not to "whatever session
+# started most recently" — that distinction is load-bearing (a review caught
+# an earlier draft that refreshed it unconditionally on every invocation,
+# which meant an unrelated session B/C/D/... starting in an otherwise-active
+# repo kept sliding the window forward forever and the marker became
+# immortal). The write is therefore CONDITIONAL, decided AFTER checking the
+# marker, not before:
+#   - no live marker at all: refresh freely — "the session that could next
+#     enter /dev is me" is exactly the fact this record exists to hold.
+#   - live marker AND session_id == prev_sid: refresh. This is the owner
+#     heartbeating through a resume/compaction, and it's what keeps a
+#     genuinely long /ca:dev sitting from being force-closed at the 6h mark.
+#   - live marker AND a DIFFERENT session_id: do NOT write. `prev_ts` stays
+#     anchored to the OWNER's last known activity — a different session
+#     merely observing the marker must not reset that clock, or it would
+#     never elapse in any repo that sees regular unrelated activity.
+#
+# Net effect: a marker owned by a session that crashed is left alone by every
+# later, unrelated session (they cannot know it is dead) but self-heals
+# DEV_SESSION_LIVENESS_WINDOW after the OWNER's own last recorded activity —
+# not after the most recent unrelated SessionStart. Symmetric residual: a
+# genuinely live /ca:dev sitting untouched (no resume/compaction of its own)
+# for longer than the window can still be force-closed by a later session,
+# same as the pre-#271 behavior would have done immediately. No session_id
+# available on this invocation/host (Codex parity unverified), or no prior
+# record at all, degrades to the original unconditional clear — a marker that
+# can NEVER be cleared is a worse failure mode than one cleared too eagerly.
+DEV_SESSION_LIVENESS_WINDOW = 6 * 3600  # 6h: generous single-sitting bound
+
+
+def _dev_session_owner_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-session-owner.json")
+
+
+def _read_dev_session_owner(root):
+    """(session_id, ts) last recorded by ANY SessionStart invocation in this
+    repo, or (None, None) on an absent/corrupt/malformed record. Never
+    raises."""
+    try:
+        with open(_dev_session_owner_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        sid = data.get("session_id")
+        ts = data.get("ts")
+        if isinstance(sid, str) and sid and isinstance(ts, (int, float)):
+            return sid, float(ts)
+    except Exception:  # noqa: BLE001 — corrupt/absent record -> no signal
+        pass
+    return None, None
+
+
+def _write_dev_session_owner(root, session_id, ts):
+    """Best-effort refresh of the last-known-active-session record. Never
+    raises — a write failure just means the NEXT SessionStart degrades to the
+    conservative no-prior-record fallback, exactly as if this were the first
+    session ever."""
+    try:
+        path = _dev_session_owner_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps({"session_id": session_id, "ts": ts}))
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
     synthetic DEV: exit line to overrides.log BEFORE removing it
@@ -461,29 +536,77 @@ def clear_dev_marker(root, host_name=None):
     (ADR-0011). Optional and defaults to resolving it here via `get_host()`
     (#257) — main() already holds a Host instance and passes its `.name`
     through to avoid a second resolution, but any other caller (tests
-    included) may omit it."""
+    included) may omit it.
+
+    `session_id` (#271 C-5) is THIS invocation's own session id from the
+    SessionStart hook payload, when the host supplies one. See the module
+    comment above `DEV_SESSION_LIVENESS_WINDOW` for the full session-scoping
+    contract: a live marker is only force-closed when there is no reason to
+    believe a DIFFERENT, still-running session currently owns it — and the
+    ownership record's timestamp is refreshed ONLY by the owner itself (never
+    by an unrelated session merely observing the marker), so the liveness
+    window is anchored to the owner's last activity, not reset by every
+    passerby SessionStart. `now` (epoch seconds) is injectable for
+    deterministic tests; defaults to `time.time()`."""
+    now = time.time() if now is None else now
+    prev_sid, prev_ts = _read_dev_session_owner(root)
+
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
-    if os.path.isfile(marker):
-        if host_name is None:
-            try:
-                # get_host() (#257), not a direct hostapi.load_host(): resolves
-                # the SAME Host run(host) injected instead of a second load.
-                host_name = get_host().name
-            except Exception:  # noqa: BLE001 — must never brick session startup
-                host_name = "unknown"
+    marker_live = os.path.isfile(marker)
+
+    if not marker_live:
+        # No live marker: this record is purely "who could next enter /dev" —
+        # any session refreshing it is harmless and correct. Nothing else to
+        # do — there is no marker to clear and no close to log.
+        if session_id:
+            _write_dev_session_owner(root, session_id, now)
+        return
+
+    if session_id and prev_sid:
+        if prev_sid == session_id:
+            # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
+            # heartbeat (this is the only case where a write is safe while the
+            # marker is live) and leave the marker untouched.
+            _write_dev_session_owner(root, session_id, now)
+            return
+        if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
+            # A different session, and the OWNER's own clock hasn't elapsed
+            # yet — do NOT touch the record (an unrelated observer must never
+            # reset a clock it doesn't own) and do not clobber the marker.
+            return
+        # Different session AND the owner's own record is stale beyond the
+        # window: proceed to the force-close below. Deliberately do not write
+        # a fresh record here either — there is no live owner left to anchor
+        # a new one to; the write happens naturally next time /dev is entered.
+
+    if session_id and not prev_sid:
+        # No prior record at all (first session ever, or a dropped record) —
+        # no signal to protect a concurrent owner; seed the record for next
+        # time and fall through to the pre-#271 unconditional-clear behavior.
+        _write_dev_session_owner(root, session_id, now)
+
+    # Force-close: either no session_id/no prior record (unconditional-clear
+    # fallback), or a genuinely stale owner beyond the window.
+    if host_name is None:
         try:
-            arbiter_ref = get_host().cmd_ref("arbiter")
+            # get_host() (#257), not a direct hostapi.load_host(): resolves
+            # the SAME Host run(host) injected instead of a second load.
+            host_name = get_host().name
         except Exception:  # noqa: BLE001 — must never brick session startup
-            arbiter_ref = "/ca:arbiter"
-        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
-                f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-        try:
-            with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                      "a", encoding="utf-8") as f:
-                f.write(line)
-        except OSError:
-            pass
+            host_name = "unknown"
+    try:
+        arbiter_ref = get_host().cmd_ref("arbiter")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        arbiter_ref = "/ca:arbiter"
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
+            f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
+    try:
+        with open(os.path.join(root, ".codearbiter", "overrides.log"),
+                  "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
     try:
         os.remove(marker)
     except OSError:
@@ -560,6 +683,30 @@ def spawn_background_update_refresh(plugin, spawner=None):
         return None
 
 
+def _session_id_from_stdin():
+    """Best-effort session_id from the SessionStart hook's own JSON payload
+    (#271 C-5) — session-start.py has never read its stdin before this. Reads
+    directly rather than via `_hooklib.read_input()` so an absent/empty
+    session_id degrades SILENTLY (it is a normal, expected condition on a host
+    that doesn't supply one — not a parse error worth a `warn()` breadcrumb on
+    every single session start). Guards against a blocking read on an
+    interactive stdin the same way statusline.py's `main()` does (`isatty()`
+    check) — this hook must never hang session startup waiting for input that
+    will never arrive. Returns "" on any failure, absence, or malformed
+    payload; the caller treats an empty session_id as "unavailable" and
+    degrades to the pre-#271 unconditional-clear behavior."""
+    try:
+        if sys.stdin.isatty():
+            return ""
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return ""
+        data = json.loads(raw)
+        return str(data.get("session_id") or "") if isinstance(data, dict) else ""
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        return ""
+
+
 def main():
     utf8_stdio()
     # get_host() (#257): resolves the SAME Host run(host) already primed via
@@ -568,11 +715,15 @@ def main():
     root = project_root()
     plugin = host.plugin_root()
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
+    session_id = _session_id_from_stdin()
 
     # /dev developer-override is per-session: clear its statusline marker on
     # startup — a new session restores orchestration. A live marker means a prior
     # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
-    clear_dev_marker(root, host.name)
+    # session_id (#271 C-5) lets this distinguish "the same session resuming"
+    # and "a different, possibly still-live session" from a genuinely
+    # abandoned marker — see clear_dev_marker's docstring.
+    clear_dev_marker(root, host.name, session_id)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/core/pysrc/statusline.py
+++ b/core/pysrc/statusline.py
@@ -134,6 +134,7 @@ try:
     ANSI = _colorlib.ANSI
     _cw, vlen, clip, pad, gradient_h = (_colorlib._cw, _colorlib.vlen, _colorlib.clip,
                                         _colorlib.pad, _colorlib.gradient_h)
+    strip_control = _colorlib.strip_control
 except Exception:  # pragma: no cover — never let an import break the statusline
     _colorlib = None
     ANSI = re.compile(r"\033\[[0-9;]*m")
@@ -156,6 +157,9 @@ except Exception:  # pragma: no cover — never let an import break the statusli
 
     def gradient_h(text, width, c_from=None, c_to=None):
         return text
+
+    def strip_control(s):
+        return s if not isinstance(s, str) else re.sub(r"[\000-\037]", "", s)
 
 # --------------------------------------------------------------------------- coercion
 def num(x, default=0.0):
@@ -593,7 +597,7 @@ def _render_active_palette(raw):
     if branch:
         dirty = "*" if safe(git_dirty, root) else ""
         gp += f" {V0}{V}{RESET} {(WARN if dirty else OK)}{branch}{dirty}{RESET}"
-    model = get(data, "model", "display_name") or get(data, "model", "id") or "?"
+    model = strip_control(get(data, "model", "display_name") or get(data, "model", "id") or "?")
     pill = safe(model_pill, model, effort) or f"{V2}{model}{RESET}"
     rates = safe(seg_window_inline, data) or ""
     prseg = safe(seg_pr, data) or ""

--- a/core/pysrc/taskwrite.py
+++ b/core/pysrc/taskwrite.py
@@ -27,7 +27,9 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
+from _hooklib import (  # noqa: E402
+    acquire_lock, project_root, release_lock, set_host, utf8_stdio,
+)
 
 # reliability-007 (#190): project_root() is now _hooklib.project_root —
 # imported above, not a local copy. The prior local copy ran `git rev-parse
@@ -35,6 +37,31 @@ from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
 # skipping the CLAUDE_PROJECT_DIR-first read _hooklib.project_root() exists
 # for; taskwrite mutates .codearbiter/open-tasks.md, so a wrong root silently
 # wrote into the wrong repository's board.
+#
+# #271 C-2/C-3 — lock + re-read-under-lock CAS (spec D-4). taskwrite is the
+# only *programmatic* board mutator, but it is NOT the only writer: the
+# harvest/decompose paths mutate open-tasks.md directly via the host's own
+# Edit/Write tool and will never take this lock (ADR-0008 tolerates that
+# out-of-band path deliberately). A lock alone would therefore still let an
+# interleaved external Edit get silently overwritten by a stale in-memory
+# snapshot, AND would still let two lock-serialized taskwrite calls mint the
+# SAME dotted id if each computed next_seq() against the text it opened with
+# rather than the text current at write time. Taking the lock and THEN
+# reading the board — re-running the pure transform against that fresh read —
+# fixes both: an interleaved external edit is preserved (detected-loss instead
+# of silent clobber), and next_seq() always runs against current text.
+#
+# Fail-soft choice: _ledgerlib's convention is to silently no-op when the lock
+# handle is None (a statusline render is disposable — nobody is worse off if
+# ONE render skips the ledger write). A board mutation is not disposable: it
+# is the single user-visible effect of the whole `taskwrite` invocation, and
+# /ca:task has no other way to report "your task was recorded." Silently
+# proceeding unlocked on contention would silently reintroduce the exact race
+# this fix exists to close (two writers both read-modify-write with no
+# serialization at all). So on a None lock handle, taskwrite refuses to write
+# and exits nonzero with a clear stderr message — the caller (a skill/command)
+# sees a failed exit code and can retry, rather than a false "added"/"marked"
+# success hiding a lost or colliding write.
 
 
 def _date(s):
@@ -45,6 +72,46 @@ def _date(s):
         return datetime.datetime.strptime(s, "%Y-%m-%d").date()
     except ValueError:
         return None
+
+
+def _parse_gid(gid):
+    """Split a `--id GROUP.TYPE` value, or None with an error message on a bad
+    spelling. Pure — no I/O — so it can run before OR after the lock is held."""
+    parts = gid.split(".")
+    if len(parts) != 2 or not all(parts):
+        return None, None, (f"bad --id '{gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
+                             f"the 4-digit seq is minted automatically)")
+    return parts[0], parts[1], None
+
+
+def _apply(args, text):
+    """Pure text -> (new_text, action) | (None, error_msg) transform against
+    the board text the caller hands in. Deliberately takes NO lock and does NO
+    I/O itself — the caller (main()) re-runs this against a FRESH read taken
+    INSIDE the lock (#271 C-3/D-4), so next_seq()'s duplicate-id mint and any
+    interleaved external Edit are both resolved against current text, never a
+    stale snapshot."""
+    if args.verb == "add":
+        group = typ = None
+        if args.gid:
+            group, typ, err = _parse_gid(args.gid)
+            if err:
+                return None, err
+        boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
+        new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
+                           type=typ, boundaries=boundaries, section=args.section)
+        return new, f"added queued task: {args.desc}"
+
+    # start / done
+    state = "in_progress" if args.verb == "start" else "done"
+    day = _date(args.date)
+    if day is None:
+        return None, f"bad --date '{args.date}' (expected YYYY-MM-DD)"
+    assign = getattr(args, "assign", None)
+    new = tb.set_state(text, args.target, state, day, assign=assign)
+    if new == text:
+        return None, f"no change: '{args.target}' not found or already {state}"
+    return new, f"marked {state}: {args.target}"
 
 
 def main(argv=None):
@@ -72,52 +139,57 @@ def main(argv=None):
 
     root = project_root()
     board_path = os.path.join(root, ".codearbiter", "open-tasks.md")
-    text = tb.read_board(board_path)
-    if text is None:
+
+    # An uninitialized repo (no board at all) is a static precondition, not
+    # part of the race this fix closes — check it BEFORE touching the lock so
+    # a run against an uninitialized repo creates no side effect (no
+    # .codearbiter/ dir, no lock sidecar file), exactly as before #271.
+    if not os.path.isfile(board_path):
         print(f"no board at {board_path} — is this an initialized repo?", file=sys.stderr)
         return 1
 
-    if args.verb == "add":
-        group = typ = None
-        if args.gid:
-            parts = args.gid.split(".")
-            if len(parts) != 2 or not all(parts):
-                print(f"bad --id '{args.gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
-                      f"the 4-digit seq is minted automatically)", file=sys.stderr)
-                return 1
-            group, typ = parts
-        boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
-        new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
-                           type=typ, boundaries=boundaries, section=args.section)
-        action = f"added queued task: {args.desc}"
-    else:  # start / done
-        state = "in_progress" if args.verb == "start" else "done"
-        day = _date(args.date)
-        if day is None:
-            print(f"bad --date '{args.date}' (expected YYYY-MM-DD)", file=sys.stderr)
-            return 1
-        assign = getattr(args, "assign", None)
-        new = tb.set_state(text, args.target, state, day, assign=assign)
-        if new == text:
-            print(f"no change: '{args.target}' not found or already {state}", file=sys.stderr)
-            return 1
-        action = f"marked {state}: {args.target}"
-
-    # Atomic write: write to a sibling temp file, then os.replace() into place.
-    # os.replace() is atomic on POSIX and a same-volume rename on Windows, so a
-    # crash between open() and f.write() never leaves the board truncated.
-    board_dir = os.path.dirname(board_path)
-    fd, tmp_path = tempfile.mkstemp(dir=board_dir, suffix=".tmp", prefix="open-tasks.")
+    # #271 C-3 (spec D-4): take the lock FIRST, THEN read the board — everything
+    # from here to the write is inside the critical section, so the read this
+    # transaction acts on is guaranteed fresh relative to any other
+    # lock-taking writer. Fail-soft nuance: unlike _ledgerlib's disposable
+    # statusline write, a board mutation must never be silently dropped on
+    # contention — refuse and exit nonzero instead (see module docstring).
+    lock = acquire_lock(board_path)
+    if lock is None:
+        print(f"could not acquire the task-board lock ({board_path}.lock) — "
+              f"another writer holds it; no changes were written, retry the "
+              f"{args.verb}", file=sys.stderr)
+        return 1
     try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
-            f.write(new)
-        os.replace(tmp_path, board_path)
-    except Exception:
+        text = tb.read_board(board_path)
+        if text is None:
+            print(f"no board at {board_path} — is this an initialized repo?", file=sys.stderr)
+            return 1
+
+        new, action_or_err = _apply(args, text)
+        if new is None:
+            print(action_or_err, file=sys.stderr)
+            return 1
+        action = action_or_err
+
+        # Atomic write: write to a sibling temp file, then os.replace() into
+        # place. os.replace() is atomic on POSIX and a same-volume rename on
+        # Windows, so a crash between open() and f.write() never leaves the
+        # board truncated.
+        board_dir = os.path.dirname(board_path)
+        fd, tmp_path = tempfile.mkstemp(dir=board_dir, suffix=".tmp", prefix="open-tasks.")
         try:
-            os.remove(tmp_path)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+                f.write(new)
+            os.replace(tmp_path, board_path)
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+    finally:
+        release_lock(lock)
     print(action)
     return 0
 

--- a/core/surface/commands/arbiter.md
+++ b/core/surface/commands/arbiter.md
@@ -28,3 +28,9 @@ orchestration — the exit is on the audit trail like the entry. MUST NOT rewrit
 ended mid-dev, SessionStart has already appended the synthetic `BY: session-cleanup | DEV: exit` close
 line and cleared the marker (`session-start.py`, observability-001). In that case MUST NOT write a
 second `DEV: exit` for that orphaned entry — the close is already on the trail.
+
+Session-scoped clearing (#271): SessionStart's synthetic close is now conditional on the marker
+plausibly being abandoned rather than owned by a different, still-live session — it will NOT clobber
+another concurrently-running session's live `/dev` marker or write a false `DEV: exit` for it.
+`{{CMD:arbiter}}` remains the ONLY way to cleanly close your OWN `/dev` session's audit pair; do not
+rely on a future SessionStart to do it for you.

--- a/core/surface/commands/dev.md
+++ b/core/surface/commands/dev.md
@@ -26,6 +26,10 @@ Suspends orchestration for working ON codeArbiter — skill, agent, command, and
 4. **Mode** — plain, direct coding assistant: no routing, no skills, no gates, no `[CONFIRM-NN]`
    surfacing, no redirect. Persists until `{{CMD:arbiter}}` or a new session.
 
+Note (#271): if another session starts in this repo while this marker is live, SessionStart no longer
+unconditionally clears it out from under you — it is session-scoped now, so a concurrently-running dev
+session's marker survives a different session's startup. See `{{CMD:arbiter}}` for the exit-path detail.
+
 ## Hard gate
 
 MUST refuse without `CODEARBITER_DEV=1`. MUST write the `DEV: enter` log line before suspending

--- a/plugins/ca-codex/hooks/_arbiterstatelib.py
+++ b/plugins/ca-codex/hooks/_arbiterstatelib.py
@@ -198,5 +198,11 @@ def _arbiter_state_uncached(cad, count_in_flight=None, read_board=None, frontmat
 
 def dev_active(root):
     """True when /dev developer-override mode is on — signalled by a transient marker
-    the orchestrator drops on /dev and clears on /arbiter (a local UI flag, not a log)."""
+    the orchestrator drops on /dev and clears on /arbiter (a local UI flag, not a log).
+
+    Presence-only by design, unaffected by #271 C-5's session-scoped clearing:
+    the marker still means "dev mode is on for SOMEONE" regardless of which
+    session owns it. Session-scoping only changes WHEN SessionStart is willing
+    to clear a live marker (never a different, possibly still-live session's
+    own marker) — it does not change what "present" means to this reader."""
     return os.path.exists(os.path.join(root, ".codearbiter", ".markers", "dev-active"))

--- a/plugins/ca-codex/hooks/_colorlib.py
+++ b/plugins/ca-codex/hooks/_colorlib.py
@@ -20,6 +20,7 @@
 #   clip(s, w) -> str                         truncate to <= w visible columns (ANSI-preserving)
 #   pad(s, w) -> str                          pad/clip to exactly w visible columns
 #   gradient_h(text, width, c_from, c_to) -> str   per-character violet sheen
+#   strip_control(s) -> str                   strip C0 control bytes + OSC/CSI escape sequences
 
 import json
 import os
@@ -110,7 +111,7 @@ def _read_custom(path):
             return None
         value = json.loads(raw.decode("utf-8"))
         return value if isinstance(value, dict) else None
-    except (OSError, UnicodeError, ValueError, TypeError):
+    except (OSError, UnicodeError, ValueError, TypeError, RecursionError):
         return None
 
 
@@ -211,6 +212,26 @@ BOLT = "↯"
 SPARK = "▁▂▃▄▅▆▇█"
 
 ANSI = re.compile(r"\033\[[0-9;]*m")
+
+# Host-controlled strings (a model display name, a subagent's derived label)
+# reach the render path verbatim. Neither the host payload nor a subagent
+# transcript is a trusted source, so any C0 control byte or OSC/CSI escape
+# sequence embedded in one is terminal-escape injection into the user's
+# prompt line — strip it before the string is ever composed into a row.
+_OSC_RE = re.compile(r"\033\][^\007\033]*(?:\007|\033\\)?")
+_CSI_RE = re.compile(r"\033\[[0-?]*[ -/]*[@-~]?")
+_C0_RE = re.compile(r"[\000-\037]")
+
+
+def strip_control(s):
+    """Strip OSC/CSI escape sequences and any remaining C0 control byte
+    (0x00-0x1f) from a host- or transcript-derived string. Non-string input
+    passes through unchanged; this must never raise."""
+    if not isinstance(s, str):
+        return s
+    s = _OSC_RE.sub("", s)
+    s = _CSI_RE.sub("", s)
+    return _C0_RE.sub("", s)
 
 
 def _cw(ch):

--- a/plugins/ca-codex/hooks/_githooks.py
+++ b/plugins/ca-codex/hooks/_githooks.py
@@ -7,43 +7,56 @@
 # repo-level .git/hooks/pre-commit and pre-push that invoke git-enforce.py at the
 # git operation itself, where spelling no longer matters.
 #
-# Design decisions:
+# Design decisions (ADR-0014, resolves #265 / tribunal reliability-009):
 #   * The shim is a tiny POSIX `sh` script that detects the interpreter ONCE
 #     (python3 else python) and runs the enforcer EXACTLY once — never
 #     `python3 X || python X`, which would (a) swallow a BLOCK when python3 both
 #     exists and blocks, and (b) drain stdin before the fallback (pre-push feeds
 #     the ref list on stdin). Same hazard hooks.json avoids via two entries; a
 #     single hook file must guard it inline.
-#   * The shim points at the enforcer by ABSOLUTE PATH, resolved from THIS file's
-#     location (inside the plugin) at install time. install() is re-run every
-#     SessionStart, so the path is refreshed each session — if a plugin update
-#     moves the install dir, the next session rewrites the shim. During the brief
-#     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
-#     our OWN staleness only — never brick a user's commits because our path
-#     drifted; the pre-bash + Claude layers still apply).
+#   * The shim itself is HOST-NEUTRAL: it embeds no absolute enforcer path at
+#     all. It instead points at a shared, non-versioned drop-in directory
+#     inside the repo's OWN `.git/`:
 #
-#     Accepted residual, dual-host widening (reliability-009 / #265, LOW,
-#     ACCEPT-RISK): with BOTH `ca` and `ca-codex` installed against one repo,
-#     each SessionStart (whichever host ran last) rewrites the shim to point at
-#     THAT plugin's own `_enforcer_path()` — the two hosts manage entirely
-#     separate, independently versioned plugin caches (e.g. Claude Code's
-#     `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`; Codex's
-#     cache root and layout are not fixed by anything in this repo), so the
-#     sibling plugin's absolute enforcer path is NOT reliably derivable from
-#     this file's own path at write time — no path-substitution or fixed
-#     sibling-directory guess survives an independent version bump on either
-#     side. Multiple-candidate embedding (try both known paths) and a runtime
-#     filesystem search (glob likely cache roots from inside the POSIX `sh`
-#     shim) were both considered and rejected: the former requires knowing a
-#     path this file cannot derive, and the latter would mean an unverified,
-#     host-layout-guessing filesystem search on every commit/push under
-#     Windows Git-Bash `sh` — a fragile git-level backstop is worse than the
-#     accepted trade. Net effect: uninstalling whichever plugin most recently
-#     ran SessionStart leaves the shim fail-open until the SURVIVING host's
-#     next SessionStart rewrites it (single-plugin behavior — install()
-#     writing its own current path — is unchanged and unaffected by this
-#     residual). Revisit only if a host-neutral, version-independent enforcer
-#     location becomes available (e.g. a shared non-versioned shim target).
+#         .git/codearbiter-hooksd/<plugin>.path      # e.g. ca.path, ca-codex.path
+#
+#     Each installed host writes its OWN current `_enforcer_path()` into its
+#     own `<plugin>.path` file every SessionStart (install() below) — a live
+#     host self-heals a stale entry on its very next session. The shim iterates
+#     the directory and execs the FIRST enforcer path that resolves (`[ -f "$E" ]`
+#     succeeds); a dead entry from an uninstalled plugin simply fails that test
+#     and the loop moves on to the next one. `uninstall()` removes only ITS OWN
+#     `.path` file — never the shared shim, which a sibling plugin may still
+#     depend on.
+#   * FAIL CLOSED, not fail-open: if the directory is empty, absent, or every
+#     entry it contains names a file that no longer exists, the shim prints a
+#     diagnostic to stderr and exits non-zero — it BLOCKS the git operation
+#     rather than silently allowing it. This is a deliberate reversal of the
+#     single-plugin fail-open era: ADR-0014 records why. Before this drop-in dir
+#     existed, the shim embedded ONE absolute enforcer path (whichever plugin's
+#     SessionStart ran last), so uninstalling that plugin — or even the OTHER
+#     plugin, if IT never got a chance to write its own copy afterward — could
+#     silently unwire the git-level backstop for every host. The drop-in dir
+#     removes the reason fail-open existed (a plugin no longer has to derive a
+#     SIBLING's path — each writes only its own), so the residual failure mode
+#     (truly nothing resolves) can safely — and must — fail closed instead.
+#   * The drop-in directory itself is resolved via the repo's git COMMON dir
+#     (mirrors `git rev-parse --git-common-dir`, resolved without a git spawn
+#     when possible — see `_git_common_dir`), never `--git-dir` and never a
+#     per-worktree path: a linked worktree's `.git` is a FILE pointing at
+#     `<main>/.git/worktrees/<name>`, and the shared hooks/backstop must resolve
+#     to the ONE drop-in dir inside the MAIN repo's `.git/`, so every worktree
+#     and every host agree on the same directory — a per-worktree drop-in dir
+#     would defeat the entire cross-host purpose.
+#   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
+#     so an existing husky / pre-commit-framework setup is preserved.
+#   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
+#     ours-hook is refreshed. Because the shim no longer embeds any
+#     plugin-specific path, an enforcer-path change (e.g. a version bump moving
+#     the install dir) does NOT by itself require rewriting the shim file — only
+#     this plugin's own `<plugin>.path` drop-in entry, which install() refreshes
+#     unconditionally every session regardless of whether the shim itself needed
+#     a rewrite.
 #   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
@@ -146,17 +159,132 @@ def _enforcer_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-enforce.py")
 
 
-def _shim(enforcer, phase):
-    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK exit
-    # code. `exit 0` when the enforcer file is absent is deliberate fail-open on
-    # our own path staleness (see module header).
+def _plugin_name():
+    """A stable per-plugin identifier for THIS install's drop-in `.path`
+    filename (ADR-0014) — derived from THIS file's own vendored location,
+    exactly the same directory `_enforcer_path()` already anchors on:
+    `.../plugins/<plugin>/hooks/_githooks.py` -> `<plugin>` (e.g. "ca",
+    "ca-codex"). No plugin ever has to know a SIBLING's name or path — each
+    only ever writes its own `<plugin>.path` entry, using its own directory
+    name as the key. Running the unsynced `core/pysrc/_githooks.py` directly
+    (dev-only; tests always import the vendored copy) walks one level higher
+    than a real install and yields a less meaningful name, but still a stable,
+    non-empty one — never a hard failure."""
+    hooks_dir_path = os.path.dirname(os.path.abspath(__file__))
+    plugin_dir = os.path.dirname(hooks_dir_path)
+    return os.path.basename(plugin_dir) or "plugin"
+
+
+_DROPIN_DIRNAME = "codearbiter-hooksd"
+
+
+def _git_common_dir(root):
+    """The directory `git rev-parse --git-common-dir` would report for
+    `root` — resolved WITHOUT a git spawn whenever the on-disk layout is
+    cheaply readable, falling back to a real git spawn only when it isn't.
+
+    Deliberately mirrors --git-common-dir, NOT --git-dir: a linked worktree's
+    `.git` is a FILE (not a directory) holding a `gitdir: <path>` pointer into
+    `<main>/.git/worktrees/<name>`, and THAT directory in turn holds a
+    `commondir` file naming the real, SHARED main `.git`. Every worktree of a
+    repo must resolve to the SAME common dir here, or the #265 drop-in dir
+    would fork per-worktree and defeat the entire cross-host purpose (a shim
+    installed from worktree A would never see an entry written from
+    worktree B). The main-repo case (`.git` is a directory) needs no spawn at
+    all: it IS its own common dir. Returns None if nothing resolves — callers
+    must treat that as "can't place the drop-in dir right now" and never
+    invent a per-worktree fallback."""
+    git_path = os.path.join(root, ".git")
+    if os.path.isdir(git_path):
+        return os.path.abspath(git_path)
+    if os.path.isfile(git_path):
+        text = _read(git_path)
+        if text:
+            for line in text.splitlines():
+                line = line.strip()
+                if line.lower().startswith("gitdir:"):
+                    wt_gitdir = line.split(":", 1)[1].strip()
+                    if not os.path.isabs(wt_gitdir):
+                        wt_gitdir = os.path.normpath(os.path.join(root, wt_gitdir))
+                    cd_text = _read(os.path.join(wt_gitdir, "commondir"))
+                    if cd_text:
+                        cd = cd_text.strip()
+                        common = (cd if os.path.isabs(cd)
+                                  else os.path.normpath(os.path.join(wt_gitdir, cd)))
+                        return os.path.abspath(common)
+                    break
+    r = _git(["rev-parse", "--git-common-dir"], root)
+    if r is not None and r.returncode == 0 and r.stdout.strip():
+        out = r.stdout.strip()
+        return os.path.abspath(out if os.path.isabs(out) else os.path.join(root, out))
+    return None
+
+
+def _dropin_dir(root):
+    """The shared, non-versioned drop-in directory (ADR-0014) each installed
+    host writes its own `<plugin>.path` entry into. Lives inside the repo's
+    git COMMON dir (never a per-worktree one — see `_git_common_dir`) so
+    every worktree and every host share exactly ONE directory. Returns None
+    when the common dir itself can't be resolved (no git dir at all)."""
+    common = _git_common_dir(root)
+    return os.path.join(common, _DROPIN_DIRNAME) if common else None
+
+
+def _path_entry_file(dropin_dir, plugin):
+    return os.path.join(dropin_dir, f"{plugin}.path")
+
+
+def _path_entry_current(dropin_dir, plugin, enforcer):
+    """True iff this plugin's own drop-in entry already names `enforcer`."""
+    existing = _read(_path_entry_file(dropin_dir, plugin))
+    return existing is not None and existing.strip() == enforcer
+
+
+def _write_path_entry(dropin_dir, plugin, enforcer):
+    """Best-effort (never fatal) write/refresh of this plugin's OWN
+    `<plugin>.path` drop-in entry — the self-heal half of ADR-0014: a live
+    host rewrites its own entry every SessionStart regardless of whether the
+    shared shim itself needed any change, so a stale entry from a version
+    bump never outlives one session on a live install."""
+    if _path_entry_current(dropin_dir, plugin, enforcer):
+        return True
+    try:
+        os.makedirs(dropin_dir, exist_ok=True)
+        _hooklib.write_text_atomic(
+            _path_entry_file(dropin_dir, plugin), enforcer + "\n", newline="\n")
+        return True
+    except Exception as e:  # noqa: BLE001
+        _warn(f"could not write drop-in enforcer entry for '{plugin}' at {dropin_dir}: {e}")
+        return False
+
+
+def _shim(dropin_dir, phase):
+    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK
+    # exit code. The shim is HOST-NEUTRAL (ADR-0014): it embeds no plugin-
+    # specific enforcer path, only the shared drop-in directory. It iterates
+    # every "*.path" entry there and execs the FIRST enforcer that resolves
+    # (`[ -f "$E" ]`); a dead entry from an uninstalled plugin just fails that
+    # test and the loop tries the next one. An unmatched glob (dir absent or
+    # empty) leaves `c` as the literal, un-expanded "$D/*.path" string in
+    # POSIX `sh` — `[ -f "$c" ]` on that literal correctly fails too, so the
+    # loop falls straight through to the same fail-closed tail with no special
+    # case needed. When NOTHING resolves, this now FAILS CLOSED: a loud
+    # stderr diagnostic and a non-zero exit, blocking the git operation,
+    # rather than the old single-plugin era's `exit 0`.
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
-        f'E="{enforcer}"\n'
-        '[ -f "$E" ] || exit 0\n'
+        f'D="{dropin_dir}"\n'
         'if python3 -c "" 2>/dev/null; then PY=python3; else PY=python; fi\n'
-        f'exec "$PY" "$E" {phase}\n'
+        'for c in "$D"/*.path; do\n'
+        '  [ -f "$c" ] || continue\n'
+        '  E=$(cat "$c" 2>/dev/null) || continue\n'
+        f'  [ -f "$E" ] && exec "$PY" "$E" {phase}\n'
+        'done\n'
+        'echo "codeArbiter: no registered git-enforce.py could be resolved from '
+        '\\"$D\\" -- failing CLOSED (#161/#265 git backstop, ADR-0014). Reinstall '
+        'codeArbiter, or check .git/codearbiter-hooksd/*.path entries." >&2\n'
+        'exit 1\n'
     )
 
 
@@ -297,18 +425,26 @@ def _write_hooks_dir_cache(root, hd):
         pass
 
 
-def _hooks_current(hd, enforcer):
+def _hooks_current(hd, dropin_dir):
     """True iff BOTH phase shims at `hd` already match what install() would
-    write right now for `enforcer` — i.e. install() would be a complete no-op.
-    Filesystem-only (no git spawn): this is exactly the check that lets
-    install() skip the git-config/rev-parse re-probe when a prior session
-    already installed current hooks. A foreign (non-sentinel) hook, a stale
-    shim, or a missing file all correctly return False here, falling the
-    caller through to the full probe (which then re-derives the right action:
-    refresh, warn-and-preserve, or install fresh)."""
+    write right now for `dropin_dir` — i.e. install() would be a complete
+    no-op for the SHIM files themselves. Filesystem-only (no git spawn): this
+    is exactly the check that lets install() skip the git-config/rev-parse
+    re-probe when a prior session already installed current hooks. A foreign
+    (non-sentinel) hook, a stale shim, or a missing file all correctly return
+    False here, falling the caller through to the full probe (which then
+    re-derives the right action: refresh, warn-and-preserve, or install
+    fresh).
+
+    Note (ADR-0014): the shim is host-neutral — it depends only on
+    `dropin_dir` (repo-derived, stable across plugin versions), never on this
+    plugin's own enforcer path. So a plugin-version bump that only changes
+    `_enforcer_path()` does NOT make this return False; install() refreshes
+    the plugin's OWN drop-in `.path` entry unconditionally every call,
+    independent of whether this check short-circuits the shim-file rewrite."""
     for phase in PHASES:
         existing = _read(os.path.join(hd, phase))
-        if existing is None or existing != _shim(enforcer, phase):
+        if existing is None or existing != _shim(dropin_dir, phase):
             return False
     return True
 
@@ -338,21 +474,32 @@ def install(root):
          after the cache was written — e.g. adopting husky / pre-commit-
          framework — silently left the NEW hooks dir unwired while returning
          `[]`);
-      4. the shims at that dir are already current for the CURRENT enforcer
-         path (_hooks_current).
-    Any single miss/mismatch — including a genuine cold install, a moved
-    plugin path, a foreign hook, a changed core.hooksPath, or ambiguity in the
-    config read — falls through to the original git-based probe below,
-    unchanged. Fail direction is "install when unsure," never "skip when
-    unsure"."""
+      4. the shims at that dir are already current for the drop-in dir
+         (_hooks_current — ADR-0014: the shim depends only on `dropin_dir`,
+         never on this plugin's own enforcer path).
+    Any single miss/mismatch — including a genuine cold install, a foreign
+    hook, a changed core.hooksPath, or ambiguity in the config read — falls
+    through to the original git-based probe below, unchanged. Fail direction
+    is "install when unsure," never "skip when unsure".
+
+    ADR-0014: regardless of which path this function takes (fast path or full
+    probe), THIS plugin's own drop-in `<plugin>.path` entry is refreshed
+    every single call — a live host self-heals a stale entry (e.g. after a
+    version bump moved `_enforcer_path()`) every SessionStart, independent of
+    whether the shared shim FILE itself needed any rewrite."""
+    plugin = _plugin_name()
     enforcer = _enforcer_path()
+    dropin_dir = _dropin_dir(root)
+    if dropin_dir is None:
+        return []  # no resolvable git dir at all — nothing to install against
     cached_hd = _cached_hooks_dir(root)
     if cached_hd is not None:
         default_hd = os.path.normcase(os.path.abspath(_default_hooks_dir(root)))
         cached_norm = os.path.normcase(os.path.abspath(cached_hd))
         if (cached_norm == default_hd
                 and _confirmed_no_local_hooks_path(root)
-                and _hooks_current(cached_hd, enforcer)):
+                and _hooks_current(cached_hd, dropin_dir)):
+            _write_path_entry(dropin_dir, plugin, enforcer)
             return []
     hd = hooks_dir(root)
     if not hd:
@@ -365,7 +512,7 @@ def install(root):
     actions = []
     for phase in PHASES:
         dest = os.path.join(hd, phase)
-        desired = _shim(enforcer, phase)
+        desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
             if existing is not None and SENTINEL not in existing:
@@ -392,26 +539,35 @@ def install(root):
     # Cache the resolved location so the NEXT call can skip the git-config/
     # rev-parse re-probe entirely (performance-002) — best-effort, never fatal.
     _write_hooks_dir_cache(root, hd)
+    # ADR-0014: refresh THIS plugin's own drop-in entry every call, whether or
+    # not the shim files above needed a rewrite.
+    if _write_path_entry(dropin_dir, plugin, enforcer):
+        pass
     return actions
 
 
 def uninstall(root):
-    """Remove ONLY codeArbiter-managed hooks (identified by the sentinel);
-    a foreign hook is left in place. Returns the actions taken."""
-    hd = hooks_dir(root)
-    if not hd:
+    """Remove ONLY this plugin's OWN drop-in `<plugin>.path` entry (ADR-0014).
+
+    Deliberately does NOT touch the shared shim file (.git/hooks/pre-commit /
+    pre-push) — that shim is host-neutral and a sibling plugin may still
+    depend on it. Leaving a genuinely EMPTY drop-in dir behind (every plugin
+    uninstalled) is the intended fail-closed contract, not a bug: the next
+    commit finds no resolvable enforcer and blocks with a clear diagnostic
+    (see `_shim`'s tail), rather than the old single-plugin era silently
+    passing. Returns the actions taken."""
+    plugin = _plugin_name()
+    dropin_dir = _dropin_dir(root)
+    if dropin_dir is None:
         return []
-    actions = []
-    for phase in PHASES:
-        dest = os.path.join(hd, phase)
-        existing = _read(dest)
-        if existing is not None and SENTINEL in existing:
-            try:
-                os.remove(dest)
-                actions.append(f"{phase}: removed")
-            except Exception as e:  # noqa: BLE001
-                _warn(f"could not remove {dest}: {e}")
-    return actions
+    entry = _path_entry_file(dropin_dir, plugin)
+    if os.path.isfile(entry):
+        try:
+            os.remove(entry)
+            return [f"{plugin}.path: removed"]
+        except Exception as e:  # noqa: BLE001
+            _warn(f"could not remove {entry}: {e}")
+    return []
 
 
 if __name__ == "__main__":

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -57,6 +57,19 @@
 #   is_context_md(rel) -> bool            True iff rel is the CONTEXT.md activation file (#159)
 #   is_marker_path(rel) -> bool           True iff rel is under .codearbiter/.markers/ (#160)
 #   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
+#   is_sensitive_scan_exempt(rel) -> bool  True iff rel is exempt from the H-09b/H-10b
+#                                         crypto/secret scan (gate-events.log only, #279)
+#   SECURITY_DIFF_GIT_ARGS                pinned `git diff` argv suffix (fixed a/ b/
+#                                         prefixes, no external diff) every H-09b/H-10b
+#                                         sensitive-line reader MUST use (#279 review)
+#   diff_added_lines(diff_text) -> list[tuple[str|None, str]]  path-aware walk of a unified
+#                                         diff's added ('+') lines (from SECURITY_DIFF_GIT_ARGS
+#                                         output), paired with the destination path each
+#                                         belongs to, attributed from `+++ b/<path>` via a
+#                                         fixed-prefix strip within an unspoofable `diff `
+#                                         section (#279 review)
+#   sensitive_scan_added_lines(diff_text) -> list[str]  diff_added_lines() narrowed to the
+#                                         H-09b/H-10b candidate set (exempt paths dropped)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
 #   acquire_lock(path) -> handle|None     OS-owned cross-process file lock (#271 C-2);
@@ -360,6 +373,182 @@ def classify_protected(fpath, root):
         if is_marker_path(p):
             hits.add("marker")
     return hits
+
+
+# Sensitive-scan exemption (H-09b/H-10b, #279). gate-events.log is the durable
+# BLOCK/REMIND/WARN sink block()/remind()/warn() append to (observability-001,
+# #186) — it is machine-written, never source code, and structurally
+# guaranteed to echo the crypto/secret detector's OWN message text back at
+# itself the moment the gate ever fires a crypto/secret REMIND (e.g. "Crypto/
+# TLS pattern detected" itself matches CRYPTO_RE). That makes it a permanent,
+# self-perpetuating false positive with zero disclosure value: nothing
+# written there is a genuine crypto/secret USE, only a report ABOUT one.
+# Deliberately narrow — overrides.log/triage.log/sprint-log.md stay IN SCOPE:
+# they carry human-written prose (an override reason, a triage note) that
+# COULD legitimately contain a leaked secret worth catching. This set is
+# anchored on the REPO-RELATIVE PATH a line belongs to, never a substring
+# match on the line's own text — a secret cannot escape the scan by merely
+# mentioning gate-events.log on its line; only lines that actually LIVE in
+# that file are exempt.
+SENSITIVE_SCAN_EXEMPT_RELPATHS = frozenset({".codearbiter/gate-events.log"})
+
+
+def is_sensitive_scan_exempt(rel):
+    """True iff `rel` (a repo-relative path, as attributed by `diff_added_
+    lines` or as returned by a bare `git ls-files` listing) names a file
+    exempt from the H-09b/H-10b crypto/secret scan. The ONE predicate both
+    the diff walk and the untracked/unborn-branch file listings route
+    through (#279 review LOW) — deliberately strict: no case-folding, no
+    `./`/`//` collapsing. An identifier that isn't an exact, `norm_path`'d
+    match resolves toward IN SCOPE (not exempt), which is the safe
+    direction. See SENSITIVE_SCAN_EXEMPT_RELPATHS."""
+    return norm_path(rel) in SENSITIVE_SCAN_EXEMPT_RELPATHS
+
+
+# Every H-09b/H-10b sensitive-line reader (security-pass.py, pre-bash.py,
+# git-enforce.py) MUST run `git diff` through this pinned argv, never a bare
+# `["diff", ...]` (#279 review MEDIUM-1). Two independent user/global git
+# config knobs change the destination-path prefix `diff_added_lines` below
+# depends on: `diff.mnemonicPrefix=true` emits `c/`/`w/`/`i/`/`o/` instead of
+# `a/`/`b/`, and `diff.noprefix=true` emits no prefix at all. Either one, left
+# unpinned, silently un-exempts the REAL gate-events.log for any dev/CI runner
+# with that config set — bringing back the exact self-DoS this whole change
+# exists to close. `-c` overrides win over any config file (including repo,
+# global, and system config), so pinning both flags to false here forces the
+# standard `a/`/`b/` prefixes regardless of the caller's environment.
+# `--no-ext-diff` additionally blocks a configured `GIT_EXTERNAL_DIFF` /
+# `diff.external` from replacing git's own unified-diff output with something
+# this parser was never designed to read. Centralized so a call site cannot
+# forget to pin it (that was exactly how this hole would keep reopening).
+SECURITY_DIFF_GIT_ARGS = (
+    "-c", "diff.mnemonicPrefix=false", "-c", "diff.noprefix=false",
+    "diff", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/",
+)
+
+# The fixed-width destination-path prefix `diff_added_lines` strips off a
+# preamble `+++ ` line. MUST be a fixed-length slice, never a search for a
+# separator: a greedy/`.+`-based parse of "diff --git a/<path> b/<path>" (the
+# prior approach) resolves ambiguously when <path> itself contains " b/" —
+# e.g. a real repo path `x b/.codearbiter/gate-events.log` renders that
+# header as `diff --git a/x b/.codearbiter/gate-events.log b/x
+# b/.codearbiter/gate-events.log`, and a greedy match backtracks group(1) to
+# `.codearbiter/gate-events.log`, exempting the WHOLE unrelated source file
+# (#279 review HIGH — reproduced end-to-end: an md5() call and a committed
+# password both passed H-09b with no marker). Stripping a FIXED 6-character
+# prefix has no such ambiguity: `"+++ b/x b/.codearbiter/gate-events.log"[6:]`
+# is unconditionally `"x b/.codearbiter/gate-events.log"`, the correct full
+# path, no matter what the path itself contains.
+_PLUS_B_PREFIX = "+++ b/"
+_PLUS_DEV_NULL = "+++ /dev/null"
+
+
+def diff_added_lines(diff_text):
+    """Added (`+`) lines of a unified `git diff`-style text (produced via
+    SECURITY_DIFF_GIT_ARGS — pinned `a/`/`b/` prefixes, no external diff), as
+    `(path, line)` tuples — a PATH-AWARE walk so a caller can exclude lines by
+    the FILE they live in, never by matching the line's own text (which a
+    hidden secret could otherwise dodge by naming the excluded file).
+
+    Two-phase state machine per file section, `path`/`in_hunk`/`seen_section`:
+
+    1. A bare, UNPREFIXED `diff ` line (`diff --git`, `diff --cc`, `diff
+       --combined`, ...) starts a new section: `path` resets to `None` and
+       `in_hunk` resets to False. Content can NEVER forge this line at column
+       0 — every diff-body line (context/added/removed) carries a leading
+       ' '/'+'/'-'/'\\' character, so a file whose own content is literally
+       "diff --git a/x b/y" renders as "+diff --git a/x b/y" (added), never as
+       a bare match. Resetting `path` to None (not inheriting the PREVIOUS
+       section's path) on ANY `diff ` spelling matters for combined/merge
+       diffs (#279 review MEDIUM-2): git-enforce.py's `git diff --cached` at a
+       merge commit emits `diff --cc <path>` sections, which the prior
+       `diff --git`-only reset missed, letting a `--cc` section's added lines
+       silently inherit whatever path the section before it had — failing
+       toward EXEMPTION if that was gate-events.log.
+    2. While NOT yet `in_hunk` (the section's preamble, before its first `@@`
+       / `@@@` hunk header), a `+++ b/<path>` line sets `path` by stripping
+       the FIXED 6-character prefix `_PLUS_B_PREFIX` — never a regex search
+       for a separator (see `_PLUS_B_PREFIX`'s comment for the ambiguity a
+       greedy `diff --git` parse had). `+++ /dev/null` (a deleted
+       destination) sets `path` back to None explicitly — no added lines are
+       expected in a deletion's hunk body anyway. Every other preamble line
+       (`--- a/<path>`, `index ...`, `new/deleted file mode`, `rename
+       from/to`, `similarity index`, `Binary files ... differ`) is inert
+       noise. A `+++ b/...`-shaped line can ONLY be trusted here, before the
+       section's first `@@`: once `in_hunk` is True, an apparently identical
+       `+++ b/...` string is body CONTENT (it carries the hunk body's own
+       leading `+`, i.e. the underlying source line was "++ b/..." or "+++
+       b/..." before diff-prefixing) and is captured as an added line like any
+       other, never re-parsed as an attribution header (closes the #279
+       review's own earlier finding: an added content line forging `+++
+       b/<path>` used to hijack attribution for the rest of the file).
+    3. Once `in_hunk`, `+`-prefixed lines are collected as `(path, content)`;
+       `-`/` `/`\\` (no-newline-marker) lines are skipped; anything else ends
+       the hunk (not producible by well-formed `git diff` output there, but
+       handled rather than guessed at).
+
+    FAILS SAFE: a `+` line seen before ANY `diff ` section header at all (not
+    producible by real `git diff` output) is attributed to `path=None` and
+    STILL COLLECTED, never silently dropped. `sensitive_scan_added_lines`
+    treats an unattributed (`None`) path as NOT exempt — in scope for
+    scanning. Exempting, or discarding, an unattributable line would be the
+    dangerous direction; over-scanning only risks a false positive, the
+    harmless failure mode here.
+
+    The shared primitive behind the H-09b/H-10b crypto/secret gate's producer
+    (security-pass.py) and both consumers (pre-bash.py, git-enforce.py) —
+    implemented once here so the gate-events.log exemption can never drift
+    between the three independent line-collectors that used to each do their
+    own flat `[ln[1:] for ln in text.splitlines() if ln.startswith("+") ...]`
+    walk with no path information (and no forgery-resistance) at all."""
+    path = None
+    in_hunk = False
+    seen_section = False  # True once the first `diff ` section header is seen
+    out = []
+    for line in diff_text.splitlines():
+        if line.startswith("diff "):
+            path = None
+            in_hunk = False
+            seen_section = True
+            continue
+        if line.startswith("@@"):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            if not seen_section:
+                # No `diff ` section header seen yet at all: not producible
+                # by real `git diff` output. Fail SAFE (see docstring) rather
+                # than silently dropping a line that cannot be confidently
+                # classed as header noise either.
+                if line.startswith("+"):
+                    out.append((None, line[1:]))
+                continue
+            # Section preamble: only a genuine `+++ b/<path>` (or `+++
+            # /dev/null`) line here can set `path` — see point 2 above.
+            if line.startswith(_PLUS_B_PREFIX):
+                path = line[len(_PLUS_B_PREFIX):]
+            elif line == _PLUS_DEV_NULL:
+                path = None
+            continue
+        if line.startswith("+"):
+            out.append((path, line[1:]))
+        elif line.startswith(("-", " ", "\\")):
+            pass  # removed / context / "\ No newline at end of file"
+        else:
+            # Not producible by well-formed `git diff` output (a hunk body
+            # line is always one of the four prefixes above); treat it as the
+            # hunk having ended rather than guessing.
+            in_hunk = False
+    return out
+
+
+def sensitive_scan_added_lines(diff_text):
+    """`diff_added_lines(diff_text)` narrowed to the H-09b/H-10b crypto/secret
+    scan's candidate set: every added line EXCEPT those belonging to a
+    sensitive-scan-exempt path (currently only gate-events.log). Call this
+    instead of a raw `+`-line filter anywhere the crypto/secret scan reads a
+    diff, so the exemption is applied uniformly."""
+    return [ln for path, ln in diff_added_lines(diff_text)
+            if not (path and is_sensitive_scan_exempt(path))]
 
 
 def utf8_stdio():

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -59,6 +59,10 @@
 #   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
+#   acquire_lock(path) -> handle|None     OS-owned cross-process file lock (#271 C-2);
+#                                         non-blocking + bounded LOCK_WAIT retry spin,
+#                                         fail-soft None on contention/timeout/OSError
+#   release_lock(handle) -> None          release + close; None handle is a no-op
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -91,6 +95,15 @@ _GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
+
+# Bounded best-effort wait for another cross-process writer to release
+# acquire_lock()'s sidecar lock file (#271 C-2). Originally _ledgerlib-private
+# (the statusline's cost/token ledger); hoisted here so taskwrite.py's board
+# writer (a second, genuinely different caller) can share ONE lock
+# implementation instead of a second hand-rolled copy. _ledgerlib re-exports
+# this name (`from _hooklib import LOCK_WAIT`) so its own module-level
+# mock.patch.object(L, "LOCK_WAIT", ...) test seam keeps working unchanged.
+LOCK_WAIT = 0.2
 
 
 def _is_lock_contention(exc):
@@ -750,6 +763,74 @@ def write_text_atomic(path, text, newline=None):
         raise
 
 
+def acquire_lock(path):
+    """Acquire an OS-owned cross-process file lock keyed on `path`; process
+    death releases it automatically (#271 C-2 — hoisted from the
+    statusline-ledger-only `_ledgerlib._acquire_lock`, now shared with
+    taskwrite.py's board writer).
+
+    Sidecar lock file `f"{abspath(path)}.lock"`, opened `"a+b"` and seeded
+    with one byte so the OS byte-range lock has a byte to lock (an empty file
+    has no range to range-lock). Non-blocking (`msvcrt.locking(..., LK_NBLCK,
+    1)` on Windows, `fcntl.flock(..., LOCK_EX | LOCK_NB)` elsewhere) with a
+    bounded `LOCK_WAIT`-second retry spin; any `OSError` opening the lock file,
+    or exhausting the deadline still contended, is FAIL-SOFT: returns `None`
+    rather than raising or blocking indefinitely. Callers decide what
+    "fail-soft" means for them — `_ledgerlib.ledger_update`/`persist_sess_start`
+    treat `None` as a disposable no-op (a statusline render is throwaway), but
+    `taskwrite.py` treats it as a hard error (a board write is NOT disposable;
+    see its module docstring)."""
+    lock_path = f"{os.path.abspath(path)}.lock"
+    parent = os.path.dirname(lock_path)
+    try:
+        os.makedirs(parent, exist_ok=True)
+        handle = open(lock_path, "a+b")
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+    except OSError:
+        return None
+    deadline = time.monotonic() + LOCK_WAIT
+    while True:
+        try:
+            handle.seek(0)
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except (OSError, BlockingIOError):
+            if time.monotonic() >= deadline:
+                handle.close()
+                return None
+            time.sleep(0.005)
+
+
+def release_lock(handle):
+    """Release + close a handle from acquire_lock(). None is a no-op —
+    callers that never got the lock don't need to guard the release call."""
+    if handle is None:
+        return
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
 def marker_fresh(path, minutes):
     """True if the marker file exists and was touched within `minutes`."""
     try:
@@ -875,6 +956,16 @@ def warn(msg):
 # override.md) with no analogous "still in progress" marker anywhere in the
 # framework, so per CONFIRM-09's own "do not invent new state" constraint it
 # is not tracked here — there is no existing signal to detect it from.
+#
+# #271 C-5: this staleness WARN is presence + age based (marker mtime vs. an
+# audit-log write), which is unaffected by session-start.py's newer
+# session-scoped CLEARING decision for the SAME dev-active marker — the two
+# consumers ask different questions ("has this sat around too long with no
+# matching log activity?" vs. "am I sure enough this belongs to nobody live
+# right now that I should force-close it?") and neither needs to agree with
+# the other's answer. A dev marker owned by a still-live different session
+# can legitimately trip THIS warning (it really has been open a while) even
+# though session-start.py correctly declines to clobber it.
 _STALE_FLOWS = (
     # (flow name, marker path parts, expected-log path parts)
     ("dev", (".markers", "dev-active"), ("overrides.log",)),

--- a/plugins/ca-codex/hooks/_ledgerlib.py
+++ b/plugins/ca-codex/hooks/_ledgerlib.py
@@ -29,14 +29,26 @@
 import hashlib
 import json
 import os
+import sys
 import time
 from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
+# taskwrite.py's board writer can share ONE lock implementation instead of a
+# second hand-rolled copy. Re-exported under their ORIGINAL private names so
+# this module's own call sites (ledger_update/persist_sess_start) and the test
+# suite's `mock.patch.object(L, "_acquire_lock", ...)` / `mock.patch.object(L,
+# "LOCK_WAIT", ...)` seams keep working unchanged — no import-cycle risk:
+# _hooklib imports only hostapi, never _ledgerlib.
+from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
+from _hooklib import release_lock as _release_lock  # noqa: E402
+from _hooklib import LOCK_WAIT  # noqa: E402
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
-LOCK_WAIT = 0.2          # bounded best-effort wait for another statusline writer
 
 # API list prices, USD per 1M tokens (captured 2026-06-10 from Anthropic's
 # pricing pages). Used ONLY to estimate the pay-as-you-go API-equivalent cost of
@@ -148,57 +160,6 @@ def _atomic_json(path, value):
                 os.remove(tmp)
             except OSError:
                 pass
-
-
-def _acquire_lock(path):
-    """Acquire an OS-owned file lock; process death releases it automatically."""
-    lock_path = f"{os.path.abspath(path)}.lock"
-    parent = os.path.dirname(lock_path)
-    try:
-        os.makedirs(parent, exist_ok=True)
-        handle = open(lock_path, "a+b")
-        handle.seek(0, os.SEEK_END)
-        if handle.tell() == 0:
-            handle.write(b"\0")
-            handle.flush()
-    except OSError:
-        return None
-    deadline = time.monotonic() + LOCK_WAIT
-    while True:
-        try:
-            handle.seek(0)
-            if os.name == "nt":
-                import msvcrt
-                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-            else:
-                import fcntl
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return handle
-        except (OSError, BlockingIOError):
-            if time.monotonic() >= deadline:
-                handle.close()
-                return None
-            time.sleep(0.005)
-
-
-def _release_lock(handle):
-    if handle is None:
-        return
-    try:
-        handle.seek(0)
-        if os.name == "nt":
-            import msvcrt
-            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-    except OSError:
-        pass
-    finally:
-        try:
-            handle.close()
-        except OSError:
-            pass
 
 
 def _session_dir(path):

--- a/plugins/ca-codex/hooks/_subagentslib.py
+++ b/plugins/ca-codex/hooks/_subagentslib.py
@@ -23,6 +23,15 @@ import os
 import re
 import time
 
+try:
+    import _colorlib
+    strip_control = _colorlib.strip_control
+except Exception:  # pragma: no cover — never let an import break the statusline
+    _colorlib = None
+
+    def strip_control(s):
+        return s if not isinstance(s, str) else re.sub(r"[\000-\037]", "", s)
+
 ACTIVE_WINDOW = 150       # secs: a subagent file touched this recently is "active"
 SHOW_WINDOW = 600         # secs: still display recently-finished subagents
 MAX_SUB_ROWS = 4
@@ -34,7 +43,7 @@ def display_model(model_id):
     """Compact a host model ID while retaining its family and version."""
     if not isinstance(model_id, str):
         return "model:?"
-    name = model_id.strip()
+    name = strip_control(model_id).strip()
     if not name:
         return "model:?"
     if name.startswith("claude-"):
@@ -170,7 +179,7 @@ def sub_label(content):
             if isinstance(blk, str):
                 text = blk
                 break
-    raw = str(text)
+    raw = strip_control(str(text))
     # strip leading reminder/system blocks up front (multi-line safe), then a lone tag
     raw = re.sub(r"^\s*(?:<([^>\s]+)[^>]*>.*?</\1>\s*)+", "", raw, flags=re.S)
     raw = re.sub(r"^\s*<[^>]+>\s*", "", raw)

--- a/plugins/ca-codex/hooks/git-enforce.py
+++ b/plugins/ca-codex/hooks/git-enforce.py
@@ -11,9 +11,10 @@
 #
 # It mirrors pre-bash.py's commit/push gates and reuses the SAME detection
 # primitives from _hooklib (CRYPTO_RE / SECRET_RE / line_digest / content_digest
-# / is_migration_path / marker_fresh), so the two enforcement points can never
-# drift on what counts as sensitive or as a migration, or on how a gate-pass
-# marker binds to the lines it approved.
+# / is_migration_path / marker_fresh / sensitive_scan_added_lines), so the two
+# enforcement points can never drift on what counts as sensitive or as a
+# migration, on how a gate-pass marker binds to the lines it approved, or on
+# which path (gate-events.log, #279) is exempt from the sensitive-line scan.
 #
 # Contract: a git hook aborts its operation on ANY non-zero exit, so a BLOCK is
 # exit 1 with a loud stderr message. Exit 0 allows. The security/migration scans
@@ -27,8 +28,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, set_host, utf8_stdio,
+    CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, arbiter_active,
+    content_digest, is_migration_path, line_digest, marker_fresh,
+    sensitive_scan_added_lines, set_host, utf8_stdio,
 )
 
 
@@ -144,12 +146,23 @@ def head_on_protected_tip(cwd):
 def cached_added_lines(cwd):
     """Added (`+`) lines of the staged diff — exactly what a commit records
     (including `commit -a` sweeps, which git has already staged by pre-commit
-    time). None on a git read error → caller fails closed."""
-    r = _git(["diff", "--cached"], cwd)
+    time). None on a git read error -> caller fails closed.
+
+    Excludes gate-events.log (#279): `sensitive_scan_added_lines` walks the
+    diff path-aware, dropping lines that belong to the crypto/secret gate's
+    own machine-written audit sink, so this backstop's view of "sensitive
+    lines" never drifts from the producer (security-pass.py) or the
+    PreToolUse gate (pre-bash.py) — see the shared helper's docstring in
+    `_hooklib`. Reads the diff via SECURITY_DIFF_GIT_ARGS (pinned a/ b/
+    prefixes, no external diff) so a hostile `diff.mnemonicPrefix`/
+    `diff.noprefix`/external-diff config can never break that attribution
+    (#279 review MEDIUM-1) — a merge commit's `--cc` combined-diff sections
+    are also handled correctly (MEDIUM-2): the diff walk resets attribution on
+    ANY `diff ` section header, not just `diff --git`."""
+    r = _git([*SECURITY_DIFF_GIT_ARGS, "--cached"], cwd)
     if r is None or r.returncode != 0:
         return None
-    return [ln[1:] for ln in r.stdout.splitlines()
-            if ln.startswith("+") and not ln.startswith("+++")]
+    return sensitive_scan_added_lines(r.stdout)
 
 
 def cached_names(cwd):

--- a/plugins/ca-codex/hooks/pre-bash.py
+++ b/plugins/ca-codex/hooks/pre-bash.py
@@ -260,6 +260,43 @@ GATE_MARKER_WRITE_RE = re.compile(
     r"|Move-Item|Copy-Item|Clear-Content|Set-Content|Out-File|Add-Content)\b"
     r"[^|;&]*" + GATE_MARKER, re.I,
 )
+# #237: an arbitrary interpreter invocation is a flank the verb list above
+# cannot see — `python -c "open('.markers/security-gate-passed','w')..."`
+# reuses the sanctioned producer's own public helpers to self-compute valid
+# digests, and no mv/cp/tee/sed spelling ever appears on the command line.
+# Interpreter one-liners get their OWN, wider regex rather than joining the
+# verb list above: the payload is a single quoted string handed to the
+# interpreter, and that string may itself contain `;` as a statement
+# separator (`python -c "x=1; open(...security-gate-passed...)"`). The
+# `[^|;&]*` bound on GATE_MARKER_WRITE_RE exists to keep a write verb from
+# reaching across an UNRELATED shell-chained command; applying that same
+# bound here would stop scanning at the interpreter's OWN internal `;` and
+# silently reopen exactly the hole this closes. There is no reliable way to
+# tell a chained shell command from a `;`-separated statement inside an
+# opaque interpreter string without full shell/language tokenization, so
+# this guard fails CLOSED: any command line invoking one of these
+# interpreters that ALSO names a gate marker anywhere on the line is
+# blocked, whether the marker is written or merely read. A read of a gate
+# marker has no legitimate reason to go through a raw interpreter one-liner
+# either (cat/grep already pass the audit-log flanks above untouched).
+#
+# review finding (post-B-2): a `-c`/`-e` payload is ordinary multi-line
+# source — the interpreter token and the marker path can sit on different
+# physical lines of the SAME invocation (`python -c "\nopen('...security-
+# gate-passed'...)\n"`). `[^\n]*` cannot cross that newline, leaving the
+# identical attack open in its multi-line spelling. `[\s\S]*` (DOTALL-
+# equivalent) closes it. This regex is applied to the heredoc-stripped
+# `git_view` at the call site below, gated on `heredoc_shell_fallback` for
+# the raw-`cmd` leg exactly like the commit/push/add guards already are —
+# scanning the raw, unstripped `cmd` unconditionally would make crossing
+# newlines here false-trip on inert PROSE inside a heredoc body fed to a
+# non-shell consumer (`gh pr create --body "$(cat <<EOF … a python -c
+# one-liner wrote .markers/security-gate-passed … EOF)"` — a PR/issue body
+# merely DESCRIBING this very fix), the same D-3 (#223) distinction the
+# other guards already draw.
+GATE_MARKER_INTERP_RE = re.compile(
+    r"\b(python3?|node|perl|ruby|sh)\b[\s\S]*" + GATE_MARKER, re.I,
+)
 
 
 def git_cwd(cmd, root):
@@ -888,12 +925,28 @@ def _run(root):
 
     # H-19: the gate-pass markers (#160) are recorded only by the sanctioned
     # python producers — shell flank against `echo <digest> > security-gate-passed`
-    # and `cp`/`sed`/`tee` forges naming a gate marker.
-    if GATE_MARKER_REDIRECT_RE.search(cmd) or GATE_MARKER_WRITE_RE.search(cmd):
+    # and `cp`/`sed`/`tee` forges naming a gate marker, plus an interpreter
+    # one-liner (#237).
+    #
+    # review finding (post-B-2): scan `git_view` (heredoc bodies stripped),
+    # with the raw-`cmd` leg gated on `heredoc_shell_fallback` — mirroring
+    # how commit/push/add already work post-D-3 (#223). Scanning raw `cmd`
+    # unconditionally, as this used to, means a heredoc body fed to a
+    # NON-shell consumer that merely QUOTES a gate-marker path (a PR/issue
+    # body describing this very fix) false-trips H-19; scanning only
+    # `git_view` would miss the genuine case where the heredoc's body DOES
+    # reach an executor (`bash -c "$(cat <<EOF … EOF)"`).
+    def _gate_marker_hit(view):
+        return (GATE_MARKER_REDIRECT_RE.search(view)
+                or GATE_MARKER_WRITE_RE.search(view)
+                or GATE_MARKER_INTERP_RE.search(view))
+
+    if _gate_marker_hit(git_view) or (heredoc_shell_fallback and _gate_marker_hit(cmd)):
         block("H-19", "The .codearbiter/.markers/ security-gate-passed / migration-gate-passed "
                       "tokens are recorded only by the sanctioned gate producers (#160) — a shell "
-                      "redirect or write verb naming a gate marker forges a security/migration "
-                      "gate pass and is prohibited.")
+                      "redirect, write verb, or interpreter invocation (python/node/perl/ruby/sh) "
+                      "naming a gate marker forges a security/migration gate pass and is "
+                      "prohibited.")
 
     # H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     # a recorded security-gate pass. The crypto-compliance / secret-handling skills

--- a/plugins/ca-codex/hooks/pre-bash.py
+++ b/plugins/ca-codex/hooks/pre-bash.py
@@ -22,6 +22,8 @@ import traceback
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _gitlib  # noqa: E402 — reused for its spawn-free, worktree-aware
+                # (.git-as-a-FILE / gitdir: pointer) project_root() climb (#223)
 from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
     GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
@@ -298,6 +300,148 @@ def git_cwd(cmd, root):
         val = raw.strip("\"'")
         acc = val if os.path.isabs(val) else os.path.join(acc, val)
     return acc
+
+
+def _effective_exec_root(payload, root):
+    """The git root that a `-C`-less git command in THIS Bash call actually
+    runs against — the command's effective cwd — rather than always the
+    pinned `root` (CLAUDE_PROJECT_DIR) (#223).
+
+    #223's bug: `root` is pinned to CLAUDE_PROJECT_DIR (the MAIN checkout),
+    so a `git commit` fired from a LINKED WORKTREE was judged against the
+    main checkout's branch — both a false positive (worktree on a feature
+    branch, main checkout on main -> wrongly blocked) and a false negative
+    (worktree on main/master, main checkout on a feature branch -> H-01
+    silently sidestepped, the more serious direction).
+
+    D-2 (spec pre-release-hardening): this function governs BRANCH/DIFF
+    resolution (git_cwd's seed) ONLY. Gate MARKERS always keep reading from
+    the pinned `root` regardless of this function's answer — a linked
+    worktree has `.codearbiter/` (tracked) but not `.codearbiter/.markers/`
+    (gitignored), so marker paths must stay anchored at the main checkout.
+    This split existed accidentally before #223 (pre-bash.py:769,828 already
+    read markers from `root` while everything else read from `cwd`); this is
+    now the intentional, documented contract.
+
+    Resolution reuses `_gitlib.project_root` — the existing linked-worktree-
+    aware precedent (`_gitlib.head_branch` already parses a `.git` FILE's
+    `gitdir:` pointer for exactly this case) — rather than a fresh
+    `git rev-parse --show-toplevel` spawn. It climbs from the hook payload's
+    own `cwd` (a trusted-harness input, same footing as CLAUDE_PROJECT_DIR
+    itself — see security-controls.md's Repo resolution section) or, absent
+    one, the hook process's own cwd, stopping at the nearest ancestor with a
+    `.git` (dir OR file) or a `.codearbiter` directory — a linked worktree's
+    `.git` is a FILE, and it also carries its own `.codearbiter/`, so either
+    check alone stops the climb at the worktree root, never the main
+    checkout.
+
+    When that climb lands on the SAME root as `root`, this returns `root`
+    unchanged — the overwhelmingly common (non-worktree) case sees zero
+    behavioral difference. It returns the climbed root only when it names a
+    genuinely DIFFERENT filesystem location."""
+    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
+        return root
+    return exec_root
+
+
+# D-3 (spec pre-release-hardening, #223): the raw-`cmd` fallback below (used
+# when a heredoc is present) must fire ONLY when the heredoc body can
+# genuinely reach a shell — via EITHER of two independent routes, checked by
+# the two functions below (`_heredoc_fed_to_shell` and `_has_shell_executor`,
+# OR'd together at the call site): (1) the heredoc's DIRECT consumer is
+# itself a shell-like program whose stdin is executed as code (`bash <<EOF`),
+# or (2) some OTHER token in the command is a shell/interpreter executor that
+# runs a command-substitution result carrying the heredoc's output
+# (`bash -c "$(cat <<EOF … EOF)"` — the heredoc's direct consumer is `cat`,
+# route (1) says no, but `bash -c` EXECUTES what `cat` produced, so route (2)
+# must say yes). A heredoc handed to a non-shell consumer with NO executor
+# anywhere in the command (`gh pr create --body "$(cat <<EOF … EOF)"`) is
+# inert prose to this guard even though it is substituted into another
+# command's argument — neither route fires, so the fallback correctly stays
+# off and a PR/issue body merely QUOTING "git commit" does not false-trip.
+SHELL_HEREDOC_CONSUMERS = frozenset({
+    "bash", "sh", "zsh", "dash", "ksh",
+    "python", "python2", "python3", "perl", "ruby", "node", "nodejs",
+})
+
+
+def _heredoc_fed_to_shell(cmd):
+    """True iff at least one `<<` heredoc operator in `cmd` attaches to a
+    shell-like consumer (SHELL_HEREDOC_CONSUMERS) — a program whose stdin IS
+    executed, not merely read as inert text.
+
+    The consumer is the FIRST token of the "simple command" the heredoc
+    operator sits at the end of: scan backward from the operator to the
+    nearest unquoted `|`, `;`, `&`, or `(` (or the start of the string) —
+    that is where the current simple command began — then take its first
+    token. This correctly finds `bash` in `bash <<EOF` and `cat` (not `gh`)
+    in `gh pr create --body "$(cat <<EOF … EOF)"` (the `(` from `$(` bounds
+    the segment)."""
+    for m in re.finditer(r"<<", cmd):
+        start = m.start()
+        seg_start = 0
+        in_dq = in_sq = False
+        for i in range(start - 1, -1, -1):
+            ch = cmd[i]
+            if ch == '"' and not in_sq:
+                in_dq = not in_dq
+            elif ch == "'" and not in_dq:
+                in_sq = not in_sq
+            elif not in_dq and not in_sq and ch in "|;&(":
+                seg_start = i + 1
+                break
+        segment = cmd[seg_start:start]
+        tokens = re.findall(r'"[^"]*"|\'[^\']*\'|\S+', segment)
+        if not tokens:
+            continue
+        head = os.path.basename(tokens[0].strip("\"'"))
+        if head in SHELL_HEREDOC_CONSUMERS:
+            return True
+    return False
+
+
+# security-reviewer finding (post-A-4): `_heredoc_fed_to_shell` alone answers
+# "is the heredoc's DIRECT consumer a shell" — that is NOT the same question
+# as "does the heredoc's body reach a shell." `bash -c "$(cat <<EOF … EOF)"`
+# has `cat` as the heredoc's direct consumer (correctly classified non-shell
+# by the check above), but `bash -c` then EXECUTES the substituted result of
+# that `cat` — the body reaches a shell by a route the direct-consumer check
+# cannot see (same hole for `eval "$(cat <<EOF … EOF)"`, `sh -c "$(…)"`, and
+# any command-substitution chain ending in a shell/interpreter executor).
+# This second check asks the complementary question: does ANY token in the
+# whole command invoke something that executes a string as code, regardless
+# of where the heredoc sits relative to it. FAILS CLOSED on uncertainty —
+# `eval` and `xargs` (which can forward its input straight into an executor)
+# are treated as always-executor, no flag required.
+SHELL_C_PROGRAMS = frozenset({"bash", "sh", "zsh", "dash", "ksh"})
+INTERP_C_PROGRAMS = frozenset({"python", "python2", "python3"})
+INTERP_E_PROGRAMS = frozenset({"perl", "ruby", "node", "nodejs"})
+ALWAYS_EXECUTOR_PROGRAMS = frozenset({"eval", "xargs"})
+
+
+def _has_shell_executor(cmd):
+    """True iff `cmd` invokes ANYWHERE a program that executes a string as
+    code: `bash -c`/`sh -c`/`zsh -c`/`dash -c`/`ksh -c`, `python[23]? -c`,
+    `perl -e`/`ruby -e`/`node[js]? -e`, or a bare `eval`/`xargs` (both can
+    hand an arbitrary string straight to an executor — `xargs bash -c '...'`,
+    `eval "$var"` — so both are treated as executors unconditionally, no
+    flag needed, per the fail-closed mandate).
+
+    Scans the RAW command (heredoc bodies included) — a heredoc body that
+    happens to mention one of these tokens as prose causes a conservative
+    over-block, never an under-scan, matching this file's established
+    ambiguity-resolves-CLOSED stance (D-3)."""
+    tokens = [t.strip("\"'") for t in re.findall(r'"[^"]*"|\'[^\']*\'|\S+', cmd)]
+    basenames = [os.path.basename(t) for t in tokens]
+    if any(b in ALWAYS_EXECUTOR_PROGRAMS for b in basenames):
+        return True
+    if "-c" in tokens and any(
+            b in SHELL_C_PROGRAMS or b in INTERP_C_PROGRAMS for b in basenames):
+        return True
+    if "-e" in tokens and any(b in INTERP_E_PROGRAMS for b in basenames):
+        return True
+    return False
 
 
 def current_branch(cwd):
@@ -588,15 +732,34 @@ def _run(root):
     # a body-stripped view so message content (which may contain `;`/`|`/`&`,
     # or mention `git -C`) never truncates the args capture, poisons the cwd
     # extraction, or leaks words into the pathspec parse. The RAW command stays
-    # as a fallback matcher: a heredoc fed TO a shell (`bash <<EOF … EOF`)
-    # executes its body, so a commit/push/add visible only in the raw text must
-    # still be guarded — ambiguity resolves CLOSED, so the fallback over-blocks
-    # (e.g. a message QUOTING a force-push) rather than under-scans.
+    # as a fallback matcher, but ONLY when the heredoc's consumer is a shell
+    # (D-3, #223, `_heredoc_fed_to_shell` above): a heredoc fed TO a shell
+    # (`bash <<EOF … EOF`) genuinely executes its body, so a commit/push/add
+    # visible only in the raw text must still be guarded there — ambiguity
+    # resolves CLOSED. A heredoc fed to a non-shell consumer (`gh`, `cat`, …)
+    # is inert prose and must NOT fall back to the raw-text scan, or a PR/issue
+    # body merely QUOTING "git commit" false-trips H-01/H-09b/H-14.
     git_view = _strip_heredoc_bodies(cmd) if "<<" in cmd else cmd
+    # Both legs are OR'd: the heredoc's direct consumer being a shell
+    # (`bash <<EOF`) is one route to execution; a shell/interpreter executor
+    # appearing ANYWHERE in the command (`bash -c "$(cat <<EOF … EOF)"`,
+    # `eval "$(cat <<EOF … EOF)"`) is another that the direct-consumer check
+    # alone cannot see (security-reviewer finding, post-A-4) — either is
+    # sufficient to keep the fallback closed.
+    heredoc_shell_fallback = "<<" in cmd and (
+        _heredoc_fed_to_shell(cmd) or _has_shell_executor(cmd))
 
-    commit = COMMIT_RE.search(git_view) or COMMIT_RE.search(cmd)
-    push_probe = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
-    cwd = git_cwd(git_view, root)
+    commit = COMMIT_RE.search(git_view) or (
+        heredoc_shell_fallback and COMMIT_RE.search(cmd))
+    push_probe = PUSH_RE.search(git_view) or (
+        heredoc_shell_fallback and PUSH_RE.search(cmd))
+
+    # #223: -C-less git commands run against the command's EFFECTIVE cwd, not
+    # unconditionally CLAUDE_PROJECT_DIR — see _effective_exec_root's
+    # docstring (D-2: gate MARKERS stay pinned to `root` regardless; only
+    # branch/diff resolution follows the command's real cwd).
+    exec_root = _effective_exec_root(payload, root)
+    cwd = git_cwd(git_view, exec_root)
 
     # reliability-004 (#190): fail CLOSED for commit/push when the `-C` target
     # git_cwd() resolved does not exist as a directory — an unresolvable -C
@@ -632,7 +795,8 @@ def _run(root):
             block("H-01", f"Direct commit to {target} is prohibited (ORCHESTRATOR §3). "
                           f"Create a feature branch.")
 
-    push = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
+    push = PUSH_RE.search(git_view) or (
+        heredoc_shell_fallback and PUSH_RE.search(cmd))
     if push:
         pargs = push.group("args")
 
@@ -678,7 +842,8 @@ def _run(root):
     # flag spellings (-A/--all/-u/.) and the argument spellings (globs,
     # directories, pathspec magic) — `git add src/` stages everything beneath
     # src/ just as surely as `git add -A` does.
-    add = ADD_RE.search(git_view) or ADD_RE.search(cmd)
+    add = ADD_RE.search(git_view) or (
+        heredoc_shell_fallback and ADD_RE.search(cmd))
     if add:
         if WILDCARD_ADD_RE.search(add.group("args")):
             block("H-03", "'git add -A' / 'git add .' / 'git add --all' / 'git add -u' "

--- a/plugins/ca-codex/hooks/pre-bash.py
+++ b/plugins/ca-codex/hooks/pre-bash.py
@@ -26,9 +26,10 @@ import _gitlib  # noqa: E402 — reused for its spawn-free, worktree-aware
                 # (.git-as-a-FILE / gitdir: pointer) project_root() climb (#223)
 from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
-    GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
-    get_host, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, set_host, tool_input, utf8_stdio,
+    GATE_MARKER_NAMES, SECRET_RE, SECURITY_DIFF_GIT_ARGS, arbiter_active,
+    block, content_digest, get_host, is_migration_path, line_digest,
+    marker_fresh, project_root, read_input, sensitive_scan_added_lines,
+    set_host, tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -563,8 +564,15 @@ def added_lines(cwd, ref, paths=None):
     Decoded as UTF-8 with replacement: `text=True` alone uses the locale code
     page (cp1252 on stock Windows), where a non-cp1252 byte in the diff raised
     UnicodeDecodeError into the bare except below and the security gate
-    silently failed OPEN on exactly the platform this layer protects."""
-    argv = ["git", "diff", ref] + (["--", *paths] if paths else [])
+    silently failed OPEN on exactly the platform this layer protects.
+
+    Excludes gate-events.log (#279): `sensitive_scan_added_lines` walks the
+    diff path-aware, dropping lines that belong to the crypto/secret gate's
+    own machine-written audit sink — see its docstring in `_hooklib`. Reads
+    the diff via SECURITY_DIFF_GIT_ARGS (pinned a/ b/ prefixes, no external
+    diff) so a hostile `diff.mnemonicPrefix`/`diff.noprefix`/external-diff
+    config can never break that attribution (#279 review MEDIUM-1)."""
+    argv = ["git", *SECURITY_DIFF_GIT_ARGS, ref] + (["--", *paths] if paths else [])
     try:
         out = subprocess.run(
             argv, cwd=cwd,
@@ -577,10 +585,7 @@ def added_lines(cwd, ref, paths=None):
     except Exception as e:  # noqa: BLE001
         _note_read_err(argv, repr(e))
         return None
-    return "\n".join(
-        line[1:] for line in out.stdout.splitlines()
-        if line.startswith("+") and not line.startswith("+++")
-    )
+    return "\n".join(sensitive_scan_added_lines(out.stdout))
 
 
 def _names(cwd, args):

--- a/plugins/ca-codex/hooks/security-pass.py
+++ b/plugins/ca-codex/hooks/security-pass.py
@@ -24,8 +24,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, line_digest, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
+    line_digest, project_root, sensitive_scan_added_lines, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -53,19 +54,34 @@ def candidate_lines(root):
     """Every line the next commit could introduce: added lines of the
     worktree-vs-HEAD diff (staged and unstaged alike), plus the full content
     of untracked files — `git diff HEAD` never shows those, but they land in
-    the staged diff the moment commit-gate stages them."""
+    the staged diff the moment commit-gate stages them.
+
+    Excludes gate-events.log (#279, is_sensitive_scan_exempt): the crypto/
+    secret gate's own machine-written audit sink, which structurally echoes
+    the detector's message text back at itself. The diff branch drops those
+    lines via the shared path-aware `sensitive_scan_added_lines`; the
+    unborn-branch and untracked-file branches skip the file outright since
+    they read whole-file content rather than a diff.
+
+    The diff is read via SECURITY_DIFF_GIT_ARGS (not a bare `["diff", ...]`):
+    it pins the `a/`/`b/` prefix format `sensitive_scan_added_lines` depends
+    on for path attribution, regardless of the caller's `diff.mnemonicPrefix`
+    / `diff.noprefix` / external-diff config (#279 review MEDIUM-1)."""
     lines = []
-    diff = run_git(["diff", "HEAD"], root)
+    diff = run_git([*SECURITY_DIFF_GIT_ARGS, "HEAD"], root)
     if diff.returncode == 0:
-        lines += [ln[1:] for ln in diff.stdout.splitlines()
-                  if ln.startswith("+") and not ln.startswith("+++")]
+        lines += sensitive_scan_added_lines(diff.stdout)
     else:
         # Unborn branch (no HEAD yet): every tracked file is new content.
         ls = run_git(["ls-files"], root)
         for rel in ls.stdout.splitlines():
+            if is_sensitive_scan_exempt(rel):
+                continue
             lines += file_lines(root, rel)
     untracked = run_git(["ls-files", "--others", "--exclude-standard"], root)
     for rel in untracked.stdout.splitlines():
+        if is_sensitive_scan_exempt(rel):
+            continue
         lines += file_lines(root, rel)
     return lines
 

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -21,6 +21,7 @@
 import concurrent.futures
 import copy
 import datetime
+import json
 import os
 import re
 import subprocess
@@ -31,6 +32,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
+    write_text_atomic,
 )
 from _standuplib import (  # noqa: E402
     any_actionable,
@@ -447,7 +449,80 @@ def has_source(root):
     return False
 
 
-def clear_dev_marker(root, host_name=None):
+# #271 C-5 — session-scoping the repo-global dev marker. The marker itself
+# carries no owner: it is dropped by /dev's own prose (dev.md), which has no
+# reliable way to stamp a real session_id into its content (slash-command
+# prose never receives the hook JSON payload — only actual HOOKS do). So
+# ownership is tracked SEPARATELY, by SessionStart itself: every invocation
+# records (its OWN session_id, now) as "the last session known to have
+# started in this repo" BEFORE deciding what to do with the dev marker.
+#
+# This is a heuristic, not true liveness detection (there is no SessionEnd
+# signal this hook can rely on) — documented tradeoff, not a defect. The
+# record's timestamp is ANCHORED TO THE OWNER, not to "whatever session
+# started most recently" — that distinction is load-bearing (a review caught
+# an earlier draft that refreshed it unconditionally on every invocation,
+# which meant an unrelated session B/C/D/... starting in an otherwise-active
+# repo kept sliding the window forward forever and the marker became
+# immortal). The write is therefore CONDITIONAL, decided AFTER checking the
+# marker, not before:
+#   - no live marker at all: refresh freely — "the session that could next
+#     enter /dev is me" is exactly the fact this record exists to hold.
+#   - live marker AND session_id == prev_sid: refresh. This is the owner
+#     heartbeating through a resume/compaction, and it's what keeps a
+#     genuinely long /ca:dev sitting from being force-closed at the 6h mark.
+#   - live marker AND a DIFFERENT session_id: do NOT write. `prev_ts` stays
+#     anchored to the OWNER's last known activity — a different session
+#     merely observing the marker must not reset that clock, or it would
+#     never elapse in any repo that sees regular unrelated activity.
+#
+# Net effect: a marker owned by a session that crashed is left alone by every
+# later, unrelated session (they cannot know it is dead) but self-heals
+# DEV_SESSION_LIVENESS_WINDOW after the OWNER's own last recorded activity —
+# not after the most recent unrelated SessionStart. Symmetric residual: a
+# genuinely live /ca:dev sitting untouched (no resume/compaction of its own)
+# for longer than the window can still be force-closed by a later session,
+# same as the pre-#271 behavior would have done immediately. No session_id
+# available on this invocation/host (Codex parity unverified), or no prior
+# record at all, degrades to the original unconditional clear — a marker that
+# can NEVER be cleared is a worse failure mode than one cleared too eagerly.
+DEV_SESSION_LIVENESS_WINDOW = 6 * 3600  # 6h: generous single-sitting bound
+
+
+def _dev_session_owner_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-session-owner.json")
+
+
+def _read_dev_session_owner(root):
+    """(session_id, ts) last recorded by ANY SessionStart invocation in this
+    repo, or (None, None) on an absent/corrupt/malformed record. Never
+    raises."""
+    try:
+        with open(_dev_session_owner_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        sid = data.get("session_id")
+        ts = data.get("ts")
+        if isinstance(sid, str) and sid and isinstance(ts, (int, float)):
+            return sid, float(ts)
+    except Exception:  # noqa: BLE001 — corrupt/absent record -> no signal
+        pass
+    return None, None
+
+
+def _write_dev_session_owner(root, session_id, ts):
+    """Best-effort refresh of the last-known-active-session record. Never
+    raises — a write failure just means the NEXT SessionStart degrades to the
+    conservative no-prior-record fallback, exactly as if this were the first
+    session ever."""
+    try:
+        path = _dev_session_owner_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps({"session_id": session_id, "ts": ts}))
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
     synthetic DEV: exit line to overrides.log BEFORE removing it
@@ -461,29 +536,77 @@ def clear_dev_marker(root, host_name=None):
     (ADR-0011). Optional and defaults to resolving it here via `get_host()`
     (#257) — main() already holds a Host instance and passes its `.name`
     through to avoid a second resolution, but any other caller (tests
-    included) may omit it."""
+    included) may omit it.
+
+    `session_id` (#271 C-5) is THIS invocation's own session id from the
+    SessionStart hook payload, when the host supplies one. See the module
+    comment above `DEV_SESSION_LIVENESS_WINDOW` for the full session-scoping
+    contract: a live marker is only force-closed when there is no reason to
+    believe a DIFFERENT, still-running session currently owns it — and the
+    ownership record's timestamp is refreshed ONLY by the owner itself (never
+    by an unrelated session merely observing the marker), so the liveness
+    window is anchored to the owner's last activity, not reset by every
+    passerby SessionStart. `now` (epoch seconds) is injectable for
+    deterministic tests; defaults to `time.time()`."""
+    now = time.time() if now is None else now
+    prev_sid, prev_ts = _read_dev_session_owner(root)
+
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
-    if os.path.isfile(marker):
-        if host_name is None:
-            try:
-                # get_host() (#257), not a direct hostapi.load_host(): resolves
-                # the SAME Host run(host) injected instead of a second load.
-                host_name = get_host().name
-            except Exception:  # noqa: BLE001 — must never brick session startup
-                host_name = "unknown"
+    marker_live = os.path.isfile(marker)
+
+    if not marker_live:
+        # No live marker: this record is purely "who could next enter /dev" —
+        # any session refreshing it is harmless and correct. Nothing else to
+        # do — there is no marker to clear and no close to log.
+        if session_id:
+            _write_dev_session_owner(root, session_id, now)
+        return
+
+    if session_id and prev_sid:
+        if prev_sid == session_id:
+            # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
+            # heartbeat (this is the only case where a write is safe while the
+            # marker is live) and leave the marker untouched.
+            _write_dev_session_owner(root, session_id, now)
+            return
+        if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
+            # A different session, and the OWNER's own clock hasn't elapsed
+            # yet — do NOT touch the record (an unrelated observer must never
+            # reset a clock it doesn't own) and do not clobber the marker.
+            return
+        # Different session AND the owner's own record is stale beyond the
+        # window: proceed to the force-close below. Deliberately do not write
+        # a fresh record here either — there is no live owner left to anchor
+        # a new one to; the write happens naturally next time /dev is entered.
+
+    if session_id and not prev_sid:
+        # No prior record at all (first session ever, or a dropped record) —
+        # no signal to protect a concurrent owner; seed the record for next
+        # time and fall through to the pre-#271 unconditional-clear behavior.
+        _write_dev_session_owner(root, session_id, now)
+
+    # Force-close: either no session_id/no prior record (unconditional-clear
+    # fallback), or a genuinely stale owner beyond the window.
+    if host_name is None:
         try:
-            arbiter_ref = get_host().cmd_ref("arbiter")
+            # get_host() (#257), not a direct hostapi.load_host(): resolves
+            # the SAME Host run(host) injected instead of a second load.
+            host_name = get_host().name
         except Exception:  # noqa: BLE001 — must never brick session startup
-            arbiter_ref = "/ca:arbiter"
-        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
-                f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-        try:
-            with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                      "a", encoding="utf-8") as f:
-                f.write(line)
-        except OSError:
-            pass
+            host_name = "unknown"
+    try:
+        arbiter_ref = get_host().cmd_ref("arbiter")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        arbiter_ref = "/ca:arbiter"
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
+            f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
+    try:
+        with open(os.path.join(root, ".codearbiter", "overrides.log"),
+                  "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
     try:
         os.remove(marker)
     except OSError:
@@ -560,6 +683,30 @@ def spawn_background_update_refresh(plugin, spawner=None):
         return None
 
 
+def _session_id_from_stdin():
+    """Best-effort session_id from the SessionStart hook's own JSON payload
+    (#271 C-5) — session-start.py has never read its stdin before this. Reads
+    directly rather than via `_hooklib.read_input()` so an absent/empty
+    session_id degrades SILENTLY (it is a normal, expected condition on a host
+    that doesn't supply one — not a parse error worth a `warn()` breadcrumb on
+    every single session start). Guards against a blocking read on an
+    interactive stdin the same way statusline.py's `main()` does (`isatty()`
+    check) — this hook must never hang session startup waiting for input that
+    will never arrive. Returns "" on any failure, absence, or malformed
+    payload; the caller treats an empty session_id as "unavailable" and
+    degrades to the pre-#271 unconditional-clear behavior."""
+    try:
+        if sys.stdin.isatty():
+            return ""
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return ""
+        data = json.loads(raw)
+        return str(data.get("session_id") or "") if isinstance(data, dict) else ""
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        return ""
+
+
 def main():
     utf8_stdio()
     # get_host() (#257): resolves the SAME Host run(host) already primed via
@@ -568,11 +715,15 @@ def main():
     root = project_root()
     plugin = host.plugin_root()
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
+    session_id = _session_id_from_stdin()
 
     # /dev developer-override is per-session: clear its statusline marker on
     # startup — a new session restores orchestration. A live marker means a prior
     # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
-    clear_dev_marker(root, host.name)
+    # session_id (#271 C-5) lets this distinguish "the same session resuming"
+    # and "a different, possibly still-live session" from a genuinely
+    # abandoned marker — see clear_dev_marker's docstring.
+    clear_dev_marker(root, host.name, session_id)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/plugins/ca-codex/hooks/statusline.py
+++ b/plugins/ca-codex/hooks/statusline.py
@@ -134,6 +134,7 @@ try:
     ANSI = _colorlib.ANSI
     _cw, vlen, clip, pad, gradient_h = (_colorlib._cw, _colorlib.vlen, _colorlib.clip,
                                         _colorlib.pad, _colorlib.gradient_h)
+    strip_control = _colorlib.strip_control
 except Exception:  # pragma: no cover — never let an import break the statusline
     _colorlib = None
     ANSI = re.compile(r"\033\[[0-9;]*m")
@@ -156,6 +157,9 @@ except Exception:  # pragma: no cover — never let an import break the statusli
 
     def gradient_h(text, width, c_from=None, c_to=None):
         return text
+
+    def strip_control(s):
+        return s if not isinstance(s, str) else re.sub(r"[\000-\037]", "", s)
 
 # --------------------------------------------------------------------------- coercion
 def num(x, default=0.0):
@@ -593,7 +597,7 @@ def _render_active_palette(raw):
     if branch:
         dirty = "*" if safe(git_dirty, root) else ""
         gp += f" {V0}{V}{RESET} {(WARN if dirty else OK)}{branch}{dirty}{RESET}"
-    model = get(data, "model", "display_name") or get(data, "model", "id") or "?"
+    model = strip_control(get(data, "model", "display_name") or get(data, "model", "id") or "?")
     pill = safe(model_pill, model, effort) or f"{V2}{model}{RESET}"
     rates = safe(seg_window_inline, data) or ""
     prseg = safe(seg_pr, data) or ""

--- a/plugins/ca-codex/hooks/taskwrite.py
+++ b/plugins/ca-codex/hooks/taskwrite.py
@@ -27,7 +27,9 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
+from _hooklib import (  # noqa: E402
+    acquire_lock, project_root, release_lock, set_host, utf8_stdio,
+)
 
 # reliability-007 (#190): project_root() is now _hooklib.project_root —
 # imported above, not a local copy. The prior local copy ran `git rev-parse
@@ -35,6 +37,31 @@ from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
 # skipping the CLAUDE_PROJECT_DIR-first read _hooklib.project_root() exists
 # for; taskwrite mutates .codearbiter/open-tasks.md, so a wrong root silently
 # wrote into the wrong repository's board.
+#
+# #271 C-2/C-3 — lock + re-read-under-lock CAS (spec D-4). taskwrite is the
+# only *programmatic* board mutator, but it is NOT the only writer: the
+# harvest/decompose paths mutate open-tasks.md directly via the host's own
+# Edit/Write tool and will never take this lock (ADR-0008 tolerates that
+# out-of-band path deliberately). A lock alone would therefore still let an
+# interleaved external Edit get silently overwritten by a stale in-memory
+# snapshot, AND would still let two lock-serialized taskwrite calls mint the
+# SAME dotted id if each computed next_seq() against the text it opened with
+# rather than the text current at write time. Taking the lock and THEN
+# reading the board — re-running the pure transform against that fresh read —
+# fixes both: an interleaved external edit is preserved (detected-loss instead
+# of silent clobber), and next_seq() always runs against current text.
+#
+# Fail-soft choice: _ledgerlib's convention is to silently no-op when the lock
+# handle is None (a statusline render is disposable — nobody is worse off if
+# ONE render skips the ledger write). A board mutation is not disposable: it
+# is the single user-visible effect of the whole `taskwrite` invocation, and
+# /ca:task has no other way to report "your task was recorded." Silently
+# proceeding unlocked on contention would silently reintroduce the exact race
+# this fix exists to close (two writers both read-modify-write with no
+# serialization at all). So on a None lock handle, taskwrite refuses to write
+# and exits nonzero with a clear stderr message — the caller (a skill/command)
+# sees a failed exit code and can retry, rather than a false "added"/"marked"
+# success hiding a lost or colliding write.
 
 
 def _date(s):
@@ -45,6 +72,46 @@ def _date(s):
         return datetime.datetime.strptime(s, "%Y-%m-%d").date()
     except ValueError:
         return None
+
+
+def _parse_gid(gid):
+    """Split a `--id GROUP.TYPE` value, or None with an error message on a bad
+    spelling. Pure — no I/O — so it can run before OR after the lock is held."""
+    parts = gid.split(".")
+    if len(parts) != 2 or not all(parts):
+        return None, None, (f"bad --id '{gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
+                             f"the 4-digit seq is minted automatically)")
+    return parts[0], parts[1], None
+
+
+def _apply(args, text):
+    """Pure text -> (new_text, action) | (None, error_msg) transform against
+    the board text the caller hands in. Deliberately takes NO lock and does NO
+    I/O itself — the caller (main()) re-runs this against a FRESH read taken
+    INSIDE the lock (#271 C-3/D-4), so next_seq()'s duplicate-id mint and any
+    interleaved external Edit are both resolved against current text, never a
+    stale snapshot."""
+    if args.verb == "add":
+        group = typ = None
+        if args.gid:
+            group, typ, err = _parse_gid(args.gid)
+            if err:
+                return None, err
+        boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
+        new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
+                           type=typ, boundaries=boundaries, section=args.section)
+        return new, f"added queued task: {args.desc}"
+
+    # start / done
+    state = "in_progress" if args.verb == "start" else "done"
+    day = _date(args.date)
+    if day is None:
+        return None, f"bad --date '{args.date}' (expected YYYY-MM-DD)"
+    assign = getattr(args, "assign", None)
+    new = tb.set_state(text, args.target, state, day, assign=assign)
+    if new == text:
+        return None, f"no change: '{args.target}' not found or already {state}"
+    return new, f"marked {state}: {args.target}"
 
 
 def main(argv=None):
@@ -72,52 +139,57 @@ def main(argv=None):
 
     root = project_root()
     board_path = os.path.join(root, ".codearbiter", "open-tasks.md")
-    text = tb.read_board(board_path)
-    if text is None:
+
+    # An uninitialized repo (no board at all) is a static precondition, not
+    # part of the race this fix closes — check it BEFORE touching the lock so
+    # a run against an uninitialized repo creates no side effect (no
+    # .codearbiter/ dir, no lock sidecar file), exactly as before #271.
+    if not os.path.isfile(board_path):
         print(f"no board at {board_path} — is this an initialized repo?", file=sys.stderr)
         return 1
 
-    if args.verb == "add":
-        group = typ = None
-        if args.gid:
-            parts = args.gid.split(".")
-            if len(parts) != 2 or not all(parts):
-                print(f"bad --id '{args.gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
-                      f"the 4-digit seq is minted automatically)", file=sys.stderr)
-                return 1
-            group, typ = parts
-        boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
-        new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
-                           type=typ, boundaries=boundaries, section=args.section)
-        action = f"added queued task: {args.desc}"
-    else:  # start / done
-        state = "in_progress" if args.verb == "start" else "done"
-        day = _date(args.date)
-        if day is None:
-            print(f"bad --date '{args.date}' (expected YYYY-MM-DD)", file=sys.stderr)
-            return 1
-        assign = getattr(args, "assign", None)
-        new = tb.set_state(text, args.target, state, day, assign=assign)
-        if new == text:
-            print(f"no change: '{args.target}' not found or already {state}", file=sys.stderr)
-            return 1
-        action = f"marked {state}: {args.target}"
-
-    # Atomic write: write to a sibling temp file, then os.replace() into place.
-    # os.replace() is atomic on POSIX and a same-volume rename on Windows, so a
-    # crash between open() and f.write() never leaves the board truncated.
-    board_dir = os.path.dirname(board_path)
-    fd, tmp_path = tempfile.mkstemp(dir=board_dir, suffix=".tmp", prefix="open-tasks.")
+    # #271 C-3 (spec D-4): take the lock FIRST, THEN read the board — everything
+    # from here to the write is inside the critical section, so the read this
+    # transaction acts on is guaranteed fresh relative to any other
+    # lock-taking writer. Fail-soft nuance: unlike _ledgerlib's disposable
+    # statusline write, a board mutation must never be silently dropped on
+    # contention — refuse and exit nonzero instead (see module docstring).
+    lock = acquire_lock(board_path)
+    if lock is None:
+        print(f"could not acquire the task-board lock ({board_path}.lock) — "
+              f"another writer holds it; no changes were written, retry the "
+              f"{args.verb}", file=sys.stderr)
+        return 1
     try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
-            f.write(new)
-        os.replace(tmp_path, board_path)
-    except Exception:
+        text = tb.read_board(board_path)
+        if text is None:
+            print(f"no board at {board_path} — is this an initialized repo?", file=sys.stderr)
+            return 1
+
+        new, action_or_err = _apply(args, text)
+        if new is None:
+            print(action_or_err, file=sys.stderr)
+            return 1
+        action = action_or_err
+
+        # Atomic write: write to a sibling temp file, then os.replace() into
+        # place. os.replace() is atomic on POSIX and a same-volume rename on
+        # Windows, so a crash between open() and f.write() never leaves the
+        # board truncated.
+        board_dir = os.path.dirname(board_path)
+        fd, tmp_path = tempfile.mkstemp(dir=board_dir, suffix=".tmp", prefix="open-tasks.")
         try:
-            os.remove(tmp_path)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+                f.write(new)
+            os.replace(tmp_path, board_path)
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+    finally:
+        release_lock(lock)
     print(action)
     return 0
 

--- a/plugins/ca-codex/skills/ca-arbiter/SKILL.md
+++ b/plugins/ca-codex/skills/ca-arbiter/SKILL.md
@@ -28,3 +28,9 @@ orchestration — the exit is on the audit trail like the entry. MUST NOT rewrit
 ended mid-dev, SessionStart has already appended the synthetic `BY: session-cleanup | DEV: exit` close
 line and cleared the marker (`session-start.py`, observability-001). In that case MUST NOT write a
 second `DEV: exit` for that orphaned entry — the close is already on the trail.
+
+Session-scoped clearing (#271): SessionStart's synthetic close is now conditional on the marker
+plausibly being abandoned rather than owned by a different, still-live session — it will NOT clobber
+another concurrently-running session's live `/dev` marker or write a false `DEV: exit` for it.
+`$ca-arbiter` remains the ONLY way to cleanly close your OWN `/dev` session's audit pair; do not
+rely on a future SessionStart to do it for you.

--- a/plugins/ca-codex/skills/ca-dev/SKILL.md
+++ b/plugins/ca-codex/skills/ca-dev/SKILL.md
@@ -26,6 +26,10 @@ Suspends orchestration for working ON codeArbiter — skill, agent, command, and
 4. **Mode** — plain, direct coding assistant: no routing, no skills, no gates, no `[CONFIRM-NN]`
    surfacing, no redirect. Persists until `$ca-arbiter` or a new session.
 
+Note (#271): if another session starts in this repo while this marker is live, SessionStart no longer
+unconditionally clears it out from under you — it is session-scoped now, so a concurrently-running dev
+session's marker survives a different session's startup. See `$ca-arbiter` for the exit-path detail.
+
 ## Hard gate
 
 MUST refuse without `CODEARBITER_DEV=1`. MUST write the `DEV: enter` log line before suspending

--- a/plugins/ca/commands/arbiter.md
+++ b/plugins/ca/commands/arbiter.md
@@ -28,3 +28,9 @@ orchestration — the exit is on the audit trail like the entry. MUST NOT rewrit
 ended mid-dev, SessionStart has already appended the synthetic `BY: session-cleanup | DEV: exit` close
 line and cleared the marker (`session-start.py`, observability-001). In that case MUST NOT write a
 second `DEV: exit` for that orphaned entry — the close is already on the trail.
+
+Session-scoped clearing (#271): SessionStart's synthetic close is now conditional on the marker
+plausibly being abandoned rather than owned by a different, still-live session — it will NOT clobber
+another concurrently-running session's live `/dev` marker or write a false `DEV: exit` for it.
+`/ca:arbiter` remains the ONLY way to cleanly close your OWN `/dev` session's audit pair; do not
+rely on a future SessionStart to do it for you.

--- a/plugins/ca/commands/dev.md
+++ b/plugins/ca/commands/dev.md
@@ -26,6 +26,10 @@ Suspends orchestration for working ON codeArbiter — skill, agent, command, and
 4. **Mode** — plain, direct coding assistant: no routing, no skills, no gates, no `[CONFIRM-NN]`
    surfacing, no redirect. Persists until `/ca:arbiter` or a new session.
 
+Note (#271): if another session starts in this repo while this marker is live, SessionStart no longer
+unconditionally clears it out from under you — it is session-scoped now, so a concurrently-running dev
+session's marker survives a different session's startup. See `/ca:arbiter` for the exit-path detail.
+
 ## Hard gate
 
 MUST refuse without `CODEARBITER_DEV=1`. MUST write the `DEV: enter` log line before suspending

--- a/plugins/ca/hooks/_arbiterstatelib.py
+++ b/plugins/ca/hooks/_arbiterstatelib.py
@@ -198,5 +198,11 @@ def _arbiter_state_uncached(cad, count_in_flight=None, read_board=None, frontmat
 
 def dev_active(root):
     """True when /dev developer-override mode is on — signalled by a transient marker
-    the orchestrator drops on /dev and clears on /arbiter (a local UI flag, not a log)."""
+    the orchestrator drops on /dev and clears on /arbiter (a local UI flag, not a log).
+
+    Presence-only by design, unaffected by #271 C-5's session-scoped clearing:
+    the marker still means "dev mode is on for SOMEONE" regardless of which
+    session owns it. Session-scoping only changes WHEN SessionStart is willing
+    to clear a live marker (never a different, possibly still-live session's
+    own marker) — it does not change what "present" means to this reader."""
     return os.path.exists(os.path.join(root, ".codearbiter", ".markers", "dev-active"))

--- a/plugins/ca/hooks/_colorlib.py
+++ b/plugins/ca/hooks/_colorlib.py
@@ -20,6 +20,7 @@
 #   clip(s, w) -> str                         truncate to <= w visible columns (ANSI-preserving)
 #   pad(s, w) -> str                          pad/clip to exactly w visible columns
 #   gradient_h(text, width, c_from, c_to) -> str   per-character violet sheen
+#   strip_control(s) -> str                   strip C0 control bytes + OSC/CSI escape sequences
 
 import json
 import os
@@ -110,7 +111,7 @@ def _read_custom(path):
             return None
         value = json.loads(raw.decode("utf-8"))
         return value if isinstance(value, dict) else None
-    except (OSError, UnicodeError, ValueError, TypeError):
+    except (OSError, UnicodeError, ValueError, TypeError, RecursionError):
         return None
 
 
@@ -211,6 +212,26 @@ BOLT = "↯"
 SPARK = "▁▂▃▄▅▆▇█"
 
 ANSI = re.compile(r"\033\[[0-9;]*m")
+
+# Host-controlled strings (a model display name, a subagent's derived label)
+# reach the render path verbatim. Neither the host payload nor a subagent
+# transcript is a trusted source, so any C0 control byte or OSC/CSI escape
+# sequence embedded in one is terminal-escape injection into the user's
+# prompt line — strip it before the string is ever composed into a row.
+_OSC_RE = re.compile(r"\033\][^\007\033]*(?:\007|\033\\)?")
+_CSI_RE = re.compile(r"\033\[[0-?]*[ -/]*[@-~]?")
+_C0_RE = re.compile(r"[\000-\037]")
+
+
+def strip_control(s):
+    """Strip OSC/CSI escape sequences and any remaining C0 control byte
+    (0x00-0x1f) from a host- or transcript-derived string. Non-string input
+    passes through unchanged; this must never raise."""
+    if not isinstance(s, str):
+        return s
+    s = _OSC_RE.sub("", s)
+    s = _CSI_RE.sub("", s)
+    return _C0_RE.sub("", s)
 
 
 def _cw(ch):

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -7,43 +7,56 @@
 # repo-level .git/hooks/pre-commit and pre-push that invoke git-enforce.py at the
 # git operation itself, where spelling no longer matters.
 #
-# Design decisions:
+# Design decisions (ADR-0014, resolves #265 / tribunal reliability-009):
 #   * The shim is a tiny POSIX `sh` script that detects the interpreter ONCE
 #     (python3 else python) and runs the enforcer EXACTLY once — never
 #     `python3 X || python X`, which would (a) swallow a BLOCK when python3 both
 #     exists and blocks, and (b) drain stdin before the fallback (pre-push feeds
 #     the ref list on stdin). Same hazard hooks.json avoids via two entries; a
 #     single hook file must guard it inline.
-#   * The shim points at the enforcer by ABSOLUTE PATH, resolved from THIS file's
-#     location (inside the plugin) at install time. install() is re-run every
-#     SessionStart, so the path is refreshed each session — if a plugin update
-#     moves the install dir, the next session rewrites the shim. During the brief
-#     window before that, a missing enforcer makes the shim exit 0 (fail-OPEN on
-#     our OWN staleness only — never brick a user's commits because our path
-#     drifted; the pre-bash + Claude layers still apply).
+#   * The shim itself is HOST-NEUTRAL: it embeds no absolute enforcer path at
+#     all. It instead points at a shared, non-versioned drop-in directory
+#     inside the repo's OWN `.git/`:
 #
-#     Accepted residual, dual-host widening (reliability-009 / #265, LOW,
-#     ACCEPT-RISK): with BOTH `ca` and `ca-codex` installed against one repo,
-#     each SessionStart (whichever host ran last) rewrites the shim to point at
-#     THAT plugin's own `_enforcer_path()` — the two hosts manage entirely
-#     separate, independently versioned plugin caches (e.g. Claude Code's
-#     `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/...`; Codex's
-#     cache root and layout are not fixed by anything in this repo), so the
-#     sibling plugin's absolute enforcer path is NOT reliably derivable from
-#     this file's own path at write time — no path-substitution or fixed
-#     sibling-directory guess survives an independent version bump on either
-#     side. Multiple-candidate embedding (try both known paths) and a runtime
-#     filesystem search (glob likely cache roots from inside the POSIX `sh`
-#     shim) were both considered and rejected: the former requires knowing a
-#     path this file cannot derive, and the latter would mean an unverified,
-#     host-layout-guessing filesystem search on every commit/push under
-#     Windows Git-Bash `sh` — a fragile git-level backstop is worse than the
-#     accepted trade. Net effect: uninstalling whichever plugin most recently
-#     ran SessionStart leaves the shim fail-open until the SURVIVING host's
-#     next SessionStart rewrites it (single-plugin behavior — install()
-#     writing its own current path — is unchanged and unaffected by this
-#     residual). Revisit only if a host-neutral, version-independent enforcer
-#     location becomes available (e.g. a shared non-versioned shim target).
+#         .git/codearbiter-hooksd/<plugin>.path      # e.g. ca.path, ca-codex.path
+#
+#     Each installed host writes its OWN current `_enforcer_path()` into its
+#     own `<plugin>.path` file every SessionStart (install() below) — a live
+#     host self-heals a stale entry on its very next session. The shim iterates
+#     the directory and execs the FIRST enforcer path that resolves (`[ -f "$E" ]`
+#     succeeds); a dead entry from an uninstalled plugin simply fails that test
+#     and the loop moves on to the next one. `uninstall()` removes only ITS OWN
+#     `.path` file — never the shared shim, which a sibling plugin may still
+#     depend on.
+#   * FAIL CLOSED, not fail-open: if the directory is empty, absent, or every
+#     entry it contains names a file that no longer exists, the shim prints a
+#     diagnostic to stderr and exits non-zero — it BLOCKS the git operation
+#     rather than silently allowing it. This is a deliberate reversal of the
+#     single-plugin fail-open era: ADR-0014 records why. Before this drop-in dir
+#     existed, the shim embedded ONE absolute enforcer path (whichever plugin's
+#     SessionStart ran last), so uninstalling that plugin — or even the OTHER
+#     plugin, if IT never got a chance to write its own copy afterward — could
+#     silently unwire the git-level backstop for every host. The drop-in dir
+#     removes the reason fail-open existed (a plugin no longer has to derive a
+#     SIBLING's path — each writes only its own), so the residual failure mode
+#     (truly nothing resolves) can safely — and must — fail closed instead.
+#   * The drop-in directory itself is resolved via the repo's git COMMON dir
+#     (mirrors `git rev-parse --git-common-dir`, resolved without a git spawn
+#     when possible — see `_git_common_dir`), never `--git-dir` and never a
+#     per-worktree path: a linked worktree's `.git` is a FILE pointing at
+#     `<main>/.git/worktrees/<name>`, and the shared hooks/backstop must resolve
+#     to the ONE drop-in dir inside the MAIN repo's `.git/`, so every worktree
+#     and every host agree on the same directory — a per-worktree drop-in dir
+#     would defeat the entire cross-host purpose.
+#   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
+#     so an existing husky / pre-commit-framework setup is preserved.
+#   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
+#     ours-hook is refreshed. Because the shim no longer embeds any
+#     plugin-specific path, an enforcer-path change (e.g. a version bump moving
+#     the install dir) does NOT by itself require rewriting the shim file — only
+#     this plugin's own `<plugin>.path` drop-in entry, which install() refreshes
+#     unconditionally every session regardless of whether the shim itself needed
+#     a rewrite.
 #   * A pre-existing NON-ours hook is NEVER clobbered — we warn loudly and skip,
 #     so an existing husky / pre-commit-framework setup is preserved.
 #   * Idempotent: an up-to-date ours-hook is left untouched (no churn); a stale
@@ -146,17 +159,132 @@ def _enforcer_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "git-enforce.py")
 
 
-def _shim(enforcer, phase):
-    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK exit
-    # code. `exit 0` when the enforcer file is absent is deliberate fail-open on
-    # our own path staleness (see module header).
+def _plugin_name():
+    """A stable per-plugin identifier for THIS install's drop-in `.path`
+    filename (ADR-0014) — derived from THIS file's own vendored location,
+    exactly the same directory `_enforcer_path()` already anchors on:
+    `.../plugins/<plugin>/hooks/_githooks.py` -> `<plugin>` (e.g. "ca",
+    "ca-codex"). No plugin ever has to know a SIBLING's name or path — each
+    only ever writes its own `<plugin>.path` entry, using its own directory
+    name as the key. Running the unsynced `core/pysrc/_githooks.py` directly
+    (dev-only; tests always import the vendored copy) walks one level higher
+    than a real install and yields a less meaningful name, but still a stable,
+    non-empty one — never a hard failure."""
+    hooks_dir_path = os.path.dirname(os.path.abspath(__file__))
+    plugin_dir = os.path.dirname(hooks_dir_path)
+    return os.path.basename(plugin_dir) or "plugin"
+
+
+_DROPIN_DIRNAME = "codearbiter-hooksd"
+
+
+def _git_common_dir(root):
+    """The directory `git rev-parse --git-common-dir` would report for
+    `root` — resolved WITHOUT a git spawn whenever the on-disk layout is
+    cheaply readable, falling back to a real git spawn only when it isn't.
+
+    Deliberately mirrors --git-common-dir, NOT --git-dir: a linked worktree's
+    `.git` is a FILE (not a directory) holding a `gitdir: <path>` pointer into
+    `<main>/.git/worktrees/<name>`, and THAT directory in turn holds a
+    `commondir` file naming the real, SHARED main `.git`. Every worktree of a
+    repo must resolve to the SAME common dir here, or the #265 drop-in dir
+    would fork per-worktree and defeat the entire cross-host purpose (a shim
+    installed from worktree A would never see an entry written from
+    worktree B). The main-repo case (`.git` is a directory) needs no spawn at
+    all: it IS its own common dir. Returns None if nothing resolves — callers
+    must treat that as "can't place the drop-in dir right now" and never
+    invent a per-worktree fallback."""
+    git_path = os.path.join(root, ".git")
+    if os.path.isdir(git_path):
+        return os.path.abspath(git_path)
+    if os.path.isfile(git_path):
+        text = _read(git_path)
+        if text:
+            for line in text.splitlines():
+                line = line.strip()
+                if line.lower().startswith("gitdir:"):
+                    wt_gitdir = line.split(":", 1)[1].strip()
+                    if not os.path.isabs(wt_gitdir):
+                        wt_gitdir = os.path.normpath(os.path.join(root, wt_gitdir))
+                    cd_text = _read(os.path.join(wt_gitdir, "commondir"))
+                    if cd_text:
+                        cd = cd_text.strip()
+                        common = (cd if os.path.isabs(cd)
+                                  else os.path.normpath(os.path.join(wt_gitdir, cd)))
+                        return os.path.abspath(common)
+                    break
+    r = _git(["rev-parse", "--git-common-dir"], root)
+    if r is not None and r.returncode == 0 and r.stdout.strip():
+        out = r.stdout.strip()
+        return os.path.abspath(out if os.path.isabs(out) else os.path.join(root, out))
+    return None
+
+
+def _dropin_dir(root):
+    """The shared, non-versioned drop-in directory (ADR-0014) each installed
+    host writes its own `<plugin>.path` entry into. Lives inside the repo's
+    git COMMON dir (never a per-worktree one — see `_git_common_dir`) so
+    every worktree and every host share exactly ONE directory. Returns None
+    when the common dir itself can't be resolved (no git dir at all)."""
+    common = _git_common_dir(root)
+    return os.path.join(common, _DROPIN_DIRNAME) if common else None
+
+
+def _path_entry_file(dropin_dir, plugin):
+    return os.path.join(dropin_dir, f"{plugin}.path")
+
+
+def _path_entry_current(dropin_dir, plugin, enforcer):
+    """True iff this plugin's own drop-in entry already names `enforcer`."""
+    existing = _read(_path_entry_file(dropin_dir, plugin))
+    return existing is not None and existing.strip() == enforcer
+
+
+def _write_path_entry(dropin_dir, plugin, enforcer):
+    """Best-effort (never fatal) write/refresh of this plugin's OWN
+    `<plugin>.path` drop-in entry — the self-heal half of ADR-0014: a live
+    host rewrites its own entry every SessionStart regardless of whether the
+    shared shim itself needed any change, so a stale entry from a version
+    bump never outlives one session on a live install."""
+    if _path_entry_current(dropin_dir, plugin, enforcer):
+        return True
+    try:
+        os.makedirs(dropin_dir, exist_ok=True)
+        _hooklib.write_text_atomic(
+            _path_entry_file(dropin_dir, plugin), enforcer + "\n", newline="\n")
+        return True
+    except Exception as e:  # noqa: BLE001
+        _warn(f"could not write drop-in enforcer entry for '{plugin}' at {dropin_dir}: {e}")
+        return False
+
+
+def _shim(dropin_dir, phase):
+    # Single-interpreter selection preserves stdin (pre-push) and the BLOCK
+    # exit code. The shim is HOST-NEUTRAL (ADR-0014): it embeds no plugin-
+    # specific enforcer path, only the shared drop-in directory. It iterates
+    # every "*.path" entry there and execs the FIRST enforcer that resolves
+    # (`[ -f "$E" ]`); a dead entry from an uninstalled plugin just fails that
+    # test and the loop tries the next one. An unmatched glob (dir absent or
+    # empty) leaves `c` as the literal, un-expanded "$D/*.path" string in
+    # POSIX `sh` — `[ -f "$c" ]` on that literal correctly fails too, so the
+    # loop falls straight through to the same fail-closed tail with no special
+    # case needed. When NOTHING resolves, this now FAILS CLOSED: a loud
+    # stderr diagnostic and a non-zero exit, blocking the git operation,
+    # rather than the old single-plugin era's `exit 0`.
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
-        f'E="{enforcer}"\n'
-        '[ -f "$E" ] || exit 0\n'
+        f'D="{dropin_dir}"\n'
         'if python3 -c "" 2>/dev/null; then PY=python3; else PY=python; fi\n'
-        f'exec "$PY" "$E" {phase}\n'
+        'for c in "$D"/*.path; do\n'
+        '  [ -f "$c" ] || continue\n'
+        '  E=$(cat "$c" 2>/dev/null) || continue\n'
+        f'  [ -f "$E" ] && exec "$PY" "$E" {phase}\n'
+        'done\n'
+        'echo "codeArbiter: no registered git-enforce.py could be resolved from '
+        '\\"$D\\" -- failing CLOSED (#161/#265 git backstop, ADR-0014). Reinstall '
+        'codeArbiter, or check .git/codearbiter-hooksd/*.path entries." >&2\n'
+        'exit 1\n'
     )
 
 
@@ -297,18 +425,26 @@ def _write_hooks_dir_cache(root, hd):
         pass
 
 
-def _hooks_current(hd, enforcer):
+def _hooks_current(hd, dropin_dir):
     """True iff BOTH phase shims at `hd` already match what install() would
-    write right now for `enforcer` — i.e. install() would be a complete no-op.
-    Filesystem-only (no git spawn): this is exactly the check that lets
-    install() skip the git-config/rev-parse re-probe when a prior session
-    already installed current hooks. A foreign (non-sentinel) hook, a stale
-    shim, or a missing file all correctly return False here, falling the
-    caller through to the full probe (which then re-derives the right action:
-    refresh, warn-and-preserve, or install fresh)."""
+    write right now for `dropin_dir` — i.e. install() would be a complete
+    no-op for the SHIM files themselves. Filesystem-only (no git spawn): this
+    is exactly the check that lets install() skip the git-config/rev-parse
+    re-probe when a prior session already installed current hooks. A foreign
+    (non-sentinel) hook, a stale shim, or a missing file all correctly return
+    False here, falling the caller through to the full probe (which then
+    re-derives the right action: refresh, warn-and-preserve, or install
+    fresh).
+
+    Note (ADR-0014): the shim is host-neutral — it depends only on
+    `dropin_dir` (repo-derived, stable across plugin versions), never on this
+    plugin's own enforcer path. So a plugin-version bump that only changes
+    `_enforcer_path()` does NOT make this return False; install() refreshes
+    the plugin's OWN drop-in `.path` entry unconditionally every call,
+    independent of whether this check short-circuits the shim-file rewrite."""
     for phase in PHASES:
         existing = _read(os.path.join(hd, phase))
-        if existing is None or existing != _shim(enforcer, phase):
+        if existing is None or existing != _shim(dropin_dir, phase):
             return False
     return True
 
@@ -338,21 +474,32 @@ def install(root):
          after the cache was written — e.g. adopting husky / pre-commit-
          framework — silently left the NEW hooks dir unwired while returning
          `[]`);
-      4. the shims at that dir are already current for the CURRENT enforcer
-         path (_hooks_current).
-    Any single miss/mismatch — including a genuine cold install, a moved
-    plugin path, a foreign hook, a changed core.hooksPath, or ambiguity in the
-    config read — falls through to the original git-based probe below,
-    unchanged. Fail direction is "install when unsure," never "skip when
-    unsure"."""
+      4. the shims at that dir are already current for the drop-in dir
+         (_hooks_current — ADR-0014: the shim depends only on `dropin_dir`,
+         never on this plugin's own enforcer path).
+    Any single miss/mismatch — including a genuine cold install, a foreign
+    hook, a changed core.hooksPath, or ambiguity in the config read — falls
+    through to the original git-based probe below, unchanged. Fail direction
+    is "install when unsure," never "skip when unsure".
+
+    ADR-0014: regardless of which path this function takes (fast path or full
+    probe), THIS plugin's own drop-in `<plugin>.path` entry is refreshed
+    every single call — a live host self-heals a stale entry (e.g. after a
+    version bump moved `_enforcer_path()`) every SessionStart, independent of
+    whether the shared shim FILE itself needed any rewrite."""
+    plugin = _plugin_name()
     enforcer = _enforcer_path()
+    dropin_dir = _dropin_dir(root)
+    if dropin_dir is None:
+        return []  # no resolvable git dir at all — nothing to install against
     cached_hd = _cached_hooks_dir(root)
     if cached_hd is not None:
         default_hd = os.path.normcase(os.path.abspath(_default_hooks_dir(root)))
         cached_norm = os.path.normcase(os.path.abspath(cached_hd))
         if (cached_norm == default_hd
                 and _confirmed_no_local_hooks_path(root)
-                and _hooks_current(cached_hd, enforcer)):
+                and _hooks_current(cached_hd, dropin_dir)):
+            _write_path_entry(dropin_dir, plugin, enforcer)
             return []
     hd = hooks_dir(root)
     if not hd:
@@ -365,7 +512,7 @@ def install(root):
     actions = []
     for phase in PHASES:
         dest = os.path.join(hd, phase)
-        desired = _shim(enforcer, phase)
+        desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
             if existing is not None and SENTINEL not in existing:
@@ -392,26 +539,35 @@ def install(root):
     # Cache the resolved location so the NEXT call can skip the git-config/
     # rev-parse re-probe entirely (performance-002) — best-effort, never fatal.
     _write_hooks_dir_cache(root, hd)
+    # ADR-0014: refresh THIS plugin's own drop-in entry every call, whether or
+    # not the shim files above needed a rewrite.
+    if _write_path_entry(dropin_dir, plugin, enforcer):
+        pass
     return actions
 
 
 def uninstall(root):
-    """Remove ONLY codeArbiter-managed hooks (identified by the sentinel);
-    a foreign hook is left in place. Returns the actions taken."""
-    hd = hooks_dir(root)
-    if not hd:
+    """Remove ONLY this plugin's OWN drop-in `<plugin>.path` entry (ADR-0014).
+
+    Deliberately does NOT touch the shared shim file (.git/hooks/pre-commit /
+    pre-push) — that shim is host-neutral and a sibling plugin may still
+    depend on it. Leaving a genuinely EMPTY drop-in dir behind (every plugin
+    uninstalled) is the intended fail-closed contract, not a bug: the next
+    commit finds no resolvable enforcer and blocks with a clear diagnostic
+    (see `_shim`'s tail), rather than the old single-plugin era silently
+    passing. Returns the actions taken."""
+    plugin = _plugin_name()
+    dropin_dir = _dropin_dir(root)
+    if dropin_dir is None:
         return []
-    actions = []
-    for phase in PHASES:
-        dest = os.path.join(hd, phase)
-        existing = _read(dest)
-        if existing is not None and SENTINEL in existing:
-            try:
-                os.remove(dest)
-                actions.append(f"{phase}: removed")
-            except Exception as e:  # noqa: BLE001
-                _warn(f"could not remove {dest}: {e}")
-    return actions
+    entry = _path_entry_file(dropin_dir, plugin)
+    if os.path.isfile(entry):
+        try:
+            os.remove(entry)
+            return [f"{plugin}.path: removed"]
+        except Exception as e:  # noqa: BLE001
+            _warn(f"could not remove {entry}: {e}")
+    return []
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -57,6 +57,19 @@
 #   is_context_md(rel) -> bool            True iff rel is the CONTEXT.md activation file (#159)
 #   is_marker_path(rel) -> bool           True iff rel is under .codearbiter/.markers/ (#160)
 #   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
+#   is_sensitive_scan_exempt(rel) -> bool  True iff rel is exempt from the H-09b/H-10b
+#                                         crypto/secret scan (gate-events.log only, #279)
+#   SECURITY_DIFF_GIT_ARGS                pinned `git diff` argv suffix (fixed a/ b/
+#                                         prefixes, no external diff) every H-09b/H-10b
+#                                         sensitive-line reader MUST use (#279 review)
+#   diff_added_lines(diff_text) -> list[tuple[str|None, str]]  path-aware walk of a unified
+#                                         diff's added ('+') lines (from SECURITY_DIFF_GIT_ARGS
+#                                         output), paired with the destination path each
+#                                         belongs to, attributed from `+++ b/<path>` via a
+#                                         fixed-prefix strip within an unspoofable `diff `
+#                                         section (#279 review)
+#   sensitive_scan_added_lines(diff_text) -> list[str]  diff_added_lines() narrowed to the
+#                                         H-09b/H-10b candidate set (exempt paths dropped)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
 #   acquire_lock(path) -> handle|None     OS-owned cross-process file lock (#271 C-2);
@@ -360,6 +373,182 @@ def classify_protected(fpath, root):
         if is_marker_path(p):
             hits.add("marker")
     return hits
+
+
+# Sensitive-scan exemption (H-09b/H-10b, #279). gate-events.log is the durable
+# BLOCK/REMIND/WARN sink block()/remind()/warn() append to (observability-001,
+# #186) — it is machine-written, never source code, and structurally
+# guaranteed to echo the crypto/secret detector's OWN message text back at
+# itself the moment the gate ever fires a crypto/secret REMIND (e.g. "Crypto/
+# TLS pattern detected" itself matches CRYPTO_RE). That makes it a permanent,
+# self-perpetuating false positive with zero disclosure value: nothing
+# written there is a genuine crypto/secret USE, only a report ABOUT one.
+# Deliberately narrow — overrides.log/triage.log/sprint-log.md stay IN SCOPE:
+# they carry human-written prose (an override reason, a triage note) that
+# COULD legitimately contain a leaked secret worth catching. This set is
+# anchored on the REPO-RELATIVE PATH a line belongs to, never a substring
+# match on the line's own text — a secret cannot escape the scan by merely
+# mentioning gate-events.log on its line; only lines that actually LIVE in
+# that file are exempt.
+SENSITIVE_SCAN_EXEMPT_RELPATHS = frozenset({".codearbiter/gate-events.log"})
+
+
+def is_sensitive_scan_exempt(rel):
+    """True iff `rel` (a repo-relative path, as attributed by `diff_added_
+    lines` or as returned by a bare `git ls-files` listing) names a file
+    exempt from the H-09b/H-10b crypto/secret scan. The ONE predicate both
+    the diff walk and the untracked/unborn-branch file listings route
+    through (#279 review LOW) — deliberately strict: no case-folding, no
+    `./`/`//` collapsing. An identifier that isn't an exact, `norm_path`'d
+    match resolves toward IN SCOPE (not exempt), which is the safe
+    direction. See SENSITIVE_SCAN_EXEMPT_RELPATHS."""
+    return norm_path(rel) in SENSITIVE_SCAN_EXEMPT_RELPATHS
+
+
+# Every H-09b/H-10b sensitive-line reader (security-pass.py, pre-bash.py,
+# git-enforce.py) MUST run `git diff` through this pinned argv, never a bare
+# `["diff", ...]` (#279 review MEDIUM-1). Two independent user/global git
+# config knobs change the destination-path prefix `diff_added_lines` below
+# depends on: `diff.mnemonicPrefix=true` emits `c/`/`w/`/`i/`/`o/` instead of
+# `a/`/`b/`, and `diff.noprefix=true` emits no prefix at all. Either one, left
+# unpinned, silently un-exempts the REAL gate-events.log for any dev/CI runner
+# with that config set — bringing back the exact self-DoS this whole change
+# exists to close. `-c` overrides win over any config file (including repo,
+# global, and system config), so pinning both flags to false here forces the
+# standard `a/`/`b/` prefixes regardless of the caller's environment.
+# `--no-ext-diff` additionally blocks a configured `GIT_EXTERNAL_DIFF` /
+# `diff.external` from replacing git's own unified-diff output with something
+# this parser was never designed to read. Centralized so a call site cannot
+# forget to pin it (that was exactly how this hole would keep reopening).
+SECURITY_DIFF_GIT_ARGS = (
+    "-c", "diff.mnemonicPrefix=false", "-c", "diff.noprefix=false",
+    "diff", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/",
+)
+
+# The fixed-width destination-path prefix `diff_added_lines` strips off a
+# preamble `+++ ` line. MUST be a fixed-length slice, never a search for a
+# separator: a greedy/`.+`-based parse of "diff --git a/<path> b/<path>" (the
+# prior approach) resolves ambiguously when <path> itself contains " b/" —
+# e.g. a real repo path `x b/.codearbiter/gate-events.log` renders that
+# header as `diff --git a/x b/.codearbiter/gate-events.log b/x
+# b/.codearbiter/gate-events.log`, and a greedy match backtracks group(1) to
+# `.codearbiter/gate-events.log`, exempting the WHOLE unrelated source file
+# (#279 review HIGH — reproduced end-to-end: an md5() call and a committed
+# password both passed H-09b with no marker). Stripping a FIXED 6-character
+# prefix has no such ambiguity: `"+++ b/x b/.codearbiter/gate-events.log"[6:]`
+# is unconditionally `"x b/.codearbiter/gate-events.log"`, the correct full
+# path, no matter what the path itself contains.
+_PLUS_B_PREFIX = "+++ b/"
+_PLUS_DEV_NULL = "+++ /dev/null"
+
+
+def diff_added_lines(diff_text):
+    """Added (`+`) lines of a unified `git diff`-style text (produced via
+    SECURITY_DIFF_GIT_ARGS — pinned `a/`/`b/` prefixes, no external diff), as
+    `(path, line)` tuples — a PATH-AWARE walk so a caller can exclude lines by
+    the FILE they live in, never by matching the line's own text (which a
+    hidden secret could otherwise dodge by naming the excluded file).
+
+    Two-phase state machine per file section, `path`/`in_hunk`/`seen_section`:
+
+    1. A bare, UNPREFIXED `diff ` line (`diff --git`, `diff --cc`, `diff
+       --combined`, ...) starts a new section: `path` resets to `None` and
+       `in_hunk` resets to False. Content can NEVER forge this line at column
+       0 — every diff-body line (context/added/removed) carries a leading
+       ' '/'+'/'-'/'\\' character, so a file whose own content is literally
+       "diff --git a/x b/y" renders as "+diff --git a/x b/y" (added), never as
+       a bare match. Resetting `path` to None (not inheriting the PREVIOUS
+       section's path) on ANY `diff ` spelling matters for combined/merge
+       diffs (#279 review MEDIUM-2): git-enforce.py's `git diff --cached` at a
+       merge commit emits `diff --cc <path>` sections, which the prior
+       `diff --git`-only reset missed, letting a `--cc` section's added lines
+       silently inherit whatever path the section before it had — failing
+       toward EXEMPTION if that was gate-events.log.
+    2. While NOT yet `in_hunk` (the section's preamble, before its first `@@`
+       / `@@@` hunk header), a `+++ b/<path>` line sets `path` by stripping
+       the FIXED 6-character prefix `_PLUS_B_PREFIX` — never a regex search
+       for a separator (see `_PLUS_B_PREFIX`'s comment for the ambiguity a
+       greedy `diff --git` parse had). `+++ /dev/null` (a deleted
+       destination) sets `path` back to None explicitly — no added lines are
+       expected in a deletion's hunk body anyway. Every other preamble line
+       (`--- a/<path>`, `index ...`, `new/deleted file mode`, `rename
+       from/to`, `similarity index`, `Binary files ... differ`) is inert
+       noise. A `+++ b/...`-shaped line can ONLY be trusted here, before the
+       section's first `@@`: once `in_hunk` is True, an apparently identical
+       `+++ b/...` string is body CONTENT (it carries the hunk body's own
+       leading `+`, i.e. the underlying source line was "++ b/..." or "+++
+       b/..." before diff-prefixing) and is captured as an added line like any
+       other, never re-parsed as an attribution header (closes the #279
+       review's own earlier finding: an added content line forging `+++
+       b/<path>` used to hijack attribution for the rest of the file).
+    3. Once `in_hunk`, `+`-prefixed lines are collected as `(path, content)`;
+       `-`/` `/`\\` (no-newline-marker) lines are skipped; anything else ends
+       the hunk (not producible by well-formed `git diff` output there, but
+       handled rather than guessed at).
+
+    FAILS SAFE: a `+` line seen before ANY `diff ` section header at all (not
+    producible by real `git diff` output) is attributed to `path=None` and
+    STILL COLLECTED, never silently dropped. `sensitive_scan_added_lines`
+    treats an unattributed (`None`) path as NOT exempt — in scope for
+    scanning. Exempting, or discarding, an unattributable line would be the
+    dangerous direction; over-scanning only risks a false positive, the
+    harmless failure mode here.
+
+    The shared primitive behind the H-09b/H-10b crypto/secret gate's producer
+    (security-pass.py) and both consumers (pre-bash.py, git-enforce.py) —
+    implemented once here so the gate-events.log exemption can never drift
+    between the three independent line-collectors that used to each do their
+    own flat `[ln[1:] for ln in text.splitlines() if ln.startswith("+") ...]`
+    walk with no path information (and no forgery-resistance) at all."""
+    path = None
+    in_hunk = False
+    seen_section = False  # True once the first `diff ` section header is seen
+    out = []
+    for line in diff_text.splitlines():
+        if line.startswith("diff "):
+            path = None
+            in_hunk = False
+            seen_section = True
+            continue
+        if line.startswith("@@"):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            if not seen_section:
+                # No `diff ` section header seen yet at all: not producible
+                # by real `git diff` output. Fail SAFE (see docstring) rather
+                # than silently dropping a line that cannot be confidently
+                # classed as header noise either.
+                if line.startswith("+"):
+                    out.append((None, line[1:]))
+                continue
+            # Section preamble: only a genuine `+++ b/<path>` (or `+++
+            # /dev/null`) line here can set `path` — see point 2 above.
+            if line.startswith(_PLUS_B_PREFIX):
+                path = line[len(_PLUS_B_PREFIX):]
+            elif line == _PLUS_DEV_NULL:
+                path = None
+            continue
+        if line.startswith("+"):
+            out.append((path, line[1:]))
+        elif line.startswith(("-", " ", "\\")):
+            pass  # removed / context / "\ No newline at end of file"
+        else:
+            # Not producible by well-formed `git diff` output (a hunk body
+            # line is always one of the four prefixes above); treat it as the
+            # hunk having ended rather than guessing.
+            in_hunk = False
+    return out
+
+
+def sensitive_scan_added_lines(diff_text):
+    """`diff_added_lines(diff_text)` narrowed to the H-09b/H-10b crypto/secret
+    scan's candidate set: every added line EXCEPT those belonging to a
+    sensitive-scan-exempt path (currently only gate-events.log). Call this
+    instead of a raw `+`-line filter anywhere the crypto/secret scan reads a
+    diff, so the exemption is applied uniformly."""
+    return [ln for path, ln in diff_added_lines(diff_text)
+            if not (path and is_sensitive_scan_exempt(path))]
 
 
 def utf8_stdio():

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -59,6 +59,10 @@
 #   classify_protected(fpath, root) -> set  protected classes hit, raw+realpath (#162)
 #   marker_fresh(path, minutes) -> bool   True iff marker file exists and is recent
 #   write_text_atomic(path, text) -> None  crash-safe write (temp + os.replace)
+#   acquire_lock(path) -> handle|None     OS-owned cross-process file lock (#271 C-2);
+#                                         non-blocking + bounded LOCK_WAIT retry spin,
+#                                         fail-soft None on contention/timeout/OSError
+#   release_lock(handle) -> None          release + close; None handle is a no-op
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -91,6 +95,15 @@ _GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
+
+# Bounded best-effort wait for another cross-process writer to release
+# acquire_lock()'s sidecar lock file (#271 C-2). Originally _ledgerlib-private
+# (the statusline's cost/token ledger); hoisted here so taskwrite.py's board
+# writer (a second, genuinely different caller) can share ONE lock
+# implementation instead of a second hand-rolled copy. _ledgerlib re-exports
+# this name (`from _hooklib import LOCK_WAIT`) so its own module-level
+# mock.patch.object(L, "LOCK_WAIT", ...) test seam keeps working unchanged.
+LOCK_WAIT = 0.2
 
 
 def _is_lock_contention(exc):
@@ -750,6 +763,74 @@ def write_text_atomic(path, text, newline=None):
         raise
 
 
+def acquire_lock(path):
+    """Acquire an OS-owned cross-process file lock keyed on `path`; process
+    death releases it automatically (#271 C-2 — hoisted from the
+    statusline-ledger-only `_ledgerlib._acquire_lock`, now shared with
+    taskwrite.py's board writer).
+
+    Sidecar lock file `f"{abspath(path)}.lock"`, opened `"a+b"` and seeded
+    with one byte so the OS byte-range lock has a byte to lock (an empty file
+    has no range to range-lock). Non-blocking (`msvcrt.locking(..., LK_NBLCK,
+    1)` on Windows, `fcntl.flock(..., LOCK_EX | LOCK_NB)` elsewhere) with a
+    bounded `LOCK_WAIT`-second retry spin; any `OSError` opening the lock file,
+    or exhausting the deadline still contended, is FAIL-SOFT: returns `None`
+    rather than raising or blocking indefinitely. Callers decide what
+    "fail-soft" means for them — `_ledgerlib.ledger_update`/`persist_sess_start`
+    treat `None` as a disposable no-op (a statusline render is throwaway), but
+    `taskwrite.py` treats it as a hard error (a board write is NOT disposable;
+    see its module docstring)."""
+    lock_path = f"{os.path.abspath(path)}.lock"
+    parent = os.path.dirname(lock_path)
+    try:
+        os.makedirs(parent, exist_ok=True)
+        handle = open(lock_path, "a+b")
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+    except OSError:
+        return None
+    deadline = time.monotonic() + LOCK_WAIT
+    while True:
+        try:
+            handle.seek(0)
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except (OSError, BlockingIOError):
+            if time.monotonic() >= deadline:
+                handle.close()
+                return None
+            time.sleep(0.005)
+
+
+def release_lock(handle):
+    """Release + close a handle from acquire_lock(). None is a no-op —
+    callers that never got the lock don't need to guard the release call."""
+    if handle is None:
+        return
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
 def marker_fresh(path, minutes):
     """True if the marker file exists and was touched within `minutes`."""
     try:
@@ -875,6 +956,16 @@ def warn(msg):
 # override.md) with no analogous "still in progress" marker anywhere in the
 # framework, so per CONFIRM-09's own "do not invent new state" constraint it
 # is not tracked here — there is no existing signal to detect it from.
+#
+# #271 C-5: this staleness WARN is presence + age based (marker mtime vs. an
+# audit-log write), which is unaffected by session-start.py's newer
+# session-scoped CLEARING decision for the SAME dev-active marker — the two
+# consumers ask different questions ("has this sat around too long with no
+# matching log activity?" vs. "am I sure enough this belongs to nobody live
+# right now that I should force-close it?") and neither needs to agree with
+# the other's answer. A dev marker owned by a still-live different session
+# can legitimately trip THIS warning (it really has been open a while) even
+# though session-start.py correctly declines to clobber it.
 _STALE_FLOWS = (
     # (flow name, marker path parts, expected-log path parts)
     ("dev", (".markers", "dev-active"), ("overrides.log",)),

--- a/plugins/ca/hooks/_ledgerlib.py
+++ b/plugins/ca/hooks/_ledgerlib.py
@@ -29,14 +29,26 @@
 import hashlib
 import json
 import os
+import sys
 import time
 from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
+# taskwrite.py's board writer can share ONE lock implementation instead of a
+# second hand-rolled copy. Re-exported under their ORIGINAL private names so
+# this module's own call sites (ledger_update/persist_sess_start) and the test
+# suite's `mock.patch.object(L, "_acquire_lock", ...)` / `mock.patch.object(L,
+# "LOCK_WAIT", ...)` seams keep working unchanged — no import-cycle risk:
+# _hooklib imports only hostapi, never _ledgerlib.
+from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
+from _hooklib import release_lock as _release_lock  # noqa: E402
+from _hooklib import LOCK_WAIT  # noqa: E402
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
-LOCK_WAIT = 0.2          # bounded best-effort wait for another statusline writer
 
 # API list prices, USD per 1M tokens (captured 2026-06-10 from Anthropic's
 # pricing pages). Used ONLY to estimate the pay-as-you-go API-equivalent cost of
@@ -148,57 +160,6 @@ def _atomic_json(path, value):
                 os.remove(tmp)
             except OSError:
                 pass
-
-
-def _acquire_lock(path):
-    """Acquire an OS-owned file lock; process death releases it automatically."""
-    lock_path = f"{os.path.abspath(path)}.lock"
-    parent = os.path.dirname(lock_path)
-    try:
-        os.makedirs(parent, exist_ok=True)
-        handle = open(lock_path, "a+b")
-        handle.seek(0, os.SEEK_END)
-        if handle.tell() == 0:
-            handle.write(b"\0")
-            handle.flush()
-    except OSError:
-        return None
-    deadline = time.monotonic() + LOCK_WAIT
-    while True:
-        try:
-            handle.seek(0)
-            if os.name == "nt":
-                import msvcrt
-                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-            else:
-                import fcntl
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return handle
-        except (OSError, BlockingIOError):
-            if time.monotonic() >= deadline:
-                handle.close()
-                return None
-            time.sleep(0.005)
-
-
-def _release_lock(handle):
-    if handle is None:
-        return
-    try:
-        handle.seek(0)
-        if os.name == "nt":
-            import msvcrt
-            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-    except OSError:
-        pass
-    finally:
-        try:
-            handle.close()
-        except OSError:
-            pass
 
 
 def _session_dir(path):

--- a/plugins/ca/hooks/_subagentslib.py
+++ b/plugins/ca/hooks/_subagentslib.py
@@ -23,6 +23,15 @@ import os
 import re
 import time
 
+try:
+    import _colorlib
+    strip_control = _colorlib.strip_control
+except Exception:  # pragma: no cover — never let an import break the statusline
+    _colorlib = None
+
+    def strip_control(s):
+        return s if not isinstance(s, str) else re.sub(r"[\000-\037]", "", s)
+
 ACTIVE_WINDOW = 150       # secs: a subagent file touched this recently is "active"
 SHOW_WINDOW = 600         # secs: still display recently-finished subagents
 MAX_SUB_ROWS = 4
@@ -34,7 +43,7 @@ def display_model(model_id):
     """Compact a host model ID while retaining its family and version."""
     if not isinstance(model_id, str):
         return "model:?"
-    name = model_id.strip()
+    name = strip_control(model_id).strip()
     if not name:
         return "model:?"
     if name.startswith("claude-"):
@@ -170,7 +179,7 @@ def sub_label(content):
             if isinstance(blk, str):
                 text = blk
                 break
-    raw = str(text)
+    raw = strip_control(str(text))
     # strip leading reminder/system blocks up front (multi-line safe), then a lone tag
     raw = re.sub(r"^\s*(?:<([^>\s]+)[^>]*>.*?</\1>\s*)+", "", raw, flags=re.S)
     raw = re.sub(r"^\s*<[^>]+>\s*", "", raw)

--- a/plugins/ca/hooks/git-enforce.py
+++ b/plugins/ca/hooks/git-enforce.py
@@ -11,9 +11,10 @@
 #
 # It mirrors pre-bash.py's commit/push gates and reuses the SAME detection
 # primitives from _hooklib (CRYPTO_RE / SECRET_RE / line_digest / content_digest
-# / is_migration_path / marker_fresh), so the two enforcement points can never
-# drift on what counts as sensitive or as a migration, or on how a gate-pass
-# marker binds to the lines it approved.
+# / is_migration_path / marker_fresh / sensitive_scan_added_lines), so the two
+# enforcement points can never drift on what counts as sensitive or as a
+# migration, on how a gate-pass marker binds to the lines it approved, or on
+# which path (gate-events.log, #279) is exempt from the sensitive-line scan.
 #
 # Contract: a git hook aborts its operation on ANY non-zero exit, so a BLOCK is
 # exit 1 with a loud stderr message. Exit 0 allows. The security/migration scans
@@ -27,8 +28,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, arbiter_active, content_digest, is_migration_path,
-    line_digest, marker_fresh, set_host, utf8_stdio,
+    CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, arbiter_active,
+    content_digest, is_migration_path, line_digest, marker_fresh,
+    sensitive_scan_added_lines, set_host, utf8_stdio,
 )
 
 
@@ -144,12 +146,23 @@ def head_on_protected_tip(cwd):
 def cached_added_lines(cwd):
     """Added (`+`) lines of the staged diff — exactly what a commit records
     (including `commit -a` sweeps, which git has already staged by pre-commit
-    time). None on a git read error → caller fails closed."""
-    r = _git(["diff", "--cached"], cwd)
+    time). None on a git read error -> caller fails closed.
+
+    Excludes gate-events.log (#279): `sensitive_scan_added_lines` walks the
+    diff path-aware, dropping lines that belong to the crypto/secret gate's
+    own machine-written audit sink, so this backstop's view of "sensitive
+    lines" never drifts from the producer (security-pass.py) or the
+    PreToolUse gate (pre-bash.py) — see the shared helper's docstring in
+    `_hooklib`. Reads the diff via SECURITY_DIFF_GIT_ARGS (pinned a/ b/
+    prefixes, no external diff) so a hostile `diff.mnemonicPrefix`/
+    `diff.noprefix`/external-diff config can never break that attribution
+    (#279 review MEDIUM-1) — a merge commit's `--cc` combined-diff sections
+    are also handled correctly (MEDIUM-2): the diff walk resets attribution on
+    ANY `diff ` section header, not just `diff --git`."""
+    r = _git([*SECURITY_DIFF_GIT_ARGS, "--cached"], cwd)
     if r is None or r.returncode != 0:
         return None
-    return [ln[1:] for ln in r.stdout.splitlines()
-            if ln.startswith("+") and not ln.startswith("+++")]
+    return sensitive_scan_added_lines(r.stdout)
 
 
 def cached_names(cwd):

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -260,6 +260,43 @@ GATE_MARKER_WRITE_RE = re.compile(
     r"|Move-Item|Copy-Item|Clear-Content|Set-Content|Out-File|Add-Content)\b"
     r"[^|;&]*" + GATE_MARKER, re.I,
 )
+# #237: an arbitrary interpreter invocation is a flank the verb list above
+# cannot see — `python -c "open('.markers/security-gate-passed','w')..."`
+# reuses the sanctioned producer's own public helpers to self-compute valid
+# digests, and no mv/cp/tee/sed spelling ever appears on the command line.
+# Interpreter one-liners get their OWN, wider regex rather than joining the
+# verb list above: the payload is a single quoted string handed to the
+# interpreter, and that string may itself contain `;` as a statement
+# separator (`python -c "x=1; open(...security-gate-passed...)"`). The
+# `[^|;&]*` bound on GATE_MARKER_WRITE_RE exists to keep a write verb from
+# reaching across an UNRELATED shell-chained command; applying that same
+# bound here would stop scanning at the interpreter's OWN internal `;` and
+# silently reopen exactly the hole this closes. There is no reliable way to
+# tell a chained shell command from a `;`-separated statement inside an
+# opaque interpreter string without full shell/language tokenization, so
+# this guard fails CLOSED: any command line invoking one of these
+# interpreters that ALSO names a gate marker anywhere on the line is
+# blocked, whether the marker is written or merely read. A read of a gate
+# marker has no legitimate reason to go through a raw interpreter one-liner
+# either (cat/grep already pass the audit-log flanks above untouched).
+#
+# review finding (post-B-2): a `-c`/`-e` payload is ordinary multi-line
+# source — the interpreter token and the marker path can sit on different
+# physical lines of the SAME invocation (`python -c "\nopen('...security-
+# gate-passed'...)\n"`). `[^\n]*` cannot cross that newline, leaving the
+# identical attack open in its multi-line spelling. `[\s\S]*` (DOTALL-
+# equivalent) closes it. This regex is applied to the heredoc-stripped
+# `git_view` at the call site below, gated on `heredoc_shell_fallback` for
+# the raw-`cmd` leg exactly like the commit/push/add guards already are —
+# scanning the raw, unstripped `cmd` unconditionally would make crossing
+# newlines here false-trip on inert PROSE inside a heredoc body fed to a
+# non-shell consumer (`gh pr create --body "$(cat <<EOF … a python -c
+# one-liner wrote .markers/security-gate-passed … EOF)"` — a PR/issue body
+# merely DESCRIBING this very fix), the same D-3 (#223) distinction the
+# other guards already draw.
+GATE_MARKER_INTERP_RE = re.compile(
+    r"\b(python3?|node|perl|ruby|sh)\b[\s\S]*" + GATE_MARKER, re.I,
+)
 
 
 def git_cwd(cmd, root):
@@ -888,12 +925,28 @@ def _run(root):
 
     # H-19: the gate-pass markers (#160) are recorded only by the sanctioned
     # python producers — shell flank against `echo <digest> > security-gate-passed`
-    # and `cp`/`sed`/`tee` forges naming a gate marker.
-    if GATE_MARKER_REDIRECT_RE.search(cmd) or GATE_MARKER_WRITE_RE.search(cmd):
+    # and `cp`/`sed`/`tee` forges naming a gate marker, plus an interpreter
+    # one-liner (#237).
+    #
+    # review finding (post-B-2): scan `git_view` (heredoc bodies stripped),
+    # with the raw-`cmd` leg gated on `heredoc_shell_fallback` — mirroring
+    # how commit/push/add already work post-D-3 (#223). Scanning raw `cmd`
+    # unconditionally, as this used to, means a heredoc body fed to a
+    # NON-shell consumer that merely QUOTES a gate-marker path (a PR/issue
+    # body describing this very fix) false-trips H-19; scanning only
+    # `git_view` would miss the genuine case where the heredoc's body DOES
+    # reach an executor (`bash -c "$(cat <<EOF … EOF)"`).
+    def _gate_marker_hit(view):
+        return (GATE_MARKER_REDIRECT_RE.search(view)
+                or GATE_MARKER_WRITE_RE.search(view)
+                or GATE_MARKER_INTERP_RE.search(view))
+
+    if _gate_marker_hit(git_view) or (heredoc_shell_fallback and _gate_marker_hit(cmd)):
         block("H-19", "The .codearbiter/.markers/ security-gate-passed / migration-gate-passed "
                       "tokens are recorded only by the sanctioned gate producers (#160) — a shell "
-                      "redirect or write verb naming a gate marker forges a security/migration "
-                      "gate pass and is prohibited.")
+                      "redirect, write verb, or interpreter invocation (python/node/perl/ruby/sh) "
+                      "naming a gate marker forges a security/migration gate pass and is "
+                      "prohibited.")
 
     # H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     # a recorded security-gate pass. The crypto-compliance / secret-handling skills

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -22,6 +22,8 @@ import traceback
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+import _gitlib  # noqa: E402 — reused for its spawn-free, worktree-aware
+                # (.git-as-a-FILE / gitdir: pointer) project_root() climb (#223)
 from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
     GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
@@ -298,6 +300,148 @@ def git_cwd(cmd, root):
         val = raw.strip("\"'")
         acc = val if os.path.isabs(val) else os.path.join(acc, val)
     return acc
+
+
+def _effective_exec_root(payload, root):
+    """The git root that a `-C`-less git command in THIS Bash call actually
+    runs against — the command's effective cwd — rather than always the
+    pinned `root` (CLAUDE_PROJECT_DIR) (#223).
+
+    #223's bug: `root` is pinned to CLAUDE_PROJECT_DIR (the MAIN checkout),
+    so a `git commit` fired from a LINKED WORKTREE was judged against the
+    main checkout's branch — both a false positive (worktree on a feature
+    branch, main checkout on main -> wrongly blocked) and a false negative
+    (worktree on main/master, main checkout on a feature branch -> H-01
+    silently sidestepped, the more serious direction).
+
+    D-2 (spec pre-release-hardening): this function governs BRANCH/DIFF
+    resolution (git_cwd's seed) ONLY. Gate MARKERS always keep reading from
+    the pinned `root` regardless of this function's answer — a linked
+    worktree has `.codearbiter/` (tracked) but not `.codearbiter/.markers/`
+    (gitignored), so marker paths must stay anchored at the main checkout.
+    This split existed accidentally before #223 (pre-bash.py:769,828 already
+    read markers from `root` while everything else read from `cwd`); this is
+    now the intentional, documented contract.
+
+    Resolution reuses `_gitlib.project_root` — the existing linked-worktree-
+    aware precedent (`_gitlib.head_branch` already parses a `.git` FILE's
+    `gitdir:` pointer for exactly this case) — rather than a fresh
+    `git rev-parse --show-toplevel` spawn. It climbs from the hook payload's
+    own `cwd` (a trusted-harness input, same footing as CLAUDE_PROJECT_DIR
+    itself — see security-controls.md's Repo resolution section) or, absent
+    one, the hook process's own cwd, stopping at the nearest ancestor with a
+    `.git` (dir OR file) or a `.codearbiter` directory — a linked worktree's
+    `.git` is a FILE, and it also carries its own `.codearbiter/`, so either
+    check alone stops the climb at the worktree root, never the main
+    checkout.
+
+    When that climb lands on the SAME root as `root`, this returns `root`
+    unchanged — the overwhelmingly common (non-worktree) case sees zero
+    behavioral difference. It returns the climbed root only when it names a
+    genuinely DIFFERENT filesystem location."""
+    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
+        return root
+    return exec_root
+
+
+# D-3 (spec pre-release-hardening, #223): the raw-`cmd` fallback below (used
+# when a heredoc is present) must fire ONLY when the heredoc body can
+# genuinely reach a shell — via EITHER of two independent routes, checked by
+# the two functions below (`_heredoc_fed_to_shell` and `_has_shell_executor`,
+# OR'd together at the call site): (1) the heredoc's DIRECT consumer is
+# itself a shell-like program whose stdin is executed as code (`bash <<EOF`),
+# or (2) some OTHER token in the command is a shell/interpreter executor that
+# runs a command-substitution result carrying the heredoc's output
+# (`bash -c "$(cat <<EOF … EOF)"` — the heredoc's direct consumer is `cat`,
+# route (1) says no, but `bash -c` EXECUTES what `cat` produced, so route (2)
+# must say yes). A heredoc handed to a non-shell consumer with NO executor
+# anywhere in the command (`gh pr create --body "$(cat <<EOF … EOF)"`) is
+# inert prose to this guard even though it is substituted into another
+# command's argument — neither route fires, so the fallback correctly stays
+# off and a PR/issue body merely QUOTING "git commit" does not false-trip.
+SHELL_HEREDOC_CONSUMERS = frozenset({
+    "bash", "sh", "zsh", "dash", "ksh",
+    "python", "python2", "python3", "perl", "ruby", "node", "nodejs",
+})
+
+
+def _heredoc_fed_to_shell(cmd):
+    """True iff at least one `<<` heredoc operator in `cmd` attaches to a
+    shell-like consumer (SHELL_HEREDOC_CONSUMERS) — a program whose stdin IS
+    executed, not merely read as inert text.
+
+    The consumer is the FIRST token of the "simple command" the heredoc
+    operator sits at the end of: scan backward from the operator to the
+    nearest unquoted `|`, `;`, `&`, or `(` (or the start of the string) —
+    that is where the current simple command began — then take its first
+    token. This correctly finds `bash` in `bash <<EOF` and `cat` (not `gh`)
+    in `gh pr create --body "$(cat <<EOF … EOF)"` (the `(` from `$(` bounds
+    the segment)."""
+    for m in re.finditer(r"<<", cmd):
+        start = m.start()
+        seg_start = 0
+        in_dq = in_sq = False
+        for i in range(start - 1, -1, -1):
+            ch = cmd[i]
+            if ch == '"' and not in_sq:
+                in_dq = not in_dq
+            elif ch == "'" and not in_dq:
+                in_sq = not in_sq
+            elif not in_dq and not in_sq and ch in "|;&(":
+                seg_start = i + 1
+                break
+        segment = cmd[seg_start:start]
+        tokens = re.findall(r'"[^"]*"|\'[^\']*\'|\S+', segment)
+        if not tokens:
+            continue
+        head = os.path.basename(tokens[0].strip("\"'"))
+        if head in SHELL_HEREDOC_CONSUMERS:
+            return True
+    return False
+
+
+# security-reviewer finding (post-A-4): `_heredoc_fed_to_shell` alone answers
+# "is the heredoc's DIRECT consumer a shell" — that is NOT the same question
+# as "does the heredoc's body reach a shell." `bash -c "$(cat <<EOF … EOF)"`
+# has `cat` as the heredoc's direct consumer (correctly classified non-shell
+# by the check above), but `bash -c` then EXECUTES the substituted result of
+# that `cat` — the body reaches a shell by a route the direct-consumer check
+# cannot see (same hole for `eval "$(cat <<EOF … EOF)"`, `sh -c "$(…)"`, and
+# any command-substitution chain ending in a shell/interpreter executor).
+# This second check asks the complementary question: does ANY token in the
+# whole command invoke something that executes a string as code, regardless
+# of where the heredoc sits relative to it. FAILS CLOSED on uncertainty —
+# `eval` and `xargs` (which can forward its input straight into an executor)
+# are treated as always-executor, no flag required.
+SHELL_C_PROGRAMS = frozenset({"bash", "sh", "zsh", "dash", "ksh"})
+INTERP_C_PROGRAMS = frozenset({"python", "python2", "python3"})
+INTERP_E_PROGRAMS = frozenset({"perl", "ruby", "node", "nodejs"})
+ALWAYS_EXECUTOR_PROGRAMS = frozenset({"eval", "xargs"})
+
+
+def _has_shell_executor(cmd):
+    """True iff `cmd` invokes ANYWHERE a program that executes a string as
+    code: `bash -c`/`sh -c`/`zsh -c`/`dash -c`/`ksh -c`, `python[23]? -c`,
+    `perl -e`/`ruby -e`/`node[js]? -e`, or a bare `eval`/`xargs` (both can
+    hand an arbitrary string straight to an executor — `xargs bash -c '...'`,
+    `eval "$var"` — so both are treated as executors unconditionally, no
+    flag needed, per the fail-closed mandate).
+
+    Scans the RAW command (heredoc bodies included) — a heredoc body that
+    happens to mention one of these tokens as prose causes a conservative
+    over-block, never an under-scan, matching this file's established
+    ambiguity-resolves-CLOSED stance (D-3)."""
+    tokens = [t.strip("\"'") for t in re.findall(r'"[^"]*"|\'[^\']*\'|\S+', cmd)]
+    basenames = [os.path.basename(t) for t in tokens]
+    if any(b in ALWAYS_EXECUTOR_PROGRAMS for b in basenames):
+        return True
+    if "-c" in tokens and any(
+            b in SHELL_C_PROGRAMS or b in INTERP_C_PROGRAMS for b in basenames):
+        return True
+    if "-e" in tokens and any(b in INTERP_E_PROGRAMS for b in basenames):
+        return True
+    return False
 
 
 def current_branch(cwd):
@@ -588,15 +732,34 @@ def _run(root):
     # a body-stripped view so message content (which may contain `;`/`|`/`&`,
     # or mention `git -C`) never truncates the args capture, poisons the cwd
     # extraction, or leaks words into the pathspec parse. The RAW command stays
-    # as a fallback matcher: a heredoc fed TO a shell (`bash <<EOF … EOF`)
-    # executes its body, so a commit/push/add visible only in the raw text must
-    # still be guarded — ambiguity resolves CLOSED, so the fallback over-blocks
-    # (e.g. a message QUOTING a force-push) rather than under-scans.
+    # as a fallback matcher, but ONLY when the heredoc's consumer is a shell
+    # (D-3, #223, `_heredoc_fed_to_shell` above): a heredoc fed TO a shell
+    # (`bash <<EOF … EOF`) genuinely executes its body, so a commit/push/add
+    # visible only in the raw text must still be guarded there — ambiguity
+    # resolves CLOSED. A heredoc fed to a non-shell consumer (`gh`, `cat`, …)
+    # is inert prose and must NOT fall back to the raw-text scan, or a PR/issue
+    # body merely QUOTING "git commit" false-trips H-01/H-09b/H-14.
     git_view = _strip_heredoc_bodies(cmd) if "<<" in cmd else cmd
+    # Both legs are OR'd: the heredoc's direct consumer being a shell
+    # (`bash <<EOF`) is one route to execution; a shell/interpreter executor
+    # appearing ANYWHERE in the command (`bash -c "$(cat <<EOF … EOF)"`,
+    # `eval "$(cat <<EOF … EOF)"`) is another that the direct-consumer check
+    # alone cannot see (security-reviewer finding, post-A-4) — either is
+    # sufficient to keep the fallback closed.
+    heredoc_shell_fallback = "<<" in cmd and (
+        _heredoc_fed_to_shell(cmd) or _has_shell_executor(cmd))
 
-    commit = COMMIT_RE.search(git_view) or COMMIT_RE.search(cmd)
-    push_probe = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
-    cwd = git_cwd(git_view, root)
+    commit = COMMIT_RE.search(git_view) or (
+        heredoc_shell_fallback and COMMIT_RE.search(cmd))
+    push_probe = PUSH_RE.search(git_view) or (
+        heredoc_shell_fallback and PUSH_RE.search(cmd))
+
+    # #223: -C-less git commands run against the command's EFFECTIVE cwd, not
+    # unconditionally CLAUDE_PROJECT_DIR — see _effective_exec_root's
+    # docstring (D-2: gate MARKERS stay pinned to `root` regardless; only
+    # branch/diff resolution follows the command's real cwd).
+    exec_root = _effective_exec_root(payload, root)
+    cwd = git_cwd(git_view, exec_root)
 
     # reliability-004 (#190): fail CLOSED for commit/push when the `-C` target
     # git_cwd() resolved does not exist as a directory — an unresolvable -C
@@ -632,7 +795,8 @@ def _run(root):
             block("H-01", f"Direct commit to {target} is prohibited (ORCHESTRATOR §3). "
                           f"Create a feature branch.")
 
-    push = PUSH_RE.search(git_view) or PUSH_RE.search(cmd)
+    push = PUSH_RE.search(git_view) or (
+        heredoc_shell_fallback and PUSH_RE.search(cmd))
     if push:
         pargs = push.group("args")
 
@@ -678,7 +842,8 @@ def _run(root):
     # flag spellings (-A/--all/-u/.) and the argument spellings (globs,
     # directories, pathspec magic) — `git add src/` stages everything beneath
     # src/ just as surely as `git add -A` does.
-    add = ADD_RE.search(git_view) or ADD_RE.search(cmd)
+    add = ADD_RE.search(git_view) or (
+        heredoc_shell_fallback and ADD_RE.search(cmd))
     if add:
         if WILDCARD_ADD_RE.search(add.group("args")):
             block("H-03", "'git add -A' / 'git add .' / 'git add --all' / 'git add -u' "

--- a/plugins/ca/hooks/pre-bash.py
+++ b/plugins/ca/hooks/pre-bash.py
@@ -26,9 +26,10 @@ import _gitlib  # noqa: E402 — reused for its spawn-free, worktree-aware
                 # (.git-as-a-FILE / gitdir: pointer) project_root() climb (#223)
 from _hooklib import (  # noqa: E402
     AUDIT_LOG_BASENAMES, AUDIT_LOG_NAMES, CRYPTO_RE, DECISIONS_DIR_RE,
-    GATE_MARKER_NAMES, SECRET_RE, arbiter_active, block, content_digest,
-    get_host, is_migration_path, line_digest, marker_fresh, project_root,
-    read_input, set_host, tool_input, utf8_stdio,
+    GATE_MARKER_NAMES, SECRET_RE, SECURITY_DIFF_GIT_ARGS, arbiter_active,
+    block, content_digest, get_host, is_migration_path, line_digest,
+    marker_fresh, project_root, read_input, sensitive_scan_added_lines,
+    set_host, tool_input, utf8_stdio,
 )
 
 # The most recent git-read failure, surfaced in the H-01/H-09b/H-14 fail-closed
@@ -563,8 +564,15 @@ def added_lines(cwd, ref, paths=None):
     Decoded as UTF-8 with replacement: `text=True` alone uses the locale code
     page (cp1252 on stock Windows), where a non-cp1252 byte in the diff raised
     UnicodeDecodeError into the bare except below and the security gate
-    silently failed OPEN on exactly the platform this layer protects."""
-    argv = ["git", "diff", ref] + (["--", *paths] if paths else [])
+    silently failed OPEN on exactly the platform this layer protects.
+
+    Excludes gate-events.log (#279): `sensitive_scan_added_lines` walks the
+    diff path-aware, dropping lines that belong to the crypto/secret gate's
+    own machine-written audit sink — see its docstring in `_hooklib`. Reads
+    the diff via SECURITY_DIFF_GIT_ARGS (pinned a/ b/ prefixes, no external
+    diff) so a hostile `diff.mnemonicPrefix`/`diff.noprefix`/external-diff
+    config can never break that attribution (#279 review MEDIUM-1)."""
+    argv = ["git", *SECURITY_DIFF_GIT_ARGS, ref] + (["--", *paths] if paths else [])
     try:
         out = subprocess.run(
             argv, cwd=cwd,
@@ -577,10 +585,7 @@ def added_lines(cwd, ref, paths=None):
     except Exception as e:  # noqa: BLE001
         _note_read_err(argv, repr(e))
         return None
-    return "\n".join(
-        line[1:] for line in out.stdout.splitlines()
-        if line.startswith("+") and not line.startswith("+++")
-    )
+    return "\n".join(sensitive_scan_added_lines(out.stdout))
 
 
 def _names(cwd, args):

--- a/plugins/ca/hooks/security-pass.py
+++ b/plugins/ca/hooks/security-pass.py
@@ -24,8 +24,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 from _hooklib import (  # noqa: E402
-    CRYPTO_RE, SECRET_RE, line_digest, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
+    line_digest, project_root, sensitive_scan_added_lines, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -53,19 +54,34 @@ def candidate_lines(root):
     """Every line the next commit could introduce: added lines of the
     worktree-vs-HEAD diff (staged and unstaged alike), plus the full content
     of untracked files — `git diff HEAD` never shows those, but they land in
-    the staged diff the moment commit-gate stages them."""
+    the staged diff the moment commit-gate stages them.
+
+    Excludes gate-events.log (#279, is_sensitive_scan_exempt): the crypto/
+    secret gate's own machine-written audit sink, which structurally echoes
+    the detector's message text back at itself. The diff branch drops those
+    lines via the shared path-aware `sensitive_scan_added_lines`; the
+    unborn-branch and untracked-file branches skip the file outright since
+    they read whole-file content rather than a diff.
+
+    The diff is read via SECURITY_DIFF_GIT_ARGS (not a bare `["diff", ...]`):
+    it pins the `a/`/`b/` prefix format `sensitive_scan_added_lines` depends
+    on for path attribution, regardless of the caller's `diff.mnemonicPrefix`
+    / `diff.noprefix` / external-diff config (#279 review MEDIUM-1)."""
     lines = []
-    diff = run_git(["diff", "HEAD"], root)
+    diff = run_git([*SECURITY_DIFF_GIT_ARGS, "HEAD"], root)
     if diff.returncode == 0:
-        lines += [ln[1:] for ln in diff.stdout.splitlines()
-                  if ln.startswith("+") and not ln.startswith("+++")]
+        lines += sensitive_scan_added_lines(diff.stdout)
     else:
         # Unborn branch (no HEAD yet): every tracked file is new content.
         ls = run_git(["ls-files"], root)
         for rel in ls.stdout.splitlines():
+            if is_sensitive_scan_exempt(rel):
+                continue
             lines += file_lines(root, rel)
     untracked = run_git(["ls-files", "--others", "--exclude-standard"], root)
     for rel in untracked.stdout.splitlines():
+        if is_sensitive_scan_exempt(rel):
+            continue
         lines += file_lines(root, rel)
     return lines
 

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -21,6 +21,7 @@
 import concurrent.futures
 import copy
 import datetime
+import json
 import os
 import re
 import subprocess
@@ -31,6 +32,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
+    write_text_atomic,
 )
 from _standuplib import (  # noqa: E402
     any_actionable,
@@ -447,7 +449,80 @@ def has_source(root):
     return False
 
 
-def clear_dev_marker(root, host_name=None):
+# #271 C-5 — session-scoping the repo-global dev marker. The marker itself
+# carries no owner: it is dropped by /dev's own prose (dev.md), which has no
+# reliable way to stamp a real session_id into its content (slash-command
+# prose never receives the hook JSON payload — only actual HOOKS do). So
+# ownership is tracked SEPARATELY, by SessionStart itself: every invocation
+# records (its OWN session_id, now) as "the last session known to have
+# started in this repo" BEFORE deciding what to do with the dev marker.
+#
+# This is a heuristic, not true liveness detection (there is no SessionEnd
+# signal this hook can rely on) — documented tradeoff, not a defect. The
+# record's timestamp is ANCHORED TO THE OWNER, not to "whatever session
+# started most recently" — that distinction is load-bearing (a review caught
+# an earlier draft that refreshed it unconditionally on every invocation,
+# which meant an unrelated session B/C/D/... starting in an otherwise-active
+# repo kept sliding the window forward forever and the marker became
+# immortal). The write is therefore CONDITIONAL, decided AFTER checking the
+# marker, not before:
+#   - no live marker at all: refresh freely — "the session that could next
+#     enter /dev is me" is exactly the fact this record exists to hold.
+#   - live marker AND session_id == prev_sid: refresh. This is the owner
+#     heartbeating through a resume/compaction, and it's what keeps a
+#     genuinely long /ca:dev sitting from being force-closed at the 6h mark.
+#   - live marker AND a DIFFERENT session_id: do NOT write. `prev_ts` stays
+#     anchored to the OWNER's last known activity — a different session
+#     merely observing the marker must not reset that clock, or it would
+#     never elapse in any repo that sees regular unrelated activity.
+#
+# Net effect: a marker owned by a session that crashed is left alone by every
+# later, unrelated session (they cannot know it is dead) but self-heals
+# DEV_SESSION_LIVENESS_WINDOW after the OWNER's own last recorded activity —
+# not after the most recent unrelated SessionStart. Symmetric residual: a
+# genuinely live /ca:dev sitting untouched (no resume/compaction of its own)
+# for longer than the window can still be force-closed by a later session,
+# same as the pre-#271 behavior would have done immediately. No session_id
+# available on this invocation/host (Codex parity unverified), or no prior
+# record at all, degrades to the original unconditional clear — a marker that
+# can NEVER be cleared is a worse failure mode than one cleared too eagerly.
+DEV_SESSION_LIVENESS_WINDOW = 6 * 3600  # 6h: generous single-sitting bound
+
+
+def _dev_session_owner_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-session-owner.json")
+
+
+def _read_dev_session_owner(root):
+    """(session_id, ts) last recorded by ANY SessionStart invocation in this
+    repo, or (None, None) on an absent/corrupt/malformed record. Never
+    raises."""
+    try:
+        with open(_dev_session_owner_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        sid = data.get("session_id")
+        ts = data.get("ts")
+        if isinstance(sid, str) and sid and isinstance(ts, (int, float)):
+            return sid, float(ts)
+    except Exception:  # noqa: BLE001 — corrupt/absent record -> no signal
+        pass
+    return None, None
+
+
+def _write_dev_session_owner(root, session_id, ts):
+    """Best-effort refresh of the last-known-active-session record. Never
+    raises — a write failure just means the NEXT SessionStart degrades to the
+    conservative no-prior-record fallback, exactly as if this were the first
+    session ever."""
+    try:
+        path = _dev_session_owner_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps({"session_id": session_id, "ts": ts}))
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
     synthetic DEV: exit line to overrides.log BEFORE removing it
@@ -461,29 +536,77 @@ def clear_dev_marker(root, host_name=None):
     (ADR-0011). Optional and defaults to resolving it here via `get_host()`
     (#257) — main() already holds a Host instance and passes its `.name`
     through to avoid a second resolution, but any other caller (tests
-    included) may omit it."""
+    included) may omit it.
+
+    `session_id` (#271 C-5) is THIS invocation's own session id from the
+    SessionStart hook payload, when the host supplies one. See the module
+    comment above `DEV_SESSION_LIVENESS_WINDOW` for the full session-scoping
+    contract: a live marker is only force-closed when there is no reason to
+    believe a DIFFERENT, still-running session currently owns it — and the
+    ownership record's timestamp is refreshed ONLY by the owner itself (never
+    by an unrelated session merely observing the marker), so the liveness
+    window is anchored to the owner's last activity, not reset by every
+    passerby SessionStart. `now` (epoch seconds) is injectable for
+    deterministic tests; defaults to `time.time()`."""
+    now = time.time() if now is None else now
+    prev_sid, prev_ts = _read_dev_session_owner(root)
+
     marker = os.path.join(root, ".codearbiter", ".markers", "dev-active")
-    if os.path.isfile(marker):
-        if host_name is None:
-            try:
-                # get_host() (#257), not a direct hostapi.load_host(): resolves
-                # the SAME Host run(host) injected instead of a second load.
-                host_name = get_host().name
-            except Exception:  # noqa: BLE001 — must never brick session startup
-                host_name = "unknown"
+    marker_live = os.path.isfile(marker)
+
+    if not marker_live:
+        # No live marker: this record is purely "who could next enter /dev" —
+        # any session refreshing it is harmless and correct. Nothing else to
+        # do — there is no marker to clear and no close to log.
+        if session_id:
+            _write_dev_session_owner(root, session_id, now)
+        return
+
+    if session_id and prev_sid:
+        if prev_sid == session_id:
+            # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
+            # heartbeat (this is the only case where a write is safe while the
+            # marker is live) and leave the marker untouched.
+            _write_dev_session_owner(root, session_id, now)
+            return
+        if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
+            # A different session, and the OWNER's own clock hasn't elapsed
+            # yet — do NOT touch the record (an unrelated observer must never
+            # reset a clock it doesn't own) and do not clobber the marker.
+            return
+        # Different session AND the owner's own record is stale beyond the
+        # window: proceed to the force-close below. Deliberately do not write
+        # a fresh record here either — there is no live owner left to anchor
+        # a new one to; the write happens naturally next time /dev is entered.
+
+    if session_id and not prev_sid:
+        # No prior record at all (first session ever, or a dropped record) —
+        # no signal to protect a concurrent owner; seed the record for next
+        # time and fall through to the pre-#271 unconditional-clear behavior.
+        _write_dev_session_owner(root, session_id, now)
+
+    # Force-close: either no session_id/no prior record (unconditional-clear
+    # fallback), or a genuinely stale owner beyond the window.
+    if host_name is None:
         try:
-            arbiter_ref = get_host().cmd_ref("arbiter")
+            # get_host() (#257), not a direct hostapi.load_host(): resolves
+            # the SAME Host run(host) injected instead of a second load.
+            host_name = get_host().name
         except Exception:  # noqa: BLE001 — must never brick session startup
-            arbiter_ref = "/ca:arbiter"
-        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
-                f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-        try:
-            with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                      "a", encoding="utf-8") as f:
-                f.write(line)
-        except OSError:
-            pass
+            host_name = "unknown"
+    try:
+        arbiter_ref = get_host().cmd_ref("arbiter")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        arbiter_ref = "/ca:arbiter"
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
+            f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
+    try:
+        with open(os.path.join(root, ".codearbiter", "overrides.log"),
+                  "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
     try:
         os.remove(marker)
     except OSError:
@@ -560,6 +683,30 @@ def spawn_background_update_refresh(plugin, spawner=None):
         return None
 
 
+def _session_id_from_stdin():
+    """Best-effort session_id from the SessionStart hook's own JSON payload
+    (#271 C-5) — session-start.py has never read its stdin before this. Reads
+    directly rather than via `_hooklib.read_input()` so an absent/empty
+    session_id degrades SILENTLY (it is a normal, expected condition on a host
+    that doesn't supply one — not a parse error worth a `warn()` breadcrumb on
+    every single session start). Guards against a blocking read on an
+    interactive stdin the same way statusline.py's `main()` does (`isatty()`
+    check) — this hook must never hang session startup waiting for input that
+    will never arrive. Returns "" on any failure, absence, or malformed
+    payload; the caller treats an empty session_id as "unavailable" and
+    degrades to the pre-#271 unconditional-clear behavior."""
+    try:
+        if sys.stdin.isatty():
+            return ""
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return ""
+        data = json.loads(raw)
+        return str(data.get("session_id") or "") if isinstance(data, dict) else ""
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        return ""
+
+
 def main():
     utf8_stdio()
     # get_host() (#257): resolves the SAME Host run(host) already primed via
@@ -568,11 +715,15 @@ def main():
     root = project_root()
     plugin = host.plugin_root()
     ctx = os.path.join(root, ".codearbiter", "CONTEXT.md")
+    session_id = _session_id_from_stdin()
 
     # /dev developer-override is per-session: clear its statusline marker on
     # startup — a new session restores orchestration. A live marker means a prior
     # session never ran /ca:arbiter, so close the DEV audit pair before clearing.
-    clear_dev_marker(root, host.name)
+    # session_id (#271 C-5) lets this distinguish "the same session resuming"
+    # and "a different, possibly still-live session" from a genuinely
+    # abandoned marker — see clear_dev_marker's docstring.
+    clear_dev_marker(root, host.name, session_id)
 
     # Self-heal a stale ca-owned statusLine pin before the dormant gate: the
     # statusline is wired GLOBALLY in ~/.claude/settings.json, so a plugin update

--- a/plugins/ca/hooks/statusline.py
+++ b/plugins/ca/hooks/statusline.py
@@ -134,6 +134,7 @@ try:
     ANSI = _colorlib.ANSI
     _cw, vlen, clip, pad, gradient_h = (_colorlib._cw, _colorlib.vlen, _colorlib.clip,
                                         _colorlib.pad, _colorlib.gradient_h)
+    strip_control = _colorlib.strip_control
 except Exception:  # pragma: no cover — never let an import break the statusline
     _colorlib = None
     ANSI = re.compile(r"\033\[[0-9;]*m")
@@ -156,6 +157,9 @@ except Exception:  # pragma: no cover — never let an import break the statusli
 
     def gradient_h(text, width, c_from=None, c_to=None):
         return text
+
+    def strip_control(s):
+        return s if not isinstance(s, str) else re.sub(r"[\000-\037]", "", s)
 
 # --------------------------------------------------------------------------- coercion
 def num(x, default=0.0):
@@ -593,7 +597,7 @@ def _render_active_palette(raw):
     if branch:
         dirty = "*" if safe(git_dirty, root) else ""
         gp += f" {V0}{V}{RESET} {(WARN if dirty else OK)}{branch}{dirty}{RESET}"
-    model = get(data, "model", "display_name") or get(data, "model", "id") or "?"
+    model = strip_control(get(data, "model", "display_name") or get(data, "model", "id") or "?")
     pill = safe(model_pill, model, effort) or f"{V2}{model}{RESET}"
     rates = safe(seg_window_inline, data) or ""
     prseg = safe(seg_pr, data) or ""

--- a/plugins/ca/hooks/taskwrite.py
+++ b/plugins/ca/hooks/taskwrite.py
@@ -27,7 +27,9 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _taskboardlib as tb  # noqa: E402
-from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
+from _hooklib import (  # noqa: E402
+    acquire_lock, project_root, release_lock, set_host, utf8_stdio,
+)
 
 # reliability-007 (#190): project_root() is now _hooklib.project_root —
 # imported above, not a local copy. The prior local copy ran `git rev-parse
@@ -35,6 +37,31 @@ from _hooklib import project_root, set_host, utf8_stdio  # noqa: E402
 # skipping the CLAUDE_PROJECT_DIR-first read _hooklib.project_root() exists
 # for; taskwrite mutates .codearbiter/open-tasks.md, so a wrong root silently
 # wrote into the wrong repository's board.
+#
+# #271 C-2/C-3 — lock + re-read-under-lock CAS (spec D-4). taskwrite is the
+# only *programmatic* board mutator, but it is NOT the only writer: the
+# harvest/decompose paths mutate open-tasks.md directly via the host's own
+# Edit/Write tool and will never take this lock (ADR-0008 tolerates that
+# out-of-band path deliberately). A lock alone would therefore still let an
+# interleaved external Edit get silently overwritten by a stale in-memory
+# snapshot, AND would still let two lock-serialized taskwrite calls mint the
+# SAME dotted id if each computed next_seq() against the text it opened with
+# rather than the text current at write time. Taking the lock and THEN
+# reading the board — re-running the pure transform against that fresh read —
+# fixes both: an interleaved external edit is preserved (detected-loss instead
+# of silent clobber), and next_seq() always runs against current text.
+#
+# Fail-soft choice: _ledgerlib's convention is to silently no-op when the lock
+# handle is None (a statusline render is disposable — nobody is worse off if
+# ONE render skips the ledger write). A board mutation is not disposable: it
+# is the single user-visible effect of the whole `taskwrite` invocation, and
+# /ca:task has no other way to report "your task was recorded." Silently
+# proceeding unlocked on contention would silently reintroduce the exact race
+# this fix exists to close (two writers both read-modify-write with no
+# serialization at all). So on a None lock handle, taskwrite refuses to write
+# and exits nonzero with a clear stderr message — the caller (a skill/command)
+# sees a failed exit code and can retry, rather than a false "added"/"marked"
+# success hiding a lost or colliding write.
 
 
 def _date(s):
@@ -45,6 +72,46 @@ def _date(s):
         return datetime.datetime.strptime(s, "%Y-%m-%d").date()
     except ValueError:
         return None
+
+
+def _parse_gid(gid):
+    """Split a `--id GROUP.TYPE` value, or None with an error message on a bad
+    spelling. Pure — no I/O — so it can run before OR after the lock is held."""
+    parts = gid.split(".")
+    if len(parts) != 2 or not all(parts):
+        return None, None, (f"bad --id '{gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
+                             f"the 4-digit seq is minted automatically)")
+    return parts[0], parts[1], None
+
+
+def _apply(args, text):
+    """Pure text -> (new_text, action) | (None, error_msg) transform against
+    the board text the caller hands in. Deliberately takes NO lock and does NO
+    I/O itself — the caller (main()) re-runs this against a FRESH read taken
+    INSIDE the lock (#271 C-3/D-4), so next_seq()'s duplicate-id mint and any
+    interleaved external Edit are both resolved against current text, never a
+    stale snapshot."""
+    if args.verb == "add":
+        group = typ = None
+        if args.gid:
+            group, typ, err = _parse_gid(args.gid)
+            if err:
+                return None, err
+        boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
+        new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
+                           type=typ, boundaries=boundaries, section=args.section)
+        return new, f"added queued task: {args.desc}"
+
+    # start / done
+    state = "in_progress" if args.verb == "start" else "done"
+    day = _date(args.date)
+    if day is None:
+        return None, f"bad --date '{args.date}' (expected YYYY-MM-DD)"
+    assign = getattr(args, "assign", None)
+    new = tb.set_state(text, args.target, state, day, assign=assign)
+    if new == text:
+        return None, f"no change: '{args.target}' not found or already {state}"
+    return new, f"marked {state}: {args.target}"
 
 
 def main(argv=None):
@@ -72,52 +139,57 @@ def main(argv=None):
 
     root = project_root()
     board_path = os.path.join(root, ".codearbiter", "open-tasks.md")
-    text = tb.read_board(board_path)
-    if text is None:
+
+    # An uninitialized repo (no board at all) is a static precondition, not
+    # part of the race this fix closes — check it BEFORE touching the lock so
+    # a run against an uninitialized repo creates no side effect (no
+    # .codearbiter/ dir, no lock sidecar file), exactly as before #271.
+    if not os.path.isfile(board_path):
         print(f"no board at {board_path} — is this an initialized repo?", file=sys.stderr)
         return 1
 
-    if args.verb == "add":
-        group = typ = None
-        if args.gid:
-            parts = args.gid.split(".")
-            if len(parts) != 2 or not all(parts):
-                print(f"bad --id '{args.gid}' (expected GROUP.TYPE, e.g. 'mvp1.store'; "
-                      f"the 4-digit seq is minted automatically)", file=sys.stderr)
-                return 1
-            group, typ = parts
-        boundaries = [b.strip() for b in args.boundaries.split(",")] if args.boundaries else None
-        new = tb.add_entry(text, desc=args.desc, origin=args.origin, group=group,
-                           type=typ, boundaries=boundaries, section=args.section)
-        action = f"added queued task: {args.desc}"
-    else:  # start / done
-        state = "in_progress" if args.verb == "start" else "done"
-        day = _date(args.date)
-        if day is None:
-            print(f"bad --date '{args.date}' (expected YYYY-MM-DD)", file=sys.stderr)
-            return 1
-        assign = getattr(args, "assign", None)
-        new = tb.set_state(text, args.target, state, day, assign=assign)
-        if new == text:
-            print(f"no change: '{args.target}' not found or already {state}", file=sys.stderr)
-            return 1
-        action = f"marked {state}: {args.target}"
-
-    # Atomic write: write to a sibling temp file, then os.replace() into place.
-    # os.replace() is atomic on POSIX and a same-volume rename on Windows, so a
-    # crash between open() and f.write() never leaves the board truncated.
-    board_dir = os.path.dirname(board_path)
-    fd, tmp_path = tempfile.mkstemp(dir=board_dir, suffix=".tmp", prefix="open-tasks.")
+    # #271 C-3 (spec D-4): take the lock FIRST, THEN read the board — everything
+    # from here to the write is inside the critical section, so the read this
+    # transaction acts on is guaranteed fresh relative to any other
+    # lock-taking writer. Fail-soft nuance: unlike _ledgerlib's disposable
+    # statusline write, a board mutation must never be silently dropped on
+    # contention — refuse and exit nonzero instead (see module docstring).
+    lock = acquire_lock(board_path)
+    if lock is None:
+        print(f"could not acquire the task-board lock ({board_path}.lock) — "
+              f"another writer holds it; no changes were written, retry the "
+              f"{args.verb}", file=sys.stderr)
+        return 1
     try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
-            f.write(new)
-        os.replace(tmp_path, board_path)
-    except Exception:
+        text = tb.read_board(board_path)
+        if text is None:
+            print(f"no board at {board_path} — is this an initialized repo?", file=sys.stderr)
+            return 1
+
+        new, action_or_err = _apply(args, text)
+        if new is None:
+            print(action_or_err, file=sys.stderr)
+            return 1
+        action = action_or_err
+
+        # Atomic write: write to a sibling temp file, then os.replace() into
+        # place. os.replace() is atomic on POSIX and a same-volume rename on
+        # Windows, so a crash between open() and f.write() never leaves the
+        # board truncated.
+        board_dir = os.path.dirname(board_path)
+        fd, tmp_path = tempfile.mkstemp(dir=board_dir, suffix=".tmp", prefix="open-tasks.")
         try:
-            os.remove(tmp_path)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+                f.write(new)
+            os.replace(tmp_path, board_path)
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+    finally:
+        release_lock(lock)
     print(action)
     return 0
 

--- a/plugins/ca/hooks/tests/test_colorlib.py
+++ b/plugins/ca/hooks/tests/test_colorlib.py
@@ -113,6 +113,80 @@ class TestCustomPalette(unittest.TestCase):
             palette = _colorlib.resolve_palette("custom", "$THEME_HOME/theme.json")
         self.assertEqual(palette.text_normal, _colorlib.RGB(171, 205, 239))
 
+    def test_deeply_nested_theme_falls_back_instead_of_crashing(self):
+        # A pathologically nested JSON array blows the interpreter's recursion
+        # limit inside json.loads() well before it reaches MAX_THEME_BYTES —
+        # the exact bracket depth needed is CPython-build/platform-dependent
+        # (C-stack-based recursion tracking varies by version), so this test
+        # both (a) writes a real deeply-nested payload that fits under the
+        # size cap and (b) proves the catch itself by forcing RecursionError
+        # out of json.loads deterministically, the same way
+        # test_oversized_file_is_rejected_before_json_parse proves the size
+        # gate. RecursionError must be caught the same as any other
+        # malformed-input failure mode (E-1).
+        violet = _colorlib.resolve_palette("violet")
+        depth = 8000   # deep, but still well under MAX_THEME_BYTES (16 KiB)
+        payload = "[" * depth + "]" * depth
+        self.assertLessEqual(len(payload), _colorlib.MAX_THEME_BYTES)
+        with open(self.path, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        with mock.patch("_colorlib.json.loads", side_effect=RecursionError(
+                "maximum recursion depth exceeded")):
+            self.assertEqual(_colorlib.resolve_palette("custom", self.path), violet)
+
+    def test_invalid_hex_boundary_cases_fall_back_to_violet(self):
+        violet = _colorlib.resolve_palette("violet")
+        for bad_hex in ("#01020", "#0102030", "#0102GG"):
+            with self.subTest(bad_hex=bad_hex):
+                self._write({"accent": {"primary": bad_hex}})
+                palette = _colorlib.resolve_palette("custom", self.path)
+                self.assertEqual(palette.accent_primary, violet.accent_primary)
+
+
+class TestStripControl(unittest.TestCase):
+    """E-3: host/transcript-derived strings must never carry a raw C0 control
+    byte or an OSC/CSI escape sequence into the rendered statusline."""
+
+    def test_strips_c0_control_bytes(self):
+        self.assertEqual(_colorlib.strip_control("a\x00b\x01c\x1fd"), "abcd")
+
+    def test_strips_osc_title_injection(self):
+        injected = "before\x1b]0;pwned\x07after"
+        cleaned = _colorlib.strip_control(injected)
+        self.assertNotIn("\x1b", cleaned)
+        self.assertNotIn("\x07", cleaned)
+        self.assertEqual(cleaned, "beforeafter")
+
+    def test_strips_csi_sgr_sequence(self):
+        injected = "before\x1b[31mred\x1b[0mafter"
+        cleaned = _colorlib.strip_control(injected)
+        self.assertNotIn("\x1b", cleaned)
+        self.assertEqual(cleaned, "beforeredafter")
+
+    def test_non_string_passes_through(self):
+        self.assertIsNone(_colorlib.strip_control(None))
+        self.assertEqual(_colorlib.strip_control(42), 42)
+
+    def test_display_model_strips_injected_escape(self):
+        import _subagentslib
+        cleaned = _subagentslib.display_model("claude-\x1b]0;pwned\x07sonnet-4-6-20260101")
+        self.assertNotIn("\x1b", cleaned)
+        self.assertNotIn("\x07", cleaned)
+
+    def test_sub_label_strips_injected_control_bytes(self):
+        import _subagentslib
+        label = _subagentslib.sub_label("Fix the \x1b]0;pwned\x07 bug\x01now")
+        self.assertNotIn("\x1b", label)
+        self.assertNotIn("\x07", label)
+        self.assertNotIn("\x01", label)
+
+    def test_render_never_emits_injected_escape_from_model_name(self):
+        import statusline as sl
+        payload = json.dumps({"model": {"display_name": "claude\x1b]0;pwned\x07-sonnet"}})
+        out = sl.render(payload)
+        self.assertNotIn("\x1b]0;pwned\x07", out)
+        self.assertNotIn("\x07", out)
+
 
 class TestActivePaletteCompatibility(unittest.TestCase):
     def tearDown(self):

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -388,14 +388,26 @@ class TestDropInSharedDir(_GitFixture):
     would never see an entry another worktree/host wrote)."""
 
     def test_linked_worktree_shares_the_same_dropin_dir_as_main(self):
+        # realpath BOTH sides before comparing (portability, not a weakened
+        # assertion): on macOS `/var` is itself a symlink to `/private/var`,
+        # and `tempfile`-issued paths come back unresolved while git
+        # internally canonicalizes the absolute paths IT writes (the linked
+        # worktree's `gitdir:` pointer) -- so main_dropin and wt_dropin can
+        # legitimately differ as STRINGS while naming the exact same
+        # directory (the OS resolves `/var` <-> `/private/var` transparently
+        # for every open/stat/makedirs call either side of the real shim
+        # would ever make -- see the production-benign analysis in the class
+        # docstring / commit note). realpath collapses that representational
+        # difference without weakening what this test actually proves: main
+        # and worktree resolve to the SAME directory.
         wt_dir = os.path.join(os.path.dirname(self.root), "wt")
         _git(["worktree", "add", "-q", "-b", "feat/wt", wt_dir], self.root)
         main_dropin = _githooks._dropin_dir(self.root)
         wt_dropin = _githooks._dropin_dir(wt_dir)
         self.assertIsNotNone(main_dropin)
         self.assertIsNotNone(wt_dropin)
-        self.assertEqual(os.path.normcase(os.path.normpath(main_dropin)),
-                         os.path.normcase(os.path.normpath(wt_dropin)))
+        self.assertEqual(os.path.normcase(os.path.realpath(main_dropin)),
+                         os.path.normcase(os.path.realpath(wt_dropin)))
 
     def test_git_common_dir_resolves_without_a_git_spawn_for_the_main_repo(self):
         # The common (non-worktree) case must be resolvable purely from the

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -19,6 +19,7 @@ import contextlib
 import importlib.util as _ilu
 import io
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -112,10 +113,23 @@ class TestInstall(_GitFixture):
         self.assertIn("husky", body)
         self.assertNotIn(_githooks.SENTINEL, body)
 
-    def test_uninstall_removes_only_ours(self):
+    def test_uninstall_removes_only_own_dropin_entry(self):
+        # ADR-0014: uninstall() removes ONLY this plugin's own drop-in
+        # `<plugin>.path` entry -- never the shared, host-neutral shim file,
+        # which a sibling plugin may still depend on. Leaving the (now
+        # empty) drop-in dir behind is the fail-closed contract working as
+        # designed, not a bug -- see TestDropInFailClosed below.
         _githooks.install(self.root)
-        _githooks.uninstall(self.root)
-        self.assertFalse(os.path.isfile(os.path.join(self._hooks_dir(), "pre-commit")))
+        dropin = _githooks._dropin_dir(self.root)
+        plugin = _githooks._plugin_name()
+        entry = _githooks._path_entry_file(dropin, plugin)
+        self.assertTrue(os.path.isfile(entry))
+        actions = _githooks.uninstall(self.root)
+        self.assertIn(f"{plugin}.path: removed", actions)
+        self.assertFalse(os.path.isfile(entry))
+        for phase in ("pre-commit", "pre-push"):
+            self.assertTrue(os.path.isfile(os.path.join(self._hooks_dir(), phase)),
+                            f"{phase} shim must survive uninstall of a single plugin")
 
 
 class TestInstallSkipsReprobeWhenCurrent(_GitFixture):
@@ -187,18 +201,28 @@ class TestInstallSkipsReprobeWhenCurrent(_GitFixture):
         for phase in ("pre-commit", "pre-push"):
             self.assertTrue(os.path.isfile(os.path.join(self._hooks_dir(), phase)))
 
-    def test_mismatched_enforcer_path_falls_through_not_silently_skipped(self):
-        # If the enforcer path changed (e.g. a plugin update moved the install
-        # dir) since the cache was written, the shim content no longer matches
-        # -> _hooks_current() must return False -> the full probe must run and
-        # refresh the shim, never silently skip a needed update.
-        _githooks.install(self.root)  # writes the cache with the real enforcer path
+    def test_mismatched_enforcer_path_refreshes_dropin_entry_not_the_shim(self):
+        # ADR-0014: the shim is host-neutral (it depends only on the shared
+        # drop-in dir, never on this plugin's own enforcer path), so a plugin
+        # update moving the install dir no longer requires rewriting the
+        # SHIM file itself -- _hooks_current() correctly still reports
+        # "current" for the shim (the fast path may fire), but install()
+        # unconditionally refreshes THIS plugin's own `<plugin>.path` entry
+        # every call regardless, so a version-bumped enforcer path is never
+        # left stale.
+        _githooks.install(self.root)  # writes the cache + the real enforcer path
+        dropin = _githooks._dropin_dir(self.root)
+        plugin = _githooks._plugin_name()
+        entry = _githooks._path_entry_file(dropin, plugin)
+        with open(entry, encoding="utf-8") as f:
+            self.assertNotIn("/moved/enforcer.py", f.read())
         with mock.patch.object(_githooks, "_enforcer_path", return_value="/moved/enforcer.py"):
             actions = _githooks.install(self.root)
-        self.assertIn("pre-commit: installed", actions)
-        self.assertIn("pre-push: installed", actions)
-        with open(os.path.join(self._hooks_dir(), "pre-commit"), encoding="utf-8") as f:
-            self.assertIn("/moved/enforcer.py", f.read())
+        self.assertEqual(actions, [],
+                         "the shim file itself must NOT be rewritten for an enforcer-path-only change")
+        with open(entry, encoding="utf-8") as f:
+            self.assertIn("/moved/enforcer.py", f.read(),
+                         "this plugin's own drop-in entry must self-heal every call")
 
     # ------------------------------------------------------------------
     # CRITICAL regression (security review, post-#194): a LOCAL core.hooksPath
@@ -354,6 +378,116 @@ class TestInstallSkipsReprobeWhenCurrent(_GitFixture):
         self.assertEqual(result, [])  # still a no-op...
         self.assertTrue(calls, "a cached CUSTOM hooksPath must always re-confirm via git, "
                               "never take the zero-spawn fast path")
+
+
+class TestDropInSharedDir(_GitFixture):
+    """ADR-0014 / #265 (AC-7): the drop-in dir the shim reads from resolves to
+    the repo's git COMMON dir, so every linked worktree of a repo shares the
+    SAME `.git/codearbiter-hooksd/` -- never a per-worktree copy, which would
+    defeat the whole cross-host purpose (a shim installed from one worktree
+    would never see an entry another worktree/host wrote)."""
+
+    def test_linked_worktree_shares_the_same_dropin_dir_as_main(self):
+        wt_dir = os.path.join(os.path.dirname(self.root), "wt")
+        _git(["worktree", "add", "-q", "-b", "feat/wt", wt_dir], self.root)
+        main_dropin = _githooks._dropin_dir(self.root)
+        wt_dropin = _githooks._dropin_dir(wt_dir)
+        self.assertIsNotNone(main_dropin)
+        self.assertIsNotNone(wt_dropin)
+        self.assertEqual(os.path.normcase(os.path.normpath(main_dropin)),
+                         os.path.normcase(os.path.normpath(wt_dropin)))
+
+    def test_git_common_dir_resolves_without_a_git_spawn_for_the_main_repo(self):
+        # The common (non-worktree) case must be resolvable purely from the
+        # filesystem -- required so the performance-002 fast path (see
+        # TestInstallSkipsReprobeWhenCurrent) still makes zero git spawns.
+        calls = []
+        orig = _githooks._git
+
+        def spy(args, cwd):
+            calls.append(list(args))
+            return orig(args, cwd)
+
+        _githooks._git = spy
+        try:
+            common = _githooks._git_common_dir(self.root)
+        finally:
+            _githooks._git = orig
+        self.assertIsNotNone(common)
+        self.assertEqual(calls, [], "the main-repo case must resolve with zero git spawns")
+
+
+class TestDropInMultiPluginFailClosed(_GitFixture):
+    """AC-7 (#265): two plugins registered in the shared drop-in dir -- the
+    shim resolves through whichever entry is actually live, independent of
+    write order, and BLOCKS (fails closed) when NOTHING resolves."""
+
+    def _write_entry(self, dropin, name, target):
+        os.makedirs(dropin, exist_ok=True)
+        with open(os.path.join(dropin, f"{name}.path"), "w", encoding="utf-8") as f:
+            f.write(target + "\n")
+
+    def _stage(self, name, content):
+        self._write(os.path.join(self.root, name), content)
+        _git(["add", name], self.root)
+
+    def test_survivor_plugin_still_enforces_when_the_other_is_uninstalled(self):
+        # AC-7a: this plugin's own install() writes a REAL, resolvable entry.
+        # A second plugin is ALSO registered but its enforcer is gone (as if
+        # uninstalled) -- the shim must still resolve to the survivor and
+        # enforcement must still fire (a direct commit to main is BLOCKED).
+        _githooks.install(self.root)
+        dropin = _githooks._dropin_dir(self.root)
+        self._write_entry(dropin, "other-plugin",
+                          os.path.join(self.root, "_removed", "git-enforce.py"))
+        self._stage("f.txt", "x\n")
+        res = _sh(["sh", "-c", "git commit -m x"], self.root)
+        self.assertNotEqual(res.returncode, 0, res.stderr)
+        self.assertIn("H-01", res.stderr + res.stdout)
+
+    def test_survivor_enforces_regardless_of_which_entry_was_written_last(self):
+        # Symmetric ordering: write the DEAD entry first, the REAL one last --
+        # the loop must not stop at (or prefer) whichever was written most
+        # recently; every entry is tried until one resolves.
+        dropin = _githooks._dropin_dir(self.root)
+        self._write_entry(dropin, "aaa-dead",
+                          os.path.join(self.root, "_removed", "git-enforce.py"))
+        _githooks.install(self.root)  # writes THIS plugin's real entry after
+        self._stage("f.txt", "x\n")
+        res = _sh(["sh", "-c", "git commit -m x"], self.root)
+        self.assertNotEqual(res.returncode, 0, res.stderr)
+        self.assertIn("H-01", res.stderr + res.stdout)
+
+    def test_zero_resolvable_enforcers_fails_closed_not_open(self):
+        # AC-7b: every registered entry points at a missing file (or the dir
+        # is emptied entirely) -- the shim must BLOCK (non-zero exit), never
+        # silently allow (exit 0) the way the old single-embedded-path shim
+        # did on its own staleness.
+        _githooks.install(self.root)
+        dropin = _githooks._dropin_dir(self.root)
+        for name in os.listdir(dropin):
+            if name.endswith(".path"):
+                os.remove(os.path.join(dropin, name))
+        self.assertEqual([n for n in os.listdir(dropin) if n.endswith(".path")], [])
+        _git(["checkout", "-q", "-b", "feat/x"], self.root)  # not itself a protected branch
+        self._stage("f.txt", "x\n")
+        res = _sh(["sh", "-c", "git commit -m x"], self.root)
+        self.assertNotEqual(res.returncode, 0,
+                           "an empty drop-in dir must fail CLOSED, not silently allow")
+        log = _git(["rev-list", "--all", "--count"], self.root, check=False)
+        self.assertEqual(log.stdout.strip(), "0", "nothing must be committed on a fail-closed block")
+
+    def test_dropin_dir_missing_entirely_fails_closed(self):
+        # The un-expanded "$D/*.path" glob-literal case: the drop-in dir
+        # itself doesn't exist at all (not merely empty).
+        _githooks.install(self.root)
+        dropin = _githooks._dropin_dir(self.root)
+        shutil.rmtree(dropin)
+        _git(["checkout", "-q", "-b", "feat/y"], self.root)
+        self._stage("f.txt", "x\n")
+        res = _sh(["sh", "-c", "git commit -m x"], self.root)
+        self.assertNotEqual(res.returncode, 0,
+                           "a missing drop-in dir must fail CLOSED, not silently allow")
 
 
 class TestPreCommitEnforce(_GitFixture):

--- a/plugins/ca/hooks/tests/test_ledgerlib.py
+++ b/plugins/ca/hooks/tests/test_ledgerlib.py
@@ -20,6 +20,7 @@ _HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
+import _hooklib
 import _ledgerlib as L
 from _helpers import redirect_home, restore_home
 
@@ -213,7 +214,13 @@ class TestPersistence(unittest.TestCase):
                                name="ledger-first")
         two = threading.Thread(target=lambda: outputs.setdefault("second", second()),
                                name="ledger-second")
-        with mock.patch.object(L, "LOCK_WAIT", CONCURRENCY_TEST_WAIT), \
+        # NB: acquire_lock's retry deadline (core/pysrc/_hooklib.py) reads its
+        # OWN module global `LOCK_WAIT` at call time, not `_ledgerlib.LOCK_WAIT`
+        # (a same-named but distinct binding imported for back-compat re-export
+        # only — see _ledgerlib.py's header comment). Patching `L.LOCK_WAIT`
+        # alone is inert; patch `_hooklib.LOCK_WAIT`, the name the real retry
+        # loop actually consults, so this harness's headroom is real.
+        with mock.patch.object(_hooklib, "LOCK_WAIT", CONCURRENCY_TEST_WAIT), \
                 mock.patch.object(L, "_acquire_lock", side_effect=coordinated_acquire):
             one.start()
             self.assertTrue(first_acquired.wait(CONCURRENCY_TEST_WAIT))
@@ -221,7 +228,13 @@ class TestPersistence(unittest.TestCase):
                 while_first_holds()
             two.start()
             self.assertTrue(second_attempted.wait(CONCURRENCY_TEST_WAIT))
-            self.assertFalse(second_acquired.is_set())
+            # Time-bounded negative wait (E-4): waiting for second_attempted
+            # only proves the second thread got scheduled and reached the
+            # lock call — it says nothing about whether the lock actually
+            # excluded it. Give the second thread a real window to sneak an
+            # acquisition through before the first releases; if serialization
+            # were broken, this wait would very likely observe it fire.
+            self.assertFalse(second_acquired.wait(0.2))
             release_first.set()
             self.assertTrue(second_acquired.wait(CONCURRENCY_TEST_WAIT))
             one.join(CONCURRENCY_TEST_WAIT)

--- a/plugins/ca/hooks/tests/test_repo_resolution.py
+++ b/plugins/ca/hooks/tests/test_repo_resolution.py
@@ -74,6 +74,16 @@ def _init_repo(root, branch="main"):
         f.write(ARBITER)
 
 
+def _commit(root, name="seed.txt", content="seed\n", msg="seed"):
+    """A trivial commit — `git worktree add` needs at least one commit to
+    check anything out from (an unborn-HEAD repo has nothing to branch off)."""
+    path = os.path.join(root, name)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    _git(["add", name], root)
+    _git(["commit", "-q", "-m", msg], root)
+
+
 # ---------------------------------------------------------------------------
 # reliability-004: pre-bash.py's git_cwd() must extract -C past global options
 # ---------------------------------------------------------------------------
@@ -218,6 +228,136 @@ class TestGitCwdEndToEnd(unittest.TestCase):
         # entirely, not joined or left standing as a prior last-wins target.
         os.makedirs(os.path.join(self.session_root, "feat"), exist_ok=True)
         res = self.run_bash(f'git -C feat -C "{self.other_root}" commit -m x')
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    # -- #223 (A-1): a `git commit` run inside a LINKED WORKTREE (no -C at
+    # all — the ordinary, everyday spelling) must be judged against the
+    # worktree's OWN branch, not CLAUDE_PROJECT_DIR's (the main checkout,
+    # which another agent may be sitting in on an unrelated branch). Both
+    # directions matter: the false NEGATIVE (a worktree on main/master
+    # sidesteps H-01 because the main checkout happens to be on a feature
+    # branch) is the more serious one — it lets a protected-branch commit
+    # through — but the false POSITIVE (a worktree on a feature branch is
+    # wrongly blocked because the main checkout is on main) must not regress
+    # either.
+
+    def test_worktree_on_main_is_blocked_even_when_main_checkout_is_on_a_feature_branch(self):
+        # The false negative: today, CLAUDE_PROJECT_DIR (main_checkout, on a
+        # feature branch) is judged instead of the worktree's actual branch
+        # (main) — so this commit wrongly sails through. Must BLOCK.
+        main_checkout = os.path.join(self._tmp.name, "wt-main-checkout")
+        _init_repo(main_checkout, branch="feat/other-work")
+        _commit(main_checkout)
+        wt_dir = os.path.join(self._tmp.name, "wt-on-main")
+        _git(["worktree", "add", "-b", "main", wt_dir], main_checkout)
+        res = _sh([sys.executable, PRE_BASH], wt_dir,
+                  input=json.dumps({"tool_name": "Bash",
+                                    "tool_input": {"command": "git commit -m x"}}),
+                  env={**os.environ, "CLAUDE_PROJECT_DIR": main_checkout})
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_worktree_on_feature_branch_is_allowed_even_when_main_checkout_is_on_main(self):
+        # The false positive: today, CLAUDE_PROJECT_DIR (main_checkout, on
+        # main) is judged instead of the worktree's actual branch (a feature
+        # branch) — so this legitimate commit is wrongly blocked. Must NOT
+        # block.
+        main_checkout = os.path.join(self._tmp.name, "wt-main-checkout-2")
+        _init_repo(main_checkout, branch="main")
+        _commit(main_checkout)
+        wt_dir = os.path.join(self._tmp.name, "wt-on-feature")
+        _git(["worktree", "add", "-b", "feat/from-worktree", wt_dir], main_checkout)
+        res = _sh([sys.executable, PRE_BASH], wt_dir,
+                  input=json.dumps({"tool_name": "Bash",
+                                    "tool_input": {"command": "git commit -m x"}}),
+                  env={**os.environ, "CLAUDE_PROJECT_DIR": main_checkout})
+        self.assertNotIn("H-01", res.stderr)
+
+
+# ---------------------------------------------------------------------------
+# #223 (A-2): heredoc BODY prose must not be mistaken for a real command
+# (D-3) — but a heredoc actually FED TO A SHELL still executes its body and
+# must still be guarded.
+# ---------------------------------------------------------------------------
+
+class TestHeredocFallbackNarrowing(unittest.TestCase):
+    """pre-bash.py's raw-cmd fallback (the one that lets a heredoc genuinely
+    fed to a shell still trip H-01) must be narrowed to shell-consuming
+    heredocs only (D-3) — a heredoc whose consumer is NOT a shell (`cat`,
+    inert text later substituted into `gh`'s --body) must not false-trip H-01
+    merely because its body happens to CONTAIN the text "git commit"."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.join(self._tmp.name, "repo")
+        _init_repo(self.root, branch="main")  # on main: a REAL commit here blocks
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run_bash(self, command):
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+        return _sh([sys.executable, PRE_BASH], self.root, input=payload,
+                  env={**os.environ, "CLAUDE_PROJECT_DIR": self.root})
+
+    def test_heredoc_prose_inside_gh_pr_create_body_does_not_trip_h01(self):
+        # The exact #223 evidence spelling: `cat <<'EOF' ... EOF` substituted
+        # into gh's --body. The heredoc's DIRECT consumer is `cat` (inert
+        # text), not a shell — must NOT block.
+        cmd = ('gh pr create --body "$(cat <<\'EOF\'\n'
+               'This PR includes a git commit -m x as part of the change\n'
+               'EOF\n)"')
+        res = self._run_bash(cmd)
+        self.assertNotIn("H-01", res.stderr)
+
+    def test_heredoc_fed_to_bash_still_blocks(self):
+        # A heredoc fed directly to `bash` genuinely executes its body — must
+        # still BLOCK (ambiguity resolves closed, D-3).
+        cmd = "bash <<'EOF'\ngit commit -m x\nEOF\n"
+        res = self._run_bash(cmd)
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_heredoc_prose_inside_gh_issue_create_body_does_not_trip_h01(self):
+        # Same shape as the pr-create case, different subcommand — must NOT
+        # block either.
+        cmd = ('gh issue create --body "$(cat <<\'EOF\'\n'
+               'This issue references a git commit -m x from another PR\n'
+               'EOF\n)"')
+        res = self._run_bash(cmd)
+        self.assertNotIn("H-01", res.stderr)
+
+    # -- review finding: `_heredoc_fed_to_shell` alone keys on the heredoc's
+    # DIRECT consumer only. `bash -c "$(cat <<EOF … EOF)"` has `cat` as the
+    # direct consumer (non-shell, correctly), but `bash -c` EXECUTES the
+    # substituted result of that `cat` — the heredoc body genuinely reaches a
+    # shell by a route the direct-consumer check cannot see. Narrowing must
+    # also fail closed whenever the command invokes ANY shell/interpreter
+    # executor ANYWHERE (`bash -c`, `eval`, `sh -c`, …), not only when the
+    # heredoc's immediate consumer is one.
+
+    def test_heredoc_via_command_substitution_fed_to_bash_dash_c_still_blocks(self):
+        cmd = ('bash -c "$(cat <<\'EOF\'\n'
+               'git commit -m x\n'
+               'EOF\n)"')
+        res = self._run_bash(cmd)
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_heredoc_via_command_substitution_fed_to_eval_still_blocks(self):
+        cmd = ('eval "$(cat <<\'EOF\'\n'
+               'git commit -m x\n'
+               'EOF\n)"')
+        res = self._run_bash(cmd)
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-01", res.stderr)
+
+    def test_heredoc_via_command_substitution_fed_to_sh_dash_c_still_blocks(self):
+        cmd = ('sh -c "$(cat <<\'EOF\'\n'
+               'git commit -m x\n'
+               'EOF\n)"')
+        res = self._run_bash(cmd)
         self.assertEqual(res.returncode, 2, res.stderr)
         self.assertIn("H-01", res.stderr)
 

--- a/plugins/ca/hooks/tests/test_security_pass.py
+++ b/plugins/ca/hooks/tests/test_security_pass.py
@@ -122,6 +122,44 @@ class TestSecurityPassBranches(_Fixture):
         self.assertEqual(res.returncode, 0)
         self.assertIn("1 sensitive line", res.stdout)
 
+    def test_gate_events_log_untracked_contributes_no_digests(self):
+        # #279: gate-events.log is the gate's own machine-written audit sink —
+        # its REMIND text ("no MD5/SHA1/DES/3DES/RC2/RC4/Blowfish") matches
+        # CRYPTO_RE just as well as a genuine algorithm choice would, so an
+        # UNTRACKED gate-events.log full of such lines must contribute ZERO
+        # digests to the marker (the untracked-file branch of candidate_lines).
+        self._ca()
+        self._write(".codearbiter/gate-events.log", CRYPTO_LINE * 3)
+        res = self.run_pass()
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("0 sensitive line", res.stdout)
+        self.assertEqual(self.marker(), "")
+
+    def test_gate_events_log_diff_contributes_no_digests(self):
+        # #279: same exemption via the `git diff HEAD` branch — a COMMITTED
+        # gate-events.log with a new, uncommitted REMIND line appended must
+        # still contribute zero digests, proving the diff walk (not just the
+        # untracked-file walk) is path-aware.
+        self._ca()
+        self._write(".codearbiter/gate-events.log", "seed\n")
+        _git(["add", ".codearbiter/gate-events.log"], self.root)
+        _git(["commit", "-q", "-m", "seed log"], self.root)
+        self._write(".codearbiter/gate-events.log", "seed\n" + CRYPTO_LINE)
+        res = self.run_pass()
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("0 sensitive line", res.stdout)
+        self.assertEqual(self.marker(), "")
+
+    def test_gate_events_log_exemption_is_narrow(self):
+        # #279 non-weakening proof: the SAME sensitive line, in a DIFFERENT
+        # file, must still be recorded — only gate-events.log is exempt.
+        self._ca()
+        self._write(".codearbiter/overrides.log", CRYPTO_LINE)
+        res = self.run_pass()
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("1 sensitive line", res.stdout)
+        self.assertTrue(self.marker().strip())
+
     def test_marker_write_leaves_no_temp_file(self):
         # migration-002: the marker is written atomically (temp + os.replace), so
         # after a successful run the .markers dir holds the marker and no .tmp.

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -447,6 +447,117 @@ class TestDevExitAudit(unittest.TestCase):
         _mod.clear_dev_marker(self.root)
         self.assertEqual(self._read_log(), seed, "no marker -> overrides.log untouched")
 
+    # -- #271 C-4/C-5: session-scoped clearing -------------------------------
+    # A repo-global marker with no owner concept meant ANY SessionStart
+    # (including one from a totally different, concurrently-running session)
+    # would unconditionally clear it and write a false DEV: exit. These tests
+    # simulate two sessions sharing one repo: session A's own SessionStart
+    # runs (recording itself as the last-known active session) BEFORE it
+    # enters /dev; session B's SessionStart must not clobber A's still-live
+    # marker.
+
+    def test_concurrent_live_session_marker_is_not_clobbered(self):
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        # Session A's own SessionStart, BEFORE it enters /dev (no marker yet).
+        _mod.clear_dev_marker(self.root, session_id="sess-A")
+        # A enters /dev.
+        self._drop_marker()
+        # Session B starts concurrently, while A is still live in dev mode.
+        _mod.clear_dev_marker(self.root, session_id="sess-B")
+        self.assertTrue(os.path.isfile(self.marker),
+                         "session B must not clear session A's live marker")
+        log = self._read_log()
+        self.assertNotIn("DEV: exit", log,
+                          "session B must not write a false DEV: exit for session A")
+
+    def test_same_session_resume_does_not_clobber_its_own_marker(self):
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        _mod.clear_dev_marker(self.root, session_id="sess-A")
+        self._drop_marker()
+        # The SAME session resumes/compacts mid-dev — not "ended".
+        _mod.clear_dev_marker(self.root, session_id="sess-A")
+        self.assertTrue(os.path.isfile(self.marker))
+        self.assertNotIn("DEV: exit", self._read_log())
+
+    def test_stale_owner_beyond_liveness_window_is_still_cleared(self):
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        _mod.clear_dev_marker(self.root, session_id="sess-A", now=1000.0)
+        self._drop_marker()
+        later = 1000.0 + _mod.DEV_SESSION_LIVENESS_WINDOW + 1
+        _mod.clear_dev_marker(self.root, session_id="sess-B", now=later)
+        self.assertFalse(os.path.isfile(self.marker),
+                          "a genuinely abandoned marker must still self-heal eventually")
+        self.assertIn("DEV: exit", self._read_log())
+
+    def test_no_session_id_degrades_to_unconditional_clear(self):
+        # Codex parity unverified: a host that supplies no session_id at all
+        # must fall back to today's behavior rather than never clearing.
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        _mod.clear_dev_marker(self.root, session_id="sess-A")
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root, session_id=None)
+        self.assertFalse(os.path.isfile(self.marker))
+        self.assertIn("DEV: exit", self._read_log())
+
+    def test_no_prior_owner_record_degrades_to_unconditional_clear(self):
+        # A marker present with NO recorded owner at all (e.g. a legacy
+        # marker, or the very first session ever) — no signal to protect a
+        # concurrent session, so proceed exactly as before #271.
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root, session_id="sess-B")
+        self.assertFalse(os.path.isfile(self.marker))
+        self.assertIn("DEV: exit", self._read_log())
+
+    def test_unrelated_sessions_do_not_reset_the_owners_clock(self):
+        """The liveness window must be anchored to the OWNER's last activity,
+        never to whatever session most recently started. A sequence of
+        unrelated sessions (B, C, D, ...), each only minutes apart, must NOT
+        keep resetting the clock — the marker must still self-heal once
+        DEV_SESSION_LIVENESS_WINDOW has elapsed from A's own last activity,
+        even though many other unrelated sessions started in the meantime."""
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        t0 = 1000.0
+        _mod.clear_dev_marker(self.root, session_id="sess-A", now=t0)
+        self._drop_marker()
+
+        # A crashes. Unrelated sessions B, C, D, ... start every 5 minutes —
+        # each individually well inside the window relative to the LAST
+        # observer, but the total elapsed time relative to A's t0 exceeds it.
+        step = 5 * 60
+        t = t0
+        for i in range(200):  # 200 * 5min = ~16.7h of unrelated activity
+            t += step
+            _mod.clear_dev_marker(self.root, session_id=f"sess-unrelated-{i}", now=t)
+            if t - t0 >= _mod.DEV_SESSION_LIVENESS_WINDOW:
+                break
+
+        self.assertGreaterEqual(t - t0, _mod.DEV_SESSION_LIVENESS_WINDOW,
+                                 "test setup must actually cross the window")
+        self.assertFalse(os.path.isfile(self.marker),
+                          "unrelated sessions must not reset A's clock and keep the marker immortal")
+        self.assertIn("DEV: exit", self._read_log())
+
+    def test_owner_heartbeat_past_window_is_never_clobbered(self):
+        """The OWNER itself resuming/compacting repeatedly, well past the 6h
+        mark, must keep its own marker alive indefinitely — only an UNRELATED
+        session's passive observation must decline to refresh the clock."""
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev@example.com | DEV: enter | NOTE: —\n")
+        t0 = 1000.0
+        _mod.clear_dev_marker(self.root, session_id="sess-A", now=t0)
+        self._drop_marker()
+
+        t = t0
+        for _ in range(10):
+            t += _mod.DEV_SESSION_LIVENESS_WINDOW - 1  # always just under the bound
+            _mod.clear_dev_marker(self.root, session_id="sess-A", now=t)
+
+        self.assertGreater(t - t0, _mod.DEV_SESSION_LIVENESS_WINDOW,
+                            "test setup must actually run past one window's worth of elapsed time")
+        self.assertTrue(os.path.isfile(self.marker),
+                         "the owner's own heartbeat must never be clobbered by its own resume")
+        self.assertNotIn("DEV: exit", self._read_log())
+
     def test_append_is_a_single_line_after_existing_content(self):
         seed = "[2026-01-01T00:00:00Z] | BY: dev | DEV: enter | NOTE: —\n"
         self._seed_log(seed)

--- a/plugins/ca/hooks/tests/test_taskwrite.py
+++ b/plugins/ca/hooks/tests/test_taskwrite.py
@@ -1,0 +1,180 @@
+"""Tests for taskwrite.py — the sanctioned task-board mutator behind /ca:task
+(#271 C-1/C-3). taskwrite.py has no test coverage today; this file is the
+first.
+
+Covers the lock-free read-modify-write race that let two concurrent
+`taskwrite` invocations silently drop one writer's edit and mint a DUPLICATE
+dotted task ID (both readers see the same stale board, so `next_seq` computes
+the same "next" number for both). Pattern-matches the contention harness in
+test_ledgerlib.py's `_serialize_transactions` (the `while_first_holds` shape
+used by `test_same_session_concurrent_updates_do_not_regress_accounting`):
+serialize two writers via the REAL lock, inject a third-party mutation (an
+out-of-band harvest/decompose Edit) while the first holds the lock, then
+assert nothing is lost and no duplicate ID is minted.
+
+Stdlib unittest only; no real ~/.codearbiter, no subprocess (in-process
+`taskwrite.run(host, argv)` calls against a throwaway fixture repo).
+"""
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+_HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+import _hooklib
+import hostapi
+import taskwrite as TW
+
+CONCURRENCY_TEST_WAIT = 5.0
+
+BOARD = """\
+# Open tasks
+
+## In-flight
+- [ ] mvp1.store.0001 - existing queued task
+"""
+
+
+class _FixtureHost(hostapi.Host):
+    name = "fixture"
+
+    def __init__(self, root):
+        self._root = root
+
+    def project_root(self, payload=None):
+        return self._root
+
+
+class TaskwriteContentionTest(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.cad = os.path.join(self.root, ".codearbiter")
+        os.makedirs(self.cad)
+        self.board_path = os.path.join(self.cad, "open-tasks.md")
+        with open(self.board_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(BOARD)
+        self.host = _FixtureHost(self.root)
+        _hooklib._reset_root_cache()
+
+    def tearDown(self):
+        _hooklib.reset_host()
+        _hooklib._reset_root_cache()
+        self._tmp.cleanup()
+
+    def _read(self):
+        with open(self.board_path, encoding="utf-8") as f:
+            return f.read()
+
+    def _run(self, argv):
+        # Fresh Host injection per call (mirrors production: run(host, argv)
+        # is the entry point, exactly as the __main__ guard invokes it).
+        return TW.run(self.host, argv)
+
+    def _serialize_writers(self, first, second, while_first_holds=None):
+        """Prove the second writer cannot observe/mutate the board until the
+        first releases the lock — the exact shape of
+        test_ledgerlib._serialize_transactions."""
+        real_acquire = _hooklib.acquire_lock
+        first_acquired = threading.Event()
+        second_attempted = threading.Event()
+        second_acquired = threading.Event()
+        release_first = threading.Event()
+        outputs = {}
+
+        def coordinated_acquire(path):
+            if threading.current_thread().name == "taskwrite-second":
+                second_attempted.set()
+            token = real_acquire(path)
+            if token is not None and threading.current_thread().name == "taskwrite-first":
+                first_acquired.set()
+                self.assertTrue(release_first.wait(CONCURRENCY_TEST_WAIT))
+            elif token is not None and threading.current_thread().name == "taskwrite-second":
+                second_acquired.set()
+            return token
+
+        one = threading.Thread(target=lambda: outputs.setdefault("first", first()),
+                               name="taskwrite-first")
+        two = threading.Thread(target=lambda: outputs.setdefault("second", second()),
+                               name="taskwrite-second")
+        with mock.patch.object(TW, "acquire_lock", side_effect=coordinated_acquire):
+            one.start()
+            self.assertTrue(first_acquired.wait(CONCURRENCY_TEST_WAIT))
+            if while_first_holds:
+                while_first_holds()
+            two.start()
+            self.assertTrue(second_attempted.wait(CONCURRENCY_TEST_WAIT))
+            self.assertFalse(second_acquired.is_set())
+            release_first.set()
+            self.assertTrue(second_acquired.wait(CONCURRENCY_TEST_WAIT))
+            one.join(CONCURRENCY_TEST_WAIT)
+            two.join(CONCURRENCY_TEST_WAIT)
+        self.assertFalse(one.is_alive())
+        self.assertFalse(two.is_alive())
+        return outputs
+
+    def test_concurrent_add_entries_both_survive_no_lost_update(self):
+        """Two concurrent `taskwrite add` calls must BOTH land — the classic
+        lost-update shape: without a lock + re-read, the second os.replace()
+        silently discards the first writer's edit."""
+        outputs = self._serialize_writers(
+            lambda: self._run(["add", "first concurrent task", "--id", "mvp1.store"]),
+            lambda: self._run(["add", "second concurrent task", "--id", "mvp1.store"]))
+        self.assertEqual(outputs["first"], 0)
+        self.assertEqual(outputs["second"], 0)
+        text = self._read()
+        self.assertIn("first concurrent task", text,
+                       "the first writer's edit was silently lost")
+        self.assertIn("second concurrent task", text,
+                       "the second writer's edit was silently lost")
+
+    def test_concurrent_add_entries_do_not_mint_duplicate_dotted_id(self):
+        """Both concurrent adds mint a dotted ID in the SAME group.type
+        namespace. Reading the board fresh under the lock (not the stale
+        snapshot each thread opened with) is what makes next_seq allocate two
+        DISTINCT ids instead of both computing the same 'max + 1'."""
+        self._serialize_writers(
+            lambda: self._run(["add", "first concurrent task", "--id", "mvp1.store"]),
+            lambda: self._run(["add", "second concurrent task", "--id", "mvp1.store"]))
+        text = self._read()
+        ids = sorted(set(__import__("re").findall(r"mvp1\.store\.\d{4}", text)))
+        # The seed board already holds mvp1.store.0001; the two new adds must
+        # mint 0002 and 0003 — never the SAME id twice.
+        self.assertEqual(len(ids), 3, f"expected 3 distinct dotted ids, got {ids}")
+
+    def test_external_edit_while_lock_held_is_not_silently_clobbered(self):
+        """D-4: an out-of-band Edit (harvest/decompose writing the board
+        directly, never taking the lock) that lands WHILE the lock-holder is
+        mid-transaction must still be present afterward — re-reading the
+        board under the lock, rather than writing back the stale snapshot the
+        writer opened with, is what preserves it."""
+        def external_edit():
+            # Simulate the host's own Edit tool call mutating the board
+            # directly while the lock-holder is still inside its critical
+            # section — exactly the harvest/decompose path (D-4), which never
+            # takes taskwrite's lock.
+            current = self._read()
+            with open(self.board_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(current + "- [ ] out-of-band harvested item\n")
+
+        outputs = self._serialize_writers(
+            lambda: self._run(["add", "lock holder's task", "--id", "mvp1.store"]),
+            lambda: self._run(["add", "second writer's task", "--id", "mvp1.store"]),
+            while_first_holds=external_edit)
+        self.assertEqual(outputs["first"], 0)
+        self.assertEqual(outputs["second"], 0)
+        text = self._read()
+        self.assertIn("out-of-band harvested item", text,
+                       "an interleaved external Edit must not be silently clobbered")
+        self.assertIn("lock holder's task", text)
+        self.assertIn("second writer's task", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_taskwrite.py
+++ b/plugins/ca/hooks/tests/test_taskwrite.py
@@ -25,6 +25,14 @@ without guessing at wall-clock timing. Neither knob exists in the real
 `core/pysrc/_hooklib.py` — this is scaffolding added only to the throwaway
 copy, never the shipped hook.
 
+Portability fix (macOS CI flake): the copy also raises `LOCK_WAIT` (test-only,
+default 8s vs production's real 0.2s — see `_HOLD_HOOK`) so a genuinely
+contended second writer BLOCKS deterministically until the first releases,
+rather than racing production's own tight fail-soft retry budget against
+scheduler jitter on a loaded CI runner. Serialization is proven by the ORDER
+of real lock acquisitions (the marker timestamps / final-file assertions
+below), never by tuning a hold duration against the real 0.2s deadline.
+
 Covers the lock-free read-modify-write race that let two concurrent
 `taskwrite` invocations silently drop one writer's edit and mint a DUPLICATE
 dotted task ID (both readers saw the same stale board, so `next_seq`
@@ -71,6 +79,21 @@ import time as _ca_test_time
 
 _CA_TEST_HOLD_MS = float(_ca_test_os.environ.get("CA_TEST_LOCK_HOLD_MS", "0") or 0)
 _CA_TEST_MARKER = _ca_test_os.environ.get("CA_TEST_ACQUIRED_MARKER")
+
+# Portability fix (macOS CI flake, test-only — see test_taskwrite.py's class
+# docstring): production's LOCK_WAIT (0.2s, core/pysrc/_hooklib.py) is a
+# fail-soft retry BUDGET tuned for a real interactive /ca:task invocation, not
+# a contention-proof harness racing wall-clock scheduler jitter on a loaded CI
+# runner. This test-only copy raises it so a genuinely-contended second writer
+# BLOCKS deterministically until the first releases its real, OS-owned lock,
+# instead of occasionally exhausting a 0.2s budget under jitter and correctly
+# fail-hard exiting (never writing its acquired-marker, which is what made
+# `_wait_for_file(m2)` time out on a slow runner). The retry loop in
+# `acquire_lock` reads this module-level name dynamically on every iteration,
+# so this override reaches every call in this copy — wrapped (the hold-hook
+# below) or not. Never present in core/pysrc/_hooklib.py or any shipped
+# plugin copy.
+LOCK_WAIT = float(_ca_test_os.environ.get("CA_TEST_LOCK_WAIT", "8.0"))
 
 if _CA_TEST_HOLD_MS > 0:
     _ca_test_real_acquire_lock = acquire_lock
@@ -244,12 +267,20 @@ class TaskwriteContentionTest(unittest.TestCase):
         window closes is guaranteed to be visible to the holder's own
         re-read, exactly the ordering C-3 exists to guarantee.
 
-        `hold_ms` is deliberately kept UNDER production's own fail-soft
-        `LOCK_WAIT` (0.2s, core/pysrc/_hooklib.py) — this test proves the
-        real, unmodified contention behavior end-to-end, including the
-        second writer's own real (unpatched) retry budget; it must not need
-        a longer deadline than production actually gives a real second
-        `/ca:task` invocation."""
+        `hold_ms` no longer needs to stay under production's own fail-soft
+        `LOCK_WAIT` (0.2s, core/pysrc/_hooklib.py, unchanged in production):
+        this test's private hooklib copy raises `LOCK_WAIT` (see
+        `_HOLD_HOOK`) so the second writer BLOCKS deterministically until the
+        first releases, instead of racing the real 0.2s budget against
+        scheduler jitter (the macOS CI flake this file was rewritten to
+        close — a loaded runner's jitter could push the first writer's hold
+        past the second's unpatched 0.2s retry window, correctly fail-hard
+        exiting it before it ever wrote its own marker). Serialization is
+        still proven end-to-end by the real OS lock and the outcome
+        assertions below (the external edit survives, both writes land) —
+        only the RETRY BUDGET is no longer the real production one; the lock
+        primitive itself, the hold, and the re-read-under-lock CAS all run
+        completely unmodified."""
         hold_ms = 120
         m1 = self._marker("holder")
         p1 = self._popen(["add", "lock holder's task", "--id", "mvp1.store"],

--- a/plugins/ca/hooks/tests/test_taskwrite.py
+++ b/plugins/ca/hooks/tests/test_taskwrite.py
@@ -1,36 +1,55 @@
 """Tests for taskwrite.py — the sanctioned task-board mutator behind /ca:task
-(#271 C-1/C-3). taskwrite.py has no test coverage today; this file is the
-first.
+(#271 C-1/C-3). taskwrite.py has no other test coverage today; this file is
+the first.
+
+E-6 (pre-release-hardening): the original version of this file proved its
+contention properties with two THREADS inside one interpreter. That is the
+wrong instrument. #271's real bug is two SEPARATE /ca:task invocations — two
+OS PROCESSES — racing on the same `.codearbiter/open-tasks.md` + its lock
+sidecar. A thread harness shares one `_hooklib` module instance between both
+"writers", so it can silently pass for reasons that say nothing about the
+cross-process lock taskwrite.py actually depends on. This file now spawns
+REAL `taskwrite.py` subprocesses.
+
+To make two independent processes' critical sections *provably* overlap
+(not just "launched close together and hopefully raced"), each subprocess
+runs against a private copy of the hook sources with one test-only
+instrumentation line appended to the copied `_hooklib.py`: when
+`CA_TEST_LOCK_HOLD_MS` is set, `acquire_lock` sleeps for that many
+milliseconds AFTER the real OS lock is taken and BEFORE returning the handle
+to its caller — extending, never faking, the real hold. When
+`CA_TEST_ACQUIRED_MARKER` is also set, the wrapper writes a wall-clock
+timestamp to that file the instant the real lock succeeds, so the test
+harness can observe precisely when a subprocess entered its held window
+without guessing at wall-clock timing. Neither knob exists in the real
+`core/pysrc/_hooklib.py` — this is scaffolding added only to the throwaway
+copy, never the shipped hook.
 
 Covers the lock-free read-modify-write race that let two concurrent
 `taskwrite` invocations silently drop one writer's edit and mint a DUPLICATE
-dotted task ID (both readers see the same stale board, so `next_seq` computes
-the same "next" number for both). Pattern-matches the contention harness in
-test_ledgerlib.py's `_serialize_transactions` (the `while_first_holds` shape
-used by `test_same_session_concurrent_updates_do_not_regress_accounting`):
-serialize two writers via the REAL lock, inject a third-party mutation (an
-out-of-band harvest/decompose Edit) while the first holds the lock, then
-assert nothing is lost and no duplicate ID is minted.
+dotted task ID (both readers saw the same stale board, so `next_seq`
+computed the same "next" number for both), plus the D-4 guarantee that an
+out-of-band Edit (the harvest/decompose path, which never takes this lock)
+is preserved rather than silently clobbered by a lock-holder writing back a
+stale in-memory snapshot.
 
-Stdlib unittest only; no real ~/.codearbiter, no subprocess (in-process
-`taskwrite.run(host, argv)` calls against a throwaway fixture repo).
+Stdlib only: subprocess + a temp-dir source copy, no third-party deps, no
+real ~/.codearbiter.
 """
 import os
+import re
+import shutil
+import subprocess
 import sys
 import tempfile
-import threading
+import time
 import unittest
-from unittest import mock
 
 _HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-import _hooklib
-import hostapi
-import taskwrite as TW
-
-CONCURRENCY_TEST_WAIT = 5.0
+CONCURRENCY_TEST_WAIT = 10.0
 
 BOARD = """\
 # Open tasks
@@ -39,18 +58,67 @@ BOARD = """\
 - [ ] mvp1.store.0001 - existing queued task
 """
 
+# Appended verbatim to the COPIED `_hooklib.py` only (never core/pysrc/ or the
+# vendored plugin copy). Guarded by an env var so importing the copy with no
+# env vars set behaves byte-identically to the real module.
+_HOLD_HOOK = '''
 
-class _FixtureHost(hostapi.Host):
-    name = "fixture"
+# ---- test-only instrumentation (E-6 subprocess contention harness) ----
+# Appended by plugins/ca/hooks/tests/test_taskwrite.py to a private COPY of
+# this file. Never present in core/pysrc/_hooklib.py or any shipped plugin.
+import os as _ca_test_os
+import time as _ca_test_time
 
-    def __init__(self, root):
-        self._root = root
+_CA_TEST_HOLD_MS = float(_ca_test_os.environ.get("CA_TEST_LOCK_HOLD_MS", "0") or 0)
+_CA_TEST_MARKER = _ca_test_os.environ.get("CA_TEST_ACQUIRED_MARKER")
 
-    def project_root(self, payload=None):
-        return self._root
+if _CA_TEST_HOLD_MS > 0:
+    _ca_test_real_acquire_lock = acquire_lock
+
+    def acquire_lock(path):
+        token = _ca_test_real_acquire_lock(path)
+        if token is not None:
+            if _CA_TEST_MARKER:
+                with open(_CA_TEST_MARKER, "w", encoding="utf-8") as _marker_f:
+                    _marker_f.write(str(_ca_test_time.time()))
+            _ca_test_time.sleep(_CA_TEST_HOLD_MS / 1000.0)
+        return token
+'''
+
+
+def _wait_for_file(path, timeout=CONCURRENCY_TEST_WAIT):
+    """Bounded poll for a marker file's existence. Returns True/False; never
+    raises, never blocks past `timeout`."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.005)
+    return False
 
 
 class TaskwriteContentionTest(unittest.TestCase):
+    """Cross-PROCESS contention proof for taskwrite.py's lock + re-read-under-
+    lock CAS (#271 C-2/C-3)."""
+
+    @classmethod
+    def setUpClass(cls):
+        # One instrumented source copy shared by every test in this class:
+        # taskwrite.py, hostapi.py, _taskboardlib.py, _hooklib.py are the
+        # complete, stdlib-only dependency closure (verified — none of them
+        # imports anything else project-local).
+        cls._copy_dir = tempfile.mkdtemp(prefix="ca-taskwrite-hookscopy-")
+        for name in ("taskwrite.py", "hostapi.py", "_taskboardlib.py", "_hooklib.py"):
+            shutil.copy2(os.path.join(_HOOKS_DIR, name),
+                        os.path.join(cls._copy_dir, name))
+        hooklib_copy = os.path.join(cls._copy_dir, "_hooklib.py")
+        with open(hooklib_copy, "a", encoding="utf-8") as f:
+            f.write(_HOLD_HOOK)
+        cls._taskwrite_script = os.path.join(cls._copy_dir, "taskwrite.py")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._copy_dir, ignore_errors=True)
 
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -60,118 +128,152 @@ class TaskwriteContentionTest(unittest.TestCase):
         self.board_path = os.path.join(self.cad, "open-tasks.md")
         with open(self.board_path, "w", encoding="utf-8", newline="\n") as f:
             f.write(BOARD)
-        self.host = _FixtureHost(self.root)
-        _hooklib._reset_root_cache()
+        self._markers = tempfile.mkdtemp(prefix="ca-taskwrite-markers-")
 
     def tearDown(self):
-        _hooklib.reset_host()
-        _hooklib._reset_root_cache()
         self._tmp.cleanup()
+        shutil.rmtree(self._markers, ignore_errors=True)
 
     def _read(self):
         with open(self.board_path, encoding="utf-8") as f:
             return f.read()
 
-    def _run(self, argv):
-        # Fresh Host injection per call (mirrors production: run(host, argv)
-        # is the entry point, exactly as the __main__ guard invokes it).
-        return TW.run(self.host, argv)
+    def _marker(self, name):
+        return os.path.join(self._markers, name)
 
-    def _serialize_writers(self, first, second, while_first_holds=None):
-        """Prove the second writer cannot observe/mutate the board until the
-        first releases the lock — the exact shape of
-        test_ledgerlib._serialize_transactions."""
-        real_acquire = _hooklib.acquire_lock
-        first_acquired = threading.Event()
-        second_attempted = threading.Event()
-        second_acquired = threading.Event()
-        release_first = threading.Event()
-        outputs = {}
+    def _popen(self, argv, hold_ms=0, marker=None):
+        """Launch a REAL taskwrite.py subprocess against the fixture board."""
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = self.root
+        if hold_ms:
+            env["CA_TEST_LOCK_HOLD_MS"] = str(hold_ms)
+        else:
+            env.pop("CA_TEST_LOCK_HOLD_MS", None)
+        if marker:
+            env["CA_TEST_ACQUIRED_MARKER"] = marker
+        else:
+            env.pop("CA_TEST_ACQUIRED_MARKER", None)
+        return subprocess.Popen(
+            [sys.executable, self._taskwrite_script] + argv,
+            cwd=self.root, env=env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        def coordinated_acquire(path):
-            if threading.current_thread().name == "taskwrite-second":
-                second_attempted.set()
-            token = real_acquire(path)
-            if token is not None and threading.current_thread().name == "taskwrite-first":
-                first_acquired.set()
-                self.assertTrue(release_first.wait(CONCURRENCY_TEST_WAIT))
-            elif token is not None and threading.current_thread().name == "taskwrite-second":
-                second_acquired.set()
-            return token
-
-        one = threading.Thread(target=lambda: outputs.setdefault("first", first()),
-                               name="taskwrite-first")
-        two = threading.Thread(target=lambda: outputs.setdefault("second", second()),
-                               name="taskwrite-second")
-        with mock.patch.object(TW, "acquire_lock", side_effect=coordinated_acquire):
-            one.start()
-            self.assertTrue(first_acquired.wait(CONCURRENCY_TEST_WAIT))
-            if while_first_holds:
-                while_first_holds()
-            two.start()
-            self.assertTrue(second_attempted.wait(CONCURRENCY_TEST_WAIT))
-            self.assertFalse(second_acquired.is_set())
-            release_first.set()
-            self.assertTrue(second_acquired.wait(CONCURRENCY_TEST_WAIT))
-            one.join(CONCURRENCY_TEST_WAIT)
-            two.join(CONCURRENCY_TEST_WAIT)
-        self.assertFalse(one.is_alive())
-        self.assertFalse(two.is_alive())
-        return outputs
+    def _finish(self, proc):
+        out, err = proc.communicate(timeout=CONCURRENCY_TEST_WAIT)
+        return proc.returncode, out, err
 
     def test_concurrent_add_entries_both_survive_no_lost_update(self):
-        """Two concurrent `taskwrite add` calls must BOTH land — the classic
-        lost-update shape: without a lock + re-read, the second os.replace()
-        silently discards the first writer's edit."""
-        outputs = self._serialize_writers(
-            lambda: self._run(["add", "first concurrent task", "--id", "mvp1.store"]),
-            lambda: self._run(["add", "second concurrent task", "--id", "mvp1.store"]))
-        self.assertEqual(outputs["first"], 0)
-        self.assertEqual(outputs["second"], 0)
+        """Two concurrent `taskwrite add` PROCESSES must BOTH land — the
+        classic lost-update shape: without a lock + re-read, the second
+        os.replace() silently discards the first writer's edit.
+
+        Genuine overlap (not a lucky race) is proven directly: each process
+        stamps a wall-clock timestamp into its own marker file the instant it
+        holds the REAL OS lock, then holds it for `hold_ms`. If the lock
+        truly serializes, the second stamp cannot land before
+        (first stamp + hold_ms) — that gap is asserted below, not assumed."""
+        hold_ms = 150
+        m1, m2 = self._marker("m1"), self._marker("m2")
+        p1 = self._popen(["add", "first concurrent task", "--id", "mvp1.store"],
+                         hold_ms=hold_ms, marker=m1)
+        p2 = self._popen(["add", "second concurrent task", "--id", "mvp1.store"],
+                         hold_ms=hold_ms, marker=m2)
+        self.assertTrue(_wait_for_file(m1), "process 1 never acquired the real lock")
+        self.assertTrue(_wait_for_file(m2), "process 2 never acquired the real lock")
+        with open(m1, encoding="utf-8") as f:
+            t1 = float(f.read())
+        with open(m2, encoding="utf-8") as f:
+            t2 = float(f.read())
+
+        rc1, out1, err1 = self._finish(p1)
+        rc2, out2, err2 = self._finish(p2)
+        self.assertEqual(rc1, 0, err1)
+        self.assertEqual(rc2, 0, err2)
+
+        # The proof: whichever writer acquired second could not have stamped
+        # its marker until the first released — i.e. at least ~hold_ms after
+        # the first's own stamp. A generous floor (60% of hold_ms) absorbs
+        # scheduler jitter while still ruling out "both acquired at once".
+        gap = abs(t2 - t1)
+        self.assertGreaterEqual(
+            gap, (hold_ms / 1000.0) * 0.6,
+            f"lock did not serialize the two acquisitions: gap={gap:.3f}s, "
+            f"expected >= {(hold_ms / 1000.0) * 0.6:.3f}s (hold_ms={hold_ms})")
+
         text = self._read()
         self.assertIn("first concurrent task", text,
-                       "the first writer's edit was silently lost")
+                      "the first writer's edit was silently lost")
         self.assertIn("second concurrent task", text,
-                       "the second writer's edit was silently lost")
+                      "the second writer's edit was silently lost")
 
     def test_concurrent_add_entries_do_not_mint_duplicate_dotted_id(self):
         """Both concurrent adds mint a dotted ID in the SAME group.type
         namespace. Reading the board fresh under the lock (not the stale
-        snapshot each thread opened with) is what makes next_seq allocate two
-        DISTINCT ids instead of both computing the same 'max + 1'."""
-        self._serialize_writers(
-            lambda: self._run(["add", "first concurrent task", "--id", "mvp1.store"]),
-            lambda: self._run(["add", "second concurrent task", "--id", "mvp1.store"]))
+        snapshot each process opened with) is what makes next_seq allocate
+        two DISTINCT ids instead of both computing the same 'max + 1'."""
+        hold_ms = 150
+        m1, m2 = self._marker("m1"), self._marker("m2")
+        p1 = self._popen(["add", "first concurrent task", "--id", "mvp1.store"],
+                         hold_ms=hold_ms, marker=m1)
+        p2 = self._popen(["add", "second concurrent task", "--id", "mvp1.store"],
+                         hold_ms=hold_ms, marker=m2)
+        self.assertTrue(_wait_for_file(m1), "process 1 never acquired the real lock")
+        self.assertTrue(_wait_for_file(m2), "process 2 never acquired the real lock")
+        rc1, _out1, err1 = self._finish(p1)
+        rc2, _out2, err2 = self._finish(p2)
+        self.assertEqual(rc1, 0, err1)
+        self.assertEqual(rc2, 0, err2)
+
         text = self._read()
-        ids = sorted(set(__import__("re").findall(r"mvp1\.store\.\d{4}", text)))
+        ids = sorted(set(re.findall(r"mvp1\.store\.\d{4}", text)))
         # The seed board already holds mvp1.store.0001; the two new adds must
         # mint 0002 and 0003 — never the SAME id twice.
         self.assertEqual(len(ids), 3, f"expected 3 distinct dotted ids, got {ids}")
 
     def test_external_edit_while_lock_held_is_not_silently_clobbered(self):
         """D-4: an out-of-band Edit (harvest/decompose writing the board
-        directly, never taking the lock) that lands WHILE the lock-holder is
-        mid-transaction must still be present afterward — re-reading the
+        directly, never taking the lock) that lands WHILE a taskwrite process
+        holds the lock must still be present afterward — re-reading the
         board under the lock, rather than writing back the stale snapshot the
-        writer opened with, is what preserves it."""
-        def external_edit():
-            # Simulate the host's own Edit tool call mutating the board
-            # directly while the lock-holder is still inside its critical
-            # section — exactly the harvest/decompose path (D-4), which never
-            # takes taskwrite's lock.
-            current = self._read()
-            with open(self.board_path, "w", encoding="utf-8", newline="\n") as f:
-                f.write(current + "- [ ] out-of-band harvested item\n")
+        process opened with, is what preserves it (a detected-loss-free
+        outcome, not a silent clobber).
 
-        outputs = self._serialize_writers(
-            lambda: self._run(["add", "lock holder's task", "--id", "mvp1.store"]),
-            lambda: self._run(["add", "second writer's task", "--id", "mvp1.store"]),
-            while_first_holds=external_edit)
-        self.assertEqual(outputs["first"], 0)
-        self.assertEqual(outputs["second"], 0)
+        The marker file pins the exact moment: the holder has the REAL lock
+        and (thanks to the injected hold) has not yet even called
+        `tb.read_board()` — so any write landing before the marker's hold
+        window closes is guaranteed to be visible to the holder's own
+        re-read, exactly the ordering C-3 exists to guarantee.
+
+        `hold_ms` is deliberately kept UNDER production's own fail-soft
+        `LOCK_WAIT` (0.2s, core/pysrc/_hooklib.py) — this test proves the
+        real, unmodified contention behavior end-to-end, including the
+        second writer's own real (unpatched) retry budget; it must not need
+        a longer deadline than production actually gives a real second
+        `/ca:task` invocation."""
+        hold_ms = 120
+        m1 = self._marker("holder")
+        p1 = self._popen(["add", "lock holder's task", "--id", "mvp1.store"],
+                         hold_ms=hold_ms, marker=m1)
+        self.assertTrue(_wait_for_file(m1), "lock holder never acquired the real lock")
+
+        # The out-of-band Edit: the host's own Edit tool writing the board
+        # directly (harvest/decompose), never taking taskwrite's lock.
+        current = self._read()
+        with open(self.board_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(current + "- [ ] out-of-band harvested item\n")
+
+        # A second REAL taskwrite writer, contending for the same lock while
+        # the first is still (per the marker) inside its held window.
+        p2 = self._popen(["add", "second writer's task", "--id", "mvp1.store"])
+
+        rc1, _out1, err1 = self._finish(p1)
+        rc2, _out2, err2 = self._finish(p2)
+        self.assertEqual(rc1, 0, err1)
+        self.assertEqual(rc2, 0, err2)
+
         text = self._read()
         self.assertIn("out-of-band harvested item", text,
-                       "an interleaved external Edit must not be silently clobbered")
+                      "an interleaved external Edit must not be silently clobbered")
         self.assertIn("lock holder's task", text)
         self.assertIn("second writer's task", text)
 

--- a/site/src/content/docs/codearbiter-directory.md
+++ b/site/src/content/docs/codearbiter-directory.md
@@ -35,7 +35,7 @@ those are noted below.
 | `overrides.log` | `/ca:override`, `/ca:dev` entry/exit | statusline, `/ca:status`, `/ca:audit`, staleness-warn | No — append-only, guarded (H-05) |
 | `triage.log` | `/ca:feature` small-lane triage | `/ca:metrics`, `/ca:audit` | No — append-only, guarded (H-05) |
 | `gate-events.log` | every `block()`/`remind()`/`warn()` call in the hooks | (durable sink; no reader ships yet) | No — append-only, guarded (H-05) |
-| `.markers/` | `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr` | the commit-gate hooks (`pre-bash.py`, `pre-write.py`, `pre-edit.py`) | No — guarded, and hand-written markers can't satisfy a gate |
+| `.markers/` | `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr` | the commit-gate hooks (`pre-bash.py`, `pre-write.py`, `pre-edit.py`) | No — guarded, and hand-writing one is friction and an audit trail, not a proof (see below) |
 | `.provenance/*.json` | `context-creation`, `decompose`, `context-check` (re-scout/re-baseline) | `SessionStart` (drift line), `commit-gate` (auto-heal) | Not by hand — regenerate via `/ca:context-check` |
 | `security-controls.md`, `tech-stack.md`, `coding-standards.md` | `/ca:init` / `/ca:create-context` / `/ca:decompose`, kept current by hand or `/ca:context-check` | every reviewer agent, the crypto/secret gates | Yes |
 | `last-checkpoint` | `checkpoint-aggregator` agent | `/ca:status`, the statusline (overrides-since-checkpoint) | Not normally — it's a counter, not a note |
@@ -256,10 +256,15 @@ the first marker-writing action runs. The load-bearing ones:
 **Writers:** `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr`.
 **Readers:** the commit-gate hooks (`pre-bash.py`) that check `security-gate-passed` and
 `migration-gate-passed` before allowing a `git commit`.
-**Editable by hand?** No, and a hand-written marker can't satisfy a gate anyway — `pre-write.py`
-and `pre-edit.py` block Write/Edit targeting this directory (issue #160), because a load-bearing
-marker that turns a BLOCK into an allow must only ever come from the process that actually ran the
-check.
+**Editable by hand?** No — `pre-write.py`/`pre-edit.py` block Write/Edit targeting this directory
+(issue #160), and `pre-bash.py`'s H-19 flank blocks the shell forge spellings too (`cp`/`mv`/`tee`/
+`sed`/a redirect, and an interpreter one-liner such as `python -c "open(...).write(...)"`). These
+flanks add real friction and leave an audit trail on the cooperative-agent path (ADR-0010) — they
+are not a proof. The marker is a *cooperative attestation*: `security-pass.py`/`migration-pass.py`
+re-derive digests from a public, pure function of the file content the forger already holds, so no
+digest scheme can make the marker unforgeable to a determined same-user process willing to
+reproduce that computation outside the sanctioned producer. Its value is the friction and the
+record it leaves, not unforgeability.
 **Delete it:** every commit-time crypto/secret/migration gate reverts to its unpassed state — the
 next sensitive commit blocks until the corresponding gate runs again and re-records a pass. No
 enforcement is weakened; you just lose the standing "already checked" credit.


### PR DESCRIPTION
## Pre-release enforcement-integrity sprint

Closes #223, #237, #271, #265. Each was a case where a gate could be sidestepped, silently unwired, or lost to a race. One additional bug was found in flight and fixed under this branch (see below). Ratifies **ADR-0014**.

Autonomous `/ca:sprint` run in an isolated worktree (a concurrent Codex session held the main checkout). Every auto-decision is logged in `.codearbiter/sprint-log.md` (SD-01…SD-12), including two security-review BLOCKs.

### What changed

| Commit | Issue | Fix |
|---|---|---|
| `6738581` | #223 | Branch guards resolve against the command's real cwd, not `CLAUDE_PROJECT_DIR` — closes a false **negative** where a commit from a worktree on `main` sidestepped the protected-branch guard. Heredoc *bodies* no longer trip H-01, narrowed to shell-reachable payloads (incl. command-substitution into `bash -c`/`eval`). |
| `5cfb89a` | #237 | H-19 now catches interpreter one-liners (`python -c`, `node -e`, …) writing a gate marker — the flank that let a hand-written marker satisfy the security gate. Docs corrected: a marker is a cooperative attestation (ADR-0010), not a proof. |
| `e50d58b` | #271 | Board writes take the hoisted OS lock **and re-read under it** (a lock alone can't stop the Edit-tool harvest path); duplicate dotted-ID mint fixed. SessionStart session-scopes the dev marker so it stops writing a false `DEV: exit` for another session's live `/ca:dev`. |
| `a97d87b` | — (found in-sprint) | The crypto/secret gate was scanning `gate-events.log`, its own audit sink, and reading its "Crypto/TLS pattern detected" lines back as sensitive changes — a permanent self-poisoning false positive once the gate had ever fired. Now exempt (that file only), via a path-anchored diff walk hardened over three rounds and **two security reviews**. Plus the five PR #304 harvest items (RecursionError guard, invalid-hex tests, terminal-escape stripping, a real subprocess board-contention proof, PY2 cold-install assertion). |
| `9c09172` | #265 | Git-hook shim resolves either host's enforcer from a shared `.git/codearbiter-hooksd/` drop-in dir and **fails closed** — uninstalling one of two plugins no longer silently unwires the git-level backstop for both. Ratifies ADR-0014. |
| `1617448` | — | Sprint governance trail. |

### Load-bearing decisions (in `sprint-log.md`)

- **#237 is not fixed by consumer-side digest recomputation** (SD, spec D-1). That would make coverage vacuously true and degrade the gate to an mtime check. `line_digest` is a pure public function of content the forger already holds, so no recomputation distinguishes a genuine marker from a forged one — the honest fix is the missing flank plus honest docs.
- **#265 reverses a documented accept-risk** in `_githooks.py`'s own header — but satisfies the exit condition that header itself named ("a host-neutral, version-independent enforcer location"), rather than overriding its rejection of path-guessing. Fail-closed has a real blast radius; that's the intended direction for a security backstop and it's bounded because any live host refreshes its own entry.

### Review trail

Every lane was authored test-first, reviewed against a fresh diff, and **three lanes were sent back once each** for a false negative the author's own green suite missed — the recurring shape was fixing a false positive by opening a false negative in the same guard. The `a97d87b` scanner change produced a confirmed bypass on two of three rounds (forged `+++` header; ambiguous `diff --git` path) before passing a dedicated adversarial security review. The crypto-gate pass for `a97d87b` was recorded via the **sanctioned producer** after an auth-crypto-reviewer PASS, never hand-written.

### Deferred (SD-11)

- **Board reconciliation** — the 5 harvest tasks live only in the concurrent session's uncommitted board; flipping them here would collide three ways. Done post-merge.
- **Harvested papercuts** (guard vs shell variables: `git -C "$VAR"` fails closed; a quoted `-C` target mis-parsed as a staging pathspec; the #223 marker-root split that made ADR authoring need a marker in two locations — the same mismatch that *caused* #237). Queued post-merge, not fixed here.
- **#270** (Codex MCP write-gate) was cut at the spec gate: it rests on an `mcp__*` payload schema never observed from a live install. Its own session.

### Verification

967 hook tests, all 25 `.github/scripts` suites, `sync-core --check` + `build-surface --check` byte-identical, site 403/403. AC-1…AC-10 met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
