### PR TITLE
fix(farm): isolate and atomically publish run receipts, fail the run when they cannot land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,17 +48,23 @@ predate the plugin rewrite and are grouped by date.
   allowing invalid legacy values to escape fail-open handling.
 - Farm runs now own their receipts. Every run publishes its stream, per-task
   diffs, and JSON/Markdown report under `.farm/runs/<run-id>/`, so two farm
-  processes against one repository can no longer erase each other's evidence;
+  processes against one repository can no longer erase each other's artifacts;
   the familiar top-level `.farm/` paths remain as a latest pointer. Every report
-  write is atomic (same-directory temp file, fsync, rename), so a crash
-  mid-publication leaves the previous complete artifact instead of truncated
-  JSON. `FARM_RUN_ID` pins a run's id and artifact directory.
-- A farm run that cannot publish its authoritative report now fails with a
-  dedicated exit code 3 and suppresses the success `Report:` breadcrumb,
-  instead of exiting 0 and pointing operators at a file that was never
-  written. Streaming-rail and per-task diff write failures are no longer
-  swallowed: the published report records the rail as incomplete and names
-  every task whose diff evidence is unavailable.
+  write is atomic (same-directory temp file, rename), so a crash mid-publication
+  leaves the previous complete artifact instead of truncated JSON. `FARM_RUN_ID`
+  pins a run's id and artifact directory, and minted run ids widened to 64 bits
+  now that the id names a directory rather than only a log field. Concurrent
+  runs still share git state; the farm docs now name the exact settings
+  (`FARM_INTEGRATION_BRANCH`, `FARM_WORKTREE_ROOT`, non-overlapping task ids)
+  that a second simultaneous run needs.
+- A farm run that cannot publish its authoritative, run-scoped report now fails
+  with a dedicated exit code 3 and suppresses the success `Report:` breadcrumb,
+  instead of exiting 0 and pointing operators at a file that was never written.
+  A failure to refresh the non-authoritative top-level latest pointer is
+  reported as a warning and does not fail the run. Streaming-rail and per-task
+  diff write failures are no longer swallowed: the published report records the
+  rail as incomplete and names the tasks whose diff evidence is unavailable,
+  with a true total alongside the bounded list.
 
 ## [2.9.1] — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ predate the plugin rewrite and are grouped by date.
   no longer inflate the context-benefit decision or arm the cold-cache nudge.
 - Prune hooks now ignore and repair malformed per-session state instead of
   allowing invalid legacy values to escape fail-open handling.
+- Farm runs now own their receipts. Every run publishes its stream, per-task
+  diffs, and JSON/Markdown report under `.farm/runs/<run-id>/`, so two farm
+  processes against one repository can no longer erase each other's evidence;
+  the familiar top-level `.farm/` paths remain as a latest pointer. Every report
+  write is atomic (same-directory temp file, fsync, rename), so a crash
+  mid-publication leaves the previous complete artifact instead of truncated
+  JSON. `FARM_RUN_ID` pins a run's id and artifact directory.
+- A farm run that cannot publish its authoritative report now fails with a
+  dedicated exit code 3 and suppresses the success `Report:` breadcrumb,
+  instead of exiting 0 and pointing operators at a file that was never
+  written. Streaming-rail and per-task diff write failures are no longer
+  swallowed: the published report records the rail as incomplete and names
+  every task whose diff evidence is unavailable.
 
 ## [2.9.1] — 2026-07-20
 

--- a/core/surface/includes/farm.md
+++ b/core/surface/includes/farm.md
@@ -126,6 +126,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -175,13 +176,29 @@ Normal use: `{{CMD:sprint}} --farm` — the skill handles model selection and di
 
 ## Report artifacts
 
-After a run, the farm writes to `{{PROJECT_DIR}}/.farm/`:
+Every run owns an artifact directory keyed by its run id — `{{PROJECT_DIR}}/.farm/runs/<run-id>/` — and
+that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
+overwrite each other's evidence:
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
-  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons.
+  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
+  `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
+  unavailable.
 - `farm-report.md` — human-readable summary table.
+- `farm-results.jsonl` — this run's incremental settlement stream.
 - `diffs/<task-id>.patch` — the actual change each task produced, for audit.
+
+The historical top-level paths remain as a **latest** convenience pointer, republished from the run's
+own artifacts: `.farm/farm-report.json`, `.farm/farm-report.md`, `.farm/farm-results.jsonl`,
+`.farm/diffs/<task-id>.patch`. Under concurrency the pointer is last-writer-wins — always a complete
+artifact, never a truncated one, but attributable only via its `run_id`. Reconcile against the run
+directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
+
+Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
+leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
+be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
+failure is reported distinctly from a task failure (exit 2), never as success.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/core/surface/includes/farm.md
+++ b/core/surface/includes/farm.md
@@ -126,7 +126,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
-| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. Reusing an id publishes over that directory's receipts, so pin a fresh one per run. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -177,8 +177,9 @@ Normal use: `{{CMD:sprint}} --farm` — the skill handles model selection and di
 ## Report artifacts
 
 Every run owns an artifact directory keyed by its run id — `{{PROJECT_DIR}}/.farm/runs/<run-id>/` — and
-that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
-overwrite each other's evidence:
+that directory is the **durable receipt**, written by that run alone. Two farm processes against one
+repository therefore cannot overwrite each other's *evidence* (see the concurrency caveat below — the
+receipts are isolated, the git state is not):
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
   warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
   `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
@@ -195,10 +196,27 @@ directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
 
-Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
-leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
-be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
-failure is reported distinctly from a task failure (exit 2), never as success.
+Every report write is atomic (same-directory temp file, then rename), so a reader of a report path sees
+either the previous complete artifact or the new one — never a truncated one, and never a half-written
+file left by a crash mid-publication. (Atomicity, not crash durability: the rename itself is not
+fsynced, so a host power-loss immediately after publication can still lose it.) If the run's
+**authoritative, run-scoped** report cannot be published in full, the run **exits 3** and suppresses the
+success `Report:` breadcrumb — a receipt failure is reported distinctly from a task failure (exit 2),
+never as success. Failing to refresh the *latest* pointer is **not** exit 3: it is non-authoritative, so
+it prints a warning naming what was not refreshed and the run still settles on its task outcome.
+
+### Concurrency: what is and is not safe
+
+Run-scoped receipts make concurrent runs non-destructive to each other's **artifacts**. They do not make
+the **git state** concurrent. At default settings a second simultaneous run fails at startup with
+`cannot lock ref 'refs/heads/farm/integration'`, because every run claims the same integration branch.
+To run two farms against one repository at the same time, give each process:
+- a distinct `FARM_INTEGRATION_BRANCH` (default `farm/integration` is shared and single-claim);
+- a distinct `FARM_WORKTREE_ROOT` (default `.farm/worktrees`), unless the plans' task ids are disjoint —
+  per-task worktrees are `<FARM_WORKTREE_ROOT>/<task-id>`;
+- plans whose **task ids do not overlap**: each task's branch is `farm/<task-id>` regardless of run id,
+  so two runs carrying the same task id fight over one branch. There is no env var for this — rename
+  the tasks.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/core/surface/skills/subagent-driven-development/references/farm-dispatch.md
+++ b/core/surface/skills/subagent-driven-development/references/farm-dispatch.md
@@ -64,7 +64,22 @@ enforces gates and a zero-token anti-gaming guard, and writes to `{{PROJECT_DIR}
   each task settles (drives completion-order consumption — see Step 2.6)
 - `diffs/<task-id>.patch` — the actual change per task, for audit
 
-Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
+Each of those is published twice: once under the run's own artifact directory
+`{{PROJECT_DIR}}/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
+overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
+The final summary line prints both. When two runs may share a repository, reconcile against the run
+directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
+**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
+not a task failure — the tasks may all have been green — and it means there is no durable record to
+reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
+exited 3.
+
+`farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
+streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
+`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
+Never assume a `diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/core/surface/skills/subagent-driven-development/references/farm-dispatch.md
+++ b/core/surface/skills/subagent-driven-development/references/farm-dispatch.md
@@ -66,20 +66,31 @@ enforces gates and a zero-token anti-gaming guard, and writes to `{{PROJECT_DIR}
 
 Each of those is published twice: once under the run's own artifact directory
 `{{PROJECT_DIR}}/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
-overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
-The final summary line prints both. When two runs may share a repository, reconcile against the run
-directory; the pointer is last-writer-wins (always complete, never truncated).
+overwrite each other's artifacts) and once at the top-level `.farm/` path above as a **latest**
+convenience pointer. The final summary line prints both. When two runs may share a repository, reconcile
+against the run directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Isolated receipts are not a licence to run two farms on one repository unattended: the git state is
+still shared. Concurrent runs each need a distinct `FARM_INTEGRATION_BRANCH` and `FARM_WORKTREE_ROOT`,
+and non-overlapping task ids (each task branch is `farm/<task-id>`). At defaults the second run fails at
+startup on `cannot lock ref 'refs/heads/farm/integration'`.
 
 Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
-**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
-not a task failure — the tasks may all have been green — and it means there is no durable record to
-reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
-exited 3.
+**exit code 3 = the run's authoritative, run-scoped report could not be published in full.** Exit 3 is a
+RECEIPT failure, not a task failure — the tasks may all have been green — and it means this run's
+durable record is missing or incomplete. Treat the run as unverified and re-dispatch; do not accept
+tasks off a run that exited 3. Inspect `.farm/runs/<run-id>/` for whatever did land before discarding.
+
+A failure to refresh the top-level **latest** pointer is *not* exit 3 — that pointer is explicitly
+non-authoritative. The run settles on its task outcome and prints a `WARNING:` naming what could not be
+refreshed; when you see it, `.farm/farm-report.json` describes some *other* run, so read the run
+directory.
 
 `farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
 streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
-`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
-Never assume a `diffs/<task-id>.patch` exists for a task listed there.
+`artifacts.diffs.unavailable[]` names tasks whose patch could not be written, with the reason. That
+list is capped — `artifacts.diffs.unavailable_total` is the true count. Never assume a
+`diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/includes/farm.md
+++ b/plugins/ca-codex/includes/farm.md
@@ -120,7 +120,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
-| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. Reusing an id publishes over that directory's receipts, so pin a fresh one per run. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -163,8 +163,9 @@ Normal use: `$ca-sprint --farm` — the skill handles model selection and dispat
 ## Report artifacts
 
 Every run owns an artifact directory keyed by its run id — `<project-root>/.farm/runs/<run-id>/` — and
-that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
-overwrite each other's evidence:
+that directory is the **durable receipt**, written by that run alone. Two farm processes against one
+repository therefore cannot overwrite each other's *evidence* (see the concurrency caveat below — the
+receipts are isolated, the git state is not):
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
   warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
   `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
@@ -181,10 +182,27 @@ directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
 
-Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
-leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
-be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
-failure is reported distinctly from a task failure (exit 2), never as success.
+Every report write is atomic (same-directory temp file, then rename), so a reader of a report path sees
+either the previous complete artifact or the new one — never a truncated one, and never a half-written
+file left by a crash mid-publication. (Atomicity, not crash durability: the rename itself is not
+fsynced, so a host power-loss immediately after publication can still lose it.) If the run's
+**authoritative, run-scoped** report cannot be published in full, the run **exits 3** and suppresses the
+success `Report:` breadcrumb — a receipt failure is reported distinctly from a task failure (exit 2),
+never as success. Failing to refresh the *latest* pointer is **not** exit 3: it is non-authoritative, so
+it prints a warning naming what was not refreshed and the run still settles on its task outcome.
+
+### Concurrency: what is and is not safe
+
+Run-scoped receipts make concurrent runs non-destructive to each other's **artifacts**. They do not make
+the **git state** concurrent. At default settings a second simultaneous run fails at startup with
+`cannot lock ref 'refs/heads/farm/integration'`, because every run claims the same integration branch.
+To run two farms against one repository at the same time, give each process:
+- a distinct `FARM_INTEGRATION_BRANCH` (default `farm/integration` is shared and single-claim);
+- a distinct `FARM_WORKTREE_ROOT` (default `.farm/worktrees`), unless the plans' task ids are disjoint —
+  per-task worktrees are `<FARM_WORKTREE_ROOT>/<task-id>`;
+- plans whose **task ids do not overlap**: each task's branch is `farm/<task-id>` regardless of run id,
+  so two runs carrying the same task id fight over one branch. There is no env var for this — rename
+  the tasks.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/plugins/ca-codex/includes/farm.md
+++ b/plugins/ca-codex/includes/farm.md
@@ -120,6 +120,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -161,13 +162,29 @@ Normal use: `$ca-sprint --farm` — the skill handles model selection and dispat
 
 ## Report artifacts
 
-After a run, the farm writes to `<project-root>/.farm/`:
+Every run owns an artifact directory keyed by its run id — `<project-root>/.farm/runs/<run-id>/` — and
+that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
+overwrite each other's evidence:
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
-  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons.
+  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
+  `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
+  unavailable.
 - `farm-report.md` — human-readable summary table.
+- `farm-results.jsonl` — this run's incremental settlement stream.
 - `diffs/<task-id>.patch` — the actual change each task produced, for audit.
+
+The historical top-level paths remain as a **latest** convenience pointer, republished from the run's
+own artifacts: `.farm/farm-report.json`, `.farm/farm-report.md`, `.farm/farm-results.jsonl`,
+`.farm/diffs/<task-id>.patch`. Under concurrency the pointer is last-writer-wins — always a complete
+artifact, never a truncated one, but attributable only via its `run_id`. Reconcile against the run
+directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
+
+Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
+leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
+be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
+failure is reported distinctly from a task failure (exit 2), never as success.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/plugins/ca-codex/routines/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca-codex/routines/subagent-driven-development/references/farm-dispatch.md
@@ -53,20 +53,31 @@ enforces gates and a zero-token anti-gaming guard, and writes to `<project-root>
 
 Each of those is published twice: once under the run's own artifact directory
 `<project-root>/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
-overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
-The final summary line prints both. When two runs may share a repository, reconcile against the run
-directory; the pointer is last-writer-wins (always complete, never truncated).
+overwrite each other's artifacts) and once at the top-level `.farm/` path above as a **latest**
+convenience pointer. The final summary line prints both. When two runs may share a repository, reconcile
+against the run directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Isolated receipts are not a licence to run two farms on one repository unattended: the git state is
+still shared. Concurrent runs each need a distinct `FARM_INTEGRATION_BRANCH` and `FARM_WORKTREE_ROOT`,
+and non-overlapping task ids (each task branch is `farm/<task-id>`). At defaults the second run fails at
+startup on `cannot lock ref 'refs/heads/farm/integration'`.
 
 Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
-**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
-not a task failure — the tasks may all have been green — and it means there is no durable record to
-reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
-exited 3.
+**exit code 3 = the run's authoritative, run-scoped report could not be published in full.** Exit 3 is a
+RECEIPT failure, not a task failure — the tasks may all have been green — and it means this run's
+durable record is missing or incomplete. Treat the run as unverified and re-dispatch; do not accept
+tasks off a run that exited 3. Inspect `.farm/runs/<run-id>/` for whatever did land before discarding.
+
+A failure to refresh the top-level **latest** pointer is *not* exit 3 — that pointer is explicitly
+non-authoritative. The run settles on its task outcome and prints a `WARNING:` naming what could not be
+refreshed; when you see it, `.farm/farm-report.json` describes some *other* run, so read the run
+directory.
 
 `farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
 streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
-`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
-Never assume a `diffs/<task-id>.patch` exists for a task listed there.
+`artifacts.diffs.unavailable[]` names tasks whose patch could not be written, with the reason. That
+list is capped — `artifacts.diffs.unavailable_total` is the true count. Never assume a
+`diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/plugins/ca-codex/routines/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca-codex/routines/subagent-driven-development/references/farm-dispatch.md
@@ -51,7 +51,22 @@ enforces gates and a zero-token anti-gaming guard, and writes to `<project-root>
   each task settles (drives completion-order consumption — see Step 2.6)
 - `diffs/<task-id>.patch` — the actual change per task, for audit
 
-Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
+Each of those is published twice: once under the run's own artifact directory
+`<project-root>/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
+overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
+The final summary line prints both. When two runs may share a repository, reconcile against the run
+directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
+**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
+not a task failure — the tasks may all have been green — and it means there is no durable record to
+reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
+exited 3.
+
+`farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
+streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
+`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
+Never assume a `diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.4] - 2026-07-24
+
+### Changed
+
+- Refreshed the bundled farm surface (`includes/farm.md`, the
+  `subagent-driven-development` farm-dispatch reference) for run-scoped farm
+  receipts: the run's artifact directory is the authoritative receipt, the
+  top-level `.farm/` paths are a non-authoritative latest pointer, exit 3 is
+  reserved for a failure of the run-scoped report, and the concurrency caveat
+  (`FARM_INTEGRATION_BRANCH`, `FARM_WORKTREE_ROOT`, non-overlapping task ids)
+  is now stated where operators read it. Prose-only; no Pi adapter code changed.
+
 ## [0.1.3] - 2026-07-24
 
 ### Security

--- a/plugins/ca-pi/includes/farm.md
+++ b/plugins/ca-pi/includes/farm.md
@@ -119,7 +119,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
-| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. Reusing an id publishes over that directory's receipts, so pin a fresh one per run. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -165,8 +165,9 @@ Normal use: `/ca-sprint --farm` — the skill handles model selection and dispat
 ## Report artifacts
 
 Every run owns an artifact directory keyed by its run id — `<project-root>/.farm/runs/<run-id>/` — and
-that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
-overwrite each other's evidence:
+that directory is the **durable receipt**, written by that run alone. Two farm processes against one
+repository therefore cannot overwrite each other's *evidence* (see the concurrency caveat below — the
+receipts are isolated, the git state is not):
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
   warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
   `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
@@ -183,10 +184,27 @@ directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
 
-Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
-leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
-be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
-failure is reported distinctly from a task failure (exit 2), never as success.
+Every report write is atomic (same-directory temp file, then rename), so a reader of a report path sees
+either the previous complete artifact or the new one — never a truncated one, and never a half-written
+file left by a crash mid-publication. (Atomicity, not crash durability: the rename itself is not
+fsynced, so a host power-loss immediately after publication can still lose it.) If the run's
+**authoritative, run-scoped** report cannot be published in full, the run **exits 3** and suppresses the
+success `Report:` breadcrumb — a receipt failure is reported distinctly from a task failure (exit 2),
+never as success. Failing to refresh the *latest* pointer is **not** exit 3: it is non-authoritative, so
+it prints a warning naming what was not refreshed and the run still settles on its task outcome.
+
+### Concurrency: what is and is not safe
+
+Run-scoped receipts make concurrent runs non-destructive to each other's **artifacts**. They do not make
+the **git state** concurrent. At default settings a second simultaneous run fails at startup with
+`cannot lock ref 'refs/heads/farm/integration'`, because every run claims the same integration branch.
+To run two farms against one repository at the same time, give each process:
+- a distinct `FARM_INTEGRATION_BRANCH` (default `farm/integration` is shared and single-claim);
+- a distinct `FARM_WORKTREE_ROOT` (default `.farm/worktrees`), unless the plans' task ids are disjoint —
+  per-task worktrees are `<FARM_WORKTREE_ROOT>/<task-id>`;
+- plans whose **task ids do not overlap**: each task's branch is `farm/<task-id>` regardless of run id,
+  so two runs carrying the same task id fight over one branch. There is no env var for this — rename
+  the tasks.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/plugins/ca-pi/includes/farm.md
+++ b/plugins/ca-pi/includes/farm.md
@@ -119,6 +119,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -163,13 +164,29 @@ Normal use: `/ca-sprint --farm` — the skill handles model selection and dispat
 
 ## Report artifacts
 
-After a run, the farm writes to `<project-root>/.farm/`:
+Every run owns an artifact directory keyed by its run id — `<project-root>/.farm/runs/<run-id>/` — and
+that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
+overwrite each other's evidence:
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
-  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons.
+  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
+  `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
+  unavailable.
 - `farm-report.md` — human-readable summary table.
+- `farm-results.jsonl` — this run's incremental settlement stream.
 - `diffs/<task-id>.patch` — the actual change each task produced, for audit.
+
+The historical top-level paths remain as a **latest** convenience pointer, republished from the run's
+own artifacts: `.farm/farm-report.json`, `.farm/farm-report.md`, `.farm/farm-results.jsonl`,
+`.farm/diffs/<task-id>.patch`. Under concurrency the pointer is last-writer-wins — always a complete
+artifact, never a truncated one, but attributable only via its `run_id`. Reconcile against the run
+directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
+
+Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
+leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
+be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
+failure is reported distinctly from a task failure (exit 2), never as success.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/routines/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca-pi/routines/subagent-driven-development/references/farm-dispatch.md
@@ -60,20 +60,31 @@ enforces gates and a zero-token anti-gaming guard, and writes to `<project-root>
 
 Each of those is published twice: once under the run's own artifact directory
 `<project-root>/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
-overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
-The final summary line prints both. When two runs may share a repository, reconcile against the run
-directory; the pointer is last-writer-wins (always complete, never truncated).
+overwrite each other's artifacts) and once at the top-level `.farm/` path above as a **latest**
+convenience pointer. The final summary line prints both. When two runs may share a repository, reconcile
+against the run directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Isolated receipts are not a licence to run two farms on one repository unattended: the git state is
+still shared. Concurrent runs each need a distinct `FARM_INTEGRATION_BRANCH` and `FARM_WORKTREE_ROOT`,
+and non-overlapping task ids (each task branch is `farm/<task-id>`). At defaults the second run fails at
+startup on `cannot lock ref 'refs/heads/farm/integration'`.
 
 Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
-**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
-not a task failure — the tasks may all have been green — and it means there is no durable record to
-reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
-exited 3.
+**exit code 3 = the run's authoritative, run-scoped report could not be published in full.** Exit 3 is a
+RECEIPT failure, not a task failure — the tasks may all have been green — and it means this run's
+durable record is missing or incomplete. Treat the run as unverified and re-dispatch; do not accept
+tasks off a run that exited 3. Inspect `.farm/runs/<run-id>/` for whatever did land before discarding.
+
+A failure to refresh the top-level **latest** pointer is *not* exit 3 — that pointer is explicitly
+non-authoritative. The run settles on its task outcome and prints a `WARNING:` naming what could not be
+refreshed; when you see it, `.farm/farm-report.json` describes some *other* run, so read the run
+directory.
 
 `farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
 streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
-`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
-Never assume a `diffs/<task-id>.patch` exists for a task listed there.
+`artifacts.diffs.unavailable[]` names tasks whose patch could not be written, with the reason. That
+list is capped — `artifacts.diffs.unavailable_total` is the true count. Never assume a
+`diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/plugins/ca-pi/routines/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca-pi/routines/subagent-driven-development/references/farm-dispatch.md
@@ -58,7 +58,22 @@ enforces gates and a zero-token anti-gaming guard, and writes to `<project-root>
   each task settles (drives completion-order consumption — see Step 2.6)
 - `diffs/<task-id>.patch` — the actual change per task, for audit
 
-Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
+Each of those is published twice: once under the run's own artifact directory
+`<project-root>/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
+overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
+The final summary line prints both. When two runs may share a repository, reconcile against the run
+directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
+**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
+not a task failure — the tasks may all have been green — and it means there is no durable record to
+reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
+exited 3.
+
+`farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
+streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
+`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
+Never assume a `diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -120,7 +120,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
-| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. Reusing an id publishes over that directory's receipts, so pin a fresh one per run. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -163,8 +163,9 @@ Normal use: `/ca:sprint --farm` — the skill handles model selection and dispat
 ## Report artifacts
 
 Every run owns an artifact directory keyed by its run id — `${CLAUDE_PROJECT_DIR}/.farm/runs/<run-id>/` — and
-that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
-overwrite each other's evidence:
+that directory is the **durable receipt**, written by that run alone. Two farm processes against one
+repository therefore cannot overwrite each other's *evidence* (see the concurrency caveat below — the
+receipts are isolated, the git state is not):
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
   warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
   `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
@@ -181,10 +182,27 @@ directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
 
-Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
-leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
-be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
-failure is reported distinctly from a task failure (exit 2), never as success.
+Every report write is atomic (same-directory temp file, then rename), so a reader of a report path sees
+either the previous complete artifact or the new one — never a truncated one, and never a half-written
+file left by a crash mid-publication. (Atomicity, not crash durability: the rename itself is not
+fsynced, so a host power-loss immediately after publication can still lose it.) If the run's
+**authoritative, run-scoped** report cannot be published in full, the run **exits 3** and suppresses the
+success `Report:` breadcrumb — a receipt failure is reported distinctly from a task failure (exit 2),
+never as success. Failing to refresh the *latest* pointer is **not** exit 3: it is non-authoritative, so
+it prints a warning naming what was not refreshed and the run still settles on its task outcome.
+
+### Concurrency: what is and is not safe
+
+Run-scoped receipts make concurrent runs non-destructive to each other's **artifacts**. They do not make
+the **git state** concurrent. At default settings a second simultaneous run fails at startup with
+`cannot lock ref 'refs/heads/farm/integration'`, because every run claims the same integration branch.
+To run two farms against one repository at the same time, give each process:
+- a distinct `FARM_INTEGRATION_BRANCH` (default `farm/integration` is shared and single-claim);
+- a distinct `FARM_WORKTREE_ROOT` (default `.farm/worktrees`), unless the plans' task ids are disjoint —
+  per-task worktrees are `<FARM_WORKTREE_ROOT>/<task-id>`;
+- plans whose **task ids do not overlap**: each task's branch is `farm/<task-id>` regardless of run id,
+  so two runs carrying the same task id fight over one branch. There is no env var for this — rename
+  the tasks.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -120,6 +120,7 @@ picks a model by *measurement*, not hearsay:
 | `FARM_MUTATION_WARN_BELOW` | `0.5` | Score below this attaches a warning into Phase 3. |
 | `FARM_MUTATION_ESCALATE_BELOW` | `0.1` | Score at/below this (≥5 mutants) hard-escalates. |
 | `FARM_MUTATION_CMD` | _(unset)_ | Pluggable external mutation framework hook. |
+| `FARM_RUN_ID` | _(random)_ | Pin this run's id — also the name of its artifact directory (`.farm/runs/<run-id>/`). Must be 1–64 chars of `[A-Za-z0-9._-]`; anything else is refused at startup. |
 
 ## Per-worktree setup (dependency hook)
 
@@ -161,13 +162,29 @@ Normal use: `/ca:sprint --farm` — the skill handles model selection and dispat
 
 ## Report artifacts
 
-After a run, the farm writes to `${CLAUDE_PROJECT_DIR}/.farm/`:
+Every run owns an artifact directory keyed by its run id — `${CLAUDE_PROJECT_DIR}/.farm/runs/<run-id>/` — and
+that directory is the **durable receipt**. Two farm processes against one repository therefore cannot
+overwrite each other's evidence:
 - `farm-report.json` — structured results: per-task status, attempts, files written, worker token spend,
-  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons.
+  warnings (gaming-risk), and an `aborted` flag; plus a `blocked[]` array with reasons, and an
+  `artifacts` block stating whether the streaming rail was complete and which tasks' diff evidence is
+  unavailable.
 - `farm-report.md` — human-readable summary table.
+- `farm-results.jsonl` — this run's incremental settlement stream.
 - `diffs/<task-id>.patch` — the actual change each task produced, for audit.
+
+The historical top-level paths remain as a **latest** convenience pointer, republished from the run's
+own artifacts: `.farm/farm-report.json`, `.farm/farm-report.md`, `.farm/farm-results.jsonl`,
+`.farm/diffs/<task-id>.patch`. Under concurrency the pointer is last-writer-wins — always a complete
+artifact, never a truncated one, but attributable only via its `run_id`. Reconcile against the run
+directory when it matters. Also in `.farm/`:
 - `canary-report.json` — model-probe ranking (when `--canary` was run).
 - `model-cache.json` — last selected model + timestamp + canary pass-rate.
+
+Every report write is atomic (same-directory temp file, fsync, rename), so a crash mid-publication
+leaves the previous complete artifact rather than a truncated one. If the authoritative report cannot
+be published at all, the run **exits 3** and suppresses the success `Report:` breadcrumb — a receipt
+failure is reported distinctly from a task failure (exit 2), never as success.
 
 Escalated tasks leave their worktrees at `.farm/worktrees/<task-id>/` for inspection.
 

--- a/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
@@ -51,7 +51,22 @@ enforces gates and a zero-token anti-gaming guard, and writes to `${CLAUDE_PROJE
   each task settles (drives completion-order consumption — see Step 2.6)
 - `diffs/<task-id>.patch` — the actual change per task, for audit
 
-Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted.
+Each of those is published twice: once under the run's own artifact directory
+`${CLAUDE_PROJECT_DIR}/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
+overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
+The final summary line prints both. When two runs may share a repository, reconcile against the run
+directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
+**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
+not a task failure — the tasks may all have been green — and it means there is no durable record to
+reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
+exited 3.
+
+`farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
+streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
+`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
+Never assume a `diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
+++ b/plugins/ca/skills/subagent-driven-development/references/farm-dispatch.md
@@ -53,20 +53,31 @@ enforces gates and a zero-token anti-gaming guard, and writes to `${CLAUDE_PROJE
 
 Each of those is published twice: once under the run's own artifact directory
 `${CLAUDE_PROJECT_DIR}/.farm/runs/<run-id>/` (the durable, attributable receipt — concurrent runs never
-overwrite each other) and once at the top-level `.farm/` path above as a **latest** convenience pointer.
-The final summary line prints both. When two runs may share a repository, reconcile against the run
-directory; the pointer is last-writer-wins (always complete, never truncated).
+overwrite each other's artifacts) and once at the top-level `.farm/` path above as a **latest**
+convenience pointer. The final summary line prints both. When two runs may share a repository, reconcile
+against the run directory; the pointer is last-writer-wins (always complete, never truncated).
+
+Isolated receipts are not a licence to run two farms on one repository unattended: the git state is
+still shared. Concurrent runs each need a distinct `FARM_INTEGRATION_BRANCH` and `FARM_WORKTREE_ROOT`,
+and non-overlapping task ids (each task branch is `farm/<task-id>`). At defaults the second run fails at
+startup on `cannot lock ref 'refs/heads/farm/integration'`.
 
 Exit code 0 = all green; exit code 2 = some tasks escalated, blocked, or the run was aborted;
-**exit code 3 = the run's authoritative report could not be published.** Exit 3 is a RECEIPT failure,
-not a task failure — the tasks may all have been green — and it means there is no durable record to
-reconcile against. Treat the run as unverified and re-dispatch; do not accept tasks off a run that
-exited 3.
+**exit code 3 = the run's authoritative, run-scoped report could not be published in full.** Exit 3 is a
+RECEIPT failure, not a task failure — the tasks may all have been green — and it means this run's
+durable record is missing or incomplete. Treat the run as unverified and re-dispatch; do not accept
+tasks off a run that exited 3. Inspect `.farm/runs/<run-id>/` for whatever did land before discarding.
+
+A failure to refresh the top-level **latest** pointer is *not* exit 3 — that pointer is explicitly
+non-authoritative. The run settles on its task outcome and prints a `WARNING:` naming what could not be
+refreshed; when you see it, `.farm/farm-report.json` describes some *other* run, so read the run
+directory.
 
 `farm-report.json` also carries an `artifacts` block: `artifacts.stream.complete` is `false` when a
 streaming-rail write failed (so a short `.jsonl` is not mistaken for a short run), and
-`artifacts.diffs.unavailable[]` names every task whose patch could not be written, with the reason.
-Never assume a `diffs/<task-id>.patch` exists for a task listed there.
+`artifacts.diffs.unavailable[]` names tasks whose patch could not be written, with the reason. That
+list is capped — `artifacts.diffs.unavailable_total` is the true count. Never assume a
+`diffs/<task-id>.patch` exists for a task listed there.
 
 ## Step 2.5 — Circuit-breaker abort
 

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -896,7 +896,7 @@ async function resetWorktree(wt) {
   await git(["clean", "-fd"], wt);
 }
 function mintRunId() {
-  return randomBytes(3).toString("hex");
+  return randomBytes(8).toString("hex");
 }
 var msgOf = (e) => e instanceof Error ? e.message : String(e);
 var SAFE_RUN_ID = /^[A-Za-z0-9._-]{1,64}$/;
@@ -943,12 +943,25 @@ async function atomicWriteFile(dest, data) {
   }
 }
 function newRunArtifactHealth() {
-  return { stream: { errors: [] }, diffs: { unavailable: [], latestMirrorErrors: [] } };
+  return {
+    stream: { errors: [] },
+    diffs: { unavailable: [], unavailableTotal: 0, latestMirrorErrors: [] },
+    report: { latestMirrorErrors: [] }
+  };
 }
 var MAX_RECORDED_ARTIFACT_ERRORS = 10;
 function noteArtifactError(bucket, message) {
   if (bucket.length < MAX_RECORDED_ARTIFACT_ERRORS) bucket.push(message);
   else if (bucket.length === MAX_RECORDED_ARTIFACT_ERRORS) bucket.push("(further errors suppressed)");
+}
+function noteUnavailableDiff(diffs, id, reason) {
+  diffs.unavailableTotal += 1;
+  if (diffs.unavailable.length < MAX_RECORDED_ARTIFACT_ERRORS) diffs.unavailable.push({ id, reason });
+  else if (diffs.unavailable.length === MAX_RECORDED_ARTIFACT_ERRORS)
+    diffs.unavailable.push({
+      id: "(suppressed)",
+      reason: `further entries suppressed after ${MAX_RECORDED_ARTIFACT_ERRORS}`
+    });
 }
 var mergeChain = Promise.resolve();
 var integrationWorktree;
@@ -1568,6 +1581,7 @@ ${String(e.stack).slice(0, 1500)}` : ""}`
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
   const runExitCode = esc || blocked.length || aborted ? 2 : 0;
   const exitCode = publishError ? 3 : runExitCode;
+  const latestReportErrors = health.report.latestMirrorErrors;
   const summary = [
     aborted ? `
 ABORTED by circuit breaker \u2014 escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
@@ -1576,14 +1590,30 @@ Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
     `Run: ${runId}  (artifacts: ${runDir})`,
-    // The success breadcrumb is SUPPRESSED when publication failed — pointing an
-    // operator at a farm-report.md that is not there is the defect.
+    // The success breadcrumb is SUPPRESSED when the authoritative publication
+    // failed — pointing an operator at a farm-report.md that is not there is
+    // the defect. Every claim below has to be true of what is actually on disk:
+    // the message names the run directory and says "missing or incomplete"
+    // rather than asserting no receipt exists, because a partial failure (e.g.
+    // the JSON landed and the Markdown did not) leaves a real receipt behind.
     publishError ? [
       `
-RECEIPT PUBLICATION FAILED \u2014 run ${runId} could not publish its authoritative report: ${msgOf(publishError)}`,
-      `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but there is no durable receipt for this run,`,
-      `so it cannot be reconciled or audited. Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`
-    ].join("\n") : `Report: ${path3.join(runDir, "farm-report.md")}  (latest: ${path3.join(ENV.reportDir, "farm-report.md")})`,
+RECEIPT PUBLICATION FAILED \u2014 run ${runId} could not publish its complete authoritative report under ${runDir}: ${msgOf(publishError)}`,
+      `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but this run's durable receipt is missing or incomplete,`,
+      `so it cannot be reliably reconciled or audited. Inspect ${runDir} for whatever did land.`,
+      `${path3.join(ENV.reportDir, "farm-report.json")} / .md were NOT refreshed and do not describe run ${runId}.`,
+      `Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`
+    ].join("\n") : latestReportErrors.length ? (
+      // Non-fatal, and stated as such. The authoritative receipt is
+      // unaffected; what the operator must not assume is that the shared
+      // path now describes THIS run.
+      [
+        `Report: ${path3.join(runDir, "farm-report.md")}`,
+        `WARNING: the latest convenience pointer under ${ENV.reportDir} could not be refreshed for this run:`,
+        ...latestReportErrors.map((m) => `  - ${m}`),
+        `The authoritative receipt above is unaffected, but ${path3.join(ENV.reportDir, "farm-report.json")} does not describe run ${runId}.`
+      ].join("\n")
+    ) : `Report: ${path3.join(runDir, "farm-report.md")}  (latest: ${path3.join(ENV.reportDir, "farm-report.md")})`,
     ""
   ].join("\n");
   await new Promise((resolve) => process.stdout.write(summary, () => resolve()));
@@ -1604,12 +1634,12 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
   );
   for (const r of results) {
     if (diffsDirError !== null) {
-      unavailable.push({ id: r.id, reason: `diffs directory unavailable: ${diffsDirError}` });
+      noteUnavailableDiff(health.diffs, r.id, `diffs directory unavailable: ${diffsDirError}`);
       continue;
     }
     const d = await git(["diff", `${ENV.base}...${r.branch}`]);
     if (d.code !== 0) {
-      unavailable.push({ id: r.id, reason: `git diff failed: ${d.out.trim().split("\n")[0] ?? ""}`.slice(0, 300) });
+      noteUnavailableDiff(health.diffs, r.id, `git diff failed: ${d.out.trim().split("\n")[0] ?? ""}`.slice(0, 300));
       continue;
     }
     if (!d.out.trim()) continue;
@@ -1618,7 +1648,7 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
       await atomicWriteFile(dest, d.out);
       patchPath.set(r.id, dest);
     } catch (e) {
-      unavailable.push({ id: r.id, reason: `patch write failed: ${msgOf(e)}` });
+      noteUnavailableDiff(health.diffs, r.id, `patch write failed: ${msgOf(e)}`);
       continue;
     }
     await atomicWriteFile(path3.join(latestDiffsDir, `${r.id}.patch`), d.out).catch(
@@ -1639,7 +1669,10 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
     diffs: {
       dir: diffsDir,
       latest_dir: latestDiffsDir,
+      // `unavailable` is capped; `unavailable_total` is not, so a bounded list
+      // never understates how many tasks lack diff evidence.
       unavailable,
+      unavailable_total: health.diffs.unavailableTotal,
       latest_mirror_errors: health.diffs.latestMirrorErrors
     }
   };
@@ -1667,7 +1700,10 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
     ...results.filter((r) => r.status === "escalate").map((r) => `- **${r.id}** \u2014 worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
     ``,
     `## Diff evidence`,
-    ...unavailable.length ? unavailable.map((u) => `- **${u.id}** \u2014 diff evidence unavailable: ${u.reason}`) : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`],
+    ...health.diffs.unavailableTotal ? [
+      `${health.diffs.unavailableTotal} task(s) have no diff evidence${unavailable.length < health.diffs.unavailableTotal ? ` (first ${MAX_RECORDED_ARTIFACT_ERRORS} listed)` : ``}:`,
+      ...unavailable.map((u) => `- **${u.id}** \u2014 diff evidence unavailable: ${u.reason}`)
+    ] : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`],
     ``,
     `## Warnings \u2014 review during spec-compliance`,
     ...results.filter((r) => r.warning).map((r) => {
@@ -1677,8 +1713,13 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
   ].join("\n");
   await atomicWriteFile(path3.join(runDir, "farm-report.json"), json);
   await atomicWriteFile(path3.join(runDir, "farm-report.md"), md);
-  await atomicWriteFile(path3.join(ENV.reportDir, "farm-report.json"), json);
-  await atomicWriteFile(path3.join(ENV.reportDir, "farm-report.md"), md);
+  for (const [dest, data] of [
+    [path3.join(ENV.reportDir, "farm-report.json"), json],
+    [path3.join(ENV.reportDir, "farm-report.md"), md]
+  ])
+    await atomicWriteFile(dest, data).catch(
+      (e) => noteArtifactError(health.report.latestMirrorErrors, `${dest}: ${msgOf(e)}`)
+    );
 }
 var _thisFile = fileURLToPath(import.meta.url);
 var _entryFile = path3.resolve(process.argv[1] ?? "");

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // farm.ts
-import { readFile as readFile2, writeFile, appendFile, mkdir as mkdir2, rm } from "node:fs/promises";
+import { readFile as readFile2, writeFile, appendFile, mkdir as mkdir2, rm, rename, open as open2 } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import path3 from "node:path";
@@ -441,6 +441,10 @@ var ENV = {
   integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
   worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
+  // #397: an orchestrator may PIN this run's id, which is also the name of the
+  // run-scoped artifact directory (`${reportDir}/runs/<runId>/`). Absent → a
+  // fresh random id per invocation (mintRunId).
+  runId: process.env.FARM_RUN_ID ?? null,
   // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
   requestTimeoutMs: numEnv("FARM_REQUEST_TIMEOUT_MS", 12e4, { min: 1 }),
   // Per-candidate wall-clock cap for the #93 entitlement pre-screen, so one
@@ -685,12 +689,12 @@ function extractFileBlocks(content) {
   const blocks = [];
   let i = 0;
   while (i < lines.length) {
-    const open2 = lines[i].match(/^\s*```(.*)$/);
-    if (!open2) {
+    const open3 = lines[i].match(/^\s*```(.*)$/);
+    if (!open3) {
       i++;
       continue;
     }
-    const info = open2[1].trim();
+    const info = open3[1].trim();
     const body = [];
     i++;
     while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
@@ -893,6 +897,58 @@ async function resetWorktree(wt) {
 }
 function mintRunId() {
   return randomBytes(3).toString("hex");
+}
+var msgOf = (e) => e instanceof Error ? e.message : String(e);
+var SAFE_RUN_ID = /^[A-Za-z0-9._-]{1,64}$/;
+function assertSafeRunId(id) {
+  if (!SAFE_RUN_ID.test(id) || id === "." || id === "..")
+    throw new Error(
+      `FARM_RUN_ID must be 1-64 characters of [A-Za-z0-9._-] and not "." or ".." (got ${JSON.stringify(id)})`
+    );
+  return id;
+}
+function runArtifactDir(runId) {
+  return path3.join(ENV.reportDir, "runs", runId);
+}
+async function renameWithRetry(from, to, attempts = 4) {
+  for (let i = 0; ; i++) {
+    try {
+      await rename(from, to);
+      return;
+    } catch (e) {
+      const code = e.code ?? "";
+      if (i >= attempts - 1 || !["EPERM", "EACCES", "EBUSY"].includes(code)) throw e;
+      await new Promise((r) => setTimeout(r, 15 * (i + 1)));
+    }
+  }
+}
+async function atomicWriteFile(dest, data) {
+  const tmp = path3.join(
+    path3.dirname(dest),
+    `.${path3.basename(dest)}.${process.pid}-${randomBytes(4).toString("hex")}.tmp`
+  );
+  const fh = await open2(tmp, "w");
+  try {
+    await fh.writeFile(data, "utf8");
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+  try {
+    await renameWithRetry(tmp, dest);
+  } catch (e) {
+    await rm(tmp, { force: true }).catch(() => {
+    });
+    throw e;
+  }
+}
+function newRunArtifactHealth() {
+  return { stream: { errors: [] }, diffs: { unavailable: [], latestMirrorErrors: [] } };
+}
+var MAX_RECORDED_ARTIFACT_ERRORS = 10;
+function noteArtifactError(bucket, message) {
+  if (bucket.length < MAX_RECORDED_ARTIFACT_ERRORS) bucket.push(message);
+  else if (bucket.length === MAX_RECORDED_ARTIFACT_ERRORS) bucket.push("(further errors suppressed)");
 }
 var mergeChain = Promise.resolve();
 var integrationWorktree;
@@ -1376,19 +1432,37 @@ async function main() {
   }
   if (canary) return runCanary(plan);
   const { model, apiBaseUrl, apiKey } = resolveConfig(plan);
-  const runId = mintRunId();
+  let runId;
+  try {
+    runId = ENV.runId === null ? mintRunId() : assertSafeRunId(ENV.runId);
+  } catch (e) {
+    console.error(`Error: ${msgOf(e)}`);
+    return process.exit(1);
+  }
+  const runDir = runArtifactDir(runId);
   await mkdir2(ENV.worktreeRoot, { recursive: true });
   await mkdir2(ENV.reportDir, { recursive: true });
-  const resultsStream = path3.join(ENV.reportDir, "farm-results.jsonl");
-  await writeFile(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
+  await mkdir2(runDir, { recursive: true });
+  const health = newRunArtifactHealth();
+  const resultsStream = path3.join(runDir, "farm-results.jsonl");
+  const latestStream = path3.join(ENV.reportDir, "farm-results.jsonl");
+  const streamLines = [];
+  const noteStreamFailure = (what, e) => {
+    const m = `${what}: ${msgOf(e)}`;
+    console.error(`results stream ${m}`);
+    noteArtifactError(health.stream.errors, m);
+  };
+  await writeFile(resultsStream, "").catch((e) => noteStreamFailure("run-scoped init failed", e));
+  await atomicWriteFile(latestStream, "").catch((e) => noteStreamFailure("latest pointer init failed", e));
   const done = /* @__PURE__ */ new Map();
   const blocked = [];
   let aborted = false;
+  let publishError = null;
   try {
     const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
     if (branchResult.code !== 0)
       throw new Error(`could not create integration branch '${ENV.integration}' from '${ENV.base}': ${branchResult.out}`);
-    integrationWorktree = path3.resolve(ENV.reportDir, "integration-wt");
+    integrationWorktree = path3.resolve(runDir, "integration-wt");
     await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
     });
     await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {
@@ -1463,7 +1537,12 @@ ${String(e.stack).slice(0, 1500)}` : ""}`
         r.note = r.note ? `${r.note} (run aborted by circuit breaker while in flight)` : "escalate: run aborted (in flight)";
       }
       done.set(id, r);
-      await appendFile(resultsStream, JSON.stringify(r) + "\n").catch((e) => console.error("results stream append failed:", e));
+      const line = JSON.stringify(r) + "\n";
+      streamLines.push(line);
+      await appendFile(resultsStream, line).catch((e) => noteStreamFailure("run-scoped append failed", e));
+      await atomicWriteFile(latestStream, streamLines.join("")).catch(
+        (e) => noteStreamFailure("latest pointer publish failed", e)
+      );
       if (r.status === "escalate") escalated.add(id);
     }
     for (const id of pending) {
@@ -1472,7 +1551,12 @@ ${String(e.stack).slice(0, 1500)}` : ""}`
       blocked.push({ id, reason: aborted ? "run aborted (circuit breaker)" : culprit ? `dependency ${culprit} escalated` : "not scheduled" });
     }
   } finally {
-    await writeReport(plan, [...done.values()], blocked, aborted, runId).catch((e) => console.error("report write failed:", e));
+    try {
+      await writeReport(plan, [...done.values()], blocked, aborted, runId, health);
+    } catch (e) {
+      publishError = e;
+      console.error("report publication failed:", e);
+    }
     if (integrationWorktree)
       await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
       });
@@ -1482,7 +1566,8 @@ ${String(e.stack).slice(0, 1500)}` : ""}`
   const green = results.filter((r) => r.status === "green").length;
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
-  const exitCode = esc || blocked.length || aborted ? 2 : 0;
+  const runExitCode = esc || blocked.length || aborted ? 2 : 0;
+  const exitCode = publishError ? 3 : runExitCode;
   const summary = [
     aborted ? `
 ABORTED by circuit breaker \u2014 escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
@@ -1490,32 +1575,87 @@ ABORTED by circuit breaker \u2014 escalation rate exceeded ${ENV.abortEscalation
 Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
-    `Report: ${path3.join(ENV.reportDir, "farm-report.md")}`,
+    `Run: ${runId}  (artifacts: ${runDir})`,
+    // The success breadcrumb is SUPPRESSED when publication failed — pointing an
+    // operator at a farm-report.md that is not there is the defect.
+    publishError ? [
+      `
+RECEIPT PUBLICATION FAILED \u2014 run ${runId} could not publish its authoritative report: ${msgOf(publishError)}`,
+      `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but there is no durable receipt for this run,`,
+      `so it cannot be reconciled or audited. Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`
+    ].join("\n") : `Report: ${path3.join(runDir, "farm-report.md")}  (latest: ${path3.join(ENV.reportDir, "farm-report.md")})`,
     ""
   ].join("\n");
   await new Promise((resolve) => process.stdout.write(summary, () => resolve()));
   process.exit(exitCode);
 }
-async function writeReport(plan, results, blocked, aborted, runId) {
-  await mkdir2(path3.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {
+async function writeReport(plan, results, blocked, aborted, runId, health) {
+  const runDir = runArtifactDir(runId);
+  const diffsDir = path3.join(runDir, "diffs");
+  const latestDiffsDir = path3.join(ENV.reportDir, "diffs");
+  const unavailable = health.diffs.unavailable;
+  const patchPath = /* @__PURE__ */ new Map();
+  let diffsDirError = null;
+  await mkdir2(diffsDir, { recursive: true }).catch((e) => {
+    diffsDirError = msgOf(e);
   });
+  await mkdir2(latestDiffsDir, { recursive: true }).catch(
+    (e) => noteArtifactError(health.diffs.latestMirrorErrors, `mkdir: ${msgOf(e)}`)
+  );
   for (const r of results) {
+    if (diffsDirError !== null) {
+      unavailable.push({ id: r.id, reason: `diffs directory unavailable: ${diffsDirError}` });
+      continue;
+    }
     const d = await git(["diff", `${ENV.base}...${r.branch}`]);
-    if (d.code === 0 && d.out.trim())
-      await writeFile(path3.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {
-      });
+    if (d.code !== 0) {
+      unavailable.push({ id: r.id, reason: `git diff failed: ${d.out.trim().split("\n")[0] ?? ""}`.slice(0, 300) });
+      continue;
+    }
+    if (!d.out.trim()) continue;
+    const dest = path3.join(diffsDir, `${r.id}.patch`);
+    try {
+      await atomicWriteFile(dest, d.out);
+      patchPath.set(r.id, dest);
+    } catch (e) {
+      unavailable.push({ id: r.id, reason: `patch write failed: ${msgOf(e)}` });
+      continue;
+    }
+    await atomicWriteFile(path3.join(latestDiffsDir, `${r.id}.patch`), d.out).catch(
+      (e) => noteArtifactError(health.diffs.latestMirrorErrors, `${r.id}: ${msgOf(e)}`)
+    );
   }
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
-  await writeFile(
-    path3.join(ENV.reportDir, "farm-report.json"),
-    JSON.stringify({ run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, ts: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)
+  const streamComplete = health.stream.errors.length === 0;
+  const artifacts = {
+    run_dir: runDir,
+    stream: {
+      path: path3.join(runDir, "farm-results.jsonl"),
+      latest: path3.join(ENV.reportDir, "farm-results.jsonl"),
+      complete: streamComplete,
+      errors: health.stream.errors
+    },
+    diffs: {
+      dir: diffsDir,
+      latest_dir: latestDiffsDir,
+      unavailable,
+      latest_mirror_errors: health.diffs.latestMirrorErrors
+    }
+  };
+  const json = JSON.stringify(
+    { run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, artifacts, ts: (/* @__PURE__ */ new Date()).toISOString() },
+    null,
+    2
   );
   const md = [
     `# Farm report \u2014 ${plan.meta.name}`,
     ``,
     aborted ? `> **ABORTED by circuit breaker** \u2014 escalation rate exceeded threshold.
 ` : ``,
+    streamComplete ? `` : `> **Streaming rail incomplete** \u2014 ${health.stream.errors.length} write failure(s) on \`farm-results.jsonl\`; this report is authoritative for settled tasks.
+`,
+    `Run: \`${runId}\` \u2014 artifacts under \`${runDir}\``,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     ``,
     `| task | status | attempts | files | mut | branch | note |`,
@@ -1526,10 +1666,19 @@ async function writeReport(plan, results, blocked, aborted, runId) {
     `## Escalations \u2014 handle only these`,
     ...results.filter((r) => r.status === "escalate").map((r) => `- **${r.id}** \u2014 worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
     ``,
+    `## Diff evidence`,
+    ...unavailable.length ? unavailable.map((u) => `- **${u.id}** \u2014 diff evidence unavailable: ${u.reason}`) : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`],
+    ``,
     `## Warnings \u2014 review during spec-compliance`,
-    ...results.filter((r) => r.warning).map((r) => `- **${r.id}** \u2014 ${r.warning} (diff: \`${path3.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`)
+    ...results.filter((r) => r.warning).map((r) => {
+      const p = patchPath.get(r.id);
+      return `- **${r.id}** \u2014 ${r.warning} (${p ? `diff: \`${p}\`` : "diff evidence unavailable"})`;
+    })
   ].join("\n");
-  await writeFile(path3.join(ENV.reportDir, "farm-report.md"), md);
+  await atomicWriteFile(path3.join(runDir, "farm-report.json"), json);
+  await atomicWriteFile(path3.join(runDir, "farm-report.md"), md);
+  await atomicWriteFile(path3.join(ENV.reportDir, "farm-report.json"), json);
+  await atomicWriteFile(path3.join(ENV.reportDir, "farm-report.md"), md);
 }
 var _thisFile = fileURLToPath(import.meta.url);
 var _entryFile = path3.resolve(process.argv[1] ?? "");
@@ -1541,11 +1690,14 @@ if (_thisFile === _entryFile) {
 }
 export {
   DEFAULT_API_BASE_URL,
+  SAFE_RUN_ID,
   SAFE_TASK_ID,
   _resetAllowedWorktreeRoot,
   allowedWorktreeRoot,
   assertContainedWorktree,
+  assertSafeRunId,
   assertSecureBaseUrl,
+  atomicWriteFile,
   buildChatBody,
   buildPrompt,
   captureInScope,
@@ -1557,12 +1709,14 @@ export {
   httpWorker,
   makeEntitlementProbe,
   mintRunId,
+  newRunArtifactHealth,
   numEnv,
   parseChatCompletion,
   parseMutationHookOutput,
   readSampling,
   redactSecrets,
   run,
+  runArtifactDir,
   runGate,
   runTask,
   screenEntitlements,

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -1591,4 +1591,69 @@ describe("farm artifact publication (#397 / #387)", () => {
     expect(report.artifacts.diffs.unavailable.map((u: { id: string }) => u.id)).toEqual(["task-a"]);
     expect(existsSync(join(tmpDir, ".farm/runs/patchbad/diffs/task-b.patch"))).toBe(true);
   });
+
+  // -------------------------------------------------------------------------
+  // #387 — the authoritative/convenience split has to hold in BOTH directions.
+  // Exit 3 is reserved for a failure of the run-scoped receipt; the "latest"
+  // pointer is explicitly non-authoritative, so its failure must not sink a run
+  // whose durable receipt is on disk, and no emitted message may deny a receipt
+  // that exists.
+  // -------------------------------------------------------------------------
+  it("#387: a failed LATEST report pointer does not fail a run whose authoritative receipt landed", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("mirror-fail", ["task-a", "task-b"], port));
+    // Block only the non-authoritative convenience pointer.
+    mkdirSync(join(tmpDir, ".farm/farm-report.json"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "mirrorbad" });
+
+    // The durable receipt is on disk, so this is not a receipt failure.
+    expect(existsSync(join(tmpDir, ".farm/runs/mirrorbad/farm-report.json"))).toBe(true);
+    expect(existsSync(join(tmpDir, ".farm/runs/mirrorbad/farm-report.md"))).toBe(true);
+    expect(result.code, result.out).toBe(0);
+    expect(result.out).not.toMatch(/RECEIPT PUBLICATION FAILED/);
+    // The operator is still pointed at the receipt that exists...
+    expect(result.out).toContain(join(".farm", "runs", "mirrorbad", "farm-report.md"));
+    // ...and told, truthfully, that the shared pointer was not refreshed.
+    expect(result.out).toMatch(/latest.*pointer.*not.*refresh/i);
+  });
+
+  it("#387: the exit-3 message names the run's artifact directory and never denies a receipt that exists", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("md-only-fail", ["task-a"], port));
+    // The Markdown receipt cannot be published; the JSON one still can.
+    mkdirSync(join(tmpDir, ".farm/runs/mdonly/farm-report.md"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "mdonly" });
+    expect(result.code).toBe(3);
+    // The JSON receipt DID land — a message asserting "there is no durable
+    // receipt for this run" would be false.
+    expect(existsSync(join(tmpDir, ".farm/runs/mdonly/farm-report.json"))).toBe(true);
+    expect(result.out).not.toMatch(/there is no durable receipt/i);
+    expect(result.out).toContain(join(".farm", "runs", "mdonly"));
+  });
+
+  it("#387: the unavailable-diff list is bounded and still reports the true total", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const ids = Array.from({ length: 12 }, (_, i) => `bulk${i}`);
+    const planPath = writePlan("plan.json", planFor("bounded", ids, port));
+    mkdirSync(join(tmpDir, ".farm/runs/bounded"), { recursive: true });
+    // A regular FILE where the diffs directory belongs → every task's diff
+    // evidence is unavailable for the same single reason.
+    writeFileSync(join(tmpDir, ".farm/runs/bounded/diffs"), "not a directory");
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_RUN_ID: "bounded",
+      FARM_CONCURRENCY: "6",
+    });
+    expect(result.code, result.out).toBe(0);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/runs/bounded/farm-report.json"), "utf8"));
+    // 12 tasks, one diagnosis — the report carries the diagnosis and the count,
+    // not 12 copies of the same line.
+    expect(report.artifacts.diffs.unavailable_total).toBe(12);
+    expect(report.artifacts.diffs.unavailable.length).toBeLessThanOrEqual(11);
+    const md = readFileSync(join(tmpDir, ".farm/runs/bounded/farm-report.md"), "utf8");
+    expect(md).toMatch(/12 task\(s\) have no diff evidence/i);
+  });
 });

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -1332,3 +1332,263 @@ describe("farm.ts smoke tests", () => {
     expect(result.out).toContain("FARM_API_KEY is not set");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #397 — run-scoped artifact isolation + atomic publication.
+// #387 — a failure to publish the authoritative receipt fails the run.
+//
+// These exercise the full dispatcher through a subprocess because the defects
+// live in main()'s artifact lifecycle (stream init/append, diff writes, final
+// report publication, exit-code derivation), not in a pure helper.
+// ---------------------------------------------------------------------------
+describe("farm artifact publication (#397 / #387)", () => {
+  let tmpDir: string;
+  let mockServer: Server;
+  let port: number;
+
+  // Every task in these plans owns exactly one `src/<id>.ts`; the worker echoes
+  // back whichever in-scope file the prompt names.
+  function greenHandler(): MockHandler {
+    return (body) => {
+      const content = (body as { messages?: Array<{ content?: string }> }).messages?.[0]?.content ?? "";
+      const m = /\bsrc\/([A-Za-z0-9_-]+)\.ts\b/.exec(content);
+      const file = m ? `src/${m[1]}.ts` : "src/fallback.ts";
+      return ["```typescript", `// path: ${file}`, "export const x = 1;", "```"].join("\n");
+    };
+  }
+
+  function planFor(name: string, ids: string[], p: number) {
+    return {
+      meta: { name, model: "test-model", apiBaseUrl: `http://127.0.0.1:${p}` },
+      tasks: ids.map((id) => ({
+        id,
+        description: `Write src/${id}.ts`,
+        deps: [] as string[],
+        filesInScope: [`src/${id}.ts`],
+        test: { path: `src/${id}.spec.ts` },
+        gate: { commands: ["node -p 0"] },
+      })),
+    };
+  }
+
+  function writePlan(file: string, plan: unknown) {
+    const p = join(tmpDir, file);
+    writeFileSync(p, JSON.stringify(plan));
+    return p;
+  }
+
+  function jsonl(file: string) {
+    return readFileSync(file, "utf8")
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as { id: string; runId?: string });
+  }
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `farm-artifacts-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    createTempRepo(tmpDir);
+  });
+
+  afterEach(() => {
+    mockServer?.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // #397
+  // -------------------------------------------------------------------------
+  it("#397: a run publishes its receipts under a run-scoped directory and still exposes the latest convenience copies", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("scoped", ["task-a", "task-b"], port));
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_RUN_ID: "runone",
+    });
+    expect(result.code).toBe(0);
+
+    const runDir = join(tmpDir, ".farm/runs/runone");
+    const report = JSON.parse(readFileSync(join(runDir, "farm-report.json"), "utf8"));
+    expect(report.run_id).toBe("runone");
+    expect(report.results.map((r: { id: string }) => r.id).sort()).toEqual(["task-a", "task-b"]);
+    expect(existsSync(join(runDir, "farm-report.md"))).toBe(true);
+    expect(jsonl(join(runDir, "farm-results.jsonl"))).toHaveLength(2);
+    expect(existsSync(join(runDir, "diffs/task-a.patch"))).toBe(true);
+    expect(existsSync(join(runDir, "diffs/task-b.patch"))).toBe(true);
+
+    // The documented "latest" convenience paths still resolve to this run.
+    const latest = JSON.parse(readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8"));
+    expect(latest.run_id).toBe("runone");
+    expect(existsSync(join(tmpDir, ".farm/farm-report.md"))).toBe(true);
+    expect(jsonl(join(tmpDir, ".farm/farm-results.jsonl"))).toHaveLength(2);
+  });
+
+  it("#397: two concurrent farm processes on one repo both keep complete, independently parseable receipts", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planA = writePlan("plan-a.json", planFor("run-a", ["alpha1", "alpha2"], port));
+    const planB = writePlan("plan-b.json", planFor("run-b", ["bravo1", "bravo2"], port));
+
+    // Same repo, same shared `.farm` report dir, launched together. The git-side
+    // scratch (integration branch, worktree root) is separated per process so
+    // this test isolates the ARTIFACT contract rather than git ref contention.
+    const common = { FARM_API_KEY: "test-key", FARM_CONCURRENCY: "2" };
+    const [a, b] = await Promise.all([
+      runFarm(tmpDir, planA, {
+        ...common,
+        FARM_RUN_ID: "runalpha",
+        FARM_WORKTREE_ROOT: ".farm/wt-alpha",
+        FARM_INTEGRATION_BRANCH: "farm/integration-alpha",
+      }),
+      runFarm(tmpDir, planB, {
+        ...common,
+        FARM_RUN_ID: "runbravo",
+        FARM_WORKTREE_ROOT: ".farm/wt-bravo",
+        FARM_INTEGRATION_BRANCH: "farm/integration-bravo",
+      }),
+    ]);
+
+    expect([a.code, b.code], `${a.out}\n---\n${b.out}`).toEqual([0, 0]);
+
+    for (const [runId, ids] of [
+      ["runalpha", ["alpha1", "alpha2"]],
+      ["runbravo", ["bravo1", "bravo2"]],
+    ] as const) {
+      const runDir = join(tmpDir, ".farm/runs", runId);
+      const report = JSON.parse(readFileSync(join(runDir, "farm-report.json"), "utf8"));
+      expect(report.run_id).toBe(runId);
+      expect(report.results.map((r: { id: string }) => r.id).sort()).toEqual([...ids]);
+      expect(report.results.every((r: { status: string }) => r.status === "green")).toBe(true);
+
+      // The streaming rail is this run's alone — no cross-run lines, no
+      // truncation by the sibling process.
+      const lines = jsonl(join(runDir, "farm-results.jsonl"));
+      expect(lines.map((l) => l.id).sort()).toEqual([...ids]);
+      expect(lines.every((l) => l.runId === runId)).toBe(true);
+
+      // Markdown + per-task diff evidence survive for both runs.
+      expect(readFileSync(join(runDir, "farm-report.md"), "utf8")).toContain(ids[0]);
+      for (const id of ids) expect(existsSync(join(runDir, "diffs", `${id}.patch`))).toBe(true);
+    }
+  });
+
+  it("#397: a failed report publication leaves the previous run's complete report intact — never a truncated one", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("prior", ["task-a", "task-b"], port));
+
+    const first = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "goodrun" });
+    expect(first.code).toBe(0);
+    const before = readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8");
+    expect(JSON.parse(before).run_id).toBe("goodrun");
+
+    // Make the second run's authoritative JSON unwritable (a directory sits at
+    // the destination path) so publication fails mid-run.
+    mkdirSync(join(tmpDir, ".farm/runs/badrun/farm-report.json"), { recursive: true });
+    const second = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "badrun" });
+    expect(second.code).not.toBe(0);
+
+    const after = readFileSync(join(tmpDir, ".farm/farm-report.json"), "utf8");
+    expect(() => JSON.parse(after)).not.toThrow();
+    expect(JSON.parse(after).run_id).toBe("goodrun");
+    expect(after).toBe(before);
+  });
+
+  it("#397: rejects a caller-supplied run id that is not a safe single path segment", async () => {
+    const planPath = writePlan("plan.json", planFor("bad-id", ["task-a"], 9));
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_RUN_ID: "../escape",
+    });
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("FARM_RUN_ID");
+  });
+
+  // -------------------------------------------------------------------------
+  // #387
+  // -------------------------------------------------------------------------
+  it("#387: a green run whose farm-report.json cannot be published exits non-zero and never claims a Report path", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("json-fail", ["task-a", "task-b"], port));
+    mkdirSync(join(tmpDir, ".farm/runs/jsonbad/farm-report.json"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "jsonbad" });
+
+    // Every task went green — the RUN succeeded, the RECEIPT did not. Those are
+    // distinguished in both the exit code and the message.
+    expect(result.out).toContain("green=2");
+    expect(result.code).toBe(3);
+    expect(result.out).toMatch(/receipt/i);
+    expect(result.out).not.toMatch(/^Report: /m);
+  });
+
+  it("#387: a failure to publish farm-report.md also fails the run", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("md-fail", ["task-a"], port));
+    mkdirSync(join(tmpDir, ".farm/runs/mdbad/farm-report.md"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "mdbad" });
+    expect(result.code).toBe(3);
+    expect(result.out).toMatch(/receipt/i);
+  });
+
+  it("#387: a broken streaming rail is recorded as incomplete in the published report", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("stream-fail", ["task-a", "task-b"], port));
+    mkdirSync(join(tmpDir, ".farm/runs/streambad/farm-results.jsonl"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "streambad" });
+    // The rail is best-effort — the run still settles on task outcome...
+    expect(result.code).toBe(0);
+    // ...but the authoritative report says so, instead of leaving a consumer to
+    // infer completeness from a silently short file.
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/runs/streambad/farm-report.json"), "utf8"));
+    expect(report.artifacts.stream.complete).toBe(false);
+    expect(report.artifacts.stream.errors.length).toBeGreaterThan(0);
+    expect(readFileSync(join(tmpDir, ".farm/runs/streambad/farm-report.md"), "utf8")).toMatch(
+      /streaming rail incomplete/i,
+    );
+  });
+
+  it("#387: a broken latest streaming pointer is also recorded as incomplete", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("latest-stream-fail", ["task-a"], port));
+    mkdirSync(join(tmpDir, ".farm/farm-results.jsonl"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "lstream" });
+    expect(result.code).toBe(0);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/runs/lstream/farm-report.json"), "utf8"));
+    expect(report.artifacts.stream.complete).toBe(false);
+    // The run-scoped rail itself is fine — only the shared pointer failed.
+    expect(jsonl(join(tmpDir, ".farm/runs/lstream/farm-results.jsonl"))).toHaveLength(1);
+  });
+
+  it("#387: an unusable diffs directory marks every task's diff evidence unavailable", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("diffdir-fail", ["task-a", "task-b"], port));
+    mkdirSync(join(tmpDir, ".farm/runs/diffdirbad"), { recursive: true });
+    // A regular FILE where the diffs directory belongs.
+    writeFileSync(join(tmpDir, ".farm/runs/diffdirbad/diffs"), "not a directory");
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "diffdirbad" });
+    expect(result.code).toBe(0);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/runs/diffdirbad/farm-report.json"), "utf8"));
+    expect(report.artifacts.diffs.unavailable.map((u: { id: string }) => u.id).sort()).toEqual([
+      "task-a",
+      "task-b",
+    ]);
+    expect(readFileSync(join(tmpDir, ".farm/runs/diffdirbad/farm-report.md"), "utf8")).toMatch(
+      /diff evidence unavailable/i,
+    );
+  });
+
+  it("#387: a single failed patch write marks only that task's diff evidence unavailable", async () => {
+    ({ server: mockServer, port } = await startMockServer(greenHandler()));
+    const planPath = writePlan("plan.json", planFor("patch-fail", ["task-a", "task-b"], port));
+    mkdirSync(join(tmpDir, ".farm/runs/patchbad/diffs/task-a.patch"), { recursive: true });
+
+    const result = await runFarm(tmpDir, planPath, { FARM_API_KEY: "test-key", FARM_RUN_ID: "patchbad" });
+    expect(result.code).toBe(0);
+    const report = JSON.parse(readFileSync(join(tmpDir, ".farm/runs/patchbad/farm-report.json"), "utf8"));
+    expect(report.artifacts.diffs.unavailable.map((u: { id: string }) => u.id)).toEqual(["task-a"]);
+    expect(existsSync(join(tmpDir, ".farm/runs/patchbad/diffs/task-b.patch"))).toBe(true);
+  });
+});

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -989,11 +989,18 @@ type Result = {
   runId?: string;
 };
 
-// observability-003 (T-07c): a short run-id minted once at main() startup. Six
-// hex chars from crypto.randomBytes — enough to disambiguate concurrent runs in
-// the shared JSONL stream without bloating every line.
+// observability-003 (T-07c): a run-id minted once at main() startup.
+//
+// #397 widened this from 3 bytes to 8. It was originally a cosmetic
+// correlation label in a shared JSONL stream, where a rare duplicate cost
+// nothing; it is now the NAME OF THE DIRECTORY that holds a run's durable
+// receipts, so a collision does not merely duplicate a label — it makes a new
+// run publish over a previous run's evidence. 24 bits put a birthday collision
+// at roughly 4k runs in one long-lived `.farm/`, which is reachable; 64 bits
+// put it past any plausible number of runs. 16 hex chars still fits
+// assertSafeRunId's 64-character path-segment budget.
 export function mintRunId(): string {
-  return randomBytes(3).toString("hex");
+  return randomBytes(8).toString("hex");
 }
 
 const msgOf = (e: unknown) => (e instanceof Error ? e.message : String(e));
@@ -1046,11 +1053,19 @@ async function renameWithRetry(from: string, to: string, attempts = 4): Promise<
 // before it writes, so a crash — or a second farm process — can leave a
 // half-written farm-report.json where a complete one used to be, destroying the
 // restart evidence exactly when it is needed. Write the whole payload to a
-// same-directory temp file, fsync it (durability is claimed for these receipts:
-// they are the recovery record), then rename over the destination. A rename
-// within a directory is atomic, so a reader sees either the previous complete
-// artifact or the new complete artifact — never a truncated one. On failure the
-// temp file is removed and the destination is left exactly as it was.
+// same-directory temp file, fsync its CONTENTS, then rename over the
+// destination. A rename within a directory is atomic, so a reader sees either
+// the previous complete artifact or the new complete artifact — never a
+// truncated one. On failure the temp file is removed and the destination is
+// left exactly as it was.
+//
+// Scope of the guarantee, stated precisely rather than generously: what this
+// buys is NO-TORN-FILE ATOMICITY against process death and against a concurrent
+// publisher — the failure modes farm actually hits. It is NOT full crash
+// durability: the directory entry created by the rename is never fsynced (Node
+// has no portable directory-fsync, and none at all on Windows), so a power loss
+// immediately after publication may still lose the rename. Do not read the
+// fh.sync() below as a promise that a published receipt survives a host crash.
 export async function atomicWriteFile(dest: string, data: string): Promise<void> {
   const tmp = path.join(
     path.dirname(dest),
@@ -1071,20 +1086,45 @@ export async function atomicWriteFile(dest: string, data: string): Promise<void>
   }
 }
 
-// #387: the artifacts a run publishes are of two kinds. The JSON/Markdown
-// report is AUTHORITATIVE — failing to publish it fails the run. The streaming
-// rail and the per-task diffs are best-effort EVIDENCE — a failure there must
-// not sink an otherwise good run, but it can no longer be swallowed silently
-// either: it is recorded here and surfaced in the published report so a
-// consumer never infers completeness from a silently short file or follows a
-// patch link that was never written.
+// #387/#397: the artifacts a run publishes fall into exactly two classes, and
+// the whole exit-code contract rests on keeping them apart.
+//
+//   AUTHORITATIVE — `${reportDir}/runs/<runId>/farm-report.{json,md}`. This is
+//   the run's durable, attributable receipt, written by this process alone.
+//   Failing to publish it fails the run (exit 3): there is then nothing to
+//   reconcile or audit against.
+//
+//   NON-AUTHORITATIVE — the shared "latest" pointers under `${reportDir}/`
+//   (farm-report.{json,md}, farm-results.jsonl, diffs/) and the streaming rail
+//   and per-task diffs generally. These are convenience and best-effort
+//   evidence. A failure here must NOT sink a run whose authoritative receipt
+//   landed — that would over-report failure exactly where two concurrent runs
+//   race the same pointer, which is the case #397 exists for. But it can no
+//   longer be swallowed silently either: it is recorded here and surfaced so a
+//   consumer never infers completeness from a silently short file, follows a
+//   patch link that was never written, or reads a stale pointer as this run's.
 export type RunArtifactHealth = {
   stream: { errors: string[] };
-  diffs: { unavailable: { id: string; reason: string }[]; latestMirrorErrors: string[] };
+  diffs: {
+    unavailable: { id: string; reason: string }[];
+    // The TRUE count, which `unavailable` deliberately stops recording at
+    // MAX_RECORDED_ARTIFACT_ERRORS. Reported separately so bounding the list
+    // never understates the damage.
+    unavailableTotal: number;
+    latestMirrorErrors: string[];
+  };
+  // Failures to refresh the shared latest report pointers. These cannot appear
+  // inside the report itself (the payload is already serialized by the time the
+  // pointers are written), so main() surfaces them on the summary instead.
+  report: { latestMirrorErrors: string[] };
 };
 
 export function newRunArtifactHealth(): RunArtifactHealth {
-  return { stream: { errors: [] }, diffs: { unavailable: [], latestMirrorErrors: [] } };
+  return {
+    stream: { errors: [] },
+    diffs: { unavailable: [], unavailableTotal: 0, latestMirrorErrors: [] },
+    report: { latestMirrorErrors: [] },
+  };
 }
 
 // Bound the recorded error list — a dead stream path fails once per settled
@@ -1093,6 +1133,20 @@ const MAX_RECORDED_ARTIFACT_ERRORS = 10;
 function noteArtifactError(bucket: string[], message: string) {
   if (bucket.length < MAX_RECORDED_ARTIFACT_ERRORS) bucket.push(message);
   else if (bucket.length === MAX_RECORDED_ARTIFACT_ERRORS) bucket.push("(further errors suppressed)");
+}
+
+// Same bound for the per-task diff-evidence list, which has the identical
+// failure shape (one unusable diffs directory = one entry per task in the
+// plan). The running total is kept so the report states how many tasks are
+// actually affected even though it only lists the first few.
+function noteUnavailableDiff(diffs: RunArtifactHealth["diffs"], id: string, reason: string) {
+  diffs.unavailableTotal += 1;
+  if (diffs.unavailable.length < MAX_RECORDED_ARTIFACT_ERRORS) diffs.unavailable.push({ id, reason });
+  else if (diffs.unavailable.length === MAX_RECORDED_ARTIFACT_ERRORS)
+    diffs.unavailable.push({
+      id: "(suppressed)",
+      reason: `further entries suppressed after ${MAX_RECORDED_ARTIFACT_ERRORS}`,
+    });
 }
 
 // Integration merges happen inside a dedicated worktree — never the main
@@ -2111,30 +2165,53 @@ async function main() {
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
   // #387: two independent outcomes, two distinguishable exit codes.
-  //   0 — every task settled green AND the receipt was published.
+  //   0 — every task settled green AND the authoritative receipt was published.
   //   2 — the RUN did not come out clean (escalation, blocked, breaker abort);
   //       the receipt IS on disk and can be reconciled.
-  //   3 — the RECEIPT could not be published. Whatever the tasks did, this run
-  //       left no durable, authoritative record, so it cannot be reconciled or
-  //       audited — that is its own failure mode and must not be reported as a
-  //       success (nor conflated with "tasks failed").
+  //   3 — the run-scoped AUTHORITATIVE receipt could not be published in full.
+  //       Whatever the tasks did, this run's durable record is missing or
+  //       incomplete, so it cannot be reliably reconciled or audited — its own
+  //       failure mode, not a success and not "tasks failed".
+  //
+  // Deliberately NOT exit 3: a failure to refresh the shared "latest" pointers
+  // under `${reportDir}`. Those are documented as non-authoritative and
+  // last-writer-wins; failing the run on them would over-report failure in
+  // exactly the concurrent-run case this design exists to make safe. They are
+  // reported as a warning below instead.
   const runExitCode = esc || blocked.length || aborted ? 2 : 0;
   const exitCode = publishError ? 3 : runExitCode;
+  const latestReportErrors = health.report.latestMirrorErrors;
   const summary = [
     aborted ? `\nABORTED by circuit breaker — escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
     `\nDone. green=${green} escalate=${esc} blocked=${blocked.length}`,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
     `Run: ${runId}  (artifacts: ${runDir})`,
-    // The success breadcrumb is SUPPRESSED when publication failed — pointing an
-    // operator at a farm-report.md that is not there is the defect.
+    // The success breadcrumb is SUPPRESSED when the authoritative publication
+    // failed — pointing an operator at a farm-report.md that is not there is
+    // the defect. Every claim below has to be true of what is actually on disk:
+    // the message names the run directory and says "missing or incomplete"
+    // rather than asserting no receipt exists, because a partial failure (e.g.
+    // the JSON landed and the Markdown did not) leaves a real receipt behind.
     publishError
       ? [
-          `\nRECEIPT PUBLICATION FAILED — run ${runId} could not publish its authoritative report: ${msgOf(publishError)}`,
-          `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but there is no durable receipt for this run,`,
-          `so it cannot be reconciled or audited. Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`,
+          `\nRECEIPT PUBLICATION FAILED — run ${runId} could not publish its complete authoritative report under ${runDir}: ${msgOf(publishError)}`,
+          `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but this run's durable receipt is missing or incomplete,`,
+          `so it cannot be reliably reconciled or audited. Inspect ${runDir} for whatever did land.`,
+          `${path.join(ENV.reportDir, "farm-report.json")} / .md were NOT refreshed and do not describe run ${runId}.`,
+          `Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`,
         ].join("\n")
-      : `Report: ${path.join(runDir, "farm-report.md")}  (latest: ${path.join(ENV.reportDir, "farm-report.md")})`,
+      : latestReportErrors.length
+        ? // Non-fatal, and stated as such. The authoritative receipt is
+          // unaffected; what the operator must not assume is that the shared
+          // path now describes THIS run.
+          [
+            `Report: ${path.join(runDir, "farm-report.md")}`,
+            `WARNING: the latest convenience pointer under ${ENV.reportDir} could not be refreshed for this run:`,
+            ...latestReportErrors.map((m) => `  - ${m}`),
+            `The authoritative receipt above is unaffected, but ${path.join(ENV.reportDir, "farm-report.json")} does not describe run ${runId}.`,
+          ].join("\n")
+        : `Report: ${path.join(runDir, "farm-report.md")}  (latest: ${path.join(ENV.reportDir, "farm-report.md")})`,
     "",
   ].join("\n");
   await new Promise<void>((resolve) => process.stdout.write(summary, () => resolve()));
@@ -2170,12 +2247,12 @@ async function writeReport(
 
   for (const r of results) {
     if (diffsDirError !== null) {
-      unavailable.push({ id: r.id, reason: `diffs directory unavailable: ${diffsDirError}` });
+      noteUnavailableDiff(health.diffs, r.id, `diffs directory unavailable: ${diffsDirError}`);
       continue;
     }
     const d = await git(["diff", `${ENV.base}...${r.branch}`]);
     if (d.code !== 0) {
-      unavailable.push({ id: r.id, reason: `git diff failed: ${d.out.trim().split("\n")[0] ?? ""}`.slice(0, 300) });
+      noteUnavailableDiff(health.diffs, r.id, `git diff failed: ${d.out.trim().split("\n")[0] ?? ""}`.slice(0, 300));
       continue;
     }
     // An empty diff is a legitimate outcome (nothing was written), not missing
@@ -2186,7 +2263,7 @@ async function writeReport(
       await atomicWriteFile(dest, d.out);
       patchPath.set(r.id, dest);
     } catch (e) {
-      unavailable.push({ id: r.id, reason: `patch write failed: ${msgOf(e)}` });
+      noteUnavailableDiff(health.diffs, r.id, `patch write failed: ${msgOf(e)}`);
       continue;
     }
     await atomicWriteFile(path.join(latestDiffsDir, `${r.id}.patch`), d.out).catch((e) =>
@@ -2212,7 +2289,10 @@ async function writeReport(
     diffs: {
       dir: diffsDir,
       latest_dir: latestDiffsDir,
+      // `unavailable` is capped; `unavailable_total` is not, so a bounded list
+      // never understates how many tasks lack diff evidence.
       unavailable,
+      unavailable_total: health.diffs.unavailableTotal,
       latest_mirror_errors: health.diffs.latestMirrorErrors,
     },
   };
@@ -2242,8 +2322,11 @@ async function writeReport(
       .map((r) => `- **${r.id}** — worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
     ``,
     `## Diff evidence`,
-    ...(unavailable.length
-      ? unavailable.map((u) => `- **${u.id}** — diff evidence unavailable: ${u.reason}`)
+    ...(health.diffs.unavailableTotal
+      ? [
+          `${health.diffs.unavailableTotal} task(s) have no diff evidence${unavailable.length < health.diffs.unavailableTotal ? ` (first ${MAX_RECORDED_ARTIFACT_ERRORS} listed)` : ``}:`,
+          ...unavailable.map((u) => `- **${u.id}** — diff evidence unavailable: ${u.reason}`),
+        ]
       : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`]),
     ``,
     `## Warnings — review during spec-compliance`,
@@ -2253,14 +2336,29 @@ async function writeReport(
     }),
   ].join("\n");
 
-  // #387/#397: the AUTHORITATIVE publication. Run-scoped first (the durable,
-  // attributable receipt), then the shared "latest" convenience pointers. Every
-  // write is atomic (temp + fsync + rename), and any failure THROWS — main()
-  // turns it into exit 3 instead of a console line behind a green summary.
+  // #387/#397: publication, in two clearly separated tiers.
+  //
+  // Tier 1 — the AUTHORITATIVE receipt, run-scoped and exclusively owned. Any
+  // failure THROWS, and main() turns it into exit 3 instead of a console line
+  // behind a green summary.
   await atomicWriteFile(path.join(runDir, "farm-report.json"), json);
   await atomicWriteFile(path.join(runDir, "farm-report.md"), md);
-  await atomicWriteFile(path.join(ENV.reportDir, "farm-report.json"), json);
-  await atomicWriteFile(path.join(ENV.reportDir, "farm-report.md"), md);
+
+  // Tier 2 — the shared "latest" convenience pointers. These are explicitly
+  // NON-authoritative and last-writer-wins, so their failure must not fail a
+  // run whose durable receipt just landed above. (Getting this wrong inverts
+  // the fix: two concurrent runs racing this very rename on Windows are what
+  // renameWithRetry exists for, and exhausting its retries would otherwise sink
+  // a fully green, fully receipted run.) Recorded and surfaced on the summary,
+  // never silently dropped — a stale pointer that is not this run's is exactly
+  // the thing an operator must not be left to assume.
+  for (const [dest, data] of [
+    [path.join(ENV.reportDir, "farm-report.json"), json],
+    [path.join(ENV.reportDir, "farm-report.md"), md],
+  ] as const)
+    await atomicWriteFile(dest, data).catch((e) =>
+      noteArtifactError(health.report.latestMirrorErrors, `${dest}: ${msgOf(e)}`),
+    );
 }
 
 // Only execute when this file is the direct entry point (not when imported by

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -34,7 +34,7 @@
  * model in FARM_CANDIDATE_MODELS and reports a measured pass-rate ranking, so
  * model selection is objective rather than web hearsay. No merge, no mutation.
  */
-import { readFile, writeFile, appendFile, mkdir, rm, stat } from "node:fs/promises";
+import { readFile, writeFile, appendFile, mkdir, rm, stat, rename, open } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
@@ -110,6 +110,10 @@ const ENV = {
   integration: process.env.FARM_INTEGRATION_BRANCH ?? "farm/integration",
   worktreeRoot: process.env.FARM_WORKTREE_ROOT ?? ".farm/worktrees",
   reportDir: process.env.FARM_REPORT_DIR ?? ".farm",
+  // #397: an orchestrator may PIN this run's id, which is also the name of the
+  // run-scoped artifact directory (`${reportDir}/runs/<runId>/`). Absent → a
+  // fresh random id per invocation (mintRunId).
+  runId: process.env.FARM_RUN_ID ?? null,
   // Per-request hard timeout so a hung endpoint can't deadlock a worker slot.
   requestTimeoutMs: numEnv("FARM_REQUEST_TIMEOUT_MS", 120_000, { min: 1 }),
   // Per-candidate wall-clock cap for the #93 entitlement pre-screen, so one
@@ -992,6 +996,105 @@ export function mintRunId(): string {
   return randomBytes(3).toString("hex");
 }
 
+const msgOf = (e: unknown) => (e instanceof Error ? e.message : String(e));
+
+// #397: a caller-supplied FARM_RUN_ID becomes a DIRECTORY NAME under
+// `${reportDir}/runs/`, so it has to be exactly one safe path segment — no
+// separator, no traversal, no dot-only id. Fail closed and loudly at startup
+// rather than silently substituting a random id (which would hide a
+// misconfigured orchestrator) or letting `../` place artifacts outside the
+// report dir.
+export const SAFE_RUN_ID = /^[A-Za-z0-9._-]{1,64}$/;
+export function assertSafeRunId(id: string): string {
+  if (!SAFE_RUN_ID.test(id) || id === "." || id === "..")
+    throw new Error(
+      `FARM_RUN_ID must be 1-64 characters of [A-Za-z0-9._-] and not "." or ".." (got ${JSON.stringify(id)})`,
+    );
+  return id;
+}
+
+// #397: every run owns a directory. The run dir holds this run's DURABLE
+// receipts — stream, per-task diffs, JSON + Markdown report — written by this
+// process alone, so two farm invocations against one repository can no longer
+// erase each other's evidence. The historical top-level `.farm/farm-report.*`
+// and `.farm/farm-results.jsonl` paths are retained as a "latest" convenience
+// pointer for the documented consumer contract; under concurrency the pointer
+// is last-writer-wins (but always a COMPLETE artifact — see atomicWriteFile),
+// while the run dirs stay authoritative and attributable.
+export function runArtifactDir(runId: string): string {
+  return path.join(ENV.reportDir, "runs", runId);
+}
+
+// Windows can transiently refuse a replace-rename with EPERM/EACCES/EBUSY while
+// another process (or a virus scanner) still holds the destination open — the
+// exact situation two concurrent farm runs publishing a shared "latest" pointer
+// create. A short bounded retry keeps that from spuriously failing a run.
+async function renameWithRetry(from: string, to: string, attempts = 4): Promise<void> {
+  for (let i = 0; ; i++) {
+    try {
+      await rename(from, to);
+      return;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code ?? "";
+      if (i >= attempts - 1 || !["EPERM", "EACCES", "EBUSY"].includes(code)) throw e;
+      await new Promise((r) => setTimeout(r, 15 * (i + 1)));
+    }
+  }
+}
+
+// #397: publish-or-preserve. A plain writeFile() TRUNCATES the destination
+// before it writes, so a crash — or a second farm process — can leave a
+// half-written farm-report.json where a complete one used to be, destroying the
+// restart evidence exactly when it is needed. Write the whole payload to a
+// same-directory temp file, fsync it (durability is claimed for these receipts:
+// they are the recovery record), then rename over the destination. A rename
+// within a directory is atomic, so a reader sees either the previous complete
+// artifact or the new complete artifact — never a truncated one. On failure the
+// temp file is removed and the destination is left exactly as it was.
+export async function atomicWriteFile(dest: string, data: string): Promise<void> {
+  const tmp = path.join(
+    path.dirname(dest),
+    `.${path.basename(dest)}.${process.pid}-${randomBytes(4).toString("hex")}.tmp`,
+  );
+  const fh = await open(tmp, "w");
+  try {
+    await fh.writeFile(data, "utf8");
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+  try {
+    await renameWithRetry(tmp, dest);
+  } catch (e) {
+    await rm(tmp, { force: true }).catch(() => {});
+    throw e;
+  }
+}
+
+// #387: the artifacts a run publishes are of two kinds. The JSON/Markdown
+// report is AUTHORITATIVE — failing to publish it fails the run. The streaming
+// rail and the per-task diffs are best-effort EVIDENCE — a failure there must
+// not sink an otherwise good run, but it can no longer be swallowed silently
+// either: it is recorded here and surfaced in the published report so a
+// consumer never infers completeness from a silently short file or follows a
+// patch link that was never written.
+export type RunArtifactHealth = {
+  stream: { errors: string[] };
+  diffs: { unavailable: { id: string; reason: string }[]; latestMirrorErrors: string[] };
+};
+
+export function newRunArtifactHealth(): RunArtifactHealth {
+  return { stream: { errors: [] }, diffs: { unavailable: [], latestMirrorErrors: [] } };
+}
+
+// Bound the recorded error list — a dead stream path fails once per settled
+// task, and the report should carry a diagnosis, not N copies of it.
+const MAX_RECORDED_ARTIFACT_ERRORS = 10;
+function noteArtifactError(bucket: string[], message: string) {
+  if (bucket.length < MAX_RECORDED_ARTIFACT_ERRORS) bucket.push(message);
+  else if (bucket.length === MAX_RECORDED_ARTIFACT_ERRORS) bucket.push("(further errors suppressed)");
+}
+
 // Integration merges happen inside a dedicated worktree — never the main
 // checkout. mergeChain serializes access to that worktree.
 let mergeChain: Promise<unknown> = Promise.resolve();
@@ -1789,29 +1892,65 @@ async function main() {
 
   // observability-003 (T-07c): one run-id for this whole invocation, threaded
   // into every farm-results.jsonl line and the farm-report.json header.
-  const runId = mintRunId();
+  // #397: the run-id is now also an OWNERSHIP BOUNDARY — every artifact this
+  // run publishes lives under `${reportDir}/runs/<runId>/`, which is what makes
+  // two farm processes on one repository non-destructive to each other.
+  let runId: string;
+  try {
+    runId = ENV.runId === null ? mintRunId() : assertSafeRunId(ENV.runId);
+  } catch (e) {
+    console.error(`Error: ${msgOf(e)}`);
+    return process.exit(1);
+  }
+  const runDir = runArtifactDir(runId);
 
   await mkdir(ENV.worktreeRoot, { recursive: true });
   await mkdir(ENV.reportDir, { recursive: true });
+  await mkdir(runDir, { recursive: true });
+
+  const health = newRunArtifactHealth();
 
   // Streaming rail (AC-08 / D7): the incremental, append-only record of settled
-  // tasks, consumed in completion order. Truncate/initialize it at run start so
-  // a re-run does not accumulate stale lines (the "safe to run twice" invariant).
-  // The authoritative final summary remains farm-report.json (written in the
-  // finally, even on abort); on abort the consumer reconciles against it.
-  const resultsStream = path.join(ENV.reportDir, "farm-results.jsonl");
-  await writeFile(resultsStream, "").catch((e) => console.error("results stream init failed:", e));
+  // tasks, consumed in completion order. The authoritative final summary remains
+  // farm-report.json (written in the finally, even on abort); on abort the
+  // consumer reconciles against it.
+  //
+  // #397: the rail this run appends to is run-scoped and therefore exclusively
+  // owned — no other farm process truncates it or interleaves its lines. The
+  // documented `${reportDir}/farm-results.jsonl` path is kept as the "latest"
+  // convenience pointer and is REPUBLISHED ATOMICALLY (full content, temp +
+  // rename) after every settlement, so a consumer of that path always reads a
+  // complete, parseable file. It is initialized empty at run start, preserving
+  // the "safe to run twice" invariant (a re-run never shows stale lines).
+  const resultsStream = path.join(runDir, "farm-results.jsonl");
+  const latestStream = path.join(ENV.reportDir, "farm-results.jsonl");
+  const streamLines: string[] = [];
+  const noteStreamFailure = (what: string, e: unknown) => {
+    const m = `${what}: ${msgOf(e)}`;
+    console.error(`results stream ${m}`);
+    noteArtifactError(health.stream.errors, m);
+  };
+  await writeFile(resultsStream, "").catch((e) => noteStreamFailure("run-scoped init failed", e));
+  await atomicWriteFile(latestStream, "").catch((e) => noteStreamFailure("latest pointer init failed", e));
 
   const done = new Map<string, Result>();
   const blocked: { id: string; reason: string }[] = [];
   let aborted = false;
+  // #387: publication of the authoritative receipt is part of the run's
+  // outcome, not a console breadcrumb. Captured here, consumed by the exit-code
+  // derivation below.
+  let publishError: unknown = null;
 
   try {
     const branchResult = await git(["branch", "-f", ENV.integration, ENV.base]);
     if (branchResult.code !== 0)
       throw new Error(`could not create integration branch '${ENV.integration}' from '${ENV.base}': ${branchResult.out}`);
 
-    integrationWorktree = path.resolve(ENV.reportDir, "integration-wt");
+    // #397: the integration worktree is per-run scratch that lived at a shared,
+    // run-agnostic path — a second farm process force-removed it out from under
+    // the first mid-merge. Scope it to the run directory alongside the run's
+    // receipts.
+    integrationWorktree = path.resolve(runDir, "integration-wt");
     await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
     await rm(integrationWorktree, { recursive: true, force: true }).catch(() => {});
     const wtResult = await git(["worktree", "add", integrationWorktree, ENV.integration]);
@@ -1924,9 +2063,17 @@ async function main() {
       done.set(id, r);
       // Streaming rail (AC-08 / D7): append this settled task as one JSONL line
       // the moment it settles, so a pipelined consumer can act in completion
-      // order. Resilient by design — mirror the report-write .catch so a stream
-      // failure logs but never crashes the run (the report stays authoritative).
-      await appendFile(resultsStream, JSON.stringify(r) + "\n").catch((e) => console.error("results stream append failed:", e));
+      // order. Resilient by design — a stream failure never crashes the run (the
+      // report stays authoritative) — but #387: it is no longer MUTE either. Each
+      // failure is recorded and republished in farm-report.json, so a consumer
+      // can tell "the rail is short because the run is short" from "the rail is
+      // short because writes failed".
+      const line = JSON.stringify(r) + "\n";
+      streamLines.push(line);
+      await appendFile(resultsStream, line).catch((e) => noteStreamFailure("run-scoped append failed", e));
+      await atomicWriteFile(latestStream, streamLines.join("")).catch((e) =>
+        noteStreamFailure("latest pointer publish failed", e),
+      );
       if (r.status === "escalate") escalated.add(id);
     }
 
@@ -1937,7 +2084,17 @@ async function main() {
       blocked.push({ id, reason: aborted ? "run aborted (circuit breaker)" : culprit ? `dependency ${culprit} escalated` : "not scheduled" });
     }
   } finally {
-    await writeReport(plan, [...done.values()], blocked, aborted, runId).catch((e) => console.error("report write failed:", e));
+    // #387: the report is still written from the `finally` (so an abort or a
+    // mid-run throw still produces a receipt), but its failure is no longer
+    // absorbed by a console.error. It is captured and turned into a distinct
+    // non-zero exit below. The catch is kept here only so a publication failure
+    // cannot MASK an in-flight exception propagating out of the try.
+    try {
+      await writeReport(plan, [...done.values()], blocked, aborted, runId, health);
+    } catch (e) {
+      publishError = e;
+      console.error("report publication failed:", e);
+    }
     // reliability-004 (T-07a): only remove the integration worktree if it was
     // actually assigned. An early throw (e.g. the integration branch could not
     // be created) leaves `integrationWorktree` undefined; passing undefined as an
@@ -1953,40 +2110,125 @@ async function main() {
   const green = results.filter((r) => r.status === "green").length;
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
-  const exitCode = esc || blocked.length || aborted ? 2 : 0;
+  // #387: two independent outcomes, two distinguishable exit codes.
+  //   0 — every task settled green AND the receipt was published.
+  //   2 — the RUN did not come out clean (escalation, blocked, breaker abort);
+  //       the receipt IS on disk and can be reconciled.
+  //   3 — the RECEIPT could not be published. Whatever the tasks did, this run
+  //       left no durable, authoritative record, so it cannot be reconciled or
+  //       audited — that is its own failure mode and must not be reported as a
+  //       success (nor conflated with "tasks failed").
+  const runExitCode = esc || blocked.length || aborted ? 2 : 0;
+  const exitCode = publishError ? 3 : runExitCode;
   const summary = [
     aborted ? `\nABORTED by circuit breaker — escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
     `\nDone. green=${green} escalate=${esc} blocked=${blocked.length}`,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
-    `Report: ${path.join(ENV.reportDir, "farm-report.md")}`,
+    `Run: ${runId}  (artifacts: ${runDir})`,
+    // The success breadcrumb is SUPPRESSED when publication failed — pointing an
+    // operator at a farm-report.md that is not there is the defect.
+    publishError
+      ? [
+          `\nRECEIPT PUBLICATION FAILED — run ${runId} could not publish its authoritative report: ${msgOf(publishError)}`,
+          `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but there is no durable receipt for this run,`,
+          `so it cannot be reconciled or audited. Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`,
+        ].join("\n")
+      : `Report: ${path.join(runDir, "farm-report.md")}  (latest: ${path.join(ENV.reportDir, "farm-report.md")})`,
     "",
   ].join("\n");
   await new Promise<void>((resolve) => process.stdout.write(summary, () => resolve()));
   process.exit(exitCode);
 }
 
-async function writeReport(plan: Plan, results: Result[], blocked: { id: string; reason: string }[], aborted: boolean, runId?: string) {
-  // per-task diff artifacts for audit
-  await mkdir(path.join(ENV.reportDir, "diffs"), { recursive: true }).catch(() => {});
+async function writeReport(
+  plan: Plan,
+  results: Result[],
+  blocked: { id: string; reason: string }[],
+  aborted: boolean,
+  runId: string,
+  health: RunArtifactHealth,
+) {
+  const runDir = runArtifactDir(runId);
+  const diffsDir = path.join(runDir, "diffs");
+  const latestDiffsDir = path.join(ENV.reportDir, "diffs");
+  const unavailable = health.diffs.unavailable;
+  // Only tasks whose patch actually landed get a link below (#387: the report
+  // previously linked patch paths that the swallowed writes never created).
+  const patchPath = new Map<string, string>();
+
+  // Per-task diff artifacts for audit. Best-effort evidence: a failure here
+  // does not sink the run, but it is recorded per task instead of being
+  // discarded by a bare `.catch(() => {})`.
+  let diffsDirError: string | null = null;
+  await mkdir(diffsDir, { recursive: true }).catch((e) => {
+    diffsDirError = msgOf(e);
+  });
+  await mkdir(latestDiffsDir, { recursive: true }).catch((e) =>
+    noteArtifactError(health.diffs.latestMirrorErrors, `mkdir: ${msgOf(e)}`),
+  );
+
   for (const r of results) {
+    if (diffsDirError !== null) {
+      unavailable.push({ id: r.id, reason: `diffs directory unavailable: ${diffsDirError}` });
+      continue;
+    }
     const d = await git(["diff", `${ENV.base}...${r.branch}`]);
-    if (d.code === 0 && d.out.trim())
-      await writeFile(path.join(ENV.reportDir, "diffs", `${r.id}.patch`), d.out).catch(() => {});
+    if (d.code !== 0) {
+      unavailable.push({ id: r.id, reason: `git diff failed: ${d.out.trim().split("\n")[0] ?? ""}`.slice(0, 300) });
+      continue;
+    }
+    // An empty diff is a legitimate outcome (nothing was written), not missing
+    // evidence — it produces no patch and no "unavailable" marker.
+    if (!d.out.trim()) continue;
+    const dest = path.join(diffsDir, `${r.id}.patch`);
+    try {
+      await atomicWriteFile(dest, d.out);
+      patchPath.set(r.id, dest);
+    } catch (e) {
+      unavailable.push({ id: r.id, reason: `patch write failed: ${msgOf(e)}` });
+      continue;
+    }
+    await atomicWriteFile(path.join(latestDiffsDir, `${r.id}.patch`), d.out).catch((e) =>
+      noteArtifactError(health.diffs.latestMirrorErrors, `${r.id}: ${msgOf(e)}`),
+    );
   }
 
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
 
-  await writeFile(
-    path.join(ENV.reportDir, "farm-report.json"),
-    JSON.stringify({ run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, ts: new Date().toISOString() }, null, 2),
+  // #387: the report carries its own integrity statement, so a consumer never
+  // has to guess whether a short stream or a missing patch is real or a
+  // swallowed write failure.
+  const streamComplete = health.stream.errors.length === 0;
+  const artifacts = {
+    run_dir: runDir,
+    stream: {
+      path: path.join(runDir, "farm-results.jsonl"),
+      latest: path.join(ENV.reportDir, "farm-results.jsonl"),
+      complete: streamComplete,
+      errors: health.stream.errors,
+    },
+    diffs: {
+      dir: diffsDir,
+      latest_dir: latestDiffsDir,
+      unavailable,
+      latest_mirror_errors: health.diffs.latestMirrorErrors,
+    },
+  };
+
+  const json = JSON.stringify(
+    { run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, artifacts, ts: new Date().toISOString() },
+    null,
+    2,
   );
 
   const md = [
     `# Farm report — ${plan.meta.name}`,
     ``,
     aborted ? `> **ABORTED by circuit breaker** — escalation rate exceeded threshold.\n` : ``,
+    streamComplete ? `` : `> **Streaming rail incomplete** — ${health.stream.errors.length} write failure(s) on \`farm-results.jsonl\`; this report is authoritative for settled tasks.\n`,
+    `Run: \`${runId}\` — artifacts under \`${runDir}\``,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     ``,
     `| task | status | attempts | files | mut | branch | note |`,
@@ -1999,10 +2241,26 @@ async function writeReport(plan: Plan, results: Result[], blocked: { id: string;
       .filter((r) => r.status === "escalate")
       .map((r) => `- **${r.id}** — worktree \`${r.worktree}\`, branch \`${r.branch}\`. ${r.note ?? ""}`),
     ``,
+    `## Diff evidence`,
+    ...(unavailable.length
+      ? unavailable.map((u) => `- **${u.id}** — diff evidence unavailable: ${u.reason}`)
+      : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`]),
+    ``,
     `## Warnings — review during spec-compliance`,
-    ...results.filter((r) => r.warning).map((r) => `- **${r.id}** — ${r.warning} (diff: \`${path.join(ENV.reportDir, "diffs", r.id + ".patch")}\`)`),
+    ...results.filter((r) => r.warning).map((r) => {
+      const p = patchPath.get(r.id);
+      return `- **${r.id}** — ${r.warning} (${p ? `diff: \`${p}\`` : "diff evidence unavailable"})`;
+    }),
   ].join("\n");
-  await writeFile(path.join(ENV.reportDir, "farm-report.md"), md);
+
+  // #387/#397: the AUTHORITATIVE publication. Run-scoped first (the durable,
+  // attributable receipt), then the shared "latest" convenience pointers. Every
+  // write is atomic (temp + fsync + rename), and any failure THROWS — main()
+  // turns it into exit 3 instead of a console line behind a green summary.
+  await atomicWriteFile(path.join(runDir, "farm-report.json"), json);
+  await atomicWriteFile(path.join(runDir, "farm-report.md"), md);
+  await atomicWriteFile(path.join(ENV.reportDir, "farm-report.json"), json);
+  await atomicWriteFile(path.join(ENV.reportDir, "farm-report.md"), md);
 }
 
 // Only execute when this file is the direct entry point (not when imported by

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -1701,11 +1701,20 @@ describe("T-07a validate() named errors on malformed required fields (migration-
 });
 
 describe("T-07c run-id correlation (observability-003)", () => {
-  it("mints a short, non-empty, distinct run id", () => {
+  // #397 widened this from 6 hex chars to 16: the run id stopped being a
+  // cosmetic log label and became the name of the directory that holds a run's
+  // durable receipts, so a birthday collision now silently OVERWRITES a prior
+  // run's evidence. 64 bits of entropy puts a collision beyond any plausible
+  // number of runs in one `.farm/`.
+  it("mints a collision-resistant, non-empty, distinct run id", () => {
     const a = mintRunId();
     const b = mintRunId();
-    expect(a).toMatch(/^[0-9a-f]{6}$/);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
     expect(a).not.toBe(b); // overwhelmingly likely distinct
+  });
+
+  it("mints ids that are valid run-artifact directory names", () => {
+    for (let i = 0; i < 32; i++) expect(() => assertSafeRunId(mintRunId())).not.toThrow();
   });
 });
 

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -6,9 +6,9 @@ import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, readFile as fsReadFile, rm as fsRm, symlink as fsSymlink } from "node:fs/promises";
+import { mkdtemp, writeFile as fsWriteFile, mkdir as fsMkdir, readFile as fsReadFile, rm as fsRm, symlink as fsSymlink, readdir as fsReaddir } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, makeEntitlementProbe, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot, numEnv } from "./farm.ts";
+import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, makeEntitlementProbe, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot, numEnv, atomicWriteFile, assertSafeRunId } from "./farm.ts";
 import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
 import { scrubbedEnv } from "./exec.ts";
@@ -2202,5 +2202,59 @@ describe("assertContainedWorktree — no path escapes the root (#163)", () => {
       /strictly inside/,
     );
     expect(() => assertContainedWorktree("/etc")).toThrow(/strictly inside/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #397 — atomicWriteFile is the publication primitive: a reader of the
+// destination path only ever sees a COMPLETE artifact, and a failed
+// publication leaves the prior artifact untouched with no temp residue.
+// ---------------------------------------------------------------------------
+describe("atomicWriteFile — publish-or-preserve (#397)", () => {
+  it("writes the full payload to the destination", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "farm-atomic-"));
+    const dest = path.join(dir, "report.json");
+    await atomicWriteFile(dest, '{"a":1}');
+    expect(await fsReadFile(dest, "utf8")).toBe('{"a":1}');
+    await fsRm(dir, { recursive: true, force: true });
+  });
+
+  it("leaves no temporary residue behind on success", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "farm-atomic-"));
+    await atomicWriteFile(path.join(dir, "report.json"), "x".repeat(4096));
+    expect(await fsReaddir(dir)).toEqual(["report.json"]);
+    await fsRm(dir, { recursive: true, force: true });
+  });
+
+  it("preserves the prior complete artifact and cleans up when publication fails", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "farm-atomic-"));
+    const dest = path.join(dir, "report.json");
+    await fsWriteFile(dest, '{"prior":true}');
+    // A directory at the destination makes the rename fail — the stand-in for
+    // any mid-publication failure.
+    const blocked = path.join(dir, "blocked");
+    await fsMkdir(blocked, { recursive: true });
+    await expect(atomicWriteFile(blocked, "new")).rejects.toThrow();
+    // The unrelated prior artifact is untouched and still parseable...
+    expect(JSON.parse(await fsReadFile(dest, "utf8"))).toEqual({ prior: true });
+    // ...and the aborted write left no partial temp file lying around.
+    expect((await fsReaddir(dir)).sort()).toEqual(["blocked", "report.json"]);
+    await fsRm(dir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #397 — a caller-supplied run id becomes a directory name, so it must be a
+// single safe path segment.
+// ---------------------------------------------------------------------------
+describe("assertSafeRunId — run id is a path segment (#397)", () => {
+  it("accepts a minted-shaped id and ordinary slugs", () => {
+    expect(assertSafeRunId("a1b2c3")).toBe("a1b2c3");
+    expect(assertSafeRunId("nightly_2026-07-24.1")).toBe("nightly_2026-07-24.1");
+  });
+
+  it("rejects traversal, separators, dot ids and empty/oversized ids", () => {
+    for (const bad of ["..", ".", "../escape", "a/b", "a\\b", "", "x".repeat(65), "a b"])
+      expect(() => assertSafeRunId(bad)).toThrow(/FARM_RUN_ID/);
   });
 });


### PR DESCRIPTION
## Summary

Two farm receipt-integrity defects, TDD'd one at a time, plus a remediation pass answering an adversarial review of the first round.

Closes #397
Closes #387

### #397 — isolate and atomically publish artifacts per concurrent run

Verified against `origin/main` at the time of authoring (post-#425). The audit's claims held; only line numbers had drifted:

| audit claim | verified at |
| --- | --- |
| `runId` minted but artifact paths run-agnostic | `farm.ts:1792` |
| shared `${reportDir}/farm-results.jsonl` truncated with `writeFile(resultsStream, "")` | `farm.ts:1803` |
| every run appends to that same shared path | `farm.ts:1929` |
| `writeReport` overwrites `diffs/<task>.patch`, `farm-report.json`, `farm-report.md` directly, no lock / temp+rename | `farm.ts:1969-2006` |

Additionally found and fixed as part of the same defect: the **integration worktree** also sat at a shared, run-agnostic path (`.farm/integration-wt`). A second farm process `git worktree remove --force`d it out from under the first mid-merge — this is what made the concurrency test fail with `green=0 escalate=2` on one side and a fatal `index.lock: File exists` on the other before the fix.

**Fix.** The run-id becomes an ownership boundary:

- Every run publishes its stream, per-task diffs, JSON report and Markdown report under `.farm/runs/<run-id>/` — its **durable, attributable receipt**, written by that process alone. The integration worktree moves there too.
- New `atomicWriteFile(dest, data)`: same-directory temp file → `fsync` of the file contents → `rename` (with a short bounded retry for Windows `EPERM`/`EBUSY` replace-races). A reader of a destination path sees the previous complete artifact or the new complete artifact — never a truncated one. On failure the temp file is removed and the destination is untouched. **This is no-torn-file atomicity, not crash durability**: the rename's directory entry is never fsynced (Node has no portable directory fsync, and none on Windows), so a power loss immediately after publication can still lose the rename. The code comment and `farm.md` now say exactly that instead of claiming durability.
- New `FARM_RUN_ID` lets an orchestrator pin the id. Because it becomes a directory name it is validated as a single safe path segment (`assertSafeRunId`) — traversal, separators, `.`/`..`, empty and oversized ids are refused at startup rather than silently replaced.
- `mintRunId()` widened from 3 random bytes to 8 (6 → 16 hex chars). At 24 bits a birthday collision arrives around ~4k runs in one long-lived `.farm/`; that used to duplicate a cosmetic log label, but the id now names the directory holding a run's receipts, so a collision would publish over a prior run's evidence. Reusing a **pinned** `FARM_RUN_ID` does the same thing deliberately, and `farm.md` now says so.

**"Latest" convenience path — preserved, not changed.** The documented consumer contract (`.farm/farm-report.json`, `.farm/farm-report.md`, `.farm/farm-results.jsonl`, `.farm/diffs/<task>.patch`) still resolves after every run. It is now *republished* from the run's own artifacts through `atomicWriteFile` — the JSONL pointer is re-published in full after each settlement, so a consumer of that path always reads a complete, parseable file, and the "safe to run twice" invariant (no stale lines on a re-run) is unchanged. Under concurrency the pointer is explicitly last-writer-wins — always complete, attributable via its `run_id` — while the run dirs stay authoritative.

**Concurrency, stated honestly.** Run-scoped receipts make concurrent runs non-destructive to each other's *artifacts*. They do **not** make the *git state* concurrent — at defaults a second simultaneous run dies on `cannot lock ref 'refs/heads/farm/integration'`. Both surface docs (`core/surface/includes/farm.md`, the `farm-dispatch.md` consumer reference) now carry that caveat and name what a second run actually needs: a distinct `FARM_INTEGRATION_BRANCH`, a distinct `FARM_WORKTREE_ROOT`, and non-overlapping task ids (task branches are `farm/<task-id>` regardless of run id). The earlier revision of this PR claimed concurrent runs "cannot overwrite each other's evidence" without that caveat; that claim was too broad and has been narrowed.

### #387 — fail the run when the *authoritative* report cannot be published

Verified: `writeReport(...).catch(e => console.error(...))` at `farm.ts:1940` inside the `finally`, `exitCode` derived purely from task state at `farm.ts:1956`, and `Report: .../farm-report.md` printed unconditionally at `farm.ts:1962`. Inside `writeReport`, the diffs `mkdir` (`1971`) and each per-task patch write (`1975`) were `.catch(() => {})`; stream init (`1803`) and append (`1929`) only `console.error`'d.

**Fix.**

- Publication of the run's **authoritative, run-scoped** receipt now **fails the run** with its own exit code and its own diagnostic. The run's outcome and the receipt's outcome are not conflated:
  - `0` — all tasks green **and** the authoritative receipt published.
  - `2` — the run did not come out clean (escalation / blocked / breaker abort); the receipt **is** on disk and can be reconciled.
  - `3` — the run-scoped receipt could not be published in full. The success `Report:` breadcrumb is suppressed rather than pointing at a file that was never written.
- **Publication is two explicit tiers.** Only `.farm/runs/<run-id>/farm-report.{json,md}` is authoritative and throws. The shared `.farm/farm-report.{json,md}` "latest" pointers are non-authoritative and last-writer-wins; their failure is recorded and printed as a non-fatal `WARNING:` naming what could not be refreshed, and the run still settles on its task outcome. (The first revision of this PR ran all four writes unguarded, so a blocked *pointer* rename exited 3 on a fully green, fully receipted run — the exact case `renameWithRetry` exists for. That is fixed and regression-tested.)
- **Every emitted message is true of what is on disk.** The exit-3 text names the run's artifact directory, says the receipt is "missing or incomplete" rather than asserting no receipt exists (a partial failure — JSON landed, Markdown did not — leaves a real receipt behind), and states that the latest pointer was not refreshed either.
- Best-effort evidence is no longer mute. Stream init/append failures (run-scoped rail and latest pointer, tracked separately) and diffs-mkdir / per-task-patch failures are recorded and republished in the report:
  - `artifacts.stream.complete: false` + `artifacts.stream.errors[]`, plus a `> **Streaming rail incomplete**` banner in the Markdown — so a short `.jsonl` is never mistaken for a short run.
  - `artifacts.diffs.unavailable[]` (`{id, reason}`) plus a `## Diff evidence` section. That list is **bounded** at 10 like the other artifact-error lists, and `artifacts.diffs.unavailable_total` carries the true, unbounded count so the cap cannot understate the damage. The Markdown Warnings section links a patch **only** when that patch actually landed; otherwise it says "diff evidence unavailable".
  - A genuinely empty diff produces no patch and no "unavailable" marker — it is a legitimate outcome, not missing evidence.
- The `finally` still writes the report (an abort or a mid-run throw still produces a receipt); the `try/catch` around it exists only so a publication failure cannot *mask* an exception propagating out of the `try`.

## Red-test evidence (verbatim)

**Round 1 — the original 15 tests**, written and run **before** any implementation:

```
 ❯ farm.test.ts (36 tests | 10 failed | 26 skipped) 11592ms
   × #397: a run publishes its receipts under a run-scoped directory and still exposes the latest convenience copies 815ms
     → ENOENT: no such file or directory, open '…\.farm\runs\runone\farm-report.json'
   × #397: two concurrent farm processes on one repo both keep complete, independently parseable receipts 357ms
     → expected [ 1, 1 ] to deeply equal [ +0, +0 ]
   × #397: a failed report publication leaves the previous run's complete report intact — never a truncated one 766ms
     → expected 'dc514b' to be 'goodrun' // Object.is equality
   × #397: rejects a caller-supplied run id that is not a safe single path segment 5194ms
     → Test timed out in 5000ms.
   × #387: a green run whose farm-report.json cannot be published exits non-zero and never claims a Report path 778ms
     → expected +0 to be 3 // Object.is equality
   × #387: a failure to publish farm-report.md also fails the run 690ms
     → expected +0 to be 3 // Object.is equality
   × #387: a broken streaming rail is recorded as incomplete in the published report 776ms
     → ENOENT: no such file or directory, open '…\.farm\runs\streambad\farm-report.json'
   × #387: a broken latest streaming pointer is also recorded as incomplete 677ms
     → ENOENT: no such file or directory, open '…\.farm\runs\lstream\farm-report.json'
   × #387: an unusable diffs directory marks every task's diff evidence unavailable 754ms
     → ENOENT: no such file or directory, open '…\.farm\runs\diffdirbad\farm-report.json'
   × #387: a single failed patch write marks only that task's diff evidence unavailable 785ms
     → ENOENT: no such file or directory, open '…\.farm\runs\patchbad\farm-report.json'

 FAIL farm.unit.test.ts > atomicWriteFile — publish-or-preserve (#397)  (×3)
TypeError: (0 , atomicWriteFile) is not a function
 FAIL farm.unit.test.ts > assertSafeRunId — run id is a path segment (#397)  (×2)
AssertionError: expected [Function] to throw error matching /FARM_RUN_ID/ but got '(0 , assertSafe…'

 Test Files  2 failed | 1 skipped (3)
      Tests  15 failed | 208 skipped (223)
```

The **concurrency** failure was the load-bearing one — on the pre-fix code both processes destroyed each other:

```
Done. green=0 escalate=2 blocked=0
Integration: farm/integration-alpha  ->  review & PR to main
Report: .farm\farm-report.md
---
Error: could not create integration worktree: Preparing worktree (checking out 'farm/integration-bravo')
fatal: Unable to create '…/.git/worktrees/integration-wt1/index.lock': File exists.
: expected [ 2, 1 ] to deeply equal [ +0, +0 ]
```

**Round 2 — the review remediation**, 4 new/changed tests written and run **before** the corresponding code change. Each fails for its own defect:

```
 ❯ farm.unit.test.ts (182 tests | 1 failed) 770ms
   × T-07c run-id correlation > mints a collision-resistant, non-empty, distinct run id 5ms
     → expected '0a1594' to match /^[0-9a-f]{16}$/

 ❯ farm.test.ts (39 tests | 3 failed) 35893ms
   × #387: a failed LATEST report pointer does not fail a run whose authoritative receipt landed 1108ms
     → RECEIPT PUBLICATION FAILED — run mirrorbad could not publish its authoritative report:
       EPERM: operation not permitted, rename '…\.farm\.farm-report.json.54688-ab9f183c.tmp'
       -> '…\.farm\farm-report.json'
       so it cannot be reconciled or audited. Exiting 3 (receipt failure) rather than 0 (task outcome).
       : expected 3 to be +0 // Object.is equality
   × #387: the exit-3 message names the run's artifact directory and never denies a receipt that exists 820ms
     → expected 'report publication failed: Error: EPE…' not to match /there is no durable receipt/i
   × #387: the unavailable-diff list is bounded and still reports the true total 1499ms
     → expected undefined to be 12 // Object.is equality

 Test Files  2 failed | 1 passed (3)
      Tests  4 failed | 222 passed | 1 skipped (227)
```

The first of those reproduces the review's HIGH exactly: a green run whose non-authoritative pointer could not be renamed exited 3 while `.farm/runs/mirrorbad/farm-report.{json,md}` were both on disk.

**Mutation check on the fix (run on the current head).** Reverting *only* the tier-2 guard — replacing the `.catch(… noteArtifactError …)` around the two latest-pointer writes with a bare `await atomicWriteFile(dest, data)` — reproduces the review's HIGH verbatim and fails exactly the one test written for it, so that assertion is load-bearing rather than decorative:

```
- 0
+ 3
 ❯ renameWithRetry farm.ts:1042:7
 ❯ atomicWriteFile farm.ts:1082:5
 ❯ writeReport farm.ts:2359:5
 ❯ farm.test.ts:1613:37
    1613|     expect(result.code, result.out).toBe(0);
 Test Files  1 failed (1)
      Tests  1 failed | 38 skipped (39)
```

## Verification (re-measured on the current head)

| Check | Result |
| --- | --- |
| `plugins/ca/tools` — `npx vitest run` | **226 passed, 1 skipped** (was 222 + 1 before this round; 19 new tests over `origin/main`) |
| `plugins/ca/tools` — `npx tsc --noEmit` | clean (exit 0) |
| `plugins/ca/tools` — `npm run build` | `farm.js 70.8kb`, working tree clean afterwards — the committed esbuild artifact is not stale |
| `.github/scripts` — `python -m unittest discover` | `Ran 1065 tests in 76.520s … OK (skipped=5)` |
| `plugins/ca/hooks/tests` — `python -m unittest discover` | pre-existing local failures, none attributable to this branch — see the note below |
| `python tools/build-surface.py --check` | `OK (claude, codex, pi in sync)` |
| `python tools/sync-core.py --check` | `OK (47 core file(s) x 3 plugin(s), all byte-identical)` |
| `python .github/scripts/check-plugin-refs.py ca \| ca-codex \| ca-pi` | `Plugin reference graph intact` for all three |
| `python tools/build-host-packages.py --check --release-guard-base $(git merge-base origin/main HEAD)` | `Pi payload, version, changelog, and root metadata advanced together: 0.1.3 -> 0.1.4` |
| `git diff --check origin/main HEAD` | exit 0 |
| CRLF audit of every changed file | 0 CRLF pairs — all LF |
| `.codearbiter/gate-events.log`, `overrides.log`, `security-controls.md` in the diff | none |

**The `plugins/ca/hooks/tests` failures are pre-existing and not caused by this PR.** The proof of non-causation is structural rather than a judgement call: `git diff --name-only origin/main HEAD -- plugins/ca/hooks core/pysrc .github/scripts` is **empty** — this branch changes no Python file at all, so the code under test is byte-identical to `origin/main` and the suite necessarily produces whatever `origin/main` already produces. The failures observed are in `test_colorlib` / `test_statusline` palette rendering (e.g. `AssertionError: missing custom colors: [(4, 5, 6), (13, 14, 15)]`). They reproduce on this machine/worktree only; CI's own run is the authority. **Do not run this suite casually — see NEEDS-TRIAGE #7.**

The earlier revision of this PR reported 4 `.github/scripts` failures as "environmental". That was correct but under-diagnosed: they were `test_pi_benchmark` failing with `RuntimeError: Pi benchmark requires the installed pinned esbuild` because `plugins/ca-pi/tools` had no `node_modules` in this worktree. After `npm ci` there, the suite is fully green (above) — re-confirmed on the current head.

## Payload version gate

The earlier revision of this PR claimed `build-host-packages.py --check --release-guard-base <merge-base>` returned *"no Pi payload change - version bump not required"*. **That claim was false** and has been removed: that string is only printed when the base ref yields an empty diff. The regenerated `plugins/ca-pi/**` surface files put this diff inside the guarded path, and CI was red on `[GATE] | [PI] | Payload version` with:

```
ca-pi version must strictly advance from 0.1.3 to a higher SemVer (got 0.1.3)
```

`pi_release_guard` has no "unpublished version is exempt" branch — the tag check at line 165 only *adds* a rejection. Resolved by merging `origin/main` (which landed ca-pi `0.1.3` via #427 — merge, not rebase, per the branch policy) and advancing:

- `plugins/ca-pi/package.json` → `0.1.4`
- root `package.json` → `0.1.4`, regenerated by `python tools/build-host-packages.py` (not hand-edited)
- `plugins/ca-pi/CHANGELOG.md` → new `## [0.1.4] - 2026-07-24` heading describing the refreshed farm surface

The gate now passes both locally (table above) and in CI — `[GATE ] | [PI  ] | Payload version` is green on the current head.

**`ca` and `ca-codex` need no bump.** Unlike Pi's strict-advance guard, those two gates are tag-based: `ci.yml` prints `payload changed on unpublished version $ver (no tag …) - allowed`. `plugins/ca` is at `2.9.1` and `ca-codex` at `0.3.0`, and neither `v2.9.1` nor `ca-codex-v0.3.0` exists as a tag (`git tag --list` tops out at `v2.8.13` and `ca-codex-v0.2.4`), so both take that allowed branch — confirmed by `[GATE ] | [CA  ]` and `[GATE ] | [CDX ]` passing on the current head. A root `CHANGELOG.md` entry was added under `[Unreleased] → Fixed`.

## Artifacts rebuilt

- `plugins/ca/tools/farm.js` — rebuilt via `npm run build` (committed esbuild artifact, CI staleness gate). Re-running the build on the current head leaves the working tree clean, so the committed artifact matches its source.
- Surface trees rebuilt via `python tools/build-surface.py` after editing the canonical `core/surface/**` prose; `--check` reports `OK (claude, codex, pi in sync)`. The `plugins/ca`, `plugins/ca-codex`, `plugins/ca-pi` copies are generated, never hand-edited.
- No Python hook changed, so `tools/sync-core.py` is a no-op (verified with `--check`).

## Security gate

Both commits tripped hook **H-10b** — `FARM_API_KEY: "test-key"` lines in `farm.test.ts` match `SECRET_RE`. The `secret-handling` gate was run each time rather than overridden (3 sensitive lines bound for the remediation commit, 10 for the first).

- **Source:** the literal is the repo's established clearly-dummy test fixture. Production sourcing is untouched — `ENV.apiKey = process.env.FARM_API_KEY`, the access method `security-controls.md` explicitly approves for this project.
- **Sinks:** the dummy flows to the spawned child's env (a discrete env entry, never argv or shell text) → an `Authorization: Bearer` header → the test's own `http://127.0.0.1:<ephemeral>` mock server. It reaches no logger, error response, telemetry, LLM prompt, or persisted state, and does not outlive the test subprocess.
- **New sinks audited:** the report's `artifacts` block and the new summary/warning lines carry only filesystem paths and `errno` strings — never a provider response body, env value, or credential. Grepping this branch's added `farm.ts` lines for `apikey|api_key|authorization|bearer|secret|credential|password` returns nothing.
- *Caveat:* the skill asks for an `auth-crypto-reviewer` subagent to confirm; no subagent-dispatch tool was available in this execution context, so the Phase 1–3 review was performed inline against `security-controls.md`. Flagging it rather than implying a dispatch that did not happen.

## Declined review finding

**[LOW] the latest JSONL pointer is republished in full after every settlement (O(n²) bytes).** Not changed, deliberately. The full atomic republish is precisely what makes the shared pointer always a complete, parseable file when two runs race it — switching to `appendFile` restores the interleaved/partial-line behaviour this PR removes. The cost is bounded and small at real plan sizes (a 500-task plan at ~1 KB per serialized `Result` writes ~125 MB across a run that takes hours), and the in-memory retention is a second serialized copy of results the `done` map already holds for the whole run. Recorded below as a triage item rather than silently dropped.

## NEEDS-TRIAGE (not in this diff)

1. **Concurrent farm runs still collide on git state, not artifacts.** This PR makes *receipts* concurrency-safe; it does not make concurrent *execution* safe. Two runs on one repo still share `FARM_INTEGRATION_BRANCH` (`farm/integration`), `FARM_WORKTREE_ROOT` (`.farm/worktrees/<task-id>`), and per-task branch names `farm/<task-id>`. The concurrency test separates the first two per process to isolate the artifact contract under test. This is now **documented in the shipped surface docs** so an operator is not left to discover it; making concurrent execution safe (run-scoped integration branch + worktree root, or a repo-level lock) is a distinct, larger change.
2. **Run directories are never pruned.** `.farm/runs/<run-id>/` accumulates one directory per run indefinitely. Intentional here (receipts are meant to be retained), but a retention policy — age or count based, behind a flag — is worth a follow-up.
3. **A pinned `FARM_RUN_ID` is not refused when its run directory is already populated.** `assertSafeRunId` validates shape only. Refusing a populated directory would break the "safe to run twice" invariant for a pinned id, so it is documented (`farm.md`) rather than enforced; a `--fresh-run-dir` style opt-in would be the clean fix.
4. **`runCanary` still publishes `canary-report.json` with a bare `writeFile`** to the shared `${reportDir}`, and still uses the shared `.farm/integration-wt` path. Same truncate-on-crash and cross-process collision shape, but neither issue names it and canary is a separate mode.
5. **`plan.meta` is copied verbatim into `farm-report.json`.** Pre-existing, unchanged by this PR; worth deciding whether the persisted report should carry a sanitized meta.
6. **O(n²) latest-JSONL republication** — see "Declined review finding" above.
7. **`plugins/ca/hooks/tests` rewrites the developer's REAL `~/.claude/settings.json`.** Found while verifying this PR. **Pre-existing on `origin/main` and untouched by this branch** (this diff changes no Python file), so it is reported rather than fixed here — fixing it would put an unrelated Python change into a farm lane. `session-start.py:main()` calls `heal_statusline_wiring(plugin)` with the default `settings_path`, i.e. the real `~/.claude/settings.json`. `test_standup.py`'s `_MainHarness._run_main()` drives that real `main()` without faking `HOME`/`expanduser` and without patching the heal — unlike `test_session_start.py`'s `TestMainHealsBeforeDormantGate`, which correctly points `expanduser` at a temp home. Running the suite therefore re-pins the developer's global `statusLine` (and `_codearbiterStatuslineOwner`) to whatever checkout the suite ran from; observed here rewriting it to a throwaway worktree path (`…/.claude/worktrees/<id>/plugins/ca/hooks/statusline.py`), which breaks the statusline the moment that worktree is removed. Fix shape: give `_MainHarness` the same temp-`HOME` isolation the session-start tests already use, or have `_run_main()` patch `heal_statusline_wiring` to a no-op.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
