### PR TITLE
fix(prune): repair malformed session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ predate the plugin rewrite and are grouped by date.
 - Prune dry-run records, audit logs, CLI, footer, and cold-cache metrics now separate
   model-visible context savings from file-only sidecar cleanup; sidecar bytes
   no longer inflate the context-benefit decision or arm the cold-cache nudge.
+- Prune hooks now ignore and repair malformed per-session state instead of
+  allowing invalid legacy values to escape fail-open handling.
 
 ## [2.9.0] — 2026-07-12
 

--- a/core/pysrc/_prunelib.py
+++ b/core/pysrc/_prunelib.py
@@ -22,6 +22,7 @@
 import calendar
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -1222,6 +1223,9 @@ def hook_run(payload, env=None):
     except Exception:  # noqa: BLE001 — fail open on any state-read fault
         return 0
     rec = state.get(session, {})
+    if not isinstance(rec, dict):
+        rec = {}
+        state[session] = rec
     # Cold-miss nudge (opt-in): the ONLY non-zero return in this hook. Evaluated
     # before the growth short-circuit so an idle user (no new bytes) still nudges.
     if cfg.execute and (e.get("CODEARBITER_PRUNE_NUDGE", "off") or "off").lower() == "on":
@@ -1238,7 +1242,14 @@ def hook_run(payload, env=None):
                 return 2
         except Exception:  # noqa: BLE001 — fail open; pruner fault must never block
             pass
-    if rec and (st.st_size - rec.get("last_pruned_size", 0)) < cfg.min_growth:
+    last_pruned_size = rec.get("last_pruned_size")
+    valid_last_pruned_size = (
+        (type(last_pruned_size) is int and last_pruned_size >= 0)
+        or (type(last_pruned_size) is float
+            and last_pruned_size >= 0 and math.isfinite(last_pruned_size))
+    )
+    if valid_last_pruned_size \
+            and (st.st_size - last_pruned_size) < cfg.min_growth:
         return 0  # cheap stat short-circuit: not enough new bytes
     # performance-001: read + parse the transcript ONCE here and thread the
     # bytes/lines/pre_stat through to run() below, instead of letting run()

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 - Prune metrics now separate model-visible context savings from file-only
   sidecar cleanup, preventing sidecar bytes from inflating the context-benefit
   decision or cold-cache nudge.
+- Prune hooks ignore and repair malformed per-session state rather than letting
+  invalid legacy values escape fail-open handling.
 - Shared statusline ledger records use ownership-safe atomic shards, so
   concurrent host activity cannot discard session token/cost state.
 - Linked-worktree branch metadata is parsed from Git pointer files instead of

--- a/plugins/ca-codex/hooks/_prunelib.py
+++ b/plugins/ca-codex/hooks/_prunelib.py
@@ -22,6 +22,7 @@
 import calendar
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -1222,6 +1223,9 @@ def hook_run(payload, env=None):
     except Exception:  # noqa: BLE001 — fail open on any state-read fault
         return 0
     rec = state.get(session, {})
+    if not isinstance(rec, dict):
+        rec = {}
+        state[session] = rec
     # Cold-miss nudge (opt-in): the ONLY non-zero return in this hook. Evaluated
     # before the growth short-circuit so an idle user (no new bytes) still nudges.
     if cfg.execute and (e.get("CODEARBITER_PRUNE_NUDGE", "off") or "off").lower() == "on":
@@ -1238,7 +1242,14 @@ def hook_run(payload, env=None):
                 return 2
         except Exception:  # noqa: BLE001 — fail open; pruner fault must never block
             pass
-    if rec and (st.st_size - rec.get("last_pruned_size", 0)) < cfg.min_growth:
+    last_pruned_size = rec.get("last_pruned_size")
+    valid_last_pruned_size = (
+        (type(last_pruned_size) is int and last_pruned_size >= 0)
+        or (type(last_pruned_size) is float
+            and last_pruned_size >= 0 and math.isfinite(last_pruned_size))
+    )
+    if valid_last_pruned_size \
+            and (st.st_size - last_pruned_size) < cfg.min_growth:
         return 0  # cheap stat short-circuit: not enough new bytes
     # performance-001: read + parse the transcript ONCE here and thread the
     # bytes/lines/pre_stat through to run() below, instead of letting run()

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to `ca-pi` are documented in this file.
 - Shared prune metrics now distinguish model-visible context savings from
   file-only sidecar cleanup, including explicit strategy scopes and corrected
   footer and cold-cache decisions.
+- Shared prune hooks ignore and repair malformed per-session state rather than
+  allowing invalid legacy values to escape fail-open handling.
 
 ### Changed
 

--- a/plugins/ca-pi/hooks/_prunelib.py
+++ b/plugins/ca-pi/hooks/_prunelib.py
@@ -22,6 +22,7 @@
 import calendar
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -1222,6 +1223,9 @@ def hook_run(payload, env=None):
     except Exception:  # noqa: BLE001 — fail open on any state-read fault
         return 0
     rec = state.get(session, {})
+    if not isinstance(rec, dict):
+        rec = {}
+        state[session] = rec
     # Cold-miss nudge (opt-in): the ONLY non-zero return in this hook. Evaluated
     # before the growth short-circuit so an idle user (no new bytes) still nudges.
     if cfg.execute and (e.get("CODEARBITER_PRUNE_NUDGE", "off") or "off").lower() == "on":
@@ -1238,7 +1242,14 @@ def hook_run(payload, env=None):
                 return 2
         except Exception:  # noqa: BLE001 — fail open; pruner fault must never block
             pass
-    if rec and (st.st_size - rec.get("last_pruned_size", 0)) < cfg.min_growth:
+    last_pruned_size = rec.get("last_pruned_size")
+    valid_last_pruned_size = (
+        (type(last_pruned_size) is int and last_pruned_size >= 0)
+        or (type(last_pruned_size) is float
+            and last_pruned_size >= 0 and math.isfinite(last_pruned_size))
+    )
+    if valid_last_pruned_size \
+            and (st.st_size - last_pruned_size) < cfg.min_growth:
         return 0  # cheap stat short-circuit: not enough new bytes
     # performance-001: read + parse the transcript ONCE here and thread the
     # bytes/lines/pre_stat through to run() below, instead of letting run()

--- a/plugins/ca/hooks/_prunelib.py
+++ b/plugins/ca/hooks/_prunelib.py
@@ -22,6 +22,7 @@
 import calendar
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -1222,6 +1223,9 @@ def hook_run(payload, env=None):
     except Exception:  # noqa: BLE001 — fail open on any state-read fault
         return 0
     rec = state.get(session, {})
+    if not isinstance(rec, dict):
+        rec = {}
+        state[session] = rec
     # Cold-miss nudge (opt-in): the ONLY non-zero return in this hook. Evaluated
     # before the growth short-circuit so an idle user (no new bytes) still nudges.
     if cfg.execute and (e.get("CODEARBITER_PRUNE_NUDGE", "off") or "off").lower() == "on":
@@ -1238,7 +1242,14 @@ def hook_run(payload, env=None):
                 return 2
         except Exception:  # noqa: BLE001 — fail open; pruner fault must never block
             pass
-    if rec and (st.st_size - rec.get("last_pruned_size", 0)) < cfg.min_growth:
+    last_pruned_size = rec.get("last_pruned_size")
+    valid_last_pruned_size = (
+        (type(last_pruned_size) is int and last_pruned_size >= 0)
+        or (type(last_pruned_size) is float
+            and last_pruned_size >= 0 and math.isfinite(last_pruned_size))
+    )
+    if valid_last_pruned_size \
+            and (st.st_size - last_pruned_size) < cfg.min_growth:
         return 0  # cheap stat short-circuit: not enough new bytes
     # performance-001: read + parse the transcript ONCE here and thread the
     # bytes/lines/pre_stat through to run() below, instead of letting run()

--- a/plugins/ca/hooks/tests/test_hook.py
+++ b/plugins/ca/hooks/tests/test_hook.py
@@ -75,6 +75,37 @@ class TestHook(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(os.path.getsize(self.path), size_after)
 
+    def test_malformed_session_state_is_ignored_and_repaired(self):
+        malformed_records = (
+            "not-a-record",
+            True,
+            [],
+            {},
+            {"last_pruned_size": True},
+            {"last_pruned_size": "not-a-number"},
+            {"last_pruned_size": float("nan")},
+            {"last_pruned_size": float("inf")},
+            {"last_pruned_size": -1},
+            {"last_pruned_size": []},
+            {"last_pruned_size": {}},
+        )
+        for record in malformed_records:
+            with self.subTest(record=record):
+                with open(self.path, "wb") as handle:
+                    handle.write(make_transcript(n_pairs=8, result_bytes=30000))
+                P.save_state({"sess": record})
+                before = os.path.getsize(self.path)
+                rc = P.hook_run(self.payload(), env=self.env(
+                    CODEARBITER_PRUNE="on",
+                    CODEARBITER_PRUNE_MIN_GROWTH="999999999",
+                ))
+                self.assertEqual(rc, 0)
+                self.assertLess(os.path.getsize(self.path), before)
+                repaired = P.load_state().get("sess")
+                self.assertIsInstance(repaired, dict)
+                self.assertEqual(
+                    repaired.get("last_pruned_size"), os.path.getsize(self.path))
+
     def test_min_size_floor(self):
         small = os.path.join(self.repo, "small.jsonl")
         with open(small, "wb") as f:


### PR DESCRIPTION
## Summary

- Normalize malformed per-session prune state before any nudge, growth, or carry-forward consumer reads it.
- Allow only nonnegative finite integers and floats to control the minimum-growth shortcut.
- Repair malformed records through the next normal prune while preserving the existing valid numeric shortcut.

## Regression coverage

The regression exercises strings, booleans, lists, missing sizes, nonnumeric strings, NaN, infinity, negative values, and container-shaped sizes. Each malformed record must allow a normal prune and be replaced by a valid state record.

## Test plan

- Full hook suite (1,023 passed, 1 skipped)
- All 42 `.github/scripts/test_*.py` suites
- Pi TypeScript typecheck and Vitest (544 passed, 1 skipped)
- Focused prune hook and nudge tests (66 passed plus the 43-test nudge entry suite)
- Core sync, host package, generated surface, reference graph, badge, license, JSON, secret-preview, syntax, and reproducible Pi build checks
- Independent coverage review: CLEAN

This PR is stacked on #360 to keep the shared-core change isolated. It closes #361 without changing prune transformations, metrics, defaults, or thresholds.

Closes #361