### PR TITLE
fix(sandbox): stop executing an unpinned remote installer; pin container inputs by digest

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -448,7 +448,26 @@ reopens if the threat model expands to untrusted agents.
 | Gate command shell execution | `plan.json` `gate.commands` / `test.command` and `FARM_MUTATION_CMD` run via `cmd.exe /c` / `bash -c` in `farm.ts` | Operator-authored, length-capped (≤1024), PR-reviewed; deterministic gate by design — no untrusted source. See ADR for the trust model |
 | Loopback `http://` for API base | `assertSecureBaseUrl` in `farm.ts` allows `http://127.0.0.1`/`localhost` (no userinfo); farm POSTs use `redirect: "error"` | Test mocks bind without TLS; same WHATWG parser as `fetch` → connection target is loopback, and redirect refusal prevents a mock from forwarding the body to a remote cleartext target |
 | Untrusted git clone | `ca-sandbox` clones an attacker-controlled url in a throwaway, `--rm`, networked `alpine/git` container | Input is allowlisted by `validateRepoUrl` + `--` end-of-options; blast radius is the disposable clone container only (no host bind, never co-run with the sandbox) — see ADR-0007 |
-| `curl \| bash` nixpacks install | `build.ts` runs `curl -fsSL https://nixpacks.com/install.sh \| bash` when nixpacks is absent | Build-time host convenience; the URL is a hardcoded constant (not attacker-controllable). Tracked: prefer declaring nixpacks a prerequisite or pinning a checksum (NEEDS-TRIAGE in the ca-sandbox plan) |
 | Pi host-managed provider authentication | Pi resolves its user-owned auth store, provider environment, or credential command outside codeArbiter | Opaque trusted-runtime boundary under ADR-0014; `ca-pi` never reads/copies/logs credentials and child environments are minimal and provider-specific |
 | Pi child process isolation | Fresh Pi processes run with discovery/session loading disabled and only explicit enforcement/skill/charter inputs | Cooperative process isolation for context and recursion control, not an OS sandbox; bounded IPC and process-tree cleanup limit accidental spill |
 | Trusted same-process Pi extensions | An operator-approved extension may execute arbitrary same-user code in Pi's process | Accepted ADR-0010 cooperative-agent residual; final governed-argument ordering remains a live promotion STOP under ADR-0014 |
+
+### Closed exceptions
+
+- **`curl | bash` nixpacks install** — CLOSED 2026-07-24 (issue #401). `build.ts`
+  no longer acquires nixpacks: the pipe-to-shell branch is deleted, nixpacks is a
+  documented prerequisite, and a missing prerequisite fails closed to the
+  generated-Dockerfile fallback. A structural test in
+  `plugins/ca-sandbox/tools/supply-chain.test.ts` keeps remote-fetch-and-execute
+  out of ca-sandbox production code.
+
+### Container image inputs
+
+Every external container image ca-sandbox pulls is bound to a reviewed content
+digest (`name:tag@sha256:<digest>`) — the clone image (`create.ts`), the
+generated-Dockerfile fallback base (`build.ts`), and the `--with-claude` base
+image (`claude-inside.ts`, which co-runs with `CLAUDE_CODE_OAUTH_TOKEN`). A
+floating tag is a mutable registry input: a retag or registry compromise would
+silently change executable code inside a sandbox build. Digest bumps are reviewed
+dependency changes, and `supply-chain.test.ts` rejects `:latest` and digest-free
+external image references in production code (issue #402).

--- a/plugins/ca-sandbox/.claude-plugin/plugin.json
+++ b/plugins/ca-sandbox/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca-sandbox",
   "displayName": "codeArbiter Sandbox",
   "description": "Locally-hosted Codespace equivalent for codeArbiter. Pulls an untrusted repo into an ephemeral, isolated Docker container with no host-filesystem access and configurable egress, caches dependencies by content hash, then tears the box down. Requires Docker and nixpacks on PATH.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca-sandbox/CHANGELOG.md
+++ b/plugins/ca-sandbox/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the **ca-sandbox** plugin are recorded here. Format follo
 
 ---
 
+## [0.1.4] — 2026-07-24 — Supply-chain hardening: no pipe-to-shell, digest-pinned images
+
+Two tribunal supply-chain findings closed. Both concern EXTERNAL bytes the driver pulled in unpinned.
+
+### Security
+- **No remote-fetch-and-execute (#401).** `build.ts` no longer runs `curl -fsSL <installer> | bash` when nixpacks is missing. That branch executed arbitrary remote bytes on the developer host with the developer's privileges, BEFORE any container boundary exists. nixpacks is a documented prerequisite (README / SKILL / command description), so a missing prerequisite now FAILS CLOSED to the pre-existing generated-Dockerfile fallback with an actionable install note. The `curl | bash` declared exception in `security-controls.md` is closed, not merely narrowed.
+- **Container inputs pinned by digest (#402).** The throwaway clone image, the generated-Dockerfile fallback base, and the `--with-claude` base image are each bound to a reviewed multi-arch index digest (`name:tag@sha256:<digest>`). A retag or registry compromise can no longer silently change executable code inside a sandbox build — least of all in the Claude box, whose base image co-runs with `CLAUDE_CODE_OAUTH_TOKEN`.
+
+### Added
+- **`supply-chain.test.ts`** — structural guards that cannot be stubbed past: they reject pipe-to-shell patterns and digest-free external image references across the shipped driver sources AND the committed `sandbox.js` bundle. Test fixtures are exempt (`lifecycle.test.ts` drives docker with a literal tag on purpose).
+- **`defaultEnsureNixpacks` is exported with an injectable process seam**, closing a real coverage gap: every other suite stubs `BuildDeps.ensureNixpacks`, so the actual default toolchain-probe path had zero tests. It is now asserted to probe only — never to mutate the host toolchain.
+
+---
+
 ## [0.1.3] — 2026-07-02 — Single docker primitive + helper-container hardening
 
 Consolidation and hardening of the sandbox driver's container handling (part of the tribunal remediation).

--- a/plugins/ca-sandbox/CHANGELOG.md
+++ b/plugins/ca-sandbox/CHANGELOG.md
@@ -13,8 +13,12 @@ Two tribunal supply-chain findings closed. Both concern EXTERNAL bytes the drive
 - **Container inputs pinned by digest (#402).** The throwaway clone image, the generated-Dockerfile fallback base, and the `--with-claude` base image are each bound to a reviewed multi-arch index digest (`name:tag@sha256:<digest>`). A retag or registry compromise can no longer silently change executable code inside a sandbox build — least of all in the Claude box, whose base image co-runs with `CLAUDE_CODE_OAUTH_TOKEN`.
 
 ### Added
-- **`supply-chain.test.ts`** — structural guards that cannot be stubbed past: they reject pipe-to-shell patterns and digest-free external image references across the shipped driver sources AND the committed `sandbox.js` bundle. Test fixtures are exempt (`lifecycle.test.ts` drives docker with a literal tag on purpose).
+- **`supply-chain.test.ts`** — structural guards that cannot be stubbed past: they reject pipe-to-shell patterns and digest-free external image references across the shipped driver sources AND the committed `sandbox.js` bundle. The digest scanner reads JOINED file text, so it matches the multi-line declaration style every image constant in this driver uses (`export const CLONE_IMAGE =` / newline / `"<ref>"`); it also flags any namespaced `ns/name:tag` literal regardless of the constant's name, and only accepts a `FROM ${…}` interpolation that demonstrably resolves to a digest-pinned constant in the same file. Test fixtures are exempt (`lifecycle.test.ts` drives docker with a literal tag on purpose).
+- **A regression suite for the scanner itself** — synthetic multi-line sources assert the rules actually FIRE. A structural scanner that quietly matches nothing is indistinguishable from a clean codebase, and the first cut of this one was inert against exactly the declaration style it was written to guard.
 - **`defaultEnsureNixpacks` is exported with an injectable process seam**, closing a real coverage gap: every other suite stubs `BuildDeps.ensureNixpacks`, so the actual default toolchain-probe path had zero tests. It is now asserted to probe only — never to mutate the host toolchain.
+
+### Documentation
+- **`sandbox-claude-inside` SKILL states the base-image pin.** Phase 2 said only "the base is `node:22-slim`"; it now records that the base is digest-bound, why that pin is the highest-stakes one in the driver (the base image's code runs in the same container as `CLAUDE_CODE_OAUTH_TOKEN`), and that an unpinned base fails the phase gate.
 
 ---
 

--- a/plugins/ca-sandbox/skills/sandbox-claude-inside/SKILL.md
+++ b/plugins/ca-sandbox/skills/sandbox-claude-inside/SKILL.md
@@ -57,13 +57,21 @@ Build (or reuse) the pinned `--with-claude` image via `buildClaudeImageDockerfil
 - The image installs `@anthropic-ai/claude-code@<pinned>` — a PINNED semver,
   never `@latest` — and bakes `DISABLE_AUTOUPDATER=1` so the box never silently
   pulls an unreviewed CLI into a token-bearing environment.
-- The base is `node:22-slim` (Spike B installed the CLI cleanly there). HOME is
-  baked to the in-container claude home so the named volume has a writable mount
-  point.
+- The base is `node:22-slim` (Spike B installed the CLI cleanly there), bound to a
+  reviewed content DIGEST — `node:22-slim@sha256:…`, the `CLAUDE_BASE_IMAGE`
+  constant. The tag is kept only as human-readable provenance; docker resolves the
+  digest. This is the driver's highest-stakes pin: the base image's code runs in
+  the SAME container as `CLAUDE_CODE_OAUTH_TOKEN`, so a retag or registry
+  compromise would otherwise execute unreviewed code alongside a live credential.
+  Pinning the CLI version alone is not enough. HOME is baked to the in-container
+  claude home so the named volume has a writable mount point.
 
-Gate: the image carries the exact pinned version (`claude --version` reports it)
-and `DISABLE_AUTOUPDATER=1`. A floating or unpinned CLI fails the gate — image
-reproducibility is non-negotiable for a token box.
+Gate: the image carries the exact pinned version (`claude --version` reports it),
+`DISABLE_AUTOUPDATER=1`, and a digest-pinned base. A floating or unpinned CLI —
+or an unpinned base image — fails the gate; image reproducibility is
+non-negotiable for a token box. Changing the digest is a reviewed dependency
+change: re-resolve it with `docker buildx imagetools inspect`, then re-run the
+credential-boundary and isolation suites.
 
 ## Phase 3 — Token · gate: BLOCK
 

--- a/plugins/ca-sandbox/tools/build.ts
+++ b/plugins/ca-sandbox/tools/build.ts
@@ -12,11 +12,12 @@
  *   3. CACHE MISS — build the image and tag it `<tag>`:
  *        a. nixpacks is the intended builder. If `nixpacks --version` works we wrap
  *           it (`nixpacks build <repoDir> --name <tag>`).
- *        b. If nixpacks is absent we try to install it via its official install
- *           script (https://nixpacks.com/install.sh). If the install is BLOCKED
- *           (offline / sandboxed / non-zero exit) we FALL BACK to a generated
+ *        b. If nixpacks is absent we FAIL CLOSED — ca-sandbox never acquires it
+ *           (issue #401: acquiring a builder means executing remote bytes on the
+ *           developer host, before any container boundary exists; nixpacks is a
+ *           documented prerequisite instead). We FALL BACK to a generated
  *           Dockerfile that mimics what nixpacks bakes, and we NOTE the missing
- *           dependency in the result (the plan's [NEEDS-TRIAGE] environment-UX item).
+ *           dependency in the result so the user can install the real builder.
  *      Either way, the build RELOCATES installed deps OUT OF TREE to `/deps` and
  *      exports `NODE_PATH=/deps/node_modules` / `PYTHONPATH=/deps/site-packages`
  *      via image ENV (Spike A: mounting the source volume over the app dir at
@@ -55,13 +56,32 @@ export const APP_DIR = "/work/repo";
  *  relocation overlay moves deps from HERE to /deps — NOT from APP_DIR (Spike A
  *  recorded this; the never-run native path had it pointing at APP_DIR). */
 export const NIXPACKS_APP_DIR = "/app";
-/** Official nixpacks install script (used only when nixpacks is absent). */
-export const NIXPACKS_INSTALL_URL = "https://nixpacks.com/install.sh";
+/**
+ * Base image for the generated-Dockerfile fallback, PINNED to a reviewed
+ * multi-arch index digest (issue #402). A floating tag would let a retag or
+ * registry compromise change the code baked into every fallback sandbox build,
+ * and would also defeat the dephash cache's reproducibility evidence.
+ *
+ * Resolved 2026-07-24 with `docker buildx imagetools inspect node:20-slim`.
+ * Bump this ONLY through a reviewed dependency change (re-resolve the digest and
+ * re-run the multistack/layering docker-gated suites).
+ */
+export const FALLBACK_BASE_IMAGE =
+  "node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0";
 
 // --------------------------------------------------------------------------
 // process helper (mirrors farm.ts run()/RunResult)
 // --------------------------------------------------------------------------
 export type RunResult = { code: number; out: string; stdout: string; stderr: string };
+
+/**
+ * The child-process seam used by the toolchain probes (`defaultEnsureNixpacks`
+ * and its WSL-bridge helper). It defaults to the real `run()`; tests inject a
+ * recorder so the ACTUAL default probe path — not a stubbed `ensureNixpacks` —
+ * can be asserted on, including the invariant that a missing prerequisite spawns
+ * NOTHING that mutates the host toolchain (secrets-supply-002 / issue #401).
+ */
+export type ProbeRun = (cmd: string, args: string[]) => Promise<RunResult>;
 
 // docker build of the nixpacks-generated Dockerfile needs BuildKit (it emits
 // `RUN --mount=type=cache`). Docker Desktop defaults to BuildKit, but set it
@@ -200,10 +220,10 @@ async function defaultNixpacksVersion(): Promise<string> {
  * it. Returns the absolute nixpacks path inside the default distro + version, or
  * null if WSL/nixpacks is absent.
  */
-async function detectWslNixpacks(): Promise<{ bin: string; version: string } | null> {
+async function detectWslNixpacks(exec: ProbeRun = run): Promise<{ bin: string; version: string } | null> {
   // Resolve the nixpacks path inside the default distro. `command -v` covers a
   // PATH install; the `||` fallback covers the user-dir install ($HOME/.local/bin).
-  const probe = await run("wsl.exe", [
+  const probe = await exec("wsl.exe", [
     "bash",
     "-lc",
     'command -v nixpacks || echo "$HOME/.local/bin/nixpacks"',
@@ -212,23 +232,27 @@ async function detectWslNixpacks(): Promise<{ bin: string; version: string } | n
   const bin = probe.stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean).pop();
   if (!bin) return null;
   // Verify it actually runs in WSL (the fallback path may not exist).
-  const ver = await run("wsl.exe", ["--", bin, "--version"]);
+  const ver = await exec("wsl.exe", ["--", bin, "--version"]);
   if (ver.code !== 0) return null;
   const m = ver.stdout.match(/(\d+\.\d+\.\d+)/);
   return { bin, version: m ? m[1] : ver.stdout.trim() };
 }
 
 /**
- * Ensure nixpacks is available, by precedence:
+ * Detect a usable nixpacks, by precedence:
  *   1. host `nixpacks` on PATH (Linux/macOS, or a Windows host that has it);
  *   2. the WSL bridge (Windows) — nixpacks in a WSL distro generates the
  *      Dockerfile, host Docker builds it;
- *   3. the official install script on the host;
  * else report unavailable so the caller uses the generated-Dockerfile fallback
- * and surfaces the dependency.
+ * and surfaces the dependency. Both steps are READ-ONLY probes of an
+ * already-installed tool: this function NEVER acquires nixpacks (issue #401).
+ *
+ * Exported (with an injectable `exec`) so the real default path is testable —
+ * every other suite stubs `BuildDeps.ensureNixpacks`, which left this the one
+ * uncovered effect in the module.
  */
-async function defaultEnsureNixpacks(): Promise<EnsureNixpacksResult> {
-  const probe = await run("nixpacks", ["--version"]);
+export async function defaultEnsureNixpacks(exec: ProbeRun = run): Promise<EnsureNixpacksResult> {
+  const probe = await exec("nixpacks", ["--version"]);
   if (probe.code === 0) {
     const m = probe.stdout.match(/(\d+\.\d+\.\d+)/);
     return { available: true, via: { via: "host" }, version: m ? m[1] : probe.stdout.trim() };
@@ -237,7 +261,7 @@ async function defaultEnsureNixpacks(): Promise<EnsureNixpacksResult> {
   // WSL bridge: only meaningful on Windows, but the probe is harmless elsewhere
   // (no `wsl.exe` => null). nixpacks-in-WSL generates the Dockerfile; host Docker builds it.
   if (process.platform === "win32") {
-    const wsl = await detectWslNixpacks();
+    const wsl = await detectWslNixpacks(exec);
     if (wsl) {
       return {
         available: true,
@@ -250,22 +274,20 @@ async function defaultEnsureNixpacks(): Promise<EnsureNixpacksResult> {
     }
   }
 
-  // Try the official install script: `curl -fsSL <url> | bash`.
-  const install = await run("bash", ["-c", `curl -fsSL ${NIXPACKS_INSTALL_URL} | bash`]);
-  if (install.code === 0) {
-    const after = await run("nixpacks", ["--version"]);
-    if (after.code === 0) {
-      const m = after.stdout.match(/(\d+\.\d+\.\d+)/);
-      return { available: true, via: { via: "host" }, version: m ? m[1] : after.stdout.trim() };
-    }
-  }
+  // FAIL CLOSED. ca-sandbox NEVER acquires nixpacks itself: this code runs on the
+  // developer host, BEFORE any container boundary exists, so fetching and
+  // executing an installer here would grant remote bytes the developer's
+  // privileges (secrets-supply-002 / issue #401). nixpacks is a documented
+  // prerequisite (README / sandbox-lifecycle SKILL / the command description all
+  // say so); when it is absent we take the generated-Dockerfile fallback and tell
+  // the user how to get the intended build path.
   return {
     available: false,
     note:
-      "nixpacks is not installed (no host binary, no WSL bridge, install script " +
-      `blocked: ${NIXPACKS_INSTALL_URL}); fell back to a generated Dockerfile that ` +
-      "mimics nixpacks. Install nixpacks for the intended build path (NEEDS-TRIAGE: " +
-      "nixpacks-as-runtime-dependency).",
+      "nixpacks is not installed (no host binary, no WSL bridge); fell back to a " +
+      "generated Dockerfile that mimics nixpacks (node/python only). Install " +
+      "nixpacks for the intended build path — see https://nixpacks.com for the " +
+      "install options; ca-sandbox deliberately does not install it for you.",
   };
 }
 
@@ -286,7 +308,7 @@ export function generateDockerfile(stack: { node: boolean; python: boolean }): s
   const lines: string[] = [];
   // node:20-slim has both node and (via apt) python tooling for the common cases;
   // it matches the Node 20 driver stack and Spike B's clean install base family.
-  lines.push("FROM node:20-slim");
+  lines.push(`FROM ${FALLBACK_BASE_IMAGE}`);
   lines.push(`ENV NODE_PATH=${DEPS_DIR}/node_modules`);
   lines.push(`ENV PYTHONPATH=${DEPS_DIR}/site-packages`);
   lines.push(`RUN mkdir -p ${DEPS_DIR} ${APP_DIR}`);

--- a/plugins/ca-sandbox/tools/claude-inside.ts
+++ b/plugins/ca-sandbox/tools/claude-inside.ts
@@ -51,8 +51,19 @@ import { defaultDockerRun, type RunResult } from "./docker.ts";
 export const CLAUDE_CODE_VERSION = "2.1.183";
 /** The npm package the image installs at the pinned version. */
 export const CLAUDE_CODE_PACKAGE = "@anthropic-ai/claude-code";
-/** Base image — node:22-slim installs the CLI cleanly (Spike B). */
-export const CLAUDE_BASE_IMAGE = "node:22-slim";
+/**
+ * Base image — node:22-slim installs the CLI cleanly (Spike B) — PINNED to a
+ * reviewed multi-arch index digest (issue #402). This is the highest-stakes pin
+ * in the driver: the base image's code later runs in the SAME container as
+ * CLAUDE_CODE_OAUTH_TOKEN, so an unreviewed upstream change would execute
+ * alongside a live credential. Pinning the CLI version alone is not enough.
+ *
+ * Resolved 2026-07-24 with `docker buildx imagetools inspect node:22-slim`.
+ * Bump this ONLY through a reviewed dependency change (re-resolve the digest and
+ * re-run the credential-boundary + isolation suites).
+ */
+export const CLAUDE_BASE_IMAGE =
+  "node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3";
 /**
  * In-container HOME for the claude run. The named volume mounts here, so the
  * credential store `$HOME/.claude/.credentials.json` (and the rest of the .claude

--- a/plugins/ca-sandbox/tools/create.ts
+++ b/plugins/ca-sandbox/tools/create.ts
@@ -46,8 +46,20 @@ import { computeDepHash, type ManifestFile } from "./dephash.ts";
 import { SANDBOX_LABEL, idLabel } from "./registry.ts";
 import { DOCKER_ENV, defaultDockerRun, type DockerRun } from "./docker.ts";
 
-/** Image used for the throwaway clone step (small, git built in). */
-export const CLONE_IMAGE = "alpine/git:latest";
+/**
+ * Image used for the throwaway clone step (small, git built in), PINNED to a
+ * reviewed multi-arch index digest (issue #402). A floating tag would let a
+ * retag or registry compromise swap the binary that checks out attacker-supplied
+ * source into the sandbox volume. Docker resolves the digest, not the tag, so
+ * the tag is kept only as human-readable provenance.
+ *
+ * Resolved 2026-07-24 with `docker buildx imagetools inspect alpine/git` (which
+ * resolves the default tag).
+ * Bump this ONLY through a reviewed dependency change (re-resolve the digest,
+ * re-run the ca-sandbox suite including the docker-gated lifecycle tests).
+ */
+export const CLONE_IMAGE =
+  "alpine/git:latest@sha256:77418e6e7c7f434c4a98eaff04ef16840cf03649c881c03948e3e213923e3136";
 /** In-container app dir; the source volume mounts here for both clone and run. */
 export const APP_DIR = "/work/repo";
 /** Prefix for the named volume of a sandbox. */

--- a/plugins/ca-sandbox/tools/sandbox.js
+++ b/plugins/ca-sandbox/tools/sandbox.js
@@ -175,7 +175,7 @@ var IMAGE_PREFIX = "ca-sbx";
 var DEPS_DIR = "/deps";
 var APP_DIR2 = "/work/repo";
 var NIXPACKS_APP_DIR = "/app";
-var NIXPACKS_INSTALL_URL = "https://nixpacks.com/install.sh";
+var FALLBACK_BASE_IMAGE = "node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0";
 var BUILD_ENV = { ...DOCKER_ENV, DOCKER_BUILDKIT: "1" };
 function run(cmd, args, opts = {}) {
   return new Promise((resolve) => {
@@ -206,8 +206,8 @@ async function defaultNixpacksVersion() {
   const m = r.stdout.match(/(\d+\.\d+\.\d+)/);
   return m ? m[1] : r.stdout.trim();
 }
-async function detectWslNixpacks() {
-  const probe = await run("wsl.exe", [
+async function detectWslNixpacks(exec = run) {
+  const probe = await exec("wsl.exe", [
     "bash",
     "-lc",
     'command -v nixpacks || echo "$HOME/.local/bin/nixpacks"'
@@ -215,19 +215,19 @@ async function detectWslNixpacks() {
   if (probe.code !== 0) return null;
   const bin = probe.stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean).pop();
   if (!bin) return null;
-  const ver = await run("wsl.exe", ["--", bin, "--version"]);
+  const ver = await exec("wsl.exe", ["--", bin, "--version"]);
   if (ver.code !== 0) return null;
   const m = ver.stdout.match(/(\d+\.\d+\.\d+)/);
   return { bin, version: m ? m[1] : ver.stdout.trim() };
 }
-async function defaultEnsureNixpacks() {
-  const probe = await run("nixpacks", ["--version"]);
+async function defaultEnsureNixpacks(exec = run) {
+  const probe = await exec("nixpacks", ["--version"]);
   if (probe.code === 0) {
     const m = probe.stdout.match(/(\d+\.\d+\.\d+)/);
     return { available: true, via: { via: "host" }, version: m ? m[1] : probe.stdout.trim() };
   }
   if (process.platform === "win32") {
-    const wsl = await detectWslNixpacks();
+    const wsl = await detectWslNixpacks(exec);
     if (wsl) {
       return {
         available: true,
@@ -237,22 +237,14 @@ async function defaultEnsureNixpacks() {
       };
     }
   }
-  const install = await run("bash", ["-c", `curl -fsSL ${NIXPACKS_INSTALL_URL} | bash`]);
-  if (install.code === 0) {
-    const after = await run("nixpacks", ["--version"]);
-    if (after.code === 0) {
-      const m = after.stdout.match(/(\d+\.\d+\.\d+)/);
-      return { available: true, via: { via: "host" }, version: m ? m[1] : after.stdout.trim() };
-    }
-  }
   return {
     available: false,
-    note: `nixpacks is not installed (no host binary, no WSL bridge, install script blocked: ${NIXPACKS_INSTALL_URL}); fell back to a generated Dockerfile that mimics nixpacks. Install nixpacks for the intended build path (NEEDS-TRIAGE: nixpacks-as-runtime-dependency).`
+    note: "nixpacks is not installed (no host binary, no WSL bridge); fell back to a generated Dockerfile that mimics nixpacks (node/python only). Install nixpacks for the intended build path \u2014 see https://nixpacks.com for the install options; ca-sandbox deliberately does not install it for you."
   };
 }
 function generateDockerfile(stack) {
   const lines = [];
-  lines.push("FROM node:20-slim");
+  lines.push(`FROM ${FALLBACK_BASE_IMAGE}`);
   lines.push(`ENV NODE_PATH=${DEPS_DIR}/node_modules`);
   lines.push(`ENV PYTHONPATH=${DEPS_DIR}/site-packages`);
   lines.push(`RUN mkdir -p ${DEPS_DIR} ${APP_DIR2}`);
@@ -468,7 +460,7 @@ function resolveContainerId(id, dockerRun = defaultDockerRun) {
 }
 
 // create.ts
-var CLONE_IMAGE = "alpine/git:latest";
+var CLONE_IMAGE = "alpine/git:latest@sha256:77418e6e7c7f434c4a98eaff04ef16840cf03649c881c03948e3e213923e3136";
 var APP_DIR3 = "/work/repo";
 var VOLUME_PREFIX = "ca-sbx-vol";
 var CLONE_TIMEOUT_MS = Number(process.env.CA_SANDBOX_CLONE_TIMEOUT_MS ?? 5 * 6e4);

--- a/plugins/ca-sandbox/tools/supply-chain.test.ts
+++ b/plugins/ca-sandbox/tools/supply-chain.test.ts
@@ -1,0 +1,219 @@
+/**
+ * supply-chain.test.ts — structural supply-chain guards for the ca-sandbox driver.
+ *
+ * Two tribunal findings are locked down here, both about EXTERNAL BYTES that
+ * ca-sandbox would otherwise pull in unpinned:
+ *
+ *   #401 (secrets-supply-002) — no ca-sandbox runtime path may pipe
+ *     network-fetched bytes into a shell. `defaultEnsureNixpacks` used to run
+ *     `bash -c "curl -fsSL https://nixpacks.com/install.sh | bash"` on the
+ *     developer host, BEFORE any container boundary exists. nixpacks is a
+ *     documented prerequisite (README / SKILL / command description all say so),
+ *     so the missing-prerequisite path now FAILS CLOSED to the pre-existing
+ *     generated-Dockerfile fallback and tells the user to install nixpacks.
+ *
+ *   #402 (secrets-supply-004) — every external container image reference must be
+ *     bound to a reviewed content digest (`name:tag@sha256:<64 hex>`), so a retag
+ *     or registry compromise cannot silently swap executable code into a sandbox
+ *     build — least of all into the `--with-claude` box, which co-runs the base
+ *     image with CLAUDE_CODE_OAUTH_TOKEN.
+ *
+ * These are STRUCTURAL tests on purpose: `defaultEnsureNixpacks` and the image
+ * constants are defaults that every other suite stubs out, so the real path had
+ * ZERO coverage. A structural scan cannot be stubbed past — it reads the shipped
+ * bytes. Test files are exempt from the scan (lifecycle.test.ts deliberately
+ * hardcodes `alpine/git:latest` when driving docker directly), which is why the
+ * scan enumerates production sources explicitly rather than globbing everything.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  defaultEnsureNixpacks,
+  generateDockerfile,
+  type RunResult,
+} from "./build.ts";
+import { CLONE_IMAGE } from "./create.ts";
+import { CLAUDE_BASE_IMAGE, buildClaudeImageDockerfile } from "./claude-inside.ts";
+
+const TOOLS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The production surface of the driver: every shipped source file plus the
+ * committed esbuild bundle (`sandbox.js` — the bytes that actually run on a
+ * user's machine). Test files, fixtures and the vitest config are NOT production
+ * code and are deliberately excluded.
+ */
+function productionFiles(): string[] {
+  const entries = readdirSync(TOOLS_DIR, { withFileTypes: true });
+  const files = entries
+    .filter((e) => e.isFile())
+    .map((e) => e.name)
+    .filter((n) => n.endsWith(".ts") || n === "sandbox.js")
+    .filter((n) => !n.endsWith(".test.ts"))
+    .filter((n) => n !== "vitest.config.ts");
+  return files.sort().map((n) => path.join(TOOLS_DIR, n));
+}
+
+function rel(file: string): string {
+  return path.relative(TOOLS_DIR, file).replace(/\\/g, "/");
+}
+
+/** A `sha256:<64 hex>` digest binding, optionally preceded by a tag. */
+const DIGEST_PINNED = /@sha256:[0-9a-f]{64}\b/;
+
+/**
+ * Does this string name an image PULLED FROM A REGISTRY (and therefore in need
+ * of a digest pin), as opposed to a locally built one? An external ref carries a
+ * registry namespace (`alpine/git`) or a tag (`node:22-slim`); the driver's own
+ * `ca-sbx` tag prefix carries neither and has nothing upstream to pin.
+ */
+function isExternalImageRef(ref: string): boolean {
+  return ref.includes("/") || ref.includes(":");
+}
+
+describe("supply chain: no remote-fetch-and-execute in production code (#401)", () => {
+  it("has at least one production file to scan (guards the scanner itself)", () => {
+    const files = productionFiles();
+    expect(files.length).toBeGreaterThan(5);
+    expect(files.map(rel)).toContain("build.ts");
+    expect(files.map(rel)).toContain("sandbox.js");
+  });
+
+  it("never pipes network-fetched bytes into a shell or interpreter", () => {
+    // A downloader (curl/wget/Invoke-WebRequest) whose output flows into a shell,
+    // an interpreter, or `source`/`eval` — in any order, on one line.
+    const PIPE_TO_SHELL = [
+      /\b(curl|wget|iwr|Invoke-WebRequest)\b[^\n]*\|[^\n]*\b(ba|z|da|k)?sh\b/i,
+      /\b(curl|wget|iwr|Invoke-WebRequest)\b[^\n]*\|[^\n]*\b(python3?|node|perl|ruby)\b/i,
+      /\b(eval|source)\b[^\n]*\$\([^\n]*\b(curl|wget)\b/i,
+      /\b(ba|z)?sh\b[^\n]*<\(\s*(curl|wget)\b/i,
+    ];
+    const hits: string[] = [];
+    for (const file of productionFiles()) {
+      const lines = readFileSync(file, "utf8").split(/\r?\n/);
+      lines.forEach((line, i) => {
+        if (PIPE_TO_SHELL.some((re) => re.test(line))) {
+          hits.push(`${rel(file)}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(
+      hits,
+      "ca-sandbox production code must never execute network-fetched bytes " +
+        "(no `curl | bash`): remote code would run with the developer's privileges " +
+        "BEFORE any container boundary exists. Declare the tool a prerequisite and " +
+        "fail closed to the generated-Dockerfile fallback instead.",
+    ).toEqual([]);
+  });
+
+  it("ships no remote-installer endpoint constant", async () => {
+    const build = (await import("./build.ts")) as Record<string, unknown>;
+    expect(Object.keys(build)).not.toContain("NIXPACKS_INSTALL_URL");
+    const src = readFileSync(path.join(TOOLS_DIR, "build.ts"), "utf8");
+    expect(src).not.toMatch(/nixpacks\.com\/install\.sh/);
+  });
+
+  it("fails closed when nixpacks is absent: probes only, no host mutation", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const absent: RunResult = { code: 127, out: "not found", stdout: "", stderr: "not found" };
+    const probe = async (cmd: string, args: string[]): Promise<RunResult> => {
+      calls.push({ cmd, args });
+      return absent;
+    };
+
+    const res = await defaultEnsureNixpacks(probe);
+
+    // Fails CLOSED to the documented fallback, with an actionable note.
+    expect(res.available).toBe(false);
+    expect(res.via).toBeUndefined();
+    expect(res.note).toMatch(/install nixpacks/i);
+
+    // And it mutated NOTHING on the host: every command spawned is a read-only
+    // version/location probe of an already-installed tool.
+    const argv = calls.map((c) => [c.cmd, ...c.args].join(" "));
+    const installerish = argv.filter((s) =>
+      /\b(curl|wget|Invoke-WebRequest)\b|\binstall\b|\|\s*(ba)?sh\b/i.test(s),
+    );
+    expect(
+      installerish,
+      "a missing nixpacks prerequisite must not fetch or install anything",
+    ).toEqual([]);
+    expect(calls.map((c) => c.cmd).every((c) => c === "nixpacks" || c === "wsl.exe")).toBe(true);
+  });
+});
+
+describe("supply chain: container inputs are digest-pinned (#402)", () => {
+  it("pins the throwaway clone image by digest", () => {
+    expect(CLONE_IMAGE).toMatch(DIGEST_PINNED);
+  });
+
+  it("pins the --with-claude base image by digest (token co-runs with it)", () => {
+    expect(CLAUDE_BASE_IMAGE).toMatch(DIGEST_PINNED);
+  });
+
+  it("emits only digest-pinned FROM lines from every generated Dockerfile", () => {
+    const dockerfiles = [
+      generateDockerfile({ node: false, python: false }),
+      generateDockerfile({ node: true, python: true }),
+      buildClaudeImageDockerfile(),
+    ];
+    for (const df of dockerfiles) {
+      const froms = df.split(/\r?\n/).filter((l) => /^\s*FROM\s/i.test(l));
+      expect(froms.length).toBeGreaterThan(0);
+      for (const line of froms) {
+        expect(line, `unpinned base image: ${line}`).toMatch(DIGEST_PINNED);
+      }
+    }
+  });
+
+  it("references no floating `:latest` tag in production code", () => {
+    const hits: string[] = [];
+    for (const file of productionFiles()) {
+      const lines = readFileSync(file, "utf8").split(/\r?\n/);
+      lines.forEach((line, i) => {
+        // `:latest` is tolerated ONLY when immediately bound to a digest.
+        for (const m of line.matchAll(/:latest\b(@sha256:[0-9a-f]{64})?/g)) {
+          if (!m[1]) hits.push(`${rel(file)}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(
+      hits,
+      "a floating `:latest` tag lets a retag or registry compromise swap " +
+        "executable code into a sandbox build; bind it as name:tag@sha256:<digest>",
+    ).toEqual([]);
+  });
+
+  it("digest-pins every image constant and literal FROM in production code", () => {
+    const hits: string[] = [];
+    for (const file of productionFiles()) {
+      const src = readFileSync(file, "utf8");
+      const lines = src.split(/\r?\n/);
+      lines.forEach((line, i) => {
+        // (a) named image constants: `export const CLONE_IMAGE = "..."` (and the
+        //     bundled `var CLONE_IMAGE = "..."` form in sandbox.js). Only refs
+        //     that name an EXTERNAL registry image are in scope — a bare local
+        //     tag prefix like `ca-sbx` (IMAGE_PREFIX, images this driver builds
+        //     itself) has no registry namespace or tag and nothing to pin.
+        const constDecl = line.match(/\b(?:const|let|var)\s+\w*IMAGE\w*\s*=\s*(["'`])([^"'`]+)\1/);
+        if (constDecl && isExternalImageRef(constDecl[2]) && !DIGEST_PINNED.test(constDecl[2])) {
+          hits.push(`${rel(file)}:${i + 1}: unpinned image constant: ${constDecl[2]}`);
+        }
+        // (b) literal `FROM <ref>` inside emitted Dockerfile text. A `${...}`
+        //     interpolation is allowed — the constant it reads is covered by (a)
+        //     and by the generated-Dockerfile assertions above.
+        const from = line.match(/\bFROM\s+([^\s"'`\\]+)/);
+        if (from && !from[1].includes("${") && !DIGEST_PINNED.test(from[1])) {
+          hits.push(`${rel(file)}:${i + 1}: unpinned FROM: ${from[1]}`);
+        }
+      });
+    }
+    expect(
+      hits,
+      "every external container image reference must be bound to a reviewed " +
+        "sha256 digest (name:tag@sha256:<digest>)",
+    ).toEqual([]);
+  });
+});

--- a/plugins/ca-sandbox/tools/supply-chain.test.ts
+++ b/plugins/ca-sandbox/tools/supply-chain.test.ts
@@ -73,6 +73,134 @@ function isExternalImageRef(ref: string): boolean {
   return ref.includes("/") || ref.includes(":");
 }
 
+// --------------------------------------------------------------------------
+// the digest scanner (#402 AC-2)
+// --------------------------------------------------------------------------
+//
+// This scanner reads JOINED FILE TEXT, never line-by-line. That is load-bearing:
+// every image constant in this driver is written with the value on its own
+// continuation line —
+//
+//     export const CLONE_IMAGE =
+//       "alpine/git:latest@sha256:...";
+//
+// — so a per-line rule that expects `const NAME = "<ref>"` on ONE line matches
+// none of the shipped declarations and is silently inert. `scannerSelfTest`
+// below locks that in: it runs these same rules against synthetic multi-line
+// sources and asserts they actually fire.
+
+/** 1-based line number of `index` within `src`. */
+function lineOf(src: string, index: number): number {
+  return src.slice(0, index).split(/\r?\n/).length;
+}
+
+/**
+ * A named image constant — `export const CLONE_IMAGE = "<ref>"`, the bundled
+ * `var CLONE_IMAGE = "<ref>"` form, and (critically) the multi-line form where
+ * the literal sits on the next line. `\s*` spans the newline; the value class
+ * does not, so the literal itself is still single-line.
+ */
+const IMAGE_CONST = /\b(?:const|let|var)\s+(\w*IMAGE\w*)\s*=\s*(["'`])([^"'`\n]*)\2/g;
+
+/**
+ * A string literal that IS a namespaced registry reference (`ns/name:tag`) —
+ * name-independent, so `const TRIVY = "aquasec/trivy:0.50.0"` and a bare argv
+ * element `"alpine/git:latest"` are both caught even though neither is named
+ * `*IMAGE*`. Requiring the `/` namespace is what keeps this free of false
+ * positives: node builtin specifiers (`node:path`, `node:fs/promises`) and
+ * docs placeholders (`host:container`, `1000:1000`) never match.
+ *
+ * Residual, accepted: an official-library image with no namespace and a
+ * non-`latest` tag (`"node:22-slim"`) bound to a constant NOT named `*IMAGE*`
+ * would evade this rule — `node:<builtin>` import specifiers are structurally
+ * identical to it. Today's two such images are both `*IMAGE*`-named (caught by
+ * IMAGE_CONST) and additionally asserted by name in the tests below.
+ */
+const NAMESPACED_IMAGE_LITERAL =
+  /(["'`])([a-z0-9]+(?:[._-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[._-][a-z0-9]+)*)+:[A-Za-z0-9][A-Za-z0-9._-]*(?:@sha256:[0-9a-f]{64})?)\1/g;
+
+/** `FROM <ref>` inside emitted Dockerfile text. */
+const FROM_REF = /\bFROM\s+([^\s"'`\\]+)/g;
+
+/** `const <name> = <initializer>` — used to follow a FROM interpolation home. */
+const ANY_BINDING = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^;\n]*)/g;
+
+/**
+ * Names that provably carry a digest-pinned image in this file: the pinned image
+ * constants themselves, plus bindings initialized from one (`const base =
+ * opts.baseImage ?? CLAUDE_BASE_IMAGE`). Anything else interpolated into a
+ * `FROM` is unproven and is reported.
+ */
+function pinnedNames(src: string, pinnedConsts: Set<string>): Set<string> {
+  const names = new Set(pinnedConsts);
+  // Iterate to a fixed point so an alias of an alias still resolves.
+  for (let pass = 0; pass < 3; pass++) {
+    const before = names.size;
+    for (const m of src.matchAll(ANY_BINDING)) {
+      const [, name, init] = m;
+      const ids = init.match(/[A-Za-z_$][\w$]*/g) ?? [];
+      if (ids.some((id) => names.has(id))) names.add(name);
+    }
+    if (names.size === before) break;
+  }
+  return names;
+}
+
+/**
+ * Report every external image reference in `src` that is not bound to a reviewed
+ * sha256 digest. `label` prefixes each hit so failures name the file and line.
+ */
+function scanUnpinnedImages(src: string, label: string): string[] {
+  const hits: string[] = [];
+  const pinnedConsts = new Set<string>();
+  // Literal offsets already reported, so the namespaced-literal pass does not
+  // double-report a constant the named-constant pass just flagged.
+  const reported = new Set<number>();
+
+  // (a) named image constants, single- OR multi-line. Only refs that name an
+  //     EXTERNAL registry image are in scope — a bare local tag prefix like
+  //     `ca-sbx` (IMAGE_PREFIX, images this driver builds itself) has no
+  //     registry namespace or tag and nothing upstream to pin.
+  for (const m of src.matchAll(IMAGE_CONST)) {
+    const [, name, , value] = m;
+    if (!isExternalImageRef(value)) continue;
+    if (DIGEST_PINNED.test(value)) {
+      pinnedConsts.add(name);
+      continue;
+    }
+    const quoteAt = m.index + m[0].length - value.length - 2;
+    reported.add(quoteAt);
+    hits.push(`${label}:${lineOf(src, quoteAt)}: unpinned image constant: ${name} = ${value}`);
+  }
+
+  // (b) any namespaced registry ref, whatever it is bound to.
+  for (const m of src.matchAll(NAMESPACED_IMAGE_LITERAL)) {
+    if (DIGEST_PINNED.test(m[2]) || reported.has(m.index)) continue;
+    hits.push(`${label}:${lineOf(src, m.index)}: unpinned image reference: ${m[2]}`);
+  }
+
+  // (c) `FROM <ref>` in emitted Dockerfile text. An interpolation is allowed
+  //     ONLY when it demonstrably reads a digest-pinned constant from this file;
+  //     a blanket `${...}` pass would let an unpinned constant through (a) via
+  //     the Dockerfile it emits.
+  const resolvable = pinnedNames(src, pinnedConsts);
+  for (const m of src.matchAll(FROM_REF)) {
+    const ref = m[1];
+    const at = `${label}:${lineOf(src, m.index)}`;
+    const interpolated = ref.match(/^\$\{(.*)\}$/);
+    if (interpolated) {
+      const ids = interpolated[1].match(/[A-Za-z_$][\w$]*/g) ?? [];
+      if (!ids.some((id) => resolvable.has(id))) {
+        hits.push(`${at}: FROM ${ref} does not resolve to a digest-pinned image constant`);
+      }
+      continue;
+    }
+    if (!DIGEST_PINNED.test(ref)) hits.push(`${at}: unpinned FROM: ${ref}`);
+  }
+
+  return hits;
+}
+
 describe("supply chain: no remote-fetch-and-execute in production code (#401)", () => {
   it("has at least one production file to scan (guards the scanner itself)", () => {
     const files = productionFiles();
@@ -189,31 +317,65 @@ describe("supply chain: container inputs are digest-pinned (#402)", () => {
   it("digest-pins every image constant and literal FROM in production code", () => {
     const hits: string[] = [];
     for (const file of productionFiles()) {
-      const src = readFileSync(file, "utf8");
-      const lines = src.split(/\r?\n/);
-      lines.forEach((line, i) => {
-        // (a) named image constants: `export const CLONE_IMAGE = "..."` (and the
-        //     bundled `var CLONE_IMAGE = "..."` form in sandbox.js). Only refs
-        //     that name an EXTERNAL registry image are in scope — a bare local
-        //     tag prefix like `ca-sbx` (IMAGE_PREFIX, images this driver builds
-        //     itself) has no registry namespace or tag and nothing to pin.
-        const constDecl = line.match(/\b(?:const|let|var)\s+\w*IMAGE\w*\s*=\s*(["'`])([^"'`]+)\1/);
-        if (constDecl && isExternalImageRef(constDecl[2]) && !DIGEST_PINNED.test(constDecl[2])) {
-          hits.push(`${rel(file)}:${i + 1}: unpinned image constant: ${constDecl[2]}`);
-        }
-        // (b) literal `FROM <ref>` inside emitted Dockerfile text. A `${...}`
-        //     interpolation is allowed — the constant it reads is covered by (a)
-        //     and by the generated-Dockerfile assertions above.
-        const from = line.match(/\bFROM\s+([^\s"'`\\]+)/);
-        if (from && !from[1].includes("${") && !DIGEST_PINNED.test(from[1])) {
-          hits.push(`${rel(file)}:${i + 1}: unpinned FROM: ${from[1]}`);
-        }
-      });
+      hits.push(...scanUnpinnedImages(readFileSync(file, "utf8"), rel(file)));
     }
     expect(
       hits,
       "every external container image reference must be bound to a reviewed " +
         "sha256 digest (name:tag@sha256:<digest>)",
     ).toEqual([]);
+  });
+});
+
+/**
+ * The scanner's own regression suite. The rules above are only worth the bytes
+ * they occupy if they FIRE, and a scanner that quietly matches nothing looks
+ * exactly like a clean codebase. The previous per-line version of this scanner
+ * shipped inert against the multi-line declaration style every image constant in
+ * this driver uses; these cases make that failure mode loud.
+ */
+describe("supply chain: the digest scanner itself fires (#402)", () => {
+  it("catches an unpinned image constant declared across two lines", () => {
+    const src = ["export const PROBE_HELPER_IMAGE =", '  "aquasec/trivy:0.50.0";'].join("\n");
+    expect(scanUnpinnedImages(src, "probe.ts")).toEqual([
+      "probe.ts:2: unpinned image constant: PROBE_HELPER_IMAGE = aquasec/trivy:0.50.0",
+    ]);
+  });
+
+  it("catches an unpinned namespaced ref bound to a constant not named *IMAGE*", () => {
+    const src = 'const scanner =\n  "aquasec/trivy:0.50.0";';
+    expect(scanUnpinnedImages(src, "probe.ts")).toEqual([
+      "probe.ts:2: unpinned image reference: aquasec/trivy:0.50.0",
+    ]);
+  });
+
+  it("catches a literal FROM and a FROM interpolating an unproven binding", () => {
+    const src = [
+      "const other = opts.baseImage;",
+      "lines.push(`FROM ${other}`);",
+      "lines.push(`FROM debian:bookworm`);",
+    ].join("\n");
+    expect(scanUnpinnedImages(src, "probe.ts")).toEqual([
+      "probe.ts:2: FROM ${other} does not resolve to a digest-pinned image constant",
+      "probe.ts:3: unpinned FROM: debian:bookworm",
+    ]);
+  });
+
+  it("reports an unpinned constant exactly once, not once per rule", () => {
+    const src = 'export const CLONE_IMAGE =\n  "alpine/git:latest";';
+    expect(scanUnpinnedImages(src, "probe.ts")).toHaveLength(1);
+  });
+
+  it("stays silent on the pinned multi-line form the driver actually ships", () => {
+    const pinned = `alpine/git:latest@sha256:${"0".repeat(64)}`;
+    const src = [
+      "export const CLONE_IMAGE =",
+      `  "${pinned}";`,
+      "const base = opts.baseImage ?? CLONE_IMAGE;",
+      "lines.push(`FROM ${base}`);",
+      'const IMAGE_PREFIX = "ca-sbx";',
+      'import { x } from "node:fs/promises";',
+    ].join("\n");
+    expect(scanUnpinnedImages(src, "probe.ts")).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #401
Closes #402

Lane **L03-sandbox-supply-chain**. Two tribunal supply-chain findings in the ca-sandbox driver. Both are about **external bytes the driver pulled in unpinned**, and — not coincidentally — both sat in `BuildDeps`/`CreateOptions` *default effects* that every existing suite injects around, so neither had any test coverage at all.

---

## #401 — stop executing an unpinned remote installer

`defaultEnsureNixpacks` ran `bash -c "curl -fsSL https://nixpacks.com/install.sh | bash"` on the **developer host** when nixpacks was absent: arbitrary remote bytes executing with the developer's privileges *before any container boundary exists*.

Per the maintainer's SMARTS ruling (**option A**), the pipe-to-shell branch is **deleted** and the path **fails closed** — no checksum pin, no opt-in env var. Pinning a rolling install script is a maintenance treadmill that decays into unreviewed hash bumps; the `generateDockerfile()` fallback already handles this case; and host-binary + WSL-bridge detection both run *before* the install branch.

- `NIXPACKS_INSTALL_URL` removed.
- Falls back to the existing generated-Dockerfile path with an actionable note. nixpacks is already a documented prerequisite (README, `sandbox-lifecycle` SKILL, the command `description`), so this aligns the code with the contract the surface already states.
- The `curl \| bash` row in `.codearbiter/security-controls.md` "Boundary crossings (declared exceptions)" is **removed** and recorded under a new **Closed exceptions** section — the exception is closed, not narrowed.

### Verifying the issue's claims

The issue cited `build.ts:58-59` and `build.ts:230-254`. Verified against source before acting: the constant was at **line 59** and the `curl | bash` call at **line 254** (`defaultEnsureNixpacks` spanning 230–270). Line numbers were accurate.

## #402 — pin container inputs by digest

Three mutable registry references, each now bound to a reviewed **multi-arch index digest** (`name:tag@sha256:<digest>`):

| Where | Was | Now (index digest) |
|---|---|---|
| `create.ts` `CLONE_IMAGE` | `alpine/git:latest` | `alpine/git:latest@sha256:77418e6e7c7f434c4a98eaff04ef16840cf03649c881c03948e3e213923e3136` |
| `build.ts` `generateDockerfile()` | `FROM node:20-slim` | `node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0` (new `FALLBACK_BASE_IMAGE` constant) |
| `claude-inside.ts` `CLAUDE_BASE_IMAGE` | `node:22-slim` | `node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3` |

**How the digests were obtained:** `docker buildx imagetools inspect <image>` on 2026-07-24, taking the top-level `Digest:` (the OCI **image index**, not a per-platform manifest) so the pin stays correct on amd64/arm64/etc. rather than nailing the sandbox to one architecture.

**Verified end-to-end, not just asserted** — each pin was pulled and exercised for real:

- `docker pull` succeeded for all three digests.
- `docker run --rm --entrypoint sh 'alpine/git:latest@sha256:7741…'` → `git version 2.54.0`, confirming docker accepts the `name:tag@digest` form in the exact string the clone path passes.
- Built `buildClaudeImageDockerfile()`'s real output against the pinned `node:22-slim`; `claude --version` in the resulting image → `2.1.183 (Claude Code)`.
- Built `generateDockerfile({node:true})`'s real output against the pinned `node:20-slim` over the node fixture; `require('is-odd')` resolved from the out-of-tree `/deps` → `true`.

The `node:22-slim` pin is the highest-stakes of the three: that base image later co-runs with `CLAUDE_CODE_OAUTH_TOKEN`, so pinning the CLI npm version alone was never sufficient.

### Verifying the issue's claims

`create.ts:50`, `build.ts:289`, `claude-inside.ts:55` — all three verified exactly as cited.

---

## The new test: `plugins/ca-sandbox/tools/supply-chain.test.ts`

14 structural tests. Structural **on purpose**: both defects lived in default effects that `build.test.ts`/`create.test.ts`/`lifecycle.test.ts` all stub out, so a behavioral test can be satisfied without the shipped bytes ever changing. A source scan cannot be stubbed past.

- Scans every shipped source **plus the committed `sandbox.js` esbuild bundle** — the bytes that actually run on a user's machine.
- Rejects pipe-to-shell / remote-fetch-and-execute (curl/wget/iwr into sh/bash/python/node, `eval $(curl …)`, process substitution).
- Rejects floating `:latest` and digest-free external image references; asserts every generated Dockerfile's `FROM` line is digest-pinned.
- The digest scanner reads **joined file text**, not line by line, so it matches the multi-line declaration style every image constant in this driver uses. It also flags any namespaced `ns/name:tag` string literal regardless of the constant's name, and accepts a `FROM ${…}` interpolation only when that identifier demonstrably resolves to a digest-pinned constant in the same file. See "Review remediation" below — the first cut of this scanner did **not** do any of that and was proven inert.
- **The scanner has its own regression suite** — synthetic multi-line sources assert the rules actually fire, plus a pinned fixture that must stay silent. A structural scanner that quietly matches nothing is indistinguishable from a clean codebase.
- **Test fixtures are exempt** — `lifecycle.test.ts` hardcodes `alpine/git:latest` deliberately when driving docker directly, so the scan enumerates production sources explicitly instead of globbing.
- Locally-built tags are exempt from the digest rule (`IMAGE_PREFIX = "ca-sbx"` names an image the driver builds itself — no registry namespace, no tag, nothing upstream to pin).

`defaultEnsureNixpacks` is additionally **exported with an injectable process seam** (`ProbeRun`, defaulting to the real `run()`). This closes the coverage gap the lane brief called out and gives issue #401's third acceptance criterion a real behavioral test: with nixpacks absent, the function must fail closed to the fallback **and mutate nothing on the host**.

---

## Red phase — verbatim failure output

The seam (`ProbeRun` + exporting `defaultEnsureNixpacks`) was added first as a pure no-behavior-change refactor, so the red run below fails on the **defects**, not on a missing import. 8 of 9 failed; the 9th is the scanner's own self-guard.

```
 RUN  v2.1.9 C:/Users/brenn/projects/codeArbiter/plugins/ca-sandbox/tools

 ❯ supply-chain.test.ts (9 tests | 8 failed) 17ms
   × supply chain: no remote-fetch-and-execute in production code (#401) > never pipes network-fetched bytes into a shell or interpreter 7ms
     → ca-sandbox production code must never execute network-fetched bytes (no `curl | bash`): remote code would run with the developer's privileges BEFORE any container boundary exists. Declare the tool a prerequisite and fail closed to the generated-Dockerfile fallback instead.: expected [ …(3) ] to deeply equal []
   × supply chain: no remote-fetch-and-execute in production code (#401) > ships no remote-installer endpoint constant 1ms
     → expected [ 'IMAGE_PREFIX', 'DEPS_DIR', …(8) ] to not include 'NIXPACKS_INSTALL_URL'
   × supply chain: no remote-fetch-and-execute in production code (#401) > fails closed when nixpacks is absent: probes only, no host mutation 2ms
     → a missing nixpacks prerequisite must not fetch or install anything: expected [ Array(1) ] to deeply equal []
   × supply chain: container inputs are digest-pinned (#402) > pins the throwaway clone image by digest 0ms
     → expected 'alpine/git:latest' to match /@sha256:[0-9a-f]{64}\b/
   × supply chain: container inputs are digest-pinned (#402) > pins the --with-claude base image by digest (token co-runs with it) 0ms
     → expected 'node:22-slim' to match /@sha256:[0-9a-f]{64}\b/
   × supply chain: container inputs are digest-pinned (#402) > emits only digest-pinned FROM lines from every generated Dockerfile 0ms
     → unpinned base image: FROM node:20-slim: expected 'FROM node:20-slim' to match /@sha256:[0-9a-f]{64}\b/
   × supply chain: container inputs are digest-pinned (#402) > references no floating `:latest` tag in production code 2ms
     → a floating `:latest` tag lets a retag or registry compromise swap executable code into a sandbox build; bind it as name:tag@sha256:<digest>: expected [ …(2) ] to deeply equal []
   × supply chain: container inputs are digest-pinned (#402) > digest-pins every image constant and literal FROM in production code 2ms
     → every external container image reference must be bound to a reviewed sha256 digest (name:tag@sha256:<digest>): expected [ …(7) ] to deeply equal []

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 8 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  supply-chain.test.ts > supply chain: no remote-fetch-and-execute in production code (#401) > never pipes network-fetched bytes into a shell or interpreter
AssertionError: ca-sandbox production code must never execute network-fetched bytes (no `curl | bash`): remote code would run with the developer's privileges BEFORE any container boundary exists. Declare the tool a prerequisite and fail closed to the generated-Dockerfile fallback instead.: expected [ …(3) ] to deeply equal []

- Expected
+ Received

- Array []
+ Array [
+   "build.ts:262: // Try the official install script: `curl -fsSL <url> | bash`.",
+   "build.ts:263: const install = await exec(\"bash\", [\"-c\", `curl -fsSL ${NIXPACKS_INSTALL_URL} | bash`]);",
+   "sandbox.js:240: const install = await run(\"bash\", [\"-c\", `curl -fsSL ${NIXPACKS_INSTALL_URL} | bash`]);",
+ ]

 ❯ supply-chain.test.ts:98:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/8]⎯

 FAIL  supply-chain.test.ts > supply chain: no remote-fetch-and-execute in production code (#401) > ships no remote-installer endpoint constant
AssertionError: expected [ 'IMAGE_PREFIX', 'DEPS_DIR', …(8) ] to not include 'NIXPACKS_INSTALL_URL'
 ❯ supply-chain.test.ts:103:36

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/8]⎯

 FAIL  supply-chain.test.ts > supply chain: no remote-fetch-and-execute in production code (#401) > fails closed when nixpacks is absent: probes only, no host mutation
AssertionError: a missing nixpacks prerequisite must not fetch or install anything: expected [ Array(1) ] to deeply equal []

- Expected
+ Received

- Array []
+ Array [
+   "bash -c curl -fsSL https://nixpacks.com/install.sh | bash",
+ ]

 ❯ supply-chain.test.ts:132:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/8]⎯

 FAIL  supply-chain.test.ts > supply chain: container inputs are digest-pinned (#402) > pins the throwaway clone image by digest
AssertionError: expected 'alpine/git:latest' to match /@sha256:[0-9a-f]{64}\b/

- Expected:
/@sha256:[0-9a-f]{64}\b/

+ Received:
"alpine/git:latest"

 ❯ supply-chain.test.ts:139:25

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/8]⎯

 FAIL  supply-chain.test.ts > supply chain: container inputs are digest-pinned (#402) > pins the --with-claude base image by digest (token co-runs with it)
AssertionError: expected 'node:22-slim' to match /@sha256:[0-9a-f]{64}\b/

- Expected:
/@sha256:[0-9a-f]{64}\b/

+ Received:
"node:22-slim"

 ❯ supply-chain.test.ts:143:31

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/8]⎯

 FAIL  supply-chain.test.ts > supply chain: container inputs are digest-pinned (#402) > emits only digest-pinned FROM lines from every generated Dockerfile
AssertionError: unpinned base image: FROM node:20-slim: expected 'FROM node:20-slim' to match /@sha256:[0-9a-f]{64}\b/

- Expected:
/@sha256:[0-9a-f]{64}\b/

+ Received:
"FROM node:20-slim"

 ❯ supply-chain.test.ts:156:54

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/8]⎯

 FAIL  supply-chain.test.ts > supply chain: container inputs are digest-pinned (#402) > references no floating `:latest` tag in production code
AssertionError: a floating `:latest` tag lets a retag or registry compromise swap executable code into a sandbox build; bind it as name:tag@sha256:<digest>: expected [ …(2) ] to deeply equal []

- Expected
+ Received

- Array []
+ Array [
+   "create.ts:50: export const CLONE_IMAGE = \"alpine/git:latest\";",
+   "sandbox.js:471: var CLONE_IMAGE = \"alpine/git:latest\";",
+ ]

 ❯ supply-chain.test.ts:176:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/8]⎯

 FAIL  supply-chain.test.ts > supply chain: container inputs are digest-pinned (#402) > digest-pins every image constant and literal FROM in production code
AssertionError: every external container image reference must be bound to a reviewed sha256 digest (name:tag@sha256:<digest>): expected [ …(7) ] to deeply equal []

- Expected
+ Received

- Array []
+ Array [
+   "build.ts:49: unpinned image constant: ca-sbx",
+   "build.ts:298: unpinned FROM: node:20-slim",
+   "claude-inside.ts:55: unpinned image constant: node:22-slim",
+   "create.ts:50: unpinned image constant: alpine/git:latest",
+   "sandbox.js:174: unpinned image constant: ca-sbx",
+   "sandbox.js:255: unpinned FROM: node:20-slim",
+   "sandbox.js:471: unpinned image constant: alpine/git:latest",
+ ]

 ❯ supply-chain.test.ts:204:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/8]⎯

 Test Files  1 failed (1)
      Tests  8 failed | 1 passed (9)
```

Every failure is the defect, not scaffolding. Note the red run flagged `build.ts:49: unpinned image constant: ca-sbx` — a **scanner false positive** (`IMAGE_PREFIX` names a locally built image, not a registry pull). That was fixed in the scanner, not worked around in production code: the digest rule now only applies to refs carrying a registry namespace or a tag.

## Green phase

```
 ✓ supply-chain.test.ts (14 tests) 16ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

---

## Review remediation

Adversarial review returned **PASS_WITH_NITS** with one MEDIUM and one LOW. Both are fixed in commit `344a998`; neither endangered the shipped pins, but the MEDIUM meant #402's AC-2 was only half delivered.

### MEDIUM — the generic digest rule was inert against this PR's own code style

The reviewer proved the generic `const *IMAGE* = "<ref>"` rule scanned **per line**, so it required the string literal on the same line as the `const` token. All three constants this PR introduces are written multi-line, so the rule matched **none** of them. The shipped pins were never at risk — each has its own direct assertion — but the reusable regression guard the issue asked for did not exist, and `claude-inside.ts` is not in the `sandbox.js` bundle so the bundle was not even a partial backstop for it.

**Reproduced before fixing.** Injecting a brand-new unpinned constant into `create.ts`:

```ts
export const PROBE_HELPER_IMAGE =
  "aquasec/trivy:0.50.0";
```

…left the whole suite green — the guard never fired:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

**After the fix, the same injection fails**, verbatim:

```
 FAIL  supply-chain.test.ts > supply chain: container inputs are digest-pinned (#402) > digest-pins every image constant and literal FROM in production code
AssertionError: every external container image reference must be bound to a reviewed sha256 digest (name:tag@sha256:<digest>): expected [ Array(1) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "create.ts:64: unpinned image constant: PROBE_HELPER_IMAGE = aquasec/trivy:0.50.0",
+ ]
```

Renaming the constant to `PROBE_SCANNER` (no `IMAGE` in the name) — which the old rule could never have caught even single-line — now fails via the new name-independent rule:

```
+   "create.ts:64: unpinned image reference: aquasec/trivy:0.50.0",
```

The injection was then reverted; `create.ts` is byte-identical to the reviewed commit.

Three changes to the scanner:

1. It reads **joined file text**, so `const NAME =` / newline / `"<ref>"` matches.
2. A new **name-independent** rule: any string literal that *is* a namespaced `ns/name:tag` reference must be digest-pinned, whatever it is bound to. Requiring the `/` namespace is what keeps it false-positive-free — node builtin specifiers (`node:path`, `node:fs/promises`) and docs placeholders (`host:container`, `1000:1000`) never match. Verified empirically against every string literal in the production tree: zero false positives.
3. The `FROM ${…}` escape hatch is closed. The old rule waved *any* interpolation through, so an unpinned constant could reach a Dockerfile through interpolation and evade every check. An interpolation now passes only if the identifier resolves — directly or through a binding like `const base = opts.baseImage ?? CLAUDE_BASE_IMAGE` — to a digest-pinned constant in that file.

**Accepted residual, documented in the test:** an official-library image with no namespace and a non-`latest` tag (`"node:22-slim"`) bound to a constant *not* named `*IMAGE*` still evades rule 2, because `node:<builtin>` import specifiers are structurally identical to it. Today's two such images are both `*IMAGE*`-named (caught by rule 1) and additionally asserted by name.

### LOW — SKILL prose under-stated the base-image pin

`sandbox-claude-inside/SKILL.md` Phase 2 said only "the base is `node:22-slim`" while CHANGELOG and `security-controls.md` advertise digest pinning as a security property of that exact image. Checked first whether it is a built copy — `core/surface/` contains no ca-sandbox tree and `build-surface --check` reports `claude, codex, pi in sync`, so this SKILL is canonical and was edited directly. It now records the digest bind, why it is the driver's highest-stakes pin (the base image's code runs in the same container as `CLAUDE_CODE_OAUTH_TOKEN`), and that an unpinned base fails the phase gate.

---

## Test counts — before / after

| Suite | Command | Before | After |
|---|---|---|---|
| **ca-sandbox** (primary) | `cd plugins/ca-sandbox/tools && npx vitest run` | 16 files / **195 passed** | 17 files / **209 passed** |
| ca-sandbox typecheck | `npx tsc --noEmit` | clean | clean |
| `.github/scripts` | `python -m unittest discover -s .github/scripts -p "test_*.py"` | 1037 run | 1037 run, same 4 pre-existing env failures (see below) |

The ca-sandbox run is **not** docker-skipped — Docker was available (`docker info` → `linux`), so the docker-gated lifecycle/layering/multistack/isolation suites all really ran and really built images against the new pins.

### The 4 `.github/scripts` failures are environmental, not caused by this PR

All four are `test_pi_benchmark.*`, failing with `RuntimeError: Pi benchmark requires the installed pinned esbuild`. Confirmed environmental rather than a regression:

- This PR touches **zero** Pi files.
- The same file passes **11/11** when run from the main checkout on unmodified `main`.
- Root cause: this lane ran in a git worktree where `plugins/ca-pi/tools/node_modules` is not installed; the benchmark requires `plugins/ca-pi/tools/node_modules/esbuild/bin/esbuild`.

---

## Payload version gate

`plugins/ca-sandbox/**` changed and `ca-sandbox-v0.1.3` is a published tag, so the `[GATE] | [SBX] | Payload version` job would fail without a bump. Bumped **0.1.3 → 0.1.4** with a matching `## [0.1.4] — 2026-07-24 — …` CHANGELOG heading (matching this file's existing em-dash convention). Derived from the ca-sandbox-scoped window only: security fixes, no API break → patch.

`plugins/ca-sandbox/tools/sandbox.js` (the committed esbuild artifact of `cli.ts`) was **rebuilt** via `npm run build` — the change reaches it through `create.ts` and `build.ts`, and the structural scan covers the bundle, so a stale artifact fails the new test as well as CI's staleness gate.

The review-remediation commit touches only `supply-chain.test.ts`, the SKILL, and the CHANGELOG — no bundled source — and `npm run build` was re-run to confirm: `sandbox.js` is byte-identical (`git status` clean after the rebuild). The 0.1.3 → 0.1.4 bump already in this PR still satisfies the payload gate.

---

## NEEDS-TRIAGE (found, deliberately not fixed — out of lane scope)

1. **`.codearbiter/security-controls.md` has mixed CRLF/LF line endings in its committed bytes.** An ordinary editor write normalizes the whole file and produces a ~330-line phantom diff (`git diff --check` then reports trailing whitespace on nearly every line). `.gitattributes` deliberately excludes `.codearbiter/**` from LF normalization ("keep their committed bytes untouched"), so this file will keep ambushing anyone who edits it. I worked around it with byte-surgical patching so this PR's diff to that file is a clean **+20 / −1**. Worth deciding: normalize the file once in a dedicated `chore`, or leave it and document the hazard.

2. **The real clone path (`cloneRepoIntoVolume`, which consumes `CLONE_IMAGE`) has no test that exercises it.** Every `create.test.ts` and `lifecycle.test.ts` case injects `cloneRepo`, and `lifecycle.test.ts` drives docker with its own hardcoded `alpine/git:latest` literal instead. Same blind spot class as `defaultEnsureNixpacks`, and the reason I verified the pinned ref by hand with `docker run` rather than trusting the suite. `defaultEnsureNixpacks` is now covered; the clone path is still only covered structurally.

3. **`docs/reports/2026-06-24-root/inventory.md:79` still records the `curl | bash` line as live.** Left untouched — it is a dated historical report, not a live declared exception, and rewriting past reports is worse than leaving them dated. Flagging so it is not mistaken for a missed edit.

---

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
