### PR TITLE
fix(farm): enforce secure API request boundaries

### DIFF
--- a/.codearbiter/open-tasks.md
+++ b/.codearbiter/open-tasks.md
@@ -52,7 +52,7 @@ per task. Schema and the count rule: see `plugins/ca/hooks/init-codearbiter.py`
   - Desc: `.codearbiter/coding-standards.md` is named as required pre-flight reading by `tdd`, `refactor`, `writing-plans`, and the author agents, but the file is absent from this repo. Confirmed still missing 2026-06-21 during the task-board-lifecycle tdd pre-flight.
   - Done when: either the file exists (style/structure/naming for the plugin's Python + TS) OR those pre-flight reads tolerate its absence.
   - Boundaries: none
-- [~] v2.security.0003 - Record/close the farm.ts assertSecureBaseUrl focused re-review (SD-02)  (started 2026-07-20)
+- [x] v2.security.0003 - Record/close the farm.ts assertSecureBaseUrl focused re-review (SD-02)  (done 2026-07-20)
   - Desc: the farm.ts `new URL()` host-normalization loosening was flagged for a focused security re-review the sprint log never records. Pass-D re-examined `assertSecureBaseUrl` and confirmed it is loopback-bounded and well-tested (https unconditional, http only for bare loopback, userinfo rejected) — risk is low, but the formally-requested focused pass is still unrecorded.
   - Done when: acceptance is confirmed in writing OR the focused pass is run and recorded.
   - Boundaries: egress, secrets

--- a/.codearbiter/open-tasks.md
+++ b/.codearbiter/open-tasks.md
@@ -52,7 +52,7 @@ per task. Schema and the count rule: see `plugins/ca/hooks/init-codearbiter.py`
   - Desc: `.codearbiter/coding-standards.md` is named as required pre-flight reading by `tdd`, `refactor`, `writing-plans`, and the author agents, but the file is absent from this repo. Confirmed still missing 2026-06-21 during the task-board-lifecycle tdd pre-flight.
   - Done when: either the file exists (style/structure/naming for the plugin's Python + TS) OR those pre-flight reads tolerate its absence.
   - Boundaries: none
-- [ ] v2.security.0003 - Record/close the farm.ts assertSecureBaseUrl focused re-review (SD-02)
+- [~] v2.security.0003 - Record/close the farm.ts assertSecureBaseUrl focused re-review (SD-02)  (started 2026-07-20)
   - Desc: the farm.ts `new URL()` host-normalization loosening was flagged for a focused security re-review the sprint log never records. Pass-D re-examined `assertSecureBaseUrl` and confirmed it is loopback-bounded and well-tested (https unconditional, http only for bare loopback, userinfo rejected) — risk is low, but the formally-requested focused pass is still unrecorded.
   - Done when: acceptance is confirmed in writing OR the focused pass is run and recorded.
   - Boundaries: egress, secrets

--- a/.codearbiter/reports/2026-07-20-farm-base-url-security-review.md
+++ b/.codearbiter/reports/2026-07-20-farm-base-url-security-review.md
@@ -1,0 +1,87 @@
+# `farm.ts` base-URL security review — 2026-07-20
+
+## Scope and disposition
+
+- Board item: `v2.security.0003` / SD-02.
+- Review target: `plugins/ca/tools/farm.ts`, its shipped `farm.js` bundle,
+  `farm.unit.test.ts`, and the TLS/secret claims in
+  `.codearbiter/security-controls.md`.
+- Base: `origin/main` at `b11f337` on branch `review/farm-base-url`.
+- Durable defect: GitHub issue #353.
+- Final verdict: **PASS after remediation**. The first review BLOCKED on two
+  HIGH and two MEDIUM findings; the final independent security re-review found
+  zero CRITICAL, HIGH, MEDIUM, or LOW findings.
+
+## Initial findings
+
+1. **HIGH — redirect downgrade/body forwarding.** Both POSTs used fetch's
+   default automatic redirect behavior. A validated URL could return 307/308
+   and forward the POST body to an unvalidated or cleartext destination.
+2. **HIGH — credential-bearing URL disclosure.** HTTPS userinfo was accepted;
+   Node fetch then rejected the request with the credential-bearing URL in its
+   error. Rejected URLs were also reflected verbatim.
+3. **MEDIUM — validation above, not at, network sinks.** The CLI and canary
+   paths validated resolved configuration, but exported `httpWorker`/`runTask`
+   and `makeEntitlementProbe` seams could reach fetch with caller-supplied
+   external HTTP URLs.
+4. **MEDIUM — provider-controlled diagnostics.** Raw response bodies and full
+   base URLs could flow into stderr, retry prompts, results, or reports.
+5. **LOW control drift.** The controls omitted the existing
+   `FARM_DEFAULT_API_BASE_URL` precedence layer.
+
+## SMARTS decisions
+
+- **Redirect handling:** refuse redirects with `redirect: "error"` on both
+  POSTs. This is the smallest securable and maintainable choice; manual redirect
+  support would add hop limits, method reconstruction, and repeated validation
+  without an accepted provider requirement.
+- **Validation placement:** retain early config validation for operator feedback
+  and repeat it at each fetch-producing boundary. The deliberate duplication is
+  defense in depth for exported programmatic seams.
+- **Diagnostics:** emit fixed validation messages, identify only a parsed
+  endpoint origin, and consume provider bodies without logging or propagating
+  them. This preserves actionable status/config guidance without treating
+  attacker-controlled text as safe telemetry.
+
+## Regression-first evidence
+
+The pre-fix focused suite passed 166 tests because HTTPS userinfo acceptance was
+explicitly expected and redirect/sink behavior was untested. New tests then
+failed for the intended reasons:
+
+- HTTPS userinfo was accepted and malformed URL contents were reflected.
+- Direct external-HTTP worker/probe calls reached mocked fetch.
+- Neither POST set a fail-closed redirect policy.
+- Provider bodies reached stderr and parse errors; endpoint query credentials
+  appeared in diagnostics.
+
+After the minimal fix, 172 focused unit tests pass. Coverage includes:
+
+- redirect refusal on both POST paths;
+- boundary validation for the worker and entitlement probe;
+- HTTP, HTTPS, and non-HTTP(S) userinfo rejection without reflection;
+- malformed/control-bearing URL non-reflection;
+- provider-body suppression in stderr, worker errors, and parse errors;
+- sanitized-origin diagnostics; and
+- preserved normal HTTPS plus bare `localhost`/`127.0.0.1` HTTP behavior.
+
+## Final verification
+
+- Farm: 198/198 Vitest tests pass.
+- TypeScript: `npm run typecheck` passes.
+- Bundle: two consecutive builds produced identical SHA-256
+  `D3FE6B4F337FBB2A7E090767E20F7A3201416793DCE34DF7281BD426ED65A218`.
+- Supply chain: `npm audit --omit=dev --audit-level=critical` reports zero
+  vulnerabilities.
+- Repository: all 15 commands listed in `.codearbiter/tech-stack.md` pass;
+  the hook suite passes 967/967; plugin reference validation passes.
+- Review fleet: security PASS (0 findings), coverage PASS, and call-site/
+  architecture PASS.
+- Whitespace: `git diff --check` passes.
+
+## Resulting invariant
+
+Every farm network boundary now validates the base URL, every farm POST refuses
+automatic redirects, userinfo is rejected on every scheme, and neither raw
+configuration nor provider-controlled bodies enter diagnostics. The generated
+runtime bundle and current security-controls record match the TypeScript source.

--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -94,11 +94,16 @@ be used for API calls, except loopback (`127.0.0.1`/`localhost`) for test mocks
 — see the boundary-crossings table.
 
 The **resolved** `apiBaseUrl` — after the `FARM_API_BASE_URL` env override,
-`plan.meta.apiBaseUrl`, and the built-in default are applied in that precedence —
-is validated before every outbound call by `assertSecureBaseUrl` (`farm.ts`),
-which requires the `https://` scheme (or the documented loopback `http://`
-exception, no userinfo). Validation uses WHATWG `URL` parsing — the same parser
-`fetch` uses for connection targeting — so there is no parser-differential bypass.
+`plan.meta.apiBaseUrl`, `FARM_DEFAULT_API_BASE_URL`, and the built-in default are
+applied in that precedence — is validated by `assertSecureBaseUrl` (`farm.ts`)
+both during configuration resolution and again at each fetch-producing boundary.
+The guard requires the `https://` scheme (or the documented loopback `http://`
+exception) and rejects userinfo on every scheme. Validation uses WHATWG `URL`
+parsing — the same parser `fetch` uses for connection targeting — so there is no
+parser-differential bypass. Both farm POSTs refuse automatic redirects, preventing
+a validated endpoint from forwarding request bodies to an unvalidated transport.
+Provider-controlled response bodies are consumed but never copied into stderr,
+retry prompts, or reports; endpoint diagnostics emit only the parsed origin.
 This supersedes the prior parse-time check that covered only `plan.meta.apiBaseUrl`.
 
 **Outbound surface — the update-available notifier.** The update-notifier
@@ -356,6 +361,6 @@ reopens if the threat model expands to untrusted agents.
 | Fail-open on hook input parse | `_hooklib.py:read_input()` | Parse failure must not brick the session |
 | Unsigned dispatcher commits | `NOSIGN` constant in `farm.ts` | CI signing servers reject unattended commits; the integration PR is the signed artifact |
 | Gate command shell execution | `plan.json` `gate.commands` / `test.command` and `FARM_MUTATION_CMD` run via `cmd.exe /c` / `bash -c` in `farm.ts` | Operator-authored, length-capped (≤1024), PR-reviewed; deterministic gate by design — no untrusted source. See ADR for the trust model |
-| Loopback `http://` for API base | `assertSecureBaseUrl` in `farm.ts` allows `http://127.0.0.1`/`localhost` (no userinfo) | Test mocks bind without TLS; same WHATWG parser as `fetch` → connection target is loopback, no cleartext-to-remote path |
+| Loopback `http://` for API base | `assertSecureBaseUrl` in `farm.ts` allows `http://127.0.0.1`/`localhost` (no userinfo); farm POSTs use `redirect: "error"` | Test mocks bind without TLS; same WHATWG parser as `fetch` → connection target is loopback, and redirect refusal prevents a mock from forwarding the body to a remote cleartext target |
 | Untrusted git clone | `ca-sandbox` clones an attacker-controlled url in a throwaway, `--rm`, networked `alpine/git` container | Input is allowlisted by `validateRepoUrl` + `--` end-of-options; blast radius is the disposable clone container only (no host bind, never co-run with the sandbox) — see ADR-0007 |
 | `curl \| bash` nixpacks install | `build.ts` runs `curl -fsSL https://nixpacks.com/install.sh \| bash` when nixpacks is absent | Build-time host convenience; the URL is a hardcoded constant (not attacker-controllable). Tracked: prefer declaring nixpacks a prerequisite or pinning a checksum (NEEDS-TRIAGE in the ca-sandbox plan) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Statusline customization and correctness hardening across concurrent sessions.
   `model:?`, captured during the existing bounded transcript scan.
 
 ### Fixed
+- Farm API calls now reject credential-bearing base URLs, revalidate at each
+  network boundary, refuse automatic redirects, and keep provider-controlled
+  response bodies out of logs and retry/report diagnostics.
 - Concurrent statusline renders no longer lose ledger updates, session-start
   metadata, or aggregate token/cost totals.
 - Linked Git worktrees report their branch correctly, third-party statusline

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -600,22 +600,27 @@ function extractFileBlocks(content) {
   }
   return blocks;
 }
+function diagnosticApiOrigin(apiBaseUrl) {
+  try {
+    return new URL(apiBaseUrl).origin;
+  } catch {
+    return "<configured endpoint>";
+  }
+}
 function parseChatCompletion(text, apiBaseUrl) {
   let data;
   try {
     data = JSON.parse(text);
   } catch {
-    const snippet = text.trim().slice(0, 120).replace(/\s+/g, " ");
     return {
       ok: false,
-      error: `endpoint ${apiBaseUrl} returned a non-JSON body (${JSON.stringify(snippet)}) \u2014 check FARM_API_BASE_URL and that the endpoint path is correct (expected an OpenAI-compatible /chat/completions)`
+      error: `endpoint ${diagnosticApiOrigin(apiBaseUrl)} returned a non-JSON body \u2014 check FARM_API_BASE_URL and that the endpoint path is correct (expected an OpenAI-compatible /chat/completions)`
     };
   }
   if (!data || typeof data !== "object" || !Array.isArray(data.choices)) {
-    const snippet = text.trim().slice(0, 120).replace(/\s+/g, " ");
     return {
       ok: false,
-      error: `endpoint ${apiBaseUrl} returned an unexpected shape (no 'choices' array): ${JSON.stringify(snippet)} \u2014 check FARM_API_BASE_URL and that the endpoint is an OpenAI-compatible /chat/completions`
+      error: `endpoint ${diagnosticApiOrigin(apiBaseUrl)} returned an unexpected shape (no 'choices' array) \u2014 check FARM_API_BASE_URL and that the endpoint is an OpenAI-compatible /chat/completions`
     };
   }
   return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
@@ -632,6 +637,11 @@ function buildChatBody(model, messages, sampling = readSampling()) {
   return body;
 }
 async function callApi(prompt, model, apiBaseUrl, apiKey, sampling = readSampling()) {
+  try {
+    assertSecureBaseUrl(apiBaseUrl);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "apiBaseUrl must use HTTPS" };
+  }
   for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), ENV.requestTimeoutMs);
@@ -644,7 +654,10 @@ async function callApi(prompt, model, apiBaseUrl, apiKey, sampling = readSamplin
           Authorization: `Bearer ${apiKey}`
         },
         body: JSON.stringify(buildChatBody(model, [{ role: "user", content: prompt }], sampling)),
-        signal: ctrl.signal
+        signal: ctrl.signal,
+        // A validated HTTPS URL is not permission to follow a 307/308 onto an
+        // unvalidated cleartext endpoint with the same POST body.
+        redirect: "error"
       });
     } catch (e) {
       clearTimeout(timer);
@@ -663,15 +676,11 @@ async function callApi(prompt, model, apiBaseUrl, apiKey, sampling = readSamplin
           await sleep(wait);
           continue;
         }
-        const body = await resp.text();
-        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 300)}
-`);
+        await resp.text();
         return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries` };
       }
       if (!resp.ok) {
-        const body = await resp.text();
-        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 500)}
-`);
+        await resp.text();
         return { ok: false, error: `API ${resp.status}` };
       }
       const text = await resp.text();
@@ -1042,12 +1051,14 @@ function assertSecureBaseUrl(url) {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`apiBaseUrl must use HTTPS, got: ${url}`);
+    throw new Error("apiBaseUrl must use HTTPS (HTTP is allowed only for bare loopback hosts)");
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new Error("apiBaseUrl must use HTTPS without embedded credentials");
   }
   if (parsed.protocol === "https:") return;
-  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname) && parsed.username === "" && parsed.password === "")
-    return;
-  throw new Error(`apiBaseUrl must use HTTPS, got: ${url}`);
+  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname)) return;
+  throw new Error("apiBaseUrl must use HTTPS (HTTP is allowed only for bare loopback hosts)");
 }
 function validate(plan) {
   if (plan.meta.apiBaseUrl) assertSecureBaseUrl(plan.meta.apiBaseUrl);
@@ -1147,6 +1158,7 @@ async function screenEntitlements(models, probe, opts = {}) {
   return { survivors, skipped };
 }
 function makeEntitlementProbe(apiBaseUrl, apiKey, timeoutMs) {
+  assertSecureBaseUrl(apiBaseUrl);
   return async (model) => {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -1155,7 +1167,8 @@ function makeEntitlementProbe(apiBaseUrl, apiKey, timeoutMs) {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
         body: JSON.stringify({ model, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),
-        signal: ctrl.signal
+        signal: ctrl.signal,
+        redirect: "error"
       });
       return { status: resp.status };
     } catch {

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -592,9 +592,19 @@ export type WorkerResult = {
 // network round-trip, and so the error it produces is actionable rather than an
 // opaque `non-JSON response: SyntaxError`. A stale/misconfigured endpoint (the
 // #90 failure: a 200 whose body is the literal "Not Found") is the common cause,
-// so the error names the endpoint and the FARM_API_BASE_URL knob the operator
-// must fix. The body snippet is bounded so a large HTML error page can't flood
-// the message.
+// so the error names a sanitized endpoint origin and the FARM_API_BASE_URL knob
+// the operator must fix. Provider-controlled response bodies are never copied
+// into logs, retry prompts, or reports.
+function diagnosticApiOrigin(apiBaseUrl: string): string {
+  try {
+    // origin excludes userinfo, path, query, and fragment, any of which may
+    // carry credentials or attacker-controlled terminal content.
+    return new URL(apiBaseUrl).origin;
+  } catch {
+    return "<configured endpoint>";
+  }
+}
+
 export function parseChatCompletion(
   text: string,
   apiBaseUrl: string,
@@ -605,10 +615,9 @@ export function parseChatCompletion(
   try {
     data = JSON.parse(text) as typeof data;
   } catch {
-    const snippet = text.trim().slice(0, 120).replace(/\s+/g, " ");
     return {
       ok: false,
-      error: `endpoint ${apiBaseUrl} returned a non-JSON body (${JSON.stringify(snippet)}) — check FARM_API_BASE_URL and that the endpoint path is correct (expected an OpenAI-compatible /chat/completions)`,
+      error: `endpoint ${diagnosticApiOrigin(apiBaseUrl)} returned a non-JSON body — check FARM_API_BASE_URL and that the endpoint path is correct (expected an OpenAI-compatible /chat/completions)`,
     };
   }
   // dx-001 (T-08a): the `as typeof data` cast is unsound — valid JSON of an
@@ -618,10 +627,9 @@ export function parseChatCompletion(
   // chat-completions shape (a `choices` array) before trusting it; on a mismatch
   // return an actionable, endpoint-naming error.
   if (!data || typeof data !== "object" || !Array.isArray((data as { choices?: unknown }).choices)) {
-    const snippet = text.trim().slice(0, 120).replace(/\s+/g, " ");
     return {
       ok: false,
-      error: `endpoint ${apiBaseUrl} returned an unexpected shape (no 'choices' array): ${JSON.stringify(snippet)} — check FARM_API_BASE_URL and that the endpoint is an OpenAI-compatible /chat/completions`,
+      error: `endpoint ${diagnosticApiOrigin(apiBaseUrl)} returned an unexpected shape (no 'choices' array) — check FARM_API_BASE_URL and that the endpoint is an OpenAI-compatible /chat/completions`,
     };
   }
   return { ok: true, content: data.choices?.[0]?.message?.content ?? "", usage: data.usage };
@@ -665,6 +673,14 @@ async function callApi(
   apiKey: string,
   sampling: Sampling = readSampling(),
 ): Promise<{ ok: true; content: string; usage?: { prompt_tokens?: number; completion_tokens?: number } } | { ok: false; error: string }> {
+  // Validate at the fetch-producing boundary as well as at CLI config
+  // resolution. Exported callers (for example httpWorker/runTask) must not be
+  // able to bypass the transport rule by supplying their own base URL.
+  try {
+    assertSecureBaseUrl(apiBaseUrl);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "apiBaseUrl must use HTTPS" };
+  }
   for (let attempt = 0; attempt <= ENV.apiMaxRetries; attempt++) {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), ENV.requestTimeoutMs);
@@ -678,6 +694,9 @@ async function callApi(
         },
         body: JSON.stringify(buildChatBody(model, [{ role: "user", content: prompt }], sampling)),
         signal: ctrl.signal,
+        // A validated HTTPS URL is not permission to follow a 307/308 onto an
+        // unvalidated cleartext endpoint with the same POST body.
+        redirect: "error",
       });
     } catch (e) {
       clearTimeout(timer);
@@ -711,15 +730,13 @@ async function callApi(
           await sleep(wait);
           continue;
         }
-        const body = await resp.text();
-        // D-3: log raw body to stderr for diagnostics; do NOT include it in the
-        // error field that flows into priorFailure and the next worker prompt.
-        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 300)}\n`);
+        // Consume the body while the timeout is armed, but never reflect
+        // provider-controlled content into stderr, retry prompts, or reports.
+        await resp.text();
         return { ok: false, error: `API ${resp.status} after ${ENV.apiMaxRetries} retries` };
       }
       if (!resp.ok) {
-        const body = await resp.text();
-        process.stderr.write(`API ${resp.status} body: ${body.slice(0, 500)}\n`);
+        await resp.text();
         return { ok: false, error: `API ${resp.status}` };
       }
 
@@ -1455,11 +1472,13 @@ export const SAFE_TASK_ID = /^[A-Za-z0-9._-]{1,64}$/;
 // (127.0.0.1 / localhost). Parsed with new URL() rather than a regex so the
 // host is the *resolved* host: userinfo tricks like
 // `http://localhost@evil.example` (whose real host is evil.example) cannot be
-// mistaken for loopback, and any userinfo on the loopback path is rejected
-// outright. A malformed/unparseable URL is treated as insecure and rejected.
+// mistaken for loopback. Userinfo is rejected on every scheme: fetch refuses
+// credential-bearing URLs, and echoing one through an error could disclose it.
+// A malformed/unparseable URL is treated as insecure and rejected without
+// reflecting attacker-controlled configuration into logs.
 // This guards the Authorization: Bearer <FARM_API_KEY> header against
-// cleartext transport — the error message intentionally echoes only the
-// offending url, never the key.
+// cleartext transport. Rejection messages are fixed text and never echo the
+// offending URL or key.
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
 
 export function assertSecureBaseUrl(url: string) {
@@ -1467,19 +1486,16 @@ export function assertSecureBaseUrl(url: string) {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`apiBaseUrl must use HTTPS, got: ${url}`);
+    throw new Error("apiBaseUrl must use HTTPS (HTTP is allowed only for bare loopback hosts)");
   }
-  // https keeps the secret inside TLS regardless of host/userinfo — scheme alone governs.
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new Error("apiBaseUrl must use HTTPS without embedded credentials");
+  }
+  // HTTPS keeps the Bearer secret inside TLS regardless of host.
   if (parsed.protocol === "https:") return;
-  // http is permitted only for a bare loopback host with no embedded credentials.
-  if (
-    parsed.protocol === "http:" &&
-    LOOPBACK_HOSTS.has(parsed.hostname) &&
-    parsed.username === "" &&
-    parsed.password === ""
-  )
-    return;
-  throw new Error(`apiBaseUrl must use HTTPS, got: ${url}`);
+  // HTTP is permitted only for a bare loopback host.
+  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname)) return;
+  throw new Error("apiBaseUrl must use HTTPS (HTTP is allowed only for bare loopback hosts)");
 }
 
 export function validate(plan: Plan) {
@@ -1644,6 +1660,9 @@ export async function screenEntitlements(
 // mocked global fetch, rather than only through the pure screenEntitlements
 // decision logic (which is already tested with an injected fake probe).
 export function makeEntitlementProbe(apiBaseUrl: string, apiKey: string, timeoutMs: number): EntitlementProbe {
+  // This function is exported and may be called without runCanary's earlier
+  // config resolution, so enforce the transport boundary at construction.
+  assertSecureBaseUrl(apiBaseUrl);
   return async (model) => {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -1653,6 +1672,7 @@ export function makeEntitlementProbe(apiBaseUrl: string, apiKey: string, timeout
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
         body: JSON.stringify({ model, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),
         signal: ctrl.signal,
+        redirect: "error",
       });
       return { status: resp.status };
     } catch {

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -418,10 +418,39 @@ describe("assertSecureBaseUrl — resolved base URL guard", () => {
     expect(() => assertSecureBaseUrl("not a url")).toThrow(/HTTPS/);
   });
 
-  it("accepts an https URL with userinfo (https acceptance is scheme-only)", () => {
-    // https keeps the secret in TLS regardless of userinfo, so scheme alone
-    // governs; userinfo only matters on the cleartext http-loopback path.
-    expect(() => assertSecureBaseUrl("https://localhost@127.0.0.1:9/")).not.toThrow();
+  it("rejects https userinfo without echoing embedded credentials", () => {
+    const url = "https://user:credential-value@example.com/v1";
+    expect(() => assertSecureBaseUrl(url)).toThrow(/HTTPS/);
+    try {
+      assertSecureBaseUrl(url);
+    } catch (e) {
+      expect((e as Error).message).not.toContain("user");
+      expect((e as Error).message).not.toContain("credential-value");
+    }
+  });
+
+  it("rejects userinfo before protocol handling for every scheme", () => {
+    const url = "ftp://user:credential-value@example.com/v1";
+    try {
+      assertSecureBaseUrl(url);
+      throw new Error("expected assertSecureBaseUrl to reject");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/HTTPS/);
+      expect((e as Error).message).not.toContain("credential-value");
+    }
+  });
+
+  it("does not echo malformed URL contents or terminal controls", () => {
+    const url = "not-a-url\r\nforged-log-line: credential-value";
+    try {
+      assertSecureBaseUrl(url);
+      throw new Error("expected assertSecureBaseUrl to reject");
+    } catch (e) {
+      expect((e as Error).message).not.toContain("forged-log-line");
+      expect((e as Error).message).not.toContain("credential-value");
+      expect((e as Error).message).not.toContain("\r");
+      expect((e as Error).message).not.toContain("\n");
+    }
   });
 
   it("never leaks FARM_API_KEY in the thrown error message", () => {
@@ -510,6 +539,55 @@ describe("Worker seam — runTask invokes an injectable Worker (AC-01)", () => {
   it("exposes a default httpWorker implementation behind the interface", () => {
     expect(httpWorker).toBeDefined();
     expect(typeof httpWorker.apply).toBe("function");
+  });
+});
+
+describe("httpWorker secure request boundary", () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  const context = (apiBaseUrl: string) => ({
+    cwd: process.cwd(),
+    prompt: "test prompt",
+    model: "test-model",
+    apiBaseUrl,
+    apiKey: "DUMMY-KEY",
+    forbidden: new Set<string>(),
+  });
+
+  it("rejects a direct external-http call before fetch", async () => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    const result = await httpWorker.apply(context("http://evil.example"));
+
+    expect(result.ok).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("refuses automatic redirects on the worker request", async () => {
+    let capturedInit: RequestInit | undefined;
+    global.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      capturedInit = init;
+      return new Response(JSON.stringify({ choices: [{ message: { content: "" } }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await httpWorker.apply(context("https://api.example/v1"));
+
+    expect(capturedInit?.redirect).toBe("error");
+  });
+
+  it("does not write an upstream response body to stderr", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    global.fetch = vi.fn(async () => new Response("opaque-provider-credential", { status: 400 })) as unknown as typeof fetch;
+
+    const result = await httpWorker.apply(context("https://api.example/v1"));
+
+    expect(stderr.mock.calls.flat().join(" ")).not.toContain("opaque-provider-credential");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).not.toContain("opaque-provider-credential");
   });
 });
 
@@ -938,24 +1016,25 @@ describe("#90 default base URL + non-JSON body", () => {
     }
   });
 
-  it("parseChatCompletion returns an actionable, endpoint-naming error for a non-JSON body", () => {
+  it("parseChatCompletion returns an actionable, sanitized-endpoint error for a non-JSON body", () => {
     // The exact failure mode of the stale endpoint: 200 with body "Not Found".
-    const r = parseChatCompletion("Not Found", "https://api.opencode.ai/v1");
+    const r = parseChatCompletion("Not Found", "https://api.opencode.ai/v1?credential=opaque-value");
     expect(r.ok).toBe(false);
     if (!r.ok) {
       // Names the knob the operator must fix...
       expect(r.error).toMatch(/FARM_API_BASE_URL/);
-      // ...echoes the offending endpoint...
-      expect(r.error).toMatch(/api\.opencode\.ai\/v1/);
+      // ...identifies the endpoint without reflecting its query credentials...
+      expect(r.error).toMatch(/api\.opencode\.ai/);
+      expect(r.error).not.toContain("opaque-value");
       // ...and is NOT the opaque raw-SyntaxError message it used to be.
       expect(r.error).not.toMatch(/^non-JSON response: SyntaxError/);
     }
   });
 
-  it("parseChatCompletion echoes a (bounded) snippet of the offending body", () => {
-    const r = parseChatCompletion("Not Found", "https://opencode.ai/zen/v1");
+  it("parseChatCompletion does not propagate the offending response body", () => {
+    const r = parseChatCompletion("opaque-provider-credential", "https://opencode.ai/zen/v1");
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error).toMatch(/Not Found/);
+    if (!r.ok) expect(r.error).not.toContain("opaque-provider-credential");
   });
 });
 
@@ -1081,12 +1160,20 @@ describe("coverage-003 (#183) makeEntitlementProbe", () => {
     expect(res.status).toBe(200);
     expect(capturedUrl).toBe("https://api.example/v1/chat/completions");
     expect(capturedInit?.method).toBe("POST");
+    expect(capturedInit?.redirect).toBe("error");
     const headers = capturedInit?.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer DUMMY-KEY-do-not-leak");
     const body = JSON.parse(String(capturedInit?.body)) as { model?: string; max_tokens?: number; messages?: unknown[] };
     expect(body.model).toBe("candidate-model");
     expect(body.max_tokens).toBe(1);
     expect(Array.isArray(body.messages)).toBe(true);
+  });
+
+  it("rejects a direct external-http probe before fetch", () => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    expect(() => makeEntitlementProbe("http://evil.example", "DUMMY-KEY", 5_000)).toThrow(/HTTPS/);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("distinguishes a real 401 response from a network throw (both map to a status, not an exception)", async () => {
@@ -1405,7 +1492,7 @@ describe("T-08a parseChatCompletion shape guard (dx-001)", () => {
     const r = parseChatCompletion(JSON.stringify({ error: "bad model" }), "https://opencode.ai/zen/v1");
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      expect(r.error).toMatch(/opencode\.ai\/zen\/v1/);
+      expect(r.error).toMatch(/opencode\.ai/);
       expect(r.error).toMatch(/choices|unexpected shape/i);
     }
   });


### PR DESCRIPTION
## Summary

Closes the SD-02 farm base-URL review and fixes the transport defects it exposed.

- Validates base URLs at both fetch-producing boundaries, including exported programmatic seams.
- Rejects userinfo on every scheme without reflecting configured credentials.
- Refuses automatic redirects for both API POST paths.
- Keeps provider response bodies and secret-bearing endpoint components out of diagnostics.
- Rebuilds the shipped `farm.js` bundle and records the focused review under `.codearbiter/reports/`.

## Why

The original guard protected CLI configuration, but direct exported calls could bypass it. Default fetch redirect handling could also forward POST bodies to an unvalidated destination. Credential-bearing URLs and provider-controlled bodies could enter logs, retry prompts, or reports.

Tradeoff (Level 2 security boundary): redirects now fail closed instead of being followed, and diagnostics identify only the parsed origin. This preserves the transport and secret-handling guarantees in ADR-0003 and `.codearbiter/security-controls.md`.

## Verification

- `npm test`: 198 passed
- `npm run typecheck`: passed
- `npm run build`: passed; second build produced the same SHA-256
- `npm audit --omit=dev --audit-level=critical`: 0 vulnerabilities
- Repository script matrix: all 15 commands passed
- Hook suite: 967 passed
- Plugin reference validation: passed
- Final security review: 0 CRITICAL, HIGH, MEDIUM, or LOW findings
- Coverage and call-site reviews: passed

Closes #353