### PR TITLE
fix(ci): add a pinned secret scan, gate the site deps, reach the parity fixture

### DIFF
--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -153,23 +153,41 @@ node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" <file>.
 
 ## CVE gate (supply chain)
 
-The configured CVE gate is `npm audit --omit=dev --audit-level=critical`, run in
-CI (the `tools` job, after `npm ci`) against the shipped dependency set. A
-CRITICAL advisory fails the build; lower severities are intentionally not
-gating, so routine dev-tool advisories don't block unrelated PRs. This enforces
-the supply-chain posture described in `security-controls.md`.
+The configured CVE gate is `npm audit --omit=dev --audit-level=high`, run after
+`npm ci` against every dependency graph the repo ships or publishes:
+
+| graph | workflow / job |
+| --- | --- |
+| `plugins/ca/tools` | `ci.yml` — `tools` |
+| `plugins/ca-sandbox/tools` | `ci.yml` — `ca-sandbox-tools` |
+| `site` (docs site) | `docs.yml` — `site-check`, which `deploy` needs |
+
+A HIGH-or-worse advisory fails the build; `--omit=dev` scopes the gate to
+shipped dependencies so routine dev-tool advisories don't block unrelated PRs.
+The threshold was `critical` until issue #403: every advisory cleared by #400
+was rated HIGH, so the gate would have passed all of them. This enforces the
+supply-chain posture described in `security-controls.md`.
 
 ## Secrets scan
 
-No dedicated secrets scanner is configured. The gate is two-layered:
+The gate is three-layered — one hosted backstop plus two cooperative local
+layers:
 
-1. Manual sweep of the staged diff for credential patterns
+1. `ci.yml`'s `secret-scan` job (issue #404): gitleaks' full default ruleset,
+   run over the tracked tree on every pull request as a required check for the
+   `ci-passed` merge gate. The scanner is pinned by image digest and runs in a
+   network-isolated, read-only container over a read-only mount. This is the
+   only layer a bot, a fork, a web edit, or a plain `git push` cannot skip — the
+   two below run only inside a contributor's local session. Its allowlist
+   (`.gitleaks.toml`) waives individual fake fixture literals by value, never a
+   file path: a `paths` waiver would drop the whole file from the scan.
+2. Manual sweep of the staged diff for credential patterns
    (`api[_-]?key|token|secret|password|private[_-]?key|passphrase|credential|BEGIN.*PRIVATE|AKIA|ghp_|sk-ant`),
    case-insensitive. This is the convenience layer; the authoritative classifier
    is `_hooklib.SECRET_RE`, pinned against the farm redactor by the shared
    `hooks/secret-detection-corpus.json`, which also matches a secret keyword as
    the trailing segment of a compound name (e.g. `FARM_API_KEY = "..."`).
-2. The plugin's own enforcement hooks: H-09b (crypto/TLS) and H-10b (secrets)
+3. The plugin's own enforcement hooks: H-09b (crypto/TLS) and H-10b (secrets)
    block any commit whose diff touches a crypto or secret line until a diff-bound
    security-gate pass marker covers those exact lines (`hooks/security-pass.py`).
 

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -156,17 +156,36 @@ node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" <file>.
 The configured CVE gate is `npm audit --omit=dev --audit-level=high`, run after
 `npm ci` against every dependency graph the repo ships or publishes:
 
-| graph | workflow / job |
-| --- | --- |
-| `plugins/ca/tools` | `ci.yml` — `tools` |
-| `plugins/ca-sandbox/tools` | `ci.yml` — `ca-sandbox-tools` |
-| `site` (docs site) | `docs.yml` — `site-check`, which `deploy` needs |
+| graph | workflow / job | production deps today |
+| --- | --- | --- |
+| `plugins/ca/tools` | `ci.yml` — `tools` | none |
+| `plugins/ca-sandbox/tools` | `ci.yml` — `ca-sandbox-tools` | none |
+| `plugins/ca-pi/tools` | `ci.yml` — `ca-pi-checks` | none |
+| `site` (docs site) | `docs.yml` — `site-check`, which `deploy` needs | astro, starlight, markdown-remark |
 
 A HIGH-or-worse advisory fails the build; `--omit=dev` scopes the gate to
 shipped dependencies so routine dev-tool advisories don't block unrelated PRs.
-The threshold was `critical` until issue #403: every advisory cleared by #400
-was rated HIGH, so the gate would have passed all of them. This enforces the
-supply-chain posture described in `security-controls.md`.
+This enforces the supply-chain posture described in `security-controls.md`.
+
+**What the threshold actually buys, honestly.** Three of the four graphs above
+declare no production dependencies at all, so `--omit=dev` audits an empty graph
+in those jobs and the threshold there is inert at any value — it is a
+*durability* setting that decides what happens the day one of them takes on a
+runtime dependency. The one live graph is `site`, and until issue #403 nothing
+audited it: #400's three HIGH advisories all lived in `site/package-lock.json`,
+which is why the site gate is the part of this change with immediate effect. The
+threshold was lowered from `critical` to `high` across all four so a single rule
+covers the repo — not because the farm or sandbox audits would have caught #400.
+They would not have seen it.
+
+The dev trees, where these packages' advisories actually are, are **not** covered
+by this gate. Measured in `plugins/ca/tools` at the time of writing, `npm audit
+--json` reports `{prod: 1, dev: 104}` — the single prod entry being the root
+package itself — and one **HIGH** advisory (`postcss`) that the shipped
+`--omit=dev` gate never sees. All four graphs pass `npm audit --omit=dev
+--audit-level=high` today. Issue #434 tracks extending the sweep to the dev
+trees, and notes the blast radius: those dev dependencies build `farm.js` and
+`sandbox.js`, which are committed, shipped artifacts.
 
 ## Secrets scan
 
@@ -174,13 +193,27 @@ The gate is three-layered — one hosted backstop plus two cooperative local
 layers:
 
 1. `ci.yml`'s `secret-scan` job (issue #404): gitleaks' full default ruleset,
-   run over the tracked tree on every pull request as a required check for the
-   `ci-passed` merge gate. The scanner is pinned by image digest and runs in a
-   network-isolated, read-only container over a read-only mount. This is the
-   only layer a bot, a fork, a web edit, or a plain `git push` cannot skip — the
-   two below run only inside a contributor's local session. Its allowlist
-   (`.gitleaks.toml`) waives individual fake fixture literals by value, never a
-   file path: a `paths` waiver would drop the whole file from the scan.
+   run as a required check for the `ci-passed` merge gate. The scanner is pinned
+   by image digest and runs in a network-isolated, read-only container over a
+   read-only mount. This is the only layer a bot, a fork, a web edit, or a plain
+   `git push` cannot skip — the two below run only inside a contributor's local
+   session. It scans in **two modes**, because each is blind to what the other
+   catches: `gitleaks dir` over the merge-result tree (what would land on main),
+   and, on a pull request, `gitleaks git --log-opts <merge-base>..HEAD` over the
+   PR's own commits. Without the second, a credential added in one commit and
+   deleted in the next passes green and still reaches main's history under a
+   merge or rebase merge, both of which this repo allows. Findings print with
+   `--redact --verbose`, so a red job names the file, line, rule, and commit
+   while the secret itself stays `REDACTED`.
+
+   Its allowlist (`.gitleaks.toml`) waives individual fake fixture literals by
+   value, never a file path — a `paths` waiver drops the whole file from the
+   scan — and every waiver is anchored `\A<literal>\z`. The anchoring is the
+   load-bearing part: gitleaks substring-matches allowlist regexes, so an
+   unanchored literal waives every secret that merely contains it, and no choice
+   of `regexTarget` fixes that. `.github/scripts/test_ci_impact.py` enforces both
+   rules, and the `secret-scan` job re-runs that contract itself, so a path-filter
+   edit can never leave the allowlist unguarded.
 2. Manual sweep of the staged diff for credential patterns
    (`api[_-]?key|token|secret|password|private[_-]?key|passphrase|credential|BEGIN.*PRIVATE|AKIA|ghp_|sk-ant`),
    case-insensitive. This is the convenience layer; the authoritative classifier

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -140,15 +140,83 @@ def gitleaks_allowlist_blocks(config: str) -> list[str]:
 def gitleaks_allowlist_regexes(config: str) -> list[str]:
     """Every literal inside an allowlist block's `regexes = [...]`.
 
-    Handles both the single-entry (`regexes = ['''x''']`) and multi-line array
-    spellings, so a waiver cannot hide from the narrowness contract by changing
-    its formatting.
+    Handles the single-entry (`regexes = ['''x''']`), multi-line array, and
+    embedded-newline spellings, so a waiver cannot hide from the narrowness
+    contract by changing its formatting.  The embedded-newline case is real: the
+    one multi-line secret this repo waives is a PEM block whose detected value
+    spans five source lines.
     """
     found: list[str] = []
     for block in gitleaks_allowlist_blocks(config):
         for array in re.findall(r"(?ms)^regexes\s*=\s*\[(.*?)\]", block):
-            found += re.findall(r"'''([^'\n]+)'''", array)
+            found += re.findall(r"(?s)'''(.*?)'''", array)
     return found
+
+
+# The characters that would let an anchored waiver match more than the single
+# fixed value it spells out.  `\` is in the set because an escape sequence is a
+# pattern, and this contract admits no patterns at all.
+_REGEX_METACHARACTERS = frozenset(".*+?()[]{}|^$\\")
+# `\A<body>\z` - Go RE2's spelling of "the WHOLE target is exactly <body>".
+_ANCHORED_WAIVER = re.compile(r"(?s)\A\\A(?P<body>.*)\\z\Z")
+
+
+def gitleaks_waiver_violations(config: str) -> list[str]:
+    """Every way `config`'s allowlist could waive more than one fixed value.
+
+    Empty means the allowlist is narrow.  Kept a pure function of the config
+    text so the contract can be exercised against adversarial configs that are
+    never written to disk.
+
+    Each rejected shape below was MEASURED against the pinned scanner image,
+    scanning this repo's tracked tree with a high-entropy key planted in
+    `plugins/ca/tools/.env.example` (the shipped config reports `leaks found: 1`
+    there; every shape below returns it to `no leaks found`):
+
+    * `paths` / `commits` un-scan a whole file or commit rather than waiving a
+      value, leaving a permanent blind spot.  `stopwords` is the same class.
+    * `regexTarget = "line"` widens the haystack to the entire source line, and
+      `regexTarget = "match"` to the rule's whole match text - so a short common
+      substring like `API_KEY` waives every line or match containing it.
+    * an UNANCHORED literal is the deeper bug, and the reason constraining
+      `regexTarget` alone is NOT sufficient: gitleaks tests allowlist regexes
+      with Go's `FindString`, a SUBSTRING search, so even against the default
+      (secret) target the literal `sk-` waives every secret beginning `sk-`.
+
+    Anchoring is what actually buys narrowness: `\\A<literal>\\z` matches only
+    when the ENTIRE detected secret is that exact fixture value.
+    """
+    problems: list[str] = []
+    for directive in re.findall(r"(?m)^\s*(paths|commits|stopwords)\s*=", config):
+        problems.append(
+            f"`{directive}` un-scans whole files or commits instead of waiving a value"
+        )
+    for target in re.findall(r'(?m)^\s*regexTarget\s*=\s*"([^"]*)"', config):
+        problems.append(
+            f'`regexTarget = "{target}"` binds the waiver to surrounding source text '
+            "rather than to the detected secret"
+        )
+    for block in gitleaks_allowlist_blocks(config):
+        head = (block.splitlines() or ["<empty>"])[0]
+        if "description =" not in block:
+            problems.append(f"allowlist block at {head!r} carries no rationale")
+        if "regexes = [" not in block:
+            problems.append(f"allowlist block at {head!r} names no value, so it is unbounded")
+    for literal in gitleaks_allowlist_regexes(config):
+        anchored = _ANCHORED_WAIVER.match(literal)
+        if anchored is None:
+            problems.append(
+                f"{literal!r} is not anchored `\\A...\\z`; gitleaks matches allowlist "
+                "regexes as substrings, so it waives anything merely containing it"
+            )
+            continue
+        stray = sorted(set(anchored.group("body")) & _REGEX_METACHARACTERS)
+        if stray:
+            problems.append(
+                f"{literal!r} carries regex metacharacter(s) {''.join(stray)!r}; "
+                "a waiver must spell out one fixed value"
+            )
+    return problems
 
 
 def aggregate_needs(ci: str) -> list[str]:
@@ -715,10 +783,20 @@ class WorkflowContractTest(unittest.TestCase):
         )
 
     def test_every_npm_audit_gate_fails_the_build_on_a_high_advisory(self):
-        # Issue #403 plus the maintainer fold-in: the farm and sandbox audits
-        # gated at `critical`, so every advisory cleared by #400 - all HIGH -
-        # would have sailed through.  One threshold, asserted per invocation,
-        # across every workflow that audits a dependency graph.
+        # Issue #403: site/package-lock.json - the ONLY graph in this repo that
+        # declares production dependencies (astro, starlight, markdown-remark) -
+        # was audited by nothing, and #400's three HIGH advisories all lived
+        # there.  The farm/sandbox gates were separately pinned at `critical`,
+        # but tightening those two is a DURABILITY change, not a live one:
+        # measured, plugins/ca/tools, plugins/ca-sandbox/tools and
+        # plugins/ca-pi/tools each declare ZERO production dependencies, so
+        # `--omit=dev` audits an empty graph there at any threshold.  It decides
+        # what happens the day one of them takes on a runtime dependency.
+        # Issue #434 tracks extending the sweep to the dev trees, which is where
+        # those packages' advisories actually are.
+        #
+        # One threshold, asserted per invocation, across every graph the repo
+        # ships or publishes.
         expected = "npm audit --omit=dev --audit-level=high"
         invocations: list[tuple[str, str]] = []
         for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
@@ -727,11 +805,24 @@ class WorkflowContractTest(unittest.TestCase):
                 for command in npm_audit_invocations(workflow.read_text(encoding="utf-8"))
             ]
         self.assertEqual(
-            len(invocations), 3, "expected exactly the farm, sandbox, and site audit gates"
+            len(invocations),
+            4,
+            "expected exactly the farm, sandbox, ca-pi, and site audit gates",
         )
         for name, command in invocations:
             with self.subTest(workflow=name, command=command):
                 self.assertEqual(command, f"run: {expected}")
+        # Every job that installs a lockfile must also audit it.  An unaudited
+        # `npm ci` is exactly how site/package-lock.json went unguarded, and
+        # plugins/ca-pi/tools is a PUBLISHED host package with the same shape.
+        # The Pi canary is deliberately excluded - it floats the host version on
+        # purpose and is advisory-only, so it is not a gate.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        for job_id in ("tools", "ca-sandbox-tools", "ca-pi-checks"):
+            with self.subTest(job=job_id):
+                job = workflow_jobs(ci)[job_id]
+                self.assertIn("npm ci", job)
+                self.assertIn(f"run: {expected}", job, "this job installs a graph it never audits")
 
     def test_docs_workflow_gates_the_site_dependency_graph_before_publishing(self):
         # Issue #403: site-check ran npm ci/typecheck/test and build ran
@@ -784,6 +875,25 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertIn("--redact", job, "a finding would print the credential in public logs")
         self.assertIn("--exit-code 1", job, "a finding would not fail the job")
         self.assertIn("--config /repo/.gitleaks.toml", job)
+        # ACTIONABLE WITHOUT LEAKING.  `--redact` alone prints only
+        # `leaks found: N` - no file, no line, no rule id - so a red job tells a
+        # maintainer nothing and the only way to triage it is to re-run the
+        # scanner unredacted.  Measured against the pinned image: adding
+        # `--verbose` prints `File:`/`Line:`/`RuleID:`/`Fingerprint:` (and
+        # `Commit:` in git mode) while still printing `Secret: REDACTED`.  Every
+        # scan step must carry BOTH, so neither mode is a dead end.
+        scan_steps = [step for step in job.split("\n      - name: ") if '"$GITLEAKS_IMAGE"' in step]
+        self.assertEqual(
+            len(scan_steps), 2, "expected exactly the tree scan and the commit-range scan"
+        )
+        for step in scan_steps:
+            with self.subTest(step=step.splitlines()[0]):
+                self.assertIn("--redact", step, "this scan would print credentials in public logs")
+                self.assertIn(
+                    "--verbose",
+                    step,
+                    "a failing scan would print only `leaks found: N` - no file, line, or rule",
+                )
         # Enforced through BOTH aggregate registrations (the #390 contract).
         self.assertIn("secret-scan", aggregate_needs(ci), "ci-passed.needs omits secret-scan")
         self.assertIn(
@@ -805,10 +915,6 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertTrue(GITLEAKS_CONFIG.is_file(), "no .gitleaks.toml in the repo root")
         config = GITLEAKS_CONFIG.read_text(encoding="utf-8")
         self.assertIn("useDefault = true", config, "the config must extend the default ruleset")
-        directives = re.findall(r"(?m)^\s*(paths|commits|stopwords)\s*=", config)
-        self.assertEqual(
-            directives, [], "path/commit waivers un-scan whole files - waive by value instead"
-        )
         blocks = gitleaks_allowlist_blocks(config)
         self.assertEqual(
             len(blocks),
@@ -816,21 +922,22 @@ class WorkflowContractTest(unittest.TestCase):
             "the allowlist block scan drifted off the config",
         )
         self.assertTrue(blocks, "no allowlist blocks found")
-        for block in blocks:
-            with self.subTest(block=block.splitlines()[0]):
-                self.assertIn("description =", block, "every waiver must carry its rationale")
-                self.assertIn("regexes = [", block, "a waiver with no value is unbounded")
         regexes = gitleaks_allowlist_regexes(config)
         self.assertTrue(regexes, "the allowlist waives no concrete value")
-        for literal in regexes:
-            with self.subTest(literal=literal):
-                # A fixed literal can only ever waive the exact fixture string
-                # it names; a metacharacter could swallow a real credential.
-                self.assertRegex(
-                    literal,
-                    r"\A[A-Za-z0-9_-]+\Z",
-                    "allowlist entries must be fixed literals, not patterns",
-                )
+        # NARROWNESS ITSELF.  Being a fixed literal is NOT enough - that was the
+        # hole in the first version of this contract.  gitleaks substring-matches
+        # allowlist regexes, so the fixed literal `sk-` waives every secret that
+        # starts with it, and `regexTarget = "line"` makes any short literal a
+        # substring test against every scanned line.  Each waiver must be
+        # `\A<literal>\z`, true only when the WHOLE detected secret is that exact
+        # fixture value.  The adversarial shapes this rejects - and the measured
+        # evidence that each one really does swallow a planted credential - are
+        # in test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract.
+        self.assertEqual(
+            gitleaks_waiver_violations(config),
+            [],
+            "the allowlist can waive more than the fixture values it names",
+        )
         # The two credential-shaped-but-benign payload files the audit named are
         # covered by the literals they carry, and named in the rationale so a
         # reviewer can check the claim.
@@ -841,7 +948,9 @@ class WorkflowContractTest(unittest.TestCase):
                 encoding="utf-8"
             )
         )
-        waived = set(regexes)
+        # Every waiver is `\A<value>\z`; compare on the anchored body so what is
+        # being checked is "this exact value", not "something resembling it".
+        waived = {_ANCHORED_WAIVER.match(literal).group("body") for literal in regexes}
         self.assertTrue(
             {literal for literal in waived if any(literal in row for row in corpus["must_match"])},
             "no corpus literal is waived - the rationale claims otherwise",
@@ -851,6 +960,171 @@ class WorkflowContractTest(unittest.TestCase):
             waived,
             "the .env.example placeholder is not the waived value, so the file is waived by "
             "something broader",
+        )
+
+    def test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract(self):
+        # A contract only means something if it FAILS on the diffs it exists to
+        # stop.  Every adversarial config below was measured against the pinned
+        # scanner image over this repo's tracked tree, with a high-entropy key
+        # planted in plugins/ca/tools/.env.example.  The shipped config reports
+        # `leaks found: 1` there; each shape below returns it to `no leaks
+        # found`, i.e. each one really does swallow a live credential.
+        quote = "'" * 3
+        shipped = GITLEAKS_CONFIG.read_text(encoding="utf-8")
+        self.assertEqual(
+            gitleaks_waiver_violations(shipped), [], "the shipped allowlist is not narrow"
+        )
+
+        def waiver(body: str, *, target: str | None = None) -> str:
+            block = ["", "[[allowlists]]", 'description = "adversarial"']
+            if target is not None:
+                block.append(f'regexTarget = "{target}"')
+            block.append(f"regexes = [{quote}{body}{quote}]")
+            return shipped + "\n".join(block) + "\n"
+
+        # 1. `regexTarget = "line"`: the haystack becomes the whole source line,
+        #    so a short literal is a substring test against every scanned line.
+        #    This is the shape that passed the first version of this contract.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver("API_KEY", target="line")) if "regexTarget" in p],
+            "a line-targeted waiver is accepted - it matches against the entire source line",
+        )
+        # Anchoring does not rescue a `line` target either: the anchors would
+        # then bind to the whole line rather than to the secret.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(waiver(r"\AAPI_KEY\z", target="line"))
+                if "regexTarget" in p
+            ],
+            "an anchored line-targeted waiver is accepted",
+        )
+        # 2. `regexTarget = "match"` is no better - measured: `API_KEY` is a
+        #    substring of the rule's own match text (`FARM_API_KEY=<secret>`).
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver("API_KEY", target="match")) if "regexTarget" in p],
+            "a match-targeted waiver is accepted",
+        )
+        # 3. The deeper bug, and the reason constraining `regexTarget` ALONE is
+        #    insufficient: with the target omitted (the detected secret) an
+        #    unanchored literal is still a SUBSTRING search.  Measured: `sk-`
+        #    waives the planted key outright.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver("sk-")) if "not anchored" in p],
+            "an unanchored waiver is accepted - it waives every secret containing it",
+        )
+        # 4. A pattern smuggled inside the anchors.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver(r"\Ask-.*\z")) if "metacharacter" in p],
+            "a wildcard waiver is accepted",
+        )
+        # 5. The blind-spot directives: these un-scan a whole file or commit.
+        for directive in ("paths", "commits", "stopwords"):
+            with self.subTest(directive=directive):
+                blinded = shipped + f"\n[[allowlists]]\n{directive} = [{quote}x{quote}]\n"
+                self.assertTrue(
+                    [p for p in gitleaks_waiver_violations(blinded) if directive in p],
+                    f"a `{directive}` waiver is accepted - it un-scans whole files",
+                )
+        # 6. A waiver with no rationale, and one with no value at all.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped + f"\n[[allowlists]]\nregexes = [{quote}\\Ax\\z{quote}]\n"
+                )
+                if "no rationale" in p
+            ],
+            "a waiver with no description is accepted",
+        )
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped + '\n[[allowlists]]\ndescription = "x"\n'
+                )
+                if "names no value" in p
+            ],
+            "a waiver naming no value is accepted",
+        )
+
+    def test_secret_scan_config_edits_reach_the_guard_that_constrains_them(self):
+        # The narrowness contract above lives in THIS file, which runs only in
+        # the path-scoped `ci-impact` job.  `.gitleaks.toml` matched no filter
+        # and no push trigger, so a PR whose ONLY change was to widen the
+        # allowlist skipped the single job that guards it - the same defect
+        # class as #384, which this branch fixes for the parity fixture.
+        # `.github/workflows/docs.yml` had the identical gap: it is guarded by
+        # test_docs_workflow_gates_the_site_dependency_graph_before_publishing
+        # (issue #403 AC-3), and a PR deleting the site audit step touches only
+        # docs.yml - exactly the diff the guard could not see.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        impact = paths_filter(ci, "impact")
+        self.assertIn(
+            "tools/ci-impact.py", impact, "the impact-filter scan drifted off the real block"
+        )
+        push = push_trigger_paths(ci)
+        self.assertIn(
+            "tools/sync-core.py", push, "the push-trigger scan drifted off the real block"
+        )
+        for guarded in (".gitleaks.toml", ".github/workflows/docs.yml"):
+            with self.subTest(path=guarded):
+                self.assertIn(
+                    guarded, impact, "a PR touching only this file skips its own contract test"
+                )
+                self.assertIn(guarded, push, "a push of this file starts no CI run")
+
+    def test_the_allowlist_guard_also_runs_unconditionally_in_the_secret_scan_job(self):
+        # Belt AND braces.  A path filter is a promise that has already been
+        # broken twice in this repo (#384, and the .gitleaks.toml gap above), so
+        # registering the config with the filter is necessary but not durable -
+        # a later edit can drop it again.  The `secret-scan` job carries no
+        # `needs: changes` gate, so hosting the narrowness contract there makes
+        # it unskippable: any PR that reaches CI at all re-proves the allowlist
+        # before the scan is allowed to trust it.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        job = workflow_jobs(ci)["secret-scan"]
+        # Job-level keys sit at four spaces; a step's own `if:` is deeper, so
+        # this reads the job's own gating and not the range step's event guard.
+        self.assertNotRegex(job, r"(?m)^    needs:", "the secret scan became path-scoped")
+        self.assertNotRegex(job, r"(?m)^    if:", "the secret scan became conditional")
+        for guard in (
+            "test_the_secret_scan_allowlist_stays_narrow_and_value_scoped",
+            "test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract",
+        ):
+            with self.subTest(guard=guard):
+                self.assertIn(
+                    f"test_ci_impact.WorkflowContractTest.{guard}",
+                    job,
+                    "the always-on job does not re-prove its own allowlist",
+                )
+
+    def test_the_secret_scan_covers_the_pull_requests_commit_range(self):
+        # Issue #404 AC-1 asks for a scan over the relevant commit RANGE.  A
+        # `gitleaks dir` scan of the merge-result tree cannot meet it, and the
+        # gap is not theoretical - measured on a scratch repo, a credential
+        # added in one commit and deleted in the next left the tree scan
+        # reporting `no leaks found` (exit 0) while `gitleaks git --log-opts
+        # <base>..HEAD` reported it with its file, line, rule, and commit sha
+        # (exit 1).  This repository allows merge and rebase merges as well as
+        # squash, so those commits reach main's history verbatim.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        job = workflow_jobs(ci)["secret-scan"]
+        # The `git` subcommand (as opposed to `dir`) is what reads history.
+        self.assertRegex(
+            job, r"(?m)^\s+git \. \\$", "the secret scan never inspects commit history"
+        )
+        self.assertIn("--log-opts", job, "the history scan is not scoped to the PR's range")
+        # History is only there to scan if the checkout actually fetched it.
+        self.assertRegex(
+            job, r"(?m)^          fetch-depth: 0$", "a shallow checkout leaves no range to scan"
+        )
+        # The range scan is a pull_request concern - it is the only event with a
+        # base to diff against, and PR checks are main's enforcement point.
+        self.assertIn(
+            "if: github.event_name == 'pull_request'",
+            job,
+            "the range scan is not scoped to the event that has a base to diff against",
         )
 
     def test_documentation_contract_is_always_required_by_merge_readiness(self):

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -20,6 +20,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOL = REPO_ROOT / "tools" / "ci-impact.py"
 _DESCRIPTORS_TOOL = REPO_ROOT / "tools" / "host_descriptors.py"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
+GITLEAKS_CONFIG = REPO_ROOT / ".gitleaks.toml"
 PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
 PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
 PI_PLATFORM_CONTRACT = REPO_ROOT / ".github" / "scripts" / "test_pi_platform_contract.py"
@@ -83,6 +85,70 @@ def workflow_jobs(text: str) -> dict[str, str]:
     if current is not None:
         jobs[current] = "".join(body)
     return jobs
+
+
+def push_trigger_paths(workflow: str) -> list[str]:
+    """Quoted globs under the workflow's `on.push.paths:` block.
+
+    Textual like every other contract here.  The block ends at the first line
+    that is not a `      - "<glob>"` entry, which is what makes this sensitive
+    to a deleted path rather than merely to the block's existence.
+    """
+    match = re.search(
+        r'(?ms)^  push:\n(?:.*?)^    paths:\n(?P<body>(?:      (?:- "[^"\n]+"|#[^\n]*)\n)+)',
+        workflow,
+    )
+    if match is None:
+        return []
+    return _globs(match.group("body"), '"')
+
+
+def paths_filter(ci: str, name: str) -> list[str]:
+    """Single-quoted globs under one `filters:` entry of the changes job."""
+    match = re.search(
+        rf"(?ms)^            {re.escape(name)}:\n"
+        rf"(?P<body>(?:              (?:- '[^'\n]+'|#[^\n]*)\n)+)",
+        ci,
+    )
+    if match is None:
+        return []
+    return _globs(match.group("body"), "'")
+
+
+def _globs(body: str, quote: str) -> list[str]:
+    """Quoted list entries in a YAML block, ignoring interleaved comments."""
+    return [
+        line.strip()[2:].strip().strip(quote)
+        for line in body.splitlines()
+        if line.strip().startswith("- ")
+    ]
+
+
+def npm_audit_invocations(workflow: str) -> list[str]:
+    """Every `npm audit ...` command line in a workflow, whitespace-normalised."""
+    return [
+        " ".join(match.group(0).split())
+        for match in re.finditer(r"(?m)^\s*(?:run: )?npm audit[^\n]*$", workflow)
+    ]
+
+
+def gitleaks_allowlist_blocks(config: str) -> list[str]:
+    """Every `[[allowlists]]` block body in the gitleaks config."""
+    return re.findall(r"(?ms)^\[\[allowlists\]\]\n(.*?)(?=^\[\[|\Z)", config)
+
+
+def gitleaks_allowlist_regexes(config: str) -> list[str]:
+    """Every literal inside an allowlist block's `regexes = [...]`.
+
+    Handles both the single-entry (`regexes = ['''x''']`) and multi-line array
+    spellings, so a waiver cannot hide from the narrowness contract by changing
+    its formatting.
+    """
+    found: list[str] = []
+    for block in gitleaks_allowlist_blocks(config):
+        for array in re.findall(r"(?ms)^regexes\s*=\s*\[(.*?)\]", block):
+            found += re.findall(r"'''([^'\n]+)'''", array)
+    return found
 
 
 def aggregate_needs(ci: str) -> list[str]:
@@ -406,6 +472,7 @@ class WorkflowContractTest(unittest.TestCase):
             "[CHECK] | [REPO] | License consistency",
             "[CHECK] | [CORE] | Generated surface",
             "[CHECK] | [CDX ] | Reference graph",
+            "[CHECK] | [REPO] | Secret scan",
             "[GATE ] | [REPO] | Merge readiness",
         )
         for name in expected:
@@ -619,6 +686,172 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertIn("GITHUB_STEP_SUMMARY", canary, "the advisory verdict must be visible")
         # And the aggregate gate stays independent of the advisory result.
         self.assertNotIn("ca-pi-latest", aggregate_required_results(ci))
+
+    def test_codex_parity_fixture_edits_reach_their_own_test(self):
+        # Issue #384: `.github/scripts/test_codex_parity_fixture.py` runs inside
+        # the path-scoped `hooks` job, but neither the push trigger nor the
+        # `hooks` filter listed the generator it tests.  A PR editing only
+        # tools/codex-parity-fixture.py therefore skipped its own test, and the
+        # merged push started no workflow at all.  Three registrations must
+        # agree: push trigger, `hooks` filter, and the test invocation.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        generator = "tools/codex-parity-fixture.py"
+        push = push_trigger_paths(ci)
+        self.assertIn(
+            "tools/sync-core.py", push, "the push-trigger scan drifted off the real block"
+        )
+        self.assertIn(generator, push, "a push of the fixture generator starts no CI run")
+        hooks = paths_filter(ci, "hooks")
+        self.assertIn(
+            ".github/scripts/**", hooks, "the hooks-filter scan drifted off the real block"
+        )
+        self.assertIn(
+            generator, hooks, "a PR touching only the fixture generator skips the hooks job"
+        )
+        self.assertIn(
+            "run: python .github/scripts/test_codex_parity_fixture.py",
+            workflow_jobs(ci)["hooks"],
+            "the hooks job no longer runs the fixture generator's own test",
+        )
+
+    def test_every_npm_audit_gate_fails_the_build_on_a_high_advisory(self):
+        # Issue #403 plus the maintainer fold-in: the farm and sandbox audits
+        # gated at `critical`, so every advisory cleared by #400 - all HIGH -
+        # would have sailed through.  One threshold, asserted per invocation,
+        # across every workflow that audits a dependency graph.
+        expected = "npm audit --omit=dev --audit-level=high"
+        invocations: list[tuple[str, str]] = []
+        for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
+            invocations += [
+                (workflow.name, command)
+                for command in npm_audit_invocations(workflow.read_text(encoding="utf-8"))
+            ]
+        self.assertEqual(
+            len(invocations), 3, "expected exactly the farm, sandbox, and site audit gates"
+        )
+        for name, command in invocations:
+            with self.subTest(workflow=name, command=command):
+                self.assertEqual(command, f"run: {expected}")
+
+    def test_docs_workflow_gates_the_site_dependency_graph_before_publishing(self):
+        # Issue #403: site-check ran npm ci/typecheck/test and build ran
+        # build/link-audit, but nothing ever audited site/package-lock.json - a
+        # known-vulnerable production dependency could build and deploy to
+        # GitHub Pages with the whole workflow green.
+        docs = DOCS_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(docs)
+        self.assertIn("site-check", sorted(jobs))
+        site_check = jobs["site-check"]
+        self.assertIn("run: npm ci", site_check)
+        self.assertIn("run: npm audit --omit=dev --audit-level=high", site_check)
+        # The audit is only a gate if the publish step waits on the job that
+        # runs it.  `deploy` needs BOTH build and site-check today; assert the
+        # site-check edge specifically so dropping it is caught.
+        deploy = jobs["deploy"]
+        self.assertRegex(
+            deploy,
+            r"(?m)^    needs: \[[^\]]*\bsite-check\b[^\]]*\]",
+            "deploy no longer waits on the audited site-check job",
+        )
+
+    def test_ci_runs_a_pinned_read_only_secret_scan_wired_into_the_merge_gate(self):
+        # Issue #404: the repository had NO independent secret scanner - only a
+        # manual staged-diff sweep and the cooperative local H-10b hook, neither
+        # of which a bot, a fork, or a direct push ever runs.  The hosted
+        # backstop must be pinned (no floating tag can be swapped under us),
+        # read-only, and enforced by the aggregate gate.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(ci)
+        self.assertIn("secret-scan", sorted(jobs), "ci.yml has no secret-scan job")
+        job = jobs["secret-scan"]
+        self.assertIn('name: "[CHECK] | [REPO] | Secret scan"', job)
+        # Pinned by image digest, not by a mutable tag.
+        self.assertRegex(
+            job,
+            r"ghcr\.io/gitleaks/gitleaks@sha256:[0-9a-f]{64}",
+            "the scanner image is not pinned by digest",
+        )
+        self.assertNotRegex(
+            job,
+            r"ghcr\.io/gitleaks/gitleaks:[^@\s]",
+            "a floating image tag defeats the pin",
+        )
+        # Read-only: the repository is mounted `:ro` and the scanner gets no
+        # network, so a supply-chain compromise of the image cannot rewrite the
+        # tree it is auditing or exfiltrate what it finds.
+        self.assertIn(":/repo:ro", job, "the scanned tree is not mounted read-only")
+        self.assertIn("--network none", job, "the scanner is not network-isolated")
+        self.assertIn("--redact", job, "a finding would print the credential in public logs")
+        self.assertIn("--exit-code 1", job, "a finding would not fail the job")
+        self.assertIn("--config /repo/.gitleaks.toml", job)
+        # Enforced through BOTH aggregate registrations (the #390 contract).
+        self.assertIn("secret-scan", aggregate_needs(ci), "ci-passed.needs omits secret-scan")
+        self.assertIn(
+            "secret-scan",
+            aggregate_required_results(ci),
+            "ci-passed.required_results omits secret-scan",
+        )
+
+    def test_the_secret_scan_allowlist_stays_narrow_and_value_scoped(self):
+        # A broad ignore defeats the whole job, and in gitleaks the broad ignore
+        # is `paths`: a global `paths = [...]` entry does not waive a finding,
+        # it drops the file from the scan entirely.  Measured against the pinned
+        # image - a config whose sole waiver was
+        # `paths = ['''^test_hooklib\\.py$''']` (condition = "AND", plus a regex
+        # matching nothing) reported `scanned ~189 bytes` and missed a freshly
+        # planted `aws_secret_access_key = "kR3m..."` in that file.  So every
+        # waiver here must be a VALUE waiver naming one fixed adversarial
+        # literal, which leaves every file fully scanned.
+        self.assertTrue(GITLEAKS_CONFIG.is_file(), "no .gitleaks.toml in the repo root")
+        config = GITLEAKS_CONFIG.read_text(encoding="utf-8")
+        self.assertIn("useDefault = true", config, "the config must extend the default ruleset")
+        directives = re.findall(r"(?m)^\s*(paths|commits|stopwords)\s*=", config)
+        self.assertEqual(
+            directives, [], "path/commit waivers un-scan whole files - waive by value instead"
+        )
+        blocks = gitleaks_allowlist_blocks(config)
+        self.assertEqual(
+            len(blocks),
+            len(re.findall(r"(?m)^\[\[allowlists\]\]$", config)),
+            "the allowlist block scan drifted off the config",
+        )
+        self.assertTrue(blocks, "no allowlist blocks found")
+        for block in blocks:
+            with self.subTest(block=block.splitlines()[0]):
+                self.assertIn("description =", block, "every waiver must carry its rationale")
+                self.assertIn("regexes = [", block, "a waiver with no value is unbounded")
+        regexes = gitleaks_allowlist_regexes(config)
+        self.assertTrue(regexes, "the allowlist waives no concrete value")
+        for literal in regexes:
+            with self.subTest(literal=literal):
+                # A fixed literal can only ever waive the exact fixture string
+                # it names; a metacharacter could swallow a real credential.
+                self.assertRegex(
+                    literal,
+                    r"\A[A-Za-z0-9_-]+\Z",
+                    "allowlist entries must be fixed literals, not patterns",
+                )
+        # The two credential-shaped-but-benign payload files the audit named are
+        # covered by the literals they carry, and named in the rationale so a
+        # reviewer can check the claim.
+        self.assertIn("plugins/ca/hooks/secret-detection-corpus.json", config)
+        self.assertIn("plugins/ca/tools/.env.example", config)
+        corpus = json.loads(
+            (REPO_ROOT / "plugins/ca/hooks/secret-detection-corpus.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        waived = set(regexes)
+        self.assertTrue(
+            {literal for literal in waived if any(literal in row for row in corpus["must_match"])},
+            "no corpus literal is waived - the rationale claims otherwise",
+        )
+        self.assertIn(
+            "sk-REPLACE_ME",
+            waived,
+            "the .env.example placeholder is not the waived value, so the file is waived by "
+            "something broader",
+        )
 
     def test_documentation_contract_is_always_required_by_merge_readiness(self):
         ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -1346,7 +1346,17 @@ class WorkflowContractTest(unittest.TestCase):
         #    Measured: `regexTarget = 'match'` plus a whole-match-anchored,
         #    metacharacter-free literal clears every other check and swallows
         #    the planted key.
-        planted = "FARM_API_KEY=sk-kR3mVq7XpZ2wNbT9sLdG4hJfA6cE1yUo"
+        #
+        #    The value below is a LOW-ENTROPY stand-in, deliberately.  The
+        #    measurement used a real high-entropy key, but this assertion is a
+        #    pure function of the config TEXT - `regexTarget` is rejected on
+        #    sight, whatever it is paired with - so the entropy buys the test
+        #    nothing and costs it a finding.  Committing the measured key here
+        #    made the secret-scan job red on its own contract, which is the job
+        #    working: a credential-shaped literal in a tracked file is exactly
+        #    what it exists to catch, and the answer to that is to stop
+        #    committing one, never to widen the allowlist around it.
+        planted = "FARM_API_KEY=sk-NOT-A-REAL-KEY"
         self.assertTrue(
             [
                 p

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -12,6 +12,7 @@ import json
 import re
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -132,24 +133,76 @@ def npm_audit_invocations(workflow: str) -> list[str]:
     ]
 
 
-def gitleaks_allowlist_blocks(config: str) -> list[str]:
-    """Every `[[allowlists]]` block body in the gitleaks config."""
-    return re.findall(r"(?ms)^\[\[allowlists\]\]\n(.*?)(?=^\[\[|\Z)", config)
+def _fold_keys(value: object, collisions: list[str]) -> object:
+    """Lower-case every mapping key, the way gitleaks' own config reader does.
+
+    gitleaks loads this file through viper, whose key lookup is case-
+    INSENSITIVE.  Measured against the pinned image: `Paths = ['''.''']`
+    reports `scanned ~0 bytes` exactly as `paths` does, `RegexTarget` rebinds
+    the waiver exactly as `regexTarget` does, and `DISABLEDRULES` deletes a
+    rule exactly as `disabledRules` does.  Every ban below is therefore
+    written against folded keys, so a capitalisation cannot walk past it.
+
+    A fold COLLISION (`paths` and `Paths` in one table) is reported rather
+    than silently resolved: which spelling the scanner would honour is not
+    something this contract should guess at.
+    """
+    if isinstance(value, dict):
+        folded: dict[str, object] = {}
+        for key, item in value.items():
+            lowered = key.lower()
+            if lowered in folded:
+                collisions.append(lowered)
+            folded[lowered] = _fold_keys(item, collisions)
+        return folded
+    if isinstance(value, list):
+        return [_fold_keys(item, collisions) for item in value]
+    return value
+
+
+def parse_gitleaks_config(config: str) -> tuple[dict, list[str]]:
+    """The gitleaks config as gitleaks itself reads it - PARSED, keys folded.
+
+    Reading this file as text was the defect this function exists to end.  A
+    regex has to guess at TOML's spellings and it guessed wrong eleven times:
+    an indented key, an indented table header, a basic string instead of a
+    literal one, a `]` inside a value, a capitalised key.  Every one of those
+    was measured GUARD-GREEN while the pinned scanner swallowed a planted
+    high-entropy key.  TOML has exactly one meaning per document, so the
+    contract now reads that meaning instead of the characters around it.
+
+    Returns the folded document and any key-fold collisions.  Raises
+    `tomllib.TOMLDecodeError` on input gitleaks itself could not load.
+    """
+    collisions: list[str] = []
+    document = _fold_keys(tomllib.loads(config), collisions)
+    assert isinstance(document, dict)
+    return document, collisions
+
+
+def gitleaks_allowlist_blocks(config: str) -> list[dict]:
+    """Every `[[allowlists]]` table in the gitleaks config, keys case-folded."""
+    document, _ = parse_gitleaks_config(config)
+    blocks = document.get("allowlists") or []
+    return [block for block in blocks if isinstance(block, dict)]
 
 
 def gitleaks_allowlist_regexes(config: str) -> list[str]:
-    """Every literal inside an allowlist block's `regexes = [...]`.
+    """Every value inside an allowlist table's `regexes`.
 
-    Handles the single-entry (`regexes = ['''x''']`), multi-line array, and
-    embedded-newline spellings, so a waiver cannot hide from the narrowness
-    contract by changing its formatting.  The embedded-newline case is real: the
-    one multi-line secret this repo waives is a PEM block whose detected value
-    spans five source lines.
+    These are the PARSED values, so the single-entry, multi-line-array,
+    embedded-newline, and alternate-quoting spellings all reduce to the same
+    list - a waiver cannot hide from the narrowness contract by reformatting.
+    The embedded-newline case is real: the one multi-line secret this repo
+    waives is a PEM block whose detected value spans five source lines.
     """
     found: list[str] = []
     for block in gitleaks_allowlist_blocks(config):
-        for array in re.findall(r"(?ms)^regexes\s*=\s*\[(.*?)\]", block):
-            found += re.findall(r"(?s)'''(.*?)'''", array)
+        entries = block.get("regexes")
+        if isinstance(entries, str):
+            entries = [entries]
+        if isinstance(entries, list):
+            found += [entry for entry in entries if isinstance(entry, str)]
     return found
 
 
@@ -159,6 +212,17 @@ def gitleaks_allowlist_regexes(config: str) -> list[str]:
 _REGEX_METACHARACTERS = frozenset(".*+?()[]{}|^$\\")
 # `\A<body>\z` - Go RE2's spelling of "the WHOLE target is exactly <body>".
 _ANCHORED_WAIVER = re.compile(r"(?s)\A\\A(?P<body>.*)\\z\Z")
+# Keys that un-scan a file or a commit rather than waiving one value.
+_UNSCANNING_KEYS = ("paths", "commits", "stopwords")
+# The only keys a waiver in this file may carry.  DEFAULT-DENY: gitleaks keeps
+# adding allowlist knobs, and the next one to widen the haystack must fail this
+# contract on the day it is typed, not on the day someone remembers to ban it.
+_ALLOWED_ALLOWLIST_KEYS = frozenset({"description", "regexes"})
+# `[extend]` selects which rules run.  This file only ever SUBTRACTS fixture
+# values from the default ruleset, so `useDefault` is the only key it may set:
+# `disabledRules` deletes a rule outright, and `path`/`url` pull in allowlists
+# that are not in this file and therefore not covered by anything below.
+_ALLOWED_EXTEND_KEYS = frozenset({"usedefault"})
 
 
 def gitleaks_waiver_violations(config: str) -> list[str]:
@@ -185,37 +249,88 @@ def gitleaks_waiver_violations(config: str) -> list[str]:
 
     Anchoring is what actually buys narrowness: `\\A<literal>\\z` matches only
     when the ENTIRE detected secret is that exact fixture value.
+
+    The checks run against the PARSED document, not the config text.  Reading
+    it as text is what let eleven measured shapes through - see
+    test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract for
+    each one and the evidence it swallowed a planted key.
     """
+    try:
+        document, collisions = parse_gitleaks_config(config)
+    except tomllib.TOMLDecodeError as error:
+        # Not "narrow" - unreadable.  gitleaks exits FTL on the same input, so
+        # reporting no violations here would call a config that cannot scan
+        # anything a config that scans everything.
+        return [f"the config is not parseable TOML ({error}), so gitleaks cannot load it"]
+
     problems: list[str] = []
-    for directive in re.findall(r"(?m)^\s*(paths|commits|stopwords)\s*=", config):
+    for key in sorted(set(collisions)):
         problems.append(
-            f"`{directive}` un-scans whole files or commits instead of waiving a value"
+            f"`{key}` is spelled two ways in one table; gitleaks reads keys "
+            "case-insensitively, so which one applies is unknowable from the file"
         )
-    for target in re.findall(r'(?m)^\s*regexTarget\s*=\s*"([^"]*)"', config):
-        problems.append(
-            f'`regexTarget = "{target}"` binds the waiver to surrounding source text '
-            "rather than to the detected secret"
-        )
-    for block in gitleaks_allowlist_blocks(config):
-        head = (block.splitlines() or ["<empty>"])[0]
-        if "description =" not in block:
-            problems.append(f"allowlist block at {head!r} carries no rationale")
-        if "regexes = [" not in block:
-            problems.append(f"allowlist block at {head!r} names no value, so it is unbounded")
-    for literal in gitleaks_allowlist_regexes(config):
-        anchored = _ANCHORED_WAIVER.match(literal)
-        if anchored is None:
+    extend = document.get("extend")
+    if isinstance(extend, dict):
+        for key in sorted(set(extend) - _ALLOWED_EXTEND_KEYS):
             problems.append(
-                f"{literal!r} is not anchored `\\A...\\z`; gitleaks matches allowlist "
-                "regexes as substrings, so it waives anything merely containing it"
+                f"`[extend] {key}` changes which rules run instead of waiving one value; "
+                "`useDefault` is the only key this config may set there"
             )
+    if document.get("rules"):
+        problems.append(
+            "a `[[rules]]` block re-declares the ruleset - one whose id matches a default "
+            "rule REPLACES it - and this file only ever subtracts fixture values"
+        )
+    for position, block in enumerate(document.get("allowlists") or [], start=1):
+        if not isinstance(block, dict):
+            problems.append(f"allowlist #{position} is not a table")
             continue
-        stray = sorted(set(anchored.group("body")) & _REGEX_METACHARACTERS)
-        if stray:
+        description = block.get("description")
+        head = str(description).strip().splitlines()[0] if str(description).strip() else ""
+        head = head or f"#{position}"
+        for key in _UNSCANNING_KEYS:
+            if key in block:
+                problems.append(
+                    f"`{key}` un-scans whole files or commits instead of waiving a value"
+                )
+        if "regextarget" in block:
             problems.append(
-                f"{literal!r} carries regex metacharacter(s) {''.join(stray)!r}; "
-                "a waiver must spell out one fixed value"
+                f"`regexTarget = {block['regextarget']!r}` binds the waiver to surrounding "
+                "source text rather than to the detected secret"
             )
+        unmodelled = set(block) - _ALLOWED_ALLOWLIST_KEYS - {"regextarget"} - set(_UNSCANNING_KEYS)
+        for key in sorted(unmodelled):
+            problems.append(
+                f"allowlist block at {head!r} sets `{key}`, which this contract cannot "
+                "reason about; a waiver may carry only `description` and `regexes`"
+            )
+        if not str(description or "").strip():
+            problems.append(f"allowlist block at {head!r} carries no rationale")
+        entries = block.get("regexes")
+        if isinstance(entries, str):
+            entries = [entries]
+        if not isinstance(entries, list) or not entries:
+            problems.append(f"allowlist block at {head!r} names no value, so it is unbounded")
+            continue
+        for literal in entries:
+            if not isinstance(literal, str):
+                problems.append(
+                    f"allowlist block at {head!r} waives {literal!r}, which is not a string"
+                )
+                continue
+            anchored = _ANCHORED_WAIVER.match(literal)
+            if anchored is None:
+                problems.append(
+                    f"{literal!r} is not anchored `\\A...\\z`; gitleaks matches allowlist "
+                    "regexes as substrings, so it waives anything merely containing it"
+                )
+                continue
+            stray = sorted(set(anchored.group("body")) & _REGEX_METACHARACTERS)
+            if stray:
+                problems.append(
+                    f"{literal!r} carries regex metacharacter(s) {''.join(stray)!r}; "
+                    "a waiver must spell out one fixed value"
+                )
     return problems
 
 
@@ -914,12 +1029,27 @@ class WorkflowContractTest(unittest.TestCase):
         # literal, which leaves every file fully scanned.
         self.assertTrue(GITLEAKS_CONFIG.is_file(), "no .gitleaks.toml in the repo root")
         config = GITLEAKS_CONFIG.read_text(encoding="utf-8")
-        self.assertIn("useDefault = true", config, "the config must extend the default ruleset")
+        document, collisions = parse_gitleaks_config(config)
+        self.assertEqual([], collisions, "a key is spelled two ways in one table")
+        # Read from the PARSE, not from the text: `assertIn("useDefault = true")`
+        # is satisfied by that string appearing in a comment and defeated by a
+        # different spacing, and neither has anything to do with what gitleaks
+        # loads.
+        self.assertIs(
+            document.get("extend", {}).get("usedefault"),
+            True,
+            "the config must extend the default ruleset",
+        )
         blocks = gitleaks_allowlist_blocks(config)
         self.assertEqual(
             len(blocks),
-            len(re.findall(r"(?m)^\[\[allowlists\]\]$", config)),
-            "the allowlist block scan drifted off the config",
+            len(re.findall(r"(?m)^\s*\[\[\s*allowlists\s*\]\]\s*$", config)),
+            # Text and parse must agree on how many waivers exist.  They can
+            # disagree: `allowlists = [{...}]` is a valid TOML array-of-tables
+            # that a header count cannot see - and, measured against the pinned
+            # image, one gitleaks silently IGNORES.  A waiver the scanner does
+            # not honour and the reader believes in is its own kind of hole.
+            "the allowlist block count disagrees with the table headers in the file",
         )
         self.assertTrue(blocks, "no allowlist blocks found")
         regexes = gitleaks_allowlist_regexes(config)
@@ -1046,6 +1176,176 @@ class WorkflowContractTest(unittest.TestCase):
                 if "names no value" in p
             ],
             "a waiver naming no value is accepted",
+        )
+
+        # ---- SPELLING BYPASSES OF THE CONTRACT ITSELF -----------------------
+        # Everything above bypasses the RULES.  Every shape below bypassed the
+        # CONTRACT: each was measured GUARD-GREEN against the first version of
+        # this file while the pinned image reported `no leaks found` (exit 0)
+        # over a tree carrying a freshly planted high-entropy key that the
+        # shipped config reports as `leaks found: 1` (exit 1).  They are one
+        # defect with eleven faces - the contract read the config as TEXT, and
+        # TOML (plus viper's case-insensitive key lookup) admits far more
+        # spellings than a regex anticipates.  The contract now PARSES.
+        def block(*lines: str) -> str:
+            return shipped + "\n[[allowlists]]\n" + "\n".join(lines) + "\n"
+
+        # 7. An INDENTED `regexes` key.  `  regexes = [...]` is valid TOML; the
+        #    extractor was anchored at column 0 so it pulled ZERO literals from
+        #    this block, while the `"regexes = [" in block` substring test still
+        #    reported the block as bounded.  Zero literals, zero violations.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    block('description = "adversarial"', f"  regexes = [{quote}sk-{quote}]")
+                )
+                if "not anchored" in p
+            ],
+            "an indented `regexes` key hides its literals from the contract",
+        )
+        # 8. `disabledRules` under `[extend]` turns the highest-value rule off
+        #    outright.  Asserting `useDefault = true` is present says nothing
+        #    about what sits beside it.  Only `useDefault` may live there.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped.replace(
+                        "useDefault = true",
+                        'useDefault = true\ndisabledRules = ["generic-api-key"]',
+                        1,
+                    )
+                )
+                if "disabledrules" in p.lower()
+            ],
+            "`[extend] disabledRules` is accepted - it deletes the rule outright",
+        )
+        # 9. A SINGLE-QUOTED `regexTarget`.  The ban matched double quotes only.
+        #    Measured: `regexTarget = 'match'` plus a whole-match-anchored,
+        #    metacharacter-free literal clears every other check and swallows
+        #    the planted key.
+        planted = "FARM_API_KEY=sk-kR3mVq7XpZ2wNbT9sLdG4hJfA6cE1yUo"
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    block(
+                        'description = "adversarial"',
+                        "regexTarget = 'match'",
+                        f"regexes = [{quote}\\A{planted}\\z{quote}]",
+                    )
+                )
+                if "regexTarget" in p
+            ],
+            "a single-quoted `regexTarget` evades the ban",
+        )
+        # 10. Any TOML string spelling other than `'''...'''`.  The literal
+        #     extractor matched triple-quoted strings only, so a basic or a
+        #     single-quoted literal string yielded ZERO literals to check.
+        for spelling in ('regexes = ["sk-"]', "regexes = ['sk-']"):
+            with self.subTest(spelling=spelling):
+                self.assertTrue(
+                    [
+                        p
+                        for p in gitleaks_waiver_violations(
+                            block('description = "adversarial"', spelling)
+                        )
+                        if "not anchored" in p
+                    ],
+                    "a waiver spelled with other quotes hides from the contract",
+                )
+        # 11. An INDENTED `[[allowlists]]` header.  The block scan was anchored
+        #     at column 0, so an indented block - and every waiver in it - was
+        #     invisible to every per-block check at once.
+        first_header = re.search(r"(?m)^\[\[allowlists\]\]$", shipped)
+        self.assertIsNotNone(first_header, "the shipped config has no allowlist header")
+        indented = (
+            shipped[: first_header.start()]
+            + f'  [[allowlists]]\n  description = "adversarial"\n  regexes = [{quote}sk-{quote}]\n\n'
+            + shipped[first_header.start() :]
+        )
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(indented) if "not anchored" in p],
+            "an indented `[[allowlists]]` header hides a whole block",
+        )
+        # 12. CASE-VARIED KEYS.  gitleaks reads its config through viper, whose
+        #     key lookup is case-INSENSITIVE, while every ban here was
+        #     case-sensitive.  Measured: `Paths = ['''.''']` reported
+        #     `scanned ~0 bytes` - the entire repository went unread - with the
+        #     guard green.
+        for line, needle in (
+            (f"Paths = [{quote}.{quote}]", "paths"),
+            ('RegexTarget = "match"', "regexTarget"),
+        ):
+            with self.subTest(line=line):
+                self.assertTrue(
+                    [
+                        p
+                        for p in gitleaks_waiver_violations(
+                            block(
+                                'description = "adversarial"',
+                                line,
+                                f"regexes = [{quote}\\Aunused\\z{quote}]",
+                            )
+                        )
+                        if needle in p
+                    ],
+                    "a case-varied key evades the ban that names it",
+                )
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped.replace(
+                        "useDefault = true",
+                        'useDefault = true\nDISABLEDRULES = ["generic-api-key"]',
+                        1,
+                    )
+                )
+                if "disabledrules" in p.lower()
+            ],
+            "a case-varied `disabledRules` evades the ban",
+        )
+        # 13. A `]` INSIDE a literal.  The array capture was non-greedy to the
+        #     first `]`, so one waiver containing a bracket truncated the scan
+        #     and every later literal in the same array went unchecked.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    block(
+                        'description = "adversarial"',
+                        f"regexes = [{quote}\\Ax]y\\z{quote}, {quote}sk-{quote}]",
+                    )
+                )
+                if "not anchored" in p
+            ],
+            "a `]` in one waiver hides every later waiver in the same array",
+        )
+        # 14. A `[[rules]]` BLOCK.  The contract only ever looked at
+        #     `[[allowlists]]`.  Measured: re-declaring the id `generic-api-key`
+        #     with a never-matching regex REPLACES the default rule, and the
+        #     planted key goes unreported.  This file subtracts fixture values
+        #     from the default ruleset; it declares no rules of its own.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped
+                    + '\n[[rules]]\nid = "generic-api-key"\ndescription = "adversarial"\n'
+                    + f"regex = {quote}zzzzz-never-matches-zzzzz{quote}\n"
+                )
+                if "rules" in p
+            ],
+            "a `[[rules]]` block is accepted - it can replace a default rule",
+        )
+        # 15. A config gitleaks cannot load is not a passing config.  The
+        #     contract must not silently report "narrow" on TOML it failed to
+        #     read; the scanner exits FTL on the same input.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations("regexes = [") if "TOML" in p],
+            "an unparseable config is reported as narrow",
         )
 
     def test_secret_scan_config_edits_reach_the_guard_that_constrains_them(self):

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -23,6 +23,8 @@ _DESCRIPTORS_TOOL = REPO_ROOT / "tools" / "host_descriptors.py"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
 GITLEAKS_CONFIG = REPO_ROOT / ".gitleaks.toml"
+# The one audit threshold every dependency graph in this repo is gated at.
+NPM_AUDIT_GATE = "npm audit --omit=dev --audit-level=high"
 PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
 PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
 PI_PLATFORM_CONTRACT = REPO_ROOT / ".github" / "scripts" / "test_pi_platform_contract.py"
@@ -96,7 +98,7 @@ def push_trigger_paths(workflow: str) -> list[str]:
     to a deleted path rather than merely to the block's existence.
     """
     match = re.search(
-        r'(?ms)^  push:\n(?:.*?)^    paths:\n(?P<body>(?:      (?:- "[^"\n]+"|#[^\n]*)\n)+)',
+        r'(?ms)^  push:\n(?:.*?)^    paths:\n(?P<body>(?:      (?:- "[^"\n]+"[^\n]*|#[^\n]*)\n)+)',
         workflow,
     )
     if match is None:
@@ -108,7 +110,7 @@ def paths_filter(ci: str, name: str) -> list[str]:
     """Single-quoted globs under one `filters:` entry of the changes job."""
     match = re.search(
         rf"(?ms)^            {re.escape(name)}:\n"
-        rf"(?P<body>(?:              (?:- '[^'\n]+'|#[^\n]*)\n)+)",
+        rf"(?P<body>(?:              (?:- '[^'\n]+'[^\n]*|#[^\n]*)\n)+)",
         ci,
     )
     if match is None:
@@ -117,19 +119,84 @@ def paths_filter(ci: str, name: str) -> list[str]:
 
 
 def _globs(body: str, quote: str) -> list[str]:
-    """Quoted list entries in a YAML block, ignoring interleaved comments."""
-    return [
-        line.strip()[2:].strip().strip(quote)
-        for line in body.splitlines()
-        if line.strip().startswith("- ")
-    ]
+    """Quoted list entries in a YAML block, ignoring interleaved comments.
+
+    The value is read out of the quotes rather than by stripping the line,
+    because an entry may carry a TRAILING comment - `- "plugins/ca/**" # the
+    reference is generated from the plugin` is a real line in docs.yml, and
+    stripping quotes off that returns the comment along with the glob.
+    """
+    found: list[str] = []
+    for line in body.splitlines():
+        entry = re.match(rf"-\s*{re.escape(quote)}([^{re.escape(quote)}]*){re.escape(quote)}",
+                         line.strip())
+        if entry is not None:
+            found.append(entry.group(1))
+    return found
 
 
 def npm_audit_invocations(workflow: str) -> list[str]:
     """Every `npm audit ...` command line in a workflow, whitespace-normalised."""
     return [
-        " ".join(match.group(0).split())
-        for match in re.finditer(r"(?m)^\s*(?:run: )?npm audit[^\n]*$", workflow)
+        " ".join(match.group("command").split())
+        for match in re.finditer(
+            r"(?m)^\s*(?:-\s+)?(?P<command>(?:run: )?npm audit[^\n]*)$", workflow
+        )
+    ]
+
+
+def event_trigger_paths(workflow: str, event: str) -> list[str]:
+    """Double-quoted globs under `on.<event>.paths` of a workflow."""
+    match = re.search(
+        rf'(?ms)^  {re.escape(event)}:\n(?:.*?)^    paths:\n'
+        rf'(?P<body>(?:      (?:- "[^"\n]+"[^\n]*|#[^\n]*)\n)+)',
+        workflow,
+    )
+    if match is None:
+        return []
+    return _globs(match.group("body"), '"')
+
+
+def npm_install_jobs(workflow: str) -> dict[str, str]:
+    """Every job that runs `npm ci`, mapped to the directory it installs into.
+
+    Derived from the workflow rather than listed by hand: a hardcoded job list
+    is exactly how a newly added graph slips in unaudited, which is the defect
+    #403 was.  The directory comes from the job's `defaults.run.working-
+    directory`, which is how every npm job in this repo scopes itself.
+    """
+    installs: dict[str, str] = {}
+    for job_id, body in workflow_jobs(workflow).items():
+        if not re.search(r"(?m)^\s*(?:-\s+)?(?:run: )?npm ci\b", body):
+            continue
+        directory = re.search(
+            r"(?ms)^    defaults:\n      run:\n        working-directory: (?P<dir>\S+)", body
+        )
+        installs[job_id] = directory.group("dir") if directory else "."
+    return installs
+
+
+def unaudited_npm_graphs(workflow: str) -> list[str]:
+    """Every `npm ci` job whose dependency graph no job in `workflow` audits.
+
+    A job may skip the audit itself - what it may NOT do is install a graph
+    nothing audits.  `ca-pi-tools` and docs.yml's `build` are both in that
+    first category today: they run `npm ci` with no audit step, and are benign
+    only because `ca-pi-checks` and `site-check` audit the very same
+    directory.  Deriving the rule this way keeps that fact CHECKED instead of
+    asserted in a comment, and makes a brand-new graph fail on arrival.
+    """
+    jobs = workflow_jobs(workflow)
+    installs = npm_install_jobs(workflow)
+    audited = {
+        directory
+        for job_id, directory in installs.items()
+        if f"run: {NPM_AUDIT_GATE}" in jobs[job_id]
+    }
+    return [
+        f"{job_id} installs {directory}, which nothing audits"
+        for job_id, directory in sorted(installs.items())
+        if directory not in audited
     ]
 
 
@@ -912,7 +979,7 @@ class WorkflowContractTest(unittest.TestCase):
         #
         # One threshold, asserted per invocation, across every graph the repo
         # ships or publishes.
-        expected = "npm audit --omit=dev --audit-level=high"
+        expected = NPM_AUDIT_GATE
         invocations: list[tuple[str, str]] = []
         for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
             invocations += [
@@ -927,17 +994,48 @@ class WorkflowContractTest(unittest.TestCase):
         for name, command in invocations:
             with self.subTest(workflow=name, command=command):
                 self.assertEqual(command, f"run: {expected}")
-        # Every job that installs a lockfile must also audit it.  An unaudited
-        # `npm ci` is exactly how site/package-lock.json went unguarded, and
-        # plugins/ca-pi/tools is a PUBLISHED host package with the same shape.
-        # The Pi canary is deliberately excluded - it floats the host version on
-        # purpose and is advisory-only, so it is not a gate.
-        ci = CI_WORKFLOW.read_text(encoding="utf-8")
-        for job_id in ("tools", "ca-sandbox-tools", "ca-pi-checks"):
-            with self.subTest(job=job_id):
-                job = workflow_jobs(ci)[job_id]
-                self.assertIn("npm ci", job)
-                self.assertIn(f"run: {expected}", job, "this job installs a graph it never audits")
+        # EVERY GRAPH THIS REPO INSTALLS IS AUDITED SOMEWHERE.  This used to
+        # iterate the hardcoded triple ("tools", "ca-sandbox-tools",
+        # "ca-pi-checks") under a comment claiming "every job that installs a
+        # lockfile must also audit it" - a claim three job names cannot make.
+        # It was already false: `ca-pi-tools` is a required gate that runs
+        # `npm ci` and never audits, and so does docs.yml's `build`.  Both are
+        # benign only because a SIBLING job audits the same lockfile, and
+        # nothing checked that.  So the list is now DERIVED and the rule is the
+        # one that actually matters: a job may skip the audit only when another
+        # job in the same workflow audits the very directory it installs.  A
+        # genuinely new graph has no such sibling and fails here on arrival -
+        # which is precisely what did not happen when site/package-lock.json
+        # went unguarded through #400 and #403.
+        for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
+            with self.subTest(workflow=workflow.name):
+                text = workflow.read_text(encoding="utf-8")
+                self.assertTrue(
+                    npm_install_jobs(text), f"{workflow.name} installs no lockfile at all"
+                )
+                self.assertEqual(
+                    [],
+                    unaudited_npm_graphs(text),
+                    "a job installs a dependency graph nothing in this workflow audits",
+                )
+        # And the rule BITES.  A derived check that merely happens to be
+        # satisfied is indistinguishable from one that checks nothing, so put
+        # the diff it exists to stop in front of it: a new job installing a
+        # graph no sibling audits.  This is the shape #403 shipped as.
+        newcomer = CI_WORKFLOW.read_text(encoding="utf-8") + (
+            "\n  brand-new-graph:\n"
+            "    name: newcomer\n"
+            "    runs-on: ubuntu-latest\n"
+            "    defaults:\n"
+            "      run:\n"
+            "        working-directory: plugins/ca-brand-new/tools\n"
+            "    steps:\n"
+            "      - run: npm ci\n"
+        )
+        self.assertTrue(
+            unaudited_npm_graphs(newcomer),
+            "a job installing an entirely new graph is accepted without an audit",
+        )
 
     def test_docs_workflow_gates_the_site_dependency_graph_before_publishing(self):
         # Issue #403: site-check ran npm ci/typecheck/test and build ran
@@ -959,6 +1057,29 @@ class WorkflowContractTest(unittest.TestCase):
             r"(?m)^    needs: \[[^\]]*\bsite-check\b[^\]]*\]",
             "deploy no longer waits on the audited site-check job",
         )
+
+    def test_the_docs_workflow_runs_on_changes_to_the_docs_workflow(self):
+        # The SAME defect class this branch exists to fix, one file over.
+        # docs.yml triggered on `site/**` and `plugins/ca/**` only, so it never
+        # ran on itself: the audit step added above did NOT execute in this
+        # PR's own CI - there was no `Site |` check among the 37 that reported.
+        # A PR that deletes the audit step, breaks the deploy edge, or drops a
+        # permission touches docs.yml and nothing else, which is exactly the
+        # diff its own jobs could not see.  #384 and the .gitleaks.toml gap are
+        # the same bug; a workflow that gates something must be reachable by a
+        # change to itself.
+        docs = DOCS_WORKFLOW.read_text(encoding="utf-8")
+        for event in ("push", "pull_request"):
+            with self.subTest(event=event):
+                paths = event_trigger_paths(docs, event)
+                self.assertIn(
+                    "site/**", paths, f"the {event} trigger scan drifted off the real block"
+                )
+                self.assertIn(
+                    ".github/workflows/docs.yml",
+                    paths,
+                    f"a {event} touching only docs.yml never runs docs.yml",
+                )
 
     def test_ci_runs_a_pinned_read_only_secret_scan_wired_into_the_merge_gate(self):
         # Issue #404: the repository had NO independent secret scanner - only a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ on:
       # (.github/scripts/test_codex_parity_fixture.py), so a push that edits
       # only the generator must still start a run.
       - "tools/codex-parity-fixture.py"
+      # Same defect class, same fix: test_ci_impact.py is the ONLY guard on the
+      # secret-scan allowlist (#404) and on docs.yml's site CVE gate (#403), so
+      # a change to either must start a run that can execute it.
+      - ".gitleaks.toml"
+      - ".github/workflows/docs.yml"
 
 permissions:
   contents: read
@@ -137,6 +142,14 @@ jobs:
               - 'core/hosts.json'
               - 'tools/ci-impact.py'
               - 'tools/host_descriptors.py'
+              # test_ci_impact.py is the only guard on the secret-scan allowlist
+              # (#404) and on docs.yml's site CVE gate (#403). Until these two
+              # were listed, a PR that ONLY weakened .gitleaks.toml - or ONLY
+              # deleted the site audit step - skipped the job that checks them.
+              # The allowlist contract additionally runs unconditionally in the
+              # secret-scan job, so it survives a future edit to this filter.
+              - '.gitleaks.toml'
+              - '.github/workflows/docs.yml'
               - '.github/workflows/ci.yml'
             manifests:
               - '**/*.json'
@@ -210,11 +223,16 @@ jobs:
         # in a production dependency fails the build. --omit=dev scopes to
         # shipped deps so routine dev-tool advisories don't block unrelated PRs.
         #
-        # The threshold was `critical` until issue #403: every advisory cleared
-        # by #400 was rated HIGH, so the gate would have passed all of them and
-        # the repo would have shipped them silently. One threshold now applies
-        # to all three audited dependency graphs (farm, sandbox, docs site);
-        # test_ci_impact.py asserts that.
+        # HONEST SCOPE: plugins/ca/tools declares ZERO production dependencies,
+        # so `--omit=dev` audits an empty graph here and this step is inert
+        # today at ANY threshold. It is a DURABILITY setting - it decides what
+        # happens the day the farm takes on a runtime dependency. #400's three
+        # HIGH advisories were all in site/package-lock.json, the only graph in
+        # this repo with production deps and one nothing audited until #403;
+        # that gate lives in docs.yml, not here. Issue #434 tracks extending the
+        # sweep to the dev trees, where this package's advisories actually are.
+        # One threshold applies to every audited graph (farm, sandbox, ca-pi,
+        # docs site); test_ci_impact.py asserts that.
         run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
@@ -249,7 +267,10 @@ jobs:
       - name: Install (locked)
         run: npm ci
       - name: Audit (CVE gate - fail on HIGH)
-        # Same threshold as the farm and docs-site audits (issue #403).
+        # Same threshold as every other audited graph (issue #403), and the same
+        # caveat as the farm: ca-sandbox/tools declares no production
+        # dependencies either, so this audits an empty graph today and is a
+        # durability setting rather than a live gate.
         run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
@@ -330,6 +351,16 @@ jobs:
         run: npm install --global @earendil-works/pi-coding-agent@${{ steps.pinned.outputs.version }} --ignore-scripts
       - name: Install reviewed toolchain (scripts disabled)
         run: npm ci --ignore-scripts
+      - name: Audit (CVE gate - fail on HIGH)
+        # plugins/ca-pi/tools is a PUBLISHED host package, so its graph belongs
+        # under the same gate as the farm, sandbox, and docs site - without this
+        # step tech-stack.md's claim to cover "every dependency graph the repo
+        # ships or publishes" was false. Like the first two it declares no
+        # production dependencies today, so this audits an empty graph; it
+        # exists so the gate is already in place when that changes. Hosted here
+        # rather than in the six-cell ca-pi-tools matrix - the verdict does not
+        # depend on OS or Pi version.
+        run: npm audit --omit=dev --audit-level=high
       - name: Check generated root package metadata
         working-directory: .
         run: python tools/build-host-packages.py --check
@@ -1021,14 +1052,55 @@ jobs:
     # READ-ONLY: the tree is mounted `:ro` into a network-isolated, capability-
     # stripped, read-only-rootfs container running as a non-root uid. The
     # scanner cannot rewrite what it audits and cannot phone home with what it
-    # finds. `--redact` keeps any finding out of the public job log; the
-    # file/line is enough for a maintainer to act on.
+    # finds.
+    #
+    # ACTIONABLE WITHOUT LEAKING: `--redact` replaces every secret with
+    # REDACTED, and `--verbose` is what actually prints the finding. With
+    # `--redact` alone the log contains only `leaks found: N` - no file, no
+    # line, no rule id - which is unactionable and would force a maintainer to
+    # re-run the scanner unredacted to triage it. Measured against the pinned
+    # image: the pair prints `File:`/`Line:`/`RuleID:`/`Fingerprint:` (plus
+    # `Commit:` in git mode) alongside `Secret: REDACTED`.
+    #
+    # TWO SCANS, TWO BLIND SPOTS: the tree scan sees the merge result, so it
+    # catches anything that would LAND on main. It cannot see a credential added
+    # in one PR commit and deleted in the next - measured on a scratch repo,
+    # that tree scan reports `no leaks found` (exit 0) while the history still
+    # carries the key and the range scan reports it with its commit sha
+    # (exit 1). This repo allows merge and rebase merges as well as squash, so
+    # those commits reach main verbatim; #404 AC-1 asks for the commit RANGE and
+    # the second scan step below is what covers it.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+    env:
+      # gitleaks v8.30.1
+      GITLEAKS_IMAGE: ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The range scan below walks the PR's own commits; a shallow checkout
+          # leaves nothing to walk.
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - name: Prove the allowlist is still narrow before trusting it
+        # This scan is only as strong as .gitleaks.toml, and a waiver that
+        # un-scans a file or matches a substring makes a green result
+        # meaningless. That contract lives in test_ci_impact.py, which runs in
+        # the path-scoped `ci-impact` job - and a PR touching only the allowlist
+        # used to skip it entirely. The path filter is now fixed, but a filter
+        # is a promise that has already been broken twice here (#384, and this).
+        # Running the contract HERE - in a job with no `needs: changes` gate -
+        # makes it unskippable: every PR that reaches CI re-proves the allowlist
+        # whatever the filters say.
+        working-directory: .github/scripts
+        run: |
+          python -m unittest -v \
+            test_ci_impact.WorkflowContractTest.test_the_secret_scan_allowlist_stays_narrow_and_value_scoped \
+            test_ci_impact.WorkflowContractTest.test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract
       - name: Materialize the tracked tree
         # Scan exactly the committed content: no .git internals, no runner-
         # generated files, no node_modules. On a pull_request HEAD is the merge
@@ -1037,9 +1109,6 @@ jobs:
           mkdir -p "$RUNNER_TEMP/secret-scan"
           git archive --format=tar HEAD | tar -x -C "$RUNNER_TEMP/secret-scan"
       - name: Scan the tracked tree for credentials
-        env:
-          # gitleaks v8.30.1
-          GITLEAKS_IMAGE: ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
         run: |
           docker run --rm \
             --network none \
@@ -1054,6 +1123,47 @@ jobs:
               --config /repo/.gitleaks.toml \
               --no-banner \
               --redact \
+              --verbose \
+              --exit-code 1
+      - name: Scan the pull request's commit range for credentials
+        # Issue #404 AC-1. Only meaningful on a pull_request - the only event
+        # with a base to diff against, and the enforcement point main's branch
+        # protection actually requires. On push the tree scan carries the job.
+        #
+        # The repository is mounted read-only WITH its .git, so gitleaks runs
+        # `git log -p` over the range and never writes. `safe.directory` is
+        # passed through GIT_CONFIG_* rather than written to a config file
+        # (nothing here is writable), pre-empting git's dubious-ownership
+        # refusal; /tmp is a small noexec tmpfs so git has scratch space without
+        # the rootfs becoming writable. Verified locally under this exact flag
+        # set, including --user, against a repo whose HEAD had already deleted
+        # the planted credential.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          base="$(git merge-base "$BASE_SHA" HEAD)"
+          echo "scanning commit range ${base}..HEAD"
+          docker run --rm \
+            --network none \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env GIT_CONFIG_COUNT=1 \
+            --env GIT_CONFIG_KEY_0=safe.directory \
+            --env GIT_CONFIG_VALUE_0=/repo \
+            --workdir /repo \
+            --volume "$GITHUB_WORKSPACE:/repo:ro" \
+            "$GITLEAKS_IMAGE" \
+            git . \
+              --config /repo/.gitleaks.toml \
+              --log-opts "${base}..HEAD" \
+              --no-banner \
+              --redact \
+              --verbose \
               --exit-code 1
 
   documentation-contract:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ on:
       - "tools/sync-core.py"
       - "tools/build-host-packages.py"
       - "tools/ci-impact.py"
+      # Issue #384: the hooks job runs this generator's own unit tests
+      # (.github/scripts/test_codex_parity_fixture.py), so a push that edits
+      # only the generator must still start a run.
+      - "tools/codex-parity-fixture.py"
 
 permissions:
   contents: read
@@ -122,6 +126,10 @@ jobs:
               - 'plugins/ca-pi/hooks/**'
               - 'core/**'
               - '.github/scripts/**'
+              # Issue #384: test_codex_parity_fixture.py runs in the hooks job
+              # below, so a PR touching only the generator it tests must flag
+              # this filter - otherwise the fixture skips its own test.
+              - 'tools/codex-parity-fixture.py'
               - '.github/workflows/ci.yml'
             impact:
               - '.github/ci-impact-map.json'
@@ -197,12 +205,17 @@ jobs:
           cache-dependency-path: plugins/ca/tools/package-lock.json
       - name: Install (locked)
         run: npm ci
-      - name: Audit (CVE gate - fail on CRITICAL)
-        # Supply-chain gate per security-controls.md: a CRITICAL advisory in a
-        # production dependency fails the build. --omit=dev scopes to shipped
-        # deps; --audit-level=critical intentionally ignores lower severities so
-        # routine dev-tool advisories don't block unrelated PRs.
-        run: npm audit --omit=dev --audit-level=critical
+      - name: Audit (CVE gate - fail on HIGH)
+        # Supply-chain gate per security-controls.md: a HIGH-or-worse advisory
+        # in a production dependency fails the build. --omit=dev scopes to
+        # shipped deps so routine dev-tool advisories don't block unrelated PRs.
+        #
+        # The threshold was `critical` until issue #403: every advisory cleared
+        # by #400 was rated HIGH, so the gate would have passed all of them and
+        # the repo would have shipped them silently. One threshold now applies
+        # to all three audited dependency graphs (farm, sandbox, docs site);
+        # test_ci_impact.py asserts that.
+        run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test
@@ -235,8 +248,9 @@ jobs:
           cache-dependency-path: plugins/ca-sandbox/tools/package-lock.json
       - name: Install (locked)
         run: npm ci
-      - name: Audit (CVE gate - fail on CRITICAL)
-        run: npm audit --omit=dev --audit-level=critical
+      - name: Audit (CVE gate - fail on HIGH)
+        # Same threshold as the farm and docs-site audits (issue #403).
+        run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test
@@ -983,6 +997,65 @@ jobs:
       - name: Check cross-reference graph (ca-codex)
         run: python3 .github/scripts/check-plugin-refs.py ca-codex
 
+  secret-scan:
+    name: "[CHECK] | [REPO] | Secret scan"
+    # Issue #404: until this job existed the repository had NO independent
+    # secret scanner. Both existing layers are COOPERATIVE - the H-10b commit
+    # hook and /ca:preview's sweep only run inside a contributor's local
+    # Claude/Codex/Pi session. A bot, a fork, a github.com web edit, or a plain
+    # `git push` runs neither, so a real credential could merge and stay in
+    # history with every hosted check green.
+    #
+    # Repo-wide and always-on, like license-consistency and surface: a
+    # credential can ride any diff, so there is deliberately no `needs: changes`
+    # path gate here. On push the workflow's own path filter still applies -
+    # main's branch protection requires this check on the pull request, which is
+    # the enforcement point.
+    #
+    # PINNED: the scanner is an image digest, not a tag. A tag can be re-pointed
+    # by anyone who compromises the upstream registry account, and a scanner
+    # runs over the entire repository - it is exactly the thing that must not be
+    # swappable. Bump the digest deliberately, the way the SHA-pinned actions
+    # above are bumped.
+    #
+    # READ-ONLY: the tree is mounted `:ro` into a network-isolated, capability-
+    # stripped, read-only-rootfs container running as a non-root uid. The
+    # scanner cannot rewrite what it audits and cannot phone home with what it
+    # finds. `--redact` keeps any finding out of the public job log; the
+    # file/line is enough for a maintainer to act on.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Materialize the tracked tree
+        # Scan exactly the committed content: no .git internals, no runner-
+        # generated files, no node_modules. On a pull_request HEAD is the merge
+        # result, which is the tree that would land on main.
+        run: |
+          mkdir -p "$RUNNER_TEMP/secret-scan"
+          git archive --format=tar HEAD | tar -x -C "$RUNNER_TEMP/secret-scan"
+      - name: Scan the tracked tree for credentials
+        env:
+          # gitleaks v8.30.1
+          GITLEAKS_IMAGE: ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
+        run: |
+          docker run --rm \
+            --network none \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
+            --workdir /repo \
+            --volume "$RUNNER_TEMP/secret-scan:/repo:ro" \
+            "$GITLEAKS_IMAGE" \
+            dir . \
+              --config /repo/.gitleaks.toml \
+              --no-banner \
+              --redact \
+              --exit-code 1
+
   documentation-contract:
     name: "[CHECK] | [REPO] | Documentation contract"
     # Repository documentation is a cross-cutting public interface: validate
@@ -1030,11 +1103,12 @@ jobs:
       - license-consistency
       - surface
       - prose-codex
+      - secret-scan
     runs-on: ubuntu-latest
     steps:
       - name: Require every required job to have succeeded or been skipped
         run: |
-          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }}"
+          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }} ${{ needs['secret-scan'].result }}"
           canary_result="${{ needs.ca-pi-latest.result }}"
           echo "upstream required results: $required_results"
           echo "advisory Pi canary result: $canary_result"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,17 +10,25 @@ name: Deploy docs
 # scoped to push: it needs pages:write/id-token:write, which a PR (especially
 # from a fork) can't safely hold.
 
+# This workflow triggers on ITSELF. It gates the site dependency graph (the
+# audit step in site-check) and the deploy edge that makes that audit binding,
+# and a change to any of that touches docs.yml and nothing else - which under
+# the old `site/** + plugins/ca/**` filters started no run at all. Measured:
+# the PR that ADDED the audit step never executed it, with 37 other checks
+# green and no `Site |` check among them. Same defect class as #384.
 on:
   push:
     branches: [main]
     paths:
       - "site/**"
       - "plugins/ca/**" # the reference is generated from the plugin, so rebuild when it changes
+      - ".github/workflows/docs.yml" # this workflow gates the site graph; it must see its own edits
   pull_request:
     branches: [main]
     paths:
       - "site/**"
       - "plugins/ca/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 # Least-privilege: only the deploy job needs pages/id-token:write, granted at

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,14 @@ jobs:
           cache-dependency-path: site/package-lock.json
       - name: Install deps
         run: npm ci
+      - name: Audit (CVE gate - fail on HIGH)
+        # Issue #403: nothing audited site/package-lock.json, so a known-
+        # vulnerable production dependency could build and publish to GitHub
+        # Pages with this whole workflow green. `deploy` needs this job, so a
+        # red audit blocks the publish. Same threshold as the farm and sandbox
+        # gates in ci.yml; --omit=dev scopes it to what the built site actually
+        # ships, keeping routine Astro/vitest dev advisories non-blocking.
+        run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -45,13 +45,32 @@
 # ruleset, which finds exactly 13 leaks in this tree across 5 distinct values.
 #
 # ADDING AN ENTRY - the rules .github/scripts/test_ci_impact.py enforces:
-#   1. No `paths` / `commits` / `stopwords` key anywhere in this file.
-#   2. No `regexTarget` key: a waiver binds to the secret, not to the line.
-#   3. Every `[[allowlists]]` block carries a `description` naming the file the
+#   1. A waiver carries ONLY `description` and `regexes`. Every other key is
+#      rejected, `paths` / `commits` / `stopwords` (which un-scan a file or a
+#      commit) and `regexTarget` (which rebinds the waiver to surrounding source
+#      text) loudest of all. The check is DEFAULT-DENY: a knob gitleaks adds
+#      later fails this contract the day it is typed here, not the day someone
+#      remembers to ban it.
+#   2. `[extend]` sets `useDefault` and nothing else. `disabledRules` deletes a
+#      rule outright - measured, `disabledRules = ["generic-api-key"]` returns a
+#      planted high-entropy key to `no leaks found` - and `path` / `url` pull in
+#      allowlists that are not in this file, so nothing here constrains them.
+#   3. No `[[rules]]` block. This file only ever SUBTRACTS fixture values from
+#      the default ruleset, and a rule whose id matches a default one REPLACES
+#      it - measured, that is the same hole as disabling it.
+#   4. Every `[[allowlists]]` block carries a `description` naming the file the
 #      literal legitimately lives in and why it is benign.
-#   4. Every block waives by `regexes`, every regex is anchored `\A...\z`, and
+#   5. Every block waives by `regexes`, every regex is anchored `\A...\z`, and
 #      the anchored body carries no regex metacharacter - no `.*`, no character
 #      class, no escape, nothing that could match an unseen value.
+#
+# REFORMATTING WILL NOT HELP. The contract PARSES this file as TOML and folds
+# keys to lower case, because gitleaks reads its config through viper, whose key
+# lookup is case-INSENSITIVE (measured: `Paths` un-scans the tree exactly as
+# `paths` does). Indenting a key or a table header, spelling a waiver `"x"` or
+# `'x'` instead of `'''x'''`, or capitalising a key changes nothing about what
+# the rules above see. Reading this file as TEXT is what let eleven measured
+# shapes through, each one guard-green while the scanner swallowed a live key.
 
 title = "codeArbiter hosted secret scan"
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,97 @@
+# Hosted secret-scan configuration (issue #404).
+#
+# codeArbiter's own secret gates are COOPERATIVE: H-10b blocks a commit whose
+# diff touches a secret line, and /ca:preview sweeps the working diff. Both run
+# locally, inside the contributor's Claude/Codex/Pi session. A bot, a fork, a
+# web edit, or a plain `git push` runs neither. The `secret-scan` job in
+# .github/workflows/ci.yml is the independent hosted backstop, and this file is
+# the only thing standing between it and a false positive.
+#
+# WHY THERE IS NO `paths` ALLOWLIST HERE
+# A global `paths = [...]` entry does not waive a finding - it removes the file
+# from the scan altogether. Verified against the pinned image: a config whose
+# only waiver was `paths = ['''^test_hooklib\.py$''']` (with condition = "AND"
+# and a regex that matches nothing) reported `scanned ~189 bytes`, i.e. the
+# 89 KB Python file was never read, and a freshly planted
+# `aws_secret_access_key = "kR3m..."` in it went unreported. Path waivers are
+# therefore permanent blind spots, not narrow exceptions, and this config uses
+# VALUE waivers instead: one exact adversarial literal per entry, waived
+# wherever it appears. Every file stays fully scanned, so a real credential
+# landing in any fixture file below still fails the job.
+#
+# ADDING AN ENTRY - the rules .github/scripts/test_ci_impact.py enforces:
+#   1. No `paths` / `commits` key anywhere in this file (see above).
+#   2. Every `[[allowlists]]` block carries a `description` naming the file the
+#      literal legitimately lives in and why it is benign.
+#   3. Every block waives by `regexes`, and every regex is a fixed literal - no
+#      `.*`, no character classes, nothing that could match an unseen value.
+
+title = "codeArbiter hosted secret scan"
+
+[extend]
+# Start from gitleaks' full first-party ruleset. This file only ever SUBTRACTS
+# known-fake fixture literals from it; it never adds a rule of its own.
+useDefault = true
+
+[[allowlists]]
+description = """
+Canonical secret-detection corpus literals (architecture-001), which live in
+plugins/ca/hooks/secret-detection-corpus.json and are inlined as test input by
+.github/scripts/test_hooklib.py, plugins/ca/tools/farm.unit.test.ts, and the
+archived .codearbiter/reports/2026-07-14-pi-support-handoff/ review packages.
+Each is a deliberately fake credential SHAPE that both first-party classifiers
+(_hooklib.SECRET_RE and the farm redactor) are required to flag; deleting them
+would delete the adversarial coverage the corpus exists to provide.
+"""
+regexTarget = "line"
+regexes = [
+  '''sk-CVlQvxKsecretvalue123''',
+  '''correct-horse-battery''',
+  '''abc12345def''',
+  '''wJalrXUtnFEMIabcd1234''',
+  '''wJalrXUtnFEMI1234''',
+  '''sk-test-abcd1234''',
+  '''AKIAIOSFODNN7EXAMPLE''',
+  '''ghp_abcdefghijklmnopqrstuvwxyz0123456789''',
+  '''sk-ant-api03-AbCdEf1234567890abcdef''',
+]
+
+[[allowlists]]
+description = """
+The fixed fake value the H-01/H-10b guard-matrix cases assign so the hook is
+proven to block them - .github/scripts/test_hook_guards.py and
+.github/scripts/test_hooklib.py.
+"""
+regexTarget = "line"
+regexes = ['''abcd1234efgh''']
+
+[[allowlists]]
+description = """
+Placeholder in the shipped env template plugins/ca/tools/.env.example:
+FARM_API_KEY carries the literal `sk-REPLACE_ME`, never a value. Waived by that
+exact literal only, so an edit that pastes a real key into the template - the
+populated-.env.example regression this job exists to catch - still fails.
+"""
+regexTarget = "line"
+regexes = ['''sk-REPLACE_ME''']
+
+[[allowlists]]
+description = """
+The non-real PEM plugins/ca/tools/farm.test.ts plants into a scratch repo. The
+BEGIN/END markers wrap the test-local constants KEY_BODY_1/2/3, whose values are
+the literal strings FAKEKEYBODYLINE{ONE,TWO,THREE} - chosen precisely because
+they carry no trigger word, which is the property that test asserts about the
+per-line redactor. Waived by the constant name that appears inside the match, so
+a PEM carrying real key material is not waived.
+"""
+regexTarget = "match"
+regexes = ['''KEY_BODY_1''']
+
+[[allowlists]]
+description = """
+`highEntropyToken` in plugins/ca-pi/tools/test/dispatch.test.ts: a hand-typed
+high-entropy string with no trigger word, used to assert safeDiagnostic never
+fragments the audit log. Not a credential for any system.
+"""
+regexTarget = "line"
+regexes = ['''Zx9qP2mK7vN4wR8tY1uJ6hL3sD5fA0cE''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,16 +15,43 @@
 # 89 KB Python file was never read, and a freshly planted
 # `aws_secret_access_key = "kR3m..."` in it went unreported. Path waivers are
 # therefore permanent blind spots, not narrow exceptions, and this config uses
-# VALUE waivers instead: one exact adversarial literal per entry, waived
-# wherever it appears. Every file stays fully scanned, so a real credential
-# landing in any fixture file below still fails the job.
+# VALUE waivers instead.
+#
+# WHY EVERY WAIVER IS ANCHORED `\A...\z`
+# Being a fixed literal is NOT enough, and assuming otherwise was a real defect
+# in the first version of this file. gitleaks tests an allowlist regex with Go's
+# `FindString`, which is a SUBSTRING search, not a full match. An unanchored
+# literal is therefore exactly as broad as whatever haystack it is tested
+# against, and `regexTarget` only chooses that haystack: omitted = the detected
+# secret, "match" = the rule's whole match text, "line" = the entire source
+# line. Measured against the pinned image over this repo's tracked tree, with a
+# high-entropy key planted in plugins/ca/tools/.env.example (which the shipped
+# config below reports as `leaks found: 1`, exit 1):
+#
+#   regexTarget = "line",   regexes = API_KEY            ->  no leaks found
+#   regexTarget = "match",  regexes = API_KEY            ->  no leaks found
+#   regexTarget omitted,    regexes = sk-                ->  no leaks found
+#   regexTarget omitted,    regexes = \Ask-REPLACE_ME\z  ->  leaks found: 1
+#
+# All three of the first shapes swallow a live credential, so constraining
+# `regexTarget` alone buys NO narrowness - the unanchored-substring case sails
+# through it. Anchoring is what works: `\A<literal>\z` matches only when the
+# ENTIRE detected secret is that exact fixture value. Every waiver below is
+# therefore anchored, and `regexTarget` is omitted everywhere so the anchors
+# bind to the detected secret rather than to surrounding source text.
+#
+# The anchored values are the secrets gitleaks actually reports, not the source
+# text around them - measured with `--report-format json` against the default
+# ruleset, which finds exactly 13 leaks in this tree across 5 distinct values.
 #
 # ADDING AN ENTRY - the rules .github/scripts/test_ci_impact.py enforces:
-#   1. No `paths` / `commits` key anywhere in this file (see above).
-#   2. Every `[[allowlists]]` block carries a `description` naming the file the
+#   1. No `paths` / `commits` / `stopwords` key anywhere in this file.
+#   2. No `regexTarget` key: a waiver binds to the secret, not to the line.
+#   3. Every `[[allowlists]]` block carries a `description` naming the file the
 #      literal legitimately lives in and why it is benign.
-#   3. Every block waives by `regexes`, and every regex is a fixed literal - no
-#      `.*`, no character classes, nothing that could match an unseen value.
+#   4. Every block waives by `regexes`, every regex is anchored `\A...\z`, and
+#      the anchored body carries no regex metacharacter - no `.*`, no character
+#      class, no escape, nothing that could match an unseen value.
 
 title = "codeArbiter hosted secret scan"
 
@@ -42,38 +69,42 @@ archived .codearbiter/reports/2026-07-14-pi-support-handoff/ review packages.
 Each is a deliberately fake credential SHAPE that both first-party classifiers
 (_hooklib.SECRET_RE and the farm redactor) are required to flag; deleting them
 would delete the adversarial coverage the corpus exists to provide.
+Two of these are live findings under the default ruleset today
+(sk-test-abcd1234 and wJalrXUtnFEMI1234, six occurrences between them); the
+rest sit below its entropy floor and produce no finding, and are waived
+defensively so a future ruleset bump cannot turn the corpus red. Each waiver is
+exact, so a defensive entry cannot waive anything but the value it names.
 """
-regexTarget = "line"
 regexes = [
-  '''sk-CVlQvxKsecretvalue123''',
-  '''correct-horse-battery''',
-  '''abc12345def''',
-  '''wJalrXUtnFEMIabcd1234''',
-  '''wJalrXUtnFEMI1234''',
-  '''sk-test-abcd1234''',
-  '''AKIAIOSFODNN7EXAMPLE''',
-  '''ghp_abcdefghijklmnopqrstuvwxyz0123456789''',
-  '''sk-ant-api03-AbCdEf1234567890abcdef''',
+  '''\Ask-CVlQvxKsecretvalue123\z''',
+  '''\Acorrect-horse-battery\z''',
+  '''\Aabc12345def\z''',
+  '''\AwJalrXUtnFEMIabcd1234\z''',
+  '''\AwJalrXUtnFEMI1234\z''',
+  '''\Ask-test-abcd1234\z''',
+  '''\AAKIAIOSFODNN7EXAMPLE\z''',
+  '''\Aghp_abcdefghijklmnopqrstuvwxyz0123456789\z''',
+  '''\Ask-ant-api03-AbCdEf1234567890abcdef\z''',
 ]
 
 [[allowlists]]
 description = """
 The fixed fake value the H-01/H-10b guard-matrix cases assign so the hook is
-proven to block them - .github/scripts/test_hook_guards.py and
-.github/scripts/test_hooklib.py.
+proven to block them - .github/scripts/test_hook_guards.py (three occurrences)
+and .github/scripts/test_hooklib.py (two).
 """
-regexTarget = "line"
-regexes = ['''abcd1234efgh''']
+regexes = ['''\Aabcd1234efgh\z''']
 
 [[allowlists]]
 description = """
 Placeholder in the shipped env template plugins/ca/tools/.env.example:
-FARM_API_KEY carries the literal `sk-REPLACE_ME`, never a value. Waived by that
-exact literal only, so an edit that pastes a real key into the template - the
-populated-.env.example regression this job exists to catch - still fails.
+FARM_API_KEY carries the literal `sk-REPLACE_ME`, never a value. It sits below
+the generic-api-key entropy floor, so it produces no finding today; it is waived
+by that exact anchored literal anyway, so the waiver can never cover the
+populated-.env.example regression this job exists to catch. Measured: replacing
+it with a high-entropy key gives `leaks found: 1` and exit 1.
 """
-regexTarget = "line"
-regexes = ['''sk-REPLACE_ME''']
+regexes = ['''\Ask-REPLACE_ME\z''']
 
 [[allowlists]]
 description = """
@@ -81,11 +112,20 @@ The non-real PEM plugins/ca/tools/farm.test.ts plants into a scratch repo. The
 BEGIN/END markers wrap the test-local constants KEY_BODY_1/2/3, whose values are
 the literal strings FAKEKEYBODYLINE{ONE,TWO,THREE} - chosen precisely because
 they carry no trigger word, which is the property that test asserts about the
-per-line redactor. Waived by the constant name that appears inside the match, so
-a PEM carrying real key material is not waived.
+per-line redactor. The secret gitleaks reports here is the whole five-line block
+of constant NAMES (the values live on earlier lines), so that block anchored is
+the waiver: any other PEM is a different secret and is not waived. Measured on
+this tree - an inline PEM added anywhere else is reported by `private-key`, and
+pasting real key material into KEY_BODY_1's value is reported by
+`generic-api-key` on the assignment line. Reformatting that array changes the
+secret and turns this job red until the waiver is re-derived, which is the
+correct direction to fail.
 """
-regexTarget = "match"
-regexes = ['''KEY_BODY_1''']
+regexes = ['''\A-----BEGIN RSA PRIVATE KEY-----",
+        KEY_BODY_1,
+        KEY_BODY_2,
+        KEY_BODY_3,
+        "-----END RSA PRIVATE KEY-----\z''']
 
 [[allowlists]]
 description = """
@@ -93,5 +133,4 @@ description = """
 high-entropy string with no trigger word, used to assert safeDiagnostic never
 fragments the audit log. Not a credential for any system.
 """
-regexTarget = "line"
-regexes = ['''Zx9qP2mK7vN4wR8tY1uJ6hL3sD5fA0cE''']
+regexes = ['''\AZx9qP2mK7vN4wR8tY1uJ6hL3sD5fA0cE\z''']


### PR DESCRIPTION
Three CI supply-chain gaps, one lane.

Closes #404
Closes #384
Closes #403

> **Revision 3.** Revision 2's adversarial review found two BLOCKs, one HIGH and two MEDIUMs — see [Round 2](#round-2--what-the-review-caught). A recheck of revision 2 then found the *narrowness contract itself* was bypassable: three BLOCKs, each measured guard-GREEN while the pinned scanner swallowed a live planted key. Auditing that defect class turned up eight more. All eleven are closed and re-measured — see [Round 3](#round-3--the-narrowness-contract-was-itself-bypassable). Every claim in this body is measured against the pinned image, not reasoned about.

---

## What changed

### #404 — an independent, pinned repository secret scan

The repo had **no** hosted secret scanner, and both existing layers are **cooperative**: H-10b blocks a commit whose diff touches a secret line, and `/ca:preview` sweeps the working diff — but both only run inside a contributor's local Claude/Codex/Pi session. A bot, a fork, a github.com web edit, or a plain `git push` runs neither.

New `secret-scan` job in `ci.yml`:

- **Pinned by image digest**, not a tag: `ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0…abbb7f` (v8.30.1). A scanner runs over the entire repository — exactly the thing that must not be swappable by whoever controls the upstream tag.
- **Read-only**: `--network none --read-only --cap-drop ALL --security-opt no-new-privileges --user $(id -u):$(id -g)`, over a `:ro` mount.
- **Two scan modes** (see the HIGH finding below): `gitleaks dir` over the merge-result tree, plus `gitleaks git --log-opts <merge-base>..HEAD` over the PR's own commits.
- **Actionable output**: `--redact --verbose` — file, line, rule, commit; `Secret: REDACTED`.
- **Always-on**, no `needs: changes` gate, registered in **both** `ci-passed` registrations per the #390 contract.

> Not chosen: `gitleaks/gitleaks-action` — it requires a paid `GITLEAKS_LICENSE` for org accounts, and a digest-pinned container is a stronger pin anyway.

### #384 — the Codex parity fixture now reaches its own test

`.github/scripts/test_codex_parity_fixture.py` runs inside the path-scoped `hooks` job, but neither the push trigger nor the `hooks` paths-filter listed `tools/codex-parity-fixture.py`. A PR editing only that generator **skipped its own test**. Added to both.

### #403 — the docs-site dependency graph is gated

`docs.yml` ran `npm ci` → typecheck → test → build → link-audit and never `npm audit`. Added `npm audit --omit=dev --audit-level=high` to `site-check`; `deploy` already `needs: [build, site-check]`, so a red audit blocks the publish.

---

## Round 2 — what the review caught

### BLOCK 1 — the allowlist guard never ran on a diff that weakens it

`test_the_secret_scan_allowlist_stays_narrow_and_value_scoped` lives in `test_ci_impact.py`, which runs **only** in the path-scoped `ci-impact` job. `.gitleaks.toml` matched no `changes` filter and was absent from the push trigger, so a PR whose only change was to widen the allowlist **skipped the one job that guards it** — the identical defect class as #384, which this very branch fixes elsewhere. `.github/workflows/docs.yml` had the same gap, which is also the MEDIUM against #403 AC-3: the diff shape that deletes the site audit step is exactly the one the guard could not see.

Fixed on three levels, because a path filter is a promise this repo has now broken twice:

1. `.gitleaks.toml` and `.github/workflows/docs.yml` added to the `impact` filter.
2. Both added to the push trigger.
3. **Belt and braces** — the narrowness contract now *also* runs inside the `secret-scan` job, which carries no `needs: changes` gate. No future filter edit can leave the allowlist unguarded.

**Proof, as asked — a diff whose only change is `.gitleaks.toml`:**

```
A. Would the `changes` job set impact=true?
   changed files : ['.gitleaks.toml']
   matching globs: ['.gitleaks.toml']
   => impact == 'true'? True   => the ci-impact job RUNS the guard

B. Is the guard also reachable with NO filter involvement?
   secret-scan job-level `needs:` present? False
   secret-scan job-level `if:`    present? False
   job invokes the narrowness guard?       True
   => unconditional: every PR reaching CI re-proves the allowlist

C. Does the guard BITE on the widening diff?
   exit=1
   FAIL: test_the_secret_scan_allowlist_stays_narrow_and_value_scoped
   FAIL: test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract
   AssertionError: Lists differ: ['`regexTarget = "line"` binds the waiver ...'] != []
```

### BLOCK 2 — the contract enforced literalness, not narrowness

The old test required each waiver to match `\A[A-Za-z0-9_-]+\Z` and never constrained `regexTarget`. The review demonstrated that `regexTarget = "line"` turns a fixed literal into a substring match against every scanned line.

**The review's prescribed fix — "constrain `regexTarget`" — is necessary but NOT sufficient, and I want to flag that explicitly rather than quietly over-deliver.** gitleaks tests allowlist regexes with Go's `FindString`, a **substring** search. So even with `regexTarget` omitted (matching against the detected secret itself), an unanchored literal is as broad as its haystack. Measured against the pinned image over the tracked tree, with a high-entropy key planted in `plugins/ca/tools/.env.example`:

| allowlist shape | result |
| --- | --- |
| *(shipped config, key planted)* | **`leaks found: 1`, exit 1** |
| `regexTarget = "line"`, `regexes = API_KEY` | `no leaks found` |
| `regexTarget = "match"`, `regexes = API_KEY` | `no leaks found` |
| `regexTarget` omitted, `regexes = sk-` | `no leaks found` ← **the case constraining `regexTarget` misses** |
| `regexTarget` omitted, `regexes = \Ask-REPLACE_ME\z` | **`leaks found: 1`, exit 1** |

So the rule is now **both**: `regexTarget` is forbidden outright *and* every waiver must be anchored `\A<literal>\z` with no regex metacharacter in the body — true only when the **entire detected secret** is that exact fixture value.

The anchored values are the secrets gitleaks *actually reports*, derived by measurement (`--report-format json` against the bare default ruleset) rather than by reading the source: **13 findings across 5 distinct values**. That is also what makes the PEM waiver honest — the reported secret there is a five-line block of constant *names* (`KEY_BODY_1/2/3`), so the waiver is that exact block anchored, and any other PEM is a different secret. Reformatting the fixture turns the job red until the waiver is re-derived, which is the correct direction to fail.

The narrowness contract is now a pure function (`gitleaks_waiver_violations`) exercised against adversarial configs that are never written to disk, so `test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract` proves the contract fails on every shape above — including the `line`-target waiver the review asked for by name.

### HIGH — #404 AC-1 asked for the commit RANGE

Correct, and undeclared. The job scanned `git archive HEAD` — the merge-result **tree** — and never inspected history. Not theoretical; measured on a scratch repo where a credential is added in commit 1 and deleted in commit 2:

```
===== TREE  scan (gitleaks dir .)            -> exit 0 =====
INF no leaks found

===== RANGE scan (gitleaks git --log-opts)   -> exit 1 =====
Finding:     aws_secret_access_key = "REDACTED"
Secret:      REDACTED
RuleID:      generic-api-key
File:        leak.py
Line:        1
Commit:      438b8cc50df157eca82f3bb1a57c6cba00cf5d96
WRN leaks found: 1
```

The repo allows merge and rebase merges, so those commits reach `main` verbatim. A second, `pull_request`-scoped step now scans the range. The workspace is mounted `:ro` **with** its `.git`; `safe.directory` is passed via `GIT_CONFIG_*` (nothing is writable) and `/tmp` is a small `noexec` tmpfs so git has scratch space without a writable rootfs. Verified under the full hardened flag set including `--user`.

### MEDIUM — a failing scan was unactionable

`--redact` without `-v` prints only `leaks found: N`, while the job comment claimed the file/line was available. `--verbose` restores `File:`/`Line:`/`RuleID:`/`Fingerprint:` (plus `Commit:` in git mode) and still prints `Secret: REDACTED` — confirmed in every scan output quoted in this body. The comment is rewritten to match what the flags actually do.

### LOW — the threshold tightening was inert and misattributed

Confirmed and corrected. Measured `dependencies` from each `package.json`:

| graph | production deps | audited by |
| --- | --- | --- |
| `plugins/ca/tools` | **0** | `ci.yml` — `tools` |
| `plugins/ca-sandbox/tools` | **0** | `ci.yml` — `ca-sandbox-tools` |
| `plugins/ca-pi/tools` | **0** | `ci.yml` — `ca-pi-checks` *(new)* |
| `site` | 3 (astro, starlight, markdown-remark) | `docs.yml` — `site-check` |

`--omit=dev` therefore audits an **empty graph** in three of four jobs, at any threshold. The comment claiming "every advisory cleared by #400 was rated HIGH, so the gate would have passed all of them" was true of the *site* gate and false of the farm step it annotated — #400's advisories were all in `site/package-lock.json`. Both `ci.yml` and `tech-stack.md` now describe the farm/sandbox/ca-pi thresholds as a **durability** setting and name the site gate as the part with immediate effect.

Two follow-ons the review surfaced:

- `plugins/ca-pi/tools` is a **published** host package that ran `npm ci` and never audited it, which made `tech-stack.md`'s "every dependency graph the repo ships or publishes" false. It is now gated, and a new assertion requires **every job that installs a lockfile to audit it**.
- The dev trees are where the real advisories are: measured in `plugins/ca/tools`, `npm audit --json` reports `{prod: 1, dev: 104}` and one **HIGH** (`postcss`) the shipped gate never sees. **Issue #434** tracks extending the sweep, and notes the blast radius — those dev deps build `farm.js` and `sandbox.js`, committed shipped artifacts.

---

## Red test evidence

All new assertions written and run **before** implementation — 9 failures across 7 test methods, each for the defect and not an import error:

```
FAIL: test_the_secret_scan_allowlist_stays_narrow_and_value_scoped
AssertionError: Lists differ: ['`regexTarget = "line"` binds the waiver [2415 chars] it"] != []
First list contains 18 additional elements.
 : the allowlist can waive more than the fixture values it names

FAIL: test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract
AssertionError: Lists differ: [...] != [] : the shipped allowlist is not narrow

FAIL: test_secret_scan_config_edits_reach_the_guard_that_constrains_them (path='.gitleaks.toml')
AssertionError: '.gitleaks.toml' not found in ['.github/ci-impact-map.json',
  '.github/scripts/test_ci_impact.py', 'core/hosts.json', 'tools/ci-impact.py',
  'tools/host_descriptors.py', '.github/workflows/ci.yml']
 : a PR touching only this file skips its own contract test

FAIL: test_secret_scan_config_edits_reach_the_guard_that_constrains_them (path='.github/workflows/docs.yml')
AssertionError: '.github/workflows/docs.yml' not found in [...]

FAIL: test_the_allowlist_guard_also_runs_unconditionally_in_the_secret_scan_job
AssertionError: 'test_ci_impact.WorkflowContractTest.test_the_secret_scan_allowlist_stays_narrow_and_value_scoped'
  not found in '  secret-scan:\n    name: "[CHECK] | [REPO] | Secret scan"\n ...'
 : the always-on job does not re-prove its own allowlist

FAIL: test_the_secret_scan_covers_the_pull_requests_commit_range
AssertionError: Regex didn't match: '(?m)^\\s+git \\. \\\\$'
 : the secret scan never inspects commit history

FAIL: test_ci_runs_a_pinned_read_only_secret_scan_wired_into_the_merge_gate
AssertionError: 1 != 2 : expected exactly the tree scan and the commit-range scan

FAIL: test_every_npm_audit_gate_fails_the_build_on_a_high_advisory
AssertionError: 3 != 4 : expected exactly the farm, sandbox, ca-pi, and site audit gates

Ran 32 tests
FAILED (failures=9)
```

### The contracts BITE — 14/14 mutations caught

Each fix reverted against a mutated copy of its subject file, then restored byte-identically:

```
BITES   BLOCK1 impact filter drops .gitleaks.toml
BITES   BLOCK1 impact filter drops docs.yml
BITES   BLOCK1 push trigger drops .gitleaks.toml
BITES   BLOCK1 secret-scan stops re-proving the allowlist
BITES   BLOCK1 secret-scan becomes path-scoped (needs: changes)
BITES   BLOCK2 a waiver loses its anchors
BITES   BLOCK2 regexTarget = "line" comes back
BITES   BLOCK2 a wildcard is smuggled inside the anchors
BITES   BLOCK2 a paths waiver returns
BITES   HIGH  the commit-range scan is deleted
BITES   HIGH  the range scan loses its --log-opts scoping
BITES   HIGH  the checkout goes shallow again
BITES   MED   the tree scan loses --verbose (unactionable log)
BITES   LOW   the ca-pi audit gate is dropped

14/14 mutations caught
```

Two mutations initially reported MISSED and were **my harness's fault, not a contract gap** — `fetch-depth: 0` appears 5× in `ci.yml` so the mutation hit the wrong job, and the ca-pi mutation renamed the step while leaving its `run:` line intact. Both re-anchored; both then bit.

### The scanner itself was run, not just configured

Against the current merge result:

```
1. shipped anchored config, unmodified tree:
exit=0  no leaks found

2. high-entropy key planted in plugins/ca/tools/.env.example (#404 AC-3):
exit=1  leaks found: 1
      Secret:      REDACTED
      RuleID:      generic-api-key
      File:        plugins/ca/tools/.env.example
      Line:        4

3. real credential planted INSIDE an allowlisted fixture file:
exit=1  leaks found: 1
      Secret:      REDACTED
      RuleID:      generic-api-key
      File:        .github/scripts/test_hooklib.py
      Line:        760
```

Case 3 is the one that matters for the allowlist design: an allowlisted fixture file is still **fully scanned**. (A first attempt at this probe reported a false pass; the planted line used escaped quotes that gitleaks does not match **even with no allowlist at all**, so it was a bad probe rather than a blind spot. Re-run with a well-formed assignment, it fires.)

---

## Suites

| suite | result |
| --- | --- |
| `.github/scripts` | **1074 tests**, 4 failures — all `test_pi_benchmark` ("requires the installed pinned esbuild"), environmental and untouched by this diff |
| `plugins/ca/hooks/tests` | **1057 OK** |
| `tools/sync-core.py --check` | OK (47 core files × 3 plugins, byte-identical) |
| `tools/build-surface.py --check` | OK (claude, codex, pi in sync) |
| payload gate | no Pi payload change — version bump not required |
| `git diff --check origin/main HEAD` | exit 0 |
| `.gitleaks.toml` TOML parse | OK (5 allowlists, `regexTarget` omitted in all) |
| `ci.yml` / `docs.yml` YAML parse | OK (24 / 3 jobs) |

`origin/main` advanced 4 commits during this round and was merged in (not rebased); every measurement above is against the merge result.

**Live CI evidence** — the new `secret-scan` steps running for real (run [30145274733](https://github.com/arbiterForge/codeArbiter/actions/runs/30145274733)), not skipped:

```
test_the_secret_scan_allowlist_stays_narrow_and_value_scoped ... ok
test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract ... ok
Ran 2 tests in 0.007s
OK
INF scanned ~13737893 bytes (13.74 MB) in 6.69s
INF no leaks found
scanning commit range 9e8768fcf79dc76378ab03cb45bbcfc2c48d212b..HEAD
INF 2 commits scanned.
INF scanned ~54382 bytes (54.38 KB) in 48.9ms
INF no leaks found
```

**Correction to revision 1's NEEDS-TRIAGE #1:** it reported 7 pre-existing failures in `plugins/ca/hooks/tests`. That suite is now **1057 OK** — those failures are gone as of current `origin/main`, so the item is withdrawn rather than carried forward.

**H-10b / H-09b gate:** this diff touches credential-shaped literals, so the commit hook correctly blocked it. The gate was then genuinely worked: every waiver literal is a **re-anchoring of a value already in this same file** on `origin/main` — no new credential material. The only new text is the PEM waiver, which carries BEGIN/END *marker* text plus three test-local *constant names*; the fake key bodies are not reproduced. No cryptographic operation is introduced (`BEGIN RSA PRIVATE KEY` appears only as a literal inside a scanner regex; the `sha256:` occurrences are image digest pins). The sole sink is gitleaks' matcher inside a network-isolated, read-only container running `--redact`. Net direction is strictly narrower, which the three measurements above confirm.

---

## Round 3 — the narrowness contract was itself bypassable

Revision 2 added a contract asserting the `.gitleaks.toml` allowlist cannot be silently widened. A recheck proved **the contract could be walked past**: three BLOCKs, each measured *guard GREEN while the pinned scanner swallowed a live planted key*.

Auditing the same defect class while fixing them turned up **eight more**. All eleven are one bug: **the contract read `.gitleaks.toml` as TEXT**, and TOML — plus viper's case-insensitive key lookup — admits far more spellings than a regex anticipates.

### How every shape was measured

```
tree     git archive HEAD (5ad8964), plus a planted key in plugins/ca/tools/.env.example:
         FARM_API_KEY=sk-kR3mVq7XpZ2wNbT9sLdG4hJfA6cE1yUo
scanner  ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0…abbb7f   (v8.30.1 — the pinned digest)
command  gitleaks dir . --config /repo/.gitleaks.toml --redact --exit-code 1
```

**Baseline — the shipped config sees the planted key:**

```
INF scanned ~13737942 bytes (13.74 MB) in 2.21s
WRN leaks found: 1
exit=1
```

### The three reported BLOCKs, verbatim

**1. Indented `regexes` key.** `gitleaks_allowlist_regexes()` extracted with `(?ms)^regexes\s*=\s*\[` — anchored at column 0 — while "names no value" was the substring test `"regexes = [" in block`. Valid TOML with leading whitespace therefore yielded **zero** literals *and* still read as bounded.

```toml
[[allowlists]]
description = "adversarial: indented regexes key"
  regexes = ['''sk-''']
```
```
INF scanned ~13737942 bytes (13.74 MB) in 2.18s
INF no leaks found
exit=0
```

**2. `disabledRules` under `[extend]`.** The contract asserted `useDefault = true` was present and never looked at what sat beside it. This deletes the highest-value rule outright.

```toml
[extend]
useDefault = true
disabledRules = ["generic-api-key"]
```
```
INF scanned ~13737942 bytes (13.74 MB) in 2.22s
INF no leaks found
exit=0
```

**3. Single-quoted `regexTarget`.** The ban matched double quotes only (`regexTarget\s*=\s*"([^"]*)"`). Bound to the `match` target, a whole-match-anchored literal also clears the anchoring *and* metacharacter checks.

```toml
[[allowlists]]
description = "adversarial: single-quoted regexTarget"
regexTarget = 'match'
regexes = ['''\AFARM_API_KEY=sk-kR3mVq7XpZ2wNbT9sLdG4hJfA6cE1yUo\z''']
```
```
INF scanned ~13738005 bytes (13.74 MB) in 2.18s
INF no leaks found
exit=0
```

> Worth recording: the same waiver bound to `regexTarget = 'line'` does **not** swallow the key, because gitleaks' `line` target carries a **leading newline**. `\AFARM_API_KEY=…\z` misses it; `'match'` is the shape that lands. The contract now rejects the key outright rather than reasoning about which target is survivable.

### Eight more of the same class, found while fixing those three

| # | shape | measured effect |
|---|---|---|
| 4 | `regexes = ["sk-"]` (basic string) | only `'''…'''` was ever extracted → zero literals |
| 5 | `regexes = ['sk-']` (literal string) | same |
| 6 | indented `[[allowlists]]` header | column-0 block scan → an entire block invisible |
| 7 | `RegexTarget = "match"` | viper's key lookup is case-**in**sensitive; the bans were not |
| 8 | `Paths = ['''.''']` | **`scanned ~0 bytes (0) in 1.46ms`** — the whole repo went unread |
| 9 | `DISABLEDRULES = [...]` | same case hole, applied to the `[extend]` ban |
| 10 | `]` inside a waiver literal | array capture was non-greedy to the first `]`; every later waiver in that array went unchecked |
| 11 | `[[rules]]` re-declaring `generic-api-key` | a matching id **replaces** the default rule — and the contract never looked at `[[rules]]` at all |

Shape 8, verbatim — a single capitalised letter un-scans the repository:

```
INF scanned ~0 bytes (0) in 1.46ms
INF no leaks found
exit=0
```

### The before/after asymmetry

`gitleaks_waiver_violations` as it shipped at `5ad8964` vs. at HEAD, run over the identical adversarial configs:

```
adversarial .gitleaks.toml                     BEFORE       AFTER
------------------------------------------------------------------
indented `regexes` key                         PASSES    rejected
`disabledRules` under [extend]                 PASSES    rejected
single-quoted `regexTarget = 'match'`          PASSES    rejected
`regexes = ["sk-"]` (basic string)             PASSES    rejected
`regexes = ['sk-']` (literal string)           PASSES    rejected
indented `[[allowlists]]` header               PASSES    rejected
`RegexTarget = "match"` (case)                 PASSES    rejected
`Paths = ['''.''']` (case)                     PASSES    rejected
`DISABLEDRULES` (case)                         PASSES    rejected
`]` inside a waiver literal                    PASSES    rejected
`[[rules]]` re-declaring generic-api-key       PASSES    rejected
------------------------------------------------------------------
THE SHIPPED CONFIG (13 waivers, 5 blocks)      PASSES      PASSES

shipped waivers extracted: 13 across 5 blocks
```

Every shape in that table is one that returned the planted key to `no leaks found`, exit 0. The legitimate shipped config — 13 anchored, metacharacter-free waivers across 5 blocks — still passes, and still reports `leaks found: 1` (exit 1) on the planted key.

### The fix — parse it, don't scrape it

`gitleaks_waiver_violations` now parses the document with `tomllib` and folds keys to lower case, the way gitleaks' own viper-backed reader does. On top of that:

- **Default-deny on waiver keys** — a waiver may carry only `description` and `regexes`. `paths`/`commits`/`stopwords`/`regexTarget` keep their specific messages; anything else is rejected by name. The next widening knob gitleaks ships fails this contract the day it is typed, not the day someone remembers to ban it.
- **`[extend]` may set nothing but `useDefault`.**
- **`[[rules]]` is rejected** — this file only ever *subtracts* fixture values.
- **Unparseable TOML is a violation**, not a silent pass. Reporting "narrow" on a config that cannot load anything is the worst possible failure direction.

`.gitleaks.toml`'s own "ADDING AN ENTRY" rules were rewritten to match, including an explicit note that reformatting will not help.

### Audited and found clean

Same class, checked against the pinned image, **not** exploitable:

| shape | why it is safe |
|---|---|
| inline `allowlists = [{…}]` | gitleaks **ignores** it — `leaks found: 1` |
| singular `[allowlist]` | `FTL [allowlist] is deprecated, it cannot be used alongside [[allowlists]]` |
| `[extend] path = …` | `FTL unable to load config due to extend.path and extend.useDefault being set` |
| `[extend] url = …` | the scan job runs `--network none`; nothing can be fetched — `leaks found: 1` |

The inline-array-of-tables case is still guarded: the contract asserts the parsed allowlist count equals the table-header count, so a waiver the scanner ignores and a reader believes in fails the build.

---

## Round 3 — the two smaller findings

### MEDIUM — `docs.yml` never ran on itself

Its triggers were `site/**` and `plugins/ca/**` only. **The commit that added the site audit step did not execute it** — 37 checks reported on this PR and not one `Site |` among them. A PR deleting that audit, or breaking the `deploy → site-check` edge, touches `docs.yml` and nothing else: exactly the diff its own jobs could not see. This is the same defect class as #384 and the `.gitleaks.toml` gap this branch already fixes.

`.github/workflows/docs.yml` added to both its own `push` and `pull_request` path filters, with a test asserting it. Verified the newly reachable gate is green before making it reachable:

```
$ cd site && npm audit --omit=dev --audit-level=high
found 0 vulnerabilities
```

### LOW — the npm-audit sweep over-claimed; **derived** rather than narrowed

`test_every_npm_audit_gate_fails_the_build_on_a_high_advisory` said *"every job that installs a lockfile must also audit it"* while iterating the hardcoded triple `("tools", "ca-sandbox-tools", "ca-pi-checks")`. The claim was already false: `ca-pi-tools` is a **required** gate that runs `npm ci` and never audits — and so does `docs.yml`'s `build`. Both are benign only because a sibling job audits the same lockfile, and nothing checked that.

**Chose derivation, not a narrower comment.** A comment that matches three hardcoded names still cannot see a fourth graph, and that is precisely how `site/package-lock.json` went unguarded through #400/#403 — the exact failure this lane exists to close. Narrowing the prose would have made the test honest and left the hole open.

The rule is now the one that actually matters: **a job may skip the audit only when another job in the same workflow audits the very directory it installs.** No job list appears in the test. It is proven to bite by a synthetic job installing a brand-new graph, which the check rejects.

Two extraction bugs surfaced while deriving it — both the same read-it-as-text class as the allowlist fix, both fixed:

- the trigger/filter glob readers stopped at the first entry carrying a **trailing comment**, so `docs.yml`'s push filter read as `['site/**']` and `plugins/ca/**` was invisible to every assertion over it;
- the `npm ci` / `npm audit` detectors matched only the `- name:`/`run:` step shape, so a job using the inline `- run: npm ci` spelling would have gone entirely unseen.

### The gate caught this branch

Worth recording, because it is the whole thesis of the lane demonstrated on its own author. The first push of Round 3 turned `[CHECK] | [REPO] | Secret scan` **red**:

```
RuleID:      generic-api-key
File:        .github/scripts/test_ci_impact.py
Line:        1349
leaks found: 1
```

The commit had pasted the real high-entropy key used to *measure* the `regexTarget` bypass into a tracked file. The scanner was right. Fixed by removing the key, **not** by waiving it — widening the allowlist to admit a credential this branch itself introduced would invert the entire point of the branch. The value is now a low-entropy stand-in, which costs the assertion nothing: `regexTarget` is rejected on sight, whatever literal it is paired with.

Reproduced and re-verified locally against the pinned image over the real tracked tree, the way the CI job scans it:

```
before   RuleID: generic-api-key / test_ci_impact.py:1349 / leaks found: 1   exit 1
after    scanned ~13759566 bytes (13.76 MB) / no leaks found                 exit 0
```

### OPEN BLOCKER — the key is still in this branch's HISTORY

The working tree is clean, but `fc55acd` **added** the key and `8ec6e6d` removed it. The tree scan is green; the commit-range scan is not, and that is the range scan doing the exact job it was added for:

```
$ gitleaks git . --log-opts a3a2df2..HEAD --config .gitleaks.toml --redact --verbose
RuleID:      generic-api-key
File:        .github/scripts/test_ci_impact.py
Line:        1228
Commit:      fc55acd910a513c1eb14a60582614e3b9404a0f6
INF 14 commits scanned.
WRN leaks found: 1
```

Current CI on `8ec6e6d`: **37 pass, 2 fail** — `Secret scan` (the above) and `Merge readiness` (its consequence). The Windows Pi adapter flake (#428) passed this run.

**Deliberately not resolved unilaterally.** The three available routes each break something this lane is built on, so the choice belongs to the maintainer:

1. **Rewrite `fc55acd`/`15d8cdf` to drop the key and force-push.** The only thing that actually removes a blob from history. Requires force-pushing a pushed PR branch, which this lane's rules prohibit without explicit authorization. *(Recommended — this is a solo branch with no downstream clones, and history is the only place the credential still exists.)*
2. **Abandon this branch and re-open from a fresh one** built as a single clean commit off `origin/main`. Never rewrites a pushed branch, but changes the PR number.
3. **Add a `.gitleaksignore` fingerprint** pinned to commit+file+rule+line. Narrow in itself, but it introduces a waiver surface the narrowness contract does **not** police — i.e. a twelfth bypass of exactly the class this PR just closed eleven of. It would need the contract extended to cover `.gitleaksignore` first, and even then it waives a credential this branch itself introduced.

Widening `.gitleaks.toml`'s allowlist is not on the list, and will not be.

### Test state

```
$ cd .github/scripts && python -m unittest discover -s . -p "test_*.py"
Ran 1075 tests in 70.011s
FAILED (failures=2, errors=2, skipped=5)
```

All four are `test_pi_benchmark`, all `RuntimeError: Pi benchmark requires the installed pinned esbuild` — environmental, a fresh worktree with no `node_modules`, unrelated to this diff. `test_ci_impact` alone: **33 tests, OK.**

---

## NEEDS-TRIAGE — not in this diff

1. **`site/src/content/docs/guides/adding-a-dependency.md:62-65`** still documents the CVE gate as `--audit-level=critical`. That describes the `/ca:add-dep` skill's gate rather than CI's, but the repo now documents two thresholds. Fixing it means touching `site/**`, which requires the full `npm test` + build + link-audit loop; deliberately out of a CI-scoped lane.

2. **`docs.yml`'s `site-check` is not a required status check.** Branch protection on `main` requires only `[GATE ] | [REPO] | Merge readiness` from `ci.yml`, so a red site audit blocks the Pages publish (#403 AC-2, satisfied) but not the merge itself. Raised by the review as pre-existing; it is a branch-protection setting, not a diff.

3. **codeArbiter's own per-line redactor degrades `/ca:doctor` when the project path contains a trigger word.** Found while verifying the suite: in a worktree at `…/pr432-secret-scan-narrowness`, `test_pi_package.test_real_isolated_rpc_command_discovery_and_keyed_status` fails because the `package`, `core` and `child` diagnosis lines — the three that embed the project path — are replaced by `[REDACTED — secret-pattern match removed before transmission]`. Confirmed by control: the same commit passes in worktrees whose paths lack the word, and a purpose-named `secret-probe` worktree at the same commit reproduces the failure. Environmental, not this diff, but a real papercut — a benign path containing `secret` silently degrades doctor output.

4. **`ci.yml`'s push trigger is path-filtered**, so a push to `main` touching only unlisted paths starts no workflow and therefore no secret scan. #404 AC-2 is satisfied through the PR check, which is `main`'s enforcement point. Broadening the push paths would drag every other job along.

---

## CI state — the red gate is pre-existing, tracked as #428

> Describes **revision 2's** run; revision 3's CI is in flight. The #428 analysis below is unaffected by it.

35/37 checks pass. The two that do not are **not this lane's**:

```
[CHECK] | [PI  ] | Adapter contract <os: windows-latest · runtime: Pi 0.80.10>  -> fail
[GATE ] | [REPO] | Merge readiness                                             -> fail  (consequence of the above)
```

The failure is `test/background-jobs.test.ts > launches and disposes a real Git Bash background job`, `Error: Test timed out in 5000ms` — a real-process spawn against a hard 5s budget on a Windows runner.

**Reproduced on `origin/main`, not introduced here.** Run [30138368211](https://github.com/arbiterForge/codeArbiter/actions/runs/30138368211) on `main` @ `9e8768fc` — the exact commit this branch merged — fails on the *same test with the same message*, differing only in which Pi matrix cell it lands in (0.80.5 there, 0.80.10 here), which is itself the signature of a timing flake rather than a version-specific defect. Re-running the failed jobs reproduced it.

This diff touches **no Pi file** (`git diff --name-only origin/main HEAD` → `tech-stack.md`, `test_ci_impact.py`, `ci.yml`, `docs.yml`, `.gitleaks.toml`). Already tracked as **#428 — "Windows ca-pi adapter suites flake on hard 5s timing budgets"**; out of lane scope and deliberately not papered over here.

Every check this lane owns is green, including the new work: `[CHECK] | [REPO] | Secret scan` passed with all seven steps executing — the allowlist guard, the tree scan, and the commit-range scan.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L

