### PR TITLE
docs(site): complete visual guide coverage

### DIFF
--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -970,3 +970,15 @@ feat/pi-support in the main checkout, ratifying ADR-0013 — legitimate, out of 
 - The gate-events.log self-poisoning bug (#279-shaped) was NOT on the sprint's issue list; found by using
   the system, surfaced as a hard gate, user-scoped, fixed under two security reviews. Recorded as the
   sprint's one genuinely new find.
+
+## SD-13 [#333] complete only the unshipped visual-doc findings | confidence: high
+- **Point:** Findings 01 and 02 already ship on PR #313. Finding 07 needs real brand assets. Findings 03, 04, 08, and 09 are independent documentation improvements that can be verified on main.
+- **Options:** (a) recreate all nine opportunities; (b) implement 03, 04, 08, and 09, leave 01 and 02 on PR #313, and keep 07 deferred; (c) defer the whole issue until PR #313 merges.
+- **SMARTS:** (b). It avoids divergent copies of the two shipped diagrams, does not fabricate brand artwork, and produces a focused docs-only diff with no dependency or runtime change. (a) duplicates live work. (c) blocks independent low-risk work without a technical dependency.
+- **Chosen:** (b). Strength: strong.
+
+## SD-14 [#333] preserve the real statusline capture and use reviewable native assets | confidence: high
+- **Point:** The statusline must remain a real renderer capture. The activation flow needs one shared visual, but the site has no Mermaid pipeline and adding one would be disproportionate.
+- **Options:** (a) redraw or regenerate the statusline and add Mermaid; (b) keep statusline.png unchanged, overlay responsive HTML markers, and hand-author two precise SVGs in the existing house style; (c) omit findings 04 and 09.
+- **SMARTS:** (b). It keeps the evidence image byte-for-byte intact, gives table rows an exact visual key, avoids a new dependency, and makes the security claims directly reviewable in source. (a) violates the real-capture constraint and expands the dependency surface. (c) leaves approved comprehension gaps open.
+- **Chosen:** (b). Strength: strong.

--- a/site/public/diagrams/activation-states.svg
+++ b/site/public/diagrams/activation-states.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 430" role="img"
+     aria-label="Activation classification flow. A missing CONTEXT.md file or a file without leading frontmatter is dormant. Frontmatter that opens but never closes is malformed and surfaces an error. Properly closed frontmatter containing arbiter enabled activates codeArbiter; a closed block without that flag remains dormant.">
+  <title>How CONTEXT.md selects dormant, malformed, or enabled state</title>
+  <defs>
+    <linearGradient id="as-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#131a23"/>
+    </linearGradient>
+    <pattern id="as-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#e6edf3" stroke-opacity="0.028"/>
+    </pattern>
+    <marker id="as-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0 0v6l8-3z" fill="#828d9a"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="430" fill="url(#as-bg)"/>
+  <rect width="900" height="430" fill="url(#as-grid)"/>
+  <rect x="8" y="8" width="884" height="414" fill="none" stroke="#e3b341" stroke-opacity="0.14"/>
+
+  <text x="450" y="43" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="11" letter-spacing="3" fill="#8b95a2">ACTIVATION CONTRACT</text>
+  <rect x="315" y="64" width="270" height="58" rx="5" fill="#1c2430" stroke="#d29922" stroke-width="1.5"/>
+  <text x="450" y="89" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="16" font-weight="700" fill="#f0f3f6">Read .codearbiter/CONTEXT.md</text>
+  <text x="450" y="108" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#a8b2bd">classify leading YAML frontmatter</text>
+
+  <path d="M450 122V157H150V197" fill="none" stroke="#828d9a" stroke-width="1.5" marker-end="url(#as-arrow)"/>
+  <path d="M450 122V197" fill="none" stroke="#828d9a" stroke-width="1.5" marker-end="url(#as-arrow)"/>
+  <path d="M450 157H750V197" fill="none" stroke="#828d9a" stroke-width="1.5" marker-end="url(#as-arrow)"/>
+
+  <text x="150" y="151" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#8b95a2">missing file or no leading block</text>
+  <text x="450" y="184" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#c9a868">opens, never closes</text>
+  <text x="750" y="151" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#8b95a2">properly closed block</text>
+
+  <rect x="54" y="205" width="192" height="112" rx="6" fill="#17202a" stroke="#6b7785" stroke-width="1.5"/>
+  <circle cx="78" cy="231" r="6" fill="#6b7785"/>
+  <text x="150" y="238" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="20" font-weight="700" fill="#f0f3f6">Dormant</text>
+  <text x="150" y="268" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#a8b2bd">nothing loads</text>
+  <text x="150" y="288" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#a8b2bd">nothing blocks</text>
+
+  <rect x="354" y="205" width="192" height="112" rx="6" fill="#2a1a1d" stroke="#c04040" stroke-width="1.5"/>
+  <circle cx="378" cy="231" r="6" fill="#ff566e"/>
+  <text x="450" y="238" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="20" font-weight="700" fill="#f0f3f6">Malformed</text>
+  <text x="450" y="268" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#ff9cab">error surfaced</text>
+  <text x="450" y="288" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#a8b2bd">never silently disabled</text>
+
+  <rect x="654" y="205" width="192" height="112" rx="6" fill="#14251f" stroke="#4dbb7b" stroke-width="1.5"/>
+  <circle cx="678" cy="231" r="6" fill="#78dc96"/>
+  <text x="750" y="238" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="20" font-weight="700" fill="#f0f3f6">Enabled</text>
+  <text x="750" y="268" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="12" fill="#78dc96">arbiter: enabled</text>
+  <text x="750" y="288" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#a8b2bd">persona and gates active</text>
+
+  <path d="M654 338H246" fill="none" stroke="#828d9a" stroke-width="1.5" marker-end="url(#as-arrow)"/>
+  <text x="450" y="331" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#8b95a2">closed block without arbiter: enabled</text>
+  <text x="450" y="382" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#a8b2bd">Changing the file changes the classification on the next activation check.</text>
+</svg>

--- a/site/public/diagrams/sandbox-boundary.svg
+++ b/site/public/diagrams/sandbox-boundary.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" role="img"
+     aria-label="ca-sandbox security boundary. The untrusted repository runs in a non-root container with read-only root, all capabilities dropped, no new privileges, resource limits, and network disabled by default. It uses a Docker named volume, never a host bind mount or Docker socket. Files leave only through host-initiated docker cp.">
+  <title>ca-sandbox host filesystem isolation boundary</title>
+  <defs>
+    <linearGradient id="sb-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f14"/>
+      <stop offset="1" stop-color="#131a23"/>
+    </linearGradient>
+    <pattern id="sb-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#e6edf3" stroke-opacity="0.028"/>
+    </pattern>
+    <marker id="sb-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0 0v6l8-3z" fill="#d29922"/>
+    </marker>
+  </defs>
+
+  <rect width="960" height="520" fill="url(#sb-bg)"/>
+  <rect width="960" height="520" fill="url(#sb-grid)"/>
+  <rect x="8" y="8" width="944" height="504" fill="none" stroke="#e3b341" stroke-opacity="0.14"/>
+
+  <text x="480" y="40" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace"
+        font-size="11" letter-spacing="3" fill="#8b95a2">HOST FILESYSTEM ISOLATION</text>
+
+  <rect x="38" y="67" width="236" height="342" rx="6" fill="#171d25" stroke="#6b7785" stroke-width="1.2"/>
+  <text x="156" y="98" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="18" font-weight="700" fill="#f0f3f6">Host</text>
+  <rect x="69" y="126" width="174" height="69" rx="4" fill="#202a35" stroke="#828d9a"/>
+  <text x="156" y="153" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="13" fill="#e6edf3">Host filesystem</text>
+  <text x="156" y="175" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#8b95a2">projects · credentials</text>
+  <rect x="69" y="231" width="174" height="69" rx="4" fill="#202a35" stroke="#828d9a"/>
+  <text x="156" y="258" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="13" fill="#e6edf3">Docker daemon</text>
+  <text x="156" y="280" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#8b95a2">/var/run/docker.sock</text>
+  <rect x="69" y="336" width="174" height="48" rx="4" fill="#201f1a" stroke="#d29922"/>
+  <text x="156" y="365" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#e3b341">reviewed output</text>
+
+  <rect x="342" y="67" width="580" height="342" rx="8" fill="#111923" stroke="#d29922" stroke-width="2"/>
+  <text x="632" y="98" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="18" font-weight="700" fill="#f0f3f6">ca-sandbox container</text>
+  <text x="632" y="118" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#c9a868">untrusted repository boundary</text>
+
+  <rect x="383" y="145" width="228" height="113" rx="5" fill="#1c2430" stroke="#4dbb7b"/>
+  <text x="497" y="172" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="15" font-weight="700" fill="#f0f3f6">Runtime controls</text>
+  <text x="405" y="197" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#a8b2bd">--user 1000:1000</text>
+  <text x="405" y="218" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#a8b2bd">--read-only</text>
+  <text x="405" y="239" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#a8b2bd">--cap-drop ALL</text>
+
+  <rect x="648" y="145" width="233" height="113" rx="5" fill="#1c2430" stroke="#4dbb7b"/>
+  <text x="765" y="172" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="15" font-weight="700" fill="#f0f3f6">Policy controls</text>
+  <text x="671" y="197" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#a8b2bd">no-new-privileges</text>
+  <text x="671" y="218" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#a8b2bd">--network none</text>
+  <text x="671" y="239" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#a8b2bd">resource caps</text>
+
+  <rect x="383" y="290" width="498" height="78" rx="5" fill="#14251f" stroke="#4dbb7b"/>
+  <text x="632" y="319" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="15" font-weight="700" fill="#f0f3f6">Docker named volume</text>
+  <text x="632" y="345" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="11" fill="#78dc96">repository lives at /work/repo, outside the host filesystem</text>
+
+  <path d="M243 160H342" fill="none" stroke="#c04040" stroke-width="2" stroke-dasharray="7 6"/>
+  <circle cx="293" cy="160" r="15" fill="#2a1a1d" stroke="#ff566e" stroke-width="2"/>
+  <path d="M283 150l20 20m0-20l-20 20" stroke="#ff566e" stroke-width="2"/>
+  <text x="293" y="143" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#ff9cab">no bind mounts</text>
+
+  <path d="M243 265H342" fill="none" stroke="#c04040" stroke-width="2" stroke-dasharray="7 6"/>
+  <circle cx="293" cy="265" r="15" fill="#2a1a1d" stroke="#ff566e" stroke-width="2"/>
+  <path d="M283 255l20 20m0-20l-20 20" stroke="#ff566e" stroke-width="2"/>
+  <text x="293" y="248" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#ff9cab">no socket mount</text>
+
+  <path d="M383 360H251" fill="none" stroke="#d29922" stroke-width="1.8" marker-end="url(#sb-arrow)"/>
+  <text x="317" y="389" text-anchor="middle" font-family="ui-monospace, 'Cascadia Code', Consolas, monospace" font-size="10" fill="#c9a868">host-initiated docker cp out</text>
+
+  <rect x="38" y="438" width="884" height="47" rx="4" fill="#171d25" stroke="#6b7785" stroke-opacity="0.8"/>
+  <text x="480" y="467" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="13" fill="#a8b2bd">Unknown network policies fail closed. The container never receives --privileged.</text>
+</svg>

--- a/site/scripts/generator/generate.ts
+++ b/site/scripts/generator/generate.ts
@@ -242,7 +242,7 @@ export function generate(
       return `${heading}\n\n${TABLE_HEADER[group.type]}\n${rows.join("\n")}`;
     })
     .join("\n\n");
-  const indexContent = `---\ntitle: Reference\ndescription: Auto-generated reference for codeArbiter commands, skills, and agents.\n---\n\nThis section is generated from the plugin's own frontmatter and regenerates on every build, so it can never drift from the source.\n\n${indexBody}\n`;
+  const indexContent = `---\ntitle: Reference\ndescription: Auto-generated reference for codeArbiter commands, skills, and agents.\n---\n\nThis section is generated from the plugin's own frontmatter and regenerates on every build, so it can never drift from the source. See how the three catalogs cooperate in [How a Request Flows](/overview/#how-a-request-flows): a command routes to an owning skill, which may dispatch specialist agents.\n\n${indexBody}\n`;
 
   mkdirSync(outDir, { recursive: true });
   mkdirSync(dirname(resolvedSidebarPath), { recursive: true });

--- a/site/src/content/docs/codearbiter-directory.md
+++ b/site/src/content/docs/codearbiter-directory.md
@@ -60,6 +60,17 @@ checks for it: present with source code in the repo but the marker absent routes
 `/ca:create-context`; absent with no source routes to `/ca:decompose`. Once the marker and
 frontmatter are both in place, the orchestrator persona loads on every session in this repo.
 
+<figure class="ca-diagram">
+  <img
+    src="/codeArbiter/diagrams/activation-states.svg"
+    alt="Activation classification flow: a missing CONTEXT.md or missing leading frontmatter is dormant; an unclosed block is malformed and surfaces an error; a closed block containing arbiter enabled activates the persona and gates."
+    loading="lazy"
+    width="900"
+    height="430"
+  />
+  <figcaption>`CONTEXT.md` is classified on each activation check; the file does not carry hidden activation state.</figcaption>
+</figure>
+
 **Writers:** `/ca:init` (scaffold), `/ca:decompose` and `/ca:create-context` (populate + lock).
 **Readers:** every enforcement hook, the `SessionStart` injector, the statusline.
 **Editable by hand?** The prose body, yes. The frontmatter is guarded: a Write/Edit that would

--- a/site/src/content/docs/enforcement.md
+++ b/site/src/content/docs/enforcement.md
@@ -20,6 +20,17 @@ codeArbiter is dormant until a repository opts in. Every enforcement hook calls 
 - **Persona injection.** On an enabled repo, the `SessionStart` hook injects the orchestrator persona. That single file is the only always-loaded context.
 - **Malformed frontmatter fails loud.** A frontmatter block that opens (`---` on line 1) but never closes is surfaced as a malformed-state error, not silently treated as disabled. A file with no frontmatter at all is simply dormant.
 
+<figure class="ca-diagram">
+  <img
+    src="/codeArbiter/diagrams/activation-states.svg"
+    alt="Activation classification flow: a missing CONTEXT.md or missing leading frontmatter is dormant; an unclosed block is malformed and surfaces an error; a closed block containing arbiter enabled activates the persona and gates."
+    loading="lazy"
+    width="900"
+    height="430"
+  />
+  <figcaption>One parser, three visible outcomes. A closed block without `arbiter: enabled` remains dormant.</figcaption>
+</figure>
+
 ## Blocking Commit-Time Gates
 
 These run in `pre-bash.py` on `PreToolUse(Bash|PowerShell)` (plus the Write/Edit guards for the audit trail and ADRs). Each blocks the tool call outright. Ambiguity resolves **closed**: a spelling that cannot be told apart from a destructive one is blocked, and `/ca:override` is the sanctioned escape hatch.
@@ -52,6 +63,17 @@ These are advisory **because they bite at a later boundary, not at commit.** A b
 ## Sandbox Isolation for Untrusted Repositories
 
 codeArbiter runs untrusted repositories inside `ca-sandbox`, isolated as non-root (`--user 1000:1000`), with a `--read-only` root, `--cap-drop ALL`, `--security-opt no-new-privileges`, and a fail-closed network policy (default `--network none`; an unknown policy is a hard error, not a silent pass-through). No host bind mounts; the docker socket is never mounted. For how this posture evolved release over release, see [Hardening History](/concepts/hardening-history/).
+
+<figure class="ca-diagram">
+  <img
+    src="/codeArbiter/diagrams/sandbox-boundary.svg"
+    alt="ca-sandbox boundary: the untrusted repository lives in a Docker named volume inside a non-root, read-only container with dropped capabilities, no new privileges, resource limits, and network disabled by default. Host bind mounts and the Docker socket are blocked. Files leave only through host-initiated docker cp."
+    loading="lazy"
+    width="960"
+    height="520"
+  />
+  <figcaption>The container can work in its named volume, but it has no path into the host filesystem or Docker daemon.</figcaption>
+</figure>
 
 ## Fail-Loud, Never Silently Dormant
 

--- a/site/src/content/docs/guides/the-statusline.md
+++ b/site/src/content/docs/guides/the-statusline.md
@@ -11,14 +11,36 @@ your session usage in every repo and, in an arbiter-enabled one, the live projec
 dependency-free (native font glyphs only, no Nerd Font) and renders on every session once wired.
 
 <figure class="ca-diagram">
-  <img
-    src="/codeArbiter/diagrams/statusline.png"
-    alt="The codeArbiter statusline: a folder row; a git row with repo, branch, and a model pill; rate-limit percentages with reset countdowns; an arbiter row (green dot) showing stage, tasks, open questions, and overrides; and session/today token, cost, burn, and context-usage segments."
-    loading="lazy"
-    width="2174"
-    height="406"
-  />
-  <figcaption>The statusline in an arbiter-enabled repo: usage segments plus the arbiter row (green dot). Rendered from the live `statusline.py` with mock values.</figcaption>
+  <div class="ca-statusline-map">
+    <img
+      src="/codeArbiter/diagrams/statusline.png"
+      alt="The codeArbiter statusline: a folder row; a git row with repo, branch, and a model pill; rate-limit percentages with reset countdowns; an arbiter row showing stage, tasks, open questions, and overrides; and session/today token, cost, burn, and context-usage segments."
+      loading="lazy"
+      width="2174"
+      height="406"
+    />
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--1" aria-hidden="true">1</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--2" aria-hidden="true">2</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--3" aria-hidden="true">3</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--4" aria-hidden="true">4</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--5" aria-hidden="true">5</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--6" aria-hidden="true">6</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--7" aria-hidden="true">7</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--8" aria-hidden="true">8</span>
+    <span class="ca-statusline-map__marker ca-statusline-map__marker--9" aria-hidden="true">9</span>
+  </div>
+  <ol class="ca-statusline-map__legend" aria-label="Statusline capture key">
+    <li><span>1</span> folder</li>
+    <li><span>2</span> git</li>
+    <li><span>3</span> rate limits</li>
+    <li><span>4</span> model</li>
+    <li><span>5</span> arbiter</li>
+    <li><span>6</span> tokens</li>
+    <li><span>7</span> cost</li>
+    <li><span>8</span> burn</li>
+    <li><span>9</span> context</li>
+  </ol>
+  <figcaption>The real renderer capture, annotated in HTML so the image remains unchanged. Values are deterministic test data.</figcaption>
 </figure>
 
 **You will need:** the plugin installed (see [Install](/getting-started/install/)).
@@ -95,28 +117,28 @@ The bar has two tiers of segments.
 
 These render in every Claude Code session, regardless of whether the open repo is arbiter-enabled.
 
-| Segment | Shows |
-|---------|-------|
-| **folder** | Active working directory, abbreviated to key path components |
-| **git** | Repo owner/name and current branch, with a dirty-state marker when uncommitted changes are present |
-| **model** | Model display name and effort level as a colored pill |
-| **rate limits** | 5-hour and 7-day API usage percentages, with reset countdowns when the host supplies them |
-| **context** | Context window usage bar, used percentage, and remaining headroom before auto-compaction |
-| **tokens** | Session and daily in/out token counts, deduplicated by request ID across transcript entries |
-| **cost** | Cumulative API-equivalent cost from Claude Code's authoritative session total, persisted across sessions in `~/.codearbiter/ledger.json` |
-| **burn** | Per-message token sparkline built from recent transcript calls |
-| **subagents** | Recent tasks with liveness, selected model, input/output tokens, and age; mixed or missing model metadata is explicit |
+| Key | Segment | Shows |
+|-----|---------|-------|
+| 1 | **folder** | Active working directory, abbreviated to key path components |
+| 2 | **git** | Repo owner/name and current branch, with a dirty-state marker when uncommitted changes are present |
+| 4 | **model** | Model display name and effort level as a colored pill |
+| 3 | **rate limits** | 5-hour and 7-day API usage percentages, with reset countdowns when the host supplies them |
+| 9 | **context** | Context window usage bar, used percentage, and remaining headroom before auto-compaction |
+| 6 | **tokens** | Session and daily in/out token counts, deduplicated by request ID across transcript entries |
+| 7 | **cost** | Cumulative API-equivalent cost from Claude Code's authoritative session total, persisted across sessions in `~/.codearbiter/ledger.json` |
+| 8 | **burn** | Per-message token sparkline built from recent transcript calls |
+| not shown | **subagents** | Recent tasks with liveness, selected model, input/output tokens, and age; mixed or missing model metadata is explicit |
 
 ### Arbiter Segments
 
 These render only when the open repo carries `arbiter: enabled` in `.codearbiter/CONTEXT.md`. The activation check uses the same frontmatter parser the enforcement hooks use, so the bar and the gates always agree on whether a repo is active. See [Enforcement & Security](/enforcement/) for the activation contract.
 
-| Segment | Shows |
-|---------|-------|
-| **stage** | Current project stage from the `stage` key in `CONTEXT.md` frontmatter |
-| **tasks** | In-flight task count from `open-tasks.md`; done tasks are excluded |
-| **questions** | Count of open `CONFIRM-NN` questions in `open-questions.md` |
-| **overrides** | Override entries logged since the last `/ca:checkpoint` |
+| Key | Segment | Shows |
+|-----|---------|-------|
+| 5 | **stage** | Current project stage from the `stage` key in `CONTEXT.md` frontmatter |
+| 5 | **tasks** | In-flight task count from `open-tasks.md`; done tasks are excluded |
+| 5 | **questions** | Count of open `CONFIRM-NN` questions in `open-questions.md` |
+| 5 | **overrides** | Override entries logged since the last `/ca:checkpoint` |
 
 A non-zero `questions` or `overrides` count renders in red. A non-zero `tasks` count renders in white. A green dot before the arbiter row confirms the repo is active.
 

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -61,6 +61,17 @@ arbiter: enabled
 
 If the file is absent, run `/ca:init` to scaffold it.
 
+<figure class="ca-diagram">
+  <img
+    src="/codeArbiter/diagrams/activation-states.svg"
+    alt="Activation classification flow: a missing CONTEXT.md or missing leading frontmatter is dormant; an unclosed block is malformed and surfaces an error; a closed block containing arbiter enabled activates the persona and gates."
+    loading="lazy"
+    width="900"
+    height="430"
+  />
+  <figcaption>Use the same three-state classification when reading doctor output.</figcaption>
+</figure>
+
 ### Live-Fire Hook Probe
 
 Doctor runs a hook invocation to confirm a hook binary actually executes end-to-end, not just that an interpreter binary is on PATH. A passing interpreter check alongside a failing probe points to a registration or permissions problem with the hook files themselves.

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -332,6 +332,73 @@
   letter-spacing: 0.04em;
 }
 
+/* The statusline guide annotates the real PNG without modifying or redrawing it. */
+.ca-statusline-map {
+  position: relative;
+  width: 100%;
+}
+
+.ca-statusline-map > img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.ca-statusline-map__marker {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: clamp(1rem, 2.2vw, 1.45rem);
+  aspect-ratio: 1;
+  translate: -50% -50%;
+  border: 1px solid #f0f3f6;
+  border-radius: 50%;
+  background: #0b0f14;
+  color: #f0f3f6;
+  box-shadow: 0 0 0 2px rgb(150 92 230 / 72%);
+  font: 700 clamp(0.58rem, 1.25vw, 0.78rem) / 1 ui-monospace, "Cascadia Code", Consolas, monospace;
+}
+
+.ca-statusline-map__marker--1 { left: 3.1%; top: 8%; }
+.ca-statusline-map__marker--2 { left: 3.1%; top: 31%; }
+.ca-statusline-map__marker--3 { left: 55.5%; top: 31%; }
+.ca-statusline-map__marker--4 { left: 96.5%; top: 31%; }
+.ca-statusline-map__marker--5 { left: 3.1%; top: 52%; }
+.ca-statusline-map__marker--6 { left: 11%; top: 78%; }
+.ca-statusline-map__marker--7 { left: 27%; top: 78%; }
+.ca-statusline-map__marker--8 { left: 37%; top: 78%; }
+.ca-statusline-map__marker--9 { left: 49%; top: 78%; }
+
+.ca-statusline-map__legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.45rem 1rem;
+  width: 100%;
+  margin: 0.9rem 0 0;
+  padding: 0;
+  list-style: none;
+  color: var(--ca-text-muted);
+  font: 0.78rem / 1.4 ui-monospace, "Cascadia Code", Consolas, monospace;
+}
+
+.ca-statusline-map__legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.ca-statusline-map__legend span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.25rem;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--ca-gold) 60%, transparent);
+  border-radius: 50%;
+  color: var(--ca-text);
+  font-weight: 700;
+}
+
 /* =========================================================
    GATE-CATCH TERMINAL
    Usage: <div class="ca-terminal" role="region" aria-label="Gate catch demo">

--- a/site/test/generator/diagrams.test.ts
+++ b/site/test/generator/diagrams.test.ts
@@ -25,6 +25,8 @@ const DIAGRAMS = [
   "gate-model.svg",
   "four-tier-map.svg",
   "provenance-drift-flow.svg",
+  "activation-states.svg",
+  "sandbox-boundary.svg",
   // per-guide lane swimlanes (commands/skills/agents charted in execution order)
   "lane-feature.svg",
   "lane-sprint.svg",
@@ -49,6 +51,10 @@ function readAllPageSources(dir: string): string {
 }
 
 const allPageSources = readAllPageSources(SRC_DIR);
+const statuslineGuide = readFileSync(
+  join(SRC_DIR, "content", "docs", "guides", "the-statusline.md"),
+  "utf8",
+);
 
 describe("concept diagrams (AC-9)", () => {
   for (const name of DIAGRAMS) {
@@ -70,4 +76,18 @@ describe("concept diagrams (AC-9)", () => {
       });
     });
   }
+
+  it("references the activation-state visual from all three contract explanations", () => {
+    const references = allPageSources.match(/activation-states\.svg/g) ?? [];
+    expect(references).toHaveLength(3);
+  });
+
+  it("annotates the unchanged statusline capture with nine table keys", () => {
+    expect(statuslineGuide).toContain("/codeArbiter/diagrams/statusline.png");
+    expect(statuslineGuide.match(/ca-statusline-map__marker--\d/g)).toHaveLength(9);
+    for (let key = 1; key <= 9; key += 1) {
+      expect(statuslineGuide).toContain(`| ${key} |`);
+    }
+    expect(statuslineGuide).toContain("| not shown | **subagents** |");
+  });
 });

--- a/site/test/generator/generate.test.ts
+++ b/site/test/generator/generate.test.ts
@@ -185,6 +185,15 @@ describe("generate", () => {
   });
 
   describe("reference index — roster tables", () => {
+    it("links the three catalogs to the request-flow explanation", () => {
+      generate(pluginDir, outDir);
+      const indexContent = readFileSync(join(outDir, "index.md"), "utf8");
+      expect(indexContent).toContain(
+        "[How a Request Flows](/overview/#how-a-request-flows)",
+      );
+      expect(indexContent).toMatch(/command routes to an owning skill.*specialist agents/);
+    });
+
     it("renders one markdown table per non-empty collection, headers matching the collection", () => {
       generate(pluginDir, outDir);
       const indexContent = readFileSync(join(outDir, "index.md"), "utf8");


### PR DESCRIPTION
## Summary

- Add shared activation-state and sandbox-boundary diagrams with accessible SVG titles, alt text, and exact enforcement claims.
- Keep the real statusline PNG unchanged and map its visible segments to the guide tables with responsive HTML markers.
- Link the generated command, skill, and agent catalogs back to the existing request-flow explanation.
- Complete the actionable remainder of #333. Findings 01 and 02 are already on PR #313; the social card stays deferred until real brand assets exist.

## Test plan

- `npm test` in `site`: 412 tests passed.
- `npm run typecheck` in `site`.
- `npm run build` in `site`: 127 pages built.
- `npm run link-audit` in `site`: 17,909 internal links resolved.
- All 15 canonical Python script gates passed.
- Hook suite: 967 tests passed from a clean non-repository working directory.
- Visual QA at desktop and 390x844 mobile widths, plus direct inspection of both SVG assets.
- Independent all-path coverage review: PASS with no BLOCK findings.

## Tradeoff

Conflict hierarchy §2 L1 implementation choice: use native SVG and HTML/CSS instead of adding a Mermaid dependency. This keeps the security claims reviewable and the statusline evidence image byte-for-byte unchanged.

Closes #333