### PR TITLE
test: decouple dirty semantics from statusline deadline

### DIFF
--- a/plugins/ca/hooks/tests/test_gitlib.py
+++ b/plugins/ca/hooks/tests/test_gitlib.py
@@ -172,14 +172,22 @@ class GitDirtyTests(unittest.TestCase):
                  "user.email=test@example.invalid", "commit", "-qm", "initial"],
                 check=True)
 
-            with open(tracked, "a", encoding="utf-8") as f:
-                f.write("changed\n")
-            self.assertTrue(_gitlib.git_dirty(root))
+            # This test exercises dirty-state semantics with a real repository.
+            # The production budget is covered separately above and is too tight
+            # to serve as an integration-test deadline on a contended CI runner.
+            with mock.patch.object(
+                    _gitlib, "DIRTY_CHECK_TIMEOUT_SECONDS", 5.0):
+                with open(tracked, "a", encoding="utf-8") as f:
+                    f.write("changed\n")
+                self.assertTrue(_gitlib.git_dirty(root))
 
-            subprocess.run(["git", "-C", root, "restore", "tracked.txt"], check=True)
-            with open(os.path.join(root, "untracked.txt"), "w", encoding="utf-8") as f:
-                f.write("new\n")
-            self.assertTrue(_gitlib.git_dirty(root))
+                subprocess.run(
+                    ["git", "-C", root, "restore", "tracked.txt"], check=True)
+                with open(
+                        os.path.join(root, "untracked.txt"),
+                        "w", encoding="utf-8") as f:
+                    f.write("new\n")
+                self.assertTrue(_gitlib.git_dirty(root))
 
 
 class StatuslineLinkedWorktreeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Make the real-repository dirty-state test independent of the production statusline latency budget. The semantic check now uses a test-local 5-second deadline, while the dedicated timeout test continues to enforce the production 100 ms fail-soft contract.

This removes runner-contention sensitivity without changing shipped behavior.

Closes #352

## Verification

- `GitDirtyTests`: 3 tests passed on Linux.
- Formerly flaky real-repository test: 200 of 200 repeated runs passed.
- Full hook suite: 967 tests passed with 1 intentional skip on Linux.
- Repository checks: all 25 `.github/scripts/test_*.py` suites passed.
- Python compile, whitespace validation, and staged secrets scan passed.
- Independent coverage review: PASS with no findings.

## Tradeoff

The integration test receives a deliberately larger deadline than production. This follows the project conflict hierarchy at the test boundary: semantic coverage remains deterministic, while the separate budget test retains the actual runtime constraint.

## Follow-up

A separate pre-existing clock-boundary failure discovered during verification is tracked in #355 and is not included in this patch.