### PR TITLE
fix(sandbox): surface teardown failures and exit non-zero when removal fails

### DIFF
--- a/plugins/ca-sandbox/.claude-plugin/plugin.json
+++ b/plugins/ca-sandbox/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca-sandbox",
   "displayName": "codeArbiter Sandbox",
   "description": "Locally-hosted Codespace equivalent for codeArbiter. Pulls an untrusted repo into an ephemeral, isolated Docker container with no host-filesystem access and configurable egress, caches dependencies by content hash, then tears the box down. Requires Docker and nixpacks on PATH.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca-sandbox/CHANGELOG.md
+++ b/plugins/ca-sandbox/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the **ca-sandbox** plugin are recorded here. Format follo
 
 ---
 
+## [0.1.5] — 2026-07-24 — Teardown failures are surfaced and fail
+
+### Fixed
+- **A failed teardown can no longer report success (#393).** `destroySandbox` and `prune` wrote `if (r.code === 0) removed.push(x)` and discarded every non-zero docker result; the result types carried no failure field at all, and the CLI returned 0 for both verbs unconditionally. A daemon outage, a permission error, or an in-use object therefore left **untrusted sandbox containers and source volumes running while automation read exit 0** — the advertised teardown guarantee was false on exactly the path where cleanup matters. Both verbs now retain every failed docker operation in a bounded `failures` list (with `failureCount` staying exact past the bound), and `sandbox destroy` / `sandbox prune` exit non-zero whenever anything failed or anything remains.
+
+### Changed
+- **Teardown is best-effort but never silent.** A failure no longer influences what else is attempted: every discovered container and volume is still targeted, so a partial teardown reclaims everything it can instead of stopping at the first refusal.
+- **Teardown is verified, not assumed.** After the removals, both verbs re-list the same label scope and report what is STILL PRESENT (`remainingContainers` / `remainingVolumes`). A `--keep-volume` volume is a deliberate survivor and is excluded from that set, so keeping a volume is still a clean exit.
+- **A failed listing is itself a teardown failure.** Discovery and verification now go through `listContainersResult` / `listVolumesResult` in `registry.ts`, which retain docker's exit code — "listed nothing while the daemon was down" must never read as "nothing is left". `listContainers` / `listVolumes` are unchanged thin wrappers over them.
+- **The diagnostic names what was left behind.** On failure the CLI writes a bounded stderr report — each failed operation with docker's own exit code and message, then the ids/names of every object still present and the manual `docker rm -f` / `docker volume rm` needed to clear them. The stdout JSON keeps the full structured result for scripting.
+
+---
+
 ## [0.1.4] — 2026-07-24 — Supply-chain hardening: no pipe-to-shell, digest-pinned images
 
 Two tribunal supply-chain findings closed. Both concern EXTERNAL bytes the driver pulled in unpinned.

--- a/plugins/ca-sandbox/commands/sandbox-destroy.md
+++ b/plugins/ca-sandbox/commands/sandbox-destroy.md
@@ -21,7 +21,10 @@ reclaims any leaked labeled object — the safety net for a box whose driver die
    container, then its named volume (unless `--keep-volume`).
 3. **Prune leaks** — `prune` in `${CLAUDE_PLUGIN_ROOT}/tools/destroy.ts` finds and removes any
    remaining labeled container/volume via the `ca.sandbox=1` label alone.
-4. **Confirm** — report what was removed and what was retained (cached images, a kept volume).
+4. **Confirm** — report what was removed and what was retained (cached images, a kept volume). If any
+   removal failed, or a final label-scoped re-list still finds a targeted object, say so and NAME the
+   leftovers: the CLI exits non-zero and the JSON result carries `failures` / `remainingContainers` /
+   `remainingVolumes`.
 
 ## Routes to
 
@@ -43,3 +46,6 @@ via `destroySandbox` and `prune` in `${CLAUDE_PLUGIN_ROOT}/tools/destroy.ts`.
 - MUST retain cached `ca-sbx:<repo>-<dephash>` images — teardown removes containers and volumes, not the
   build cache.
 - MUST NOT touch any object not labeled `ca.sandbox=1`; destroy operates only on this plugin's objects.
+- MUST NOT report success when a removal, a discovery listing, or the post-teardown verification failed.
+  A failed teardown exits non-zero and names every object left behind — silently succeeding while an
+  untrusted container is still running is the one outcome this command may never produce.

--- a/plugins/ca-sandbox/skills/sandbox-lifecycle/SKILL.md
+++ b/plugins/ca-sandbox/skills/sandbox-lifecycle/SKILL.md
@@ -69,8 +69,9 @@ A sandbox is ephemeral by contract. On exit (`/ca-sandbox:sandbox-destroy`, or t
 - `destroySandbox` (`${CLAUDE_PLUGIN_ROOT}/tools/destroy.ts`) removes the container and its named volume. `--keep-volume` leaves the volume (for a deliberate re-run); nothing else survives.
 - `prune` (`${CLAUDE_PLUGIN_ROOT}/tools/destroy.ts`) reclaims any leaked `ca.sandbox=1`-labeled object — the safety net for a box whose driver died mid-run.
 - Cached images (`ca-sbx:<repo>-<dephash>`) are intentionally retained for the next cache hit; they are excepted from teardown.
+- Both verbs are **best-effort but never silent**: a failed removal does not abort the sweep (everything else is still reclaimed), every failure is retained in a bounded `failures` list with docker's own exit code, and a final label-scoped re-list reports whatever is still present. The CLI exits non-zero and names the leftovers.
 
-Gate: after a `create → interact → destroy` cycle, zero `ca.sandbox=1`-labeled containers or volumes remain (cached images excepted). A run that leaves a labeled object behind without `--keep-volume` is a leak — `prune` must be able to find and reclaim it via the label alone.
+Gate: after a `create → interact → destroy` cycle, zero `ca.sandbox=1`-labeled containers or volumes remain (cached images excepted). A run that leaves a labeled object behind without `--keep-volume` is a leak — `prune` must be able to find and reclaim it via the label alone. Teardown is verified, not assumed: a docker failure during discovery, removal, or verification means the phase FAILS loudly, because a leaked box is still running untrusted code.
 
 ## Hard rules
 
@@ -81,5 +82,6 @@ Gate: after a `create → interact → destroy` cycle, zero `ca.sandbox=1`-label
 - MUST default the network policy to `offline`. The IP egress allowlist is EXPERIMENTAL — name it experimental every time it is selected; offline and clone-then-cut are the solid defaults.
 - MUST treat all egress out of the box as host-initiated (`docker cp` out) only. A host→container bind is impossible and MUST NOT be introduced as a "convenience."
 - MUST label every container and volume `ca.sandbox=1`, and MUST tear them down on exit (cached images excepted). `prune` reclaims a leaked labeled object via the label alone.
+- MUST NOT report a teardown as successful when docker refused a removal or the post-teardown verification could not confirm the scope is empty. `destroy`/`prune` exit non-zero and name every object left behind — automation must never read exit 0 over a still-running untrusted container.
 - MUST NOT enable `--with-claude` on the default path — it routes to `sandbox-claude-inside`, and MUST NEVER co-mount the token volume with an untrusted-code run.
 - MUST STOP rather than guess when Docker or nixpacks is absent — report the missing dependency, never a stack trace.

--- a/plugins/ca-sandbox/tools/cli.test.ts
+++ b/plugins/ca-sandbox/tools/cli.test.ts
@@ -188,13 +188,27 @@ function fakeHandlers(): Handlers {
       containerId: "cid1",
       notes: [],
     })),
+    // A CLEAN teardown: nothing failed, nothing left behind. The failure surface
+    // is exercised end-to-end (real destroy/prune over a fake docker) in
+    // teardown.test.ts; these fakes only need to be a valid success shape (#393).
     destroy: vi.fn(() => ({
       id: "id1",
       removedContainers: ["cid1"],
       removedVolumes: ["vol1"],
       keptVolumes: [],
+      failures: [],
+      failureCount: 0,
+      remainingContainers: [],
+      remainingVolumes: [],
     })),
-    prune: vi.fn(() => ({ removedContainers: [], removedVolumes: [] })),
+    prune: vi.fn(() => ({
+      removedContainers: [],
+      removedVolumes: [],
+      failures: [],
+      failureCount: 0,
+      remainingContainers: [],
+      remainingVolumes: [],
+    })),
     exec: vi.fn(() => ({
       id: "id1",
       exitCode: 7,

--- a/plugins/ca-sandbox/tools/cli.ts
+++ b/plugins/ca-sandbox/tools/cli.ts
@@ -36,7 +36,14 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { createSandbox, type CreateResult } from "./create.ts";
-import { destroySandbox, prune, type DestroyResult, type PruneResult } from "./destroy.ts";
+import {
+  destroySandbox,
+  prune,
+  teardownIncomplete,
+  formatTeardownDiagnostic,
+  type DestroyResult,
+  type PruneResult,
+} from "./destroy.ts";
 import { execInSandbox, type ExecResult } from "./exec.ts";
 import { cpOut, type RunResult } from "./cp.ts";
 import { resolveContainerId } from "./registry.ts";
@@ -321,6 +328,31 @@ export const defaultHandlers: Handlers = {
 };
 
 // --------------------------------------------------------------------------
+// teardown verdict -> exit code (#393)
+// --------------------------------------------------------------------------
+/**
+ * The exit code `destroy`/`prune` return when teardown did not fully succeed.
+ * Distinct from 2 (usage error) so a caller can tell a leaked sandbox from a
+ * mistyped command.
+ */
+export const TEARDOWN_FAILURE_EXIT = 1;
+
+/**
+ * Print the teardown diagnostic (if any) and map the verdict to an exit code.
+ *
+ * `destroy`/`prune` used to `return 0` unconditionally, so a daemon outage or an
+ * in-use object left untrusted containers and source volumes running while
+ * automation saw success (#393). The structured result is still written to stdout
+ * for scripting; the human/CI-facing diagnostic — naming every object left
+ * behind — goes to stderr.
+ */
+function teardownExit(verb: "destroy" | "prune", r: DestroyResult | PruneResult): number {
+  if (!teardownIncomplete(r)) return 0;
+  process.stderr.write(`${formatTeardownDiagnostic(verb, r)}\n`);
+  return TEARDOWN_FAILURE_EXIT;
+}
+
+// --------------------------------------------------------------------------
 // runCli — parse + dispatch; returns an exit code, never throws on usage error
 // --------------------------------------------------------------------------
 /**
@@ -329,7 +361,10 @@ export const defaultHandlers: Handlers = {
  *   - usage error (`CliError`): the message goes to stderr, exit code 2.
  *   - `exec`: the in-container exit code propagates as the CLI's code (AC-09).
  *   - `cp`: docker's exit code propagates.
- *   - `create`/`destroy`/`prune`/`shell`: 0 on success (shell returns its code).
+ *   - `destroy`/`prune`: 0 only when teardown is verified complete; otherwise
+ *     `TEARDOWN_FAILURE_EXIT` with a stderr diagnostic naming what was left
+ *     behind (#393).
+ *   - `create`/`shell`: 0 on success (shell returns its code).
  *
  * Side-effecting work prints a one-line JSON/summary to stdout so the surface is
  * scriptable; the structured result objects come straight from the modules.
@@ -368,12 +403,12 @@ export async function runCli(argv: string[], handlers: Handlers = defaultHandler
     case "destroy": {
       const r = handlers.destroy(cmd.id, { keepVolume: cmd.keepVolume });
       process.stdout.write(`${JSON.stringify(r)}\n`);
-      return 0;
+      return teardownExit("destroy", r);
     }
     case "prune": {
       const r = handlers.prune();
       process.stdout.write(`${JSON.stringify(r)}\n`);
-      return 0;
+      return teardownExit("prune", r);
     }
   }
 }

--- a/plugins/ca-sandbox/tools/destroy.ts
+++ b/plugins/ca-sandbox/tools/destroy.ts
@@ -18,17 +18,82 @@
  * are excepted — images are tracked by tag, never torn down here). Process/shell
  * handling mirrors registry.ts: injectable docker runner, MSYS_NO_PATHCONV=1 on
  * Windows + Git Bash (Spike A/B).
+ *
+ * FAILURE IS PART OF THE CONTRACT (#393). Both verbs used to write
+ * `if (r.code === 0) removed.push(x)` and silently drop every non-zero docker
+ * result, and the CLI returned 0 regardless — so a daemon outage, a permission
+ * error, or an in-use object left UNTRUSTED containers and source volumes running
+ * while automation read exit 0. The teardown guarantee was therefore false on the
+ * exact path where cleanup matters. Now:
+ *
+ *   - every failed removal lands in a BOUNDED `failures` list (`failureCount`
+ *     stays truthful past the bound) instead of being discarded;
+ *   - a failure never aborts the sweep — partial teardown must still reclaim
+ *     everything it can, so all discovered targets are attempted;
+ *   - a failed DISCOVERY or VERIFICATION listing is itself a failure: "listed
+ *     nothing while the daemon was down" must never read as "nothing is left";
+ *   - after the removals a final label-scoped re-list reports what is STILL
+ *     PRESENT (`remainingContainers` / `remainingVolumes`), naming the objects an
+ *     operator has to clean up by hand. A `--keep-volume` volume is deliberate
+ *     and is excluded from that set.
+ *
+ * The verbs still RETURN a structured result rather than throwing — the exit-code
+ * decision belongs to the CLI (`teardownIncomplete` / `formatTeardownDiagnostic`),
+ * so a library caller can inspect a partial teardown instead of catching.
  */
 import {
   SANDBOX_LABEL,
   idLabel,
-  listContainers,
-  listVolumes,
-  listAllContainers,
-  listAllVolumes,
+  listContainersResult,
+  listVolumesResult,
   defaultDockerRun,
   type DockerRun,
 } from "./registry.ts";
+
+/**
+ * At most this many individual failures are retained. The list is a diagnostic,
+ * not a ledger: a wedged daemon can fail hundreds of removals and an unbounded
+ * list would be echoed into stdout JSON and stderr verbatim. `failureCount`
+ * remains exact, so the bound never understates the damage.
+ */
+export const MAX_TEARDOWN_FAILURES = 25;
+
+/** At most this many refs are named per category in the stderr diagnostic. */
+export const MAX_DIAGNOSTIC_REFS = 25;
+
+/** docker stderr is truncated to this many characters per failure. */
+export const MAX_FAILURE_MESSAGE_CHARS = 300;
+
+/** What failed: a removal, or the listing that finds/verifies the targets. */
+export type TeardownOp =
+  | "remove-container"
+  | "remove-volume"
+  | "list-containers"
+  | "list-volumes";
+
+/** One docker operation that failed during teardown. */
+export type TeardownFailure = {
+  /** Which operation failed. */
+  op: TeardownOp;
+  /** The object left behind, or (for a listing) the label scope queried. */
+  ref: string;
+  /** docker's exit code. */
+  code: number;
+  /** Bounded, single-line docker stderr. */
+  message: string;
+};
+
+/** The failure surface both teardown verbs share. */
+export type TeardownReport = {
+  /** Failed operations, capped at MAX_TEARDOWN_FAILURES. */
+  failures: TeardownFailure[];
+  /** Total failed operations, including any past the cap. */
+  failureCount: number;
+  /** Containers still carrying the target labels after teardown. */
+  remainingContainers: string[];
+  /** Volumes still carrying the target labels after teardown (kept ones excluded). */
+  remainingVolumes: string[];
+};
 
 export type DestroyOptions = {
   /** Keep the named volume (the cloned source) — only remove the container. */
@@ -37,7 +102,7 @@ export type DestroyOptions = {
   dockerRun?: DockerRun;
 };
 
-export type DestroyResult = {
+export type DestroyResult = TeardownReport & {
   /** The sandbox id targeted. */
   id: string;
   /** Container ids removed. */
@@ -47,6 +112,63 @@ export type DestroyResult = {
   /** Volume names deliberately kept (keepVolume). */
   keptVolumes: string[];
 };
+
+/** Accumulates failures while enforcing the retention bound. */
+class FailureLog {
+  readonly failures: TeardownFailure[] = [];
+  count = 0;
+
+  add(op: TeardownOp, ref: string, code: number, stderr: string): void {
+    this.count += 1;
+    if (this.failures.length >= MAX_TEARDOWN_FAILURES) return;
+    this.failures.push({ op, ref, code, message: oneLine(stderr) });
+  }
+}
+
+/** Collapse docker stderr to a bounded single line for a diagnostic. */
+function oneLine(stderr: string): string {
+  const s = stderr.replace(/\s+/g, " ").trim();
+  if (!s) return "(no stderr from docker)";
+  return s.length > MAX_FAILURE_MESSAGE_CHARS ? `${s.slice(0, MAX_FAILURE_MESSAGE_CHARS)}...` : s;
+}
+
+/**
+ * Remove each ref, recording failures instead of dropping them. Every ref is
+ * attempted even after one fails — a partial teardown must still reclaim what it
+ * can. Returns the refs that were actually removed.
+ */
+function removeEach(
+  refs: string[],
+  kind: "container" | "volume",
+  dockerRun: DockerRun,
+  log: FailureLog,
+): string[] {
+  const removed: string[] = [];
+  for (const ref of refs) {
+    const args = kind === "container" ? ["rm", "-f", ref] : ["volume", "rm", "-f", ref];
+    const r = dockerRun(args);
+    if (r.code === 0) removed.push(ref);
+    else log.add(kind === "container" ? "remove-container" : "remove-volume", ref, r.code, r.stderr);
+  }
+  return removed;
+}
+
+/**
+ * Re-list the label scope after the removals so the result reports what is STILL
+ * PRESENT rather than only what we managed to delete. A failed verification
+ * listing is recorded as a failure: an unverifiable teardown is not a clean one.
+ */
+function verifyScope(
+  labels: string | string[],
+  dockerRun: DockerRun,
+  log: FailureLog,
+): { containers: string[]; volumes: string[] } {
+  const c = listContainersResult(labels, dockerRun);
+  if (c.code !== 0) log.add("list-containers", c.scope, c.code, c.stderr);
+  const v = listVolumesResult(labels, dockerRun);
+  if (v.code !== 0) log.add("list-volumes", v.scope, v.code, v.stderr);
+  return { containers: c.items, volumes: v.items };
+}
 
 /**
  * Remove a single sandbox by id. Discovered by the `ca.sandbox.id=<id>` label
@@ -59,30 +181,39 @@ export function destroySandbox(id: string, opts: DestroyOptions = {}): DestroyRe
   if (!id) throw new Error("ca-sandbox: destroySandbox requires a sandbox id");
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const labels = [SANDBOX_LABEL, idLabel(id)];
+  const log = new FailureLog();
 
-  const containers = listContainers(labels, dockerRun);
-  const volumes = listVolumes(labels, dockerRun);
+  const containersList = listContainersResult(labels, dockerRun);
+  if (containersList.code !== 0)
+    log.add("list-containers", containersList.scope, containersList.code, containersList.stderr);
+  const volumesList = listVolumesResult(labels, dockerRun);
+  if (volumesList.code !== 0)
+    log.add("list-volumes", volumesList.scope, volumesList.code, volumesList.stderr);
 
-  const removedContainers: string[] = [];
-  for (const c of containers) {
-    const r = dockerRun(["rm", "-f", c]);
-    if (r.code === 0) removedContainers.push(c);
-  }
+  const removedContainers = removeEach(containersList.items, "container", dockerRun, log);
 
   const removedVolumes: string[] = [];
   const keptVolumes: string[] = [];
   if (opts.keepVolume) {
-    keptVolumes.push(...volumes);
+    keptVolumes.push(...volumesList.items);
   } else {
     // A volume in use by a container can't be removed until the container is
     // gone; containers were removed above, so this now succeeds.
-    for (const v of volumes) {
-      const r = dockerRun(["volume", "rm", "-f", v]);
-      if (r.code === 0) removedVolumes.push(v);
-    }
+    removedVolumes.push(...removeEach(volumesList.items, "volume", dockerRun, log));
   }
 
-  return { id, removedContainers, removedVolumes, keptVolumes };
+  const still = verifyScope(labels, dockerRun, log);
+  return {
+    id,
+    removedContainers,
+    removedVolumes,
+    keptVolumes,
+    failures: log.failures,
+    failureCount: log.count,
+    remainingContainers: still.containers,
+    // A kept volume is a deliberate survivor, not a leak.
+    remainingVolumes: still.volumes.filter((v) => !keptVolumes.includes(v)),
+  };
 }
 
 export type PruneOptions = {
@@ -90,7 +221,7 @@ export type PruneOptions = {
   dockerRun?: DockerRun;
 };
 
-export type PruneResult = {
+export type PruneResult = TeardownReport & {
   /** Every ca.sandbox=1 container id removed (including leaked ones). */
   removedContainers: string[];
   /** Every ca.sandbox=1 volume removed (including leaked ones). */
@@ -106,18 +237,66 @@ export type PruneResult = {
  */
 export function prune(opts: PruneOptions = {}): PruneResult {
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
+  const log = new FailureLog();
 
-  const removedContainers: string[] = [];
-  for (const c of listAllContainers(dockerRun)) {
-    const r = dockerRun(["rm", "-f", c]);
-    if (r.code === 0) removedContainers.push(c);
-  }
+  const containersList = listContainersResult(SANDBOX_LABEL, dockerRun);
+  if (containersList.code !== 0)
+    log.add("list-containers", containersList.scope, containersList.code, containersList.stderr);
+  const removedContainers = removeEach(containersList.items, "container", dockerRun, log);
 
-  const removedVolumes: string[] = [];
-  for (const v of listAllVolumes(dockerRun)) {
-    const r = dockerRun(["volume", "rm", "-f", v]);
-    if (r.code === 0) removedVolumes.push(v);
-  }
+  const volumesList = listVolumesResult(SANDBOX_LABEL, dockerRun);
+  if (volumesList.code !== 0)
+    log.add("list-volumes", volumesList.scope, volumesList.code, volumesList.stderr);
+  const removedVolumes = removeEach(volumesList.items, "volume", dockerRun, log);
 
-  return { removedContainers, removedVolumes };
+  const still = verifyScope(SANDBOX_LABEL, dockerRun, log);
+  return {
+    removedContainers,
+    removedVolumes,
+    failures: log.failures,
+    failureCount: log.count,
+    remainingContainers: still.containers,
+    remainingVolumes: still.volumes,
+  };
+}
+
+// --------------------------------------------------------------------------
+// the verdict the CLI turns into an exit code
+// --------------------------------------------------------------------------
+/**
+ * True when teardown did NOT fully succeed — any docker operation failed, or any
+ * targeted object is still present. The CLI maps this to a non-zero exit code so
+ * automation can never mistake a leaked untrusted container for a clean sweep.
+ */
+export function teardownIncomplete(r: TeardownReport): boolean {
+  return r.failureCount > 0 || r.remainingContainers.length > 0 || r.remainingVolumes.length > 0;
+}
+
+/** Render at most MAX_DIAGNOSTIC_REFS refs, noting how many were elided. */
+function boundedRefs(label: string, refs: string[]): string[] {
+  if (refs.length === 0) return [];
+  const shown = refs.slice(0, MAX_DIAGNOSTIC_REFS);
+  const lines = shown.map((r) => `  still present: ${label} ${r}`);
+  if (refs.length > shown.length) lines.push(`  ... and ${refs.length - shown.length} more ${label}(s)`);
+  return lines;
+}
+
+/**
+ * A bounded, operator-actionable diagnostic: what failed, with docker's own
+ * message, and — the part that matters — the NAMES of the objects still running.
+ * Returns "" when teardown was clean, so the caller can print unconditionally.
+ */
+export function formatTeardownDiagnostic(verb: string, r: TeardownReport): string {
+  if (!teardownIncomplete(r)) return "";
+  const lines: string[] = [
+    `sandbox ${verb}: teardown INCOMPLETE — ${r.failureCount} docker operation(s) failed; ` +
+      `${r.remainingContainers.length} container(s) and ${r.remainingVolumes.length} volume(s) still present.`,
+  ];
+  for (const f of r.failures) lines.push(`  ${f.op} ${f.ref}: docker exit ${f.code}: ${f.message}`);
+  if (r.failureCount > r.failures.length)
+    lines.push(`  ... and ${r.failureCount - r.failures.length} more failure(s) not shown`);
+  lines.push(...boundedRefs("container", r.remainingContainers));
+  lines.push(...boundedRefs("volume", r.remainingVolumes));
+  lines.push("  These objects may be running UNTRUSTED code — remove them by hand (`docker rm -f` / `docker volume rm`).");
+  return lines.join("\n");
 }

--- a/plugins/ca-sandbox/tools/lifecycle.test.ts
+++ b/plugins/ca-sandbox/tools/lifecycle.test.ts
@@ -36,18 +36,42 @@ import { createSandbox } from "./create.ts";
 // PURE layer — injected fake docker runner. No real docker.
 // --------------------------------------------------------------------------
 
-/** A fake docker that records calls and returns scripted stdout per arg-match. */
+/**
+ * A fake docker that records calls and returns scripted stdout per arg-match.
+ *
+ * Removal is MODELLED, not just recorded: a successful `rm`/`volume rm` drops the
+ * ref from every later label listing, exactly as real docker would. Teardown now
+ * re-lists the scope after removing to report what is still present (#393), so a
+ * fake whose listings were frozen in time would report every removed object as a
+ * leak and make these tests assert a physically impossible docker.
+ */
 function fakeDocker(routes: Array<{ match: (a: string[]) => boolean; stdout?: string; code?: number }>): {
   run: DockerRun;
   calls: string[][];
 } {
   const calls: string[][] = [];
+  const removed = new Set<string>();
+  const isListing = (a: string[]) => a[0] === "ps" || (a[0] === "volume" && a[1] === "ls");
+  const isRemoval = (a: string[]) => a[0] === "rm" || (a[0] === "volume" && a[1] === "rm");
+
   const run: DockerRun = (args) => {
     calls.push(args);
+    let res: DockerResult = { code: 0, stdout: "", stderr: "" };
     for (const r of routes) {
-      if (r.match(args)) return { code: r.code ?? 0, stdout: r.stdout ?? "", stderr: "" };
+      if (r.match(args)) {
+        res = { code: r.code ?? 0, stdout: r.stdout ?? "", stderr: "" };
+        break;
+      }
     }
-    return { code: 0, stdout: "", stderr: "" } as DockerResult;
+    if (isRemoval(args) && res.code === 0) removed.add(args[args.length - 1]);
+    if (isListing(args)) {
+      const live = res.stdout
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => l && !removed.has(l));
+      res = { ...res, stdout: live.length ? `${live.join("\n")}\n` : "" };
+    }
+    return res;
   };
   return { run, calls };
 }
@@ -110,6 +134,10 @@ describe("destroySandbox — teardown by label (AC-11)", () => {
     expect(res.keptVolumes).toEqual([]);
     expect(calls).toContainEqual(["rm", "-f", "c1"]);
     expect(calls).toContainEqual(["volume", "rm", "-f", "ca-sbx-vol-id1"]);
+    // A clean teardown is verified clean, not merely un-errored (#393).
+    expect(res.failureCount).toBe(0);
+    expect(res.remainingContainers).toEqual([]);
+    expect(res.remainingVolumes).toEqual([]);
   });
 
   it("--keep-volume removes the container but SPARES the volume", () => {
@@ -135,6 +163,9 @@ describe("prune — reclaims ALL ca.sandbox=1 objects incl. leaked (AC-11)", () 
     const res = prune({ dockerRun: run });
     expect(res.removedContainers).toEqual(["c1", "c2"]);
     expect(res.removedVolumes).toEqual(["vol-leaked"]);
+    expect(res.failureCount).toBe(0);
+    expect(res.remainingContainers).toEqual([]);
+    expect(res.remainingVolumes).toEqual([]);
     // The discovery filter is the bare membership label (no id) — so leaked
     // objects without an id label are caught.
     const psCall = calls.find((a) => a[0] === "ps")!;
@@ -390,6 +421,11 @@ d("create -> destroy lifecycle [docker] (AC-01, AC-11)", () => {
       const dres = destroySandbox(id);
       expect(dres.removedContainers).toContain(res.containerId);
       expect(dres.removedVolumes).toContain(res.volumeName);
+      // Against REAL docker the teardown reports itself verified-clean (#393).
+      expect(dres.failures).toEqual([]);
+      expect(dres.failureCount).toBe(0);
+      expect(dres.remainingContainers).toEqual([]);
+      expect(dres.remainingVolumes).toEqual([]);
       expect(findSandbox(id)).toBeNull();
     });
   }, 300_000);

--- a/plugins/ca-sandbox/tools/registry.ts
+++ b/plugins/ca-sandbox/tools/registry.ts
@@ -60,6 +60,47 @@ function labelFilterArgs(labels: string | string[]): string[] {
 }
 
 /**
+ * A label listing that RETAINS docker's exit status.
+ *
+ * `listContainers`/`listVolumes` return only the parsed ids, which means a failed
+ * listing (dead daemon, permission error) is indistinguishable from "the scope is
+ * empty". That is harmless for a read-only view but dangerous for teardown, where
+ * "found nothing" would be reported as "nothing is left" — so destroy.ts consumes
+ * this shape instead and treats a non-zero `code` as a teardown failure (#393).
+ */
+export type ListResult = {
+  /** docker's exit code (0 = the listing is trustworthy). */
+  code: number;
+  /** The parsed ids/names; empty when the listing failed. */
+  items: string[];
+  /** docker's stderr, for the failure diagnostic. */
+  stderr: string;
+  /** The label scope that was queried, for the failure diagnostic. */
+  scope: string;
+};
+
+const scopeOf = (labels: string | string[]): string =>
+  (Array.isArray(labels) ? labels : [labels]).map((l) => `label=${l}`).join(" ");
+
+/** `listContainers` with docker's exit status retained — see `ListResult`. */
+export function listContainersResult(
+  labels: string | string[] = SANDBOX_LABEL,
+  dockerRun: DockerRun = defaultDockerRun,
+): ListResult {
+  const r = dockerRun(["ps", "-a", "-q", "--no-trunc", ...labelFilterArgs(labels)]);
+  return { code: r.code, items: splitLines(r.stdout), stderr: r.stderr, scope: scopeOf(labels) };
+}
+
+/** `listVolumes` with docker's exit status retained — see `ListResult`. */
+export function listVolumesResult(
+  labels: string | string[] = SANDBOX_LABEL,
+  dockerRun: DockerRun = defaultDockerRun,
+): ListResult {
+  const r = dockerRun(["volume", "ls", "-q", ...labelFilterArgs(labels)]);
+  return { code: r.code, items: splitLines(r.stdout), stderr: r.stderr, scope: scopeOf(labels) };
+}
+
+/**
  * Container ids matching one or more label expressions (ANDed). `docker ps -a -q
  * --no-trunc --filter label=<expr> [...]` prints one full id per line; blank
  * output => none. Pass an array to require ALL labels (e.g. membership + id).
@@ -68,8 +109,7 @@ export function listContainers(
   labels: string | string[] = SANDBOX_LABEL,
   dockerRun: DockerRun = defaultDockerRun,
 ): string[] {
-  const r = dockerRun(["ps", "-a", "-q", "--no-trunc", ...labelFilterArgs(labels)]);
-  return splitLines(r.stdout);
+  return listContainersResult(labels, dockerRun).items;
 }
 
 /**
@@ -80,8 +120,7 @@ export function listVolumes(
   labels: string | string[] = SANDBOX_LABEL,
   dockerRun: DockerRun = defaultDockerRun,
 ): string[] {
-  const r = dockerRun(["volume", "ls", "-q", ...labelFilterArgs(labels)]);
-  return splitLines(r.stdout);
+  return listVolumesResult(labels, dockerRun).items;
 }
 
 function splitLines(out: string): string[] {

--- a/plugins/ca-sandbox/tools/sandbox.js
+++ b/plugins/ca-sandbox/tools/sandbox.js
@@ -425,22 +425,23 @@ function labelFilterArgs(labels) {
   const list = Array.isArray(labels) ? labels : [labels];
   return list.flatMap((l) => ["--filter", `label=${l}`]);
 }
-function listContainers(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
+var scopeOf = (labels) => (Array.isArray(labels) ? labels : [labels]).map((l) => `label=${l}`).join(" ");
+function listContainersResult(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
   const r = dockerRun(["ps", "-a", "-q", "--no-trunc", ...labelFilterArgs(labels)]);
-  return splitLines(r.stdout);
+  return { code: r.code, items: splitLines(r.stdout), stderr: r.stderr, scope: scopeOf(labels) };
+}
+function listVolumesResult(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
+  const r = dockerRun(["volume", "ls", "-q", ...labelFilterArgs(labels)]);
+  return { code: r.code, items: splitLines(r.stdout), stderr: r.stderr, scope: scopeOf(labels) };
+}
+function listContainers(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
+  return listContainersResult(labels, dockerRun).items;
 }
 function listVolumes(labels = SANDBOX_LABEL2, dockerRun = defaultDockerRun) {
-  const r = dockerRun(["volume", "ls", "-q", ...labelFilterArgs(labels)]);
-  return splitLines(r.stdout);
+  return listVolumesResult(labels, dockerRun).items;
 }
 function splitLines(out) {
   return out.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
-}
-function listAllContainers(dockerRun = defaultDockerRun) {
-  return listContainers(SANDBOX_LABEL2, dockerRun);
-}
-function listAllVolumes(dockerRun = defaultDockerRun) {
-  return listVolumes(SANDBOX_LABEL2, dockerRun);
 }
 function findSandbox(id, dockerRun = defaultDockerRun) {
   const labels = [SANDBOX_LABEL2, idLabel(id)];
@@ -680,42 +681,115 @@ ${cloneStderr.trim()}` : "";
 }
 
 // destroy.ts
+var MAX_TEARDOWN_FAILURES = 25;
+var MAX_DIAGNOSTIC_REFS = 25;
+var MAX_FAILURE_MESSAGE_CHARS = 300;
+var FailureLog = class {
+  failures = [];
+  count = 0;
+  add(op, ref, code, stderr) {
+    this.count += 1;
+    if (this.failures.length >= MAX_TEARDOWN_FAILURES) return;
+    this.failures.push({ op, ref, code, message: oneLine(stderr) });
+  }
+};
+function oneLine(stderr) {
+  const s = stderr.replace(/\s+/g, " ").trim();
+  if (!s) return "(no stderr from docker)";
+  return s.length > MAX_FAILURE_MESSAGE_CHARS ? `${s.slice(0, MAX_FAILURE_MESSAGE_CHARS)}...` : s;
+}
+function removeEach(refs, kind, dockerRun, log) {
+  const removed = [];
+  for (const ref of refs) {
+    const args = kind === "container" ? ["rm", "-f", ref] : ["volume", "rm", "-f", ref];
+    const r = dockerRun(args);
+    if (r.code === 0) removed.push(ref);
+    else log.add(kind === "container" ? "remove-container" : "remove-volume", ref, r.code, r.stderr);
+  }
+  return removed;
+}
+function verifyScope(labels, dockerRun, log) {
+  const c = listContainersResult(labels, dockerRun);
+  if (c.code !== 0) log.add("list-containers", c.scope, c.code, c.stderr);
+  const v = listVolumesResult(labels, dockerRun);
+  if (v.code !== 0) log.add("list-volumes", v.scope, v.code, v.stderr);
+  return { containers: c.items, volumes: v.items };
+}
 function destroySandbox(id, opts = {}) {
   if (!id) throw new Error("ca-sandbox: destroySandbox requires a sandbox id");
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const labels = [SANDBOX_LABEL2, idLabel(id)];
-  const containers = listContainers(labels, dockerRun);
-  const volumes = listVolumes(labels, dockerRun);
-  const removedContainers = [];
-  for (const c of containers) {
-    const r = dockerRun(["rm", "-f", c]);
-    if (r.code === 0) removedContainers.push(c);
-  }
+  const log = new FailureLog();
+  const containersList = listContainersResult(labels, dockerRun);
+  if (containersList.code !== 0)
+    log.add("list-containers", containersList.scope, containersList.code, containersList.stderr);
+  const volumesList = listVolumesResult(labels, dockerRun);
+  if (volumesList.code !== 0)
+    log.add("list-volumes", volumesList.scope, volumesList.code, volumesList.stderr);
+  const removedContainers = removeEach(containersList.items, "container", dockerRun, log);
   const removedVolumes = [];
   const keptVolumes = [];
   if (opts.keepVolume) {
-    keptVolumes.push(...volumes);
+    keptVolumes.push(...volumesList.items);
   } else {
-    for (const v of volumes) {
-      const r = dockerRun(["volume", "rm", "-f", v]);
-      if (r.code === 0) removedVolumes.push(v);
-    }
+    removedVolumes.push(...removeEach(volumesList.items, "volume", dockerRun, log));
   }
-  return { id, removedContainers, removedVolumes, keptVolumes };
+  const still = verifyScope(labels, dockerRun, log);
+  return {
+    id,
+    removedContainers,
+    removedVolumes,
+    keptVolumes,
+    failures: log.failures,
+    failureCount: log.count,
+    remainingContainers: still.containers,
+    // A kept volume is a deliberate survivor, not a leak.
+    remainingVolumes: still.volumes.filter((v) => !keptVolumes.includes(v))
+  };
 }
 function prune(opts = {}) {
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
-  const removedContainers = [];
-  for (const c of listAllContainers(dockerRun)) {
-    const r = dockerRun(["rm", "-f", c]);
-    if (r.code === 0) removedContainers.push(c);
-  }
-  const removedVolumes = [];
-  for (const v of listAllVolumes(dockerRun)) {
-    const r = dockerRun(["volume", "rm", "-f", v]);
-    if (r.code === 0) removedVolumes.push(v);
-  }
-  return { removedContainers, removedVolumes };
+  const log = new FailureLog();
+  const containersList = listContainersResult(SANDBOX_LABEL2, dockerRun);
+  if (containersList.code !== 0)
+    log.add("list-containers", containersList.scope, containersList.code, containersList.stderr);
+  const removedContainers = removeEach(containersList.items, "container", dockerRun, log);
+  const volumesList = listVolumesResult(SANDBOX_LABEL2, dockerRun);
+  if (volumesList.code !== 0)
+    log.add("list-volumes", volumesList.scope, volumesList.code, volumesList.stderr);
+  const removedVolumes = removeEach(volumesList.items, "volume", dockerRun, log);
+  const still = verifyScope(SANDBOX_LABEL2, dockerRun, log);
+  return {
+    removedContainers,
+    removedVolumes,
+    failures: log.failures,
+    failureCount: log.count,
+    remainingContainers: still.containers,
+    remainingVolumes: still.volumes
+  };
+}
+function teardownIncomplete(r) {
+  return r.failureCount > 0 || r.remainingContainers.length > 0 || r.remainingVolumes.length > 0;
+}
+function boundedRefs(label, refs) {
+  if (refs.length === 0) return [];
+  const shown = refs.slice(0, MAX_DIAGNOSTIC_REFS);
+  const lines = shown.map((r) => `  still present: ${label} ${r}`);
+  if (refs.length > shown.length) lines.push(`  ... and ${refs.length - shown.length} more ${label}(s)`);
+  return lines;
+}
+function formatTeardownDiagnostic(verb, r) {
+  if (!teardownIncomplete(r)) return "";
+  const lines = [
+    `sandbox ${verb}: teardown INCOMPLETE \u2014 ${r.failureCount} docker operation(s) failed; ${r.remainingContainers.length} container(s) and ${r.remainingVolumes.length} volume(s) still present.`
+  ];
+  for (const f of r.failures) lines.push(`  ${f.op} ${f.ref}: docker exit ${f.code}: ${f.message}`);
+  if (r.failureCount > r.failures.length)
+    lines.push(`  ... and ${r.failureCount - r.failures.length} more failure(s) not shown`);
+  lines.push(...boundedRefs("container", r.remainingContainers));
+  lines.push(...boundedRefs("volume", r.remainingVolumes));
+  lines.push("  These objects may be running UNTRUSTED code \u2014 remove them by hand (`docker rm -f` / `docker volume rm`).");
+  return lines.join("\n");
 }
 
 // exec.ts
@@ -947,6 +1021,13 @@ var defaultHandlers = {
   cp: (id, containerPath, hostDest) => cpOut(resolveContainerId(id), containerPath, hostDest),
   shell: defaultShell
 };
+var TEARDOWN_FAILURE_EXIT = 1;
+function teardownExit(verb, r) {
+  if (!teardownIncomplete(r)) return 0;
+  process.stderr.write(`${formatTeardownDiagnostic(verb, r)}
+`);
+  return TEARDOWN_FAILURE_EXIT;
+}
 async function runCli(argv, handlers = defaultHandlers) {
   let cmd;
   try {
@@ -984,13 +1065,13 @@ async function runCli(argv, handlers = defaultHandlers) {
       const r = handlers.destroy(cmd.id, { keepVolume: cmd.keepVolume });
       process.stdout.write(`${JSON.stringify(r)}
 `);
-      return 0;
+      return teardownExit("destroy", r);
     }
     case "prune": {
       const r = handlers.prune();
       process.stdout.write(`${JSON.stringify(r)}
 `);
-      return 0;
+      return teardownExit("prune", r);
     }
   }
 }
@@ -1017,6 +1098,7 @@ export {
   CliError,
   DEFAULT_SHELL,
   NET_POLICIES,
+  TEARDOWN_FAILURE_EXIT,
   defaultHandlers,
   parseCli,
   runCli

--- a/plugins/ca-sandbox/tools/teardown.test.ts
+++ b/plugins/ca-sandbox/tools/teardown.test.ts
@@ -1,0 +1,338 @@
+/**
+ * teardown.test.ts — #393. Teardown failures must be SURFACED and must FAIL.
+ *
+ * `destroySandbox` and `prune` used to write `if (r.code === 0) removed.push(x)`
+ * and drop every non-zero docker result on the floor: the result objects carried
+ * no failure field at all, and the CLI returned 0 unconditionally. A daemon
+ * outage, a permissions failure, or an in-use object therefore left UNTRUSTED
+ * sandbox containers and source volumes running while automation saw exit 0 —
+ * the advertised teardown guarantee was false exactly on the path where it
+ * matters.
+ *
+ * The obligations locked in here:
+ *   1. every failed removal is retained in a BOUNDED failure list;
+ *   2. teardown keeps attempting every discovered target after a failure
+ *      (partial teardown must still remove what it can);
+ *   3. a final label-scoped verification re-lists the scope and reports whatever
+ *      is still present (a kept volume is expected, not "remaining");
+ *   4. a discovery/verification docker failure is itself a teardown failure —
+ *      "listed nothing while the daemon was down" must never read as success;
+ *   5. `sandbox destroy` / `sandbox prune` exit NON-ZERO whenever any removal
+ *      failed or any target remains, with a diagnostic that NAMES what was left
+ *      behind so an operator can clean up.
+ *
+ * Everything here runs on an injected docker runner — no real docker. The fake
+ * is STATEFUL (a successful `rm` really removes the object from later label
+ * listings) so the post-teardown verification is exercised honestly rather than
+ * against a listing frozen in time.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { destroySandbox, prune } from "./destroy.ts";
+import { runCli, type Handlers } from "./cli.ts";
+import type { DockerRun } from "./registry.ts";
+
+// --------------------------------------------------------------------------
+// a stateful fake docker: listings reflect what has actually been removed
+// --------------------------------------------------------------------------
+type FakeOpts = {
+  /** Return a non-zero exit code to make THIS removal fail. */
+  failRemove?: (kind: "container" | "volume", ref: string) => number | undefined;
+  /** Simulate a dead daemon: every label listing fails. */
+  failList?: boolean;
+};
+
+function fakeDocker(
+  world: { containers?: string[]; volumes?: string[] },
+  opts: FakeOpts = {},
+): { run: DockerRun; calls: string[][]; containers: string[]; volumes: string[] } {
+  const calls: string[][] = [];
+  const containers = [...(world.containers ?? [])];
+  const volumes = [...(world.volumes ?? [])];
+  const lines = (xs: string[]) => (xs.length ? `${xs.join("\n")}\n` : "");
+  const DEAD = "Cannot connect to the Docker daemon at unix:///var/run/docker.sock";
+
+  const run: DockerRun = (args) => {
+    calls.push(args);
+    if (args[0] === "ps") {
+      if (opts.failList) return { code: 1, stdout: "", stderr: DEAD };
+      return { code: 0, stdout: lines(containers), stderr: "" };
+    }
+    if (args[0] === "volume" && args[1] === "ls") {
+      if (opts.failList) return { code: 1, stdout: "", stderr: DEAD };
+      return { code: 0, stdout: lines(volumes), stderr: "" };
+    }
+    if (args[0] === "rm") {
+      const ref = args[args.length - 1];
+      const code = opts.failRemove?.("container", ref);
+      if (code) return { code, stdout: "", stderr: `Error response from daemon: cannot remove container ${ref}` };
+      const i = containers.indexOf(ref);
+      if (i >= 0) containers.splice(i, 1);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "volume" && args[1] === "rm") {
+      const ref = args[args.length - 1];
+      const code = opts.failRemove?.("volume", ref);
+      if (code) return { code, stdout: "", stderr: `Error response from daemon: volume ${ref} is in use` };
+      const i = volumes.indexOf(ref);
+      if (i >= 0) volumes.splice(i, 1);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  return { run, calls, containers, volumes };
+}
+
+/** The refs a removal was ATTEMPTED against, in call order. */
+const removalTargets = (calls: string[][]): string[] =>
+  calls
+    .filter((a) => a[0] === "rm" || (a[0] === "volume" && a[1] === "rm"))
+    .map((a) => a[a.length - 1]);
+
+// --------------------------------------------------------------------------
+// destroySandbox
+// --------------------------------------------------------------------------
+describe("destroySandbox — a failed removal is retained, not dropped (#393)", () => {
+  it("complete success reports zero failures and nothing remaining", () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["ca-sbx-vol-id1"] });
+    const res = destroySandbox("id1", { dockerRun: run });
+
+    expect(res.removedContainers).toEqual(["c1"]);
+    expect(res.removedVolumes).toEqual(["ca-sbx-vol-id1"]);
+    expect(res.failures).toEqual([]);
+    expect(res.failureCount).toBe(0);
+    expect(res.remainingContainers).toEqual([]);
+    expect(res.remainingVolumes).toEqual([]);
+  });
+
+  it("a mixed run keeps the successes AND records the failure with its docker code", () => {
+    const { run } = fakeDocker(
+      { containers: ["c1"], volumes: ["ca-sbx-vol-id1"] },
+      { failRemove: (kind) => (kind === "volume" ? 125 : undefined) },
+    );
+    const res = destroySandbox("id1", { dockerRun: run });
+
+    // The container really went; the volume did not.
+    expect(res.removedContainers).toEqual(["c1"]);
+    expect(res.removedVolumes).toEqual([]);
+
+    expect(res.failureCount).toBe(1);
+    expect(res.failures).toHaveLength(1);
+    expect(res.failures[0].op).toBe("remove-volume");
+    expect(res.failures[0].ref).toBe("ca-sbx-vol-id1");
+    expect(res.failures[0].code).toBe(125);
+    expect(res.failures[0].message).toContain("in use");
+
+    // And the post-teardown verification names what was LEFT BEHIND.
+    expect(res.remainingContainers).toEqual([]);
+    expect(res.remainingVolumes).toEqual(["ca-sbx-vol-id1"]);
+  });
+
+  it("keeps attempting EVERY discovered target after the first failure", () => {
+    const { run, calls } = fakeDocker(
+      { containers: ["c1", "c2", "c3"], volumes: ["v1", "v2"] },
+      { failRemove: (_k, ref) => (ref === "c1" || ref === "v1" ? 125 : undefined) },
+    );
+    const res = destroySandbox("id1", { dockerRun: run });
+
+    // Partial teardown still removed what it could...
+    expect(res.removedContainers).toEqual(["c2", "c3"]);
+    expect(res.removedVolumes).toEqual(["v2"]);
+    // ...and no target was skipped because an earlier one failed.
+    expect(removalTargets(calls)).toEqual(["c1", "c2", "c3", "v1", "v2"]);
+
+    expect(res.failureCount).toBe(2);
+    expect(res.failures.map((f) => f.ref)).toEqual(["c1", "v1"]);
+    expect(res.remainingContainers).toEqual(["c1"]);
+    expect(res.remainingVolumes).toEqual(["v1"]);
+  });
+
+  it("a dead daemon is a FAILURE, not an empty successful sweep", () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["v1"] }, { failList: true });
+    const res = destroySandbox("id1", { dockerRun: run });
+
+    expect(res.removedContainers).toEqual([]);
+    expect(res.removedVolumes).toEqual([]);
+    // Discovery itself failed — reporting "nothing to remove" would be a lie.
+    expect(res.failureCount).toBeGreaterThan(0);
+    expect(res.failures.map((f) => f.op)).toContain("list-containers");
+    expect(res.failures.map((f) => f.op)).toContain("list-volumes");
+    expect(res.failures[0].message).toContain("Cannot connect to the Docker daemon");
+  });
+
+  it("--keep-volume: the deliberately kept volume is NOT reported as remaining", () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["ca-sbx-vol-id1"] });
+    const res = destroySandbox("id1", { keepVolume: true, dockerRun: run });
+
+    expect(res.keptVolumes).toEqual(["ca-sbx-vol-id1"]);
+    expect(res.failureCount).toBe(0);
+    expect(res.remainingVolumes).toEqual([]);
+    expect(res.remainingContainers).toEqual([]);
+  });
+
+  it("the failure list is BOUNDED while the count stays truthful", () => {
+    const many = Array.from({ length: 50 }, (_, i) => `c${i}`);
+    const { run } = fakeDocker({ containers: many }, { failRemove: () => 125 });
+    const res = destroySandbox("id1", { dockerRun: run });
+
+    expect(res.failureCount).toBe(50);
+    expect(res.failures.length).toBeGreaterThan(0);
+    expect(res.failures.length).toBeLessThanOrEqual(25);
+  });
+});
+
+// --------------------------------------------------------------------------
+// prune
+// --------------------------------------------------------------------------
+describe("prune — a failed reclaim is retained, not dropped (#393)", () => {
+  it("complete success reports zero failures and nothing remaining", () => {
+    const { run } = fakeDocker({ containers: ["c1", "c2"], volumes: ["vol-leaked"] });
+    const res = prune({ dockerRun: run });
+
+    expect(res.removedContainers).toEqual(["c1", "c2"]);
+    expect(res.removedVolumes).toEqual(["vol-leaked"]);
+    expect(res.failures).toEqual([]);
+    expect(res.failureCount).toBe(0);
+    expect(res.remainingContainers).toEqual([]);
+    expect(res.remainingVolumes).toEqual([]);
+  });
+
+  it("a mixed run records the failure and names the object left behind", () => {
+    const { run, calls } = fakeDocker(
+      { containers: ["c1", "c2"], volumes: ["vol-leaked"] },
+      { failRemove: (_k, ref) => (ref === "c2" ? 1 : undefined) },
+    );
+    const res = prune({ dockerRun: run });
+
+    expect(res.removedContainers).toEqual(["c1"]);
+    expect(res.removedVolumes).toEqual(["vol-leaked"]);
+    // c2's failure did not abort the sweep of the volumes.
+    expect(removalTargets(calls)).toEqual(["c1", "c2", "vol-leaked"]);
+
+    expect(res.failureCount).toBe(1);
+    expect(res.failures[0].op).toBe("remove-container");
+    expect(res.failures[0].ref).toBe("c2");
+    expect(res.failures[0].code).toBe(1);
+    expect(res.remainingContainers).toEqual(["c2"]);
+    expect(res.remainingVolumes).toEqual([]);
+  });
+
+  it("a dead daemon is a FAILURE, not an empty successful sweep", () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["v1"] }, { failList: true });
+    const res = prune({ dockerRun: run });
+
+    expect(res.removedContainers).toEqual([]);
+    expect(res.failureCount).toBeGreaterThan(0);
+    expect(res.failures.map((f) => f.op)).toContain("list-containers");
+  });
+});
+
+// --------------------------------------------------------------------------
+// the CLI exit code — the part automation actually reads
+// --------------------------------------------------------------------------
+function handlersOver(run: DockerRun): Handlers {
+  return {
+    create: async () => {
+      throw new Error("not used");
+    },
+    destroy: (id, opts) => destroySandbox(id, { keepVolume: opts.keepVolume, dockerRun: run }),
+    prune: () => prune({ dockerRun: run }),
+    exec: () => {
+      throw new Error("not used");
+    },
+    cp: () => {
+      throw new Error("not used");
+    },
+    shell: () => {
+      throw new Error("not used");
+    },
+  };
+}
+
+/** Run the CLI with stdout/stderr captured. */
+async function runCaptured(argv: string[], h: Handlers): Promise<{ code: number; out: string; err: string }> {
+  let out = "";
+  let err = "";
+  const o = vi.spyOn(process.stdout, "write").mockImplementation((c: any) => {
+    out += String(c);
+    return true;
+  });
+  const e = vi.spyOn(process.stderr, "write").mockImplementation((c: any) => {
+    err += String(c);
+    return true;
+  });
+  try {
+    const code = await runCli(argv, h);
+    return { code, out, err };
+  } finally {
+    o.mockRestore();
+    e.mockRestore();
+  }
+}
+
+describe("runCli — teardown failure must not exit 0 (#393)", () => {
+  it("`destroy` exits 0 and stays quiet on a clean teardown", async () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["ca-sbx-vol-id1"] });
+    const { code, err } = await runCaptured(["destroy", "id1"], handlersOver(run));
+    expect(code).toBe(0);
+    expect(err).toBe("");
+  });
+
+  it("`destroy` exits NON-ZERO and names the object left behind", async () => {
+    const { run } = fakeDocker(
+      { containers: ["c1"], volumes: ["ca-sbx-vol-id1"] },
+      { failRemove: (kind) => (kind === "volume" ? 125 : undefined) },
+    );
+    const { code, out, err } = await runCaptured(["destroy", "id1"], handlersOver(run));
+
+    expect(code).not.toBe(0);
+    // The diagnostic must name the leftover so an operator can clean up.
+    expect(err).toContain("ca-sbx-vol-id1");
+    expect(err).toMatch(/125/);
+    // The machine-readable result still carries the structured failures.
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.failureCount).toBe(1);
+    expect(parsed.remainingVolumes).toEqual(["ca-sbx-vol-id1"]);
+  });
+
+  it("`destroy` on a dead daemon exits NON-ZERO", async () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["v1"] }, { failList: true });
+    const { code, err } = await runCaptured(["destroy", "id1"], handlersOver(run));
+    expect(code).not.toBe(0);
+    expect(err).toContain("Cannot connect to the Docker daemon");
+  });
+
+  it("`destroy --keep-volume` still exits 0 — a kept volume is not a leak", async () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["ca-sbx-vol-id1"] });
+    const { code } = await runCaptured(["destroy", "id1", "--keep-volume"], handlersOver(run));
+    expect(code).toBe(0);
+  });
+
+  it("`prune` exits 0 on a clean sweep", async () => {
+    const { run } = fakeDocker({ containers: ["c1"], volumes: ["v1"] });
+    const { code, err } = await runCaptured(["prune"], handlersOver(run));
+    expect(code).toBe(0);
+    expect(err).toBe("");
+  });
+
+  it("`prune` exits NON-ZERO and names every object left behind", async () => {
+    const { run } = fakeDocker(
+      { containers: ["c1"], volumes: ["v1"] },
+      { failRemove: () => 125 },
+    );
+    const { code, out, err } = await runCaptured(["prune"], handlersOver(run));
+
+    expect(code).not.toBe(0);
+    expect(err).toContain("c1");
+    expect(err).toContain("v1");
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.failureCount).toBe(2);
+    expect(parsed.remainingContainers).toEqual(["c1"]);
+    expect(parsed.remainingVolumes).toEqual(["v1"]);
+  });
+
+  it("`prune` on a dead daemon exits NON-ZERO", async () => {
+    const { run } = fakeDocker({ containers: ["c1"] }, { failList: true });
+    const { code } = await runCaptured(["prune"], handlersOver(run));
+    expect(code).not.toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #393

## The defect, verified against source before any edit

All four claims in the issue held on current `origin/main` (`4ec1a8a`, post-#425):

| Site | Code |
|---|---|
| `destroy.ts:69` | `if (r.code === 0) removedContainers.push(c);` |
| `destroy.ts:81` | `if (r.code === 0) removedVolumes.push(v);` |
| `destroy.ts:113` | `if (r.code === 0) removedContainers.push(c);` |
| `destroy.ts:119` | `if (r.code === 0) removedVolumes.push(v);` |
| `cli.ts:368-377` | `destroy` and `prune` both `return 0;` unconditionally |

`DestroyResult` / `PruneResult` carried **no failure field at all**, so a non-zero docker result was not merely unreported — it was unrepresentable. A daemon outage, a permission error, or an in-use object left **untrusted sandbox containers and source volumes running while automation received exit 0**. That is a containment failure: the teardown guarantee was false precisely on the path where cleanup matters.

## The fix

Beyond "record the error", three properties:

1. **Best-effort, never aborting.** A failed removal no longer influences what else is attempted — every discovered container and volume is still targeted, so a partial teardown reclaims everything it can. Asserted directly: three containers, the first fails, all three are still attempted.
2. **Verified, not assumed.** After the removals both verbs re-list the same label scope and report what is **still present** (`remainingContainers` / `remainingVolumes`). A `--keep-volume` volume is a deliberate survivor and is excluded from that set, so keeping a volume is still a clean exit 0.
3. **A failed *listing* is itself a failure.** Discovery and verification route through new `listContainersResult` / `listVolumesResult` in `registry.ts`, which retain docker's exit code. Without this, a fully dead daemon discovers nothing, removes nothing, and reports a clean sweep — the exact false-negative the issue is about. `listContainers` / `listVolumes` become unchanged thin wrappers, so no read-only caller changes behavior.

Surfacing: `failures` is bounded (`MAX_TEARDOWN_FAILURES = 25`) while `failureCount` stays exact, so a wedged daemon cannot flood stdout/stderr yet the report never understates the damage. `teardownIncomplete()` is the verdict; `formatTeardownDiagnostic()` renders a bounded stderr report naming each failed op with docker's own exit code and message, then every object still present and the manual `docker rm -f` / `docker volume rm` needed. The full structured result still goes to stdout as JSON for scripting. New exit code `TEARDOWN_FAILURE_EXIT = 1`, distinct from `2` (usage error).

The verbs still **return** rather than throw — the exit-code decision belongs to the CLI, so a library caller can inspect a partial teardown instead of catching.

## Red test first — verbatim failure output

`teardown.test.ts` was written and run **before** any source change. It drives the real `destroySandbox` / `prune` and the real `runCli` over an injected **stateful** fake docker (a successful `rm` actually removes the object from later label listings), so the post-teardown verification is exercised honestly rather than against a listing frozen in time.

```
$ cd plugins/ca-sandbox/tools && npx vitest run teardown.test.ts --reporter=basic

 RUN  v2.1.9 .../plugins/ca-sandbox/tools

 ❯ teardown.test.ts (16 tests | 13 failed) 12ms
   × destroySandbox — a failed removal is retained, not dropped (#393) > complete success reports zero failures and nothing remaining 4ms
     → expected undefined to deeply equal []
   × destroySandbox — a failed removal is retained, not dropped (#393) > a mixed run keeps the successes AND records the failure with its docker code 1ms
     → expected undefined to be 1 // Object.is equality
   × destroySandbox — a failed removal is retained, not dropped (#393) > keeps attempting EVERY discovered target after the first failure 0ms
     → expected undefined to be 2 // Object.is equality
   × destroySandbox — a failed removal is retained, not dropped (#393) > a dead daemon is a FAILURE, not an empty successful sweep 2ms
     → actual value must be number or bigint, received "undefined"
   × destroySandbox — a failed removal is retained, not dropped (#393) > --keep-volume: the deliberately kept volume is NOT reported as remaining 0ms
     → expected undefined to be +0 // Object.is equality
   × destroySandbox — a failed removal is retained, not dropped (#393) > the failure list is BOUNDED while the count stays truthful 0ms
     → expected undefined to be 50 // Object.is equality
   × prune — a failed reclaim is retained, not dropped (#393) > complete success reports zero failures and nothing remaining 0ms
     → expected undefined to deeply equal []
   × prune — a failed reclaim is retained, not dropped (#393) > a mixed run records the failure and names the object left behind 0ms
     → expected undefined to be 1 // Object.is equality
   × prune — a failed reclaim is retained, not dropped (#393) > a dead daemon is a FAILURE, not an empty successful sweep 0ms
     → actual value must be number or bigint, received "undefined"
   × runCli — teardown failure must not exit 0 (#393) > `destroy` exits NON-ZERO and names the object left behind 1ms
     → expected +0 not to be +0 // Object.is equality
   × runCli — teardown failure must not exit 0 (#393) > `destroy` on a dead daemon exits NON-ZERO 0ms
     → expected +0 not to be +0 // Object.is equality
   × runCli — teardown failure must not exit 0 (#393) > `prune` exits NON-ZERO and names every object left behind 0ms
     → expected +0 not to be +0 // Object.is equality
   × runCli — teardown failure must not exit 0 (#393) > `prune` on a dead daemon exits NON-ZERO 0ms
     → expected +0 not to be +0 // Object.is equality

⎯⎯⎯⎯⎯⎯ Failed Tests 13 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  teardown.test.ts > destroySandbox — a failed removal is retained, not dropped (#393) > complete success reports zero failures and nothing remaining
AssertionError: expected undefined to deeply equal []

- Expected:
Array []

+ Received:
undefined

 ❯ teardown.test.ts:101:26
     99|     expect(res.removedContainers).toEqual(["c1"]);
    100|     expect(res.removedVolumes).toEqual(["ca-sbx-vol-id1"]);
    101|     expect(res.failures).toEqual([]);
       |                          ^
    102|     expect(res.failureCount).toBe(0);
    103|     expect(res.remainingContainers).toEqual([]);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/13]⎯

 FAIL  teardown.test.ts > destroySandbox — a failed removal is retained, not dropped (#393) > a mixed run keeps the successes AND records the failure with its docker code
AssertionError: expected undefined to be 1 // Object.is equality

- Expected:
1

+ Received:
undefined

 ❯ teardown.test.ts:118:30
    116|     expect(res.removedVolumes).toEqual([]);
    117|
    118|     expect(res.failureCount).toBe(1);
       |                              ^
    119|     expect(res.failures).toHaveLength(1);
    120|     expect(res.failures[0].op).toBe("remove-volume");

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/13]⎯

 Test Files  1 failed (1)
      Tests  13 failed | 3 passed (16)
```

Each failure is on the defect itself — the missing failure surface (`undefined` where a `failures` / `failureCount` / `remaining*` field must be) and the exit-0 path (`expected +0 not to be +0`) — not on an import or a compile error. The 3 that passed pre-fix are the clean-teardown cases, which correctly exited 0 already; they are kept so the fix cannot be a blanket "always fail".

## Before / after

| Suite | Before (origin/main `4ec1a8a`) | After |
|---|---|---|
| `plugins/ca-sandbox/tools` — `npx vitest run` (docker-gated) | 18 files / 209 passed | **18 files / 225 passed** (+16 new in `teardown.test.ts`) |
| `plugins/ca-sandbox/tools` — `npx tsc --noEmit` | clean | clean |
| `plugins/ca/hooks/tests` — `python -m unittest` | 1057 OK | **1057 OK** |
| `.github/scripts` — `python -m unittest` | 1064 run, 4 errors/failures, 5 skipped | **1064 run, same 4, 5 skipped** (unchanged — see below) |
| `python tools/build-host-packages.py --check --release-guard-base <merge-base>` | pass | pass (no Pi payload change) |
| `python3 .github/scripts/check-plugin-refs.py ca-sandbox` | pass | pass |
| `sandbox.js` staleness gate (rebuild + `git diff --quiet`) | n/a | clean after rebuild |

Baseline `209` is arithmetic-exact, not estimated: the only test file added is `teardown.test.ts` (16 cases); the edits to `cli.test.ts` and `lifecycle.test.ts` add assertions to existing cases, never new ones.

The 4 non-green `.github/scripts` results are **pre-existing and environmental**, identical before and after this branch: `test_pi_benchmark` requires `plugins/ca-pi/tools/node_modules` (the pinned esbuild), which is not installed in this worktree — the harness itself raises `RuntimeError: Pi benchmark requires the installed pinned esbuild`. Nothing in this diff touches Pi.

## Test changes to pre-existing files, and why

`lifecycle.test.ts`'s `fakeDocker` returned scripted stdout per arg-match, so its label listings were **frozen in time**: a removed object still appeared in every later listing. That was invisible while teardown never re-listed. Now that teardown verifies its own work, such a fake would report every successfully removed object as a leak and would lock in a physically impossible docker. Its `fakeDocker` now models removal (a successful `rm` drops the ref from later listings) — the same discipline the new suite uses. Existing assertions are untouched and still pass; three clean-teardown cases gained `failureCount` / `remaining*` assertions.

`cli.test.ts`'s `fakeHandlers` gained the new success-shape fields (they are required by the widened result types).

## Prose

`commands/sandbox-destroy.md` and `skills/sandbox-lifecycle/SKILL.md` state the new contract as a hard gate: a teardown may not report success when docker refused a removal or the verification could not confirm the scope is empty. The prose previously promised "zero labeled objects remain" with no statement of what happens when that promise cannot be kept.

## Payload version

`ca-sandbox` `0.1.4 -> 0.1.5` with a new dated CHANGELOG section. Tag `ca-sandbox-v0.1.4` is unpublished, so the CI guard would have tolerated staying on `0.1.4`; a distinct section was chosen so this behavioral change is not filed under #424's "supply-chain hardening" heading.

## NEEDS-TRIAGE (not in this diff)

- **`create.ts`'s clone-failure rollback has the same shape.** On a failed clone it fires `docker rm -f` / `volume rm -f` for the half-built sandbox and ignores the exit codes (`create.ts` ~L451), so a rollback that docker refuses leaves a labeled volume behind and the caller only sees the clone error. Less severe than #393 (the object is labeled, so `prune` can still reclaim it, and no container is running untrusted code yet) but it is the same silent-drop pattern. Deliberately out of scope — #393 names `destroy.ts` and `cli.ts` only.
- **`registry.ts:labelValue` swallows a failed inspect** (`if (r.code !== 0) return ""`), so a container whose inspect fails is silently grouped under the leaked/no-id bucket in `listSandboxes`. Read-only surface, no containment impact, but it makes a docker error look like a legitimately unlabeled object.
- **`destroy`/`prune` never re-attempt a failed removal.** A volume that is momentarily in-use fails once and is reported as remaining. A bounded retry (or removing containers, waiting, then volumes) would cut the false-leak rate. Explicitly not added here: it is a behavior change beyond the issue, and a wrong retry policy on a wedged daemon is worse than an honest failure report.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
