### PR TITLE
fix(ci): restructure the Pi job graph - full suite, one canonical job, deadlines, advisory canary

### DIFF
--- a/.github/ci-impact-map.json
+++ b/.github/ci-impact-map.json
@@ -12,6 +12,13 @@
       "lane": "CHECK",
       "scope": "PI",
       "contract": "Adapter contract",
+      "reproduce": "python .github/scripts/test_pi_platform_contract.py --pi-version 0.80.10"
+    },
+    {
+      "id": "pi-checks",
+      "lane": "CHECK",
+      "scope": "PI",
+      "contract": "Host-independent adapter contract",
       "reproduce": "npm --prefix plugins/ca-pi/tools test"
     },
     {
@@ -45,7 +52,7 @@
   "edges": [
     {
       "glob": "plugins/ca-pi/**",
-      "checks": ["pi-adapter", "pi-latest"]
+      "checks": ["pi-adapter", "pi-checks", "pi-latest"]
     },
     {
       "glob": "core/pysrc/**",

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -9,6 +9,7 @@ selects the broad validation lane instead of silently predicting a skip.
 """
 import importlib.util
 import json
+import re
 import sys
 import tempfile
 import unittest
@@ -18,6 +19,87 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOL = REPO_ROOT / "tools" / "ci-impact.py"
 _DESCRIPTORS_TOOL = REPO_ROOT / "tools" / "host_descriptors.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
+PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
+
+# `needs.<id>.result` and `needs['<id>'].result` are the two spellings GitHub
+# accepts; the aggregate gate uses both depending on whether the job id has a
+# hyphen in it.
+_NEEDS_RESULT = re.compile(r"needs(?:\.([A-Za-z0-9_-]+)|\['([^']+)'\])\.result")
+_JOB_TIMEOUT = re.compile(r"(?m)^    timeout-minutes: (\d+)$")
+# GitHub-hosted runners hard-stop a job at 6 hours; a repository-defined bound
+# is only meaningful well under that.
+HOSTED_JOB_MAXIMUM_MINUTES = 360
+
+
+def workflow_jobs(text: str) -> dict[str, str]:
+    """Split a workflow's top-level `jobs:` mapping into {job id: raw block}.
+
+    Deliberately textual, like the rest of this repo's workflow contracts - the
+    scripts stay stdlib-only, so there is no YAML parser to lean on.
+    """
+    lines = text.splitlines(keepends=True)
+    try:
+        start = next(index for index, line in enumerate(lines) if line.rstrip() == "jobs:")
+    except StopIteration:
+        return {}
+    jobs: dict[str, str] = {}
+    current: str | None = None
+    body: list[str] = []
+    for line in lines[start + 1:]:
+        header = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if header is not None:
+            if current is not None:
+                jobs[current] = "".join(body)
+            current, body = header.group(1), [line]
+        elif current is not None:
+            body.append(line)
+    if current is not None:
+        jobs[current] = "".join(body)
+    return jobs
+
+
+def aggregate_needs(ci: str) -> list[str]:
+    """Job ids listed in ci-passed's `needs:` block."""
+    aggregate = workflow_jobs(ci).get("ci-passed", "")
+    match = re.search(r"(?ms)^    needs:\s*\n(?P<body>(?:      - [A-Za-z0-9_-]+\n)+)", aggregate)
+    if match is None:
+        return []
+    return [line.strip()[2:].strip() for line in match.group("body").splitlines()]
+
+
+def aggregate_required_results(ci: str) -> list[str]:
+    """Job ids whose result the ci-passed gate actually enforces."""
+    aggregate = workflow_jobs(ci).get("ci-passed", "")
+    match = re.search(r'(?m)^\s+required_results="(?P<body>[^"\n]*)"\s*$', aggregate)
+    if match is None:
+        return []
+    return [first or second for first, second in _NEEDS_RESULT.findall(match.group("body"))]
+
+
+def unassigned_pi_test_files(ci: str, committed: set[str]) -> set[str]:
+    """Committed ca-pi Vitest files no *required* merge-gate job executes.
+
+    A bare `npm test` in a required Pi job covers the whole suite; a filtered
+    `npm test -- test/a.test.ts ...` covers only the files it names.  Anything
+    left over is a file that can regress with every required check green
+    (issue #405).
+    """
+    jobs = workflow_jobs(ci)
+    covered: set[str] = set()
+    for job_id in aggregate_required_results(ci):
+        if not job_id.startswith("ca-pi"):
+            continue
+        for match in re.finditer(r"(?m)^\s+run: npm test(?P<rest>[^\n]*)$", jobs.get(job_id, "")):
+            rest = match.group("rest").strip()
+            if not rest:
+                covered |= set(committed)
+                continue
+            covered |= {
+                token.rsplit("/", 1)[-1] for token in rest.split() if token.endswith(".test.ts")
+            }
+    return set(committed) - covered
 
 _spec = importlib.util.spec_from_file_location("ci_impact", _TOOL)
 module = importlib.util.module_from_spec(_spec)
@@ -208,6 +290,7 @@ class WorkflowContractTest(unittest.TestCase):
             "[CHECK] | [CORE] | Host descriptor contract",
             "[CHECK] | [CA  ] | Farm dispatcher contract",
             "[CHECK] | [SBX ] | Sandbox driver contract",
+            "[CHECK] | [PI  ] | Host-independent adapter contract",
             "[CHECK] | [PI  ] | Adapter contract  <os: ${{ matrix.os }} · runtime: Pi ${{ matrix.pi-version }}>",
             "[WATCH] | [PI  ] | Upstream compatibility  <runtime: npm latest>",
             "[CHECK] | [PI  ] | Security analysis  <language: JavaScript/TypeScript>",
@@ -227,6 +310,160 @@ class WorkflowContractTest(unittest.TestCase):
         )
         for name in expected:
             self.assertIn(f'name: "{name}"', ci)
+
+    def test_every_committed_pi_test_file_runs_in_a_required_merge_gate_job(self):
+        # Issue #405: the six-cell matrix named 6 of the 23 committed Vitest
+        # files, so a PR could regress policy/plan-mode/dispatch/background-jobs/
+        # windows-supervisor with every required check green.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        committed = {path.name for path in PI_TEST_DIR.glob("*.test.ts")}
+        self.assertTrue(committed, "no ca-pi Vitest files found - the glob is wrong")
+        self.assertEqual(
+            sorted(unassigned_pi_test_files(ci, committed)),
+            [],
+            "committed ca-pi test files that no required merge-gate job executes",
+        )
+
+    def test_the_pi_suite_partition_contract_fails_when_the_full_suite_run_is_removed(self):
+        # AC-2 of #405: the contract above must BITE, not merely pass because
+        # one job happens to run everything.  Neutering the unfiltered run has
+        # to leave test files unassigned.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        committed = {path.name for path in PI_TEST_DIR.glob("*.test.ts")}
+        jobs = workflow_jobs(ci)
+        mutated, neutered_jobs = ci, []
+        for job_id in aggregate_required_results(ci):
+            if not job_id.startswith("ca-pi"):
+                continue
+            block = jobs[job_id]
+            neutered = re.sub(r"(?m)^(\s+)run: npm test$", r"\1run: echo npm test", block)
+            if neutered != block:
+                mutated = mutated.replace(block, neutered, 1)
+                neutered_jobs.append(job_id)
+        self.assertNotEqual(
+            neutered_jobs, [], "no required ca-pi job runs the unfiltered `npm test` suite"
+        )
+        self.assertTrue(
+            unassigned_pi_test_files(mutated, committed),
+            "removing the full-suite run left every Pi test file still assigned",
+        )
+
+    def test_host_independent_pi_job_is_registered_in_both_needs_and_required_results(self):
+        # Issue #390 CRITICAL: `ci-passed` enforces jobs through TWO
+        # independent registrations - the `needs:` list (which makes it wait)
+        # and the `required_results` string (which makes it care).  Adding a
+        # job to one and not the other silently drops the verdict and nothing
+        # else in CI notices.  This asserts both exist AND that they agree for
+        # every job, with exactly one sanctioned exception: the advisory
+        # ca-pi-latest canary is intentionally awaited but not enforced.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("ca-pi-checks", sorted(workflow_jobs(ci)))
+        needs = aggregate_needs(ci)
+        required = aggregate_required_results(ci)
+        self.assertIn("ca-pi-checks", needs, "ci-passed.needs is missing ca-pi-checks")
+        self.assertIn(
+            "ca-pi-checks", required, "ci-passed.required_results is missing ca-pi-checks"
+        )
+        self.assertEqual(
+            sorted(set(needs) - set(required)),
+            ["ca-pi-latest"],
+            "awaited but unenforced jobs (only the advisory Pi canary may appear here)",
+        )
+        self.assertEqual(
+            sorted(set(required) - set(needs)),
+            [],
+            "enforced jobs the aggregate never waits for",
+        )
+
+    def test_host_independent_pi_checks_run_once_outside_the_platform_matrix(self):
+        # Issue #390: every one of these consumes neither matrix.os nor
+        # matrix.pi-version, so six cells produced six identical verdicts.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(ci)
+        self.assertIn("ca-pi-checks", sorted(jobs))
+        canonical, matrix = jobs["ca-pi-checks"], jobs["ca-pi-tools"]
+        self.assertNotIn("strategy:", canonical, "the canonical Pi job must not fan out")
+        self.assertIn("runs-on: ubuntu-latest", canonical)
+        for token in (
+            "run: python tools/build-host-packages.py --check",
+            "run: npm run typecheck",
+            "run: npm run build",
+            "run: python .github/scripts/test_pi_security.py",
+            "run: python .github/scripts/test_pi_parity.py",
+            "run: python .github/scripts/pi_benchmark.py --samples 100",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, canonical, f"ca-pi-checks must own `{token}`")
+                self.assertNotIn(token, matrix, f"ca-pi-tools still repeats `{token}` per cell")
+        # Everything whose verdict genuinely depends on the installed Pi
+        # version or the host OS stays in the six-cell matrix.
+        for token in (
+            "os: [ubuntu-latest, windows-latest, macos-latest]",
+            "npm install --global @earendil-works/pi-coding-agent@${{ matrix.pi-version }}",
+            "run: npm test -- test/package.test.ts",
+            "run: python .github/scripts/test_pi_package.py --rpc-commands",
+            "--pi-version ${{ matrix.pi-version }}",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, matrix, f"ca-pi-tools must keep `{token}`")
+
+    def test_every_pi_ci_and_promotion_job_declares_a_bounded_timeout(self):
+        # Issue #399: a wedged npm install or leaked process otherwise holds a
+        # hosted runner until GitHub's platform maximum.
+        missing: list[str] = []
+        unbounded: list[str] = []
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        candidates = [
+            (".github/workflows/ci.yml", job_id, block)
+            for job_id, block in workflow_jobs(ci).items()
+            if "[PI  ]" in block
+        ]
+        promotion = PI_PROMOTION_WORKFLOW.read_text(encoding="utf-8")
+        candidates += [
+            (".github/workflows/pi-promotion.yml", job_id, block)
+            for job_id, block in workflow_jobs(promotion).items()
+        ]
+        self.assertGreaterEqual(len(candidates), 8, "the Pi job scan found too few jobs")
+        for workflow, job_id, block in candidates:
+            declared = _JOB_TIMEOUT.search(block)
+            if declared is None:
+                missing.append(f"{workflow}:{job_id}")
+                continue
+            if not 0 < int(declared.group(1)) < HOSTED_JOB_MAXIMUM_MINUTES:
+                unbounded.append(f"{workflow}:{job_id}={declared.group(1)}")
+        self.assertEqual(missing, [], "Pi jobs with no timeout-minutes")
+        self.assertEqual(unbounded, [], "Pi job timeouts at or above the hosted maximum")
+
+    def test_pi_upstream_canary_concludes_advisory_rather_than_failed(self):
+        # Issue #381: the WATCH lane reports upstream incompatibility; that is
+        # its signal, not its failure.  Expected incompatibility is absorbed at
+        # STEP level so the check concludes green, while a break in the canary
+        # HARNESS still turns it red - which is why there is no job-level
+        # continue-on-error to swallow it.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        canary = workflow_jobs(ci)["ca-pi-latest"]
+        self.assertIsNone(
+            re.search(r"(?m)^    continue-on-error: true$", canary),
+            "job-level continue-on-error hides canary harness failures",
+        )
+        for probe in ("id: admission", "id: platform-contract"):
+            self.assertIn(probe, canary, f"the canary must address its probe step: {probe}")
+        self.assertEqual(
+            len(re.findall(r"(?m)^        continue-on-error: true$", canary)),
+            2,
+            "exactly the two upstream-compatibility probes absorb their own failure",
+        )
+        # The harness (toolchain + latest-Pi install) must NOT be absorbed.
+        harness = re.search(
+            r"(?ms)^      - name: Install reviewed toolchain and external latest Pi.*?(?=^      - name: )",
+            canary,
+        )
+        self.assertIsNotNone(harness, "canary harness install step is missing")
+        self.assertNotIn("continue-on-error", harness.group(0))
+        self.assertIn("if: always()", canary, "the advisory receipt must always publish")
+        self.assertIn("GITHUB_STEP_SUMMARY", canary, "the advisory verdict must be visible")
+        # And the aggregate gate stays independent of the advisory result.
+        self.assertNotIn("ca-pi-latest", aggregate_required_results(ci))
 
     def test_documentation_contract_is_always_required_by_merge_readiness(self):
         ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -22,6 +22,7 @@ _DESCRIPTORS_TOOL = REPO_ROOT / "tools" / "host_descriptors.py"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
 PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
+PI_PLATFORM_CONTRACT = REPO_ROOT / ".github" / "scripts" / "test_pi_platform_contract.py"
 
 # `needs.<id>.result` and `needs['<id>'].result` are the two spellings GitHub
 # accepts; the aggregate gate uses both depending on whether the job id has a
@@ -31,6 +32,30 @@ _JOB_TIMEOUT = re.compile(r"(?m)^    timeout-minutes: (\d+)$")
 # GitHub-hosted runners hard-stop a job at 6 hours; a repository-defined bound
 # is only meaningful well under that.
 HOSTED_JOB_MAXIMUM_MINUTES = 360
+
+# A Pi Vitest file is HOST-DEPENDENT when it compares the *live* process
+# platform against a literal.  Two shapes matter and both make a lane on the
+# wrong OS unable to attest the file:
+#   test.skipIf(process.platform !== "win32")(...)   - the whole test never runs
+#   process.platform === "win32" ? "junction" : "dir" - a different OS primitive
+# Deliberately NOT matched: an *injected* platform (`buildChildEnv({ platform:
+# "win32", ... })`) or one merely forwarded into a pure function
+# (`platform: process.platform`).  Those exercise the same code on every host,
+# which is exactly what makes them safe to run once on the canonical lane.
+_LIVE_PLATFORM_SELECTOR = re.compile(r"(?:process|os)\.platform\s*(?:===|!==)")
+# The three-OS fan-out that makes a job able to attest a host-dependent file.
+_PLATFORM_MATRIX = "os: [ubuntu-latest, windows-latest, macos-latest]"
+# Vitest declaration heads, with their modifier chain (`.skipIf`, `.each`, ...).
+_TEST_DECLARATION = re.compile(
+    r"(?m)^\s*(?P<kind>describe|test|it)(?P<modifier>(?:\.[A-Za-z]+)*)\s*(?=[(`])"
+)
+# Modifiers that disable tests unconditionally - at *static* time, with no host
+# predicate to satisfy.  `.only` belongs here because it silently disables every
+# sibling in the file.  A committed suite carrying any of these is "assigned" to
+# a required job while contributing no verdict (issue #405, one level down).
+# `.fails` is deliberately absent: it still executes the body and asserts it
+# throws, so it is a real verdict.
+_STATICALLY_DISABLED = frozenset({"skip", "todo", "only"})
 
 
 def workflow_jobs(text: str) -> dict[str, str]:
@@ -100,6 +125,81 @@ def unassigned_pi_test_files(ci: str, committed: set[str]) -> set[str]:
                 token.rsplit("/", 1)[-1] for token in rest.split() if token.endswith(".test.ts")
             }
     return set(committed) - covered
+
+
+def platform_sensitive_pi_test_files() -> set[str]:
+    """Committed ca-pi Vitest files whose behaviour is selected by the live OS.
+
+    File-granular assignment (``unassigned_pi_test_files`` above) proves every
+    suite runs *somewhere*.  It cannot prove the suite runs where its own
+    platform gate opens: a ``test.skipIf(process.platform !== "win32")`` case is
+    reported as "assigned" by a Linux-only lane that skips it.  This is the
+    second half of the #405 contract.
+    """
+    return {
+        path.name
+        for path in PI_TEST_DIR.glob("*.test.ts")
+        if _LIVE_PLATFORM_SELECTOR.search(path.read_text(encoding="utf-8"))
+    }
+
+
+def platform_contract_vitest_files() -> set[str]:
+    """Vitest files ``test_pi_platform_contract.py`` re-runs inside a matrix cell.
+
+    Read out of the script rather than duplicated here, so moving a file between
+    its fixture groups cannot silently desynchronise this contract.
+    """
+    source = PI_PLATFORM_CONTRACT.read_text(encoding="utf-8")
+    return {
+        name.rsplit("/", 1)[-1]
+        for name in re.findall(r'"(test/[A-Za-z0-9._-]+\.test\.ts)"', source)
+    }
+
+
+def os_matrix_pi_test_files(ci: str, committed: set[str]) -> set[str]:
+    """Vitest files a required Pi job executes on *every* supported OS.
+
+    Only a job that fans out over ``_PLATFORM_MATRIX`` counts: a job pinned to
+    one runner can never execute the other hosts' gated cases.
+    """
+    jobs = workflow_jobs(ci)
+    covered: set[str] = set()
+    for job_id in aggregate_required_results(ci):
+        block = jobs.get(job_id, "")
+        if not job_id.startswith("ca-pi") or _PLATFORM_MATRIX not in block:
+            continue
+        for match in re.finditer(r"(?m)^\s+run: npm test(?P<rest>[^\n]*)$", block):
+            rest = match.group("rest").strip()
+            if not rest:
+                covered |= set(committed)
+                continue
+            covered |= {
+                token.rsplit("/", 1)[-1] for token in rest.split() if token.endswith(".test.ts")
+            }
+        if "test_pi_platform_contract.py" in block:
+            covered |= platform_contract_vitest_files()
+    return covered
+
+
+def statically_disabled_pi_tests() -> dict[str, list[str]]:
+    """{file: [disabled declarations]} for `.skip` / `.todo` / `.only`.
+
+    These disable a case with no host predicate to satisfy, so the file stays
+    "assigned" to a required job while contributing nothing.  A genuine platform
+    gate must use ``.skipIf`` / ``.runIf``, which the OS-matrix contract above
+    then holds to running somewhere the gate opens.
+    """
+    disabled: dict[str, list[str]] = {}
+    for path in sorted(PI_TEST_DIR.glob("*.test.ts")):
+        found = [
+            f"{match.group('kind')}{match.group('modifier')}"
+            for match in _TEST_DECLARATION.finditer(path.read_text(encoding="utf-8"))
+            if _STATICALLY_DISABLED & set(match.group("modifier").split(".")[1:])
+        ]
+        if found:
+            disabled[path.name] = found
+    return disabled
+
 
 _spec = importlib.util.spec_from_file_location("ci_impact", _TOOL)
 module = importlib.util.module_from_spec(_spec)
@@ -348,6 +448,61 @@ class WorkflowContractTest(unittest.TestCase):
             "removing the full-suite run left every Pi test file still assigned",
         )
 
+    def test_every_platform_gated_pi_test_file_runs_on_every_supported_os(self):
+        # Issue #405, second half / issue #390 AC-2.  File-granular assignment
+        # is blind to a test's own platform gate: a Linux-only lane reports
+        # activation.test.ts as "assigned" while
+        # `test.skipIf(process.platform !== "win32")` at line 388 silently skips
+        # the only case that reads the fixed user-global update cache.  Any file
+        # that branches on the LIVE platform must therefore run in a job that
+        # fans out over all three operating systems, or its Windows/macOS branch
+        # is attested by nothing.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        committed = {path.name for path in PI_TEST_DIR.glob("*.test.ts")}
+        sensitive = platform_sensitive_pi_test_files()
+        self.assertTrue(sensitive, "no platform-gated Pi test files found - the scan is wrong")
+        self.assertLessEqual(
+            sensitive,
+            committed,
+            "the platform scan drifted off the committed Vitest set",
+        )
+        self.assertEqual(
+            sorted(sensitive - os_matrix_pi_test_files(ci, committed)),
+            [],
+            "Pi test files that branch on the live platform but run on one OS only",
+        )
+
+    def test_the_platform_gate_contract_binds_to_the_three_os_fan_out(self):
+        # The contract above must BITE on each way it can be broken.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        committed = {path.name for path in PI_TEST_DIR.glob("*.test.ts")}
+        covered = os_matrix_pi_test_files(ci, committed)
+        self.assertTrue(covered, "no required Pi job fans out over the OS matrix")
+        # (a) A host-INDEPENDENT suite is not credited with OS coverage, so a
+        #     future win32-gated test added to one would be caught.
+        self.assertNotIn("policy.test.ts", covered)
+        self.assertNotIn("policy.test.ts", platform_sensitive_pi_test_files())
+        # (b) Collapsing the fan-out to a single runner uncovers everything.
+        collapsed = ci.replace(_PLATFORM_MATRIX, "os: [ubuntu-latest]", 1)
+        self.assertEqual(os_matrix_pi_test_files(collapsed, committed), set())
+        # (c) Dropping one file from the matrix step uncovers exactly that file.
+        without = ci.replace(" test/activation.test.ts", "", 1)
+        self.assertEqual(
+            covered - os_matrix_pi_test_files(without, committed), {"activation.test.ts"}
+        )
+
+    def test_no_committed_pi_test_is_disabled_by_a_static_skip_todo_or_only(self):
+        # Issue #405, the "assigned but inert" hole: `npm test` makes every file
+        # a required gate, but a `test.skip` / `test.todo` inside one - or a
+        # single `test.only`, which mutes every sibling - keeps the board green
+        # with no verdict behind it.  A platform gate must be expressed as
+        # `.skipIf` / `.runIf` so the OS-matrix contract above can hold it.
+        self.assertEqual(
+            statically_disabled_pi_tests(),
+            {},
+            "ca-pi Vitest declarations disabled with no host predicate to satisfy",
+        )
+
     def test_host_independent_pi_job_is_registered_in_both_needs_and_required_results(self):
         # Issue #390 CRITICAL: `ci-passed` enforces jobs through TWO
         # independent registrations - the `needs:` list (which makes it wait)
@@ -499,7 +654,11 @@ class ReceiptCommandTest(unittest.TestCase):
             self.assertFalse(receipt["fallback"])
             self.assertEqual(
                 [check["id"] for check in receipt["selected"]],
-                ["pi-adapter", "pi-latest"],
+                # `pi-checks` is the canonical host-independent job added by
+                # issue #390.  A Pi payload edit now predicts all three Pi
+                # contracts; omitting it made the receipt under-report the
+                # required jobs a reviewer must wait on.
+                ["pi-adapter", "pi-checks", "pi-latest"],
             )
             self.assertEqual(
                 receipt["predicted_not_selected"],
@@ -507,6 +666,10 @@ class ReceiptCommandTest(unittest.TestCase):
             )
             self.assertEqual(
                 receipt["selected"][0]["reproduce"],
+                "python .github/scripts/test_pi_platform_contract.py --pi-version 0.80.10",
+            )
+            self.assertEqual(
+                receipt["selected"][1]["reproduce"],
                 "npm --prefix plugins/ca-pi/tools test",
             )
             self.assertEqual(

--- a/.github/scripts/test_pi_package.py
+++ b/.github/scripts/test_pi_package.py
@@ -729,6 +729,36 @@ def pi_ci_contract_violations(ci: str) -> list[str]:
     ) is None:
         violations.append("ca-pi-tools does not execute the live package RPC test")
 
+    # Issue #390 AC-2: a Vitest file that compares the LIVE process.platform
+    # against a literal cannot be attested by the ubuntu-only canonical job -
+    # `test.skipIf(process.platform !== "win32")` simply skips there, and
+    # `process.platform === "win32" ? "junction" : "dir"` exercises the POSIX
+    # primitive only. Every such file must run on all three operating systems.
+    # This oracle derives the set from the sources, independently of
+    # test_ci_impact.py, so both would have to be wrong to lose the coverage.
+    live_platform = re.compile(r"(?:process|os)\.platform\s*(?:===|!==)")
+    matrix_vitest: set[str] = set()
+    for match in re.finditer(r"(?m)^\s+run: npm test(?P<rest>[^\n]*)$", matrix):
+        matrix_vitest |= {
+            token.rsplit("/", 1)[-1]
+            for token in match.group("rest").split()
+            if token.endswith(".test.ts")
+        }
+    if "test_pi_platform_contract.py" in matrix:
+        contract_source = (REPO / ".github" / "scripts" / "test_pi_platform_contract.py").read_text(
+            encoding="utf-8"
+        )
+        matrix_vitest |= {
+            name.rsplit("/", 1)[-1]
+            for name in re.findall(r'"(test/[A-Za-z0-9._-]+\.test\.ts)"', contract_source)
+        }
+    pi_tests = REPO / "plugins" / "ca-pi" / "tools" / "test"
+    for source in sorted(pi_tests.glob("*.test.ts")):
+        if live_platform.search(source.read_text(encoding="utf-8")) and source.name not in matrix_vitest:
+            violations.append(
+                f"ca-pi-tools does not run platform-gated suite on every OS: {source.name}"
+            )
+
     # Issue #390/#405: the host-independent half of the Pi contract lives in one
     # canonical job, and its Vitest run is deliberately UNFILTERED so every
     # committed test/*.test.ts file is a required merge gate.
@@ -1118,6 +1148,13 @@ class PiPackageTests(unittest.TestCase):
         self.assertTrue(
             pi_ci_contract_violations(host_independent_remultiplied),
             "a host-independent step must not creep back into the six-cell matrix",
+        )
+
+        platform_gated_dropped = ci.replace(" test/activation.test.ts", "", 1)
+        self.assertNotEqual(platform_gated_dropped, ci, "the platform-gated matrix step vanished")
+        self.assertTrue(
+            pi_ci_contract_violations(platform_gated_dropped),
+            "a Vitest file that branches on the live platform must run on all three OSes",
         )
 
         aggregate_result_dropped = ci.replace(

--- a/.github/scripts/test_pi_package.py
+++ b/.github/scripts/test_pi_package.py
@@ -724,19 +724,47 @@ def pi_ci_contract_violations(ci: str) -> list[str]:
     if re.search(r"(?m)^\s{8}run: npm test -- test/package\.test\.ts\s*$", matrix) is None:
         violations.append("ca-pi-tools does not execute the native package test")
     if re.search(
-        r"(?m)^\s{8}run: npm test -- test/activation\.test\.ts test/commands\.test\.ts test/status\.test\.ts\s*$",
-        matrix,
-    ) is None:
-        violations.append("ca-pi-tools does not execute the focused lifecycle tests")
-    if re.search(
         r"(?m)^\s{8}run: python \.github/scripts/test_pi_package\.py --rpc-commands\s*$",
         matrix,
     ) is None:
         violations.append("ca-pi-tools does not execute the live package RPC test")
 
+    # Issue #390/#405: the host-independent half of the Pi contract lives in one
+    # canonical job, and its Vitest run is deliberately UNFILTERED so every
+    # committed test/*.test.ts file is a required merge gate.
+    canonical = job("ca-pi-checks")
+    if re.search(r"(?m)^\s{8}run: npm test\s*$", canonical) is None:
+        violations.append("ca-pi-checks does not execute the complete unfiltered Pi Vitest suite")
+    if "strategy:" in canonical:
+        violations.append("ca-pi-checks must not fan out across a matrix")
+    for token in (
+        "run: python tools/build-host-packages.py --check",
+        "run: npm run typecheck",
+        "run: npm run build",
+        "run: python .github/scripts/test_pi_security.py",
+        "run: python .github/scripts/test_pi_parity.py",
+        "run: python .github/scripts/pi_benchmark.py --samples 100",
+    ):
+        if token not in canonical:
+            violations.append(f"ca-pi-checks missing {token}")
+        if token in matrix:
+            violations.append(f"ca-pi-tools repeats host-independent step per cell: {token}")
+
     latest = job("ca-pi-latest")
-    if re.search(r"(?m)^    continue-on-error: true\s*$", latest) is None:
-        violations.append("ca-pi-latest must remain explicitly nonblocking at job level")
+    # Issue #381: a job-level continue-on-error still reports the check run as
+    # FAILURE, which is the false alarm this contract now forbids. The canary is
+    # made advisory by absorbing its two upstream probes at STEP level and
+    # publishing a receipt, so a harness break can still turn the check red.
+    if re.search(r"(?m)^    continue-on-error: true\s*$", latest) is not None:
+        violations.append("ca-pi-latest must not carry a job-level continue-on-error")
+    if len(re.findall(r"(?m)^\s{8}continue-on-error: true\s*$", latest)) != 2:
+        violations.append(
+            "ca-pi-latest must absorb exactly its two upstream-compatibility probes at step level",
+        )
+    if re.search(r"(?m)^\s{8}if: always\(\)\s*$", latest) is None:
+        violations.append("ca-pi-latest must always publish its advisory receipt")
+    if "GITHUB_STEP_SUMMARY" not in latest:
+        violations.append("ca-pi-latest must publish the advisory verdict to the job summary")
     canary_sequence = re.search(
         r'(?ms)^\s{10}npm install --global @earendil-works/pi-coding-agent@latest --ignore-scripts\s*$'
         r'.*?^\s{10}pi --version\s*$'
@@ -759,7 +787,7 @@ def pi_ci_contract_violations(ci: str) -> list[str]:
             for line in needs_match.group("body").splitlines()
             if line.strip().startswith("- ")
         }
-    for dependency in ("ca-pi-tools", "ca-pi-latest", "version-bump-pi"):
+    for dependency in ("ca-pi-checks", "ca-pi-tools", "ca-pi-latest", "version-bump-pi"):
         if dependency not in needs:
             violations.append(f"ci-passed.needs missing {dependency}")
     required_results = re.search(
@@ -770,6 +798,10 @@ def pi_ci_contract_violations(ci: str) -> list[str]:
         violations.append("ci-passed must enumerate required results separately from the advisory canary")
     elif "needs.ca-pi-latest.result" in required_results.group("body"):
         violations.append("ci-passed must not promote the advisory ca-pi-latest result into required results")
+    elif "needs['ca-pi-checks'].result" not in required_results.group("body"):
+        # Registering a job in `needs:` alone makes the gate wait for it without
+        # ever enforcing its verdict - the silent coverage drop issue #390 calls out.
+        violations.append("ci-passed.required_results missing ca-pi-checks")
     if 'canary_result="${{ needs.ca-pi-latest.result }}"' not in aggregate:
         violations.append("ci-passed must report the advisory ca-pi-latest result separately")
     return violations
@@ -1009,6 +1041,7 @@ class PiPackageTests(unittest.TestCase):
         required = (
             "ca-pi: ${{ steps.filter.outputs.ca-pi }}",
             "- 'plugins/ca-pi/**'",
+            "ca-pi-checks:",
             "ca-pi-tools:",
             "version-bump-pi:",
             'os: [ubuntu-latest, windows-latest, macos-latest]',
@@ -1016,10 +1049,11 @@ class PiPackageTests(unittest.TestCase):
             "npm install --global @earendil-works/pi-coding-agent@${{ matrix.pi-version }} --ignore-scripts",
             "npm ci --ignore-scripts",
             "Test package, module identity, compatibility, and native binding",
-            "Test activation, commands, and status lifecycle",
+            "Test the complete Pi adapter suite",
             "Test real package RPC activation and aliases",
             'python tools/build-host-packages.py --check --release-guard-base "$BASE_COMMIT"',
             "ca-pi-latest:",
+            "- ca-pi-checks",
             "- ca-pi-tools",
             "- ca-pi-latest",
             "- version-bump-pi",
@@ -1065,14 +1099,35 @@ class PiPackageTests(unittest.TestCase):
             "the matrix must execute the native-binding test command, not merely contain its text",
         )
 
-        focused_nooped = ci.replace(
-            "        run: npm test -- test/activation.test.ts test/commands.test.ts test/status.test.ts\n",
-            "        run: echo npm test -- test/activation.test.ts test/commands.test.ts test/status.test.ts\n",
+        full_suite_nooped = ci.replace(
+            "      - name: Test the complete Pi adapter suite\n        run: npm test\n",
+            "      - name: Test the complete Pi adapter suite\n        run: echo npm test\n",
             1,
         )
         self.assertTrue(
-            pi_ci_contract_violations(focused_nooped),
-            "every matrix cell must execute the focused lifecycle tests",
+            pi_ci_contract_violations(full_suite_nooped),
+            "the canonical Pi job must execute the complete unfiltered Vitest suite",
+        )
+
+        host_independent_remultiplied = ci.replace(
+            "      - name: Test package, module identity, compatibility, and native binding\n",
+            "      - name: Typecheck\n        run: npm run typecheck\n"
+            "      - name: Test package, module identity, compatibility, and native binding\n",
+            1,
+        )
+        self.assertTrue(
+            pi_ci_contract_violations(host_independent_remultiplied),
+            "a host-independent step must not creep back into the six-cell matrix",
+        )
+
+        aggregate_result_dropped = ci.replace(
+            "${{ needs['ca-pi-checks'].result }} ",
+            "",
+            1,
+        )
+        self.assertTrue(
+            pi_ci_contract_violations(aggregate_result_dropped),
+            "ci-passed must enforce ca-pi-checks, not merely wait for it",
         )
 
         rpc_nooped = ci.replace(
@@ -1115,14 +1170,38 @@ class PiPackageTests(unittest.TestCase):
             "the latest canary must execute the npm-latest install, not merely contain its text",
         )
 
-        latest_continue_commented = ci.replace(
-            "    continue-on-error: true\n",
-            "    # continue-on-error: true\n",
+        # Issue #381 inverted the old contract: a job-level continue-on-error
+        # still renders the check run FAILURE, so re-introducing one - or
+        # dropping either step-level absorption, or the always-published
+        # receipt - is now the violation.
+        latest_job_level_continue = ci.replace(
+            "  ca-pi-latest:\n    name:",
+            "  ca-pi-latest:\n    continue-on-error: true\n    name:",
             1,
         )
         self.assertTrue(
-            pi_ci_contract_violations(latest_continue_commented),
-            "the latest canary must retain an active job-level nonblocking declaration",
+            pi_ci_contract_violations(latest_job_level_continue),
+            "a job-level continue-on-error must not mask canary harness failures",
+        )
+
+        latest_probe_unabsorbed = ci.replace(
+            "        id: platform-contract\n        continue-on-error: true\n",
+            "        id: platform-contract\n",
+            1,
+        )
+        self.assertTrue(
+            pi_ci_contract_violations(latest_probe_unabsorbed),
+            "every upstream-compatibility probe must absorb its own failure at step level",
+        )
+
+        latest_receipt_dropped = ci.replace(
+            "        if: always()\n",
+            "        if: success()\n",
+            1,
+        )
+        self.assertTrue(
+            pi_ci_contract_violations(latest_receipt_dropped),
+            "the advisory receipt must publish even when a probe fails",
         )
 
         latest_order_drifted = ci.replace(

--- a/.github/scripts/test_verify_pi_support.py
+++ b/.github/scripts/test_verify_pi_support.py
@@ -94,6 +94,13 @@ class VerifyPiSupportTest(unittest.TestCase):
             for os_name in ("ubuntu-latest", "windows-latest", "macos-latest")
             for version in ("0.80.5", "0.80.10")
         } | {
+            # Issue #390 split the host-independent half of the adapter
+            # contract - the complete Vitest suite, the parity/security scripts,
+            # the bundle staleness gate, the benchmark - into its own required
+            # job.  The attestation names it directly: reaching it only through
+            # "Merge readiness" would let a future `required_results` edit drop
+            # the verdict without any Pi-support evidence noticing.
+            "[CHECK] | [PI  ] | Host-independent adapter contract",
             "[CHECK] | [PI  ] | Security analysis  <language: JavaScript/TypeScript>",
             "[GATE ] | [REPO] | Merge readiness",
         }

--- a/.github/scripts/verify_pi_support.py
+++ b/.github/scripts/verify_pi_support.py
@@ -55,6 +55,13 @@ REQUIRED_HOSTED_CHECKS = frozenset(
         for version in SUPPORTED
     }
     | {
+        # Issue #390 moved the host-independent half of the adapter contract -
+        # the complete Vitest suite, the parity/security scripts, the committed
+        # bundle staleness gate, the benchmark - out of the six matrix cells and
+        # into one canonical required job. It is named here directly rather than
+        # reached only through "Merge readiness", so a future edit to that gate's
+        # required_results cannot quietly drop it from the attestation.
+        "[CHECK] | [PI  ] | Host-independent adapter contract",
         "[CHECK] | [PI  ] | Security analysis  <language: JavaScript/TypeScript>",
         "[GATE ] | [REPO] | Merge readiness",
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,10 +351,26 @@ jobs:
     name: "[CHECK] | [PI  ] | Adapter contract  <os: ${{ matrix.os }} · runtime: Pi ${{ matrix.pi-version }}>"
     # Issue #390: the lean compatibility matrix. Only steps whose verdict is a
     # function of matrix.os or matrix.pi-version live here - the installed-Pi
-    # admission boundary, live package RPC activation, and the cross-platform
-    # platform contract. Everything host-independent moved to ca-pi-checks
-    # above; adding a host-independent step back here re-multiplies it by six
-    # and fails test_ci_impact.py.
+    # admission boundary, live package RPC activation, the cross-platform
+    # platform contract, and the Vitest suites that branch on the LIVE host
+    # platform. Everything host-independent moved to ca-pi-checks above; adding
+    # a host-independent step back here re-multiplies it by six and fails
+    # test_ci_impact.py.
+    #
+    # THE PARTITION RULE, stated once. A Pi Vitest file belongs here - not in
+    # the canonical ubuntu job alone - exactly when it compares the live
+    # `process.platform` against a literal, because then a Linux runner cannot
+    # reach the Windows/macOS branch at all:
+    #
+    #   test.skipIf(process.platform !== "win32")(...)      whole test skipped
+    #   process.platform === "win32" ? "junction" : "dir"   different OS primitive
+    #
+    # A platform value that is INJECTED (`buildChildEnv({ platform: "win32" })`)
+    # or merely forwarded into a pure function (`platform: process.platform`)
+    # does NOT qualify - child-env/compaction/status/tool-guard exercise the
+    # same code on every host, which is why they run once on ca-pi-checks.
+    # test_ci_impact.py derives this set from the sources; it is not a list a
+    # human keeps in sync.
     needs: changes
     if: needs.changes.outputs.ca-pi == 'true'
     strategy:
@@ -365,9 +381,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Issue #399. Worst observed cell before this split was 452s (windows-latest,
     # run 30123976665); the Windows cold `npm install --global` dominates and is
-    # unchanged by the split. 25 minutes is ~3.3x the recorded worst case, leaves
-    # room for a slow registry day, and still terminates a wedged install or a
-    # leaked process tree far short of the hosted 6-hour ceiling.
+    # unchanged by the split. That 452s cell also carried typecheck, the bundle
+    # build, the 100-sample benchmark and four Python scripts, all of which have
+    # moved to ca-pi-checks - so this job is a net reduction even with the
+    # platform-gated Vitest suites kept here. 25 minutes is ~3.3x the recorded
+    # worst case, leaves room for a slow registry day, and still terminates a
+    # wedged install or a leaked process tree far short of the 6-hour ceiling.
     timeout-minutes: 25
     defaults:
       run:
@@ -388,6 +407,14 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Test package, module identity, compatibility, and native binding
         run: npm test -- test/package.test.ts
+      # The host-dependent Vitest set, per the partition rule above. bridge,
+      # runner-isolation, process-tree and package are platform-gated too, but
+      # test_pi_platform_contract.py below already re-runs them in every cell,
+      # so they are not repeated here. Kept on ONE line on purpose: the workflow
+      # contracts in .github/scripts are textual (stdlib-only, no YAML parser)
+      # and read the covered file set straight off a `run: npm test -- ...` line.
+      - name: Test the platform-gated adapter suites on this operating system
+        run: npm test -- test/activation.test.ts test/background-jobs.test.ts test/commands.test.ts test/plan-mode.test.ts test/runtime-resolver.test.ts test/security.test.ts test/windows-supervisor.test.ts
       - name: Test real package RPC activation and aliases
         working-directory: .
         run: python .github/scripts/test_pi_package.py --rpc-commands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,16 +256,35 @@ jobs:
           fi
           echo "sandbox.js is in sync with the TypeScript sources"
 
-  ca-pi-tools:
-    name: "[CHECK] | [PI  ] | Adapter contract  <os: ${{ matrix.os }} · runtime: Pi ${{ matrix.pi-version }}>"
+  ca-pi-checks:
+    name: "[CHECK] | [PI  ] | Host-independent adapter contract"
+    # Issue #390: everything in this job consumes NEITHER matrix.os NOR
+    # matrix.pi-version, so the six-cell ca-pi-tools matrix below was producing
+    # six identical verdicts for it (1,423 runner-seconds on run 29870271440).
+    # It now runs exactly once per workflow run: package metadata, typecheck,
+    # the COMPLETE Vitest suite, the static security/parity scripts, the bundle
+    # rebuild + staleness gate, the release package contract, and the relative
+    # benchmark. ca-pi-tools keeps only the checks whose verdict genuinely
+    # depends on the installed Pi version or the host OS.
+    #
+    # Issue #405: the unfiltered `npm test` below is what makes every committed
+    # plugins/ca-pi/tools/test/*.test.ts file a required merge gate. Before
+    # this, required CI named 6 of 23 files and the rest (policy, plan-mode,
+    # dispatch, background-jobs, windows-supervisor, ...) could regress with
+    # the whole board green. Do NOT re-introduce a file filter here -
+    # test_ci_impact.py's partition contract fails if you do.
+    #
+    # REGISTRATION CONTRACT: this job must be listed in BOTH ci-passed's
+    # `needs:` block AND its `required_results` string. One without the other
+    # silently drops the verdict; test_ci_impact.py asserts the two agree.
     needs: changes
     if: needs.changes.outputs.ca-pi == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        pi-version: ["0.80.5", "0.80.10"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    # Issue #399. Observed p95 for the equivalent ubuntu matrix cell is ~135s
+    # (runs 29870271440 and 30123976665: 120/125/130/132s); the complete Vitest
+    # suite and the 100-sample benchmark add the rest, so ~5 minutes expected.
+    # 20 minutes is ~4x that and far below the hosted 6-hour job ceiling.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: plugins/ca-pi/tools
@@ -279,8 +298,22 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
+      - name: Resolve the pinned upstream Pi version from repository policy
+        # package.test.ts discovers the live Pi package root from PATH, so this
+        # job needs a real Pi installed. The version is READ from the repo's own
+        # support policy rather than hardcoded, so a Pi promotion (which rewrites
+        # the policy and the matrix, see .github/pi-promotion-targets.json) can
+        # never leave this job pinned to a stale runtime.
+        id: pinned
+        working-directory: .
+        shell: bash
+        run: |
+          policy="$(python .github/scripts/pi_promotion.py policy)"
+          version="$(python -c 'import json,sys; print(json.loads(sys.argv[1])["last_verified"])' "$policy")"
+          echo "resolved pinned Pi version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Install external Pi host (scripts disabled)
-        run: npm install --global @earendil-works/pi-coding-agent@${{ matrix.pi-version }} --ignore-scripts
+        run: npm install --global @earendil-works/pi-coding-agent@${{ steps.pinned.outputs.version }} --ignore-scripts
       - name: Install reviewed toolchain (scripts disabled)
         run: npm ci --ignore-scripts
       - name: Check generated root package metadata
@@ -288,12 +321,8 @@ jobs:
         run: python tools/build-host-packages.py --check
       - name: Typecheck
         run: npm run typecheck
-      - name: Test package, module identity, compatibility, and native binding
-        run: npm test -- test/package.test.ts
-      - name: Test activation, commands, and status lifecycle
-        run: npm test -- test/activation.test.ts test/commands.test.ts test/status.test.ts
-      - name: Test canonical bridge and final-execution enforcement
-        run: npm test -- test/bridge.test.ts test/tool-guard.test.ts
+      - name: Test the complete Pi adapter suite
+        run: npm test
       - name: Test adversarial Pi security promotion contract
         working-directory: .
         run: python .github/scripts/test_pi_security.py
@@ -314,22 +343,32 @@ jobs:
       - name: Test release package contract
         working-directory: .
         run: python .github/scripts/test_pi_package.py
-      - name: Test real package RPC activation and aliases
-        working-directory: .
-        run: python .github/scripts/test_pi_package.py --rpc-commands
-      - name: Test cross-platform paths, encoding, cancellation, process trees, prune, and generation
-        working-directory: .
-        run: python .github/scripts/test_pi_platform_contract.py --pi-version ${{ matrix.pi-version }}
       - name: Measure the three-host relative adapter benchmark
         working-directory: .
         run: python .github/scripts/pi_benchmark.py --samples 100
 
-  ca-pi-latest:
-    name: "[WATCH] | [PI  ] | Upstream compatibility  <runtime: npm latest>"
+  ca-pi-tools:
+    name: "[CHECK] | [PI  ] | Adapter contract  <os: ${{ matrix.os }} · runtime: Pi ${{ matrix.pi-version }}>"
+    # Issue #390: the lean compatibility matrix. Only steps whose verdict is a
+    # function of matrix.os or matrix.pi-version live here - the installed-Pi
+    # admission boundary, live package RPC activation, and the cross-platform
+    # platform contract. Everything host-independent moved to ca-pi-checks
+    # above; adding a host-independent step back here re-multiplies it by six
+    # and fails test_ci_impact.py.
     needs: changes
     if: needs.changes.outputs.ca-pi == 'true'
-    continue-on-error: true
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        pi-version: ["0.80.5", "0.80.10"]
+    runs-on: ${{ matrix.os }}
+    # Issue #399. Worst observed cell before this split was 452s (windows-latest,
+    # run 30123976665); the Windows cold `npm install --global` dominates and is
+    # unchanged by the split. 25 minutes is ~3.3x the recorded worst case, leaves
+    # room for a slow registry day, and still terminates a wedged install or a
+    # leaked process tree far short of the hosted 6-hour ceiling.
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: plugins/ca-pi/tools
@@ -343,18 +382,106 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
+      - name: Install external Pi host (scripts disabled)
+        run: npm install --global @earendil-works/pi-coding-agent@${{ matrix.pi-version }} --ignore-scripts
+      - name: Install reviewed toolchain (scripts disabled)
+        run: npm ci --ignore-scripts
+      - name: Test package, module identity, compatibility, and native binding
+        run: npm test -- test/package.test.ts
+      - name: Test real package RPC activation and aliases
+        working-directory: .
+        run: python .github/scripts/test_pi_package.py --rpc-commands
+      - name: Test cross-platform paths, encoding, cancellation, process trees, prune, and generation
+        working-directory: .
+        run: python .github/scripts/test_pi_platform_contract.py --pi-version ${{ matrix.pi-version }}
+
+  ca-pi-latest:
+    name: "[WATCH] | [PI  ] | Upstream compatibility  <runtime: npm latest>"
+    # Issue #381: this is a WATCH lane, not a gate. Upstream publishing a Pi
+    # outside the validated support window is the SIGNAL this job exists to
+    # report - it belongs in the job summary, never as a red check on an
+    # otherwise merge-ready PR. So the two upstream-compatibility probes below
+    # absorb their own failure at STEP level and the job publishes an advisory
+    # receipt and concludes green.
+    #
+    # There is deliberately NO job-level `continue-on-error` here. GitHub still
+    # reports a job-level continue-on-error job's check run with conclusion
+    # `failure` (observed on PR #313 and again on PR #420), which is the exact
+    # false alarm this fixes. Keeping the job honest means a failure in the
+    # canary HARNESS - checkout, toolchain install, receipt publication - is a
+    # real defect in the watch itself and still turns this check red.
+    needs: changes
+    if: needs.changes.outputs.ca-pi == 'true'
+    runs-on: ubuntu-latest
+    # Issue #399. Observed 17-18s when the probe fails fast; a compatible latest
+    # runs the package suite plus the full platform contract, so budget like the
+    # ubuntu adapter cell. 20 minutes bounds a wedged npm install without ever
+    # truncating a healthy run.
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: plugins/ca-pi/tools
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.19.0
+          cache: npm
+          cache-dependency-path: plugins/ca-pi/tools/package-lock.json
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      # HARNESS - not absorbed. If the toolchain or the latest-Pi install fails,
+      # the canary itself is broken and this check must go red.
       - name: Install reviewed toolchain and external latest Pi (scripts disabled)
         run: |
           npm ci --ignore-scripts
           npm install --global @earendil-works/pi-coding-agent@latest --ignore-scripts
+      # PROBES - absorbed. Their outcome is the observation, not the verdict.
       - name: Report latest version and test installed runtime admission
+        id: admission
+        continue-on-error: true
         run: |
           pi --version
           npm test -- test/package.test.ts -t "installed Pi runtime is admitted by the production boundary"
           npm test -- test/package.test.ts
       - name: Run the latest Pi platform contract as a nonblocking canary
+        id: platform-contract
+        continue-on-error: true
         working-directory: .
         run: python .github/scripts/test_pi_platform_contract.py --pi-version latest
+      # RECEIPT - not absorbed, and always published. A failure to publish the
+      # advisory verdict is a harness failure and must be visible.
+      - name: Publish the advisory upstream-compatibility receipt
+        if: always()
+        working-directory: .
+        shell: bash
+        env:
+          ADMISSION: ${{ steps.admission.outcome }}
+          PLATFORM_CONTRACT: ${{ steps.platform-contract.outcome }}
+        run: |
+          # `shell: bash` runs with -eo pipefail, so the probe is wrapped: an
+          # absent or broken `pi` must degrade to "unresolved", never fail the
+          # receipt step and turn this advisory check red.
+          latest="$({ pi --version 2>/dev/null || true; } | tr -d '\r' | tail -n 1)"
+          [ -n "$latest" ] || latest="unresolved"
+          {
+            echo "## Pi upstream compatibility (advisory)"
+            echo
+            echo "This is a WATCH lane. It reports whether npm-latest Pi is inside"
+            echo "the validated support window; it never blocks merge."
+            echo
+            echo "| probe | outcome |"
+            echo "| --- | --- |"
+            echo "| npm latest Pi | \`$latest\` |"
+            echo "| installed-runtime admission | \`$ADMISSION\` |"
+            echo "| latest platform contract | \`$PLATFORM_CONTRACT\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$ADMISSION" = success ] && [ "$PLATFORM_CONTRACT" = success ]; then
+            echo "latest Pi ($latest) is inside the validated support window"
+          else
+            echo "::warning title=Pi upstream compatibility::latest Pi ($latest) is outside the validated support window (admission=$ADMISSION, platform-contract=$PLATFORM_CONTRACT). Advisory only - run the Pi promotion workflow to validate and promote it."
+          fi
 
   ca-pi-codeql:
     name: "[CHECK] | [PI  ] | Security analysis  <language: JavaScript/TypeScript>"
@@ -690,6 +817,9 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.ca-pi == 'true'
     runs-on: ubuntu-latest
+    # Issue #399. Observed 4-7s (a full-history fetch plus one Python check);
+    # 10 minutes bounds a wedged `git fetch` with three orders of headroom.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -841,6 +971,14 @@ jobs:
 
   ci-passed:
     name: "[GATE ] | [REPO] | Merge readiness"
+    # REGISTRATION CONTRACT (issue #390): this gate enforces a job through TWO
+    # independent registrations - the `needs:` list below (which makes the gate
+    # WAIT for it) and the `required_results` string in the step (which makes
+    # the gate CARE about its verdict). Adding a job to one and not the other
+    # silently drops coverage with nothing else in CI to catch it. The only
+    # sanctioned divergence is ca-pi-latest, the advisory WATCH canary
+    # (issue #381), which is awaited so the run settles but never enforced.
+    # test_ci_impact.py asserts exactly that: needs - required == {ca-pi-latest}.
     if: always()
     needs:
       - documentation-contract
@@ -849,6 +987,7 @@ jobs:
       - ci-impact
       - tools
       - ca-sandbox-tools
+      - ca-pi-checks
       - ca-pi-tools
       - ca-pi-latest
       - ca-pi-codeql
@@ -868,7 +1007,7 @@ jobs:
     steps:
       - name: Require every required job to have succeeded or been skipped
         run: |
-          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }}"
+          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }}"
           canary_result="${{ needs.ca-pi-latest.result }}"
           echo "upstream required results: $required_results"
           echo "advisory Pi canary result: $canary_result"

--- a/.github/workflows/pi-promotion.yml
+++ b/.github/workflows/pi-promotion.yml
@@ -26,6 +26,10 @@ jobs:
   resolve:
     name: "[WATCH] | [PI  ] | Resolve exact candidate"
     runs-on: ubuntu-latest
+    # Issue #399. One `npm view` against the public registry plus two Python
+    # calls - seconds in practice. 15 minutes bounds a hung registry lookup
+    # without ever truncating a healthy resolve.
+    timeout-minutes: 15
     outputs:
       candidate: ${{ steps.candidate.outputs.candidate }}
       baseline: ${{ steps.candidate.outputs.baseline }}
@@ -68,6 +72,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Issue #399. This is the heaviest Pi lane: TWO external Pi installs
+    # (baseline + candidate), a bundle rebuild, the complete adapter suite, and
+    # the full platform contract. The comparable ci.yml Windows cell peaked at
+    # 452s while doing roughly half of this, so budget ~15 minutes expected and
+    # bound at 45 - three orders below the hosted 6-hour ceiling, and low enough
+    # that a wedged install cannot stall the weekly promotion for hours.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -138,6 +149,9 @@ jobs:
     needs: [resolve, validate]
     if: github.event_name == 'workflow_dispatch' && inputs.create_pr == true
     runs-on: ubuntu-latest
+    # Issue #399. A checkout, one `npm ci`, one bundle rebuild, and a `gh pr
+    # create`. 20 minutes bounds a hung push or API call with wide headroom.
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write

--- a/docs/pi-parity-testing.md
+++ b/docs/pi-parity-testing.md
@@ -26,7 +26,7 @@ pi list
 pi config
 ```
 
-For the initial release, `<version>` is `0.1.1`. `pi list` must show the pinned
+For the initial release, `<version>` is `0.1.2`. `pi list` must show the pinned
 Git source. In `pi config`, confirm that the package contributes one parent
 extension and the generated `ca-*` skills. Use `-l` only when you deliberately
 want a project-local Pi setting.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.2] - 2026-07-24
+
+### Fixed
+
+- The canonical plan-file bridge tests no longer hardcode a Windows-absolute
+  repository root, so they exercise `operatePlanFile` on Linux and macOS instead
+  of silently asserting the rejected path. Test-only; `plan-mode.ts` is
+  unchanged.
+
+
 ## [0.1.1] - 2026-07-18
 
 ### Fixed

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/test/plan-mode.test.ts
+++ b/plugins/ca-pi/tools/test/plan-mode.test.ts
@@ -16,6 +16,15 @@ import {
   type PlanSessionState,
 } from "../src/plan-mode.ts";
 
+/**
+ * operatePlanFile() rejects a repositoryRoot that is not `isAbsolute()`, and
+ * absoluteness is platform-dependent: "C:/repo" is absolute on Windows and
+ * relative everywhere else. Hardcoding the Windows spelling made these cases
+ * silently return OPERATION_FAILED on Linux and macOS. This file ran nowhere in
+ * required CI until issue #405, so that never surfaced.
+ */
+const REPOSITORY_ROOT = process.platform === "win32" ? "C:/repo" : "/repo";
+
 const ledger = (rows: readonly string[]) => [
   "# Example plan",
   "",
@@ -232,7 +241,7 @@ describe("canonical plan-file bridge operations", () => {
     ]);
     const state = enterPlan("example-plan", baseLedger)!;
     const result = await operatePlanFile(
-      state, "C:/repo", state.activePlan.specPath, { kind: "replace", content: wanted }, bridge,
+      state, REPOSITORY_ROOT, state.activePlan.specPath, { kind: "replace", content: wanted }, bridge,
     );
     expect(result).toEqual({ ok: true, content: wanted, state });
     expect(bridge.calls.map((call) => call.input)).toEqual([
@@ -251,7 +260,7 @@ describe("canonical plan-file bridge operations", () => {
     ]);
     const state = enterPlan("example-plan", baseLedger)!;
     const result = await operatePlanFile(
-      state, "C:/repo", state.activePlan.planPath,
+      state, REPOSITORY_ROOT, state.activePlan.planPath,
       { kind: "transition", taskId: "T-01", status: "IN_PROGRESS" }, bridge,
     );
     expect(result.ok).toBe(true);
@@ -269,7 +278,7 @@ describe("canonical plan-file bridge operations", () => {
     ]);
     const state = enterPlan("example-plan", baseLedger)!;
     await expect(operatePlanFile(
-      state, "C:/repo", state.activePlan.specPath, { kind: "replace", content: wanted }, bridge,
+      state, REPOSITORY_ROOT, state.activePlan.specPath, { kind: "replace", content: wanted }, bridge,
     )).resolves.toMatchObject({ ok: true, content: wanted });
     expect(bridge.calls[1]?.input).toMatchObject({ expectedHash: null });
   });
@@ -284,7 +293,7 @@ describe("canonical plan-file bridge operations", () => {
     ]);
     const state = enterPlan("example-plan", baseLedger)!;
     const result = await operatePlanFile(
-      state, "C:/repo", state.activePlan.planPath,
+      state, REPOSITORY_ROOT, state.activePlan.planPath,
       { kind: "transition", taskId: "T-01", status: "IN_PROGRESS" }, bridge,
     );
     expect(result).toMatchObject({ ok: false, committed: true, content: observed });
@@ -298,7 +307,7 @@ describe("canonical plan-file bridge operations", () => {
     const state = enterPlan("example-plan", baseLedger)!;
     const missing = new FakeBridge([bridgeResponse({ status: "unchanged", exists: false, hash: null, content: "" })]);
     await expect(operatePlanFile(
-      state, "C:/repo", state.activePlan.specPath, { kind: "read" }, missing,
+      state, REPOSITORY_ROOT, state.activePlan.specPath, { kind: "read" }, missing,
     )).resolves.toEqual({ ok: false });
 
     const conflict = new FakeBridge([
@@ -306,19 +315,19 @@ describe("canonical plan-file bridge operations", () => {
       bridgeResponse({ status: "conflict" }),
     ]);
     await expect(operatePlanFile(
-      state, "C:/repo", state.activePlan.specPath, { kind: "replace", content: "# new\n" }, conflict,
+      state, REPOSITORY_ROOT, state.activePlan.specPath, { kind: "replace", content: "# new\n" }, conflict,
     )).resolves.toEqual({ ok: false });
 
     const malformed = new FakeBridge([
       bridgeResponse({ status: "unchanged", exists: true, hash: "0".repeat(64), content: "# mismatch\n" }),
     ]);
     await expect(operatePlanFile(
-      state, "C:/repo", state.activePlan.specPath, { kind: "read" }, malformed,
+      state, REPOSITORY_ROOT, state.activePlan.specPath, { kind: "read" }, malformed,
     )).resolves.toEqual({ ok: false });
 
     const untouched = new FakeBridge([]);
     await expect(operatePlanFile(
-      state, "C:/repo", ".codearbiter/open-tasks.md", { kind: "read" }, untouched,
+      state, REPOSITORY_ROOT, ".codearbiter/open-tasks.md", { kind: "read" }, untouched,
     )).resolves.toEqual({ ok: false });
     expect(untouched.calls).toEqual([]);
   });
@@ -328,11 +337,11 @@ describe("canonical plan-file bridge operations", () => {
     const execute = cancelPlan(plan)!;
     const bridge = new FakeBridge([]);
     await expect(operatePlanFile(
-      execute, "C:/repo", plan.activePlan.planPath, { kind: "read" }, bridge,
+      execute, REPOSITORY_ROOT, plan.activePlan.planPath, { kind: "read" }, bridge,
     )).resolves.toEqual({ ok: false });
     await expect(operatePlanFile(
       { ...plan, mode: "unknown" } as unknown as PlanSessionState,
-      "C:/repo", plan.activePlan.planPath, { kind: "read" }, bridge,
+      REPOSITORY_ROOT, plan.activePlan.planPath, { kind: "read" }, bridge,
     )).resolves.toEqual({ ok: false });
     expect(bridge.calls).toEqual([]);
   });


### PR DESCRIPTION
Four CI-structure defects around the Pi jobs, fixed together because they all reshape the same job graph in `.github/workflows/ci.yml`. This lane is CI-config, so the tests are assertions in `.github/scripts/test_ci_impact.py` (`WorkflowContractTest`, extended in the file's existing style) plus the pre-existing `pi_ci_contract_violations()` oracle in `.github/scripts/test_pi_package.py`.

Closes #405
Closes #390
Closes #399
Closes #381

---

## What changed

### #405 — run every Pi adapter suite in required PR CI

Required CI named 6 of the 23 committed `plugins/ca-pi/tools/test/*.test.ts` files. The other 17 (policy, plan-mode, dispatch, background-jobs, activity, doctor, footer, notices, runtime-resolver, windows-supervisor, security, farm, compaction, child-env, final-arguments, process-tree, runner-isolation) could regress with every required merge-readiness check green.

The new canonical Pi job runs an **unfiltered `npm test`**. `test_ci_impact.py` now computes the partition from the workflow text — a bare `npm test` in a required Pi job covers the whole suite, a filtered `npm test -- test/a.test.ts` covers only what it names — and fails when any committed file is unassigned. A second test proves the contract *bites*: neutering the unfiltered run must leave files unassigned.

**File-granular assignment is not enough, and review caught that.** Two further holes are now closed:

1. **A file can be "assigned" while its own gate keeps it from running.** `activation.test.ts:388` is `test.skipIf(process.platform !== "win32")`; an ubuntu-only lane reports the file as covered and skips the case. So a *second* contract asserts that every file which branches on the **live** `process.platform` runs in a job that fans out over all three operating systems. It is asserted independently in `test_ci_impact.py` (`os_matrix_pi_test_files`) and in `pi_ci_contract_violations()`, both deriving the set from the sources rather than from a hand-kept list — both would have to be wrong to lose the coverage.
2. **A file can be "assigned" while every test inside it is disabled.** A third contract forbids a static `.skip` / `.todo` / `.only` anywhere in the committed Pi suite. (`.only` is included because it silently mutes every sibling; `.fails` is deliberately allowed — it executes the body and asserts it throws, so it is a real verdict.) A genuine platform gate must be written as `.skipIf` / `.runIf`, which contract 1 then holds to running somewhere the gate opens.

Local evidence that the previously-omitted set is runnable and green:

```
$ npx vitest run test/activity.test.ts test/background-jobs.test.ts test/dispatch.test.ts \
    test/doctor.test.ts test/footer.test.ts test/notices.test.ts test/plan-mode.test.ts \
    test/policy.test.ts test/runtime-resolver.test.ts test/windows-supervisor.test.ts
 Test Files  10 passed (10)
      Tests  222 passed (222)
```

### #390 — factor host-independent Pi checks out of the six-cell matrix

The 3 OS x 2 Pi-version matrix re-ran package-metadata checking, typecheck, the deterministic Vitest suites, the static security/parity scripts, the bundle rebuild + staleness gate, the release package contract, and a 100-sample benchmark **once per cell** — 1,423 runner-seconds on run 29870271440.

New job `ca-pi-checks` (`[CHECK] | [PI  ] | Host-independent adapter contract`), one cell on ubuntu-latest, owns:

- `python tools/build-host-packages.py --check`
- `npm run typecheck`
- `npm test` (unfiltered — see #405)
- `python .github/scripts/test_pi_security.py`
- `python .github/scripts/test_pi_parity.py`
- `npm run build` + the committed-bundle staleness gate
- `python .github/scripts/test_pi_package.py`
- `python .github/scripts/pi_benchmark.py --samples 100`

#### The partition, stated explicitly

The issue's AC is "keep every test whose behavior genuinely depends on the installed Pi version **or operating system** in the matrix." An earlier revision of this PR got that wrong and moved `activation.test.ts` / `commands.test.ts` out of the matrix; review caught it. The rule now applied — and enforced by the two contracts above, not by a list:

| shape | host-dependent? | why |
| --- | --- | --- |
| `test.skipIf(process.platform !== "win32")(...)` | **yes** | the whole test is skipped on the wrong runner |
| `process.platform === "win32" ? "junction" : "dir"` | **yes** | a *different operating-system primitive* is exercised |
| `buildChildEnv({ platform: "win32", ... })` | no | the platform is **injected**; both branches run everywhere |
| `runtime: { ..., platform: process.platform }` | no | forwarded into a pure function; same code on every host |

Applying it to the committed tree gives 11 host-dependent files. `bridge`, `package`, `process-tree` and `runner-isolation` are already re-run per cell by `test_pi_platform_contract.py`; the remaining seven — `activation`, `background-jobs`, `commands`, `plan-mode`, `runtime-resolver`, `security`, `windows-supervisor` — are executed by a new matrix step. `child-env`, `compaction`, `status` and `tool-guard` carry no live-platform comparison at all and run once on `ca-pi-checks`.

`ca-pi-tools` therefore keeps: the installed-Pi admission boundary (`npm test -- test/package.test.ts`), the platform-gated Vitest set, live package RPC activation (`test_pi_package.py --rpc-commands`), and `test_pi_platform_contract.py --pi-version ${{ matrix.pi-version }}`.

**The savings still hold.** The heavy per-cell work #390 measured — six typechecks, six bundle builds, six 100-sample benchmarks, six copies of the static Python scripts, six release-package contracts — is gone. What returns to the matrix is Vitest time on an already-installed toolchain: 7 files, **159 tests, 4.7s** locally. The pre-split worst cell (452s, windows-latest, run 30123976665) carried all of the removed work, so this job is a net reduction.

`ca-pi-checks` resolves its Pi version from the repo's own support policy (`pi_promotion.py policy` -> `last_verified`) rather than hardcoding it, so a Pi promotion — which rewrites the matrix via `.github/pi-promotion-targets.json` but would not know about a new hardcoded string — cannot leave this job pinned to a stale runtime.

**The registration contract (called out as CRITICAL).** `ci-passed` enforces a job through two independent registrations: the `needs:` list (makes the gate *wait*) and the `required_results` string (makes the gate *care*). `ca-pi-checks` is in **both**, and `test_ci_impact.py` now asserts they agree for *every* job:

```python
self.assertEqual(sorted(set(needs) - set(required)), ["ca-pi-latest"])
self.assertEqual(sorted(set(required) - set(needs)), [])
```

The only sanctioned divergence is `ca-pi-latest`, the advisory WATCH canary. `pi_ci_contract_violations()` carries the same check independently.

**Attestation and impact-map registration.** Two follow-ons the first revision deferred are closed here, because both weaken something this lane created:

- `verify_pi_support.py::REQUIRED_HOSTED_CHECKS` now names `[CHECK] | [PI  ] | Host-independent adapter contract` directly. Reaching it only through `Merge readiness` meant a future edit to that gate's `required_results` could drop the verdict with no Pi-support evidence noticing.
- `.github/ci-impact-map.json` gains the `pi-checks` id and adds it to the `plugins/ca-pi/**` edge, so a Pi payload edit predicts all three Pi contracts. `pi-adapter`'s `reproduce` is corrected at the same time: the matrix no longer runs the whole suite, so the accurate local repro is `python .github/scripts/test_pi_platform_contract.py --pi-version 0.80.10`.

### #399 — explicit job deadlines

How the values were chosen — from the two most recent hosted runs' Pi job durations (`29870271440`, `30123976665`), not from guesses:

| job | observed | timeout | reasoning |
| --- | --- | --- | --- |
| `ci.yml` `ca-pi-checks` | ubuntu cells 120/125/130/132s; plus full suite + benchmark, ~5 min expected | **20** | ~4x expected |
| `ci.yml` `ca-pi-tools` | worst cell 452s (windows-latest, run 30123976665), and that cell also carried typecheck/build/benchmark/four Python scripts which have now moved out | **25** | ~3.3x the recorded worst case, room for a slow registry day |
| `ci.yml` `ca-pi-latest` | 17-18s when the probe fails fast; a compatible latest runs the package suite + full platform contract | **20** | budgeted like the ubuntu adapter cell |
| `ci.yml` `ca-pi-codeql` | — | 30 (pre-existing, unchanged) | |
| `ci.yml` `version-bump-pi` | 4-7s | **10** | bounds a wedged full-history `git fetch` |
| `pi-promotion.yml` `resolve` | seconds | **15** | bounds a hung registry lookup |
| `pi-promotion.yml` `validate` | heaviest Pi lane: two external Pi installs + rebuild + complete suite + platform contract on three OSes; ~15 min expected | **45** | |
| `pi-promotion.yml` `open-pr` | checkout + `npm ci` + rebuild + `gh pr create` | **20** | |

Every value is far below GitHub's 6-hour hosted job ceiling; the contract test asserts each Pi job declares a timeout and that it is `0 < t < 360`.

### #381 — the latest-Pi canary concludes advisory

`ca-pi-latest` was declared `continue-on-error: true` at **job** level. That keeps the workflow run from failing but GitHub still reports the check run with conclusion `FAILURE` — observed on PR #313 and on PR #420, where `[WATCH] | [PI  ] | Upstream compatibility  <runtime: npm latest>` was red while main was green.

The failing step on PR #420 (and on run 30123976665) is `Report latest version and test installed runtime admission` — the *probe*, not the harness:

```
{"name":"Install reviewed toolchain and external latest Pi (scripts disabled)","conclusion":"success"}
{"name":"Report latest version and test installed runtime admission","conclusion":"failure"}
{"name":"Run the latest Pi platform contract as a nonblocking canary","conclusion":"skipped"}
```

Now:

- job-level `continue-on-error` is **removed** (it does not change the check conclusion, and it would mask real harness breaks);
- the two upstream-compatibility probes carry step-level `continue-on-error: true` with ids `admission` and `platform-contract`;
- a final `if: always()` step publishes an advisory receipt — the resolved latest version and each probe's outcome — to `$GITHUB_STEP_SUMMARY`, plus a `::warning` annotation, and exits 0;
- checkout / toolchain install / latest-Pi install / receipt publication are **not** absorbed, so a break in the canary harness still turns the check red (AC-2);
- `ca-pi-latest` remains out of `required_results` (AC-3).

**Would this have made PR #420's case advisory?** Yes. Simulated with the exact step outcomes from that run:

```
$ GITHUB_STEP_SUMMARY=summary.md ADMISSION=failure PLATFORM_CONTRACT=skipped bash -eo pipefail receipt.sh
::warning title=Pi upstream compatibility::latest Pi (0.80.10) is outside the validated support window
(admission=failure, platform-contract=skipped). Advisory only - run the Pi promotion workflow to validate and promote it.
exit=0
```

---

## Red-test evidence (verbatim, before any implementation)

### First revision — the four issues

`python -m unittest test_ci_impact.WorkflowContractTest` run from `.github/scripts/` against unmodified `main`:

```
AssertionError: Lists differ: ['activity.test.ts', 'background-jobs.test[330 chars].ts'] != []
First list contains 17 additional elements.
- ['activity.test.ts', 'background-jobs.test.ts', 'child-env.test.ts', 'compaction.test.ts',
-  'dispatch.test.ts', 'doctor.test.ts', 'farm.test.ts', 'final-arguments.test.ts',
-  'footer.test.ts', 'notices.test.ts', 'plan-mode.test.ts', 'policy.test.ts',
-  'process-tree.test.ts', 'runner-isolation.test.ts', 'runtime-resolver.test.ts',
-  'security.test.ts', 'windows-supervisor.test.ts'] : committed ca-pi test files that no required merge-gate job executes

AssertionError: 7 not greater than or equal to 8 : the Pi job scan found too few jobs
AssertionError: 'ca-pi-checks' not found in ['badge-consistency', 'ca-pi-codeql', 'ca-pi-latest', 'ca-pi-tools', ...]
AssertionError: <re.Match object; span=(158, 185), match='    continue-on-error: true'> is not None : job-level continue-on-error hides canary harness failures
AssertionError: [] == [] : no required ca-pi job runs the unfiltered `npm test` suite

Ran 9 tests in 0.005s
FAILED (failures=6)
```

`test_pi_package.py::pi_ci_contract_violations` also went red on the restructure and was updated in step, including three mutation assertions (a neutered full-suite run, a host-independent step creeping back into the matrix, and `ca-pi-checks` dropped from `required_results` while left in `needs:`).

### Second revision — the coverage regression review found

New contracts written first, against the head commit `40f93d6` (the ubuntu-only partition):

```
FAIL: test_every_platform_gated_pi_test_file_runs_on_every_supported_os
AssertionError: Lists differ: ['activation.test.ts', 'background-jobs.te[121 chars].ts'] != []
First list contains 7 additional elements.
- ['activation.test.ts',
-  'background-jobs.test.ts',
-  'commands.test.ts',
-  'plan-mode.test.ts',
-  'runtime-resolver.test.ts',
-  'security.test.ts',
-  'windows-supervisor.test.ts'] : Pi test files that branch on the live platform but run on one OS only

FAIL: test_the_platform_gate_contract_binds_to_the_three_os_fan_out
AssertionError: Items in the second set but not the first:
'activation.test.ts'

FAIL: test_cli_writes_deterministic_json_and_a_markdown_summary
AssertionError: Lists differ: ['pi-adapter', 'pi-latest'] != ['pi-adapter', 'pi-checks', 'pi-latest']

FAIL: test_final_hosted_attestation_requires_repo_aggregate (test_verify_pi_support)
AssertionError: frozenset({'[CHECK] | [PI  ] | Adapter co[567 chars]t>'}) != {'[CHECK] | [PI  ] | Adapter contract  <o[612 chars]pt>'}
```

Each contract was then **mutation-checked** to prove it bites rather than merely passing:

```
# a future win32-gated test added to a file only the ubuntu lane runs
$ (append test.skipIf(process.platform !== "win32")(...) to policy.test.ts)
AssertionError: Lists differ: ['policy.test.ts'] != [] : Pi test files that branch on the live platform but run on one OS only
AssertionError: Lists differ: ['ca-pi-tools does not run platform-gated suite on every OS: policy.test.ts'] != []
   ^ both oracles fire independently

# a statically disabled test inside an "assigned" file
$ (change one `test(` to `test.skip(` in policy.test.ts)
AssertionError: {'policy.test.ts': ['test.skip']} != {} : ca-pi Vitest declarations disabled with no host predicate to satisfy
```

Plus, inside `test_the_platform_gate_contract_binds_to_the_three_os_fan_out`: collapsing `os: [ubuntu-latest, windows-latest, macos-latest]` to one runner must uncover every file, and deleting one filename from the matrix step must uncover exactly that file.

---

## Verification

| suite | result |
| --- | --- |
| `python -m unittest discover -s .github/scripts -p "test_*.py"` | **1046 tests, OK, 5 skipped** |
| `plugins/ca-pi/tools` — full unfiltered `npx vitest run` (what `ca-pi-checks` runs) | 23 files / **545 passed, 1 skipped** |
| `plugins/ca-pi/tools` — the new matrix step's 7 platform-gated files, on Windows | 7 files / **159 passed, 0 skipped** |

The 159-passed / **0 skipped** line is the direct evidence the regression is repaired: on a Windows runner every one of those files' win32 branches executes. The 1 remaining skip in the full suite is `process-tree.test.ts`'s POSIX-only case, which the matrix covers on its ubuntu and macOS cells.

The four `test_pi_benchmark` failures seen in a bare worktree were `RuntimeError: Pi benchmark requires the installed pinned esbuild` — no `plugins/ca-pi/tools/node_modules`. After `npm ci --ignore-scripts` they pass; nothing in this diff touches the benchmark.

Also re-run green (always-on CI jobs a workflow edit could affect):

```
python .github/scripts/check_docs_contract.py                          -> 0
python tools/build-surface.py --check                                  -> OK (claude, codex, pi in sync)
python .github/scripts/check_license_consistency.py .                  -> consistent
python tools/build-host-packages.py --check                            -> matches
python tools/build-host-packages.py --check --release-guard-base a3a2df2
    -> "Pi payload, version, changelog, and root metadata advanced together: 0.1.1 -> 0.1.2"
git diff --check                                                       -> clean; all changed blobs LF
```

Both workflows parse under `yaml.safe_load`; `.github/ci-impact-map.json` parses and validates through `load_map`.

### Payload version

Commits `5ce9b5b` and `40f93d6` touch `plugins/ca-pi/**` (the `plan-mode.test.ts` portability fix), so the Pi payload **does** require a bump. `ca-pi` is at **0.1.2** with a matching `## [0.1.2]` CHANGELOG heading and the release guard confirms payload, version, changelog and root metadata advanced together. (An earlier version of this PR body claimed no bump was required, citing a guard run that predated those two commits — that claim was wrong and is retracted.)

---

## Known limits (disclosed, not fixed)

1. **#399 AC-2 is structural only.** Timeouts are declared and contract-tested (`0 < t < 360` on all 8 Pi jobs) but no deliberately hanging fixture was run against a hosted runner to observe a job actually terminate at its bound and leave a useful receipt. Proving it costs a burned runner slot up to the declared deadline.
2. **#381 AC-2's "red harness" arm is asserted structurally, not observed live.** The absorbed-probe path was exercised offline (`bash -eo pipefail` with `ADMISSION=failure`), and the harness steps are demonstrably un-absorbed, but a live red canary-harness run has not been produced. Note also that the `always()` receipt step wraps `pi --version` in `|| true` and defaults to `unresolved`, so the "receipt publication failure -> red check" arm is effectively unfalsifiable as written.

## Notes for later lanes rebasing onto this job graph

- Job order in `ci.yml` is now `ca-pi-checks` -> `ca-pi-tools` -> `ca-pi-latest` -> `ca-pi-codeql`. `ca-pi-tools` appears as a *new* block in the diff even though the job id is unchanged; git renders the split as "rename the old block, add a new one".
- Anything added to `ci-passed.needs` must also go into `required_results`, or `test_ci_impact.py` fails.
- The matrix's platform-gated Vitest step is kept on **one line** on purpose: the `.github/scripts` workflow contracts are textual (stdlib-only, no YAML parser) and read the covered file set straight off a `run: npm test -- ...` line. A folded scalar (`run: >-`) would silently defeat them.
- Adding a `test.skipIf(process.platform ...)` to a Pi suite now obliges that file to run in `ca-pi-tools`. Two independent contracts will tell you.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
