### PR TITLE
docs(codex): reconcile campaign milestone status

### DIFF
--- a/.codearbiter/plans/codex-support.md
+++ b/.codearbiter/plans/codex-support.md
@@ -14,6 +14,31 @@ This is newly feasible: Codex v0.142.x (verified July 2026) has near-parity exte
 
 **Approval caveat (2026-07-08):** approved as **beta only** — the maintainer has no Codex subscription until ~2026-07-09, so live-fire spike items (stdout injection, trust review, exit-2 feedback) are deferred to a live-verification pass; source-level verification against `openai/codex` proceeds immediately. `ca-codex` carries a beta / Feature Forge preview label until live verification completes.
 
+## Campaign status (reconciled 2026-07-20)
+
+The beta gate is complete, but the full M0-M5 campaign is not. Codex 0.144.1 loaded the trusted
+plugin, injected the SessionStart persona, and surfaced the live H-03 block. Stable release
+`ca-codex-v0.2.4` was tagged and published on 2026-07-12. Those receipts remove the beta label;
+they do not silently waive the remaining host-parity milestones.
+
+| Milestone | Current status | Authoritative evidence or remaining obligation |
+|---|---|---|
+| M0 spike + governance | ACCEPTED | ADR-0011 is accepted; live trust, persona injection, and structured block evidence are recorded in PR #254 and `docs/parity.md`. |
+| M1 shared-core extraction | ACCEPTED | `core/pysrc/`, `tools/sync-core.py`, and the byte-identity CI contract shipped in PR #254. |
+| M2 Codex enforcement core | ACCEPTED | The trusted hooks, host adapter, doctor probe, shared-store contract, and live H-03 block shipped in PR #254. |
+| M3 command/skill surface | ACCEPTED | The generated standalone `$ca-*` surface and Codex-only initialization path shipped through PR #295 and PR #254. |
+| M4 agents + review chains | PENDING | `docs/parity.md` still records the 28 agents and review chains as M4 work. Roles run inline; generated `.codex/agents/*.toml`, `ca-init` scaffolding, staleness diagnosis, and review-chain validation remain. |
+| M5 distribution/release/docs | PARTIAL | Stable 0.2.4 release and public install documentation shipped through PRs #301 and #302. The Codex worker-backend package remains absent and degrades to the premium path. |
+
+`codex.feature.0001` remains in progress until M4 is accepted and the remaining M5 distribution
+decision is implemented or explicitly re-scoped through a user-attributed decision. Later 0.3.x
+version work is maintenance on the shipped host and is not evidence that these two obligations closed.
+
+`.codearbiter/CONTEXT.md` still carries the superseded beta wording. A 2026-07-20 attempt to correct
+that sentence was blocked by H-18 because `CONTEXT.md` is the activation switch. Correcting it needs
+the sanctioned protected-file path or an explicit `$ca-override`; this reconciliation does not bypass
+that gate.
+
 ## Architecture
 
 ### Python core — `core/pysrc/`, vendored at build time

--- a/.codearbiter/sprint-log.md
+++ b/.codearbiter/sprint-log.md
@@ -970,3 +970,14 @@ feat/pi-support in the main checkout, ratifying ADR-0013 — legitimate, out of 
 - The gate-events.log self-poisoning bug (#279-shaped) was NOT on the sprint's issue list; found by using
   the system, surfaced as a hard gate, user-scoped, fixed under two security reviews. Recorded as the
   sprint's one genuinely new find.
+
+## SD-13 - codex.feature.0001 stale-campaign reconciliation - confidence: high
+- Decision: close the campaign; leave it unchanged; or reconcile current evidence while keeping the unfinished campaign in progress.
+- Scalable: Close=Weak. Partial milestones become invisible. Unchanged=Weak. Stale status compounds. Reconcile=Strong. Remaining milestones stay bounded and visible.
+- Maintainable: Close=Weak. Future work loses its parent plan. Unchanged=Weak. Readers reconstruct history. Reconcile=Strong. One table states evidence and remaining work.
+- Available: Close=Indifferent. No runtime effect. Unchanged=Indifferent. No runtime effect. Reconcile=Indifferent. No runtime effect.
+- Reliable: Close=Weak. M4 and M5 contradict completion. Unchanged=Weak. Beta wording contradicts release evidence. Reconcile=Strong. Status matches tags, PRs, and parity ledger.
+- Testable: Close=Weak. No evidence proves M4. Unchanged=Weak. Completion cannot be audited quickly. Reconcile=Strong. Each milestone cites an authoritative receipt or gap.
+- Securable: Close=Weak. It obscures degraded review isolation. Unchanged=Adequate. Controls remain intact. Reconcile=Strong. H-18 remains enforced and degraded boundaries stay explicit.
+- Chosen: reconcile the campaign status, keep codex.feature.0001 in progress, and preserve M4/M5 as completion obligations. Strength: strong.
+- Hard gate: H-18 blocked the attempted CONTEXT.md beta-wording correction because CONTEXT.md is the activation switch. No override was taken. The plan records the exact protected-file follow-up.


### PR DESCRIPTION
## Summary

- Record M0 through M3 as accepted from the merged Codex implementation and live 0.144.1 evidence.
- Keep M4 agent packaging pending and M5 distribution partial instead of falsely closing `codex.feature.0001`.
- Preserve the H-18 protected-file blocker for the stale beta sentence in `CONTEXT.md`; no override was taken.

## Why

The campaign task looked stale because stable `ca-codex` 0.2.4 was already tagged, published, and documented. The authoritative parity ledger still leaves packaged agents and the remaining worker-backend distribution unfinished. This change makes that boundary explicit in the approved campaign plan.

## Verification

- All canonical scripts from `.codearbiter/tech-stack.md` passed.
- `python -m unittest discover -s plugins/ca/hooks/tests -p test_*.py` passed: 967 tests.
- `python .github/scripts/check-plugin-refs.py` passed.
- Fresh evidence check matched the stable `ca-codex-v0.2.4` manifest and release to the M0 through M5 status table.
- Manual and `_hooklib.SECRET_RE` scans found zero secrets.
- `git diff --check` passed.

## Review

Coverage audit: PASS. This is documentation and append-only sprint evidence only, with no behavioral source or TDD obligation.

Conflict hierarchy level 1 applies: preserve H-18 and the activation-switch audit boundary instead of bypassing it for a status correction.

Ref: ADR-0011