### PR TITLE
test: isolate NO_COLOR palette equality from session age

### DIFF
--- a/plugins/ca/hooks/tests/test_colorlib.py
+++ b/plugins/ca/hooks/tests/test_colorlib.py
@@ -396,8 +396,9 @@ if sl.V2 != sl._colorlib.V2 or sl._boxlib._V0 != sl._colorlib.V0 \
 
     def test_no_color_makes_every_builtin_layout_byte_identical(self):
         renderer = os.path.join(_HOOKS_DIR, "statusline.py")
-        payload = json.dumps({"session_id": "palette-layout-test",
-                              "workspace": {"current_dir": self.tmp_path()},
+        # Keep this theme-only comparison independent of the mutable user ledger.
+        # Without a session id, every subprocess renders a call-local 0s age.
+        payload = json.dumps({"workspace": {"current_dir": self.tmp_path()},
                               "model": {"display_name": "Test"}})
         outputs = []
         for theme in ("violet", "blue", "green", "amber", "mono"):


### PR DESCRIPTION
## Summary

Keep the `NO_COLOR` palette equality test independent of mutable user-ledger state. The theme-only payload now omits its unused session id, so every renderer subprocess produces a call-local `age 0s` instead of racing a live age boundary.

Shipped statusline behavior is unchanged.

Closes #355

## Verification

- Deterministic red proof reproduced `age 59s` versus `age 1m` as the sole byte difference.
- Target test passed 30 of 30 fresh-process repetitions on Linux.
- Full hook suite passed 967 tests with 1 intentional skip on Linux.
- All 25 `.github/scripts/test_*.py` suites passed.
- Python compile, whitespace validation, and staged secrets scan passed.
- Independent coverage review passed with no findings.

## Tradeoff

The comparison no longer exercises session-dependent ledger output. Under the project conflict hierarchy, that behavior is outside this palette test's obligation and remains covered by dedicated ledger and statusline tests; keeping it here made a theme assertion depend on wall-clock timing.