### PR TITLE
fix(ca-codex): reject non-object hook payloads without crashing the adapter

### DIFF
--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -94,6 +94,134 @@ class TestPreToolAdapterLifecycle(unittest.TestCase):
                     proc.stderr.close()
 
 
+class TestPreToolAdapterPayloadShape(unittest.TestCase):
+    """#409: Codex delivers ONE JSON object on stdin. Every other top-level
+    JSON type (null / array / string / number / bool), an empty stream, and a
+    syntactically invalid stream must all route through the SAME bounded
+    handling path — the documented `decision: block` response at exit 0 — and
+    must never dispatch a guard with an unvalidated payload.
+
+    Before the fix the adapter called `.get()` on the decoded value while
+    catching only TypeError/ValueError, so a valid-JSON non-object payload
+    raised AttributeError out of the process (exit 1, traceback on stderr, no
+    decision emitted at all), and a non-string `tool_name` raised TypeError
+    from the write-tool set membership test one line later. The empty and
+    invalid-JSON legs did not crash but DID spawn pre-bash.py with input the
+    adapter had never validated, where `_hooklib.read_input()`'s documented
+    fail-open silently allowed the gated call.
+    """
+
+    # Every top-level JSON type the RFC allows, minus the object the adapter
+    # actually contracts for.
+    NON_OBJECT_PAYLOADS = ("null", "[]", '["Write"]', '"str"', "3", "-1.5",
+                           "true", "false")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        td = self._tmp.name
+        self.adapter = os.path.join(td, "pre-tool-adapter.py")
+        shutil.copyfile(
+            os.path.join(CODEX_HOOKS, "pre-tool-adapter.py"), self.adapter,
+        )
+        self.launch_log = os.path.join(td, "launched.log")
+        for script in ("pre-write.py", "pre-bash.py"):
+            with open(os.path.join(td, script), "w", encoding="utf-8") as f:
+                f.write(
+                    "import io\n"
+                    f"with io.open({self.launch_log!r}, 'a', encoding='utf-8') "
+                    "as fh:\n"
+                    f"    fh.write({script!r} + '\\n')\n"
+                )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run(self, raw):
+        return subprocess.run(
+            [sys.executable, self.adapter], input=raw, text=True,
+            capture_output=True, timeout=30,
+        )
+
+    def _launched(self):
+        if not os.path.exists(self.launch_log):
+            return []
+        with open(self.launch_log, encoding="utf-8") as f:
+            return f.read().split()
+
+    def assertBoundedBlock(self, res, raw):
+        tag = f"payload {raw!r}"
+        self.assertNotIn("Traceback", res.stderr, f"{tag}: leaked a traceback")
+        self.assertEqual(res.returncode, 0,
+                         f"{tag}: expected a clean exit 0 decision, got "
+                         f"exit={res.returncode} stderr={res.stderr[:300]!r}")
+        try:
+            decision = json.loads(res.stdout)
+        except ValueError:
+            self.fail(f"{tag}: stdout is not a hook decision: {res.stdout!r}")
+        self.assertEqual(decision.get("decision"), "block",
+                         f"{tag}: an unroutable payload must fail closed")
+        reason = decision.get("reason", "")
+        self.assertTrue(reason.startswith("Blocked by codeArbiter policy"), tag)
+        # Bounded: a short deterministic diagnostic, never the payload text or
+        # an exception rendering.
+        self.assertLessEqual(len(reason), 120, f"{tag}: diagnostic not bounded")
+        self.assertEqual(
+            self._launched(), [],
+            f"{tag}: a guard was dispatched with an unvalidated payload")
+
+    def test_non_object_json_payloads_block_without_a_traceback(self):
+        for raw in self.NON_OBJECT_PAYLOADS:
+            with self.subTest(payload=raw):
+                self.assertBoundedBlock(self._run(raw), raw)
+
+    def test_syntactically_invalid_json_blocks_without_dispatching_a_guard(self):
+        for raw in ("{not json", "{", "[1,", "\x00\x01"):
+            with self.subTest(payload=raw):
+                self.assertBoundedBlock(self._run(raw), raw)
+
+    def test_empty_and_whitespace_payloads_block_without_dispatching_a_guard(self):
+        for raw in ("", "   ", "\n\t "):
+            with self.subTest(payload=raw):
+                self.assertBoundedBlock(self._run(raw), raw)
+
+    def test_non_string_tool_name_blocks_instead_of_raising_typeerror(self):
+        # `tool_name in {"apply_patch", "Write", "Edit"}` raises TypeError for
+        # an unhashable value; a wrong-typed tool_name also makes the
+        # write-vs-exec routing decision unknowable, so it fails closed.
+        for value in ('["Write"]', "{}", "3", "true", "null"):
+            raw = '{"hook_event_name": "PreToolUse", "tool_name": %s}' % value
+            with self.subTest(tool_name=value):
+                self.assertBoundedBlock(self._run(raw), raw)
+
+    def test_object_payload_routes_write_tools_to_pre_write(self):
+        for tool in ("apply_patch", "Write", "Edit"):
+            with self.subTest(tool=tool):
+                res = self._run(json.dumps(
+                    {"hook_event_name": "PreToolUse", "tool_name": tool,
+                     "tool_input": {"command": PATCH_ADD}}))
+                self.assertEqual(res.returncode, 0, res.stderr[:300])
+                self.assertEqual(self._launched(), ["pre-write.py"])
+                os.remove(self.launch_log)
+
+    def test_object_payload_routes_other_tools_to_pre_bash(self):
+        for tool in ("Bash", "shell_command", "mcp__github__create_issue"):
+            with self.subTest(tool=tool):
+                res = self._run(json.dumps(
+                    {"hook_event_name": "PreToolUse", "tool_name": tool,
+                     "tool_input": {"command": "ls -la"}}))
+                self.assertEqual(res.returncode, 0, res.stderr[:300])
+                self.assertEqual(self._launched(), ["pre-bash.py"])
+                os.remove(self.launch_log)
+
+    def test_object_payload_without_tool_name_still_routes_to_pre_bash(self):
+        # An ABSENT tool_name keeps its documented default (""), which is not
+        # a write tool — unchanged pre-#409 behavior. Only a present-but-
+        # wrong-typed tool_name is a malformed shape.
+        res = self._run(json.dumps({"hook_event_name": "PreToolUse"}))
+        self.assertEqual(res.returncode, 0, res.stderr[:300])
+        self.assertEqual(self._launched(), ["pre-bash.py"])
+
+
 def _load(path, name):
     spec = importlib.util.spec_from_file_location(name, path)
     mod = importlib.util.module_from_spec(spec)

--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -42,23 +42,64 @@ CODEX_HOOKS = os.path.join(REPO, "plugins", "ca-codex", "hooks")
 CODEX_PLUGIN = os.path.join(REPO, "plugins", "ca-codex")
 
 
+def stage_codex_hooks(td, guard_body):
+    """A real ca-codex hooks tree with the two guard entries stubbed out.
+
+    A fixture holding pre-tool-adapter.py ALONE is not a faithful install:
+    the adapter resolves the repo's activation state through the same shared
+    helpers the guards use (_hooklib.arbiter_active / project_root over the
+    plugin's own _host.py), so those siblings have to be present exactly as
+    they ship. Returns the staged adapter's path.
+    """
+    hooks = os.path.join(td, "hooks")
+    shutil.copytree(CODEX_HOOKS, hooks,
+                    ignore=shutil.ignore_patterns("__pycache__"))
+    for script in ("pre-write.py", "pre-bash.py"):
+        with open(os.path.join(hooks, script), "w", encoding="utf-8",
+                  newline="\n") as f:
+            f.write(guard_body(script))
+    return os.path.join(hooks, "pre-tool-adapter.py")
+
+
+def stage_repo(td, name, enabled):
+    """A throwaway git repo; `enabled` controls the arbiter opt-in marker.
+    Mirrors test_hooks_cold_install.make_fixture — a DORMANT repo is simply
+    one with no .codearbiter/ at all."""
+    root = os.path.join(td, name)
+    os.makedirs(root)
+    subprocess.run(["git", "init", "-q", root], capture_output=True,
+                   text=True, timeout=60)
+    if enabled:
+        ca = os.path.join(root, ".codearbiter")
+        os.makedirs(ca)
+        with open(os.path.join(ca, "CONTEXT.md"), "w", encoding="utf-8",
+                  newline="\n") as f:
+            f.write("---\narbiter: enabled\nstage: 2\n---\n"
+                    "<!--INITIALIZED-->\nadapter fixture.\n")
+    return root
+
+
+def adapter_env():
+    """Codex sets NO project-dir env var, and CodexHost deliberately ignores a
+    CLAUDE_PROJECT_DIR leaked in from an adjacent Claude session (_host.py).
+    Dropping it leaves the fixture's cwd as the only root signal, so these
+    tests cannot accidentally resolve to the developer's own repo."""
+    env = dict(os.environ)
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    return env
+
+
 class TestPreToolAdapterLifecycle(unittest.TestCase):
     def test_adapter_exits_when_stdin_remains_open_and_leaves_no_descendants(self):
         with tempfile.TemporaryDirectory() as td:
-            adapter = os.path.join(td, "pre-tool-adapter.py")
-            shutil.copyfile(
-                os.path.join(CODEX_HOOKS, "pre-tool-adapter.py"), adapter,
-            )
             sentinel = os.path.join(td, "guard-launched")
-            guard = (
+            adapter = stage_codex_hooks(td, lambda script: (
                 "from pathlib import Path\n"
                 "import time\n"
                 f"Path({sentinel!r}).write_text('launched', encoding='utf-8')\n"
                 "time.sleep(60)\n"
-            )
-            for script in ("pre-write.py", "pre-bash.py"):
-                with open(os.path.join(td, script), "w", encoding="utf-8") as f:
-                    f.write(guard)
+            ))
+            repo = stage_repo(td, "repo-enabled", enabled=True)
 
             proc = subprocess.Popen(
                 [sys.executable, adapter],
@@ -66,6 +107,8 @@ class TestPreToolAdapterLifecycle(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                cwd=repo,
+                env=adapter_env(),
             )
             try:
                 started = time.monotonic()
@@ -116,22 +159,18 @@ class TestPreToolAdapterPayloadShape(unittest.TestCase):
     NON_OBJECT_PAYLOADS = ("null", "[]", '["Write"]', '"str"', "3", "-1.5",
                            "true", "false")
 
+    ARBITER_ENABLED_FIXTURE = True
+
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         td = self._tmp.name
-        self.adapter = os.path.join(td, "pre-tool-adapter.py")
-        shutil.copyfile(
-            os.path.join(CODEX_HOOKS, "pre-tool-adapter.py"), self.adapter,
-        )
         self.launch_log = os.path.join(td, "launched.log")
-        for script in ("pre-write.py", "pre-bash.py"):
-            with open(os.path.join(td, script), "w", encoding="utf-8") as f:
-                f.write(
-                    "import io\n"
-                    f"with io.open({self.launch_log!r}, 'a', encoding='utf-8') "
-                    "as fh:\n"
-                    f"    fh.write({script!r} + '\\n')\n"
-                )
+        self.adapter = stage_codex_hooks(td, lambda script: (
+            "import io\n"
+            f"with io.open({self.launch_log!r}, 'a', encoding='utf-8') as fh:\n"
+            f"    fh.write({script!r} + '\\n')\n"
+        ))
+        self.repo = stage_repo(td, "repo", enabled=self.ARBITER_ENABLED_FIXTURE)
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -139,7 +178,7 @@ class TestPreToolAdapterPayloadShape(unittest.TestCase):
     def _run(self, raw):
         return subprocess.run(
             [sys.executable, self.adapter], input=raw, text=True,
-            capture_output=True, timeout=30,
+            capture_output=True, timeout=30, cwd=self.repo, env=adapter_env(),
         )
 
     def _launched(self):
@@ -220,6 +259,115 @@ class TestPreToolAdapterPayloadShape(unittest.TestCase):
         res = self._run(json.dumps({"hook_event_name": "PreToolUse"}))
         self.assertEqual(res.returncode, 0, res.stderr[:300])
         self.assertEqual(self._launched(), ["pre-bash.py"])
+
+
+class TestPreToolAdapterDormancy(TestPreToolAdapterPayloadShape):
+    """codeArbiter is DORMANT in any repo that never opted in — no
+    `.codearbiter/CONTEXT.md` carrying `arbiter: enabled`. The contract, stated
+    verbatim by the cold-install harness (test_hooks_cold_install.py module
+    docstring) and asserted there for pre-bash.py: "the hook layer must take no
+    action — no exit 2, no stdout".
+
+    Every guard enforces that itself (`if not arbiter_active(root): sys.exit(0)`
+    is the first thing pre-bash.py / pre-write.py do). The adapter's unroutable
+    path SHORT-CIRCUITS before any guard runs, so nothing downstream is left to
+    apply the check — the adapter has to make it. Without this, installing
+    ca-codex would make a plugin that is supposed to be inert start emitting
+    `decision: block` in unrelated projects the moment Codex's Windows shell
+    boundary hands over an empty or truncated stream.
+
+    Inherits the fixture and every routing assertion from the enabled case and
+    re-points the repo at a dormant one, so the two halves of the gate can
+    never drift apart: the tests that must still BLOCK are overridden here to
+    assert silence instead, and the routing tests are inherited unchanged
+    (a well-formed payload is still dispatched — the guard applies its own
+    dormancy check, exactly as it did before the adapter existed).
+    """
+
+    ARBITER_ENABLED_FIXTURE = False
+
+    def assertBoundedBlock(self, res, raw):
+        """In a dormant repo the SAME payloads must pass through untouched."""
+        tag = f"payload {raw!r} (dormant repo)"
+        self.assertNotIn("Traceback", res.stderr, f"{tag}: leaked a traceback")
+        self.assertEqual(res.returncode, 0,
+                         f"{tag}: a dormant repo must never see a non-zero exit, "
+                         f"got exit={res.returncode} stderr={res.stderr[:300]!r}")
+        self.assertNotEqual(res.returncode, 2,
+                            f"{tag}: a dormant repo must never be blocked")
+        self.assertEqual(res.stdout, "",
+                         f"{tag}: a dormant repo must produce no stdout — a "
+                         f"decision here blocks a repo that never opted in")
+        self.assertEqual(res.stderr, "", f"{tag}: expected no stderr")
+        self.assertEqual(self._launched(), [],
+                         f"{tag}: no guard may be dispatched")
+
+    def test_incomplete_stdin_is_untouched_in_a_dormant_repo(self):
+        """The pre-existing timed-out-stdin leg is the same short-circuit and
+        the same contract violation: an unclosed stream is a plumbing condition
+        of the shell boundary this shim papers over, not consent to enforce."""
+        proc = subprocess.Popen(
+            [sys.executable, self.adapter],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, text=True, cwd=self.repo,
+            env=adapter_env(),
+        )
+        try:
+            proc.wait(timeout=20)
+            self.assertEqual(proc.returncode, 0)
+            self.assertEqual(proc.stdout.read(), "",
+                             "a dormant repo must produce no stdout")
+            self.assertEqual(self._launched(), [])
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            for stream in (proc.stdin, proc.stdout, proc.stderr):
+                if stream:
+                    stream.close()
+
+
+class TestPreToolAdapterBrokenInstall(unittest.TestCase):
+    """An install whose shared library will not import cannot ANSWER the
+    activation question — and the guards this adapter dispatches import those
+    very same modules, so it cannot enforce anything either. Indeterminate
+    therefore reads as active and the unroutable payload still fails closed:
+    exiting 0 in silence here would turn a broken install into a silent allow,
+    which is the failure mode the whole hook layer exists to prevent."""
+
+    def test_unroutable_payload_fails_closed_when_the_shared_library_is_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            adapter = stage_codex_hooks(td, lambda script: "")
+            os.remove(os.path.join(os.path.dirname(adapter), "_hooklib.py"))
+            repo = stage_repo(td, "repo-dormant", enabled=False)
+            res = subprocess.run(
+                [sys.executable, adapter], input="[]", text=True,
+                capture_output=True, timeout=60, cwd=repo, env=adapter_env())
+            self.assertEqual(res.returncode, 0, res.stderr[:300])
+            self.assertNotIn("Traceback", res.stderr)
+            self.assertEqual(json.loads(res.stdout).get("decision"), "block")
+
+
+class TestPreToolAdapterWriteToolSet(unittest.TestCase):
+    """The adapter routes write-vs-exec off its own literal set because it runs
+    BEFORE the shared helpers are imported. That copy is only safe if it is
+    gated against the canonical source rather than linked by a prose comment —
+    otherwise a change to the Codex host's patch-tool set silently forks
+    routing and an apply_patch alias skips the write gate entirely."""
+
+    def _adapter(self):
+        return _load(os.path.join(CODEX_HOOKS, "pre-tool-adapter.py"),
+                     "codex_adapter_under_test")
+
+    def test_write_tools_matches_the_codex_host_patch_tool_set(self):
+        self.assertEqual(set(self._adapter().WRITE_TOOLS),
+                         set(codex_host()._PATCH_TOOLS))
+
+    def test_write_tools_matches_every_write_category_tool_name(self):
+        host = codex_host()
+        self.assertEqual(
+            set(self._adapter().WRITE_TOOLS),
+            {name for name, cat in host.TOOL_MAP.items() if cat == "WRITE"})
 
 
 def _load(path, name):

--- a/.github/scripts/test_hooks_cold_install.py
+++ b/.github/scripts/test_hooks_cold_install.py
@@ -847,6 +847,23 @@ def run_ca_codex_campaign(hooks, paths, stub_log, enabled, dormant):
             {"hook_event_name": "PreToolUse", "tool_name": ["Write"]}),
         "object/tool_name-array")
 
+    # ---- 6c. The SAME unroutable payloads in a DORMANT repo: dormancy wins.
+    # The adapter short-circuits before any guard runs, so it is the only
+    # process left to honour the activation contract this module documents —
+    # a repo that never opted in must see no exit 2 and no stdout, not a
+    # `decision: block` produced by a plugin that is supposed to be inert.
+    for label, payload in (("null", None), ("array", []),
+                           ("array-of-str", ["Write"]), ("string", "apply_patch"),
+                           ("number", 3), ("bool", True),
+                           ("object/tool_name-array",
+                            {"hook_event_name": "PreToolUse",
+                             "tool_name": ["Write"]})):
+        e = run("pre-tool-adapter.py", "primary", "REAL", dormant, payload)
+        check(e.rc != 2, e, f"payload {label}: dormant repo must never block")
+        check(e.out == "", e,
+              f"payload {label}: dormant repo must produce no stdout")
+        assert_noop_allow(e)
+
     # ---- 7. post-write-edit, enabled: an ungoverned path is a silent allow
     post_in = patch_in(ORDINARY_PATCH, enabled)
     for scen, kind, stub_ok in allow_pairs():

--- a/.github/scripts/test_hooks_cold_install.py
+++ b/.github/scripts/test_hooks_cold_install.py
@@ -743,6 +743,23 @@ def run_ca_codex_campaign(hooks, paths, stub_log, enabled, dormant):
         check(output.get("decision") == "block" and gate in output.get("reason", ""),
               entry, f"Codex adapter must return decision:block with {gate}")
 
+    def assert_codex_shape_block(entry, label):
+        """#409: an unroutable payload must reach the model as the documented
+        bounded decision, not as an interpreter traceback on the real install."""
+        check("Traceback" not in entry.err, entry,
+              f"payload {label}: adapter must not leak a traceback")
+        check(entry.rc == 0, entry,
+              f"payload {label}: adapter must exit 0 with a decision")
+        try:
+            output = json.loads(entry.out)
+        except (TypeError, ValueError):
+            output = {}
+        reason = output.get("reason", "")
+        check(output.get("decision") == "block", entry,
+              f"payload {label}: an unroutable payload must fail closed")
+        check(reason.startswith("Blocked by codeArbiter policy") and len(reason) <= 120,
+              entry, f"payload {label}: reason must be a bounded diagnostic")
+
     # ---- 1. SessionStart, enabled repo: one OS-selected handler
     for scen in (("REAL", "STUB") if CODEX_STUB_IS_REAL_LIKE else ("REAL",)):
         p = run("session-start.py", "primary", scen, enabled, session_in())
@@ -811,6 +828,24 @@ def run_ca_codex_campaign(hooks, paths, stub_log, enabled, dormant):
         assert_noop_allow(run("pre-tool-adapter.py", kind, scen, enabled,
                               patch_in(ORDINARY_PATCH, enabled)),
                           stub_ok=stub_ok)
+
+    # ---- 6b. Non-object hook payloads on the REAL install (#409). Codex
+    # contracts one JSON object per PreToolUse event; every other top-level
+    # JSON type must still produce a decision rather than an AttributeError
+    # traceback and an exit-1 adapter. Syntactically invalid JSON cannot be
+    # expressed through this runner (it serializes its input) and is covered
+    # by test_codex_adapter.py instead.
+    for label, payload in (("null", None), ("array", []),
+                           ("array-of-str", ["Write"]), ("string", "apply_patch"),
+                           ("number", 3), ("bool", True)):
+        assert_codex_shape_block(
+            run("pre-tool-adapter.py", "primary", "REAL", enabled, payload), label)
+    # A well-shaped object with a wrong-typed tool_name is the same class of
+    # defect one line further in (unhashable set-membership test).
+    assert_codex_shape_block(
+        run("pre-tool-adapter.py", "primary", "REAL", enabled,
+            {"hook_event_name": "PreToolUse", "tool_name": ["Write"]}),
+        "object/tool_name-array")
 
     # ---- 7. post-write-edit, enabled: an ungoverned path is a silent allow
     post_in = patch_in(ORDINARY_PATCH, enabled)

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -14,7 +14,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
   payload was handed to `pre-bash.py` unvalidated, where the guard layer's
   documented fail-open silently allowed the gated call. Every unroutable payload
   now takes one bounded path: the documented `decision: block` response at
-  exit 0, with no guard dispatched.
+  exit 0, with no guard dispatched — and that path is gated on the repo having
+  opted in. codeArbiter stays dormant wherever `.codearbiter/CONTEXT.md` does
+  not carry `arbiter: enabled`: the adapter short-circuits before any guard
+  runs, so it now applies the same activation check the guards do and takes no
+  action at all in a repo that never opted in. This also closes the same gap on
+  the pre-existing incomplete-stream leg, which declined unconditionally.
 - Tribunal runs recover cumulative usage from each exact Codex agent thread
   when its local session artifact is readable, and otherwise record an explicit
   capability or instrumentation reason instead of leaving `tokens_actual`

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 ## [0.3.0] — 2026-07-12 — Shared-state concurrency hardening
 
 ### Fixed
+- The PreToolUse adapter validates the hook payload's shape before routing it.
+  A valid-JSON but non-object payload (`null`, an array, a string, a number, a
+  bool) used to raise `AttributeError` out of the adapter — exit 1, a traceback,
+  and no allow/block decision at all — and an empty or syntactically invalid
+  payload was handed to `pre-bash.py` unvalidated, where the guard layer's
+  documented fail-open silently allowed the gated call. Every unroutable payload
+  now takes one bounded path: the documented `decision: block` response at
+  exit 0, with no guard dispatched.
 - Tribunal runs recover cumulative usage from each exact Codex agent thread
   when its local session artifact is readable, and otherwise record an explicit
   capability or instrumentation reason instead of leaving `tokens_actual`

--- a/plugins/ca-codex/hooks/pre-tool-adapter.py
+++ b/plugins/ca-codex/hooks/pre-tool-adapter.py
@@ -9,8 +9,20 @@ empty stream, invalid JSON, a valid JSON top level that is not an object
 `tool_name` — goes through ONE bounded handling path: emit the documented
 `decision: block` response, exit 0, dispatch no guard.
 
-This fails CLOSED, matching the pre-existing timed-out-stdin leg below. Two
-reasons, both specific to this file:
+That path runs ONLY in an arbiter-enabled repo. codeArbiter is dormant
+wherever `.codearbiter/CONTEXT.md` does not carry `arbiter: enabled`, and the
+contract for a dormant repo is total inaction — no exit 2, no stdout, no
+decision. Every guard enforces that itself as its first statement; this
+adapter short-circuits BEFORE any guard runs, so on the unroutable path it is
+the only process left to apply the check and must apply it (see
+`_arbiter_active` below). Without it, installing the plugin would make a
+tool that is supposed to be inert start declining tool calls in projects that
+never opted in, the first time the Windows shell boundary this shim exists to
+paper over hands over an empty or truncated stream.
+
+Inside an arbiter-enabled repo the unroutable path fails CLOSED, matching the
+pre-existing timed-out-stdin leg below. Two reasons, both specific to this
+file:
 
   * There is no safe guard to dispatch. Routing is a function of `tool_name`;
     without a readable one the adapter would have to guess between the write
@@ -41,7 +53,12 @@ import threading
 STDIN_TIMEOUT_SECONDS = 5
 
 # tool_name values Codex reports for the apply_patch envelope (Write/Edit are
-# matcher-only aliases carrying the same payload) — see hooks/_host.py.
+# matcher-only aliases carrying the same payload). This is a deliberate local
+# copy of CodexHost._PATCH_TOOLS / the "WRITE" entries of CodexHost.TOOL_MAP
+# (hooks/_host.py): routing happens before — and without — the shared library
+# import, so the adapter cannot ask the Host for it. The copy is held to the
+# canonical set by TestPreToolAdapterWriteToolSet in
+# .github/scripts/test_codex_adapter.py, which fails if the two ever diverge.
 WRITE_TOOLS = frozenset({"apply_patch", "Write", "Edit"})
 
 
@@ -87,11 +104,60 @@ def _route(raw):
     return ("pre-write.py" if tool_name in WRITE_TOOLS else "pre-bash.py"), None
 
 
+def _arbiter_active():
+    """Did this repo opt into codeArbiter (`arbiter: enabled` in CONTEXT.md)?
+
+    Answered through the SHARED helpers every guard uses, never a local copy
+    of the frontmatter parser: core/activation-contract.json names
+    `_hooklib.frontmatter_enabled_text` the ONE canonical parser, and a second
+    implementation here could disagree with the guards about what "enabled"
+    means — exactly the drift that contract exists to prevent.
+
+    Takes no payload, and MUST be called before stdin is read — see main().
+
+    An INDETERMINATE answer — the shared library or the plugin's Host will not
+    import, i.e. a broken install — counts as ACTIVE, so the caller fails
+    closed. The guards this adapter dispatches import those very same modules,
+    so an install that cannot answer the activation question cannot enforce
+    anything either; returning False there would convert a broken install into
+    a silent allow, which is the "silent dormancy" failure mode the whole hook
+    layer (and .github/scripts/test_hooks_cold_install.py) exists to prevent.
+    """
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from _hooklib import arbiter_active, project_root  # noqa: PLC0415
+        return arbiter_active(project_root())
+    except Exception:  # noqa: BLE001 — indeterminate == active; see docstring
+        return True
+
+
 def main():
+    # Resolved BEFORE stdin is touched, and deliberately without the payload.
+    # Two constraints force it here:
+    #
+    #   * project_root() spawns `git rev-parse`. Once the bounded read below
+    #     times out, its reader thread is STILL blocked on stdin, and a child
+    #     that inherits that stdin then never returns — measured on Windows:
+    #     `git rev-parse --show-toplevel` hangs until its own timeout fires
+    #     instead of finishing in ~20ms. So the leg that most needs the
+    #     activation answer (an incomplete stream) is the one leg that cannot
+    #     obtain it afterwards.
+    #   * the timeout leg must also leave NO descendant process behind
+    #     (TestPreToolAdapterLifecycle), which spawning git after the fact
+    #     would violate.
+    #
+    # Dropping the payload's `cwd` leg costs nothing here: Codex runs its hooks
+    # IN the session cwd and merely repeats that cwd in the payload
+    # (hooks/_host.py), so CodexHost.project_root's payload leg and its
+    # process-cwd leg climb to the same git toplevel.
+    active = _arbiter_active()
     raw = _read_stdin_bounded()
     script, diagnostic = _route(raw)
     if script is None:
-        return _decline(diagnostic)
+        # A dormant repo — one that never opted in — sees NO action at all: no
+        # decision, no guard, no output. Failing closed is a promise made to
+        # repos that opted in, not a licence to interfere with the rest.
+        return _decline(diagnostic) if active else 0
     result = subprocess.run(
         [sys.executable, os.path.join(os.path.dirname(__file__), script)],
         input=raw,

--- a/plugins/ca-codex/hooks/pre-tool-adapter.py
+++ b/plugins/ca-codex/hooks/pre-tool-adapter.py
@@ -1,5 +1,35 @@
 #!/usr/bin/env python3
-"""Preserve shared exit-2 guards across Codex's Windows shell boundary."""
+"""Preserve shared exit-2 guards across Codex's Windows shell boundary.
+
+Payload contract (#409): Codex delivers exactly ONE JSON *object* on stdin,
+and the adapter routes it by `tool_name` to the shared pre-write / pre-bash
+guard. Anything the adapter cannot route — a stream that never closed, an
+empty stream, invalid JSON, a valid JSON top level that is not an object
+(null / array / string / number / bool), or a present-but-wrong-typed
+`tool_name` — goes through ONE bounded handling path: emit the documented
+`decision: block` response, exit 0, dispatch no guard.
+
+This fails CLOSED, matching the pre-existing timed-out-stdin leg below. Two
+reasons, both specific to this file:
+
+  * There is no safe guard to dispatch. Routing is a function of `tool_name`;
+    without a readable one the adapter would have to guess between the write
+    and exec gates, and the pre-fix code guessed pre-bash.py for every
+    unreadable payload — so an unreadable `apply_patch` skipped the write
+    gate entirely.
+  * Dispatching anyway launders the failure into a silent allow.
+    `_hooklib.read_input()` fails OPEN on an unparseable payload by explicit,
+    documented design (warn + proceed without enforcement). That exception is
+    correct at the GUARD layer, which has already been handed a payload the
+    host produced. Feeding it input the adapter itself could not validate
+    would convert "codeArbiter could not read this" into "codeArbiter allowed
+    this", which is exactly the outcome the guards exist to prevent.
+
+The emitted reason is a short deterministic diagnostic. It never carries the
+payload text or an exception rendering: it is user-facing in Codex's UI, and
+before this contract existed the failure surfaced as an AttributeError
+traceback with no decision emitted at all.
+"""
 
 import json
 import os
@@ -9,6 +39,10 @@ import threading
 
 
 STDIN_TIMEOUT_SECONDS = 5
+
+# tool_name values Codex reports for the apply_patch envelope (Write/Edit are
+# matcher-only aliases carrying the same payload) — see hooks/_host.py.
+WRITE_TOOLS = frozenset({"apply_patch", "Write", "Edit"})
 
 
 def _read_stdin_bounded():
@@ -23,19 +57,41 @@ def _read_stdin_bounded():
     return result[0] if result else None
 
 
+def _decline(diagnostic):
+    """Emit Codex's structured block decision; dispatch no guard. Always 0."""
+    print(json.dumps({
+        "decision": "block",
+        "reason": f"Blocked by codeArbiter policy: {diagnostic}",
+    }))
+    return 0
+
+
+def _route(raw):
+    """(script, diagnostic) for the decoded payload — exactly one is None."""
+    if raw is None:
+        return None, "incomplete hook payload"
+    if not raw.strip():
+        return None, "empty hook payload"
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return None, "unparseable hook payload"
+    if not isinstance(payload, dict):
+        # Bounded by construction: a type name, never the payload contents.
+        return None, f"unexpected hook payload type: {type(payload).__name__}"
+    tool_name = payload.get("tool_name", "")
+    if not isinstance(tool_name, str):
+        # Unhashable values raise from the WRITE_TOOLS membership test, and a
+        # wrong-typed tool_name makes the write-vs-exec choice unknowable.
+        return None, f"unexpected tool_name type: {type(tool_name).__name__}"
+    return ("pre-write.py" if tool_name in WRITE_TOOLS else "pre-bash.py"), None
+
+
 def main():
     raw = _read_stdin_bounded()
-    if raw is None:
-        print(json.dumps({
-            "decision": "block",
-            "reason": "Blocked by codeArbiter policy: incomplete hook payload",
-        }))
-        return 0
-    try:
-        tool_name = json.loads(raw or "{}").get("tool_name", "")
-    except (TypeError, ValueError):
-        tool_name = ""
-    script = "pre-write.py" if tool_name in {"apply_patch", "Write", "Edit"} else "pre-bash.py"
+    script, diagnostic = _route(raw)
+    if script is None:
+        return _decline(diagnostic)
     result = subprocess.run(
         [sys.executable, os.path.join(os.path.dirname(__file__), script)],
         input=raw,


### PR DESCRIPTION
Closes #409

> **Revision 2 (post-review).** The first revision shipped a fail-closed decline that was **not dormancy-aware** — a real regression, fixed in commit `1333e8e`. The section [Revision 2](#revision-2--the-decline-is-now-dormancy-aware) documents it, and the wrong claims the review disproved have been corrected in place (they are called out where they were).

## What was wrong

`plugins/ca-codex/hooks/pre-tool-adapter.py` decoded stdin and immediately dereferenced the result, catching only `TypeError`/`ValueError`. Two crash sites, one line apart:

- **line 35** — `json.loads(raw or "{}").get("tool_name", "")` raises `AttributeError` for every non-object JSON top level (`null`, `[]`, `"str"`, `3`, `-1.5`, `true`, `false`).
- **line 38** — `tool_name in {"apply_patch", "Write", "Edit"}` raises `TypeError: unhashable type` for a present-but-wrong-typed `tool_name` (`{"tool_name": ["Write"]}`). The tribunal issue named only line 35; this second site was found by reading the file and is the same defect class in the same dereference chain.

Both exited 1 with a traceback and **no allow/block decision at all**, before either shared guard was dispatched.

The two malformed legs that did *not* crash were worse than loud. An **empty stream** and **syntactically invalid JSON** both fell through to `tool_name = ""` and spawned `pre-bash.py` with input the adapter had never validated. There `_hooklib.read_input()`'s documented fail-open warned and allowed — so an unreadable `apply_patch` payload skipped the **write** gate entirely and was silently permitted. Live proof from the pre-fix file:

```
=== payload: '{not json'
rc = 0
stdout: ''
stderr: codeArbiter hook: hook input unparseable (Expecting property name enclosed in double quotes: line 1 column 2 (char 1)); proceeding without enforcement
```

That warning comes from `pre-bash.py` — i.e. the guard *was* dispatched with an unvalidated payload, and it allowed.

## Source-of-truth verification (done before editing)

The triage claimed this file is codex-specific, not vendored. Verified three ways:

1. `ls core/pysrc/` — no `pre-tool-adapter.py` (47 files, none named that).
2. `tools/sync-core.py` syncs only `core/pysrc/*.py` into each plugin's `hooks/`; a file absent from `core/pysrc` is never overwritten.
3. `git ls-files | grep pre-tool-adapter` returns exactly one path: `plugins/ca-codex/hooks/pre-tool-adapter.py`.

Post-fix confirmation that nothing drifted:

```
sync-core --check: OK (47 core file(s) x 3 plugin(s), all byte-identical)
build-surface --check: OK (claude, codex, pi in sync)
Plugin reference graph intact (ca-codex).
```

## The fix — fail closed **inside an arbiter-enabled repo**, following the file's own convention

Every unroutable payload takes **one** bounded path: emit the documented `decision: block` response, exit 0, dispatch **no** guard — **and only where the repo opted in** (see [Revision 2](#revision-2--the-decline-is-now-dormancy-aware)).

This is not a new convention. `pre-tool-adapter.py` already failed closed on a timed-out stdin stream (`{"decision": "block", "reason": "Blocked by codeArbiter policy: incomplete hook payload"}`, exit 0), with an existing test asserting *"an incomplete payload must fail closed"*. The fix extends that one leg to cover the whole unroutable set.

`_hooklib.read_input()`'s fail-open is **left unchanged**. That documented exception is correct at the *guard* layer, which has already been handed a payload the host produced. Laundering an adapter-level parse failure through it converts "codeArbiter could not read this" into "codeArbiter allowed this" — the outcome the guards exist to prevent. The adapter is also the wrong place to guess: routing is a function of `tool_name`, and the pre-fix code guessed `pre-bash.py` for every unreadable payload.

The emitted reason is a short deterministic diagnostic — a type name at most (`unexpected hook payload type: list`), never payload text or an exception rendering. Tests assert `len(reason) <= 120`.

**Behavior deliberately preserved:** an *absent* `tool_name` keeps its documented default of `""` -> `pre-bash.py`. Only a *present but wrong-typed* `tool_name` is treated as a malformed shape.

---

## Revision 2 — the decline is now dormancy-aware

### The regression review found

codeArbiter is **dormant** in any repo whose `.codearbiter/CONTEXT.md` does not carry `arbiter: enabled`. The cold-install harness states the contract in its own module docstring — *"the hook layer must take no action — no exit 2, no stdout"* — and asserts it for `pre-bash.py` at `test_hooks_cold_install.py:630-636`.

Revision 1's `_decline()` consulted only the payload. It short-circuits **before** any guard runs, and a guard's `if not arbiter_active(root): sys.exit(0)` was the only thing that had ever applied the check. So installing `ca-codex` made a plugin that is supposed to be inert start declining tool calls in projects that never opted in, the first time the Windows shell boundary this shim exists to paper over handed over an empty or truncated stream. Reproduced side by side in a dormant fixture:

```
PRE-FIX   payload ''  ->  rc=0  stdout=''
REV-1     payload ''  ->  rc=0  stdout='{"decision": "block", "reason": "Blocked by codeArbiter policy: empty hook payload"}'
```

Neither of revision 1's new tests could observe it: cold-install step 6b passed only the `enabled` fixture, and `TestPreToolAdapterPayloadShape` stubbed the guards away entirely.

### What changed

`main()` now resolves activation through the **shared** helpers every guard uses — `_hooklib.arbiter_active()` over `project_root()`, i.e. the parser `core/activation-contract.json` names canonical — and declines only in an arbiter-enabled repo:

```python
active = _arbiter_active()
raw = _read_stdin_bounded()
script, diagnostic = _route(raw)
if script is None:
    return _decline(diagnostic) if active else 0
```

- **Dormant repo → untouched.** No decision, no guard, no stdout, exit 0.
- **Arbiter-enabled repo → unchanged from revision 1.** Every unroutable payload still fails closed with the same bounded diagnostic.
- **Routable payload → unchanged in both.** It is still dispatched to `pre-write.py` / `pre-bash.py`, which apply their own dormancy check. The adapter did not take over that job.

This also closes the **same gap on the pre-existing incomplete-stream leg**, which declined unconditionally on `main` — a dormancy-contract violation that predates this PR and is fixed here rather than left behind, since it is the identical short-circuit.

### Why the lookup runs before stdin is read

It is resolved eagerly, not lazily on the decline path, and that is load-bearing. `project_root()` spawns `git rev-parse`. Once `_read_stdin_bounded()` times out, its reader thread is **still blocked** on stdin, and a child that inherits that stdin then never returns. Measured on Windows (Python 3.14), with a thread blocked on `sys.stdin.read()` and the parent's stdin an unclosed pipe:

```
git rev-parse --show-toplevel, stdin=DEVNULL   ->  0.02s, rc 0
git rev-parse --show-toplevel, stdin inherited ->  TIMEOUT at 8.00s
```

So the leg that most needs the activation answer — an incomplete stream — is the one leg that cannot obtain it afterwards. Spawning anything on the timeout leg is separately forbidden: `TestPreToolAdapterLifecycle` asserts it leaves no descendant process.

Dropping `CodexHost.project_root`'s payload-`cwd` leg costs nothing here: Codex runs its hooks **in** the session cwd and merely repeats that cwd in the payload (`hooks/_host.py` module header), so the payload leg and the process-cwd leg climb to the same git toplevel.

Cost: one `git rev-parse` (~20ms) per adapter invocation, in a process that already spawns a full Python guard (~200ms+) which resolves the same root again. Accepted for one code path over two.

### Indeterminate activation fails closed

If the shared library or the plugin's Host will not import — a broken install — `_arbiter_active()` returns `True` and the caller still declines. The guards this adapter dispatches import those very same modules, so an install that cannot answer the activation question cannot enforce anything either; exiting 0 in silence there would convert a broken install into a silent allow, which is the "silent dormancy" failure mode the cold-install harness exists to catch. `TestPreToolAdapterBrokenInstall` locks this in.

### `WRITE_TOOLS` drift (review LOW)

`WRITE_TOOLS = frozenset({"apply_patch", "Write", "Edit"})` duplicates `CodexHost._PATCH_TOOLS` and was linked to it only by a prose comment — promoting the literal to a named constant made it *read* authoritative while staying an unenforced copy. The adapter genuinely cannot ask the Host for it (routing happens before, and without, the shared-library import), so the copy stays — but `TestPreToolAdapterWriteToolSet` now fails if it diverges from either `CodexHost._PATCH_TOOLS` or the `"WRITE"` entries of `CodexHost.TOOL_MAP`.

### New tests

| Test | What it proves |
|---|---|
| `TestPreToolAdapterDormancy` | Subclasses `TestPreToolAdapterPayloadShape` and re-points the fixture at a **dormant** repo, so the two halves of the gate cannot drift: the same payloads that must BLOCK when enabled must be SILENT when dormant, and the routing tests are inherited unchanged (a well-formed payload is still dispatched). |
| `TestPreToolAdapterDormancy.test_incomplete_stdin_is_untouched_in_a_dormant_repo` | The timed-out-stdin leg honours dormancy too. |
| `TestPreToolAdapterBrokenInstall` | A missing `_hooklib.py` still fails closed rather than silently allowing. |
| `TestPreToolAdapterWriteToolSet` | The adapter's write-tool literal is gated against the Codex host's canonical set. |
| cold-install **step 6c** | The same unroutable payloads on the **REAL** install in the **dormant** fixture: no exit 2, no stdout, no stderr. |

The unit fixtures now stage the **whole** `plugins/ca-codex/hooks/` tree into the temp dir instead of `pre-tool-adapter.py` alone, and run the adapter with `cwd` pinned to a purpose-built git fixture with `CLAUDE_PROJECT_DIR` stripped. A single-file copy is no longer a faithful install (the adapter imports its siblings), and the ambient cwd is no longer allowed to decide which repo the test resolves to.

---

## Red-test evidence (verbatim)

### Revision 2 — dormancy

`.github/scripts` — `python -m unittest test_codex_adapter`, dormancy tests added, adapter unchanged:

```
Ran 81 tests in 15.658s

FAILED (failures=21)
```

All 21 in `TestPreToolAdapterDormancy`; no failure anywhere else in the file. Representative:

```
FAIL: test_empty_and_whitespace_payloads_block_without_dispatching_a_guard
      (TestPreToolAdapterDormancy) (payload='')
AssertionError: '{"decision": "block", "reason": "Blocked [41 chars]"}\n' != ''
- {"decision": "block", "reason": "Blocked by codeArbiter policy: empty hook payload"}
 : payload '' (dormant repo): a dormant repo must produce no stdout — a decision here
   blocks a repo that never opted in

FAIL: test_syntactically_invalid_json_blocks_without_dispatching_a_guard
      (TestPreToolAdapterDormancy) (payload='{not json')
AssertionError: '{"decision": "block", "reason": "Blocked [47 chars]"}\n' != ''
- {"decision": "block", "reason": "Blocked by codeArbiter policy: unparseable hook payload"}

FAIL: test_incomplete_stdin_is_untouched_in_a_dormant_repo (TestPreToolAdapterDormancy)
AssertionError: '{"decision": "block", "reason": "Blocked [46 chars]"}\n' != ''
- {"decision": "block", "reason": "Blocked by codeArbiter policy: incomplete hook payload"}
 : a dormant repo must produce no stdout
```

Cold-install — `python .github/scripts/test_hooks_cold_install.py`, step 6c added, adapter unchanged:

```
FAIL [pre-tool-adapter.py/primary/REAL] payload null: dormant repo must produce no stdout
  command : python "...\plugins\ca-codex/hooks/pre-tool-adapter.py"
  exit    : 0
  stdout  : '{"decision": "block", "reason": "Blocked by codeArbiter policy: unexpected hook payload type: NoneType"}'
  stderr  : ''

FAIL [pre-tool-adapter.py/primary/REAL] payload object/tool_name-array: dormant repo must produce no stdout
  stdout  : '{"decision": "block", "reason": "Blocked by codeArbiter policy: unexpected tool_name type: list"}'

285 assertions, 14 failed (cmd /d /s /c)

RELEASE BLOCKER: a cold-install scenario failed. Do not weaken the hook — the failing command strings are above.
```

`TestPreToolAdapterBrokenInstall` red was captured by flipping the indeterminate branch to `return False` (then restored):

```
ERROR: test_unroutable_payload_fails_closed_when_the_shared_library_is_missing
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

i.e. exit 0 with **empty stdout** — the silent allow the branch exists to prevent.

### Revision 1 — payload shape

Live reproduction against the pre-fix file:

```
=== payload: '[]'
rc = 1
stdout: ''
stderr: Traceback (most recent call last):
  File "...\plugins\ca-codex\hooks\pre-tool-adapter.py", line 55, in <module>
    raise SystemExit(main())
                     ~~~~^^
  File "...\plugins\ca-codex\hooks\pre-tool-adapter.py", line 35, in main
    tool_name = json.loads(raw or "{}").get("tool_name", "")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'

=== payload: 'null'   -> rc 1, AttributeError: 'NoneType' object has no attribute 'get'
=== payload: '"str"'  -> rc 1, AttributeError: 'str' object has no attribute 'get'
=== payload: '3'      -> rc 1, AttributeError: 'int' object has no attribute 'get'

=== payload: '{"tool_name": ["Write"]}'
rc = 1
stderr: ...
  File "...\plugins\ca-codex\hooks\pre-tool-adapter.py", line 38, in main
    script = "pre-write.py" if tool_name in {"apply_patch", "Write", "Edit"} else "pre-bash.py"
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot use 'list' as a set element (unhashable type: 'list')
```

`TestPreToolAdapterPayloadShape` against the unmodified adapter:

```
Ran 7 tests in 1.446s

FAILED (failures=20)
```

20 subtest failures across 4 of the 7 tests — `leaked a traceback` for the crash legs, `stdout is not a hook decision: ''` for the empty / invalid-JSON / non-hashable legs. The 3 routing tests passed red; they are regression guards on the working path, not proofs of the defect.

Cold-install step 6b against the pre-fix adapter:

```
FAIL [pre-tool-adapter.py/primary/REAL] payload bool: adapter must exit 0 with a decision
  exit    : 1
  stdout  : ''
  stderr  : 'Traceback (most recent call last): ... line 35, in main\r\n    tool_name ='

250 assertions, 28 failed (cmd /d /s /c)
```

## Test-count table

| Suite | Command | `origin/main` | This branch |
|---|---|---|---|
| `.github/scripts` (full) | `python -m unittest discover -s .github/scripts -p "test_*.py"` | 1037 run — 2 failures, 2 errors, 5 skipped | **1055 run — same 2 failures, 2 errors, 5 skipped** |
| `.github/scripts` codex adapter only | `... -p "test_codex_adapter.py"` | 64 OK | **82 OK** |
| cold-install matrix (standalone) | `python .github/scripts/test_hooks_cold_install.py` | 222 assertions, 0 failed — PASS | **285 assertions, 0 failed — PASS** |
| python-hooks | `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` | 1057 OK | **1057 OK** |
| sync-core parity | `python tools/sync-core.py --check` | OK | OK (47 x 3, byte-identical) |
| surface parity | `python tools/build-surface.py --check` | OK | OK (claude, codex, pi in sync) |
| plugin refs | `python .github/scripts/check-plugin-refs.py ca-codex` | OK | OK |
| docs contract | `python .github/scripts/check_docs_contract.py` | OK | OK |

**The 4 pre-existing failures are unrelated to this lane and identical before and after** — all four are in `test_pi_benchmark.py` and all fail on the same environment precondition:

```
ERROR: test_measurements_use_exact_public_shape_and_100_warm_events
ERROR: test_pi_record_does_not_load_the_generated_python_host_adapter
FAIL:  test_cli_emits_only_three_bounded_json_records
FAIL:  test_cli_real_spawn_flag_adds_a_fourth_labeled_record

RuntimeError: Pi benchmark requires the installed pinned esbuild
```

This worktree has no `node_modules` installed for `plugins/ca-pi`. No `plugins/ca-pi/**` file is touched by this PR, and `pi_benchmark.py` does not reference `pre-tool-adapter.py`.

No TypeScript or JavaScript is in the diff, so the `site` and `ca-sandbox` suites were not run; no doc under `site/src/content/docs/` states behaviour this change contradicts.

## Version gate

`ca-codex` stays at **0.3.0**. Derivation, scoped to `plugins/ca-codex/**` only:

- `git tag -l "ca-codex-v*"` -> `ca-codex-v0.2.4` (only).
- `gh release list` -> latest ca-codex release is `ca-codex 0.2.4`.
- 0.3.0 is therefore **unpublished**, so the `version-bump-codex` CI gate's published-tag rule does not bite ("payload changed on unpublished version 0.3.0 — no tag `ca-codex-v0.3.0` — allowed").

Per the repo's payload-scoped-bump rule, bumping to 0.3.1 here would be an over-bump. The fix is recorded as a new bullet under the pending `## [0.3.0]` -> `### Fixed` section instead.

`python tools/build-host-packages.py --check --release-guard-base a3a2df2` -> `no Pi payload change - version bump not required`.

## Committed build artifacts

None touched. This lane changes no `farm.js` / `sandbox.js` / `codearbiter.js` source, so no rebuild was required.

## Files changed

- `plugins/ca-codex/hooks/pre-tool-adapter.py` — shape validation, one bounded decline path, and the activation gate in front of it. The module docstring records the payload contract, the dormancy contract, and why this leg fails closed while `_hooklib.read_input()` does not.
- `.github/scripts/test_codex_adapter.py` — `TestPreToolAdapterPayloadShape` (7 tests), `TestPreToolAdapterDormancy` (8), `TestPreToolAdapterBrokenInstall` (1), `TestPreToolAdapterWriteToolSet` (2). Fixtures stage the real hooks tree and a purpose-built git repo; a stubbed launch log proves "never dispatched a guard" rather than assuming it.
- `.github/scripts/test_hooks_cold_install.py` — step 6b (non-object payloads, enabled) and step 6c (the same payloads, dormant).
- `plugins/ca-codex/CHANGELOG.md` — entry under the pending 0.3.0 `### Fixed`.

## NEEDS-TRIAGE (found, deliberately not fixed — out of lane scope)

> **Corrected after review.** Revision 1 claimed a truthy non-dict payload "reaches `.get` and raises `AttributeError`" in *every* shared guard entry. That overstated the downstream consequence and is corrected below with measurements, so whoever picks this up is not working from a wrong impact statement.

**`core/pysrc/_hooklib.py` has an unvalidated non-object-payload assumption, and it is CANONICAL (vendored into all 3 plugins).**

`read_input()` (`core/pysrc/_hooklib.py:613-626`) returns `json.loads(raw)` unvalidated, so a payload of `[]` or `3` propagates a non-dict straight into the shared guard entries. `tool_input(data)` uses `(data or {}).get("tool_input", {})` — the `or {}` rescues `null`, `[]`, `0` and `""` (all falsy) but **not** a truthy non-dict such as `[1]`, `3`, or `"str"`.

Measured consequence per entry (payload `[1]`, `ca` plugin, arbiter-enabled fixture):

| Entry | Result |
|---|---|
| `pre-bash.py` | **exit 2** — `BLOCKED [H-00]: pre-bash guard crashed while scanning this command — failing closed`. The `AttributeError` is caught by the deliberate fail-closed backstop at `core/pysrc/pre-bash.py:62-68` and converted into a block. A spurious block, not a crash and not a silent allow. |
| `pre-write.py`, `pre-edit.py` | exit 0 — same H-00 backstop exists, but no dereference is reached. |
| `post-write-edit.py` | exit 0 — `iter_file_ops` tolerates a non-dict on both hosts (`ca` yields one empty canonical op, `ca-codex` yields none). |
| `pre-read.py` | exit 0 — blanket `except Exception: sys.exit(0)` fail-open by design (AC-12). |

Every entry gates on `arbiter_active(root)` first, so none of this is reachable in a dormant repo.

So the residual risk is **a spurious H-00 block on `pre-bash.py` in an enabled repo**, not an unhandled crash and not a silent allow. It is still worth closing at the canonical layer — the type assumption is unguarded and each host is free to change its payload shape — but it is not urgent, and this lane's adapter fix means `ca-codex` can no longer deliver such a payload downstream at all. Fixing it requires editing `core/pysrc` + `python tools/sync-core.py`, touching all three plugins' payloads (three version gates), which is well outside this lane. I did not verify whether any host can actually emit a non-object payload in the first place.

## Honest caveats

- All verification ran on **Windows** (`cmd /d /s /c` cold-install branch, CPython 3.14). The POSIX `sh -c` branch of the cold-install matrix was not exercised locally; CI covers it.
- **Corrected after review.** Revision 1 claimed the malformed-payload path "is not reachable from a correctly-behaving Codex, which is precisely why the fail-closed choice carries near-zero false-block risk." That does not hold for the **empty-stream** leg: an empty or truncated stdin is a plumbing condition of the Windows shell boundary this shim exists to paper over, not a Codex-behaviour condition, and the in-file precedent the claim leaned on covers only a 5-second stdin timeout. Treating the whole unroutable set as unreachable is what let the dormancy regression through. The false-block surface is real; it is now bounded to repos that explicitly opted in.
- No live Codex CLI session was run against this build. The dormancy behaviour is proven against a real cold install (step 6c) and a staged hooks tree, not a live Codex.
- The eager activation lookup adds one `git rev-parse` per adapter invocation. Measured at ~20ms against a ~200ms+ guard spawn it already performs; not separately benchmarked under load.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
