### PR TITLE
fix(ca-pi): revoke mutator authority on trust withdrawal and correlate bridge failures

### DIFF
--- a/.github/scripts/test_pi_parity.py
+++ b/.github/scripts/test_pi_parity.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Three-host enforcement parity and descriptor mapping fixtures for ca-pi."""
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -304,6 +305,32 @@ class PiParityFixtures(unittest.TestCase):
                 f'{{"version":1,"event":"tool_result","cwd":{cwd},"tool":"write","input":{{}}}}',
             ]
             for raw in invalid:
+                with self.subTest(raw=raw), self.assertRaises(bridge.ProtocolError):
+                    bridge._request(raw.encode("utf-8"))
+
+    def test_tool_call_correlation_is_an_opaque_bounded_digest(self):
+        bridge = load_pi_bridge()
+        digest = hashlib.sha256(b"pi-tool-call").hexdigest()
+        with tempfile.TemporaryDirectory() as td:
+            root = fixture(td)
+            cwd = json.dumps(str(root))
+            accepted = [
+                f'{{"version":1,"event":"tool_call","cwd":{cwd},"tool":"read","input":{{}},"correlation":"{digest}"}}',
+                f'{{"version":1,"event":"tool_result","cwd":{cwd},"tool":"write","input":{{}},"result":{{}},"correlation":"{digest}"}}',
+            ]
+            for raw in accepted:
+                with self.subTest(raw=raw):
+                    request = bridge._request(raw.encode("utf-8"))
+                    self.assertEqual(request["correlation"], digest)
+                    self.assertNotIn("correlation", bridge._payload(request, bridge.PiHost()))
+            rejected = [
+                f'{{"version":1,"event":"tool_call","cwd":{cwd},"tool":"read","input":{{}},"correlation":"pi-raw-tool-call-id"}}',
+                f'{{"version":1,"event":"tool_call","cwd":{cwd},"tool":"read","input":{{}},"correlation":"{digest.upper()}"}}',
+                f'{{"version":1,"event":"tool_call","cwd":{cwd},"tool":"read","input":{{}},"correlation":1}}',
+                f'{{"version":1,"event":"session_start","cwd":{cwd},"correlation":"{digest}"}}',
+                f'{{"version":1,"event":"plan_file","cwd":{cwd},"input":{{}},"correlation":"{digest}"}}',
+            ]
+            for raw in rejected:
                 with self.subTest(raw=raw), self.assertRaises(bridge.ProtocolError):
                     bridge._request(raw.encode("utf-8"))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.2] - 2026-07-24
+
+### Fixed
+
+- Governed mutators now re-read live Pi project trust at final execution. Trust
+  that is withdrawn, absent, or throwing retires the ready lifecycle: bash,
+  write, edit, and custom mutators fail closed, pending approvals become stale,
+  and reads fall back to the untrusted native path until a new affirmatively
+  trusted session starts.
+- Pi bridge failures during a governed tool call now record the same hashed
+  correlation as that call's permission-audit row, so a failure joins the tool
+  call, permission decision, and result event. Lifecycle and doctor requests
+  keep a locally minted correlation. Only a SHA-256 digest is accepted on the
+  wire; the raw Pi tool-call id never reaches the request JSON or the audit log.
+
+
 ## [0.1.1] - 2026-07-18
 
 ### Fixed

--- a/plugins/ca-pi/extensions/codearbiter-child.js
+++ b/plugins/ca-pi/extensions/codearbiter-child.js
@@ -215,6 +215,11 @@ function killTree(child, taskkillExecutable) {
     child.kill("SIGKILL");
   }
 }
+var BRIDGE_CORRELATION_RE = /^[a-f0-9]{64}$/u;
+function normalizedRequest(request) {
+  const { correlation, ...rest } = request;
+  return typeof correlation === "string" && BRIDGE_CORRELATION_RE.test(correlation) ? { ...rest, correlation } : rest;
+}
 function sanitizedResponse(response, request) {
   return {
     ...response,
@@ -284,7 +289,7 @@ var BridgeClient = class {
       "HOST: pi",
       `RULE: ${response.ruleId ?? "PI-BRIDGE"}`,
       `AUDIT: ${response.auditCode ?? "PI_BRIDGE_FAILURE"}`,
-      `CORRELATION: ${randomUUID()}`,
+      `CORRELATION: ${request.correlation ?? randomUUID()}`,
       `REQUEST_BYTES: ${counts.request}`,
       `STDOUT_BYTES: ${counts.stdout}`,
       `STDERR_BYTES: ${counts.stderr}`
@@ -299,7 +304,8 @@ var BridgeClient = class {
     await this.auditFailure(request, response, counts);
     return response;
   }
-  async call(request, signal) {
+  async call(rawRequest, signal) {
+    const request = normalizedRequest(rawRequest);
     let paths;
     let userHome;
     try {
@@ -971,6 +977,22 @@ function classifyPermissionActions(descriptor, tool, params) {
 function auditCorrelation(toolCallId) {
   return createHash4("sha256").update(toolCallId, "utf8").digest("hex");
 }
+var TRUST_WITHDRAWN_MESSAGE = "codeArbiter project trust is not affirmative; mutation blocked; run /trust in Pi, approve this project, then start a new session.";
+var LIFECYCLE_STALE_MESSAGE = "codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.";
+function liveProjectTrust(context, source) {
+  if (source === "not-required") return true;
+  try {
+    const probe = context?.isProjectTrusted;
+    if (typeof probe === "function") return probe.call(context) === true;
+  } catch {
+    return false;
+  }
+  try {
+    return source() === true;
+  } catch {
+    return false;
+  }
+}
 function permissionAuditRow(toolCallId, toolClass, actionClasses, decision) {
   return Object.freeze({
     timestamp: (/* @__PURE__ */ new Date()).toISOString(),
@@ -1122,7 +1144,7 @@ function fixedFallbackSessionId() {
 function executionCwd(context, fallback) {
   return context !== null && typeof context === "object" && typeof context.cwd === "string" ? context.cwd : fallback;
 }
-function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, bridge, boundGeneration, activeGeneration, isReady, sessionIdFor, permissionPolicy, getMode, permissionAudit, wrapperSourcePath, allowNativeFallback = true, bridgeToolName = toolName) {
+function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, bridge, boundGeneration, activeGeneration, isReady, sessionIdFor, permissionPolicy, getMode, permissionAudit, wrapperSourcePath, projectTrust, onTrustWithdrawn, allowNativeFallback = true, bridgeToolName = toolName) {
   const original = factory(cwd);
   if (original.name !== toolName || typeof original.execute !== "function") {
     throw new Error(`Pi built-in ${toolName} factory identity is invalid; run /ca-doctor.`);
@@ -1136,10 +1158,16 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
   return {
     ...original,
     execute: async (toolCallId, params, signal, onUpdate, context) => {
+      const trustHeld = () => {
+        if (liveProjectTrust(context, projectTrust)) return true;
+        onTrustWithdrawn();
+        return false;
+      };
+      const trusted = trustHeld();
       const generation = activeGeneration();
-      if (generation === void 0 || generation !== boundGeneration || !isReady()) {
+      if (generation === void 0 || generation !== boundGeneration || !isReady() || !trusted) {
         if (!allowNativeFallback || generation !== void 0 && category !== "READ") {
-          return failTool("codeArbiter enforcement is not ready; mutation blocked; run /ca-doctor.");
+          return failTool(trusted ? "codeArbiter enforcement is not ready; mutation blocked; run /ca-doctor." : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, params, signal, onUpdate, context);
       }
@@ -1157,18 +1185,21 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
           cwd,
           ...category === "READ" ? { sessionId: sessionIdFor(context) } : {},
           tool: bridgeToolName,
-          input: approved
+          input: approved,
+          correlation: auditCorrelation(toolCallId)
         }, signal ?? new AbortController().signal);
       } catch (error) {
-        if (activeGeneration() === generation) throw error;
+        const stillTrusted = trustHeld();
+        if (stillTrusted && activeGeneration() === generation) throw error;
         if (category !== "READ") {
-          return failTool("codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.");
+          return failTool(stillTrusted ? LIFECYCLE_STALE_MESSAGE : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, approved, signal, onUpdate, context);
       }
-      if (activeGeneration() !== generation) {
+      const trustedAfterBridge = trustHeld();
+      if (!trustedAfterBridge || activeGeneration() !== generation) {
         if (category !== "READ") {
-          return failTool("codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.");
+          return failTool(trustedAfterBridge ? LIFECYCLE_STALE_MESSAGE : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, approved, signal, onUpdate, context);
       }
@@ -1208,6 +1239,7 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
       const revalidate = () => {
         const requestStable = currentMode(getMode) === mode && registryOwns(pi, toolName, wrapperSourcePath) && original.execute === originalExecute && matchesSnapshot(params, approved) && signal?.aborted !== true;
         if (!requestStable) return "request-stale";
+        if (!trustHeld()) return "lifecycle-stale";
         return activeGeneration() === generation && generation === boundGeneration && isReady() ? "current" : "lifecycle-stale";
       };
       if (policy.decision === "ask") {
@@ -1268,7 +1300,7 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
     }
   };
 }
-function wrapMissingBuiltins(pi, bridge, options, wrapped, definitions, definitionGenerations, activeGeneration = () => STANDALONE_GENERATION, isReady = () => true, sessionIdFor = fixedFallbackSessionId()) {
+function wrapMissingBuiltins(pi, bridge, options, wrapped, definitions, definitionGenerations, activeGeneration = () => STANDALONE_GENERATION, isReady = () => true, sessionIdFor = fixedFallbackSessionId(), onTrustWithdrawn = () => void 0) {
   const boundGeneration = activeGeneration() ?? STANDALONE_GENERATION;
   const permissionPolicy = options.permissionPolicy ?? compileBuiltinPermissionPolicy(options.descriptor, {});
   if (permissionPolicy === void 0) throw new Error("Pi permission policy descriptor is invalid; run /ca-doctor.");
@@ -1292,7 +1324,9 @@ function wrapMissingBuiltins(pi, bridge, options, wrapped, definitions, definiti
       permissionPolicy,
       getMode,
       options.permissionAudit,
-      options.wrapperSourcePath
+      options.wrapperSourcePath,
+      options.projectTrust,
+      onTrustWithdrawn
     );
     pi.registerTool(definition);
     definitions?.set(name, definition);
@@ -1311,6 +1345,7 @@ var EnforcementInstaller = class {
   definitionGenerations = /* @__PURE__ */ new Map();
   fallbackSessionId;
   lifecycleGeneration;
+  trustRevoked = false;
   sessionIdFor(context) {
     const native = nativeSessionId(context);
     if (native !== void 0) return native;
@@ -1333,7 +1368,20 @@ var EnforcementInstaller = class {
   beginBlockedGeneration() {
     this.bootstrapActive = true;
     this.ready = false;
+    this.trustRevoked = false;
     this.fallbackSessionId = randomUUID2();
+    this.lifecycleGeneration = Object.freeze({});
+  }
+  /**
+   * Retires the ready lifecycle the instant live project trust stops being
+   * affirmative. Every wrapper stays bound to the previous generation, so its
+   * mutators fail closed and its reads fall back to the untrusted native path.
+   * Enforcement only returns through a new affirmatively trusted session.
+   */
+  revokeForTrustWithdrawal() {
+    if (this.trustRevoked || this.lifecycleGeneration === void 0) return;
+    this.trustRevoked = true;
+    this.ready = false;
     this.lifecycleGeneration = Object.freeze({});
   }
   beginActivation() {
@@ -1343,11 +1391,12 @@ var EnforcementInstaller = class {
     this.beginBlockedGeneration();
   }
   markReady() {
-    if (this.bootstrapActive) this.ready = true;
+    if (this.bootstrapActive && !this.trustRevoked) this.ready = true;
   }
   deactivate() {
     this.bootstrapActive = false;
     this.ready = false;
+    this.trustRevoked = false;
     this.fallbackSessionId = void 0;
     this.lifecycleGeneration = void 0;
   }
@@ -1371,7 +1420,8 @@ var EnforcementInstaller = class {
       this.definitionGenerations,
       () => this.lifecycleGeneration,
       () => this.ready,
-      (context) => this.sessionIdFor(context)
+      (context) => this.sessionIdFor(context),
+      () => this.revokeForTrustWithdrawal()
     );
   }
   ensureCustomTool(pi, bridge, options) {
@@ -1403,6 +1453,8 @@ var EnforcementInstaller = class {
       options.getMode ?? (() => "execute"),
       options.permissionAudit,
       options.wrapperSourcePath,
+      options.projectTrust,
+      () => this.revokeForTrustWithdrawal(),
       false,
       bridgeToolName
     );
@@ -1454,6 +1506,7 @@ function bridgeToolResults(pi, bridge, descriptor, activeGeneration = () => STAN
     const name = typeof event.toolName === "string" ? event.toolName : "";
     const category = descriptor[name] ?? "OTHER";
     if (category !== "WRITE" && category !== "EDIT") return void 0;
+    const toolCallId = typeof event.toolCallId === "string" && event.toolCallId !== "" ? event.toolCallId : void 0;
     let response;
     try {
       response = await bridge.call({
@@ -1462,7 +1515,8 @@ function bridgeToolResults(pi, bridge, descriptor, activeGeneration = () => STAN
         cwd: context.cwd,
         tool: name,
         input: event.input,
-        result: { content: event.content, isError: event.isError === true }
+        result: { content: event.content, isError: event.isError === true },
+        ...toolCallId === void 0 ? {} : { correlation: auditCorrelation(toolCallId) }
       }, context.signal ?? new AbortController().signal);
     } catch (error) {
       if (activeGeneration() !== generation) return void 0;
@@ -1501,7 +1555,11 @@ function installChild(pi, dependencies) {
       descriptor,
       factories: dependencies.factories,
       nativeFactories: dependencies.nativeFactories ?? dependencies.factories,
-      wrapperSourcePath: dependencies.wrapperSourcePath
+      wrapperSourcePath: dependencies.wrapperSourcePath,
+      // The child runs deliberately with Pi project trust false: its handshake
+      // rejects any context whose isProjectTrusted is not false, and its authority
+      // is the consumed nonce plus the operator attestation, not project trust.
+      projectTrust: "not-required"
     });
     wrappersInstalled = true;
     return true;

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -562,6 +562,11 @@ function killTree(child, taskkillExecutable) {
     child.kill("SIGKILL");
   }
 }
+var BRIDGE_CORRELATION_RE = /^[a-f0-9]{64}$/u;
+function normalizedRequest(request) {
+  const { correlation, ...rest } = request;
+  return typeof correlation === "string" && BRIDGE_CORRELATION_RE.test(correlation) ? { ...rest, correlation } : rest;
+}
 function sanitizedResponse(response, request) {
   return {
     ...response,
@@ -631,7 +636,7 @@ var BridgeClient = class {
       "HOST: pi",
       `RULE: ${response.ruleId ?? "PI-BRIDGE"}`,
       `AUDIT: ${response.auditCode ?? "PI_BRIDGE_FAILURE"}`,
-      `CORRELATION: ${randomUUID()}`,
+      `CORRELATION: ${request.correlation ?? randomUUID()}`,
       `REQUEST_BYTES: ${counts.request}`,
       `STDOUT_BYTES: ${counts.stdout}`,
       `STDERR_BYTES: ${counts.stderr}`
@@ -646,7 +651,8 @@ var BridgeClient = class {
     await this.auditFailure(request, response, counts);
     return response;
   }
-  async call(request, signal) {
+  async call(rawRequest, signal) {
+    const request = normalizedRequest(rawRequest);
     let paths;
     let userHome;
     try {
@@ -5003,6 +5009,22 @@ function classifyPermissionActions(descriptor, tool, params) {
 function auditCorrelation(toolCallId) {
   return createHash4("sha256").update(toolCallId, "utf8").digest("hex");
 }
+var TRUST_WITHDRAWN_MESSAGE = "codeArbiter project trust is not affirmative; mutation blocked; run /trust in Pi, approve this project, then start a new session.";
+var LIFECYCLE_STALE_MESSAGE = "codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.";
+function liveProjectTrust(context, source) {
+  if (source === "not-required") return true;
+  try {
+    const probe = context?.isProjectTrusted;
+    if (typeof probe === "function") return probe.call(context) === true;
+  } catch {
+    return false;
+  }
+  try {
+    return source() === true;
+  } catch {
+    return false;
+  }
+}
 function permissionAuditRow(toolCallId, toolClass, actionClasses, decision) {
   return Object.freeze({
     timestamp: (/* @__PURE__ */ new Date()).toISOString(),
@@ -5287,7 +5309,7 @@ function fixedFallbackSessionId() {
 function executionCwd(context, fallback) {
   return context !== null && typeof context === "object" && typeof context.cwd === "string" ? context.cwd : fallback;
 }
-function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, bridge, boundGeneration, activeGeneration, isReady, sessionIdFor, permissionPolicy, getMode, permissionAudit, wrapperSourcePath, allowNativeFallback = true, bridgeToolName = toolName) {
+function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, bridge, boundGeneration, activeGeneration, isReady, sessionIdFor, permissionPolicy, getMode, permissionAudit, wrapperSourcePath, projectTrust, onTrustWithdrawn, allowNativeFallback = true, bridgeToolName = toolName) {
   const original = factory(cwd);
   if (original.name !== toolName || typeof original.execute !== "function") {
     throw new Error(`Pi built-in ${toolName} factory identity is invalid; run /ca-doctor.`);
@@ -5301,10 +5323,16 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
   return {
     ...original,
     execute: async (toolCallId, params, signal, onUpdate, context) => {
+      const trustHeld = () => {
+        if (liveProjectTrust(context, projectTrust)) return true;
+        onTrustWithdrawn();
+        return false;
+      };
+      const trusted = trustHeld();
       const generation = activeGeneration();
-      if (generation === void 0 || generation !== boundGeneration || !isReady()) {
+      if (generation === void 0 || generation !== boundGeneration || !isReady() || !trusted) {
         if (!allowNativeFallback || generation !== void 0 && category !== "READ") {
-          return failTool("codeArbiter enforcement is not ready; mutation blocked; run /ca-doctor.");
+          return failTool(trusted ? "codeArbiter enforcement is not ready; mutation blocked; run /ca-doctor." : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, params, signal, onUpdate, context);
       }
@@ -5322,18 +5350,21 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
           cwd,
           ...category === "READ" ? { sessionId: sessionIdFor(context) } : {},
           tool: bridgeToolName,
-          input: approved
+          input: approved,
+          correlation: auditCorrelation(toolCallId)
         }, signal ?? new AbortController().signal);
       } catch (error) {
-        if (activeGeneration() === generation) throw error;
+        const stillTrusted = trustHeld();
+        if (stillTrusted && activeGeneration() === generation) throw error;
         if (category !== "READ") {
-          return failTool("codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.");
+          return failTool(stillTrusted ? LIFECYCLE_STALE_MESSAGE : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, approved, signal, onUpdate, context);
       }
-      if (activeGeneration() !== generation) {
+      const trustedAfterBridge = trustHeld();
+      if (!trustedAfterBridge || activeGeneration() !== generation) {
         if (category !== "READ") {
-          return failTool("codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.");
+          return failTool(trustedAfterBridge ? LIFECYCLE_STALE_MESSAGE : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, approved, signal, onUpdate, context);
       }
@@ -5373,6 +5404,7 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
       const revalidate = () => {
         const requestStable = currentMode(getMode) === mode && registryOwns(pi, toolName, wrapperSourcePath) && original.execute === originalExecute && matchesSnapshot(params, approved) && signal?.aborted !== true;
         if (!requestStable) return "request-stale";
+        if (!trustHeld()) return "lifecycle-stale";
         return activeGeneration() === generation && generation === boundGeneration && isReady() ? "current" : "lifecycle-stale";
       };
       if (policy.decision === "ask") {
@@ -5433,7 +5465,7 @@ function wrappedDefinition(pi, toolName, factory, nativeFactory, category, cwd, 
     }
   };
 }
-function wrapMissingBuiltins(pi, bridge, options, wrapped, definitions, definitionGenerations, activeGeneration = () => STANDALONE_GENERATION, isReady = () => true, sessionIdFor = fixedFallbackSessionId()) {
+function wrapMissingBuiltins(pi, bridge, options, wrapped, definitions, definitionGenerations, activeGeneration = () => STANDALONE_GENERATION, isReady = () => true, sessionIdFor = fixedFallbackSessionId(), onTrustWithdrawn = () => void 0) {
   const boundGeneration = activeGeneration() ?? STANDALONE_GENERATION;
   const permissionPolicy = options.permissionPolicy ?? compileBuiltinPermissionPolicy(options.descriptor, {});
   if (permissionPolicy === void 0) throw new Error("Pi permission policy descriptor is invalid; run /ca-doctor.");
@@ -5457,7 +5489,9 @@ function wrapMissingBuiltins(pi, bridge, options, wrapped, definitions, definiti
       permissionPolicy,
       getMode,
       options.permissionAudit,
-      options.wrapperSourcePath
+      options.wrapperSourcePath,
+      options.projectTrust,
+      onTrustWithdrawn
     );
     pi.registerTool(definition);
     definitions?.set(name, definition);
@@ -5476,6 +5510,7 @@ var EnforcementInstaller = class {
   definitionGenerations = /* @__PURE__ */ new Map();
   fallbackSessionId;
   lifecycleGeneration;
+  trustRevoked = false;
   sessionIdFor(context) {
     const native = nativeSessionId(context);
     if (native !== void 0) return native;
@@ -5498,7 +5533,20 @@ var EnforcementInstaller = class {
   beginBlockedGeneration() {
     this.bootstrapActive = true;
     this.ready = false;
+    this.trustRevoked = false;
     this.fallbackSessionId = randomUUID3();
+    this.lifecycleGeneration = Object.freeze({});
+  }
+  /**
+   * Retires the ready lifecycle the instant live project trust stops being
+   * affirmative. Every wrapper stays bound to the previous generation, so its
+   * mutators fail closed and its reads fall back to the untrusted native path.
+   * Enforcement only returns through a new affirmatively trusted session.
+   */
+  revokeForTrustWithdrawal() {
+    if (this.trustRevoked || this.lifecycleGeneration === void 0) return;
+    this.trustRevoked = true;
+    this.ready = false;
     this.lifecycleGeneration = Object.freeze({});
   }
   beginActivation() {
@@ -5508,11 +5556,12 @@ var EnforcementInstaller = class {
     this.beginBlockedGeneration();
   }
   markReady() {
-    if (this.bootstrapActive) this.ready = true;
+    if (this.bootstrapActive && !this.trustRevoked) this.ready = true;
   }
   deactivate() {
     this.bootstrapActive = false;
     this.ready = false;
+    this.trustRevoked = false;
     this.fallbackSessionId = void 0;
     this.lifecycleGeneration = void 0;
   }
@@ -5536,7 +5585,8 @@ var EnforcementInstaller = class {
       this.definitionGenerations,
       () => this.lifecycleGeneration,
       () => this.ready,
-      (context) => this.sessionIdFor(context)
+      (context) => this.sessionIdFor(context),
+      () => this.revokeForTrustWithdrawal()
     );
   }
   ensureCustomTool(pi, bridge, options) {
@@ -5568,6 +5618,8 @@ var EnforcementInstaller = class {
       options.getMode ?? (() => "execute"),
       options.permissionAudit,
       options.wrapperSourcePath,
+      options.projectTrust,
+      () => this.revokeForTrustWithdrawal(),
       false,
       bridgeToolName
     );
@@ -5619,6 +5671,7 @@ function bridgeToolResults(pi, bridge, descriptor, activeGeneration = () => STAN
     const name = typeof event.toolName === "string" ? event.toolName : "";
     const category = descriptor[name] ?? "OTHER";
     if (category !== "WRITE" && category !== "EDIT") return void 0;
+    const toolCallId = typeof event.toolCallId === "string" && event.toolCallId !== "" ? event.toolCallId : void 0;
     let response;
     try {
       response = await bridge.call({
@@ -5627,7 +5680,8 @@ function bridgeToolResults(pi, bridge, descriptor, activeGeneration = () => STAN
         cwd: context.cwd,
         tool: name,
         input: event.input,
-        result: { content: event.content, isError: event.isError === true }
+        result: { content: event.content, isError: event.isError === true },
+        ...toolCallId === void 0 ? {} : { correlation: auditCorrelation(toolCallId) }
       }, context.signal ?? new AbortController().signal);
     } catch (error) {
       if (activeGeneration() !== generation) return void 0;
@@ -8396,7 +8450,7 @@ async function codeArbiterPi(pi) {
         activeTools: pi.getActiveTools(),
         allTools: pi.getAllTools(),
         expansionFingerprints,
-        childFingerprint: "a4f28245fc06ed9beacaa200996f1bb62dff884b148a731fb16b4bca54c5176c"
+        childFingerprint: "2f5ae106d763a6ef32d7fc187ecbb7f75f43a6daab66214eb238f15bc65c9341"
       });
       const wrapperSelfTest = await runPiWrapperSelfTest({
         enabled: enabledForDoctor,
@@ -8427,6 +8481,7 @@ async function codeArbiterPi(pi) {
       });
       const factories = factoriesFor(true);
       const nativeFactories = factoriesFor(false);
+      const projectTrust = () => hasAffirmativeProjectTrust(context);
       enforcement.ensureResults(pi, bridge, toolClasses);
       enforcement.ensureBuiltins(guardPi, bridge, {
         cwd,
@@ -8436,7 +8491,8 @@ async function codeArbiterPi(pi) {
         wrapperSourcePath: modulePath,
         permissionPolicy,
         getMode,
-        permissionAudit: appendPermissionAudit
+        permissionAudit: appendPermissionAudit,
+        projectTrust
       });
       if (backgroundToolFactory !== void 0) {
         enforcement.ensureCustomTool(guardPi, bridge, {
@@ -8448,7 +8504,8 @@ async function codeArbiterPi(pi) {
           wrapperSourcePath: modulePath,
           permissionPolicy,
           getMode,
-          permissionAudit: appendPermissionAudit
+          permissionAudit: appendPermissionAudit,
+          projectTrust
         });
       }
     }

--- a/plugins/ca-pi/hooks/pi-bridge.py
+++ b/plugins/ca-pi/hooks/pi-bridge.py
@@ -27,12 +27,15 @@ import _taskboardlib  # noqa: E402
 MAX_REQUEST_BYTES = 262_144
 MAX_PLAN_CONTENT_BYTES = 92_160
 MAX_CAPTURE_CHARS = 1_048_576
-ALLOWED_KEYS = frozenset({"version", "event", "cwd", "sessionId", "tool", "input", "result"})
+ALLOWED_KEYS = frozenset({"version", "event", "cwd", "sessionId", "tool", "input", "result", "correlation"})
+# Opaque join key for one originating tool call: a SHA-256 digest in lowercase hex,
+# never the raw host tool-call id and never derived from parameters or prompt text.
+CORRELATION_RE = re.compile(r"\A[0-9a-f]{64}\Z")
 EVENT_KEYS = {
     "session_start": (frozenset({"version", "event", "cwd"}), frozenset({"version", "event", "cwd", "sessionId"})),
     "before_agent_start": (frozenset({"version", "event", "cwd"}), frozenset({"version", "event", "cwd", "sessionId"})),
-    "tool_call": (frozenset({"version", "event", "cwd", "tool", "input"}), frozenset({"version", "event", "cwd", "sessionId", "tool", "input"})),
-    "tool_result": (frozenset({"version", "event", "cwd", "tool", "input", "result"}), frozenset({"version", "event", "cwd", "sessionId", "tool", "input", "result"})),
+    "tool_call": (frozenset({"version", "event", "cwd", "tool", "input"}), frozenset({"version", "event", "cwd", "sessionId", "tool", "input", "correlation"})),
+    "tool_result": (frozenset({"version", "event", "cwd", "tool", "input", "result"}), frozenset({"version", "event", "cwd", "sessionId", "tool", "input", "result", "correlation"})),
     "prune_plan": (frozenset({"version", "event", "cwd", "input"}), frozenset({"version", "event", "cwd", "input"})),
     "footer_usage_update": (frozenset({"version", "event", "cwd", "input"}), frozenset({"version", "event", "cwd", "input"})),
     "footer_status_snapshot": (frozenset({"version", "event", "cwd"}), frozenset({"version", "event", "cwd", "sessionId"})),
@@ -156,6 +159,10 @@ def _request(raw):
     for key in ("sessionId", "tool"):
         if key in value and (not isinstance(value[key], str) or len(value[key]) > 1_024):
             raise ProtocolError(f"request {key} is invalid")
+    if "correlation" in value and (
+        not isinstance(value["correlation"], str) or not CORRELATION_RE.match(value["correlation"])
+    ):
+        raise ProtocolError("request correlation is invalid")
     for key in ("input", "result"):
         if key in value:
             if not isinstance(value[key], dict):

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/bridge.ts
+++ b/plugins/ca-pi/tools/src/bridge.ts
@@ -605,6 +605,21 @@ function killTree(child: ReturnType<typeof spawn>, taskkillExecutable: string | 
   try { process.kill(-child.pid, "SIGKILL"); } catch { child.kill("SIGKILL"); }
 }
 
+/** One SHA-256 digest in lowercase hex: the only correlation shape allowed on the wire. */
+const BRIDGE_CORRELATION_RE = /^[a-f0-9]{64}$/u;
+
+/**
+ * Drops any correlation that is not a bounded opaque digest, so a raw host
+ * tool-call id can never reach the request JSON, the Python bridge, or the
+ * failure audit even if a caller supplies one.
+ */
+function normalizedRequest(request: BridgeRequest): BridgeRequest {
+  const { correlation, ...rest } = request;
+  return typeof correlation === "string" && BRIDGE_CORRELATION_RE.test(correlation)
+    ? { ...rest, correlation }
+    : rest;
+}
+
 function sanitizedResponse(response: BridgeResponse, request: BridgeRequest): BridgeResponse {
   return {
     ...response,
@@ -686,12 +701,15 @@ export class BridgeClient implements BridgePort {
     } catch {
       // A malformed selector fails toward retaining the ordinary audit.
     }
+    // A governed tool call carries its permission-audit digest, so the failure row
+    // joins that call. Lifecycle and doctor requests have no upstream call identity
+    // and therefore retain a locally minted UUID, which is distinguishable by shape.
     const line = [
       `[${new Date().toISOString()}]`,
       "HOST: pi",
       `RULE: ${response.ruleId ?? "PI-BRIDGE"}`,
       `AUDIT: ${response.auditCode ?? "PI_BRIDGE_FAILURE"}`,
-      `CORRELATION: ${randomUUID()}`,
+      `CORRELATION: ${request.correlation ?? randomUUID()}`,
       `REQUEST_BYTES: ${counts.request}`,
       `STDOUT_BYTES: ${counts.stdout}`,
       `STDERR_BYTES: ${counts.stderr}`,
@@ -713,7 +731,8 @@ export class BridgeClient implements BridgePort {
     return response;
   }
 
-  async call(request: BridgeRequest, signal: AbortSignal): Promise<BridgeResponse> {
+  async call(rawRequest: BridgeRequest, signal: AbortSignal): Promise<BridgeResponse> {
+    const request = normalizedRequest(rawRequest);
     let paths: { git: string; python: string; root: string; script: string; taskkill?: string };
     let userHome: string;
     try {

--- a/plugins/ca-pi/tools/src/child-extension.ts
+++ b/plugins/ca-pi/tools/src/child-extension.ts
@@ -69,6 +69,10 @@ export function installChild(pi: ChildPiPort, dependencies: ChildDependencies): 
       factories: dependencies.factories,
       nativeFactories: dependencies.nativeFactories ?? dependencies.factories,
       wrapperSourcePath: dependencies.wrapperSourcePath,
+      // The child runs deliberately with Pi project trust false: its handshake
+      // rejects any context whose isProjectTrusted is not false, and its authority
+      // is the consumed nonce plus the operator attestation, not project trust.
+      projectTrust: "not-required",
     });
     wrappersInstalled = true;
     return true;

--- a/plugins/ca-pi/tools/src/contracts.ts
+++ b/plugins/ca-pi/tools/src/contracts.ts
@@ -5,6 +5,13 @@ export interface BridgeRequest {
   sessionId?: string;
   tool?: string;
   input?: unknown;
+  /**
+   * Opaque join key for one originating tool call: the SHA-256 digest of the
+   * host tool-call id, exactly as the permission audit records it. Never the
+   * raw host identifier, and never derived from parameters or prompt text.
+   * Absent for lifecycle and doctor requests, which mint a local id instead.
+   */
+  correlation?: string;
   result?: unknown;
 }
 

--- a/plugins/ca-pi/tools/src/extension.ts
+++ b/plugins/ca-pi/tools/src/extension.ts
@@ -906,6 +906,10 @@ export default async function codeArbiterPi(pi: ExtensionAPI): Promise<void> {
       // installer can run. Do not re-read a mutable host signal mid-bootstrap.
       const factories = factoriesFor(true);
       const nativeFactories = factoriesFor(false);
+      // The final pre-execution gate re-reads trust live. Executions that carry a
+      // Pi tool context use that context's probe; the doctor wrapper self-test and
+      // any other context-free execution fall back to this session's probe.
+      const projectTrust = () => hasAffirmativeProjectTrust(context);
       enforcement.ensureResults(pi, bridge, toolClasses);
       enforcement.ensureBuiltins(guardPi, bridge, {
         cwd,
@@ -916,6 +920,7 @@ export default async function codeArbiterPi(pi: ExtensionAPI): Promise<void> {
         permissionPolicy,
         getMode,
         permissionAudit: appendPermissionAudit,
+        projectTrust,
       });
       if (backgroundToolFactory !== undefined) {
         enforcement.ensureCustomTool(guardPi, bridge, {
@@ -928,6 +933,7 @@ export default async function codeArbiterPi(pi: ExtensionAPI): Promise<void> {
           permissionPolicy,
           getMode,
           permissionAudit: appendPermissionAudit,
+          projectTrust,
         });
       }
     },

--- a/plugins/ca-pi/tools/src/tool-guard.ts
+++ b/plugins/ca-pi/tools/src/tool-guard.ts
@@ -28,6 +28,20 @@ import type {
 type LifecycleGeneration = object;
 const STANDALONE_GENERATION: LifecycleGeneration = Object.freeze({});
 
+/**
+ * Live project-trust source for the final pre-execution gate.
+ *
+ * A function is the session-scoped probe: it is consulted whenever an execution
+ * carries no Pi tool context of its own (the doctor wrapper self-test), while a
+ * context that does carry `isProjectTrusted` always wins.
+ *
+ * `"not-required"` is an explicit waiver for the isolated child adapter, whose
+ * authority is the consumed handshake nonce and its operator attestation, and
+ * which deliberately runs with Pi project trust false. It is required rather
+ * than optional so no call site can drop the gate by omission.
+ */
+export type ProjectTrustSource = (() => boolean) | "not-required";
+
 export interface WrapBuiltinsOptions {
   cwd: string;
   descriptor: Readonly<Record<string, ToolCategory>>;
@@ -37,6 +51,8 @@ export interface WrapBuiltinsOptions {
   permissionPolicy?: CompiledPermissionPolicyDescriptor;
   getMode?: () => PolicyMode;
   permissionAudit?: PermissionAuditPort;
+  /** Live project-trust source for the final pre-execution gate; see ProjectTrustSource. */
+  projectTrust: ProjectTrustSource;
 }
 
 export interface WrapCustomToolOptions {
@@ -49,6 +65,8 @@ export interface WrapCustomToolOptions {
   permissionPolicy?: CompiledPermissionPolicyDescriptor;
   getMode?: () => PolicyMode;
   permissionAudit?: PermissionAuditPort;
+  /** Live project-trust source for the final pre-execution gate; see ProjectTrustSource. */
+  projectTrust: ProjectTrustSource;
 }
 
 export type PermissionAuditDecision = "allow" | "approved" | "cancelled" | "denied";
@@ -188,8 +206,39 @@ export function classifyPermissionActions(
   }
 }
 
+/** One-way digest of the host tool-call id: the shared join key for audit and bridge rows. */
 function auditCorrelation(toolCallId: string): string {
   return createHash("sha256").update(toolCallId, "utf8").digest("hex");
+}
+
+const TRUST_WITHDRAWN_MESSAGE =
+  "codeArbiter project trust is not affirmative; mutation blocked; run /trust in Pi, approve this project, then start a new session.";
+const LIFECYCLE_STALE_MESSAGE =
+  "codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.";
+
+/**
+ * Live project trust for one governed execution. `isProjectTrusted` is optional on
+ * the host context, so absent, false, and throwing are all read as untrusted; only
+ * a live affirmative `true` keeps mutator authority. The session-scoped probe is
+ * consulted only when the execution context supplies no probe of its own (Pi omits
+ * the context for the doctor wrapper self-test).
+ */
+function liveProjectTrust(
+  context: ToolExecutionContextPort | undefined,
+  source: ProjectTrustSource,
+): boolean {
+  if (source === "not-required") return true;
+  try {
+    const probe = context?.isProjectTrusted;
+    if (typeof probe === "function") return probe.call(context) === true;
+  } catch {
+    return false;
+  }
+  try {
+    return source() === true;
+  } catch {
+    return false;
+  }
 }
 
 function permissionAuditRow(
@@ -564,6 +613,8 @@ function wrappedDefinition(
   getMode: () => PolicyMode,
   permissionAudit: PermissionAuditPort | undefined,
   wrapperSourcePath: string,
+  projectTrust: ProjectTrustSource,
+  onTrustWithdrawn: () => void,
   allowNativeFallback = true,
   bridgeToolName = toolName,
 ): ToolDefinitionPort {
@@ -586,10 +637,20 @@ function wrappedDefinition(
   return {
     ...original,
     execute: async (toolCallId, params, signal, onUpdate, context) => {
+      // Live trust is read before every other gate: a withdrawal retires the active
+      // lifecycle, so an approval granted under the earlier decision cannot survive it.
+      const trustHeld = (): boolean => {
+        if (liveProjectTrust(context, projectTrust)) return true;
+        onTrustWithdrawn();
+        return false;
+      };
+      const trusted = trustHeld();
       const generation = activeGeneration();
-      if (generation === undefined || generation !== boundGeneration || !isReady()) {
+      if (generation === undefined || generation !== boundGeneration || !isReady() || !trusted) {
         if (!allowNativeFallback || (generation !== undefined && category !== "READ")) {
-          return failTool("codeArbiter enforcement is not ready; mutation blocked; run /ca-doctor.");
+          return failTool(trusted
+            ? "codeArbiter enforcement is not ready; mutation blocked; run /ca-doctor."
+            : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, params, signal, onUpdate, context);
       }
@@ -608,17 +669,20 @@ function wrappedDefinition(
           ...(category === "READ" ? { sessionId: sessionIdFor(context) } : {}),
           tool: bridgeToolName,
           input: approved,
+          correlation: auditCorrelation(toolCallId),
         }, signal ?? new AbortController().signal);
       } catch (error) {
-        if (activeGeneration() === generation) throw error;
+        const stillTrusted = trustHeld();
+        if (stillTrusted && activeGeneration() === generation) throw error;
         if (category !== "READ") {
-          return failTool("codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.");
+          return failTool(stillTrusted ? LIFECYCLE_STALE_MESSAGE : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, approved, signal, onUpdate, context);
       }
-      if (activeGeneration() !== generation) {
+      const trustedAfterBridge = trustHeld();
+      if (!trustedAfterBridge || activeGeneration() !== generation) {
         if (category !== "READ") {
-          return failTool("codeArbiter lifecycle changed while approval was pending; mutation blocked; run /ca-doctor.");
+          return failTool(trustedAfterBridge ? LIFECYCLE_STALE_MESSAGE : TRUST_WITHDRAWN_MESSAGE);
         }
         return await executeNativeFromContext(toolCallId, approved, signal, onUpdate, context);
       }
@@ -664,6 +728,9 @@ function wrappedDefinition(
           && matchesSnapshot(params, approved)
           && signal?.aborted !== true;
         if (!requestStable) return "request-stale";
+        // Trust withdrawal is a lifecycle event: mutators block and reads fall back
+        // to the untrusted native path, exactly as a retired generation would.
+        if (!trustHeld()) return "lifecycle-stale";
         return activeGeneration() === generation && generation === boundGeneration && isReady()
           ? "current"
           : "lifecycle-stale";
@@ -739,6 +806,7 @@ export function wrapBuiltins(pi: ToolGuardPiPort, bridge: BridgePort, options: W
     () => STANDALONE_GENERATION,
     () => true,
     fixedFallbackSessionId(),
+    () => undefined,
   );
 }
 
@@ -752,6 +820,7 @@ function wrapMissingBuiltins(
   activeGeneration: () => LifecycleGeneration | undefined = () => STANDALONE_GENERATION,
   isReady: () => boolean = () => true,
   sessionIdFor: (context: ToolExecutionContextPort | undefined) => string = fixedFallbackSessionId(),
+  onTrustWithdrawn: () => void = () => undefined,
 ): void {
   const boundGeneration = activeGeneration() ?? STANDALONE_GENERATION;
   const permissionPolicy = options.permissionPolicy ?? compileBuiltinPermissionPolicy(options.descriptor, {});
@@ -777,6 +846,8 @@ function wrapMissingBuiltins(
       getMode,
       options.permissionAudit,
       options.wrapperSourcePath,
+      options.projectTrust,
+      onTrustWithdrawn,
     );
     pi.registerTool(definition);
     definitions?.set(name, definition);
@@ -796,6 +867,7 @@ export class EnforcementInstaller {
   private readonly definitionGenerations = new Map<string, LifecycleGeneration>();
   private fallbackSessionId: string | undefined;
   private lifecycleGeneration: LifecycleGeneration | undefined;
+  private trustRevoked = false;
 
   private sessionIdFor(context: ToolExecutionContextPort | undefined): string {
     const native = nativeSessionId(context);
@@ -821,7 +893,21 @@ export class EnforcementInstaller {
   private beginBlockedGeneration(): void {
     this.bootstrapActive = true;
     this.ready = false;
+    this.trustRevoked = false;
     this.fallbackSessionId = randomUUID();
+    this.lifecycleGeneration = Object.freeze({});
+  }
+
+  /**
+   * Retires the ready lifecycle the instant live project trust stops being
+   * affirmative. Every wrapper stays bound to the previous generation, so its
+   * mutators fail closed and its reads fall back to the untrusted native path.
+   * Enforcement only returns through a new affirmatively trusted session.
+   */
+  private revokeForTrustWithdrawal(): void {
+    if (this.trustRevoked || this.lifecycleGeneration === undefined) return;
+    this.trustRevoked = true;
+    this.ready = false;
     this.lifecycleGeneration = Object.freeze({});
   }
 
@@ -834,12 +920,13 @@ export class EnforcementInstaller {
   }
 
   markReady(): void {
-    if (this.bootstrapActive) this.ready = true;
+    if (this.bootstrapActive && !this.trustRevoked) this.ready = true;
   }
 
   deactivate(): void {
     this.bootstrapActive = false;
     this.ready = false;
+    this.trustRevoked = false;
     this.fallbackSessionId = undefined;
     this.lifecycleGeneration = undefined;
   }
@@ -867,6 +954,7 @@ export class EnforcementInstaller {
       () => this.lifecycleGeneration,
       () => this.ready,
       (context) => this.sessionIdFor(context),
+      () => this.revokeForTrustWithdrawal(),
     );
   }
 
@@ -900,6 +988,8 @@ export class EnforcementInstaller {
       options.getMode ?? (() => "execute" as const),
       options.permissionAudit,
       options.wrapperSourcePath,
+      options.projectTrust,
+      () => this.revokeForTrustWithdrawal(),
       false,
       bridgeToolName,
     );
@@ -961,6 +1051,11 @@ export function bridgeToolResults(
     const name = typeof event.toolName === "string" ? event.toolName : "";
     const category = descriptor[name] ?? "OTHER";
     if (category !== "WRITE" && category !== "EDIT") return undefined;
+    // Joins the result leg to its originating call when Pi supplies the id; a
+    // missing id leaves the bridge to mint a local correlation instead.
+    const toolCallId = typeof event.toolCallId === "string" && event.toolCallId !== ""
+      ? event.toolCallId
+      : undefined;
     let response: Awaited<ReturnType<BridgePort["call"]>>;
     try {
       response = await bridge.call({
@@ -970,6 +1065,7 @@ export function bridgeToolResults(
         tool: name,
         input: event.input,
         result: { content: event.content, isError: event.isError === true },
+        ...(toolCallId === undefined ? {} : { correlation: auditCorrelation(toolCallId) }),
       }, context.signal ?? new AbortController().signal);
     } catch (error) {
       if (activeGeneration() !== generation) return undefined;

--- a/plugins/ca-pi/tools/test/benchmark-boundary.ts
+++ b/plugins/ca-pi/tools/test/benchmark-boundary.ts
@@ -50,6 +50,7 @@ wrapBuiltins(pi, bridge, {
   factories,
   wrapperSourcePath: import.meta.filename,
   permissionAudit: async () => true,
+  projectTrust: () => true,
 });
 const registrationMs = performance.now() - startup;
 process.stdout.write(JSON.stringify({ phase: "ready", wrapperCount: definitions.size, registrationMs }) + "\n");

--- a/plugins/ca-pi/tools/test/bridge.test.ts
+++ b/plugins/ca-pi/tools/test/bridge.test.ts
@@ -218,13 +218,14 @@ async function executeWrappedRead(bridge: BridgePort, cwd: string): Promise<Reco
     descriptor: { bash: "EXEC", edit: "EDIT", read: "READ", write: "WRITE" },
     factories,
     wrapperSourcePath: resolve(cwd, "codearbiter.js"),
+    projectTrust: () => true,
   });
   return await definitions.get("read")!.execute(
     "read-diagnostic",
     { path: "README.md" },
     undefined,
     undefined,
-    { sessionManager: { getSessionId: () => "bridge-diagnostic-session" } },
+    { isProjectTrusted: () => true, sessionManager: { getSessionId: () => "bridge-diagnostic-session" } },
   );
 }
 
@@ -367,6 +368,58 @@ describe("BridgeClient", () => {
     expect(audit).toContain("AUDIT: PI_BRIDGE_WARN");
     expect(audit).toContain("CORRELATION:");
     expect(audit).not.toContain("synthetic-secret");
+  });
+
+  test("bridge failures join the originating tool call and mint a local id only without one", async () => {
+    const { bridge, packageRoot } = await clientFixture("import sys\nsys.exit(1)\n");
+    await mkdir(resolve(packageRoot, ".codearbiter"));
+    await writeFile(resolve(packageRoot, ".codearbiter", "gate-events.log"), "", "utf8");
+    const rawToolCallId = "pi-call-OPENAI_API_KEY=synthetic-secret";
+    const correlation = createHash("sha256").update(rawToolCallId, "utf8").digest("hex");
+    const second = createHash("sha256").update("pi-call-second", "utf8").digest("hex");
+
+    await bridge.call(
+      { ...request("bash", { command: "git status" }), cwd: packageRoot, correlation },
+      new AbortController().signal,
+    );
+    await bridge.call(
+      { ...request("bash", { command: "git status" }), cwd: packageRoot, correlation: second },
+      new AbortController().signal,
+    );
+    await bridge.call(
+      { version: 1, event: "session_start", cwd: packageRoot },
+      new AbortController().signal,
+    );
+
+    const lines = (await readFile(resolve(packageRoot, ".codearbiter", "gate-events.log"), "utf8"))
+      .split("\n").filter((line) => line.length > 0);
+    const recorded = lines.map((line) => /CORRELATION: ([^ |]+)/u.exec(line)?.[1]);
+    expect(recorded).toHaveLength(3);
+    expect(recorded[0]).toBe(correlation);
+    expect(recorded[1]).toBe(second);
+    expect(recorded[2]).not.toBe(correlation);
+    expect(recorded[2]).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(lines.join("\n")).not.toContain(rawToolCallId);
+  });
+
+  test("only a digest-shaped correlation reaches the bridge wire", async () => {
+    const { bridge, packageRoot } = await clientFixture(
+      "import json,sys\nsys.stdout.write(json.dumps({'version':1,'outcome':'allow','context':sys.stdin.read()}))\n",
+    );
+    const correlation = createHash("sha256").update("pi-call-wire", "utf8").digest("hex");
+
+    const accepted = await bridge.call(
+      { ...request("read", { path: "README.md" }), cwd: packageRoot, correlation },
+      new AbortController().signal,
+    );
+    expect(accepted.context).toContain(correlation);
+
+    const rejected = await bridge.call(
+      { ...request("read", { path: "README.md" }), cwd: packageRoot, correlation: "pi-call-raw-host-identity" },
+      new AbortController().signal,
+    );
+    expect(rejected.context).not.toContain("pi-call-raw-host-identity");
+    expect(rejected.context).not.toContain("correlation");
   });
 
   test("patched READ results classify invalid interpreter, script, and package paths without exposing them", async () => {

--- a/plugins/ca-pi/tools/test/final-arguments.test.ts
+++ b/plugins/ca-pi/tools/test/final-arguments.test.ts
@@ -88,7 +88,7 @@ describe("live-order final-argument promotion proof", () => {
       cwd: "C:/repo",
       descriptor,
       factories: factories(executions),
-      wrapperSourcePath: WRAPPER,
+      wrapperSourcePath: WRAPPER, projectTrust: () => true,
       permissionPolicy,
     });
     // Pi 0.80.5/0.80.6 run tool_call handlers in extension order over one input
@@ -114,7 +114,7 @@ describe("live-order final-argument promotion proof", () => {
     let confirmations = 0;
     const audits: unknown[] = [];
     wrapBuiltins(pi as never, { call: async () => ({ version: 1, outcome: "allow" }) }, {
-      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: WRAPPER, permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: WRAPPER, projectTrust: () => true, permissionPolicy,
       permissionAudit: async (_cwd, row) => { audits.push(row); return true; },
     });
 

--- a/plugins/ca-pi/tools/test/tool-guard.test.ts
+++ b/plugins/ca-pi/tools/test/tool-guard.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -15,6 +16,7 @@ import {
   guardUnknownTools,
   wrapBuiltins,
 } from "../src/tool-guard.ts";
+import type { ProjectTrustSource } from "../src/tool-guard.ts";
 
 type Execute = (
   id: string,
@@ -129,6 +131,7 @@ function interactiveContext(overrides: Record<string, unknown> = {}): Record<str
     cwd: "C:/repo",
     mode: "tui",
     hasUI: true,
+    isProjectTrusted: () => true,
     ui: {
       confirm: async () => true,
     },
@@ -159,7 +162,7 @@ describe("Pi final-wrapper permission decision", () => {
         name: "codearbiter_background_bash",
         execute: async () => ({ content: [{ type: "text", text: "started" }], isError: false }),
       }),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy: policy!,
     });
 
@@ -233,7 +236,7 @@ describe("Pi final-wrapper permission decision", () => {
           return { content: [{ type: "text", text: "started" }], isError: false };
         },
       }),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy: backgroundPolicy!,
       permissionAudit: async (_cwd, row) => { audits.push(row); return true; },
     });
@@ -291,7 +294,7 @@ describe("Pi final-wrapper permission decision", () => {
         name: "codearbiter_background_bash",
         execute: async () => ({ content: [], isError: false }),
       }),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     })).toThrow("bridge alias");
   });
   test("classifies frozen built-in facts conservatively and deterministically", () => {
@@ -334,7 +337,7 @@ describe("Pi final-wrapper permission decision", () => {
     const confirmations: unknown[] = [];
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "block", ruleId: "H-20", message: "blocked" }), {
-      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
     });
 
@@ -364,7 +367,7 @@ describe("Pi final-wrapper permission decision", () => {
       },
     });
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: permissionFactories, wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      cwd: "C:/repo", descriptor, factories: permissionFactories, wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
       permissionAudit: async (_cwd, row) => { audits.push(row); return true; },
     });
@@ -393,7 +396,7 @@ describe("Pi final-wrapper permission decision", () => {
     const auditCwds: string[] = [];
     let message = "";
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: factories([]), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: factories([]), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       permissionAudit: async (cwd) => { auditCwds.push(cwd); return true; },
     });
     await pi.definitions.get("write")!.execute("cwd-bound", { path: "src/x.ts", content: "x" }, undefined, undefined, interactiveContext({
@@ -410,7 +413,7 @@ describe("Pi final-wrapper permission decision", () => {
       const pi = new FakePi();
       const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
       wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       });
       await expect(pi.definitions.get("write")!.execute("missing-ui", { path: "src/x.ts", content: "x" }, undefined, undefined, context)).rejects.toThrow();
       expect(executions).toEqual([]);
@@ -419,7 +422,7 @@ describe("Pi final-wrapper permission decision", () => {
     const pi = new FakePi();
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       permissionAudit: async () => false,
     });
     await expect(pi.definitions.get("write")!.execute("audit-failure", { path: "src/x.ts", content: "x" }, undefined, undefined, interactiveContext())).rejects.toThrow("audit");
@@ -432,7 +435,7 @@ describe("Pi final-wrapper permission decision", () => {
       const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
       const audits: unknown[] = [];
       wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
         permissionAudit: async (_cwd, row) => { audits.push(row); return true; },
       });
       await expect(pi.definitions.get("write")!.execute("cancelled", { path: "src/x.ts", content: "x" }, undefined, undefined, interactiveContext({
@@ -446,7 +449,7 @@ describe("Pi final-wrapper permission decision", () => {
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
     let confirmations = 0;
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       getMode: () => "plan",
       permissionAudit: async () => true,
     });
@@ -461,7 +464,7 @@ describe("Pi final-wrapper permission decision", () => {
     const pi = new FakePi();
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       permissionAudit: async () => true,
     });
     const context = {
@@ -484,7 +487,7 @@ describe("Pi final-wrapper permission decision", () => {
       installer.beginBootstrap();
       let mode: "execute" | "plan" = "execute";
       installer.ensureBuiltins(pi, bridge, {
-        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
         getMode: () => mode,
         permissionAudit: async () => true,
       });
@@ -519,7 +522,7 @@ describe("Pi final-wrapper permission decision", () => {
       },
     };
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: guardedFactories, wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: guardedFactories, wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       permissionAudit: async () => { pi.sources.delete("write"); return true; },
     });
     await expect(pi.definitions.get("write")!.execute("identity", { path: "src/x.ts", content: "x" }, undefined, undefined, interactiveContext({
@@ -538,7 +541,7 @@ describe("Pi final-wrapper permission decision", () => {
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
     let received: AbortSignal | undefined;
     wrapBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
-      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+      cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
       permissionAudit: async () => true,
     });
     await expect(pi.definitions.get("write")!.execute("aborted-confirm", { path: "src/x.ts", content: "x" }, controller.signal, undefined, interactiveContext({
@@ -577,7 +580,7 @@ describe("Pi final-wrapper permission decision", () => {
       installer.beginBootstrap();
       installer.ensureBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
         cwd: "C:/repo", descriptor, factories: trustedFactories, nativeFactories,
-        wrapperSourcePath: "C:/package/extensions/codearbiter.js", permissionPolicy,
+        wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true, permissionPolicy,
         permissionAudit: async () => {
           if (drift.startsWith("lifecycle")) installer.deactivate();
           if (drift.includes("abort")) controller.abort();
@@ -706,7 +709,7 @@ describe("final-execution Pi tool enforcement", () => {
           cwd: "C:/enabled",
           descriptor,
           factories: factoriesWithStop,
-          wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+          wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
         });
         if (stage === "read") install();
         else expect(install).toThrow("partial stop");
@@ -753,7 +756,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/first-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     installer.deactivate();
@@ -771,7 +774,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/second-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     executions.length = 0;
@@ -808,7 +811,7 @@ describe("final-execution Pi tool enforcement", () => {
       descriptor,
       factories: makeFactories("trusted-first"),
       nativeFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     const retainedRead = pi.definitions.get("read")!;
@@ -828,7 +831,7 @@ describe("final-execution Pi tool enforcement", () => {
       descriptor,
       factories: makeFactories("trusted-second"),
       nativeFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     await pi.definitions.get("read")!.execute("current", {}, undefined, undefined, { cwd: "C:/same" });
@@ -860,7 +863,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/old-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
       permissionAudit: async () => true,
     });
@@ -881,7 +884,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/new-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
       permissionAudit: async () => true,
     });
@@ -923,7 +926,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/old-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
       permissionAudit: async () => true,
     });
@@ -973,7 +976,7 @@ describe("final-execution Pi tool enforcement", () => {
           },
         }),
       },
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     const pendingRead = pi.definitions.get("read")!.execute("read", { path: "README.md" });
@@ -1048,7 +1051,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/old-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     const pendingOldWrite = pi.definitions.get("write")!.execute(
@@ -1066,7 +1069,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/new-enabled",
       descriptor,
       factories: cwdFactories,
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
       permissionAudit: async () => true,
     });
@@ -1113,7 +1116,7 @@ describe("final-execution Pi tool enforcement", () => {
         cwd: "C:/old-enabled",
         descriptor,
         factories: cwdFactories,
-        wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+        wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       });
       installer.markReady();
       const originalSignal = new AbortController().signal;
@@ -1133,7 +1136,7 @@ describe("final-execution Pi tool enforcement", () => {
           cwd: "C:/new-enabled",
           descriptor,
           factories: cwdFactories,
-          wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+          wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
         });
         installer.markReady();
       }
@@ -1219,7 +1222,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/enabled",
       descriptor,
       factories: factories(executions),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     wrapperInstaller.markReady();
     const pendingWrite = wrapperPi.definitions.get("write")!.execute("write", { path: "x", content: "x" });
@@ -1263,7 +1266,7 @@ describe("final-execution Pi tool enforcement", () => {
       const bridge = new DelayedBridge();
       const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
       wrapBuiltins(pi, bridge, {
-        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+        cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
         permissionPolicy, permissionAudit: async () => true,
       });
       const mutable = structuredClone(input) as Record<string, unknown>;
@@ -1281,7 +1284,7 @@ describe("final-execution Pi tool enforcement", () => {
     const pi = new FakePi();
     const bridge = new FakeBridge({ version: 1, outcome: "allow" });
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
-    wrapBuiltins(pi, bridge, { cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js" });
+    wrapBuiltins(pi, bridge, { cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true });
     const cyclic: Record<string, unknown> = { command: "true" };
     cyclic.secret = "OPENAI_API_KEY=synthetic-secret";
     cyclic.self = cyclic;
@@ -1311,7 +1314,7 @@ describe("final-execution Pi tool enforcement", () => {
       }),
     };
     wrapBuiltins(pi, bridge, {
-      cwd: "C:/repo", descriptor, factories: snapshotFactories, wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      cwd: "C:/repo", descriptor, factories: snapshotFactories, wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy, permissionAudit: async () => true,
     });
     await pi.definitions.get("bash")!.execute("plain", { command: "true", nested: { values: [1, { ok: true }] }, }, undefined, undefined, interactiveContext());
@@ -1327,7 +1330,7 @@ describe("final-execution Pi tool enforcement", () => {
     const pi = new FakePi();
     const bridge = new FakeBridge({ version: 1, outcome: "block", ruleId: "H-19", message: "OPENAI_API_KEY=synthetic-secret" });
     const executions: Array<{ tool: string; params: Record<string, unknown> }> = [];
-    wrapBuiltins(pi, bridge, { cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js" });
+    wrapBuiltins(pi, bridge, { cwd: "C:/repo", descriptor, factories: factories(executions), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true });
     const execution = pi.definitions.get("write")!.execute("blocked", { path: "x", content: "x" });
     await expect(execution).rejects.toThrow();
     await expect(execution).rejects.not.toThrow("synthetic-secret");
@@ -1355,7 +1358,7 @@ describe("final-execution Pi tool enforcement", () => {
         return factory(cwd);
       }])) as ReturnType<typeof factories>;
       const installer = new EnforcementInstaller();
-      const options = { cwd: "C:/repo", descriptor, factories: staged, wrapperSourcePath: "C:/package/extensions/codearbiter.js" };
+      const options = { cwd: "C:/repo", descriptor, factories: staged, wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true };
       expect(() => { installer.ensureGuard(pi, descriptor, options.wrapperSourcePath); installer.ensureResults(pi, bridge, descriptor); installer.ensureBuiltins(pi, bridge, options); }).toThrow();
       installer.ensureGuard(pi, descriptor, options.wrapperSourcePath);
       installer.ensureResults(pi, bridge, descriptor);
@@ -1380,7 +1383,7 @@ describe("final-execution Pi tool enforcement", () => {
         originalRegister(tool);
       }) as typeof pi.registerTool;
       const installer = new EnforcementInstaller();
-      const options = { cwd: "C:/repo", descriptor, factories: factories([]), wrapperSourcePath: "C:/package/extensions/codearbiter.js" };
+      const options = { cwd: "C:/repo", descriptor, factories: factories([]), wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true };
       installer.ensureGuard(pi, descriptor, options.wrapperSourcePath);
       installer.ensureResults(pi, bridge, descriptor);
       expect(() => installer.ensureBuiltins(pi, bridge, options)).toThrow();
@@ -1399,7 +1402,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/repo",
       descriptor,
       factories: factories(executions),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     const finalInput = { command: "git commit --no-verify" };
     await expect(pi.definitions.get("bash")!.execute("call-1", finalInput)).rejects.toThrow("blocked");
@@ -1415,7 +1418,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/repo",
       descriptor,
       factories: factories(executions),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     const result = await pi.definitions.get("read")!.execute("call-2", { path: "README.md" });
     expect(executions).toEqual([{ tool: "read", params: { path: "README.md" } }]);
@@ -1448,7 +1451,7 @@ describe("final-execution Pi tool enforcement", () => {
           },
         }),
       },
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
 
     const result = await pi.definitions.get("read")!.execute(
@@ -1491,7 +1494,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/repo",
       descriptor,
       factories: factories([]),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
 
@@ -1522,7 +1525,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/repo",
       descriptor,
       factories: factories([]),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
     });
     installer.markReady();
     const refreshedRead = pi.definitions.get("read")!;
@@ -1547,7 +1550,7 @@ describe("final-execution Pi tool enforcement", () => {
       cwd: "C:/repo",
       descriptor,
       factories: factories(executions),
-      wrapperSourcePath: "C:/package/extensions/codearbiter.js",
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
       permissionPolicy,
       permissionAudit: async () => true,
     });
@@ -1696,5 +1699,347 @@ describe("final-execution Pi tool enforcement", () => {
     pi.sources.set("codearbiter_farm_preview", "C:/foreign/replacement.js");
     const replaced = await pi.emit("tool_call", { toolName: "codearbiter_farm_preview", input: {} });
     expect(replaced).toMatchObject({ block: true, reason: expect.stringContaining("source drift") });
+  });
+});
+
+describe("Pi live project trust withdrawal", () => {
+  const wrapperSourcePath = "C:/package/extensions/codearbiter.js";
+
+  function trustHarness(options: { projectTrust?: ProjectTrustSource } = {}) {
+    const pi = new FakePi();
+    const installer = new EnforcementInstaller();
+    const bridge = new FakeBridge({ version: 1, outcome: "allow" });
+    const governed: Array<{ tool: string; params: Record<string, unknown> }> = [];
+    const native: Array<{ tool: string; params: Record<string, unknown> }> = [];
+    const audits: unknown[] = [];
+    installer.ensureBootstrap(pi, descriptor);
+    installer.beginBootstrap();
+    installer.ensureGuard(pi, descriptor, wrapperSourcePath);
+    installer.ensureBuiltins(pi, bridge, {
+      cwd: "C:/repo",
+      descriptor,
+      factories: factories(governed),
+      nativeFactories: factories(native),
+      wrapperSourcePath,
+      permissionPolicy,
+      permissionAudit: async (_cwd, row) => { audits.push(row); return true; },
+      // No affirmative session-scoped probe by default, so an execution context
+      // that omits isProjectTrusted must be treated as untrusted.
+      projectTrust: () => false,
+      ...options,
+    });
+    installer.markReady();
+    return { pi, installer, bridge, governed, native, audits };
+  }
+
+  const mutatorCall = (tool: string): Record<string, unknown> => tool === "bash"
+    ? { command: "git commit -m fixture" }
+    : { path: "src/module.ts", content: "fixture" };
+
+  test("governed mutators execute only while live project trust is affirmative", async () => {
+    const harness = trustHarness();
+    for (const tool of ["bash", "write", "edit"]) {
+      await harness.pi.definitions.get(tool)!.execute(
+        `trusted-${tool}`,
+        mutatorCall(tool),
+        undefined,
+        undefined,
+        interactiveContext({ isProjectTrusted: () => true }),
+      );
+    }
+    expect(harness.governed.map((execution) => execution.tool)).toEqual(["bash", "write", "edit"]);
+    expect(harness.native).toEqual([]);
+  });
+
+  test("mutators fail closed when live project trust is absent, false, or throwing", async () => {
+    const states: ReadonlyArray<readonly [string, (() => boolean) | undefined]> = [
+      ["absent", undefined],
+      ["false", () => false],
+      ["throwing", () => { throw new Error("OPENAI_API_KEY=synthetic-secret trust probe failed"); }],
+    ];
+    for (const [label, isProjectTrusted] of states) {
+      const harness = trustHarness();
+      for (const tool of ["bash", "write", "edit"]) {
+        await expect(harness.pi.definitions.get(tool)!.execute(
+          `${label}-${tool}`,
+          mutatorCall(tool),
+          undefined,
+          undefined,
+          interactiveContext({ isProjectTrusted }),
+        )).rejects.toThrow(/trust/iu);
+      }
+      expect(harness.governed, label).toEqual([]);
+      expect(harness.native, label).toEqual([]);
+      expect(harness.bridge.requests, label).toEqual([]);
+    }
+  });
+
+  test("a custom mutator fails closed on withdrawn trust with no native escape", async () => {
+    const pi = new FakePi();
+    const installer = new EnforcementInstaller();
+    const bridge = new FakeBridge({ version: 1, outcome: "allow" });
+    const executions: Record<string, unknown>[] = [];
+    const backgroundDescriptor = { ...descriptor, codearbiter_background_bash: "EXEC" as const };
+    const backgroundPolicy = compileBuiltinPermissionPolicy(backgroundDescriptor, {
+      codearbiter_background_bash: "background-launch",
+    })!;
+    installer.beginBootstrap();
+    installer.ensureCustomTool(pi, bridge, {
+      cwd: "C:/repo",
+      name: "codearbiter_background_bash",
+      bridgeToolName: "bash",
+      descriptor: backgroundDescriptor,
+      factory: () => ({
+        name: "codearbiter_background_bash",
+        execute: async (_id, params) => { executions.push(params); return { content: [], isError: false }; },
+      }),
+      wrapperSourcePath,
+      permissionPolicy: backgroundPolicy,
+      permissionAudit: async () => true,
+      projectTrust: () => true,
+    });
+    installer.markReady();
+
+    await expect(pi.definitions.get("codearbiter_background_bash")!.execute(
+      "background-untrusted",
+      { command: "npm install fixture" },
+      undefined,
+      undefined,
+      interactiveContext({ isProjectTrusted: () => false }),
+    )).rejects.toThrow(/trust/iu);
+    expect(executions).toEqual([]);
+    expect(bridge.requests).toEqual([]);
+  });
+
+  test("trust withdrawal during bridge evaluation blocks the pending mutation", async () => {
+    const pi = new FakePi();
+    const installer = new EnforcementInstaller();
+    const bridge = new DelayedBridge();
+    const governed: Array<{ tool: string; params: Record<string, unknown> }> = [];
+    installer.ensureBootstrap(pi, descriptor);
+    installer.beginBootstrap();
+    installer.ensureBuiltins(pi, bridge, {
+      cwd: "C:/repo",
+      descriptor,
+      factories: factories(governed),
+      wrapperSourcePath,
+      permissionPolicy,
+      permissionAudit: async () => true,
+      projectTrust: () => true,
+    });
+    installer.markReady();
+    let trusted = true;
+    const pending = pi.definitions.get("write")!.execute(
+      "withdrawn-during-bridge",
+      { path: "src/module.ts", content: "fixture" },
+      undefined,
+      undefined,
+      interactiveContext({ isProjectTrusted: () => trusted }),
+    );
+    await bridge.entered;
+    trusted = false;
+    bridge.resume();
+
+    await expect(pending).rejects.toThrow(/blocked/iu);
+    expect(governed).toEqual([]);
+  });
+
+  test("trust withdrawal during permission confirmation makes the approval stale", async () => {
+    const pi = new FakePi();
+    const installer = new EnforcementInstaller();
+    const bridge = new FakeBridge({ version: 1, outcome: "allow" });
+    const governed: Array<{ tool: string; params: Record<string, unknown> }> = [];
+    const audits: Array<Record<string, unknown>> = [];
+    installer.ensureBootstrap(pi, descriptor);
+    installer.beginBootstrap();
+    installer.ensureBuiltins(pi, bridge, {
+      cwd: "C:/repo",
+      descriptor,
+      factories: factories(governed),
+      wrapperSourcePath,
+      permissionPolicy,
+      permissionAudit: async (_cwd, row) => { audits.push(row as unknown as Record<string, unknown>); return true; },
+      projectTrust: () => true,
+    });
+    installer.markReady();
+    let trusted = true;
+
+    await expect(pi.definitions.get("bash")!.execute(
+      "withdrawn-during-confirmation",
+      { command: "npm install fixture" },
+      undefined,
+      undefined,
+      interactiveContext({
+        isProjectTrusted: () => trusted,
+        ui: { confirm: async () => { trusted = false; return true; } },
+      }),
+    )).rejects.toThrow(/stale/iu);
+    expect(governed).toEqual([]);
+    expect(audits.at(-1)).toMatchObject({ decision: "denied" });
+  });
+
+  test("withdrawal routes reads to the untrusted native path and retires the lifecycle", async () => {
+    const harness = trustHarness();
+    let trusted = true;
+    const context = interactiveContext({ isProjectTrusted: () => trusted });
+
+    await harness.pi.definitions.get("read")!.execute("read-trusted", { path: "README.md" }, undefined, undefined, context);
+    expect(harness.governed).toEqual([{ tool: "read", params: { path: "README.md" } }]);
+    expect(harness.native).toEqual([]);
+
+    trusted = false;
+    await harness.pi.definitions.get("read")!.execute("read-withdrawn", { path: "README.md" }, undefined, undefined, context);
+    expect(harness.native).toEqual([{ tool: "read", params: { path: "README.md" } }]);
+    expect(harness.governed).toHaveLength(1);
+
+    trusted = true;
+    for (const tool of ["bash", "write", "edit"]) {
+      await expect(harness.pi.definitions.get(tool)!.execute(
+        `restored-without-new-session-${tool}`,
+        mutatorCall(tool),
+        undefined,
+        undefined,
+        context,
+      )).rejects.toThrow("/ca-doctor");
+    }
+    expect(harness.governed).toHaveLength(1);
+    expect(harness.native).toHaveLength(1);
+  });
+
+  test("withdrawal restores the bootstrap block for every potentially mutating tool", async () => {
+    const pi = new FakePi();
+    const installer = new EnforcementInstaller();
+    let trusted = true;
+    installer.ensureBootstrap(pi, descriptor);
+    installer.beginBootstrap();
+    installer.ensureBuiltins(pi, new FakeBridge({ version: 1, outcome: "allow" }), {
+      cwd: "C:/repo",
+      descriptor,
+      factories: factories([]),
+      wrapperSourcePath,
+      permissionPolicy,
+      permissionAudit: async () => true,
+      projectTrust: () => trusted,
+    });
+    installer.markReady();
+    await expect(pi.emit("tool_call", { toolName: "write", input: {} })).resolves.toBeUndefined();
+
+    trusted = false;
+    await pi.definitions.get("read")!.execute("read-withdrawal", { path: "README.md" });
+
+    for (const name of ["bash", "write", "edit", "mystery"]) {
+      await expect(pi.emit("tool_call", { toolName: name, input: {} }))
+        .resolves.toMatchObject({ block: true });
+    }
+    await expect(pi.emit("tool_call", { toolName: "read", input: {} })).resolves.toBeUndefined();
+  });
+
+  test("the session-scoped trust probe governs the doctor self-test path that carries no tool context", async () => {
+    const selfTest = { command: "git add --all --dry-run" };
+    const trusted = trustHarness({ projectTrust: () => true });
+    await trusted.installer.runDoctorWrapperSelfTest();
+    expect(trusted.governed).toEqual([{ tool: "bash", params: selfTest }]);
+
+    const withdrawn = trustHarness({ projectTrust: () => false });
+    await expect(withdrawn.installer.runDoctorWrapperSelfTest()).rejects.toThrow(/trust/iu);
+    expect(withdrawn.governed).toEqual([]);
+  });
+
+  test("the withdrawal diagnostic never echoes a trust probe failure detail", async () => {
+    const harness = trustHarness();
+    const execution = harness.pi.definitions.get("write")!.execute(
+      "redaction",
+      { path: "src/module.ts", content: "fixture" },
+      undefined,
+      undefined,
+      interactiveContext({
+        isProjectTrusted: () => { throw new Error("OPENAI_API_KEY=synthetic-secret"); },
+      }),
+    );
+
+    await expect(execution).rejects.toThrow(/trust/iu);
+    await expect(execution).rejects.not.toThrow("synthetic-secret");
+    await expect(execution).rejects.not.toThrow("OPENAI_API_KEY");
+    expect(harness.governed).toEqual([]);
+  });
+});
+
+describe("Pi bridge tool-call correlation", () => {
+  const digest = (value: string) => createHash("sha256").update(value, "utf8").digest("hex");
+
+  test("governed tool calls forward the hashed correlation shared with the permission audit", async () => {
+    const pi = new FakePi();
+    const bridge = new FakeBridge({ version: 1, outcome: "allow" });
+    const audits: Array<{ correlation: string }> = [];
+    wrapBuiltins(pi, bridge, {
+      cwd: "C:/repo",
+      descriptor,
+      factories: factories([]),
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
+      permissionPolicy,
+      permissionAudit: async (_cwd, row) => { audits.push(row as { correlation: string }); return true; },
+    });
+    const toolCallId = "pi-call-OPENAI_API_KEY=synthetic-secret";
+
+    await pi.definitions.get("write")!.execute(
+      toolCallId,
+      { path: "src/module.ts", content: "fixture" },
+      undefined,
+      undefined,
+      interactiveContext(),
+    );
+
+    expect(bridge.requests).toHaveLength(1);
+    expect(bridge.requests[0]!.correlation).toBe(digest(toolCallId));
+    expect(audits[0]!.correlation).toBe(digest(toolCallId));
+    expect(JSON.stringify(bridge.requests[0])).not.toContain("synthetic-secret");
+  });
+
+  test("concurrent governed calls carry distinct joinable correlations", async () => {
+    const pi = new FakePi();
+    const bridge = new FakeBridge({ version: 1, outcome: "allow" });
+    wrapBuiltins(pi, bridge, {
+      cwd: "C:/repo",
+      descriptor,
+      factories: factories([]),
+      wrapperSourcePath: "C:/package/extensions/codearbiter.js", projectTrust: () => true,
+      permissionPolicy,
+      permissionAudit: async () => true,
+    });
+
+    await Promise.all(["call-a", "call-b"].map((id) => pi.definitions.get("read")!.execute(
+      id,
+      { path: "README.md" },
+      undefined,
+      undefined,
+      interactiveContext(),
+    )));
+
+    const correlations = bridge.requests.map((entry) => entry.correlation);
+    expect(new Set(correlations).size).toBe(2);
+    expect(correlations).toEqual(expect.arrayContaining([digest("call-a"), digest("call-b")]));
+  });
+
+  test("tool-result bridge calls reuse the originating tool-call correlation", async () => {
+    const pi = new FakePi();
+    const bridge = new FakeBridge({ version: 1, outcome: "allow" });
+    bridgeToolResults(pi, bridge, descriptor);
+    const context: ExtensionContextPort = {
+      cwd: "C:/repo",
+      signal: undefined,
+      ui: { setStatus: () => undefined, notify: () => undefined },
+    };
+
+    for (const handler of pi.handlers.get("tool_result") ?? []) {
+      await handler({
+        toolCallId: "pi-call-result",
+        toolName: "write",
+        input: { path: "x" },
+        content: [],
+        isError: false,
+      }, context);
+    }
+
+    expect(bridge.requests.at(-1)!.correlation).toBe(digest("pi-call-result"));
   });
 });


### PR DESCRIPTION
Closes #371
Closes #389

Two Pi adapter defects in the final tool-execution path.

## #371 — mutator authority outlived a withdrawn trust decision

**Verified against source before acting.** `src/tool-guard.ts` contained **zero** references to `isProjectTrusted`. The final executor in `wrappedDefinition` gated only on lifecycle generation + readiness, and the only trust check in the whole adapter was a one-shot `hasAffirmativeProjectTrust(context)` at `src/extension.ts:408` during `session_start`. Trust withdrawn mid-session was never noticed.

The final pre-execution gate and the post-approval `revalidate()` path now re-read live trust:

- `isProjectTrusted` is **optional** on `ToolExecutionContextPort`, so **absent, `false`, and throwing all read as untrusted**. Only a live affirmative `true` keeps mutator authority.
- A withdrawal calls `EnforcementInstaller.revokeForTrustWithdrawal()`, which retires the ready lifecycle generation. Pending bridge evaluations and already-confirmed approvals therefore become stale **before** the native tool executes, `markReady()` refuses to re-arm, and the bootstrap `tool_call` handler resumes blocking every potentially mutating tool.
- Reads fall back to the untrusted native factory; mutators (`bash`/`write`/`edit` and custom mutators, which have no native fallback) fail closed.
- Enforcement returns only through a new affirmatively trusted session.

### Design note: the trust source is a *required* option

`WrapBuiltinsOptions.projectTrust` / `WrapCustomToolOptions.projectTrust` are **required**, not optional, so no call site can drop the gate by omission — TypeScript forces every caller to make the decision explicitly.

The isolated **child adapter** passes an explicit `"not-required"` waiver. This is deliberate and load-bearing: `installChild`'s handshake *rejects* any context whose `isProjectTrusted` is not `false` (`child-extension.ts:107`), because the child runs untrusted by design and its authority is the consumed handshake nonce plus the operator attestation. Gating the child on affirmative project trust would have permanently bricked the subagent runner. Making the waiver a typed, commented, mandatory choice keeps that distinction visible instead of accidental.

The session-scoped probe (a function) is consulted **only** when an execution carries no Pi tool context of its own — the doctor wrapper self-test calls `bash.execute(id, params, signal)` with no context. A context that does supply `isProjectTrusted` always wins, so mid-session withdrawal is honoured even though the session probe is still installed.

## #389 — bridge failures could not be joined to the originating tool call

`auditFailure()` minted a fresh `randomUUID()` for every row, so a bridge incident produced an isolated record with only byte counts.

- `BridgeRequest` gains a bounded opaque `correlation`: the SHA-256 digest of the host tool-call id — **exactly the value `permissionAuditRow` already writes**, so the two rows join by construction.
- `BridgeClient.call()` normalises the request first: a correlation that is not 64 lowercase hex is **dropped** before `JSON.stringify`, before the Python subprocess, and before the audit. The raw Pi `toolCallId` therefore cannot reach the request JSON, the bridge, or `gate-events.log` even if a caller supplies one.
- Lifecycle and doctor requests have no upstream call identity and keep a locally minted UUID, distinguishable from a digest by shape.
- `bridgeToolResults` forwards the same digest when Pi supplies `toolCallId`.
- `plugins/ca-pi/hooks/pi-bridge.py` (confirmed **not** vendored from `core/pysrc` — no `pi-bridge.py` exists there, and `tools/sync-core.py` has no mapping for it) accepts `correlation` on `tool_call`/`tool_result` **only**, rejects any non-digest value with a `ProtocolError`, and never forwards it into the shared hook payload.

Correlation is computed exclusively from the tool-call id — never from parameters, file contents, credentials, or prompt text. Tests assert a secret-shaped raw id never appears on the wire or in the audit.

## Red-test evidence

Tests were written first and run against unmodified `src/` and `pi-bridge.py`. Verbatim output (13 TS failures + 2 Python errors), captured by stashing **only** the source changes and re-running the final test text:

```
⎯⎯⎯⎯⎯⎯ Failed Tests 13 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/bridge.test.ts > BridgeClient > bridge failures join the originating tool call and mint a local id only without one
AssertionError: expected '073ba549-d7eb-4ece-b3d1-ab9d5535655c' to be '94f93fb41c5a70cd0e67b76b52d420d06a17e…' // Object.is equality

Expected: "94f93fb41c5a70cd0e67b76b52d420d06a17ea216077ec2e9e6364ba2fab0917"
Received: "073ba549-d7eb-4ece-b3d1-ab9d5535655c"

 ❯ test/bridge.test.ts:398:25

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/13]⎯

 FAIL  test/bridge.test.ts > BridgeClient > only a digest-shaped correlation reaches the bridge wire
AssertionError: expected '{"version":1,"event":"tool_call","cwd…' not to contain 'pi-call-raw-host-identity'

Expected: "pi-call-raw-host-identity"
Received: "{"version":1,"event":"tool_call","cwd":"C:\\Users\\brenn\\AppData\\Local\\Temp\\ca-pi-bridge-v52Qid","tool":"read","input":{"path":"README.md"},"correlation":"pi-call-raw-host-identity"}"

 ❯ test/bridge.test.ts:421:34

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > mutators fail closed when live project trust is absent, false, or throwing
AssertionError: promise resolved "{ content: [ { …(2) } ], …(2) }" instead of rejecting

- Expected
+ Received

- Error {
-   "message": "rejected promise",
+ {
+   "content": [
+     {
+       "text": "bash executed",
+       "type": "text",
+     },
+   ],
+   "details": undefined,
+   "isError": false,
  }

 ❯ test/tool-guard.test.ts:1769:11

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > a custom mutator fails closed on withdrawn trust with no native escape
AssertionError: promise resolved "{ content: [], isError: false }" instead of rejecting

 ❯ test/tool-guard.test.ts:1809:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > trust withdrawal during bridge evaluation blocks the pending mutation
AssertionError: promise resolved "{ content: [ { …(2) } ], …(2) }" instead of rejecting
   ("text": "write executed")

 ❯ test/tool-guard.test.ts:1843:26

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > trust withdrawal during permission confirmation makes the approval stale
AssertionError: promise resolved "{ content: [ { …(2) } ], …(2) }" instead of rejecting
   ("text": "bash executed")

 ❯ test/tool-guard.test.ts:1876:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > withdrawal routes reads to the untrusted native path and retires the lifecycle
AssertionError: expected [] to deeply equal [ { tool: 'read', …(1) } ]

- Expected
+ Received

- [
-   {
-     "params": {
-       "path": "README.md",
-     },
-     "tool": "read",
-   },
- ]
+ []

 ❯ test/tool-guard.test.ts:1892:28

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > withdrawal restores the bootstrap block for every potentially mutating tool
AssertionError: expected undefined to match object { block: true }

- Expected:
{
  "block": true,
}

+ Received:
undefined

 ❯ test/tool-guard.test.ts:1931:72

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > the session-scoped trust probe governs the doctor self-test path that carries no tool context
AssertionError: promise resolved "{ content: [ { …(2) } ], …(2) }" instead of rejecting
   ("text": "bash executed")

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/13]⎯

 FAIL  test/tool-guard.test.ts > Pi live project trust withdrawal > the withdrawal diagnostic never echoes a trust probe failure detail
AssertionError: promise resolved "{ content: [ { …(2) } ], …(2) }" instead of rejecting
   ("text": "write executed")

 ❯ test/tool-guard.test.ts:1960:28

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/13]⎯

 FAIL  test/tool-guard.test.ts > Pi bridge tool-call correlation > governed tool calls forward the hashed correlation shared with the permission audit
AssertionError: expected undefined to be '94f93fb41c5a70cd0e67b76b52d420d06a17e…' // Object.is equality

- Expected:
"94f93fb41c5a70cd0e67b76b52d420d06a17ea216077ec2e9e6364ba2fab0917"

+ Received:
undefined

 ❯ test/tool-guard.test.ts:1993:45

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[11/13]⎯

 FAIL  test/tool-guard.test.ts > Pi bridge tool-call correlation > concurrent governed calls carry distinct joinable correlations
AssertionError: expected 1 to be 2 // Object.is equality

- Expected
+ Received

- 2
+ 1

 ❯ test/tool-guard.test.ts:2019:40

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[12/13]⎯

 FAIL  test/tool-guard.test.ts > Pi bridge tool-call correlation > tool-result bridge calls reuse the originating tool-call correlation
AssertionError: expected undefined to be 'a2a76165f7f3c62eaa56edc8f63efc209c0d4…' // Object.is equality

- Expected:
"a2a76165f7f3c62eaa56edc8f63efc209c0d40e372ab71dbfeb1a22e151b1a79"

+ Received:
undefined

 ❯ test/tool-guard.test.ts:2043:49

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[13/13]⎯


 Test Files  2 failed (2)
      Tests  13 failed | 98 passed (111)
```

Python protocol side (`.github/scripts`):

```
EE
======================================================================
ERROR: test_tool_call_correlation_is_an_opaque_bounded_digest (test_pi_parity.PiParityFixtures.test_tool_call_correlation_is_an_opaque_bounded_digest) (raw='{"version":1,"event":"tool_call","cwd":"...\\repo","tool":"read","input":{},"correlation":"4ebc55883ff66f7c980366a4bafbacaaa9e1459a84a8f7483f437377be439cc0"}')
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".github\scripts\test_pi_parity.py", line 323, in test_tool_call_correlation_is_an_opaque_bounded_digest
    request = bridge._request(raw.encode("utf-8"))
  File "plugins\ca-pi\hooks\pi-bridge.py", line 142, in _request
    raise ProtocolError("request keys are invalid")
pi_bridge_under_test.ProtocolError: request keys are invalid

======================================================================
ERROR: test_tool_call_correlation_is_an_opaque_bounded_digest (test_pi_parity.PiParityFixtures.test_tool_call_correlation_is_an_opaque_bounded_digest) (raw='{"version":1,"event":"tool_result",...,"correlation":"4ebc5588...39cc0"}')
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".github\scripts\test_pi_parity.py", line 323, in test_tool_call_correlation_is_an_opaque_bounded_digest
    request = bridge._request(raw.encode("utf-8"))
  File "plugins\ca-pi\hooks\pi-bridge.py", line 142, in _request
    raise ProtocolError("request keys are invalid")
pi_bridge_under_test.ProtocolError: request keys are invalid

----------------------------------------------------------------------
Ran 1 test in 0.136s

FAILED (errors=2)
```

The single test that passes both before and after — `governed mutators execute only while live project trust is affirmative` — is the deliberate positive control for the gate.

## Suite results

| Suite | Before (origin/main) | After |
|---|---|---|
| `plugins/ca-pi/tools` — `npm test` | 545 passed, 1 skipped | **559 passed, 1 skipped** (+14 new) |
| `plugins/ca-pi/tools` — `npx tsc --noEmit` | clean | **clean** |
| `.github/scripts` — `python -m unittest discover` | 1037 OK, 5 skipped | **1038 OK, 5 skipped** (+1 new) |
| `plugins/ca/hooks/tests` — `python -m unittest discover` | 1057 OK | **1057 OK** |

Payload gate:

```
python tools/build-host-packages.py --check --release-guard-base a3a2df2
package.json matches plugins/ca-pi/package.json and the Pi descriptor
Pi payload, version, changelog, and root metadata advanced together: 0.1.1 -> 0.1.2
```

Both committed esbuild artifacts (`extensions/codearbiter.js` and `extensions/codearbiter-child.js`) were rebuilt via `npm run build` and committed; the parent bundle's baked child SHA-256 fingerprint is regenerated with them.

## Fixture churn

Making `projectTrust` required surfaced 45 existing wrapper call sites in `test/tool-guard.test.ts`, `test/final-arguments.test.ts`, `test/bridge.test.ts`, and `test/benchmark-boundary.ts` that had no trust source. Each was given `projectTrust: () => true` (mirroring production, where `extension.ts` always supplies the session probe), and the shared `interactiveContext()` helper now carries `isProjectTrusted: () => true`. No pre-existing assertion was weakened or deleted.

## Security gate

`crypto-compliance` run before commit, scanned against `.codearbiter/security-controls.md`:

- Broken primitives (MD5/SHA-1/DES/3DES/RC4/RC2/Blowfish, RSA<2048): **none added** (grep-verified over the staged diff).
- Disabled TLS verification: **none** — no TLS surface; the bridge is a local stdio subprocess.
- Home-rolled crypto: **none** — no cipher, AEAD, KDF, or signature scheme implemented.
- Unapproved primitive/library: **none** — only `createHash("sha256")` (Node) and `hashlib.sha256` (Python), the repo's sanctioned pair.

The only crypto added is new *call sites* of the pre-existing `auditCorrelation()` SHA-256 helper; its input is a host tool-call id, not a secret or credential, and the digest serves as an opaque join key (no KDF warranted). `randomUUID()` keeps its existing role as the locally minted fallback correlation. Pass recorded via `hooks/security-pass.py` per ADR-0010.

## NEEDS-TRIAGE

1. **`bridgeToolResults` correlation depends on an unverified Pi event field.** The result-leg correlation is derived from `event.toolCallId`, which I could not confirm Pi 0.80.5/0.80.10 actually emits on `tool_result` (unlike the tool-call executor, where `toolCallId` is a documented parameter). The code is guarded — a missing or non-string field simply omits the correlation and the bridge falls back to a minted UUID — so this is fail-soft, not a defect. But if Pi does not supply it, the tool-result leg of #389's join stays unlinked and a follow-up would need a different carrier.

2. **`markReady()` now silently no-ops after a trust revocation within the same bootstrap.** This is intentional fail-closed behaviour, but it is silent: `extension.ts`'s `session_start` would proceed to `readyLifecycle = lifecycle` and publish "pi governed" while the installer is actually not ready. The window is tiny (a governed execution would have to land between `beginBootstrap()` and `markReady()`), and every mutator still fails closed, so the enforcement outcome is correct — but the status line could briefly disagree with the enforcement state. Worth a follow-up that surfaces the revocation to `publishStatus`.

3. **`.github/scripts` CI baseline is one test wider now (1037 → 1038).** Flagging only so a stale hard-coded baseline elsewhere does not read as a regression.

---

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
