### PR TITLE
fix(site): clear high-severity build-dependency advisories and close the zero-page audit blind spot

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import { unified } from "@astrojs/markdown-remark";
 import { readFileSync } from "node:fs";
 import { rehypeBaseLinks } from "./scripts/rehype-base-links.ts";
 
@@ -39,11 +40,15 @@ export default defineConfig({
   //   - Starlight does NOT rewrite root-absolute markdown links through the
   //     base on its own. Writing [Overview](/overview) in MDX/Markdown would
   //     render a literal `/overview` href and 404 once served from a subpath.
-  //   - Instead, `markdown.rehypePlugins` below runs our local
+  //   - Instead, the `markdown.processor` below runs our local
   //     `rehypeBaseLinks(BASE)` plugin (scripts/rehype-base-links.ts) over
   //     every rendered page. It walks the HAST tree and prefixes any
   //     root-absolute href/src ("/overview") with BASE ("/codeArbiter/overview"),
   //     idempotently, so plain root-relative markdown links stay base-safe.
+  //   - The plugin is passed to `unified({ ... })` from `@astrojs/markdown-remark`,
+  //     NOT to the top-level `markdown.rehypePlugins` key. Astro 7.1 deprecated
+  //     `markdown.remarkPlugins` / `rehypePlugins` / `remarkRehype` ("will be
+  //     removed in a future major") — see the note on `markdown:` below.
   //   - In Astro component href props (not markdown), still use
   //     import.meta.env.BASE_URL: href={`${import.meta.env.BASE_URL}overview/`}
   //   - Never hardcode "/codeArbiter/" in href strings. That value desyncs
@@ -68,8 +73,19 @@ export default defineConfig({
     "/reference/skills/release-2": `${BASE}/reference/skills/release`,
     "/reference/skills/tribunal-2": `${BASE}/reference/skills/tribunal`,
   },
+  // Astro 7.1 made Sätteri the default Markdown processor and deprecated the
+  // top-level `markdown.remarkPlugins` / `rehypePlugins` / `remarkRehype` keys.
+  // Setting `processor` explicitly is the supported replacement: it selects the
+  // remark/rehype (`unified`) pipeline and takes the plugin list directly.
+  //
+  // This is behaviour-neutral versus the deprecated form — Astro's own
+  // compatibility shim did exactly this (`md.processor = unified()`, then push
+  // the legacy plugin arrays onto it) before emitting its deprecation warning.
+  // Doing it here removes the warning and takes the site off an API with a
+  // scheduled removal. `@astrojs/markdown-remark` is a direct dependency
+  // because of this import — see site/package.json.
   markdown: {
-    rehypePlugins: [rehypeBaseLinks(BASE)],
+    processor: unified({ rehypePlugins: [rehypeBaseLinks(BASE)] }),
   },
   integrations: [
     starlight({

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "codearbiter-docs",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/starlight": "^0.41.1",
         "astro": "^7.0.3"
       },
@@ -18,33 +19,33 @@
         "vitest": "^3.2.6"
       },
       "optionalDependencies": {
-        "sharp": "^0.33.5"
+        "sharp": "^0.35.0"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.2.3.tgz",
-      "integrity": "sha512-Xz3iBNse+hXXD25IXxsuXEt2ai8klAWE15CRm/EQBc9+aE3jXaF07DZx+iakk3HC6NHvWlEPzLPyxsLgPzOJsw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
+      "integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@astrojs/compiler-binding-darwin-arm64": "0.2.3",
-        "@astrojs/compiler-binding-darwin-x64": "0.2.3",
-        "@astrojs/compiler-binding-linux-arm64-gnu": "0.2.3",
-        "@astrojs/compiler-binding-linux-arm64-musl": "0.2.3",
-        "@astrojs/compiler-binding-linux-x64-gnu": "0.2.3",
-        "@astrojs/compiler-binding-linux-x64-musl": "0.2.3",
-        "@astrojs/compiler-binding-wasm32-wasi": "0.2.3",
-        "@astrojs/compiler-binding-win32-arm64-msvc": "0.2.3",
-        "@astrojs/compiler-binding-win32-x64-msvc": "0.2.3"
+        "@astrojs/compiler-binding-darwin-arm64": "0.3.1",
+        "@astrojs/compiler-binding-darwin-x64": "0.3.1",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
       }
     },
     "node_modules/@astrojs/compiler-binding-darwin-arm64": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.2.3.tgz",
-      "integrity": "sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
+      "integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
       "cpu": [
         "arm64"
       ],
@@ -58,9 +59,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-darwin-x64": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.2.3.tgz",
-      "integrity": "sha512-P0NYu6aaIeLCqFfszxxBHL0a5WRaYigNVbDoO654Gi5Q2au5duDb5xZBv5EqUg4qnQVC173FXNvGZu1M7nk+/w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
+      "integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
       "cpu": [
         "x64"
       ],
@@ -74,9 +75,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.2.3.tgz",
-      "integrity": "sha512-PqVN5AqhuDqfx3ejaerwrC8codpV9jnyKV+IOel027qsJ1anFUJLdjUlY8VVys0xgd8lmqveX11OkcaQj/otTg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
+      "integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
       "cpu": [
         "arm64"
       ],
@@ -93,9 +94,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.2.3.tgz",
-      "integrity": "sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
+      "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
       ],
@@ -112,9 +113,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.2.3.tgz",
-      "integrity": "sha512-hbLBjXVp+96psMe7/7uqyrquGiULXANrq6REVxxPK/I5VzebZ7LHmSfykmByUbLyR1u+K6CTBKgvdQsK2L+2Xw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
+      "integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
       "cpu": [
         "x64"
       ],
@@ -131,9 +132,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.2.3.tgz",
-      "integrity": "sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
+      "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +151,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.2.3.tgz",
-      "integrity": "sha512-p9S2X8z/mUR2SMzAVJRFMCt8YaalKR+pjl2DgpdjzCQc6ww4bo8kiy54tgKqxZeNF5c+/2tCDTQIxVSm9V1FsA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
+      "integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
       "cpu": [
         "wasm32"
       ],
@@ -166,9 +167,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.2.3.tgz",
-      "integrity": "sha512-vcCG6JttIb5vbSmcxO2O398hpVj7lQ349iS7cjgYP6ZuLVEnw+9qPAr2MM2kJkU5wEGZqJ2gyi/M7UJoPwH1iQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
+      "integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
       "cpu": [
         "arm64"
       ],
@@ -182,9 +183,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.2.3.tgz",
-      "integrity": "sha512-hKssjNvC36e00Inb1GW1JsVyCFSCGnIjKem4S8q0VIW6cpWAUpvYB4qQU2HIDGD6SDX0ork4F5sWkNWkp2hrGQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
+      "integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
       "cpu": [
         "x64"
       ],
@@ -198,12 +199,15 @@
       }
     },
     "node_modules/@astrojs/compiler-rs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.2.3.tgz",
-      "integrity": "sha512-JRAtRcPxS4JeAZEIQFQ6GecBs/Wyp4m6/E8vBNxSgVfo1AtRVLUqRCl5oCGOZ0X/BSBB3Vef/7IlzyiGKi2ORA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
+      "integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-binding": "0.2.3"
+        "@astrojs/compiler-binding": "0.3.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -223,12 +227,12 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
-      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/internal-helpers": "0.10.1",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
@@ -247,16 +251,49 @@
         "vfile": "^6.0.3"
       }
     },
-    "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.2.tgz",
-      "integrity": "sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==",
+    "node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.0",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
+      "integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
         "satteri": "^0.9.1"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/mdx": {
@@ -293,6 +330,31 @@
         }
       }
     },
+    "node_modules/@astrojs/mdx/node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
     "node_modules/@astrojs/prism": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
@@ -317,9 +379,9 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.1.tgz",
-      "integrity": "sha512-avf2OmrVg6GdVU18juebjjIIuLa+uS3syHuJ/3yDaEFP/8it+YvcxRrYDSf7K6rC4v770UxIddba2hAqQyTeYA==",
+      "version": "0.41.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.4.tgz",
+      "integrity": "sha512-cRCKZhM2BKYViCakBiN68aVwPn5qj/XtMMq//G54xOWdXXcvic1gMMEI+veNlIKOqqC4QmIjcjk4jiFtlZ3mMg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-satteri": "^0.3.2",
@@ -363,16 +425,15 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
-      "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+      "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
       "license": "MIT",
       "dependencies": {
         "ci-info": "^4.4.0",
         "dset": "^3.1.4",
         "is-docker": "^4.0.0",
-        "is-wsl": "^3.1.1",
-        "which-pm-runs": "^1.1.0"
+        "package-manager-detector": "^1.6.0"
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
@@ -1101,9 +1162,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1113,19 +1174,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1135,19 +1196,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1161,9 +1241,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1177,9 +1257,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1196,9 +1276,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1215,9 +1295,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1234,9 +1314,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1253,9 +1333,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1272,9 +1352,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1291,9 +1371,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1310,9 +1390,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1329,9 +1409,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1344,19 +1424,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1369,19 +1449,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1394,19 +1474,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1419,19 +1499,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1444,19 +1524,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1469,19 +1549,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1494,19 +1574,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1519,38 +1599,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1560,16 +1656,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1579,16 +1675,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1598,7 +1694,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2859,15 +2955,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.0.3.tgz",
-      "integrity": "sha512-CK+G+Tl2DMV1EXCwVG45vyurxf2IfRTklMxDhRKn+tst9Yl8rWXpudL62Fa6zin5Bt968FBvuyASj1aJShROZg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.3.tgz",
+      "integrity": "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-rs": "^0.2.2",
-        "@astrojs/internal-helpers": "0.10.0",
-        "@astrojs/markdown-satteri": "0.3.2",
-        "@astrojs/telemetry": "3.3.2",
+        "@astrojs/compiler-rs": "^0.3.1",
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/markdown-satteri": "0.3.4",
+        "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -2878,7 +2974,7 @@
         "ci-info": "^4.4.0",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
-        "cookie": "^1.1.1",
+        "cookie": "^2.0.1",
         "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
@@ -2895,14 +2991,13 @@
         "magic-string": "^0.30.21",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
-        "neotraverse": "^0.6.18",
+        "neotraverse": "^1.0.1",
         "obug": "^2.1.1",
         "p-limit": "^7.3.0",
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
         "picomatch": "^4.0.4",
-        "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
         "smol-toml": "^1.6.0",
@@ -2912,9 +3007,7 @@
         "tinyglobby": "^0.2.15",
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
-        "unist-util-visit": "^5.1.0",
         "unstorage": "^1.17.5",
-        "vfile": "^6.0.3",
         "vite": "^8.0.13",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
@@ -2934,10 +3027,10 @@
         "url": "https://opencollective.com/astrodotbuild"
       },
       "optionalDependencies": {
-        "sharp": "^0.34.0"
+        "sharp": "^0.34.0 || ^0.35.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.0"
+        "@astrojs/markdown-remark": "7.2.1"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -2958,446 +3051,20 @@
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0"
       }
     },
-    "node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "license": "MIT",
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/axobject-query": {
@@ -3586,51 +3253,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3660,12 +3282,12 @@
       }
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",
@@ -4791,13 +4413,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/is-decimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
@@ -4833,39 +4448,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -4873,21 +4455,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6347,9 +5914,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6365,9 +5932,9 @@
       }
     },
     "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -6630,9 +6197,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6649,7 +6216,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7235,43 +6802,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shiki": {
@@ -7299,16 +6876,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7456,9 +7023,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -8354,15 +7921,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/why-is-node-running": {

--- a/site/package.json
+++ b/site/package.json
@@ -20,11 +20,12 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/starlight": "^0.41.1",
     "astro": "^7.0.3"
   },
   "optionalDependencies": {
-    "sharp": "^0.33.5"
+    "sharp": "^0.35.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/site/scripts/link-audit.ts
+++ b/site/scripts/link-audit.ts
@@ -3,22 +3,29 @@
  * Runs the post-build dangling-link + base-path-safety gate against
  * site/dist/ and exits non-zero on any failure. See link-audit/lib.ts for
  * the resolution rules and rationale.
+ *
+ * Usage: tsx scripts/link-audit.ts [distDir]
+ * `distDir` defaults to site/dist; it exists so the CLI's exit-code behavior
+ * is testable against fixture dist trees.
  */
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 import { auditDist, missingRequiredAssets, BASE } from "./link-audit/lib";
 
-const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+const DEFAULT_DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
 
 function main(): void {
-  if (!existsSync(DIST)) {
-    console.error(`link-audit: dist not found at ${DIST}. Run \`npm run build\` first.`);
+  const arg = process.argv[2];
+  const dist = arg ? resolve(arg) : DEFAULT_DIST;
+
+  if (!existsSync(dist)) {
+    console.error(`link-audit: dist not found at ${dist}. Run \`npm run build\` first.`);
     process.exit(1);
   }
 
-  const { failures, checked, pageCount } = auditDist(DIST, BASE);
-  const requiredAssets = missingRequiredAssets(DIST);
+  const { failures, checked, pageCount } = auditDist(dist, BASE);
+  const requiredAssets = missingRequiredAssets(dist);
 
   if (failures.length > 0 || requiredAssets.length > 0) {
     if (failures.length > 0) {

--- a/site/scripts/link-audit/lib.ts
+++ b/site/scripts/link-audit/lib.ts
@@ -129,11 +129,23 @@ export interface AuditResult {
   pageCount: number;
 }
 
-/** Run the full dangling-link + base-safety audit against a built dist/ dir. */
+/** Run the full dangling-link + base-safety audit against a built dist/ dir.
+ *
+ * A non-empty page inventory is an explicit invariant: "audited every page and
+ * found no problems" and "found no pages to audit" must not both report green.
+ * A generator or build regression that emits zero HTML pages is recorded as a
+ * failure rather than silently producing an empty, passing result.
+ */
 export function auditDist(distRoot: string, base: string = BASE): AuditResult {
   const pages = htmlFiles(distRoot);
   const failures: AuditFailure[] = [];
   let checked = 0;
+
+  if (pages.length === 0) {
+    failures.push({
+      message: `${distRoot}  ->  audit found zero HTML pages (nothing was audited — build or generator regression?)`,
+    });
+  }
 
   for (const page of pages) {
     // The page's URL directory, base-prefixed, in posix form.

--- a/site/test/astro-config.test.ts
+++ b/site/test/astro-config.test.ts
@@ -1,0 +1,53 @@
+/** astro-config.test.ts — the base-path-safety mechanism, pinned.
+ *
+ * `rehypeBaseLinks` is what stops root-absolute markdown links (`](/overview)`)
+ * from 404-ing once the site is served from the `/codeArbiter/` subpath. Its
+ * unit test (rehype-base-links.test.ts) proves the plugin transforms a HAST
+ * tree; nothing proved the plugin was still *wired into Astro* or that the
+ * wiring used a supported API.
+ *
+ * Astro 7.1 deprecated `markdown.remarkPlugins` / `markdown.rehypePlugins` /
+ * `markdown.remarkRehype` ("will be removed in a future major") in favour of
+ * `markdown.processor: unified({ ... })` from `@astrojs/markdown-remark`. A
+ * silent removal of those keys in Astro 8 would drop the plugin and un-base
+ * every markdown link. These cases fail if the config regresses onto the
+ * deprecated keys, and fail if the configured processor stops base-prefixing.
+ */
+import { describe, it, expect } from "vitest";
+import { isUnifiedProcessor } from "@astrojs/markdown-remark";
+// astro.config.mjs is plain JS outside the tsconfig program; the shape we
+// assert on is checked here at runtime instead.
+// @ts-expect-error -- untyped .mjs config module
+import config from "../astro.config.mjs";
+
+const BASE = "/codeArbiter";
+
+describe("astro.config markdown wiring", () => {
+  it("configures no markdown plugins through the deprecated top-level keys", () => {
+    expect(config.markdown?.remarkPlugins).toBeUndefined();
+    expect(config.markdown?.rehypePlugins).toBeUndefined();
+    expect(config.markdown?.remarkRehype).toBeUndefined();
+  });
+
+  it("wires the base-path plugin onto an explicit unified processor", () => {
+    const processor = config.markdown?.processor;
+    expect(processor).toBeDefined();
+    expect(isUnifiedProcessor(processor)).toBe(true);
+    expect(processor.options.rehypePlugins).toHaveLength(1);
+  });
+
+  it("base-prefixes a root-absolute markdown link through the configured processor", async () => {
+    const renderer = await config.markdown.processor.createRenderer({});
+    const { code } = await renderer.render("[Overview](/overview)");
+
+    expect(code).toContain(`href="${BASE}/overview"`);
+    expect(code).not.toContain(`href="/overview"`);
+  });
+
+  it("leaves an external link untouched through the configured processor", async () => {
+    const renderer = await config.markdown.processor.createRenderer({});
+    const { code } = await renderer.render("[GitHub](https://github.com/arbiterForge/codeArbiter)");
+
+    expect(code).toContain(`href="https://github.com/arbiterForge/codeArbiter"`);
+  });
+});

--- a/site/test/link-audit/cli.test.ts
+++ b/site/test/link-audit/cli.test.ts
@@ -7,14 +7,29 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SITE_ROOT = join(HERE, "..", "..");
 const CLI = join(SITE_ROOT, "scripts", "link-audit.ts");
-const TSX_CLI = join(SITE_ROOT, "node_modules", "tsx", "dist", "cli.mjs");
+
+/** The production default the CLI falls back to when given no argument. */
+const DEFAULT_DIST = join(SITE_ROOT, "dist");
+
+// Resolve tsx's executable from its own `bin` field rather than hardcoding
+// `node_modules/tsx/dist/cli.mjs`. tsx is ranged `^4.19.2`, so a minor bump
+// that relocates or renames that entrypoint would otherwise break every case
+// in this file.
+const require_ = createRequire(import.meta.url);
+const TSX_PKG_JSON = require_.resolve("tsx/package.json");
+const TSX_BIN = require_("tsx/package.json").bin;
+const TSX_CLI = resolve(
+  dirname(TSX_PKG_JSON),
+  typeof TSX_BIN === "string" ? TSX_BIN : TSX_BIN.tsx,
+);
 
 const dists: string[] = [];
 
@@ -46,11 +61,17 @@ function runCli(distArg: string): { status: number | null; stdout: string; stder
 }
 
 describe("link-audit CLI", () => {
-  it("exits non-zero when the dist directory does not exist", () => {
+  it("exits non-zero and reports the given dist when that directory does not exist", () => {
     const missing = join(tmpdir(), "link-audit-cli-does-not-exist-xyz");
     const { status, stderr } = runCli(missing);
+
     expect(status).toBe(1);
-    expect(stderr).toContain("dist not found");
+    // Asserting only "dist not found" would pass vacuously against a CLI that
+    // ignores argv: it would report its own default site/dist and exit 1 for
+    // its own reason. Pinning the *argument* path — and pinning that the
+    // default is NOT the path reported — is what exercises argv handling.
+    expect(stderr).toContain(`dist not found at ${missing}`);
+    expect(stderr).not.toContain(DEFAULT_DIST);
   }, 60_000);
 
   it("exits non-zero on a zero-page dist even with both required assets present", () => {

--- a/site/test/link-audit/cli.test.ts
+++ b/site/test/link-audit/cli.test.ts
@@ -1,0 +1,76 @@
+/** cli.test.ts — end-to-end exit-code coverage for scripts/link-audit.ts.
+ *
+ * lib.test.ts proves the pure audit functions; this unit proves the CLI
+ * actually turns those results into the right process exit code. Without it a
+ * regression in the CLI's success/failure branch could let a red audit exit 0.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SITE_ROOT = join(HERE, "..", "..");
+const CLI = join(SITE_ROOT, "scripts", "link-audit.ts");
+const TSX_CLI = join(SITE_ROOT, "node_modules", "tsx", "dist", "cli.mjs");
+
+const dists: string[] = [];
+
+afterAll(() => {
+  for (const d of dists) rmSync(d, { recursive: true, force: true });
+});
+
+/** Build a throwaway dist/ with the pinned chrome assets plus `pages`. */
+function makeDist(pages: Record<string, string>): string {
+  const dist = mkdtempSync(join(tmpdir(), "link-audit-cli-"));
+  dists.push(dist);
+  writeFileSync(join(dist, "favicon.svg"), "<svg/>");
+  mkdirSync(join(dist, "_astro"), { recursive: true });
+  writeFileSync(join(dist, "_astro", "logo.abc123.svg"), "<svg/>");
+  for (const [rel, contents] of Object.entries(pages)) {
+    const full = join(dist, ...rel.split("/"));
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return dist;
+}
+
+function runCli(distArg: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [TSX_CLI, CLI, distArg], {
+    encoding: "utf8",
+    cwd: SITE_ROOT,
+  });
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+describe("link-audit CLI", () => {
+  it("exits non-zero when the dist directory does not exist", () => {
+    const missing = join(tmpdir(), "link-audit-cli-does-not-exist-xyz");
+    const { status, stderr } = runCli(missing);
+    expect(status).toBe(1);
+    expect(stderr).toContain("dist not found");
+  }, 60_000);
+
+  it("exits non-zero on a zero-page dist even with both required assets present", () => {
+    const dist = makeDist({});
+    const { status, stderr } = runCli(dist);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/zero HTML pages/i);
+  }, 60_000);
+
+  it("exits zero on a minimal complete dist", () => {
+    const dist = makeDist({ "index.html": `<a href="/codeArbiter/favicon.svg">icon</a>` });
+    const { status, stdout } = runCli(dist);
+    expect(status).toBe(0);
+    expect(stdout).toContain("link-audit: OK");
+  }, 60_000);
+
+  it("exits non-zero on a dangling internal link", () => {
+    const dist = makeDist({ "index.html": `<a href="/codeArbiter/missing/">dangling</a>` });
+    const { status, stderr } = runCli(dist);
+    expect(status).toBe(1);
+    expect(stderr).toContain("link failure");
+  }, 60_000);
+});

--- a/site/test/link-audit/lib.test.ts
+++ b/site/test/link-audit/lib.test.ts
@@ -1,14 +1,38 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   extractTargets,
   isExternalOrSkippable,
   resolveToDistFile,
   auditDist,
+  missingRequiredAssets,
   BASE,
 } from "../../scripts/link-audit/lib";
+
+/** Build a throwaway dist/ tree. `assets` controls the chrome the audit pins;
+ * `pages` is a map of dist-relative path -> file contents. */
+function makeDist(options: {
+  favicon?: boolean;
+  astroDir?: boolean;
+  logoName?: string | null;
+  pages?: Record<string, string>;
+}): string {
+  const { favicon = true, astroDir = true, logoName = "logo.abc123.svg", pages = {} } = options;
+  const dist = mkdtempSync(join(tmpdir(), "link-audit-test-"));
+  if (favicon) writeFileSync(join(dist, "favicon.svg"), "<svg/>");
+  if (astroDir) {
+    mkdirSync(join(dist, "_astro"), { recursive: true });
+    if (logoName !== null) writeFileSync(join(dist, "_astro", logoName), "<svg/>");
+  }
+  for (const [rel, contents] of Object.entries(pages)) {
+    const full = join(dist, ...rel.split("/"));
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return dist;
+}
 
 describe("extractTargets", () => {
   it("pulls href and src attribute values out of raw HTML", () => {
@@ -130,4 +154,112 @@ describe("auditDist", () => {
     expect(messages.some((m) => m.includes("good link"))).toBe(false);
     expect(result.failures.length).toBe(2);
   });
+});
+
+describe("auditDist page-inventory invariant", () => {
+  const dists: string[] = [];
+
+  afterAll(() => {
+    for (const d of dists) rmSync(d, { recursive: true, force: true });
+  });
+
+  function track(dist: string): string {
+    dists.push(dist);
+    return dist;
+  }
+
+  it("fails an existing but HTML-empty dist even when both required assets are present", () => {
+    // A generator/build regression that emits no pages must not read as green:
+    // "found nothing wrong" and "looked at nothing" are different outcomes.
+    const dist = track(makeDist({ pages: {} }));
+
+    const result = auditDist(dist, BASE);
+
+    expect(result.pageCount).toBe(0);
+    expect(missingRequiredAssets(dist)).toEqual([]);
+    expect(result.failures.length).toBeGreaterThan(0);
+    expect(result.failures.some((f) => /zero HTML pages/i.test(f.message))).toBe(true);
+  });
+
+  it("fails a dist that contains only non-HTML files", () => {
+    const dist = track(makeDist({ pages: { "robots.txt": "User-agent: *" } }));
+
+    const result = auditDist(dist, BASE);
+
+    expect(result.pageCount).toBe(0);
+    expect(result.failures.some((f) => /zero HTML pages/i.test(f.message))).toBe(true);
+  });
+
+  it("passes a minimal one-page dist, preserving the single-item boundary", () => {
+    const dist = track(
+      makeDist({
+        pages: { "index.html": `<a href="/codeArbiter/favicon.svg">icon</a>` },
+      }),
+    );
+
+    const result = auditDist(dist, BASE);
+
+    expect(result.pageCount).toBe(1);
+    expect(result.checked).toBe(1);
+    expect(result.failures).toEqual([]);
+    expect(missingRequiredAssets(dist)).toEqual([]);
+  });
+});
+
+describe("missingRequiredAssets", () => {
+  const dists: string[] = [];
+
+  afterAll(() => {
+    for (const d of dists) rmSync(d, { recursive: true, force: true });
+  });
+
+  const cases: Array<{
+    name: string;
+    options: Parameters<typeof makeDist>[0];
+    expected: string[];
+  }> = [
+    {
+      name: "a complete build reports nothing missing",
+      options: {},
+      expected: [],
+    },
+    {
+      name: "a missing favicon is reported",
+      options: { favicon: false },
+      expected: ["dist/favicon.svg"],
+    },
+    {
+      name: "a missing _astro directory is reported as a missing logo",
+      options: { astroDir: false },
+      expected: ["dist/_astro/logo.*.svg"],
+    },
+    {
+      name: "an _astro directory with no logo asset is reported",
+      options: { logoName: null },
+      expected: ["dist/_astro/logo.*.svg"],
+    },
+    {
+      name: "an unhashed logo.svg does not satisfy the hashed-logo pin",
+      options: { logoName: "logo.svg" },
+      expected: ["dist/_astro/logo.*.svg"],
+    },
+    {
+      name: "a differently named hashed svg does not satisfy the hashed-logo pin",
+      options: { logoName: "brand.abc123.svg" },
+      expected: ["dist/_astro/logo.*.svg"],
+    },
+    {
+      name: "both assets missing are reported together",
+      options: { favicon: false, astroDir: false },
+      expected: ["dist/favicon.svg", "dist/_astro/logo.*.svg"],
+    },
+  ];
+
+  for (const { name, options, expected } of cases) {
+    it(name, () => {
+      const dist = makeDist(options);
+      dists.push(dist);
+      expect(missingRequiredAssets(dist)).toEqual(expected);
+    });
+  }
 });


### PR DESCRIPTION
Closes #379
Closes #400

Lane `L04-site-deps-and-audit`. Two issues, both scoped to `site/`. No `plugins/**` file is touched, so no payload version bump is required — confirmed with `python tools/build-host-packages.py --check --release-guard-base a3a2df2` ("no Pi payload change - version bump not required").

> **Correction notice (commit `d81c093`).** An earlier revision of this body and of commit `570f7a7` claimed that `astro build` **hard-failed** until `@astrojs/markdown-remark` was added as a direct dependency. **That claim was false and has been retracted** — see [Correction: the `@astrojs/markdown-remark` justification](#correction-the-astrojsmarkdown-remark-justification) below for the falsifying experiment and the correct justification. The dependency is kept, on different and now-verified grounds. Credit to the branch reviewer, who reproduced a clean install and falsified it.

---

## #379 — zero-page and required-asset failure coverage

### The defect

`auditDist()` returned `failures: []` when `htmlFiles()` found zero pages, and the CLI treated "zero failures + both chrome assets present" as success. The audit therefore could not distinguish **"audited everything and found no problems"** from **"audited nothing"**. A generator/build regression that emitted no HTML would have reported green as long as `favicon.svg` and a hashed logo survived.

Separately, `missingRequiredAssets()` had **no tests at all** — it was never imported by the test unit.

### Changes

- `site/scripts/link-audit/lib.ts` — `auditDist()` now pushes a failure when the page inventory is empty. A non-empty inventory is an explicit audit invariant.
- `site/scripts/link-audit.ts` — accepts an optional dist-dir positional argument (defaults to `site/dist`) so the CLI's exit-code behavior is testable against fixture trees. Production usage (`npm run link-audit`) is unchanged.
- `site/test/link-audit/lib.test.ts` — new `auditDist page-inventory invariant` block (empty dist, non-HTML-only dist, minimal one-page dist) plus a table-driven `missingRequiredAssets` block covering every branch: complete build, missing favicon, missing `_astro`, `_astro` present but no logo, unhashed `logo.svg`, non-matching `brand.abc123.svg`, both missing.
- `site/test/link-audit/cli.test.ts` — **new file**, spawns the real CLI and asserts the actual process exit code for: missing dist, zero-page dist, minimal complete dist, dangling link.

### Red-test evidence (verbatim)

Tests written first, run against unmodified source. 5 failures across 2 files:

```
 ❯ test/link-audit/lib.test.ts (24 tests | 2 failed) 22ms
   ✓ auditDist > resolves base-prefixed internal links and reports base-less ones and dangling ones as failures 1ms
   × auditDist page-inventory invariant > fails an existing but HTML-empty dist even when both required assets are present 4ms
     → expected 0 to be greater than 0
   × auditDist page-inventory invariant > fails a dist that contains only non-HTML files 3ms
     → expected false to be true // Object.is equality
   ✓ auditDist page-inventory invariant > passes a minimal one-page dist, preserving the single-item boundary 2ms
```

```
 FAIL  test/link-audit/lib.test.ts > auditDist page-inventory invariant > fails an existing but HTML-empty dist even when both required assets are present
AssertionError: expected 0 to be greater than 0
 ❯ test/link-audit/lib.test.ts:180:36
    178|     expect(result.pageCount).toBe(0);
    179|     expect(missingRequiredAssets(dist)).toEqual([]);
    180|     expect(result.failures.length).toBeGreaterThan(0);
       |                                    ^
```

```
 FAIL  test/link-audit/cli.test.ts > link-audit CLI > exits zero on a minimal complete dist
AssertionError: expected 1 to be +0 // Object.is equality
 ❯ test/link-audit/cli.test.ts:66:20
```

```
 Test Files  2 failed (2)
      Tests  5 failed | 23 passed (28)
```

Every failure is the defect, not a wiring error:
- the two `lib.test.ts` failures are the missing zero-page invariant;
- the three `cli.test.ts` failures are the CLI ignoring its dist argument and always resolving `site/dist` (which does not exist in a fresh checkout), so it could not be pointed at a fixture at all.

### Honest note on what was NOT red

The seven `missingRequiredAssets` cases **passed on arrival**. That function's logic was already correct; the issue against it is a pure coverage gap ("only the current good build exercises them"), so these are characterization tests that lock the existing branches in. They prove nothing about a fix because there was no fix to make there. The genuinely red work is the zero-page invariant and the CLI exit-code unit.

The reviewer mutation-tested those seven anyway — loosening the hashed-logo regex from `/^logo\..*\.svg$/` to `/\.svg$/` turned 2 of them red — so they do catch regressions even though they were not red-first.

### Fixed after review: one CLI case was vacuous

The reviewer showed that `exits non-zero when the dist directory does not exist` stayed **green** when `scripts/link-audit.ts` was reverted (revert run: 3 failed, 1 passed). It passed for the wrong reason: the pre-argv CLI ignored `process.argv` entirely and resolved the non-existent default `site/dist`, producing the same exit 1 and the same `dist not found` stderr. It proved nothing about the new argument handling.

It now pins the **argument** path and pins that the default is *absent* from stderr:

```ts
expect(stderr).toContain(`dist not found at ${missing}`);
expect(stderr).not.toContain(DEFAULT_DIST);
```

Re-run of the reviewer's exact experiment (`git show origin/main:site/scripts/link-audit.ts > site/scripts/link-audit.ts`, `site/dist` removed) — **4 failed** where it was previously 3:

```
 × link-audit CLI > exits non-zero and reports the given dist when that directory does not exist 192ms
   → expected 'link-audit: dist not found at C:\User…' to contain 'dist not found at C:\Users\brenn\AppD…'
 × link-audit CLI > exits non-zero on a zero-page dist even with both required assets present 189ms
   → expected 'link-audit: dist not found at C:\User…' to match /zero HTML pages/i
 × link-audit CLI > exits zero on a minimal complete dist 180ms
   → expected 1 to be +0 // Object.is equality
 × link-audit CLI > exits non-zero on a dangling internal link 188ms
   → expected 'link-audit: dist not found at C:\User…' to contain 'link failure'

- Expected
+ Received
- dist not found at C:\Users\brenn\AppData\Local\Temp\link-audit-cli-does-not-exist-xyz
+ link-audit: dist not found at C:\Users\brenn\projects\codeArbiter\...\site\dist. Run `npm run build` first.
```

All four CLI cases now go red without the implementation.

Also addressed from the same review: `cli.test.ts` no longer hardcodes `node_modules/tsx/dist/cli.mjs`. `tsx` is ranged `^4.19.2`, so a minor bump that relocated that entrypoint would have broken every case in the file; the path is now read from tsx's own `bin` field via `createRequire`.

---

## #400 — vulnerable docs-site build dependencies

### `npm audit --omit=dev` BEFORE

```
astro  <=7.0.9   — high — 4 XSS / origin-check advisories; depends on vulnerable sharp
postcss  <=8.5.17 — high — GHSA-r28c-9q8g-f849 (path traversal via sourceMappingURL)
sharp  <0.35.0   — high — GHSA-f88m-g3jw-g9cj (libvips CVE-2026-33327/33328/35590/35591)
svgo  4.0.0-4.0.1 — high — GHSA-2p49-hgcm-8545 (removeScripts leaves scripts intact)

4 high severity vulnerabilities
```

### `npm audit` AFTER

```
=== npm audit --omit=dev --audit-level=high ===
found 0 vulnerabilities
PROD_EXIT=0

=== npm audit (including dev) ===
found 0 vulnerabilities
FULL_EXIT=0
```

All four ACs on #400 hold: Astro > 7.0.9, SVGO >= 4.0.2, no sharp copy below 0.35.0 (one deduped 0.35.3, all platform binaries present in the lockfile so Linux CI resolves), and build/test/typecheck/link-audit all pass.

### What moved

| Package | Before | After | Manifest range changed? |
|---|---|---|---|
| `sharp` | 0.33.5 | 0.35.3 | **yes** — `^0.33.5` → `^0.35.0` |
| `astro` | 7.0.3 | 7.1.3 | no — already `^7.0.3` |
| `@astrojs/starlight` | 0.41.1 | 0.41.4 | no — already `^0.41.1` |
| `svgo` (transitive) | 4.0.1 | 4.0.2 | n/a |
| `postcss` (transitive) | 8.5.15 | 8.5.23 | n/a |
| `@astrojs/markdown-remark` | (transitive only) | 7.2.1 | **new direct dependency** — justified below |

**Two non-minimal moves:**

1. **sharp `^0.33.5` → `^0.35.0` is a 0.x major.** `npm audit` said so ("Will install sharp@0.35.3, which is a breaking change"). It is unavoidable — the libvips advisory's fix line is 0.35.0 and there is no 0.34.x or 0.33.x patch. Verified: `npm run build` renders all 129 pages including the Starlight logo/favicon assets sharp processes, and `npm test` is green.

2. **Astro 7.0.3 → 7.1.3 is a minor.** The advisory range is `astro <=7.0.9` and **there is no 7.0.10** — `npm view astro versions` shows 7.0.x stops at 7.0.9, so 7.1.0 is the first non-vulnerable release. The minor bump is forced. Its two consequences — a new direct dependency and a deprecated API — are covered in the next two sections.

---

## Correction: the `@astrojs/markdown-remark` justification

### What was claimed, and why it was wrong

The original body and commit `570f7a7` claimed that with Astro 7.1.3 and no direct `@astrojs/markdown-remark`, `astro build` **hard-failed with exit 1** at config validation, because the package sat "nested under `@astrojs/mdx/node_modules`, not hoisted, so Astro's own `await import(...)` could not resolve it (confirmed `ERR_MODULE_NOT_FOUND`)".

**That is false.** It described an incrementally-mutated `node_modules`, not a clean resolve — and CI runs `npm ci` from the committed lockfile, never that tree. The reviewer falsified it, and it was re-falsified on this branch before writing this section.

### The falsifying experiment (reproducible)

On this branch, in `site/`: delete `@astrojs/markdown-remark` from `package.json`, delete `package-lock.json`, delete `node_modules`, then `npm install`.

```
$ node --input-type=module -e "await import('@astrojs/markdown-remark')"
IMPORT STILL OK (hoisted transitive)

$ node -e "const {createRequire}=require('module');
  const r=createRequire(require('path').resolve('node_modules/astro/dist/core/config/validate.js'));
  console.log(r.resolve('@astrojs/markdown-remark'))"
...\site\node_modules\@astrojs\markdown-remark\dist\index.js

$ npm run build
[build] 129 page(s) built in 4.73s
[build] Complete!
BUILD_EXIT=0
```

npm **hoists** `@astrojs/mdx`'s copy to the site root. Both a bare `import` from the site root and the `createRequire` resolve from Astro's own `validate.js` succeed, and the full build completes. There is no `ERR_MODULE_NOT_FOUND`, no "no longer installed by default" error, and no exit 1.

This was re-run a second time **after** the config migration below, with the same result (`BUILD_EXIT=0`, 129 pages). So the dependency is **elective, not forced**, in both the old and the new config shape. No claim to the contrary remains in this PR or in the branch history.

### Why it is kept anyway

Three verified reasons:

1. **First-party source now imports it.** `site/astro.config.mjs` imports `{ unified } from "@astrojs/markdown-remark"` (see the migration below). A first-party import of a package that is only present because npm happened to hoist a transitive is a textbook **phantom dependency**; it must be declared.

2. **The hoisted version is decided by an unrelated transitive, and they disagree.** In this repo's committed lockfile, `@astrojs/mdx@7.0.0` requires `@astrojs/markdown-remark@7.2.0` **exactly**, while `astro@7.1.3` declares its optional peer at `7.2.1` **exactly**. Whatever `mdx` happens to pin is what would get hoisted. Declaring `^7.2.1` directly is what puts the version Astro actually expects at the site root; `mdx` keeps its own nested `7.2.0`. Both facts are readable straight out of `site/package-lock.json`.

3. **Upstream expects the consumer to declare it.** Both `astro@7.1.3` and `@astrojs/starlight@0.41.4` list it under `peerDependenciesMeta` as `{"optional": true}` — npm does not install optional peers for you; the consumer declares it when it uses the optional feature. This site uses it.

---

## Disclosure: the Astro bump moved the base-path plugin onto a deprecated API — now migrated

Not disclosed in the original body; raised by the reviewer.

Astro 7.1 **deprecated** `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype`. Both the pre-fix branch build and the reviewer's control build emitted:

```
[astro] `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype`
are deprecated. Pass them to `unified({...})` from `@astrojs/markdown-remark` directly instead.
```

`astro/dist/core/config/validate.js` marks the removal as scheduled, and `@astrojs/internal-helpers` types them `@deprecated Use markdown.processor: unified({ rehypePlugins }) instead`.

That matters because the key held **`rehypeBaseLinks(BASE)`** — the plugin that base-prefixes every root-absolute markdown link so pages served from `/codeArbiter/` do not 404. `astro.config.mjs`'s own comment calls it the load-bearing base-path-safety pattern for downstream authors. This PR had quietly parked it on an API with a scheduled removal.

**Migrated rather than deferred** (commit `d81c093`) — it is a three-line config change, not scope creep:

```js
- markdown: {
-   rehypePlugins: [rehypeBaseLinks(BASE)],
- },
+ markdown: {
+   processor: unified({ rehypePlugins: [rehypeBaseLinks(BASE)] }),
+ },
```

**Behaviour-neutral, and that is checkable rather than asserted.** Astro's own compatibility shim did literally this: when `rehypePlugins` is set and no `processor` is, it runs `md.processor = unified()` and pushes the legacy arrays onto `processor.options` — then warns. Setting `processor` explicitly is the same object graph with the warning removed.

Proof it still works:
- `npm run build` now emits **zero** deprecation output (`grep -ci deprecated` over the build log: `0`), and still produces **129 pages, `[build] Complete!`**.
- `npm run link-audit` still reports **`OK — 18484 internal link(s) across 135 page(s)`** — byte-identical counts to before. `src/content/docs/**.md` does contain root-absolute `](/...)` links, and the audit fails those as "outside base path" when unprefixed, so a green audit over the same 18484 links is direct evidence the plugin still ran.

**New regression guard.** Nothing in `npm test` covered the config wiring — `rehype-base-links.test.ts` proves the plugin transforms a HAST tree but not that Astro is still calling it. `site/test/astro-config.test.ts` (new, 4 cases) closes that: it fails if the config regresses onto the deprecated keys, asserts the configured processor is a `unified` processor carrying the plugin, and renders `[Overview](/overview)` through that processor asserting it emits `href="/codeArbiter/overview"`.

Red-first, against the unmigrated config:

```
 FAIL  test/astro-config.test.ts > astro.config markdown wiring > configures no markdown plugins through the deprecated top-level keys
AssertionError: expected [ [Function anonymous] ] to be undefined
 ❯ test/astro-config.test.ts:28:44

 FAIL  test/astro-config.test.ts > astro.config markdown wiring > wires the base-path plugin onto an explicit unified processor
AssertionError: expected undefined to be defined
 ❯ test/astro-config.test.ts:34:23

 FAIL  test/astro-config.test.ts > astro.config markdown wiring > base-prefixes a root-absolute markdown link through the configured processor
TypeError: Cannot read properties of undefined (reading 'createRenderer')
 ❯ test/astro-config.test.ts:40:54

 FAIL  test/astro-config.test.ts > astro.config markdown wiring > leaves an external link untouched through the configured processor
TypeError: Cannot read properties of undefined (reading 'createRenderer')
 ❯ test/astro-config.test.ts:48:54

 Test Files  1 failed (1)
      Tests  4 failed (4)
```

Green after the migration: `4 passed`.

No follow-up issue is needed — the deprecated API is gone from this repo.

---

## Dependency review — `@astrojs/markdown-remark@7.2.1` — 2026-07-24

The reviewer correctly flagged that a new direct dependency was added without routing through `/ca:add-dep` → `dependency-reviewer`, which `core/surface/includes/routing-table.md:28` prescribes and which `core/pysrc/post-write-edit.py` H-07 nudges on any `package.json` write. That nudge is advisory (non-blocking) by its own module docstring, so no hard gate was bypassed — but the vetting was owed and had not been recorded. Performed inline here against `.codearbiter/security-controls.md` and `.codearbiter/tech-stack.md`, in the `dependency-reviewer` agent's output format.

### License: MIT — PASS
`package.json` `license: "MIT"`; npm registry metadata agrees. MIT is on the approved SPDX list in `security-controls.md`.

**Full-lockfile license delta vs `origin/main`: no new license class is introduced.** Scanning every `packages` entry in both lockfiles for identifiers outside the approved set returns the *same* four already-documented categories on both sides:

| Category | On `origin/main` | On this branch | Status |
|---|---|---|---|
| `<no SPDX field>` (`@bruits/satteri-*`) | 10 | 10 | documented in `security-controls.md` — accepted as MIT (packaging mislabel) |
| `Apache-2.0 AND LGPL-3.0-or-later [AND MIT]` (`@img/sharp-*`) | 7 | 4 | approved build-time `site/` only; **count drops** as astro's nested sharp dedupes |
| `Python-2.0` (`argparse`) | 1 | 1 | documented mislabel — upstream is MIT |

The two newly-added transitives, `@img/sharp-freebsd-wasm32` and `@img/sharp-webcontainers-wasm32` (both `0.35.3`), are **Apache-2.0** — approved, and both marked `optional: true`.

### Provenance: registry.npmjs.org + SLSA provenance attestation — PASS
- `resolved: https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz` with a pinned `sha512` integrity hash. `security-controls.md` names `https://registry.npmjs.org` as the only approved registry.
- Lockfile-wide check: **0** entries resolve to a non-`registry.npmjs.org` source (no `git+`, `file:`, or `http:`), and **0** entries are missing an integrity hash.
- `dist.signatures`: present (1). `dist.attestations`: SLSA `https://slsa.dev/provenance/v1` predicate — the artifact is build-attested, not just signed.
- `repository`: `git+https://github.com/withastro/astro.git`, `directory: packages/markdown/remark` — it is a package **of the Astro monorepo itself**, the same repo that publishes `astro` (already a direct dependency). Not a third party adjacent to Astro.

### Maintenance signal: last publish 2026-07-02 (22 days ago), 182 versions since 2021-09 — PASS
Not deprecated (`npm view ... deprecated` is empty). Maintainers are Astro core (`fredkschott`, `matthewp`). Release cadence over the last five versions is roughly monthly (7.1.0 → 7.2.1 across 2026-03 → 2026-07). No abandonment signal.

### Known CVEs: 0 critical, 0 high — PASS
`tech-stack.md`'s configured gate is `npm audit --omit=dev --audit-level=critical`. Run at the stricter `--audit-level=high` *and* including dev:

```
npm audit --omit=dev --audit-level=high  ->  found 0 vulnerabilities  (exit 0)
npm audit                                ->  found 0 vulnerabilities  (exit 0)
```

Clearing these is the point of #400; the new dependency adds none back.

### Supply chain: no install scripts — PASS
- `scripts`: `prepublish`, `build`, `build:ci`, `dev`, `test` only. **No `preinstall`, `install`, or `postinstall`** — nothing executes on `npm ci`. (The one install-script warning in this tree is pre-existing `esbuild@0.28.1`, unrelated to this dependency.)
- 17 direct dependencies, all mainstream unified/remark/rehype ecosystem packages (`unified`, `remark-parse`, `remark-rehype`, `rehype-raw`, `hast-util-*`, `vfile`, …) plus two `@astrojs/*` siblings. Proportionate for a markdown processor; nothing anomalous for the stated purpose.
- Typosquatting: not applicable — scoped `@astrojs`, the official Astro org, which already owns two of this project's existing direct dependencies.
- Net new packages in the tree from this dependency: **none**. It was already resolved transitively before this PR; declaring it changes hoisting, not membership.

### CRITICAL findings (0)
none

### HIGH findings (0)
none

### MEDIUM findings (0)
none

### LOW findings (1)

**Severity:** LOW
**Package:** `@astrojs/markdown-remark@7.2.1`
**Description:** The lockfile carries two copies at different exact versions — `7.2.1` hoisted at the root (this dependency) and `7.2.0` nested under `@astrojs/mdx@7.0.0`, which pins that exact version. Harmless (each consumer gets the version it declares, and `astro@7.1.3`'s optional peer of exactly `7.2.1` is satisfied at the root), but it is a duplicate in the graph.
**Remediation:** None required. It resolves on its own when a future `@astrojs/starlight` pulls an `@astrojs/mdx` that requires `7.2.1`. Noted, not actioned.

### Gate status
**PASS** (0 CRITICAL, 0 HIGH). Nothing to block on.

*Process note: this is vetting recorded after the fact, not a claim that `/ca:add-dep` was routed at install time. It was not, and that was a gap.*

---

## Verification

Re-run after `npm ci` from the committed lockfile (what CI does), at HEAD `d81c093`:

| Check | Command | Result |
|---|---|---|
| site suite | `cd site && npm test` | **438 passed / 38 files** |
| typecheck | `npx tsc --noEmit` | clean, exit 0 |
| build | `npm run build` | **129 pages, `Complete!`**, exit 0, **zero deprecation warnings** |
| link audit | `npm run link-audit` | `OK — 18484 internal link(s) across 135 page(s)`, exit 0 |
| prod audit | `npm audit --omit=dev --audit-level=high` | `found 0 vulnerabilities`, exit 0 |
| full audit | `npm audit` | `found 0 vulnerabilities`, exit 0 |
| payload gate | `tools/build-host-packages.py --check` | "no Pi payload change - version bump not required" |

### Test counts

| Suite | Before | At `570f7a7` | Now |
|---|---|---|---|
| site (full) | 420 passed / 36 files | 434 / 37 | **438 / 38** |
| site link-audit only | 14 / 1 | 28 / 2 | 28 / 2 |

The +4 since `570f7a7` is `test/astro-config.test.ts`. `site/package.json` and `site/package-lock.json` are **unchanged** by the follow-up commit — the config migration needed no dependency-graph change.

There is **no unit test that can assert "dependencies are not vulnerable"** — stating that plainly. The standing guard lands separately as #403.

Only `site/` is touched: no `plugins/**`, no `core/pysrc`, no `core/surface`, no committed esbuild artifact. `git diff --check` clean; all changed files LF.

---

## NEEDS-TRIAGE

1. **`site/` has no `npm audit` gate in CI at all.** `.github/workflows/docs.yml` runs no `npm audit` step for `site/` — the package this PR just fixed — so nothing prevents #400 from recurring. Separately, `.github/workflows/ci.yml:205` and `:239` run `npm audit --omit=dev --audit-level=critical` for `plugins/ca/tools` and `plugins/ca-sandbox/tools`; four **high**-severity advisories would not have failed that gate, which is consistent with #400 having to be found by a tribunal audit rather than by CI. This is the real standing guard #403 needs to build, and the reviewer agreed it deserves priority. Flagging rather than fixing.

2. **GitHub reports 9 open Dependabot advisories on the default branch** (5 high, 3 moderate, 1 low) — surfaced on push. This PR clears only `site/`. The remainder are in other packages and outside this lane.

3. **`site/node_modules` exists as an empty directory in fresh worktrees**, which lets `npm test` silently resolve `vitest` from the monorepo root instead of from `site/`. It works, but a worktree can then run the site suite against a dependency tree that is not the one `site/package-lock.json` describes. Not a defect in shipped code; noting it because it made the pre-install baseline in this lane ambiguous until `npm install` was run.

4. **The `/ca:add-dep` gate is advisory only.** `add-dep.md` says so itself ("orchestrator-enforced, not hook-enforced ... there is no pre-bash rule that blocks a bare `npm install`"), and this PR is a live example of the gap: a direct dependency landed and the vetting happened only because a reviewer asked for it. A hook-level install block is called out in `add-dep.md` as a possible future enhancement. Not filed as an issue here — deliberate existing contract, flagged for triage.

---

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
