### PR TITLE
fix(farm): make model-controlled worker writes symlink-safe at the filesystem boundary

### DIFF
--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // farm.ts
-import { readFile as readFile2, writeFile as writeFile2, appendFile, mkdir, rm } from "node:fs/promises";
+import { readFile as readFile2, writeFile, appendFile, mkdir as mkdir2, rm } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import path3 from "node:path";
@@ -130,8 +130,117 @@ function redactSecrets(contents) {
 
 // mutation.ts
 import { spawn as spawn2 } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+
+// worktree-fs.ts
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath } from "node:fs/promises";
 import path2 from "node:path";
+var UNSAFE_MESSAGE = "unsafe worktree path rejected";
+var UnsafeWorktreePathError = class extends Error {
+  constructor() {
+    super(UNSAFE_MESSAGE);
+    this.name = "UnsafeWorktreePathError";
+  }
+};
+function isUnsafeWorktreePathError(error) {
+  return error instanceof UnsafeWorktreePathError;
+}
+function unsafe() {
+  throw new UnsafeWorktreePathError();
+}
+function isMissing(error) {
+  return error?.code === "ENOENT";
+}
+function contained(root, candidate) {
+  const relative = path2.relative(root, candidate);
+  return relative === "" || !relative.startsWith(`..${path2.sep}`) && relative !== ".." && !path2.isAbsolute(relative);
+}
+function sameFile(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+function safeRegularFile(metadata) {
+  return metadata.isFile() && !metadata.isSymbolicLink() && metadata.nlink === 1;
+}
+async function writeWorktreeFile(worktree, relPath, contents, testHooks = {}) {
+  let handle;
+  try {
+    const rootMetadata = await lstat(worktree);
+    if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()) unsafe();
+    const canonicalRoot = await realpath(worktree);
+    const verifiedDirectories = [
+      { path: canonicalRoot, metadata: await lstat(canonicalRoot) }
+    ];
+    const verifyDirectories = async () => {
+      for (const verified of verifiedDirectories) {
+        const current = await lstat(verified.path);
+        if (!current.isDirectory() || current.isSymbolicLink() || !sameFile(current, verified.metadata)) unsafe();
+        if (!contained(canonicalRoot, await realpath(verified.path))) unsafe();
+      }
+    };
+    const target = path2.resolve(canonicalRoot, relPath);
+    const relative = path2.relative(canonicalRoot, target);
+    if (relative === "" || relative === ".." || relative.startsWith(`..${path2.sep}`) || path2.isAbsolute(relative)) unsafe();
+    const segments = relative.split(path2.sep);
+    let parent = canonicalRoot;
+    for (const segment of segments.slice(0, -1)) {
+      if (segment === "" || segment === "." || segment === "..") unsafe();
+      const candidate = path2.join(parent, segment);
+      let metadata;
+      try {
+        metadata = await lstat(candidate);
+      } catch (error) {
+        if (!isMissing(error)) throw error;
+        try {
+          await mkdir(candidate, { mode: 448 });
+        } catch (mkdirError) {
+          if (mkdirError?.code !== "EEXIST") throw mkdirError;
+        }
+        metadata = await lstat(candidate);
+      }
+      if (!metadata.isDirectory() || metadata.isSymbolicLink()) unsafe();
+      const canonicalCandidate = await realpath(candidate);
+      if (!contained(canonicalRoot, canonicalCandidate)) unsafe();
+      verifiedDirectories.push({ path: candidate, metadata });
+      parent = candidate;
+    }
+    await verifyDirectories();
+    const canonicalParent = await realpath(parent);
+    if (!contained(canonicalRoot, canonicalParent)) unsafe();
+    let before;
+    try {
+      before = await lstat(target);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+    }
+    if (before !== void 0 && !safeRegularFile(before)) unsafe();
+    if (before !== void 0 && !contained(canonicalRoot, await realpath(target))) unsafe();
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+    const flags = before === void 0 ? constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | noFollow : constants.O_RDWR | noFollow;
+    handle = await open(target, flags, 384);
+    const opened = await handle.stat();
+    const atPath = await lstat(target);
+    if (!safeRegularFile(opened) || !safeRegularFile(atPath) || !sameFile(opened, atPath)) unsafe();
+    await verifyDirectories();
+    if (!contained(canonicalRoot, await realpath(parent))) unsafe();
+    if (!contained(canonicalRoot, await realpath(target))) unsafe();
+    await testHooks.beforeFinalAuthorization?.();
+    await verifyDirectories();
+    if (!contained(canonicalRoot, await realpath(parent))) unsafe();
+    if (!contained(canonicalRoot, await realpath(target))) unsafe();
+    const finalAtPath = await lstat(target);
+    const finalOpened = await handle.stat();
+    if (!safeRegularFile(finalOpened) || !safeRegularFile(finalAtPath) || !sameFile(finalOpened, finalAtPath)) unsafe();
+    await handle.truncate(0);
+    await handle.writeFile(contents, { encoding: "utf8" });
+  } catch (error) {
+    if (isUnsafeWorktreePathError(error)) throw error;
+    throw new UnsafeWorktreePathError();
+  } finally {
+    await handle?.close().catch(() => void 0);
+  }
+}
+
+// mutation.ts
 var MUT = {
   enabled: (process.env.FARM_MUTATION ?? "on").toLowerCase() !== "off",
   // reliability-014: routed through the shared numEnv reader (exec.ts) so a
@@ -290,17 +399,22 @@ async function mutationCheck(wt, task) {
   try {
     for (const c of candidates) {
       if (Date.now() - start > MUT.budgetMs) break;
-      await writeFile(path2.resolve(wt, c.file), c.mutated);
+      await writeWorktreeFile(wt, c.file, c.mutated);
       const r = await run(SHELL_BIN, [SHELL_FLAG, testCmd], wt, SHELL_OPTS, GATE_TIMEOUT_MS);
       const orig = originals.get(c.file);
-      if (orig !== void 0) await writeFile(path2.resolve(wt, c.file), orig);
+      if (orig !== void 0) await writeWorktreeFile(wt, c.file, orig);
       evaluated++;
       if (r.code !== 0) killed++;
       else survivors.push(c.tag);
     }
   } finally {
-    for (const [f, src] of originals) await writeFile(path2.resolve(wt, f), src).catch(() => {
-    });
+    for (const [f, src] of originals) {
+      try {
+        await writeWorktreeFile(wt, f, src);
+      } catch (error) {
+        if (isUnsafeWorktreePathError(error)) throw error;
+      }
+    }
   }
   if (evaluated < 3) return null;
   return { score: killed / evaluated, evaluated, survivors };
@@ -571,12 +685,12 @@ function extractFileBlocks(content) {
   const blocks = [];
   let i = 0;
   while (i < lines.length) {
-    const open = lines[i].match(/^\s*```(.*)$/);
-    if (!open) {
+    const open2 = lines[i].match(/^\s*```(.*)$/);
+    if (!open2) {
       i++;
       continue;
     }
-    const info = open[1].trim();
+    const info = open2[1].trim();
     const body = [];
     i++;
     while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
@@ -712,8 +826,12 @@ async function runWorker(cwd, prompt, model, apiBaseUrl, apiKey, forbidden, samp
     if (forbidden.has(rel)) {
       return { ok: false, filesWritten, error: `worker tried to write read-only path: ${rel}` };
     }
-    await mkdir(path3.dirname(absPath), { recursive: true });
-    await writeFile2(absPath, body.endsWith("\n") ? body : body + "\n");
+    try {
+      await writeWorktreeFile(cwd, rel, body.endsWith("\n") ? body : body + "\n");
+    } catch (error) {
+      if (isUnsafeWorktreePathError(error)) return { ok: false, filesWritten, error: error.message };
+      throw error;
+    }
     filesWritten.push(rel);
   }
   if (filesWritten.length === 0) {
@@ -827,9 +945,8 @@ function effectiveSampling(samples) {
 async function writeFilesInto(wt, files) {
   for (const f of files) {
     const abs = path3.resolve(wt, f.path);
-    if (!isInside(wt, abs)) continue;
-    await mkdir(path3.dirname(abs), { recursive: true });
-    await writeFile2(abs, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
+    if (!isInside(wt, abs)) throw new UnsafeWorktreePathError();
+    await writeWorktreeFile(wt, f.path, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
   }
 }
 async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden, allowed, n, deps) {
@@ -954,7 +1071,14 @@ ${setupResult.tail}`), promptTokens, completionTokens };
         priorFailure = sel.bestFailure?.note ?? "all samples failed the gate";
         continue;
       }
-      await writeFilesInto(wt, sel.winner.files);
+      try {
+        await writeFilesInto(wt, sel.winner.files);
+      } catch (error) {
+        if (isUnsafeWorktreePathError(error)) {
+          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+        }
+        throw error;
+      }
       worker = { ok: true, filesWritten: sel.winner.filesWritten };
       lastFilesWritten = worker.filesWritten;
     }
@@ -985,7 +1109,15 @@ ${gate.tail}`);
     let risk = gaming.risk;
     let riskNote = gaming.note;
     if (risk !== "high") {
-      const mut = await deps.mutationCheck(wt, t);
+      let mut;
+      try {
+        mut = await deps.mutationCheck(wt, t);
+      } catch (error) {
+        if (isUnsafeWorktreePathError(error)) {
+          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+        }
+        throw error;
+      }
       if (mut && "score" in mut) {
         mutationScore = mut.score;
         if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {
@@ -1190,8 +1322,8 @@ async function runCanary(plan) {
     console.error("Error: FARM_API_KEY is not set.");
     process.exit(1);
   }
-  await mkdir(ENV.worktreeRoot, { recursive: true });
-  await mkdir(ENV.reportDir, { recursive: true });
+  await mkdir2(ENV.worktreeRoot, { recursive: true });
+  await mkdir2(ENV.reportDir, { recursive: true });
   await git(["branch", "-f", ENV.integration, ENV.base]);
   integrationWorktree = path3.resolve(ENV.reportDir, "integration-wt");
   await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
@@ -1221,7 +1353,7 @@ async function runCanary(plan) {
   await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
   });
   results.sort((a, b) => Number(b.green) - Number(a.green) || a.attempts - b.attempts || a.ms - b.ms);
-  await writeFile2(path3.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, skipped, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
+  await writeFile(path3.join(ENV.reportDir, "canary-report.json"), JSON.stringify({ task: task.id, results, skipped, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2));
   const summary = [
     "\nCanary results (best first):",
     ...results.map((r) => `  ${r.green ? "PASS" : "FAIL"}  ${r.model}  attempts=${r.attempts} ${r.ms}ms${r.note ? `  (${r.note})` : ""}`),
@@ -1245,10 +1377,10 @@ async function main() {
   if (canary) return runCanary(plan);
   const { model, apiBaseUrl, apiKey } = resolveConfig(plan);
   const runId = mintRunId();
-  await mkdir(ENV.worktreeRoot, { recursive: true });
-  await mkdir(ENV.reportDir, { recursive: true });
+  await mkdir2(ENV.worktreeRoot, { recursive: true });
+  await mkdir2(ENV.reportDir, { recursive: true });
   const resultsStream = path3.join(ENV.reportDir, "farm-results.jsonl");
-  await writeFile2(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
+  await writeFile(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
   const done = /* @__PURE__ */ new Map();
   const blocked = [];
   let aborted = false;
@@ -1365,17 +1497,17 @@ Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
   process.exit(exitCode);
 }
 async function writeReport(plan, results, blocked, aborted, runId) {
-  await mkdir(path3.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {
+  await mkdir2(path3.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {
   });
   for (const r of results) {
     const d = await git(["diff", `${ENV.base}...${r.branch}`]);
     if (d.code === 0 && d.out.trim())
-      await writeFile2(path3.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {
+      await writeFile(path3.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {
       });
   }
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
-  await writeFile2(
+  await writeFile(
     path3.join(ENV.reportDir, "farm-report.json"),
     JSON.stringify({ run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)
   );
@@ -1397,7 +1529,7 @@ async function writeReport(plan, results, blocked, aborted, runId) {
     `## Warnings \u2014 review during spec-compliance`,
     ...results.filter((r) => r.warning).map((r) => `- **${r.id}** \u2014 ${r.warning} (diff: \`${path3.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`)
   ].join("\n");
-  await writeFile2(path3.join(ENV.reportDir, "farm-report.md"), md);
+  await writeFile(path3.join(ENV.reportDir, "farm-report.md"), md);
 }
 var _thisFile = fileURLToPath(import.meta.url);
 var _entryFile = path3.resolve(process.argv[1] ?? "");
@@ -1435,5 +1567,6 @@ export {
   runTask,
   screenEntitlements,
   validate,
-  validateWorktreeRoot
+  validateWorktreeRoot,
+  writeFilesInto
 };

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -49,6 +49,7 @@ import { run, readWorktreeFile, SHELL_BIN, SHELL_FLAG, SHELL_OPTS, GATE_TIMEOUT_
 import type { RunResult } from "./exec.ts";
 import { redactSecrets, isSecretBearingFilename } from "./redactor.ts";
 import { MUT, mutationCheck, antiGamingCheck } from "./mutation.ts";
+import { UnsafeWorktreePathError, isUnsafeWorktreePathError, writeWorktreeFile } from "./worktree-fs.ts";
 export { run, redactSecrets, numEnv };
 export { extractLiterals, codeLineCount, parseMutationHookOutput } from "./mutation.ts";
 
@@ -794,8 +795,12 @@ async function runWorker(
     if (forbidden.has(rel)) {
       return { ok: false, filesWritten, error: `worker tried to write read-only path: ${rel}` };
     }
-    await mkdir(path.dirname(absPath), { recursive: true });
-    await writeFile(absPath, body.endsWith("\n") ? body : body + "\n");
+    try {
+      await writeWorktreeFile(cwd, rel, body.endsWith("\n") ? body : body + "\n");
+    } catch (error) {
+      if (isUnsafeWorktreePathError(error)) return { ok: false, filesWritten, error: error.message };
+      throw error;
+    }
     filesWritten.push(rel);
   }
 
@@ -1074,12 +1079,11 @@ function effectiveSampling(samples: number): Sampling {
 // in-scope impl files are written (the test is already present in `wt`); a path
 // that would escape the worktree is refused (defense-in-depth — winner files are
 // in-scope already).
-async function writeFilesInto(wt: string, files: Array<{ path: string; contents: string }>): Promise<void> {
+export async function writeFilesInto(wt: string, files: Array<{ path: string; contents: string }>): Promise<void> {
   for (const f of files) {
     const abs = path.resolve(wt, f.path);
-    if (!isInside(wt, abs)) continue;
-    await mkdir(path.dirname(abs), { recursive: true });
-    await writeFile(abs, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
+    if (!isInside(wt, abs)) throw new UnsafeWorktreePathError();
+    await writeWorktreeFile(wt, f.path, f.contents.endsWith("\n") ? f.contents : f.contents + "\n");
   }
 }
 
@@ -1303,7 +1307,14 @@ export async function runTask(
         priorFailure = sel.bestFailure?.note ?? "all samples failed the gate";
         continue;
       }
-      await writeFilesInto(wt, sel.winner.files);
+      try {
+        await writeFilesInto(wt, sel.winner.files);
+      } catch (error) {
+        if (isUnsafeWorktreePathError(error)) {
+          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+        }
+        throw error;
+      }
       worker = { ok: true, filesWritten: sel.winner.filesWritten };
       lastFilesWritten = worker.filesWritten;
     }
@@ -1359,7 +1370,15 @@ export async function runTask(
     let risk = gaming.risk;
     let riskNote = gaming.note;
     if (risk !== "high") {
-      const mut = await deps.mutationCheck(wt, t);
+      let mut: Awaited<ReturnType<typeof mutationCheck>>;
+      try {
+        mut = await deps.mutationCheck(wt, t);
+      } catch (error) {
+        if (isUnsafeWorktreePathError(error)) {
+          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+        }
+        throw error;
+      }
       if (mut && "score" in mut) {
         mutationScore = mut.score;
         if (mut.score <= MUT.escalateBelow && mut.evaluated >= 5) {

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -763,12 +763,26 @@ describe("farm worktree write containment", () => {
       "}",
     ].join("\n");
     await fsWriteFile(sentinel, externalOriginal, "utf8");
-    const script = [
-      "const fs=require('node:fs');",
-      "fs.rmSync('src',{recursive:true,force:true});",
-      `fs.symlinkSync(${JSON.stringify(external)},'src',process.platform==='win32'?'junction':'dir');`,
-    ].join("");
-    const swapCommand = `node -e "eval(Buffer.from('${Buffer.from(script).toString("base64")}','base64').toString())"`;
+    // Run the swap from a real script FILE rather than `node -e`. An inline
+    // -e payload has to survive two levels of shell quoting on both platforms,
+    // which is why this was once a base64+eval one-liner - but constructing
+    // code to eval trips CodeQL js/bad-code-sanitization, and a standing
+    // dismissal would re-raise on every bundle rebuild. A file has neither
+    // problem: same behaviour, no quoting gymnastics, no eval. Relative paths
+    // below still resolve against the worktree because the gate command runs
+    // with cwd = the worktree.
+    const scriptDir = await mkdtemp(path.join(tmpdir(), "farm-external-swap-"));
+    const scriptPath = path.join(scriptDir, "swap.cjs");
+    await fsWriteFile(
+      scriptPath,
+      [
+        "const fs=require('node:fs');",
+        "fs.rmSync('src',{recursive:true,force:true});",
+        `fs.symlinkSync(${JSON.stringify(external)},'src',process.platform==='win32'?'junction':'dir');`,
+      ].join("\n"),
+      "utf8",
+    );
+    const swapCommand = `node ${JSON.stringify(scriptPath)}`;
     const gitCalls: string[][] = [];
     try {
       const result = await runTask({

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -6,12 +6,13 @@ import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, rm as fsRm } from "node:fs/promises";
+import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, readFile as fsReadFile, rm as fsRm, symlink as fsSymlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, makeEntitlementProbe, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot, numEnv } from "./farm.ts";
 import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 import { scrubbedEnv } from "./exec.ts";
+import { mutationCheck as realMutationCheck } from "./mutation.ts";
 
 // ---------------------------------------------------------------------------
 // redactSecrets — outbound-boundary redactor must stay aligned with the hook
@@ -588,6 +589,217 @@ describe("httpWorker secure request boundary", () => {
     expect(stderr.mock.calls.flat().join(" ")).not.toContain("opaque-provider-credential");
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).not.toContain("opaque-provider-credential");
+  });
+});
+
+describe("farm worktree write containment", () => {
+  const savedSamples = process.env.FARM_SAMPLES;
+  const savedTemperature = process.env.FARM_TEMPERATURE;
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    if (savedSamples === undefined) delete process.env.FARM_SAMPLES;
+    else process.env.FARM_SAMPLES = savedSamples;
+    if (savedTemperature === undefined) delete process.env.FARM_TEMPERATURE;
+    else process.env.FARM_TEMPERATURE = savedTemperature;
+    vi.restoreAllMocks();
+  });
+
+  const taskFor = (id: string): Task => ({
+    id,
+    description: "write through a hostile worktree link",
+    filesInScope: ["linked/sentinel.txt"],
+    test: { path: "tests/read-only.test.ts" },
+    gate: { commands: ["node -p 0"] },
+    maxRetries: 0,
+  });
+
+  const worktreeFor = (id: string) => path.resolve(process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees", id);
+
+  it("escalates single-worker directory-link writes with a bounded error and stages nothing", async () => {
+    process.env.FARM_SAMPLES = "1";
+    const id = "unsafe-single-write";
+    const wt = worktreeFor(id);
+    const external = await mkdtemp(path.join(tmpdir(), "farm-external-single-"));
+    const sentinel = path.join(external, "sentinel.txt");
+    await fsWriteFile(sentinel, "outside-must-survive", "utf8");
+    const gitCalls: string[][] = [];
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: "```text:linked/sentinel.txt\noverwritten\n```" } }],
+    }), { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+    try {
+      const result = await runTask(taskFor(id), "stub-model", "https://api.example/v1", "stub-key", {
+        worker: httpWorker,
+        prepareWorktree: async () => {
+          await fsMkdir(wt, { recursive: true });
+          await fsSymlink(external, path.join(wt, "linked"), process.platform === "win32" ? "junction" : "dir");
+          return null;
+        },
+        resetWorktree: async () => {},
+        fileHash: async () => null,
+        checkDrift: async () => [],
+        runGate: async () => ({ ok: true as const }),
+        antiGamingCheck: async () => ({ risk: "none" as const }),
+        mutationCheck: async () => null,
+        git: async (args) => { gitCalls.push(args); return { code: 0, out: "", stdout: "", stderr: "" }; },
+        withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+      });
+
+      expect(result.status).toBe("escalate");
+      expect(result.note).toMatch(/unsafe worktree path rejected/u);
+      expect(result.note!.length).toBeLessThan(80);
+      expect(await fsReadFile(sentinel, "utf8")).toBe("outside-must-survive");
+      expect(gitCalls.some((args) => args[0] === "add")).toBe(false);
+    } finally {
+      await fsRm(wt, { recursive: true, force: true });
+      await fsRm(external, { recursive: true, force: true });
+    }
+  });
+
+  it("escalates best-of-N winner materialization through a directory link and stages nothing", async () => {
+    process.env.FARM_SAMPLES = "2";
+    process.env.FARM_TEMPERATURE = "0";
+    const id = "unsafe-winner-write";
+    const mainWt = worktreeFor(id);
+    const external = await mkdtemp(path.join(tmpdir(), "farm-external-winner-"));
+    const sentinel = path.join(external, "sentinel.txt");
+    await fsWriteFile(sentinel, "outside-must-survive", "utf8");
+    const gitCalls: string[][] = [];
+    try {
+      const result = await runTask(taskFor(id), "stub-model", "https://api.example/v1", "stub-key", {
+        worker: {
+          async apply(ctx) {
+            await fsMkdir(path.join(ctx.cwd, "linked"), { recursive: true });
+            await fsWriteFile(path.join(ctx.cwd, "linked", "sentinel.txt"), "winner-output", "utf8");
+            return { ok: true, filesWritten: ["linked/sentinel.txt"] } satisfies WorkerResult;
+          },
+        },
+        prepareWorktree: async (_branch, candidateWt) => {
+          await fsMkdir(candidateWt, { recursive: true });
+          if (candidateWt === mainWt) {
+            await fsSymlink(external, path.join(candidateWt, "linked"), process.platform === "win32" ? "junction" : "dir");
+          }
+          return null;
+        },
+        resetWorktree: async () => {},
+        fileHash: async () => null,
+        checkDrift: async () => [],
+        runGate: async () => ({ ok: true as const }),
+        antiGamingCheck: async () => ({ risk: "none" as const }),
+        mutationCheck: async () => null,
+        git: async (args) => { gitCalls.push(args); return { code: 0, out: "", stdout: "", stderr: "" }; },
+        withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+      });
+
+      expect(result.status).toBe("escalate");
+      expect(result.note).toBe("unsafe worktree path rejected");
+      expect(await fsReadFile(sentinel, "utf8")).toBe("outside-must-survive");
+      expect(gitCalls.some((args) => args[0] === "add")).toBe(false);
+    } finally {
+      for (const suffix of ["", "__s0", "__s1"]) {
+        await fsRm(worktreeFor(id + suffix), { recursive: true, force: true });
+      }
+      await fsRm(external, { recursive: true, force: true });
+    }
+  });
+
+  it("escalates unsafe mutation write/finally-restore paths without touching or staging the external file", async () => {
+    process.env.FARM_SAMPLES = "1";
+    const id = "unsafe-mutation-write";
+    const wt = worktreeFor(id);
+    const external = await mkdtemp(path.join(tmpdir(), "farm-external-mutation-"));
+    const sentinel = path.join(external, "impl.ts");
+    const original = [
+      "export function classify(value: number) {",
+      "  const enabled = true;",
+      "  return value > 1 && enabled;",
+      "}",
+    ].join("\n");
+    await fsWriteFile(sentinel, original, "utf8");
+    const gitCalls: string[][] = [];
+    try {
+      const result = await runTask({
+        ...taskFor(id),
+        filesInScope: ["linked/impl.ts"],
+      }, "stub-model", "https://api.example/v1", "stub-key", {
+        worker: { async apply() { return { ok: true, filesWritten: ["linked/impl.ts"] }; } },
+        prepareWorktree: async () => {
+          await fsMkdir(wt, { recursive: true });
+          await fsSymlink(external, path.join(wt, "linked"), process.platform === "win32" ? "junction" : "dir");
+          return null;
+        },
+        resetWorktree: async () => {},
+        fileHash: async () => null,
+        checkDrift: async () => [],
+        runGate: async () => ({ ok: true as const }),
+        antiGamingCheck: async () => ({ risk: "none" as const }),
+        mutationCheck: realMutationCheck,
+        git: async (args) => { gitCalls.push(args); return { code: 0, out: "", stdout: "", stderr: "" }; },
+        withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+      });
+
+      expect(result.status).toBe("escalate");
+      expect(result.note).toBe("unsafe worktree path rejected");
+      expect(await fsReadFile(sentinel, "utf8")).toBe(original);
+      expect(gitCalls.some((args) => args[0] === "add")).toBe(false);
+    } finally {
+      await fsRm(wt, { recursive: true, force: true });
+      await fsRm(external, { recursive: true, force: true });
+    }
+  });
+
+  it("escalates when the mutation command swaps an ancestor before immediate and final restore", async () => {
+    process.env.FARM_SAMPLES = "1";
+    const id = "unsafe-mutation-restore";
+    const wt = worktreeFor(id);
+    const external = await mkdtemp(path.join(tmpdir(), "farm-external-restore-"));
+    const sentinel = path.join(external, "impl.ts");
+    const externalOriginal = "external-must-survive";
+    const internalOriginal = [
+      "export function classify(value: number) {",
+      "  const enabled = true;",
+      "  return value > 1 && enabled;",
+      "}",
+    ].join("\n");
+    await fsWriteFile(sentinel, externalOriginal, "utf8");
+    const script = [
+      "const fs=require('node:fs');",
+      "fs.rmSync('src',{recursive:true,force:true});",
+      `fs.symlinkSync(${JSON.stringify(external)},'src',process.platform==='win32'?'junction':'dir');`,
+    ].join("");
+    const swapCommand = `node -e "eval(Buffer.from('${Buffer.from(script).toString("base64")}','base64').toString())"`;
+    const gitCalls: string[][] = [];
+    try {
+      const result = await runTask({
+        ...taskFor(id),
+        filesInScope: ["src/impl.ts"],
+        gate: { commands: [swapCommand] },
+      }, "stub-model", "https://api.example/v1", "stub-key", {
+        worker: { async apply() { return { ok: true, filesWritten: ["src/impl.ts"] }; } },
+        prepareWorktree: async () => {
+          await fsMkdir(path.join(wt, "src"), { recursive: true });
+          await fsWriteFile(path.join(wt, "src", "impl.ts"), internalOriginal, "utf8");
+          return null;
+        },
+        resetWorktree: async () => {},
+        fileHash: async () => null,
+        checkDrift: async () => [],
+        runGate: async () => ({ ok: true as const }),
+        antiGamingCheck: async () => ({ risk: "none" as const }),
+        mutationCheck: realMutationCheck,
+        git: async (args) => { gitCalls.push(args); return { code: 0, out: "", stdout: "", stderr: "" }; },
+        withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+      });
+
+      expect(result.status).toBe("escalate");
+      expect(result.note).toBe("unsafe worktree path rejected");
+      expect(await fsReadFile(sentinel, "utf8")).toBe(externalOriginal);
+      expect(gitCalls.some((args) => args[0] === "add")).toBe(false);
+    } finally {
+      await fsRm(wt, { recursive: true, force: true });
+      await fsRm(external, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/ca/tools/mutation.ts
+++ b/plugins/ca/tools/mutation.ts
@@ -11,8 +11,6 @@
  * identical to the prior in-farm.ts definitions.
  */
 import { spawn } from "node:child_process";
-import { writeFile } from "node:fs/promises";
-import path from "node:path";
 import {
   run,
   treeKill,
@@ -25,6 +23,7 @@ import {
   GATE_TIMEOUT_MS,
 } from "./exec.ts";
 import { redactSecrets } from "./redactor.ts";
+import { isUnsafeWorktreePathError, writeWorktreeFile } from "./worktree-fs.ts";
 import type { Task } from "./farm.ts";
 
 // Mutation guard — a zero-token quality signal. After the gate goes green we
@@ -257,7 +256,7 @@ export async function mutationCheck(wt: string, task: Task): Promise<MutationChe
   try {
     for (const c of candidates) {
       if (Date.now() - start > MUT.budgetMs) break;
-      await writeFile(path.resolve(wt, c.file), c.mutated);
+      await writeWorktreeFile(wt, c.file, c.mutated);
       // T-06: bound the mutant re-run by the wall-clock timeout. A hung test
       // here (a mutant that turns the test into an infinite loop, say) would
       // otherwise wedge the worker; the killed result counts as a "killed"
@@ -268,14 +267,20 @@ export async function mutationCheck(wt: string, task: Task): Promise<MutationChe
       // (every candidate's file is a key in `originals`) holds for the built-in
       // generator today; this guard preserves the file if that ever changes.
       const orig = originals.get(c.file);
-      if (orig !== undefined) await writeFile(path.resolve(wt, c.file), orig); // restore
+      if (orig !== undefined) await writeWorktreeFile(wt, c.file, orig); // restore
       evaluated++;
       if (r.code !== 0) killed++;
       else survivors.push(c.tag);
     }
   } finally {
     // defensive: guarantee every impl file is back to the worker's output
-    for (const [f, src] of originals) await writeFile(path.resolve(wt, f), src).catch(() => {});
+    for (const [f, src] of originals) {
+      try {
+        await writeWorktreeFile(wt, f, src);
+      } catch (error) {
+        if (isUnsafeWorktreePathError(error)) throw error;
+      }
+    }
   }
   if (evaluated < 3) return null; // too few mutants to judge fairly
   return { score: killed / evaluated, evaluated, survivors };

--- a/plugins/ca/tools/worktree-fs.test.ts
+++ b/plugins/ca/tools/worktree-fs.test.ts
@@ -1,0 +1,105 @@
+import { link, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type WorktreeFs = typeof import("./worktree-fs.ts");
+
+async function implementation(): Promise<WorktreeFs> {
+  try {
+    return await import("./worktree-fs.ts");
+  } catch (error) {
+    throw new Error("symlink-safe worktree writer is missing", { cause: error });
+  }
+}
+
+describe("symlink-safe worktree writer", () => {
+  it("writes a normal nested file beneath the canonical root", async () => {
+    const { writeWorktreeFile } = await implementation();
+    const root = await mkdtemp(path.join(tmpdir(), "farm-safe-root-"));
+    try {
+      await writeWorktreeFile(root, "src/nested/value.txt", "safe\n");
+      expect(await readFile(path.join(root, "src", "nested", "value.txt"), "utf8")).toBe("safe\n");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a directory symlink or Windows junction without changing an external sentinel", async () => {
+    const { writeWorktreeFile } = await implementation();
+    const root = await mkdtemp(path.join(tmpdir(), "farm-link-root-"));
+    const external = await mkdtemp(path.join(tmpdir(), "farm-link-external-"));
+    const sentinel = path.join(external, "sentinel.txt");
+    await writeFile(sentinel, "outside-must-survive", "utf8");
+    try {
+      await symlink(external, path.join(root, "linked"), process.platform === "win32" ? "junction" : "dir");
+      await expect(writeWorktreeFile(root, "linked/sentinel.txt", "overwrite")).rejects.toThrow("unsafe worktree path rejected");
+      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(external, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("rejects a file symlink without changing its external target", async () => {
+    const { writeWorktreeFile } = await implementation();
+    const root = await mkdtemp(path.join(tmpdir(), "farm-file-link-root-"));
+    const external = await mkdtemp(path.join(tmpdir(), "farm-file-link-external-"));
+    const sentinel = path.join(external, "sentinel.txt");
+    await writeFile(sentinel, "outside-must-survive", "utf8");
+    try {
+      await symlink(sentinel, path.join(root, "inside.txt"), "file");
+      await expect(writeWorktreeFile(root, "inside.txt", "overwrite")).rejects.toThrow("unsafe worktree path rejected");
+      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(external, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a multiply-linked existing destination", async () => {
+    const { writeWorktreeFile } = await implementation();
+    const root = await mkdtemp(path.join(tmpdir(), "farm-hardlink-root-"));
+    const external = await mkdtemp(path.join(tmpdir(), "farm-hardlink-external-"));
+    const sentinel = path.join(external, "sentinel.txt");
+    await writeFile(sentinel, "outside-must-survive", "utf8");
+    try {
+      await link(sentinel, path.join(root, "inside.txt"));
+      expect((await lstat(path.join(root, "inside.txt"))).nlink).toBeGreaterThan(1);
+      await expect(writeWorktreeFile(root, "inside.txt", "overwrite")).rejects.toThrow("unsafe worktree path rejected");
+      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(external, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a hard link introduced after initial destination validation", async () => {
+    const { writeWorktreeFile } = await implementation();
+    const root = await mkdtemp(path.join(tmpdir(), "farm-race-root-"));
+    const external = await mkdtemp(path.join(tmpdir(), "farm-race-external-"));
+    const destination = path.join(root, "inside.txt");
+    const externalLink = path.join(external, "late-link.txt");
+    await writeFile(destination, "inside-original", "utf8");
+    try {
+      await expect(writeWorktreeFile(root, "inside.txt", "overwrite", {
+        beforeFinalAuthorization: async () => await link(destination, externalLink),
+      })).rejects.toThrow("unsafe worktree path rejected");
+      expect(await readFile(destination, "utf8")).toBe("inside-original");
+      expect(await readFile(externalLink, "utf8")).toBe("inside-original");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(external, { recursive: true, force: true });
+    }
+  });
+
+  it("pins every farm and mutation write/restore path to the shared primitive", async () => {
+    const farm = await readFile(new URL("./farm.ts", import.meta.url), "utf8");
+    const mutation = await readFile(new URL("./mutation.ts", import.meta.url), "utf8");
+    expect(farm).toContain('from "./worktree-fs.ts"');
+    expect(mutation).toContain('from "./worktree-fs.ts"');
+    expect(farm).not.toMatch(/writeFile\((?:absPath|abs),/u);
+    expect(mutation).not.toContain("writeFile(path.resolve(wt");
+    expect((mutation.match(/writeWorktreeFile\(/gu) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/plugins/ca/tools/worktree-fs.ts
+++ b/plugins/ca/tools/worktree-fs.ts
@@ -1,0 +1,146 @@
+/** Symlink-safe writes for all model-controlled farm worktree mutations. */
+import { constants } from "node:fs";
+import type { Stats } from "node:fs";
+import { lstat, mkdir, open, realpath } from "node:fs/promises";
+import path from "node:path";
+
+const UNSAFE_MESSAGE = "unsafe worktree path rejected";
+
+export class UnsafeWorktreePathError extends Error {
+  constructor() {
+    super(UNSAFE_MESSAGE);
+    this.name = "UnsafeWorktreePathError";
+  }
+}
+
+export function isUnsafeWorktreePathError(error: unknown): error is UnsafeWorktreePathError {
+  return error instanceof UnsafeWorktreePathError;
+}
+
+export interface WorktreeWriteTestHooks {
+  /** Test seam for a deterministic replacement/link race before final authorization. */
+  beforeFinalAuthorization?(): Promise<void>;
+}
+
+function unsafe(): never {
+  throw new UnsafeWorktreePathError();
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
+function contained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function sameFile(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function safeRegularFile(metadata: Stats): boolean {
+  return metadata.isFile() && !metadata.isSymbolicLink() && metadata.nlink === 1;
+}
+
+/**
+ * Write one worktree-relative file without following a link/reparse point.
+ * Existing ancestors and the destination are checked before open and again
+ * before the retained handle is truncated, so the write never targets a path
+ * selected only by lexical containment.
+ */
+export async function writeWorktreeFile(
+  worktree: string,
+  relPath: string,
+  contents: string,
+  testHooks: WorktreeWriteTestHooks = {},
+): Promise<void> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    const rootMetadata = await lstat(worktree);
+    if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()) unsafe();
+    const canonicalRoot = await realpath(worktree);
+    const verifiedDirectories: Array<{ path: string; metadata: Stats }> = [
+      { path: canonicalRoot, metadata: await lstat(canonicalRoot) },
+    ];
+    const verifyDirectories = async (): Promise<void> => {
+      for (const verified of verifiedDirectories) {
+        const current = await lstat(verified.path);
+        if (!current.isDirectory() || current.isSymbolicLink() || !sameFile(current, verified.metadata)) unsafe();
+        if (!contained(canonicalRoot, await realpath(verified.path))) unsafe();
+      }
+    };
+    const target = path.resolve(canonicalRoot, relPath);
+    const relative = path.relative(canonicalRoot, target);
+    if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) unsafe();
+
+    const segments = relative.split(path.sep);
+    let parent = canonicalRoot;
+    for (const segment of segments.slice(0, -1)) {
+      if (segment === "" || segment === "." || segment === "..") unsafe();
+      const candidate = path.join(parent, segment);
+      let metadata: Stats;
+      try {
+        metadata = await lstat(candidate);
+      } catch (error) {
+        if (!isMissing(error)) throw error;
+        try {
+          await mkdir(candidate, { mode: 0o700 });
+        } catch (mkdirError) {
+          if ((mkdirError as NodeJS.ErrnoException)?.code !== "EEXIST") throw mkdirError;
+        }
+        metadata = await lstat(candidate);
+      }
+      if (!metadata.isDirectory() || metadata.isSymbolicLink()) unsafe();
+      const canonicalCandidate = await realpath(candidate);
+      if (!contained(canonicalRoot, canonicalCandidate)) unsafe();
+      verifiedDirectories.push({ path: candidate, metadata });
+      parent = candidate;
+    }
+
+    await verifyDirectories();
+    const canonicalParent = await realpath(parent);
+    if (!contained(canonicalRoot, canonicalParent)) unsafe();
+
+    let before: Stats | undefined;
+    try {
+      before = await lstat(target);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+    }
+    if (before !== undefined && !safeRegularFile(before)) unsafe();
+    if (before !== undefined && !contained(canonicalRoot, await realpath(target))) unsafe();
+
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+    const flags = before === undefined
+      ? constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | noFollow
+      : constants.O_RDWR | noFollow;
+    handle = await open(target, flags, 0o600);
+
+    const opened = await handle.stat();
+    const atPath = await lstat(target);
+    if (!safeRegularFile(opened) || !safeRegularFile(atPath) || !sameFile(opened, atPath)) unsafe();
+    await verifyDirectories();
+    if (!contained(canonicalRoot, await realpath(parent))) unsafe();
+    if (!contained(canonicalRoot, await realpath(target))) unsafe();
+
+    await testHooks.beforeFinalAuthorization?.();
+    await verifyDirectories();
+    if (!contained(canonicalRoot, await realpath(parent))) unsafe();
+    if (!contained(canonicalRoot, await realpath(target))) unsafe();
+    // These are the final awaited checks before the retained handle is
+    // truncated: path identity and link count cannot be authorized from a
+    // stale pre-open observation.
+    const finalAtPath = await lstat(target);
+    const finalOpened = await handle.stat();
+    if (!safeRegularFile(finalOpened) || !safeRegularFile(finalAtPath) || !sameFile(finalOpened, finalAtPath)) unsafe();
+
+    await handle.truncate(0);
+    await handle.writeFile(contents, { encoding: "utf8" });
+  } catch (error) {
+    if (isUnsafeWorktreePathError(error)) throw error;
+    throw new UnsafeWorktreePathError();
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}


### PR DESCRIPTION
Closes #373

Split out of #420. The original commit `980688f` bundled this farm fix with the Pi credential-projection work; the Pi half regresses the live child contract (see #420 for detail), so the two are separated and this green half ships on its own.

## What this fixes

Every model-controlled farm worker write now rejects **symlink, junction, hardlink, and replacement races** before mutating, via a new `worktree-fs.ts` boundary primitive. A farm worker running attacker-influenced content could previously be steered into writing through a link that escapes the worktree.

## Verification

| Suite | Before | After |
|---|---|---|
| ca-farm (vitest) | 198 passed | **207 passed**, 1 skipped |

- `+9` tests, including the new `worktree-fs.test.ts` boundary suite.
- `npx tsc --noEmit` clean.
- `plugins/ca/tools/farm.js` is a committed esbuild artifact — rebuilt from source and **byte-identical** to the committed copy, so it is not stale.
- `git diff --check` clean (LF preserved).

## Payload version

`plugins/ca/**` changed, but the `[GATE] | [CA] | Payload version` guard only bites once tag `v2.9.1` is published. It is not, so no ca bump rides here — consistent with the same gate passing on #420, which also touched `farm.js`.

## Conflict hierarchy

Level 1 — correctness of a security boundary.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L