### PR TITLE
fix(hooks): stop losing and corrupting durable state in three core readers

### DIFF
--- a/.github/scripts/test_provenancelib.py
+++ b/.github/scripts/test_provenancelib.py
@@ -2597,5 +2597,129 @@ class TimeoutHardeningTest(unittest.TestCase):
         )
 
 
+class ProvenanceRecordShapeTest(unittest.TestCase):
+    """#410: read_provenance documents `dict | None` but used to hand back
+    whatever json.load produced, so a syntactically valid `[]` was admitted to
+    the store as a list. load_provenance_dir then called record.get() inside a
+    single try/except wrapped around the WHOLE glob loop, so the resulting
+    AttributeError aborted the scan and silently dropped every later valid
+    record — SessionStart drift and commit-gate auto-heal then ran against a
+    truncated provenance map with no indication anything was missing."""
+
+    # Every JSON top-level type that is not a provenance record.
+    NON_RECORDS = ("[]", "null", "3", '"a string"', "true", "[{}]")
+
+    def _dir(self):
+        import shutil
+
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        return tmp
+
+    def _write_raw(self, d, name, text):
+        path = os.path.join(d, name)
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(text)
+        return path
+
+    def _valid(self, d, name, doc):
+        record = pl.new_record(doc, created="2026-06-26", entries=[
+            {"path": "package.json", "hash": "a" * 40,
+             "drift_trigger": True, "claims": []},
+        ])
+        pl.write_provenance(os.path.join(d, name), record)
+        return record
+
+    def test_read_provenance_rejects_every_non_mapping_top_level_type(self):
+        d = self._dir()
+        for i, raw in enumerate(self.NON_RECORDS):
+            path = self._write_raw(d, f"nonmap{i}.json", raw)
+            self.assertIsNone(
+                pl.read_provenance(path),
+                f"read_provenance must return None for a top-level {raw!r}",
+            )
+
+    def test_read_provenance_rejects_a_mapping_with_the_wrong_schema(self):
+        d = self._dir()
+        bad = {
+            "empty": {},
+            "no_schema": {"doc": "x", "created": "2026-01-01",
+                          "interview_derived": False, "entries": []},
+            "wrong_version": {"schema": 99, "doc": "x", "created": "2026-01-01",
+                              "interview_derived": False, "entries": []},
+            "schema_as_string": {"schema": "1", "doc": "x", "created": "2026-01-01",
+                                 "interview_derived": False, "entries": []},
+            "entries_not_a_list": {"schema": 1, "doc": "x", "created": "2026-01-01",
+                                   "interview_derived": False, "entries": {}},
+            "doc_not_a_string": {"schema": 1, "doc": 7, "created": "2026-01-01",
+                                 "interview_derived": False, "entries": []},
+            "missing_entries": {"schema": 1, "doc": "x", "created": "2026-01-01",
+                                "interview_derived": False},
+        }
+        for name, record in bad.items():
+            path = self._write_raw(d, f"{name}.json", json.dumps(record))
+            self.assertIsNone(
+                pl.read_provenance(path),
+                f"read_provenance must return None for the {name!r} record",
+            )
+
+    def test_read_provenance_still_accepts_a_canonical_record(self):
+        d = self._dir()
+        record = self._valid(d, "tech-stack.json", "tech-stack")
+        self.assertEqual(pl.read_provenance(os.path.join(d, "tech-stack.json")), record)
+
+    def test_invalid_record_does_not_drop_the_valid_records_after_it(self):
+        # Filenames chosen so the invalid file is globbed FIRST.
+        d = self._dir()
+        self._write_raw(d, "a-bad.json", "[]")
+        self._valid(d, "b-good.json", "tech-stack")
+        self._valid(d, "c-good.json", "code-map")
+        loaded = pl.load_provenance_dir(d)
+        self.assertEqual(sorted(loaded), ["code-map", "tech-stack"],
+                         "one invalid record must not abort the directory scan")
+
+    def test_a_valid_record_survives_after_every_invalid_top_level_type(self):
+        for i, raw in enumerate(self.NON_RECORDS):
+            with self.subTest(raw=raw):
+                d = self._dir()
+                self._write_raw(d, "a-bad.json", raw)
+                self._valid(d, "b-good.json", "tech-stack")
+                loaded = pl.load_provenance_dir(d)
+                self.assertIn("tech-stack", loaded,
+                              f"a valid record after {raw!r} must still load")
+                self.assertEqual(len(loaded), 1)
+
+    def test_loader_never_raises_on_an_all_invalid_directory(self):
+        d = self._dir()
+        for i, raw in enumerate(self.NON_RECORDS):
+            self._write_raw(d, f"bad{i}.json", raw)
+        self.assertEqual(pl.load_provenance_dir(d), {})
+
+    def test_loader_reports_bounded_corruption_without_exposing_contents(self):
+        d = self._dir()
+        # Stand-in for the sort of thing a provenance file really holds —
+        # repo paths and claim prose that has no business in a log line.
+        sensitive = "internal/billing/keyvault.ts"
+        self._write_raw(d, "leaky.json", json.dumps([sensitive]))
+        self._valid(d, "good.json", "tech-stack")
+        skipped = []
+        loaded = pl.load_provenance_dir(d, skipped=skipped)
+        self.assertIn("tech-stack", loaded)
+        self.assertEqual(skipped, ["leaky.json"],
+                         "the loader must name the rejected file, and only its name")
+        self.assertNotIn(sensitive, " ".join(skipped),
+                         "a corruption diagnostic must never carry file contents")
+
+    def test_corruption_diagnostic_is_bounded(self):
+        d = self._dir()
+        for i in range(40):
+            self._write_raw(d, f"bad{i:02d}.json", "[]")
+        skipped = []
+        pl.load_provenance_dir(d, skipped=skipped)
+        self.assertTrue(skipped, "rejected records must be reported")
+        self.assertLessEqual(len(skipped), pl.MAX_SKIPPED_REPORTED,
+                             "the diagnostic must be bounded, not one line per file")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/core/pysrc/_provenancelib.py
+++ b/core/pysrc/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/core/pysrc/_subagentslib.py
+++ b/core/pysrc/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_provenancelib.py
+++ b/plugins/ca-codex/hooks/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/plugins/ca-codex/hooks/_subagentslib.py
+++ b/plugins/ca-codex/hooks/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.3] - 2026-07-24
+
+### Fixed
+
+- An abandoned maintainer session's synthetic `DEV: exit` is now durable: the
+  owed audit line is staged on disk before the append is attempted and cleared
+  only once both the append and the marker removal are confirmed, so a locked
+  or failing `overrides.log` no longer erases the close and leaves an unmatched
+  `DEV: enter`.
+- The subagent transcript reader honours one result shape on every path, so a
+  subagent-directory race no longer raises out of the statusline, and a
+  syntactically valid non-object JSONL record is skipped instead of blanking
+  every subagent row.
+- Provenance records are validated before admission and each file is loaded
+  inside its own error boundary, so one schema-invalid record no longer aborts
+  the directory scan and silently drops every later valid record.
+
+
 ## [0.1.2] - 2026-07-24
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_provenancelib.py
+++ b/plugins/ca-pi/hooks/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/plugins/ca-pi/hooks/_subagentslib.py
+++ b/plugins/ca-pi/hooks/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/plugins/ca-pi/hooks/session-start.py
+++ b/plugins/ca-pi/hooks/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/hooks/_provenancelib.py
+++ b/plugins/ca/hooks/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/plugins/ca/hooks/_subagentslib.py
+++ b/plugins/ca/hooks/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -568,6 +568,144 @@ class TestDevExitAudit(unittest.TestCase):
         self.assertEqual(len(log.splitlines()), 2, "exactly one DEV: exit line appended")
 
 
+class TestDevExitRetryablePendingClose(unittest.TestCase):
+    """#396: a failed overrides.log append must not destroy the only signal that
+    a DEV: exit is still owed. `clear_dev_marker` stages a durable pending-close
+    record BEFORE attempting the append and clears it only once the append (and
+    the marker removal) are confirmed — so a locked/failing log leaves a
+    retryable record instead of an orphaned DEV: enter."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.ca = os.path.join(self.root, ".codearbiter")
+        self.markers = os.path.join(self.ca, ".markers")
+        os.makedirs(self.markers)
+        self.log = os.path.join(self.ca, "overrides.log")
+        self.marker = os.path.join(self.markers, "dev-active")
+        # The durable retry state lives beside the marker it settles.
+        self.pending = os.path.join(self.markers, "dev-close-pending.json")
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev | DEV: enter | NOTE: —\n")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _seed_log(self, text):
+        with open(self.log, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def _read_log(self):
+        with open(self.log, encoding="utf-8") as f:
+            return f.read()
+
+    def _drop_marker(self):
+        with open(self.marker, "w", encoding="utf-8") as f:
+            f.write("active\n")
+
+    def _exit_lines(self):
+        return [ln for ln in self._read_log().splitlines() if "DEV: exit" in ln]
+
+    @contextlib.contextmanager
+    def _append_fails(self):
+        """Make ONLY the append-mode open of overrides.log raise OSError."""
+        real_open = open
+
+        def fake_open(file, mode="r", *a, **kw):
+            if "a" in mode and str(file).endswith("overrides.log"):
+                raise OSError("locked")
+            return real_open(file, mode, *a, **kw)
+
+        with mock.patch("builtins.open", fake_open):
+            yield
+
+    def test_append_failure_leaves_a_durable_retryable_close_record(self):
+        # AC-1: returns successfully, but the owed close survives on disk.
+        self._drop_marker()
+        with self._append_fails():
+            _mod.clear_dev_marker(self.root)
+        self.assertEqual(self._exit_lines(), [], "the append really did fail")
+        self.assertTrue(os.path.isfile(self.pending),
+                        "a failed append must leave a durable pending-close record")
+        with open(self.pending, encoding="utf-8") as f:
+            rec = json.load(f)
+        self.assertTrue(any("DEV: exit" in ln for ln in rec.get("lines", [])),
+                        "the pending record must carry the owed DEV: exit line")
+
+    def test_later_session_appends_the_missing_exit_exactly_once(self):
+        # AC-2: the next SessionStart flushes the owed close and clears the
+        # retry state — even though the marker is already gone by then.
+        self._drop_marker()
+        with self._append_fails():
+            _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.marker))
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1,
+                         "the owed DEV: exit must land exactly once on retry")
+        self.assertFalse(os.path.isfile(self.pending),
+                         "a confirmed append must clear the pending-close record")
+        # And a third session must not append it again.
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1, "no duplicate on a later session")
+
+    def test_crash_after_append_before_cleanup_does_not_duplicate(self):
+        # AC-3: an already-landed close line is recognised on retry (bounded
+        # tail scan), so a crash between the append and the record cleanup
+        # yields ONE close row, not two.
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        landed = self._exit_lines()
+        self.assertEqual(len(landed), 1)
+        # Simulate the crash: the record was never cleaned up.
+        with open(self.pending, "w", encoding="utf-8", newline="\n") as f:
+            json.dump({"lines": [landed[0] + "\n"], "marker_mtime": None}, f)
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1,
+                         "an already-appended close must not be appended twice")
+        self.assertFalse(os.path.isfile(self.pending),
+                         "the settled record must be cleared")
+
+    def test_marker_removal_failure_does_not_duplicate_the_close_row(self):
+        # AC-3/AC-4: the append lands, but the marker cleanup fails. The next
+        # SessionStart still sees a live marker and must NOT mint a second
+        # close row for the same marker.
+        self._drop_marker()
+        real_remove = os.remove
+
+        def fake_remove(path, *a, **kw):
+            if str(path).endswith("dev-active"):
+                raise OSError("locked")
+            return real_remove(path, *a, **kw)
+
+        with mock.patch("os.remove", fake_remove):
+            _mod.clear_dev_marker(self.root)
+        self.assertTrue(os.path.isfile(self.marker), "marker cleanup really did fail")
+        self.assertEqual(len(self._exit_lines()), 1)
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1,
+                         "the same marker must not be closed twice in the audit trail")
+        self.assertFalse(os.path.isfile(self.marker), "the retry removes the marker")
+        self.assertFalse(os.path.isfile(self.pending))
+
+    def test_clean_close_leaves_no_pending_record_behind(self):
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1)
+        self.assertFalse(os.path.isfile(self.marker))
+        self.assertFalse(os.path.isfile(self.pending),
+                         "the happy path must not leave retry state on disk")
+
+    def test_corrupt_pending_record_is_discarded_not_jammed(self):
+        # A record that carries no recoverable line must not wedge the
+        # mechanism shut (nothing to replay, so drop it and carry on).
+        with open(self.pending, "w", encoding="utf-8", newline="\n") as f:
+            f.write("{not json")
+        _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.pending))
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1)
+
+
 class TestStandupBriefingGating(unittest.TestCase):
     """#61 regression: pin the once-per-LOCAL-day briefing contract so the
     documented behavior (and the absence of a marker/timezone misfire) cannot

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -891,5 +891,85 @@ class TestSegUpdate(unittest.TestCase):
         self.assertIn("2.10.0", sl.ANSI.sub("", out))
 
 
+class TestSubagentResultContract(unittest.TestCase):
+    """#413: read_subagents() must honor ONE result shape on every path, and a
+    syntactically valid but non-object JSONL record must not escape as an
+    AttributeError. Both defects erase the whole subagent section of the rich
+    statusline (a ValueError on unpack, or an exception swallowed by safe())."""
+
+    def _write(self, td, name, lines):
+        path = os.path.join(td, name)
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            for ln in lines:
+                f.write(ln + "\n")
+        return path
+
+    def test_missing_directory_returns_the_documented_four_item_result(self):
+        with tempfile.TemporaryDirectory() as td:
+            gone = os.path.join(td, "does-not-exist")
+            res = subs.read_subagents(gone)
+        self.assertEqual(len(res), 4,
+                         "every return path must produce the documented 4-item result")
+        active, recent, shown, totals = res
+        self.assertEqual(active, 0)
+        self.assertEqual(recent, 0)
+        self.assertEqual(shown, [])
+        self.assertEqual(totals, (0, 0))
+
+    def test_missing_directory_unpacks_the_same_way_as_a_real_read(self):
+        # The statusline unpacks 4 names OUTSIDE safe() — a 3-item error branch
+        # is a hard ValueError there, not a degraded segment.
+        with tempfile.TemporaryDirectory() as td:
+            gone = os.path.join(td, "raced-away")
+            active, recent, shown, (tin, tout) = subs.read_subagents(gone)
+        self.assertEqual((active, recent, shown, tin, tout), (0, 0, [], 0, 0))
+
+    def test_statusline_renders_through_a_subagent_directory_race(self):
+        with tempfile.TemporaryDirectory() as td:
+            gone = os.path.join(td, "raced-away")
+            with mock.patch.object(sl, "subagent_dir", return_value=gone):
+                out = sl.render(json.dumps({"session_id": "sid"}))
+        self.assertTrue(out, "a directory race must not break the statusline")
+
+    def test_non_object_jsonl_records_are_skipped_not_raised(self):
+        # A valid JSON line that is not an object used to reach d.get() inside
+        # a try that only caught OSError -> AttributeError out of the reader.
+        with tempfile.TemporaryDirectory() as td:
+            self._write(td, "agent-aaaaaa.jsonl", [
+                "[]",
+                "null",
+                "3",
+                '"a bare string"',
+                "{not json at all",
+                json.dumps({"requestId": "r1",
+                            "message": {"role": "user", "content": "Do the thing"}}),
+                json.dumps({"requestId": "r1",
+                            "message": {"role": "assistant",
+                                        "model": "claude-sonnet-4-6-20250514",
+                                        "usage": {"input_tokens": 10,
+                                                  "output_tokens": 4}}}),
+            ])
+            active, recent, shown, (tin, tout) = subs.read_subagents(td)
+        self.assertEqual(recent, 1)
+        self.assertEqual(len(shown), 1, "the valid records after the bad ones must survive")
+        self.assertEqual(shown[0]["label"], "Do the thing")
+        self.assertEqual((tin, tout), (10, 4))
+
+    def test_a_corrupt_file_does_not_suppress_a_later_valid_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write(td, "agent-000001.jsonl", ["[]", "null"])
+            self._write(td, "agent-000002.jsonl", [
+                json.dumps({"requestId": "r9",
+                            "message": {"role": "user", "content": "Second agent"}}),
+                json.dumps({"requestId": "r9",
+                            "message": {"role": "assistant",
+                                        "usage": {"input_tokens": 7, "output_tokens": 2}}}),
+            ])
+            active, recent, shown, (tin, tout) = subs.read_subagents(td)
+        self.assertEqual(recent, 2)
+        self.assertEqual((tin, tout), (7, 2))
+        self.assertIn("Second agent", [row["label"] for row in shown])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three durability defects in the canonical `core/pysrc/` hook layer. Each is the
same shape: the *degradation* path destroys or drops state instead of preserving
it. All three edits are in `core/pysrc/`, re-vendored into `plugins/ca`,
`plugins/ca-codex` and `plugins/ca-pi` via `python tools/sync-core.py`.

Closes #396
Closes #413
Closes #410

---

## #396 — a retryable dev-exit record when the audit append fails

`clear_dev_marker` appended the synthetic `DEV: exit` under a fire-and-forget
`except OSError: pass`, then removed `dev-active` from a **separate** try block.
A locked file, full disk, or permission blip therefore permanently erased the
only retry signal and left the append-only trail with an unmatched `DEV: enter`
— contradicting the documented SessionStart self-heal guarantee.

The close now runs through one settlement step (`_settle_dev_close`) built
around a small write-ahead record at `.codearbiter/.markers/dev-close-pending.json`:

```json
{"lines": ["<owed DEV: exit line>"], "marker_mtime": 1753405.2}
```

- `lines` — close lines still owed to `overrides.log`, emptied one at a time as
  each append is **confirmed**. Bounded to 8.
- `marker_mtime` — the identity of the `dev-active` marker the close belongs to.
  While the record still names a **live** marker it doubles as a tombstone, so a
  failed `os.remove` cannot make the next session mint a *second* close row.

Every crash boundary is covered:

| crash point | state on disk | next SessionStart |
|---|---|---|
| before the append | record present, line owed | replays the append |
| after the append, before cleanup | record present, line owed | bounded 64 KiB tail scan sees the line already landed, drops it instead of duplicating |
| marker removal fails | record present, no line owed | only retries the removal |

Startup still fails **OPEN** — `clear_dev_marker` returns normally on every
path, exactly as before. The two early returns that leave a *live* marker owned
by another session deliberately do **not** settle: discarding a tombstone for a
marker you are not entitled to touch is precisely how a duplicate close gets
minted.

## #413 — one stable result contract for the subagent JSONL reader

Two independent defects, both of which erase the entire subagent section of the
rich statusline with no diagnostic:

1. `read_subagents` returned a **3-item** tuple on its directory-error branch
   while the module docstring, the happy path, and `statusline.py`'s own
   import-failure stub all promise **4**. `statusline.py` unpacks four names
   *outside* `safe()`, so a routine directory race was a hard `ValueError`.
2. `json.loads(ln)` was followed immediately by `d.get("message")` inside a try
   that caught `OSError` only — so one syntactically valid non-object line
   (`[]`, `null`, `3`, `"s"`) raised `AttributeError` out of the reader.

Fixed: one `empty = (0, 0, [], (0, 0))` returned on every error path, an
`isinstance(d, dict)` skip before any field access, and the per-file boundary
widened from `OSError` to `Exception` so file-local corruption costs only its
own row — matching the module's own stated contract ("Never raise on malformed
input — every reader degrades to a safe blank").

## #410 — validate provenance records before admitting them

`read_provenance` documented `dict | None` but returned the raw `json.load`
result, so a file containing `[]` was admitted to the store *as a list*.
`load_provenance_dir` then wrapped the **entire** glob loop in one try/except,
so the first `record.get("doc")` `AttributeError` aborted the scan and silently
dropped every later valid record — SessionStart drift reporting and commit-gate
auto-heal then ran against a truncated provenance map with no indication
anything was missing.

- New `valid_provenance_record()` checks the **top-level** v1 shape only
  (`schema == 1` with `bool` excluded since `True == 1`, plus `doc: str`,
  `created: str`, `interview_derived: bool`, `entries: list`). Entry-level
  tolerance stays where it already lives (`compute_drift`, `provenance_pointer`),
  so one odd claim never costs a doc its whole record.
- `read_provenance` returns `None` for anything that fails it.
- `load_provenance_dir` gets a **per-file** error boundary plus an optional
  `skipped=[]` list collecting up to `MAX_SKIPPED_REPORTED` (5) rejected
  **basenames** — names only, never file contents.

Verified against the real writers: every provenance record in the repo and in
the surface prose is produced by `new_record` / `write_provenance` /
`write_stub` / `rebaseline`, all of which emit the canonical shape. No
hand-authored provenance JSON exists, so the validation admits everything that
was already valid.

---

## Red-test evidence (verbatim)

### #396 — `plugins/ca/hooks/tests/test_session_start.py::TestDevExitRetryablePendingClose`

```
F.FFFF
======================================================================
FAIL: test_append_failure_leaves_a_durable_retryable_close_record (test_session_start.TestDevExitRetryablePendingClose.test_append_failure_leaves_a_durable_retryable_close_record)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 627, in test_append_failure_leaves_a_durable_retryable_close_record
    self.assertTrue(os.path.isfile(self.pending),
                    "a failed append must leave a durable pending-close record")
AssertionError: False is not true : a failed append must leave a durable pending-close record

======================================================================
FAIL: test_corrupt_pending_record_is_discarded_not_jammed (test_session_start.TestDevExitRetryablePendingClose.test_corrupt_pending_record_is_discarded_not_jammed)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 703, in test_corrupt_pending_record_is_discarded_not_jammed
    self.assertFalse(os.path.isfile(self.pending))
AssertionError: True is not false

======================================================================
FAIL: test_crash_after_append_before_cleanup_does_not_duplicate (test_session_start.TestDevExitRetryablePendingClose.test_crash_after_append_before_cleanup_does_not_duplicate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 664, in test_crash_after_append_before_cleanup_does_not_duplicate
    self.assertFalse(os.path.isfile(self.pending),
                     "the settled record must be cleared")
AssertionError: True is not false : the settled record must be cleared

======================================================================
FAIL: test_later_session_appends_the_missing_exit_exactly_once (test_session_start.TestDevExitRetryablePendingClose.test_later_session_appends_the_missing_exit_exactly_once)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 642, in test_later_session_appends_the_missing_exit_exactly_once
    self.assertEqual(len(self._exit_lines()), 1,
                     "the owed DEV: exit must land exactly once on retry")
AssertionError: 0 != 1 : the owed DEV: exit must land exactly once on retry

======================================================================
FAIL: test_marker_removal_failure_does_not_duplicate_the_close_row (test_session_start.TestDevExitRetryablePendingClose.test_marker_removal_failure_does_not_duplicate_the_close_row)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 684, in test_marker_removal_failure_does_not_duplicate_the_close_row
    self.assertEqual(len(self._exit_lines()), 1,
                     "the same marker must not be closed twice in the audit trail")
AssertionError: 2 != 1 : the same marker must not be closed twice in the audit trail

----------------------------------------------------------------------
Ran 6 tests in 0.027s

FAILED (failures=5)
```

`0 != 1` is the defect verbatim: the owed close is gone forever. `2 != 1` is the
duplicate-close mode. The sixth test (`test_clean_close_leaves_no_pending_record_behind`)
passes red — it is the guard proving the happy path was never broken.

### #413 — `plugins/ca/hooks/tests/test_statusline.py::TestSubagentResultContract`

```
======================================================================
ERROR: test_missing_directory_unpacks_the_same_way_as_a_real_read (test_statusline.TestSubagentResultContract.test_missing_directory_unpacks_the_same_way_as_a_real_read)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 924, in test_missing_directory_unpacks_the_same_way_as_a_real_read
    active, recent, shown, (tin, tout) = subs.read_subagents(gone)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 4, got 3)

======================================================================
ERROR: test_non_object_jsonl_records_are_skipped_not_raised (test_statusline.TestSubagentResultContract.test_non_object_jsonl_records_are_skipped_not_raised)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 952, in test_non_object_jsonl_records_are_skipped_not_raised
    active, recent, shown, (tin, tout) = subs.read_subagents(td)
  File "...\plugins\ca\hooks\_subagentslib.py", line 132, in read_subagents
    msg = d.get("message")
          ^^^^^
AttributeError: 'list' object has no attribute 'get'

======================================================================
ERROR: test_statusline_renders_through_a_subagent_directory_race (test_statusline.TestSubagentResultContract.test_statusline_renders_through_a_subagent_directory_race)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 931, in test_statusline_renders_through_a_subagent_directory_race
    out = sl.render(json.dumps({"session_id": "sid"}))
  File "...\plugins\ca\hooks\statusline.py", line 535, in render
    return _render_active_palette(raw)
  File "...\plugins\ca\hooks\statusline.py", line 653, in _render_active_palette
    active, recent, shown, (tin, tout) = res
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 4, got 3)

======================================================================
FAIL: test_missing_directory_returns_the_documented_four_item_result (test_statusline.TestSubagentResultContract.test_missing_directory_returns_the_documented_four_item_result)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 911, in test_missing_directory_returns_the_documented_four_item_result
    self.assertEqual(len(res), 4,
                     "every return path must produce the documented 4-item result")
AssertionError: 3 != 4 : every return path must produce the documented 4-item result

----------------------------------------------------------------------
Ran 5 tests in 0.061s

FAILED (failures=1, errors=4)
```

The third trace is the real-world consequence reproduced end to end: a
`ValueError` thrown from `statusline.py` line 653, exactly the line the issue
names.

### #410 — `.github/scripts/test_provenancelib.py::ProvenanceRecordShapeTest`

```
FFFFFEF.EFF.
======================================================================
ERROR: test_corruption_diagnostic_is_bounded (test_provenancelib.ProvenanceRecordShapeTest.test_corruption_diagnostic_is_bounded)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2716, in test_corruption_diagnostic_is_bounded
    pl.load_provenance_dir(d, skipped=skipped)
TypeError: load_provenance_dir() got an unexpected keyword argument 'skipped'

======================================================================
FAIL: test_a_valid_record_survives_after_every_invalid_top_level_type (test_provenancelib.ProvenanceRecordShapeTest.test_a_valid_record_survives_after_every_invalid_top_level_type) (raw='[]')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2688, in test_a_valid_record_survives_after_every_invalid_top_level_type
    self.assertIn("tech-stack", loaded,
                  f"a valid record after {raw!r} must still load")
AssertionError: 'tech-stack' not found in {} : a valid record after '[]' must still load

======================================================================
FAIL: test_invalid_record_does_not_drop_the_valid_records_after_it (test_provenancelib.ProvenanceRecordShapeTest.test_invalid_record_does_not_drop_the_valid_records_after_it)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2678, in test_invalid_record_does_not_drop_the_valid_records_after_it
    self.assertEqual(sorted(loaded), ["code-map", "tech-stack"],
                     "one invalid record must not abort the directory scan")
AssertionError: Lists differ: [] != ['code-map', 'tech-stack']

Second list contains 2 additional elements.
First extra element 0:
'code-map'

- []
+ ['code-map', 'tech-stack'] : one invalid record must not abort the directory scan

======================================================================
FAIL: test_read_provenance_rejects_a_mapping_with_the_wrong_schema (test_provenancelib.ProvenanceRecordShapeTest.test_read_provenance_rejects_a_mapping_with_the_wrong_schema)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2661, in test_read_provenance_rejects_a_mapping_with_the_wrong_schema
    self.assertIsNone(
        pl.read_provenance(path),
        f"read_provenance must return None for the {name!r} record",
    )
AssertionError: {} is not None : read_provenance must return None for the 'empty' record

======================================================================
FAIL: test_read_provenance_rejects_every_non_mapping_top_level_type (test_provenancelib.ProvenanceRecordShapeTest.test_read_provenance_rejects_every_non_mapping_top_level_type)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2637, in test_read_provenance_rejects_every_non_mapping_top_level_type
    self.assertIsNone(
        pl.read_provenance(path),
        f"read_provenance must return None for a top-level {raw!r}",
    )
AssertionError: [] is not None : read_provenance must return None for a top-level '[]'

----------------------------------------------------------------------
Ran 8 tests in 0.047s

FAILED (failures=8, errors=2)
```

`'tech-stack' not found in {}` is the silent-drop defect: the loader returned an
empty map even though a perfectly valid record sat next to the bad one.

---

## Suite results

| suite | before (origin/main @ 4ec1a8a) | after |
|---|---|---|
| `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` | 1057 tests, **OK** | 1068 tests, **OK** (+11) |
| `cd .github/scripts && python -m unittest discover -s . -p "test_*.py"` | 1064 tests, 2 failures / 2 errors / 5 skipped | 1072 tests, **same** 2 failures / 2 errors / 5 skipped (+8) |
| `python tools/sync-core.py --check` | OK | OK — 47 core files x 3 plugins, byte-identical |
| `python tools/build-host-packages.py --check --release-guard-base <merge-base>` | n/a | OK — `0.1.2 -> 0.1.3` advanced together |
| `check_badge_consistency.py` / `check_docs_contract.py` / `check-plugin-refs.py` | — | all clean |
| `git diff --check` | — | clean; all touched files LF |

The four `.github/scripts` failures are pre-existing on `origin/main` and
unrelated — see NEEDS-TRIAGE below.

No TypeScript package was touched, so `plugins/ca/tools` (farm) and
`plugins/ca-sandbox/tools` were not rebuilt — `farm.js` / `sandbox.js` are
unchanged and the staleness gate is unaffected.

### Payload version gate

`plugins/ca-pi/hooks/**` changed (vendored core sync), and the Pi guard is
stricter than ca/ca-codex — it requires the version to advance regardless of
whether a tag is published. So **ca-pi 0.1.2 → 0.1.3**, with the regenerated
root `package.json` (`python tools/build-host-packages.py`) and a new
`## [0.1.3] - 2026-07-24` heading, all in one `chore(ca-pi)` commit.

`ca` (2.9.1) and `ca-codex` (0.3.0) need no bump — neither `v2.9.1` nor
`ca-codex-v0.3.0` is published, and both guards only bite once the tag exists.
Confirmed against `git ls-remote --tags origin`.

---

## NEEDS-TRIAGE

**1. `test_pi_benchmark` is red on `origin/main` before this branch exists
(environmental, not a regression).** Four tests fail identically at the
`4ec1a8a` baseline and after this change:

```
ERROR: test_measurements_use_exact_public_shape_and_100_warm_events
ERROR: test_pi_record_does_not_load_the_generated_python_host_adapter
FAIL:  test_cli_emits_only_three_bounded_json_records
FAIL:  test_cli_real_spawn_flag_adds_a_fourth_labeled_record
```

Root cause is a missing local toolchain, not the code:

```
File ".github/scripts/pi_benchmark.py", line 151, in _production_pi_samples
    raise RuntimeError("Pi benchmark requires the installed pinned esbuild")
```

CI presumably installs the pinned esbuild, so this is likely green there. Worth
a separate look at whether these should skip rather than error when the
toolchain is absent — every local contributor otherwise sees a red
`.github/scripts` suite. Out of scope for this lane; filed here rather than
fixed.

**2. The `dev-close-pending` record is settled only by SessionStart.**
`/ca:arbiter` (the normal dev exit) removes `dev-active` through its own prose
path and does not consult the pending record. That is harmless — the record is
retired by the next SessionStart's no-marker settle — but it means a genuinely
owed close can sit on disk until the next session starts rather than being
flushed at exit time. Deliberate: wiring this into the arbiter prose is a
surface change well outside a `core/pysrc` durability fix.

**3. `load_provenance_dir(skipped=...)` has no caller yet.** The parameter is
opt-in and nothing passes it today — the acceptance criterion asked for a
bounded diagnostic "where the caller supports it", and adding it to
`startup_drift_line` or the context-check surface would change the SessionStart
output line. The plumbing is in place and tested; surfacing it is a follow-up.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
