### PR TITLE
fix(hooks): stop losing and corrupting durable state in three core readers

### DIFF
--- a/.github/scripts/test_provenancelib.py
+++ b/.github/scripts/test_provenancelib.py
@@ -2597,5 +2597,129 @@ class TimeoutHardeningTest(unittest.TestCase):
         )
 
 
+class ProvenanceRecordShapeTest(unittest.TestCase):
+    """#410: read_provenance documents `dict | None` but used to hand back
+    whatever json.load produced, so a syntactically valid `[]` was admitted to
+    the store as a list. load_provenance_dir then called record.get() inside a
+    single try/except wrapped around the WHOLE glob loop, so the resulting
+    AttributeError aborted the scan and silently dropped every later valid
+    record — SessionStart drift and commit-gate auto-heal then ran against a
+    truncated provenance map with no indication anything was missing."""
+
+    # Every JSON top-level type that is not a provenance record.
+    NON_RECORDS = ("[]", "null", "3", '"a string"', "true", "[{}]")
+
+    def _dir(self):
+        import shutil
+
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        return tmp
+
+    def _write_raw(self, d, name, text):
+        path = os.path.join(d, name)
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(text)
+        return path
+
+    def _valid(self, d, name, doc):
+        record = pl.new_record(doc, created="2026-06-26", entries=[
+            {"path": "package.json", "hash": "a" * 40,
+             "drift_trigger": True, "claims": []},
+        ])
+        pl.write_provenance(os.path.join(d, name), record)
+        return record
+
+    def test_read_provenance_rejects_every_non_mapping_top_level_type(self):
+        d = self._dir()
+        for i, raw in enumerate(self.NON_RECORDS):
+            path = self._write_raw(d, f"nonmap{i}.json", raw)
+            self.assertIsNone(
+                pl.read_provenance(path),
+                f"read_provenance must return None for a top-level {raw!r}",
+            )
+
+    def test_read_provenance_rejects_a_mapping_with_the_wrong_schema(self):
+        d = self._dir()
+        bad = {
+            "empty": {},
+            "no_schema": {"doc": "x", "created": "2026-01-01",
+                          "interview_derived": False, "entries": []},
+            "wrong_version": {"schema": 99, "doc": "x", "created": "2026-01-01",
+                              "interview_derived": False, "entries": []},
+            "schema_as_string": {"schema": "1", "doc": "x", "created": "2026-01-01",
+                                 "interview_derived": False, "entries": []},
+            "entries_not_a_list": {"schema": 1, "doc": "x", "created": "2026-01-01",
+                                   "interview_derived": False, "entries": {}},
+            "doc_not_a_string": {"schema": 1, "doc": 7, "created": "2026-01-01",
+                                 "interview_derived": False, "entries": []},
+            "missing_entries": {"schema": 1, "doc": "x", "created": "2026-01-01",
+                                "interview_derived": False},
+        }
+        for name, record in bad.items():
+            path = self._write_raw(d, f"{name}.json", json.dumps(record))
+            self.assertIsNone(
+                pl.read_provenance(path),
+                f"read_provenance must return None for the {name!r} record",
+            )
+
+    def test_read_provenance_still_accepts_a_canonical_record(self):
+        d = self._dir()
+        record = self._valid(d, "tech-stack.json", "tech-stack")
+        self.assertEqual(pl.read_provenance(os.path.join(d, "tech-stack.json")), record)
+
+    def test_invalid_record_does_not_drop_the_valid_records_after_it(self):
+        # Filenames chosen so the invalid file is globbed FIRST.
+        d = self._dir()
+        self._write_raw(d, "a-bad.json", "[]")
+        self._valid(d, "b-good.json", "tech-stack")
+        self._valid(d, "c-good.json", "code-map")
+        loaded = pl.load_provenance_dir(d)
+        self.assertEqual(sorted(loaded), ["code-map", "tech-stack"],
+                         "one invalid record must not abort the directory scan")
+
+    def test_a_valid_record_survives_after_every_invalid_top_level_type(self):
+        for i, raw in enumerate(self.NON_RECORDS):
+            with self.subTest(raw=raw):
+                d = self._dir()
+                self._write_raw(d, "a-bad.json", raw)
+                self._valid(d, "b-good.json", "tech-stack")
+                loaded = pl.load_provenance_dir(d)
+                self.assertIn("tech-stack", loaded,
+                              f"a valid record after {raw!r} must still load")
+                self.assertEqual(len(loaded), 1)
+
+    def test_loader_never_raises_on_an_all_invalid_directory(self):
+        d = self._dir()
+        for i, raw in enumerate(self.NON_RECORDS):
+            self._write_raw(d, f"bad{i}.json", raw)
+        self.assertEqual(pl.load_provenance_dir(d), {})
+
+    def test_loader_reports_bounded_corruption_without_exposing_contents(self):
+        d = self._dir()
+        # Stand-in for the sort of thing a provenance file really holds —
+        # repo paths and claim prose that has no business in a log line.
+        sensitive = "internal/billing/keyvault.ts"
+        self._write_raw(d, "leaky.json", json.dumps([sensitive]))
+        self._valid(d, "good.json", "tech-stack")
+        skipped = []
+        loaded = pl.load_provenance_dir(d, skipped=skipped)
+        self.assertIn("tech-stack", loaded)
+        self.assertEqual(skipped, ["leaky.json"],
+                         "the loader must name the rejected file, and only its name")
+        self.assertNotIn(sensitive, " ".join(skipped),
+                         "a corruption diagnostic must never carry file contents")
+
+    def test_corruption_diagnostic_is_bounded(self):
+        d = self._dir()
+        for i in range(40):
+            self._write_raw(d, f"bad{i:02d}.json", "[]")
+        skipped = []
+        pl.load_provenance_dir(d, skipped=skipped)
+        self.assertTrue(skipped, "rejected records must be reported")
+        self.assertLessEqual(len(skipped), pl.MAX_SKIPPED_REPORTED,
+                             "the diagnostic must be bounded, not one line per file")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_provenancelib.py
+++ b/.github/scripts/test_provenancelib.py
@@ -20,6 +20,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
@@ -2719,6 +2720,34 @@ class ProvenanceRecordShapeTest(unittest.TestCase):
         self.assertTrue(skipped, "rejected records must be reported")
         self.assertLessEqual(len(skipped), pl.MAX_SKIPPED_REPORTED,
                              "the diagnostic must be bounded, not one line per file")
+
+    def test_a_read_that_raises_costs_only_its_own_file(self):
+        """The per-file boundary must hold for failures read_provenance does
+        NOT convert to None. read_provenance only absorbs OSError/ValueError;
+        anything else — a RecursionError from a pathologically nested file, a
+        TypeError from a future refactor — propagates into the glob loop. With
+        one try/except around the WHOLE loop that aborted the scan and dropped
+        every later valid record. This pins the boundary directly rather than
+        through the validation hunk, which can no longer produce a raise."""
+        d = self._dir()
+        self._write_raw(d, "a-boom.json", "{}")
+        self._valid(d, "b-good.json", "tech-stack")
+        self._valid(d, "c-good.json", "code-map")
+        real_read = pl.read_provenance
+
+        def exploding_read(path):
+            if os.path.basename(path) == "a-boom.json":
+                raise TypeError("a failure mode the loader never anticipated")
+            return real_read(path)
+
+        skipped = []
+        with mock.patch.object(pl, "read_provenance", exploding_read):
+            loaded = pl.load_provenance_dir(d, skipped=skipped)
+
+        self.assertEqual(sorted(loaded), ["code-map", "tech-stack"],
+                         "a raising read must not abort the directory scan")
+        self.assertEqual(skipped, ["a-boom.json"],
+                         "the file that raised must be the one — and the only one — skipped")
 
 
 if __name__ == "__main__":

--- a/core/pysrc/_provenancelib.py
+++ b/core/pysrc/_provenancelib.py
@@ -682,6 +682,16 @@ def load_provenance_dir(provenance_dir, skipped=None):
     warning can name the corrupt record. Names only — never file contents, which
     may hold paths or claims that do not belong in a log line.
 
+    NO PRODUCTION CALLER PASSES `skipped` TODAY, and that is deliberate rather
+    than an oversight. The two real call sites cannot carry the diagnostic:
+    startup_drift_line is bound by AC-08 ("degrade to silence" — an all-corrupt
+    provenance dir MUST return '', pinned by test_degrade_corrupt_json), and
+    build_index runs on every PreToolUse:Read, where a per-call warning would be
+    noise on the hottest path in the hook layer. Surfacing corruption to a user
+    therefore belongs to /ca:context-check or /ca:doctor, which are surface
+    prose and out of this module's reach. The channel exists, is bounded, and is
+    tested; anything reading it is a follow-up.
+
     Never raises — filesystem errors and malformed records are skipped (this
     runs on the SessionStart linchpin path).
     """

--- a/core/pysrc/_provenancelib.py
+++ b/core/pysrc/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/core/pysrc/_subagentslib.py
+++ b/core/pysrc/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -535,7 +535,7 @@ def _write_dev_session_owner(root, session_id, ts):
 # The fix is a small write-ahead record: the owed line is staged on disk BEFORE
 # the append is attempted, and the record is deleted only once BOTH the append
 # is confirmed AND the marker it settles is gone. That single record therefore
-# carries two facts at once:
+# carries three facts at once:
 #
 #   "lines"        — close lines still owed to overrides.log. Emptied one at a
 #                    time as each append is confirmed.
@@ -544,7 +544,22 @@ def _write_dev_session_owner(root, session_id, ts):
 #                    force-close path knows that marker has already been
 #                    closed in the audit trail and refuses to mint a second
 #                    row for it — which is what makes a failed `os.remove`
-#                    idempotent rather than duplicating the close.
+#                    idempotent rather than duplicating the close. It is
+#                    cleared the moment that marker is gone: an mtime only
+#                    identifies a file that still EXISTS, and a stale one is
+#                    free to collide with an unrelated future marker (2s
+#                    granularity on FAT32/exFAT/SMB/WSL mounts makes that a
+#                    real event, not a theoretical one) and suppress a close
+#                    that is genuinely owed.
+#   "dropped"      — how many owed close lines the bound below has discarded.
+#                    The cap keeps the record small, but the loss must not be
+#                    silent: the count is written to the trail as one
+#                    attributable note the moment overrides.log accepts writes.
+#
+# Replayed lines carry the timestamp they were MINTED with, not the time they
+# land, so a delayed replay leaves overrides.log non-chronological. Enter/exit
+# pairing is by timestamp, so that is correct — but an audit reader must not
+# assume file order is time order.
 #
 # Every boundary is covered:
 #   crash before the append      -> record present, line owed  -> replayed
@@ -553,6 +568,14 @@ def _write_dev_session_owner(root, session_id, ts):
 #                                   drops it instead of appending a duplicate
 #   marker removal fails         -> record present, no line owed -> the next
 #                                   session only retries the removal
+#
+# That tail scan is applied ONLY to lines read back off the record — the ones
+# that might have landed before a crash. A line minted in THIS process cannot
+# already be on the trail, and must never be dedupe-checked: close rows are
+# timestamped to the second, so two distinct closes minted in the same second
+# are byte-identical, and checking the fresh one against an owed copy of itself
+# would silently swallow a close that is genuinely owed.
+#
 # Everything here is best-effort by the module's standing convention: session
 # startup must never be bricked by audit bookkeeping, so nothing raises.
 _DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
@@ -568,11 +591,12 @@ def _overrides_log_path(root):
 
 
 def _read_dev_pending_close(root):
-    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
-    or None when there is nothing usable on disk. A record that exists but
-    carries no replayable line and no marker identity is reported as None so
-    the caller discards it — a corrupt record must never wedge the mechanism
-    shut. Never raises."""
+    """The pending-close record as
+    {"lines": [...], "marker_mtime": float|None, "dropped": int}, or None when
+    there is nothing usable on disk. A record that exists but carries no
+    replayable line, no marker identity and no unreported drop is reported as
+    None so the caller discards it — a corrupt record must never wedge the
+    mechanism shut. Never raises."""
     try:
         with open(_dev_pending_close_path(root), encoding="utf-8") as f:
             data = json.load(f)
@@ -582,9 +606,13 @@ def _read_dev_pending_close(root):
                  if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
         mtime = data.get("marker_mtime")
         mtime = float(mtime) if isinstance(mtime, (int, float)) else None
-        if not lines and mtime is None:
+        dropped = data.get("dropped")
+        # `isinstance(True, int)` is True, so booleans are excluded explicitly.
+        dropped = (int(dropped) if isinstance(dropped, int)
+                   and not isinstance(dropped, bool) and dropped > 0 else 0)
+        if not lines and mtime is None and not dropped:
             return None
-        return {"lines": lines, "marker_mtime": mtime}
+        return {"lines": lines, "marker_mtime": mtime, "dropped": dropped}
     except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
         return None
 
@@ -643,21 +671,37 @@ def _append_override_line(root, line):
         return False
 
 
-def _settle_dev_close(root, marker=None, new_line=None):
+def _dev_dropped_close_note(count, host_name=None):
+    """One audit line accounting for close rows the pending-close cap had to
+    discard. Deliberately NOT a `DEV: exit` row — it closes nothing; it records
+    that N closes can never be written, so a reader of the append-only trail
+    can attribute the unmatched entries instead of finding an unexplained gap.
+    """
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (f"[{ts}] | BY: session-cleanup | HOST: {host_name or 'unknown'} "
+            f"| DEV: close-dropped | NOTE: {count} owed close row(s) discarded - the "
+            f"pending-close cap ({_DEV_PENDING_CLOSE_MAX}) was reached while "
+            f"overrides.log was unwritable; that many maintainer sessions have "
+            f"no matching close row\n")
+
+
+def _settle_dev_close(root, marker=None, new_line=None, host_name=None):
     """Drive the pending-close record to settlement; the single place the owed
     DEV: exit is appended and the retry state is cleared.
 
     `marker` is the dev-active path when one is live (its mtime becomes the
     close identity), None when there is no marker to settle. `new_line` is a
     freshly minted close line to take on, or None when this is a pure replay of
-    whatever is already owed. Returns the number of close lines appended by
-    THIS call. Never raises."""
+    whatever is already owed. `host_name` only attributes the cap-overflow note
+    below; the close lines themselves already carry their own HOST field.
+    Returns the number of close lines appended by THIS call. Never raises."""
     if (marker is None and new_line is None
             and not os.path.isfile(_dev_pending_close_path(root))):
         return 0    # nothing owed, nothing to settle — the overwhelming case
     rec = _read_dev_pending_close(root)
     owed = list(rec["lines"]) if rec else []
     prev_mtime = rec["marker_mtime"] if rec else None
+    dropped = rec["dropped"] if rec else 0
 
     marker_mtime = None
     if marker:
@@ -665,6 +709,11 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_mtime = os.path.getmtime(marker)
         except OSError:
             marker_mtime = None
+
+    # Everything already in `owed` came off disk, so it MAY have reached the
+    # trail before a crash and has to be dedupe-checked. Anything appended
+    # below is minted in this process and cannot possibly be there yet.
+    replays = len(owed)
 
     if new_line is not None:
         # Already closed THIS marker (the append landed, only the removal
@@ -674,21 +723,44 @@ def _settle_dev_close(root, marker=None, new_line=None):
                           and prev_mtime == marker_mtime)
         if not already_closed:
             owed.append(new_line)
-    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+    if len(owed) > _DEV_PENDING_CLOSE_MAX:
+        # Bounded, but never SILENT. A permanently-unwritable overrides.log
+        # would otherwise accumulate owed lines forever, so the oldest are
+        # discarded — and counted, so the loss is itself auditable rather than
+        # reintroducing exactly the unmatched `DEV: enter` this record exists
+        # to prevent.
+        overflow = len(owed) - _DEV_PENDING_CLOSE_MAX
+        dropped += overflow
+        owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+        replays = max(0, replays - overflow)   # the discards come off the front
 
-    if owed or marker_mtime is not None:
+    if owed or dropped or marker_mtime is not None:
         # Write-ahead: the obligation is durable BEFORE the append is tried.
-        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+        _write_dev_pending_close(root, {"lines": owed,
+                                        "marker_mtime": marker_mtime,
+                                        "dropped": dropped})
+
+    # The overflow note goes in FIRST — the rows it accounts for are older than
+    # everything still owed. It is minted fresh each attempt, so it is not
+    # deduped by the tail scan; a crash between this append and the write-back
+    # below can repeat it once, which is the same "a duplicate beats a loss"
+    # trade the close rows themselves make.
+    if dropped and _append_override_line(root, _dev_dropped_close_note(dropped, host_name)):
+        dropped = 0
 
     appended = 0
-    remaining = list(owed)
-    for line in owed:
-        if _overrides_has_line(root, line):
-            remaining.remove(line)   # crash-after-append: already in the trail
-            continue
+    remaining = []
+    stalled = False
+    for idx, line in enumerate(owed):
+        if stalled:
+            remaining.append(line)   # the log is failing — everything after
+            continue                 # the first failure is still owed
+        if idx < replays and _overrides_has_line(root, line):
+            continue                 # crash-after-append: already in the trail
         if not _append_override_line(root, line):
-            break                    # still owed — replay on the next session
-        remaining.remove(line)
+            stalled = True
+            remaining.append(line)   # still owed — replay on the next session
+            continue
         appended += 1
 
     marker_gone = True
@@ -699,11 +771,16 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_gone = not os.path.isfile(marker)
 
     # Keep the record ONLY while it still carries information: a line still
-    # owed, or the identity of a marker that survived its own removal (the
-    # tombstone that stops the next session minting a second close for it).
-    if remaining or (not marker_gone and marker_mtime is not None):
+    # owed, an unreported cap overflow, or the identity of a marker that
+    # survived its own removal (the tombstone that stops the next session
+    # minting a second close for it). A marker that IS gone takes its tombstone
+    # with it — a dead marker's mtime identifies nothing, and leaving it behind
+    # lets an unrelated future marker collide with it and lose a real close.
+    if remaining or dropped or (not marker_gone and marker_mtime is not None):
         _write_dev_pending_close(root, {"lines": remaining,
-                                        "marker_mtime": marker_mtime})
+                                        "marker_mtime": (None if marker_gone
+                                                         else marker_mtime),
+                                        "dropped": dropped})
     else:
         _discard_dev_pending_close(root)
     return appended
@@ -754,7 +831,12 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
         # do — there is no marker to clear, but a close owed by an EARLIER
         # session whose append failed is still replayed here (#396); that is
         # precisely the case the old code could never recover from.
-        _settle_dev_close(root)
+        #
+        # `host_name` is passed through as-is (it only attributes the
+        # cap-overflow note) rather than resolved here: main() already hands
+        # the real host name down, and this branch is the overwhelmingly
+        # common one — it must not pay for a host resolution on every startup.
+        _settle_dev_close(root, host_name=host_name)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -809,7 +891,7 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     # #396: stage-then-append-then-clear, all inside one settlement step. The
     # append is no longer a fire-and-forget `except OSError: pass` followed by
     # an unconditional marker delete — the owed line outlives a failed write.
-    _settle_dev_close(root, marker=marker, new_line=line)
+    _settle_dev_close(root, marker=marker, new_line=line, host_name=host_name)
 
 
 def provenance_drift_line(root, runner=None):

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_provenancelib.py
+++ b/plugins/ca-codex/hooks/_provenancelib.py
@@ -682,6 +682,16 @@ def load_provenance_dir(provenance_dir, skipped=None):
     warning can name the corrupt record. Names only — never file contents, which
     may hold paths or claims that do not belong in a log line.
 
+    NO PRODUCTION CALLER PASSES `skipped` TODAY, and that is deliberate rather
+    than an oversight. The two real call sites cannot carry the diagnostic:
+    startup_drift_line is bound by AC-08 ("degrade to silence" — an all-corrupt
+    provenance dir MUST return '', pinned by test_degrade_corrupt_json), and
+    build_index runs on every PreToolUse:Read, where a per-call warning would be
+    noise on the hottest path in the hook layer. Surfacing corruption to a user
+    therefore belongs to /ca:context-check or /ca:doctor, which are surface
+    prose and out of this module's reach. The channel exists, is bounded, and is
+    tested; anything reading it is a follow-up.
+
     Never raises — filesystem errors and malformed records are skipped (this
     runs on the SessionStart linchpin path).
     """

--- a/plugins/ca-codex/hooks/_provenancelib.py
+++ b/plugins/ca-codex/hooks/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/plugins/ca-codex/hooks/_subagentslib.py
+++ b/plugins/ca-codex/hooks/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -535,7 +535,7 @@ def _write_dev_session_owner(root, session_id, ts):
 # The fix is a small write-ahead record: the owed line is staged on disk BEFORE
 # the append is attempted, and the record is deleted only once BOTH the append
 # is confirmed AND the marker it settles is gone. That single record therefore
-# carries two facts at once:
+# carries three facts at once:
 #
 #   "lines"        — close lines still owed to overrides.log. Emptied one at a
 #                    time as each append is confirmed.
@@ -544,7 +544,22 @@ def _write_dev_session_owner(root, session_id, ts):
 #                    force-close path knows that marker has already been
 #                    closed in the audit trail and refuses to mint a second
 #                    row for it — which is what makes a failed `os.remove`
-#                    idempotent rather than duplicating the close.
+#                    idempotent rather than duplicating the close. It is
+#                    cleared the moment that marker is gone: an mtime only
+#                    identifies a file that still EXISTS, and a stale one is
+#                    free to collide with an unrelated future marker (2s
+#                    granularity on FAT32/exFAT/SMB/WSL mounts makes that a
+#                    real event, not a theoretical one) and suppress a close
+#                    that is genuinely owed.
+#   "dropped"      — how many owed close lines the bound below has discarded.
+#                    The cap keeps the record small, but the loss must not be
+#                    silent: the count is written to the trail as one
+#                    attributable note the moment overrides.log accepts writes.
+#
+# Replayed lines carry the timestamp they were MINTED with, not the time they
+# land, so a delayed replay leaves overrides.log non-chronological. Enter/exit
+# pairing is by timestamp, so that is correct — but an audit reader must not
+# assume file order is time order.
 #
 # Every boundary is covered:
 #   crash before the append      -> record present, line owed  -> replayed
@@ -553,6 +568,14 @@ def _write_dev_session_owner(root, session_id, ts):
 #                                   drops it instead of appending a duplicate
 #   marker removal fails         -> record present, no line owed -> the next
 #                                   session only retries the removal
+#
+# That tail scan is applied ONLY to lines read back off the record — the ones
+# that might have landed before a crash. A line minted in THIS process cannot
+# already be on the trail, and must never be dedupe-checked: close rows are
+# timestamped to the second, so two distinct closes minted in the same second
+# are byte-identical, and checking the fresh one against an owed copy of itself
+# would silently swallow a close that is genuinely owed.
+#
 # Everything here is best-effort by the module's standing convention: session
 # startup must never be bricked by audit bookkeeping, so nothing raises.
 _DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
@@ -568,11 +591,12 @@ def _overrides_log_path(root):
 
 
 def _read_dev_pending_close(root):
-    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
-    or None when there is nothing usable on disk. A record that exists but
-    carries no replayable line and no marker identity is reported as None so
-    the caller discards it — a corrupt record must never wedge the mechanism
-    shut. Never raises."""
+    """The pending-close record as
+    {"lines": [...], "marker_mtime": float|None, "dropped": int}, or None when
+    there is nothing usable on disk. A record that exists but carries no
+    replayable line, no marker identity and no unreported drop is reported as
+    None so the caller discards it — a corrupt record must never wedge the
+    mechanism shut. Never raises."""
     try:
         with open(_dev_pending_close_path(root), encoding="utf-8") as f:
             data = json.load(f)
@@ -582,9 +606,13 @@ def _read_dev_pending_close(root):
                  if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
         mtime = data.get("marker_mtime")
         mtime = float(mtime) if isinstance(mtime, (int, float)) else None
-        if not lines and mtime is None:
+        dropped = data.get("dropped")
+        # `isinstance(True, int)` is True, so booleans are excluded explicitly.
+        dropped = (int(dropped) if isinstance(dropped, int)
+                   and not isinstance(dropped, bool) and dropped > 0 else 0)
+        if not lines and mtime is None and not dropped:
             return None
-        return {"lines": lines, "marker_mtime": mtime}
+        return {"lines": lines, "marker_mtime": mtime, "dropped": dropped}
     except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
         return None
 
@@ -643,21 +671,37 @@ def _append_override_line(root, line):
         return False
 
 
-def _settle_dev_close(root, marker=None, new_line=None):
+def _dev_dropped_close_note(count, host_name=None):
+    """One audit line accounting for close rows the pending-close cap had to
+    discard. Deliberately NOT a `DEV: exit` row — it closes nothing; it records
+    that N closes can never be written, so a reader of the append-only trail
+    can attribute the unmatched entries instead of finding an unexplained gap.
+    """
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (f"[{ts}] | BY: session-cleanup | HOST: {host_name or 'unknown'} "
+            f"| DEV: close-dropped | NOTE: {count} owed close row(s) discarded - the "
+            f"pending-close cap ({_DEV_PENDING_CLOSE_MAX}) was reached while "
+            f"overrides.log was unwritable; that many maintainer sessions have "
+            f"no matching close row\n")
+
+
+def _settle_dev_close(root, marker=None, new_line=None, host_name=None):
     """Drive the pending-close record to settlement; the single place the owed
     DEV: exit is appended and the retry state is cleared.
 
     `marker` is the dev-active path when one is live (its mtime becomes the
     close identity), None when there is no marker to settle. `new_line` is a
     freshly minted close line to take on, or None when this is a pure replay of
-    whatever is already owed. Returns the number of close lines appended by
-    THIS call. Never raises."""
+    whatever is already owed. `host_name` only attributes the cap-overflow note
+    below; the close lines themselves already carry their own HOST field.
+    Returns the number of close lines appended by THIS call. Never raises."""
     if (marker is None and new_line is None
             and not os.path.isfile(_dev_pending_close_path(root))):
         return 0    # nothing owed, nothing to settle — the overwhelming case
     rec = _read_dev_pending_close(root)
     owed = list(rec["lines"]) if rec else []
     prev_mtime = rec["marker_mtime"] if rec else None
+    dropped = rec["dropped"] if rec else 0
 
     marker_mtime = None
     if marker:
@@ -665,6 +709,11 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_mtime = os.path.getmtime(marker)
         except OSError:
             marker_mtime = None
+
+    # Everything already in `owed` came off disk, so it MAY have reached the
+    # trail before a crash and has to be dedupe-checked. Anything appended
+    # below is minted in this process and cannot possibly be there yet.
+    replays = len(owed)
 
     if new_line is not None:
         # Already closed THIS marker (the append landed, only the removal
@@ -674,21 +723,44 @@ def _settle_dev_close(root, marker=None, new_line=None):
                           and prev_mtime == marker_mtime)
         if not already_closed:
             owed.append(new_line)
-    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+    if len(owed) > _DEV_PENDING_CLOSE_MAX:
+        # Bounded, but never SILENT. A permanently-unwritable overrides.log
+        # would otherwise accumulate owed lines forever, so the oldest are
+        # discarded — and counted, so the loss is itself auditable rather than
+        # reintroducing exactly the unmatched `DEV: enter` this record exists
+        # to prevent.
+        overflow = len(owed) - _DEV_PENDING_CLOSE_MAX
+        dropped += overflow
+        owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+        replays = max(0, replays - overflow)   # the discards come off the front
 
-    if owed or marker_mtime is not None:
+    if owed or dropped or marker_mtime is not None:
         # Write-ahead: the obligation is durable BEFORE the append is tried.
-        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+        _write_dev_pending_close(root, {"lines": owed,
+                                        "marker_mtime": marker_mtime,
+                                        "dropped": dropped})
+
+    # The overflow note goes in FIRST — the rows it accounts for are older than
+    # everything still owed. It is minted fresh each attempt, so it is not
+    # deduped by the tail scan; a crash between this append and the write-back
+    # below can repeat it once, which is the same "a duplicate beats a loss"
+    # trade the close rows themselves make.
+    if dropped and _append_override_line(root, _dev_dropped_close_note(dropped, host_name)):
+        dropped = 0
 
     appended = 0
-    remaining = list(owed)
-    for line in owed:
-        if _overrides_has_line(root, line):
-            remaining.remove(line)   # crash-after-append: already in the trail
-            continue
+    remaining = []
+    stalled = False
+    for idx, line in enumerate(owed):
+        if stalled:
+            remaining.append(line)   # the log is failing — everything after
+            continue                 # the first failure is still owed
+        if idx < replays and _overrides_has_line(root, line):
+            continue                 # crash-after-append: already in the trail
         if not _append_override_line(root, line):
-            break                    # still owed — replay on the next session
-        remaining.remove(line)
+            stalled = True
+            remaining.append(line)   # still owed — replay on the next session
+            continue
         appended += 1
 
     marker_gone = True
@@ -699,11 +771,16 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_gone = not os.path.isfile(marker)
 
     # Keep the record ONLY while it still carries information: a line still
-    # owed, or the identity of a marker that survived its own removal (the
-    # tombstone that stops the next session minting a second close for it).
-    if remaining or (not marker_gone and marker_mtime is not None):
+    # owed, an unreported cap overflow, or the identity of a marker that
+    # survived its own removal (the tombstone that stops the next session
+    # minting a second close for it). A marker that IS gone takes its tombstone
+    # with it — a dead marker's mtime identifies nothing, and leaving it behind
+    # lets an unrelated future marker collide with it and lose a real close.
+    if remaining or dropped or (not marker_gone and marker_mtime is not None):
         _write_dev_pending_close(root, {"lines": remaining,
-                                        "marker_mtime": marker_mtime})
+                                        "marker_mtime": (None if marker_gone
+                                                         else marker_mtime),
+                                        "dropped": dropped})
     else:
         _discard_dev_pending_close(root)
     return appended
@@ -754,7 +831,12 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
         # do — there is no marker to clear, but a close owed by an EARLIER
         # session whose append failed is still replayed here (#396); that is
         # precisely the case the old code could never recover from.
-        _settle_dev_close(root)
+        #
+        # `host_name` is passed through as-is (it only attributes the
+        # cap-overflow note) rather than resolved here: main() already hands
+        # the real host name down, and this branch is the overwhelmingly
+        # common one — it must not pay for a host resolution on every startup.
+        _settle_dev_close(root, host_name=host_name)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -809,7 +891,7 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     # #396: stage-then-append-then-clear, all inside one settlement step. The
     # append is no longer a fire-and-forget `except OSError: pass` followed by
     # an unconditional marker delete — the owed line outlives a failed write.
-    _settle_dev_close(root, marker=marker, new_line=line)
+    _settle_dev_close(root, marker=marker, new_line=line, host_name=host_name)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.4] - 2026-07-25
+
+### Fixed
+
+- An abandoned maintainer session's synthetic `DEV: exit` is now durable: the
+  owed audit line is staged on disk before the append is attempted and cleared
+  only once both the append and the marker removal are confirmed, so a locked
+  or failing `overrides.log` no longer erases the close and leaves an unmatched
+  `DEV: enter`.
+- The subagent transcript reader honours one result shape on every path, so a
+  subagent-directory race no longer raises out of the statusline, and a
+  syntactically valid non-object JSONL record is skipped instead of blanking
+  every subagent row.
+- Provenance records are validated before admission and each file is loaded
+  inside its own error boundary, so one schema-invalid record no longer aborts
+  the directory scan and silently drops every later valid record.
+
+
 ## [0.1.3] - 2026-07-24
 
 ### Security
@@ -19,6 +37,7 @@ All notable changes to `ca-pi` are documented in this file.
   call, permission decision, and result event. Lifecycle and doctor requests
   keep a locally minted correlation. Only a SHA-256 digest is accepted on the
   wire; the raw Pi tool-call id never reaches the request JSON or the audit log.
+
 
 ## [0.1.2] - 2026-07-24
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
-## [0.1.4] - 2026-07-25
+## [0.1.4] - 2026-07-24
 
 ### Fixed
 
@@ -10,7 +10,8 @@ All notable changes to `ca-pi` are documented in this file.
   owed audit line is staged on disk before the append is attempted and cleared
   only once both the append and the marker removal are confirmed, so a locked
   or failing `overrides.log` no longer erases the close and leaves an unmatched
-  `DEV: enter`.
+  `DEV: enter`. The retry record is bounded, and an overflow that has to discard
+  an owed close is itself written to the trail rather than dropped silently.
 - The subagent transcript reader honours one result shape on every path, so a
   subagent-directory race no longer raises out of the statusline, and a
   syntactically valid non-object JSONL record is skipped instead of blanking
@@ -18,7 +19,6 @@ All notable changes to `ca-pi` are documented in this file.
 - Provenance records are validated before admission and each file is loaded
   inside its own error boundary, so one schema-invalid record no longer aborts
   the directory scan and silently drops every later valid record.
-
 
 ## [0.1.3] - 2026-07-24
 
@@ -37,7 +37,6 @@ All notable changes to `ca-pi` are documented in this file.
   call, permission decision, and result event. Lifecycle and doctor requests
   keep a locally minted correlation. Only a SHA-256 digest is accepted on the
   wire; the raw Pi tool-call id never reaches the request JSON or the audit log.
-
 
 ## [0.1.2] - 2026-07-24
 

--- a/plugins/ca-pi/hooks/_provenancelib.py
+++ b/plugins/ca-pi/hooks/_provenancelib.py
@@ -682,6 +682,16 @@ def load_provenance_dir(provenance_dir, skipped=None):
     warning can name the corrupt record. Names only — never file contents, which
     may hold paths or claims that do not belong in a log line.
 
+    NO PRODUCTION CALLER PASSES `skipped` TODAY, and that is deliberate rather
+    than an oversight. The two real call sites cannot carry the diagnostic:
+    startup_drift_line is bound by AC-08 ("degrade to silence" — an all-corrupt
+    provenance dir MUST return '', pinned by test_degrade_corrupt_json), and
+    build_index runs on every PreToolUse:Read, where a per-call warning would be
+    noise on the hottest path in the hook layer. Surfacing corruption to a user
+    therefore belongs to /ca:context-check or /ca:doctor, which are surface
+    prose and out of this module's reach. The channel exists, is bounded, and is
+    tested; anything reading it is a follow-up.
+
     Never raises — filesystem errors and malformed records are skipped (this
     runs on the SessionStart linchpin path).
     """

--- a/plugins/ca-pi/hooks/_provenancelib.py
+++ b/plugins/ca-pi/hooks/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/plugins/ca-pi/hooks/_subagentslib.py
+++ b/plugins/ca-pi/hooks/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/plugins/ca-pi/hooks/session-start.py
+++ b/plugins/ca-pi/hooks/session-start.py
@@ -535,7 +535,7 @@ def _write_dev_session_owner(root, session_id, ts):
 # The fix is a small write-ahead record: the owed line is staged on disk BEFORE
 # the append is attempted, and the record is deleted only once BOTH the append
 # is confirmed AND the marker it settles is gone. That single record therefore
-# carries two facts at once:
+# carries three facts at once:
 #
 #   "lines"        — close lines still owed to overrides.log. Emptied one at a
 #                    time as each append is confirmed.
@@ -544,7 +544,22 @@ def _write_dev_session_owner(root, session_id, ts):
 #                    force-close path knows that marker has already been
 #                    closed in the audit trail and refuses to mint a second
 #                    row for it — which is what makes a failed `os.remove`
-#                    idempotent rather than duplicating the close.
+#                    idempotent rather than duplicating the close. It is
+#                    cleared the moment that marker is gone: an mtime only
+#                    identifies a file that still EXISTS, and a stale one is
+#                    free to collide with an unrelated future marker (2s
+#                    granularity on FAT32/exFAT/SMB/WSL mounts makes that a
+#                    real event, not a theoretical one) and suppress a close
+#                    that is genuinely owed.
+#   "dropped"      — how many owed close lines the bound below has discarded.
+#                    The cap keeps the record small, but the loss must not be
+#                    silent: the count is written to the trail as one
+#                    attributable note the moment overrides.log accepts writes.
+#
+# Replayed lines carry the timestamp they were MINTED with, not the time they
+# land, so a delayed replay leaves overrides.log non-chronological. Enter/exit
+# pairing is by timestamp, so that is correct — but an audit reader must not
+# assume file order is time order.
 #
 # Every boundary is covered:
 #   crash before the append      -> record present, line owed  -> replayed
@@ -553,6 +568,14 @@ def _write_dev_session_owner(root, session_id, ts):
 #                                   drops it instead of appending a duplicate
 #   marker removal fails         -> record present, no line owed -> the next
 #                                   session only retries the removal
+#
+# That tail scan is applied ONLY to lines read back off the record — the ones
+# that might have landed before a crash. A line minted in THIS process cannot
+# already be on the trail, and must never be dedupe-checked: close rows are
+# timestamped to the second, so two distinct closes minted in the same second
+# are byte-identical, and checking the fresh one against an owed copy of itself
+# would silently swallow a close that is genuinely owed.
+#
 # Everything here is best-effort by the module's standing convention: session
 # startup must never be bricked by audit bookkeeping, so nothing raises.
 _DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
@@ -568,11 +591,12 @@ def _overrides_log_path(root):
 
 
 def _read_dev_pending_close(root):
-    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
-    or None when there is nothing usable on disk. A record that exists but
-    carries no replayable line and no marker identity is reported as None so
-    the caller discards it — a corrupt record must never wedge the mechanism
-    shut. Never raises."""
+    """The pending-close record as
+    {"lines": [...], "marker_mtime": float|None, "dropped": int}, or None when
+    there is nothing usable on disk. A record that exists but carries no
+    replayable line, no marker identity and no unreported drop is reported as
+    None so the caller discards it — a corrupt record must never wedge the
+    mechanism shut. Never raises."""
     try:
         with open(_dev_pending_close_path(root), encoding="utf-8") as f:
             data = json.load(f)
@@ -582,9 +606,13 @@ def _read_dev_pending_close(root):
                  if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
         mtime = data.get("marker_mtime")
         mtime = float(mtime) if isinstance(mtime, (int, float)) else None
-        if not lines and mtime is None:
+        dropped = data.get("dropped")
+        # `isinstance(True, int)` is True, so booleans are excluded explicitly.
+        dropped = (int(dropped) if isinstance(dropped, int)
+                   and not isinstance(dropped, bool) and dropped > 0 else 0)
+        if not lines and mtime is None and not dropped:
             return None
-        return {"lines": lines, "marker_mtime": mtime}
+        return {"lines": lines, "marker_mtime": mtime, "dropped": dropped}
     except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
         return None
 
@@ -643,21 +671,37 @@ def _append_override_line(root, line):
         return False
 
 
-def _settle_dev_close(root, marker=None, new_line=None):
+def _dev_dropped_close_note(count, host_name=None):
+    """One audit line accounting for close rows the pending-close cap had to
+    discard. Deliberately NOT a `DEV: exit` row — it closes nothing; it records
+    that N closes can never be written, so a reader of the append-only trail
+    can attribute the unmatched entries instead of finding an unexplained gap.
+    """
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (f"[{ts}] | BY: session-cleanup | HOST: {host_name or 'unknown'} "
+            f"| DEV: close-dropped | NOTE: {count} owed close row(s) discarded - the "
+            f"pending-close cap ({_DEV_PENDING_CLOSE_MAX}) was reached while "
+            f"overrides.log was unwritable; that many maintainer sessions have "
+            f"no matching close row\n")
+
+
+def _settle_dev_close(root, marker=None, new_line=None, host_name=None):
     """Drive the pending-close record to settlement; the single place the owed
     DEV: exit is appended and the retry state is cleared.
 
     `marker` is the dev-active path when one is live (its mtime becomes the
     close identity), None when there is no marker to settle. `new_line` is a
     freshly minted close line to take on, or None when this is a pure replay of
-    whatever is already owed. Returns the number of close lines appended by
-    THIS call. Never raises."""
+    whatever is already owed. `host_name` only attributes the cap-overflow note
+    below; the close lines themselves already carry their own HOST field.
+    Returns the number of close lines appended by THIS call. Never raises."""
     if (marker is None and new_line is None
             and not os.path.isfile(_dev_pending_close_path(root))):
         return 0    # nothing owed, nothing to settle — the overwhelming case
     rec = _read_dev_pending_close(root)
     owed = list(rec["lines"]) if rec else []
     prev_mtime = rec["marker_mtime"] if rec else None
+    dropped = rec["dropped"] if rec else 0
 
     marker_mtime = None
     if marker:
@@ -665,6 +709,11 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_mtime = os.path.getmtime(marker)
         except OSError:
             marker_mtime = None
+
+    # Everything already in `owed` came off disk, so it MAY have reached the
+    # trail before a crash and has to be dedupe-checked. Anything appended
+    # below is minted in this process and cannot possibly be there yet.
+    replays = len(owed)
 
     if new_line is not None:
         # Already closed THIS marker (the append landed, only the removal
@@ -674,21 +723,44 @@ def _settle_dev_close(root, marker=None, new_line=None):
                           and prev_mtime == marker_mtime)
         if not already_closed:
             owed.append(new_line)
-    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+    if len(owed) > _DEV_PENDING_CLOSE_MAX:
+        # Bounded, but never SILENT. A permanently-unwritable overrides.log
+        # would otherwise accumulate owed lines forever, so the oldest are
+        # discarded — and counted, so the loss is itself auditable rather than
+        # reintroducing exactly the unmatched `DEV: enter` this record exists
+        # to prevent.
+        overflow = len(owed) - _DEV_PENDING_CLOSE_MAX
+        dropped += overflow
+        owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+        replays = max(0, replays - overflow)   # the discards come off the front
 
-    if owed or marker_mtime is not None:
+    if owed or dropped or marker_mtime is not None:
         # Write-ahead: the obligation is durable BEFORE the append is tried.
-        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+        _write_dev_pending_close(root, {"lines": owed,
+                                        "marker_mtime": marker_mtime,
+                                        "dropped": dropped})
+
+    # The overflow note goes in FIRST — the rows it accounts for are older than
+    # everything still owed. It is minted fresh each attempt, so it is not
+    # deduped by the tail scan; a crash between this append and the write-back
+    # below can repeat it once, which is the same "a duplicate beats a loss"
+    # trade the close rows themselves make.
+    if dropped and _append_override_line(root, _dev_dropped_close_note(dropped, host_name)):
+        dropped = 0
 
     appended = 0
-    remaining = list(owed)
-    for line in owed:
-        if _overrides_has_line(root, line):
-            remaining.remove(line)   # crash-after-append: already in the trail
-            continue
+    remaining = []
+    stalled = False
+    for idx, line in enumerate(owed):
+        if stalled:
+            remaining.append(line)   # the log is failing — everything after
+            continue                 # the first failure is still owed
+        if idx < replays and _overrides_has_line(root, line):
+            continue                 # crash-after-append: already in the trail
         if not _append_override_line(root, line):
-            break                    # still owed — replay on the next session
-        remaining.remove(line)
+            stalled = True
+            remaining.append(line)   # still owed — replay on the next session
+            continue
         appended += 1
 
     marker_gone = True
@@ -699,11 +771,16 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_gone = not os.path.isfile(marker)
 
     # Keep the record ONLY while it still carries information: a line still
-    # owed, or the identity of a marker that survived its own removal (the
-    # tombstone that stops the next session minting a second close for it).
-    if remaining or (not marker_gone and marker_mtime is not None):
+    # owed, an unreported cap overflow, or the identity of a marker that
+    # survived its own removal (the tombstone that stops the next session
+    # minting a second close for it). A marker that IS gone takes its tombstone
+    # with it — a dead marker's mtime identifies nothing, and leaving it behind
+    # lets an unrelated future marker collide with it and lose a real close.
+    if remaining or dropped or (not marker_gone and marker_mtime is not None):
         _write_dev_pending_close(root, {"lines": remaining,
-                                        "marker_mtime": marker_mtime})
+                                        "marker_mtime": (None if marker_gone
+                                                         else marker_mtime),
+                                        "dropped": dropped})
     else:
         _discard_dev_pending_close(root)
     return appended
@@ -754,7 +831,12 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
         # do — there is no marker to clear, but a close owed by an EARLIER
         # session whose append failed is still replayed here (#396); that is
         # precisely the case the old code could never recover from.
-        _settle_dev_close(root)
+        #
+        # `host_name` is passed through as-is (it only attributes the
+        # cap-overflow note) rather than resolved here: main() already hands
+        # the real host name down, and this branch is the overwhelmingly
+        # common one — it must not pay for a host resolution on every startup.
+        _settle_dev_close(root, host_name=host_name)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -809,7 +891,7 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     # #396: stage-then-append-then-clear, all inside one settlement step. The
     # append is no longer a fire-and-forget `except OSError: pass` followed by
     # an unconditional marker delete — the owed line outlives a failed write.
-    _settle_dev_close(root, marker=marker, new_line=line)
+    _settle_dev_close(root, marker=marker, new_line=line, host_name=host_name)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca-pi/hooks/session-start.py
+++ b/plugins/ca-pi/hooks/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/hooks/_provenancelib.py
+++ b/plugins/ca/hooks/_provenancelib.py
@@ -682,6 +682,16 @@ def load_provenance_dir(provenance_dir, skipped=None):
     warning can name the corrupt record. Names only — never file contents, which
     may hold paths or claims that do not belong in a log line.
 
+    NO PRODUCTION CALLER PASSES `skipped` TODAY, and that is deliberate rather
+    than an oversight. The two real call sites cannot carry the diagnostic:
+    startup_drift_line is bound by AC-08 ("degrade to silence" — an all-corrupt
+    provenance dir MUST return '', pinned by test_degrade_corrupt_json), and
+    build_index runs on every PreToolUse:Read, where a per-call warning would be
+    noise on the hottest path in the hook layer. Surfacing corruption to a user
+    therefore belongs to /ca:context-check or /ca:doctor, which are surface
+    prose and out of this module's reach. The channel exists, is bounded, and is
+    tested; anything reading it is a follow-up.
+
     Never raises — filesystem errors and malformed records are skipped (this
     runs on the SessionStart linchpin path).
     """

--- a/plugins/ca/hooks/_provenancelib.py
+++ b/plugins/ca/hooks/_provenancelib.py
@@ -49,7 +49,11 @@
 #   new_record(doc, *, interview_derived=False, entries=None, created=None)
 #                                        -> dict   canonical record with schema=1
 #   write_provenance(path, record)       -> None   pretty JSON; creates parent dirs
+#   valid_provenance_record(record)      -> bool   True iff a well-formed v1
+#                                                  record (top-level shape)
 #   read_provenance(path)                -> dict | None  None on missing/corrupt
+#                                                  — including valid JSON whose
+#                                                  shape is not a v1 record
 #   batch_hash(paths, runner)            -> dict[str, str]  one git hash-object --stdin-paths
 #                                                            call; input-order-preserving; {}
 #                                                            on empty paths or runner failure
@@ -63,7 +67,12 @@
 #                                                  (source renamed/deleted — AC-05/T-06).
 #                                                  Both kinds filtered to drift_trigger:true only
 #                                                  (AC-09/T-05). Docs with no drift omitted (→ {}).
-#   load_provenance_dir(provenance_dir)  -> dict   {doc: record}; {} on missing/corrupt dir
+#   load_provenance_dir(provenance_dir, skipped=None)
+#                                        -> dict   {doc: record}; {} on missing/corrupt dir.
+#                                                  Per-FILE error boundary: one bad record
+#                                                  never suppresses a later valid one.
+#                                                  `skipped` (optional list) collects up to
+#                                                  MAX_SKIPPED_REPORTED rejected basenames.
 #   startup_drift_line(root, runner=None)
 #                                        -> str    "" when clean (AC-06);
 #                                                  "context drift: N stale source(s) across M doc(s) -- run /ca:context-check"
@@ -227,18 +236,65 @@ def write_provenance(path, record):
     _hooklib.write_text_atomic(path, text, newline="\n")
 
 
+# Top-level provenance-record contract (v1). Each required key maps to the
+# type(s) a canonical record — the one new_record() builds — always carries.
+# `bool` is excluded from the `schema` check explicitly because in Python
+# `True == 1`, and a record whose schema is literally `true` is corrupt, not v1.
+_RECORD_FIELD_TYPES = (
+    ("doc", str),
+    ("created", str),
+    ("interview_derived", bool),
+    ("entries", list),
+)
+
+
+def valid_provenance_record(record):
+    """True iff `record` is a well-formed v1 provenance record (#410).
+
+    Checks the TOP-LEVEL shape only: the store's own frame. Entry-level
+    tolerance stays where it already lives — compute_drift and the read-inject
+    pointer both skip a malformed entry without dropping its record — so one
+    odd claim never costs a doc its entire provenance.
+
+    A schema other than SCHEMA_VERSION is rejected rather than best-effort
+    parsed: every field expectation below is v1-specific, so admitting an
+    unknown version would mean reading it with the wrong rules. Bumping
+    SCHEMA_VERSION therefore requires revisiting this function deliberately.
+    Never raises.
+    """
+    if not isinstance(record, dict):
+        return False
+    schema = record.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        return False
+    if schema != SCHEMA_VERSION:
+        return False
+    for key, want in _RECORD_FIELD_TYPES:
+        if key not in record or not isinstance(record[key], want):
+            return False
+    return True
+
+
 def read_provenance(path):
     """Read provenance JSON from `path`; return the dict, or None if missing/corrupt.
 
     Never raises — mirrors read_board() in _taskboardlib.py. A missing file,
     a permission error, or malformed JSON all return None; the caller degrades
     gracefully.
+
+    #410: "corrupt" now includes SYNTACTICALLY VALID JSON of the wrong shape.
+    The documented return type is `dict | None`, but the raw json.load result
+    was handed straight back — so a file containing `[]` was admitted to the
+    store as a list and the first `.get()` downstream raised AttributeError.
+    Honouring the documented type here is what lets every caller treat a
+    non-None result as a usable record.
     """
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            record = json.load(f)
     except (OSError, ValueError):
         return None
+    return record if valid_provenance_record(record) else None
 
 
 # ---------------------------------------------------------------------------
@@ -602,31 +658,60 @@ def heal_worklist(staged_paths, provenance, current_hashes):
 # ---------------------------------------------------------------------------
 
 
-def load_provenance_dir(provenance_dir):
+MAX_SKIPPED_REPORTED = 5   # bounded corruption diagnostic (#410)
+
+
+def load_provenance_dir(provenance_dir, skipped=None):
     """Load all provenance records from provenance_dir into {doc: record}.
 
     Globs <provenance_dir>/*.json, calls read_provenance on each file, and
-    skips any that return None (missing, unreadable, or corrupt JSON). Each
-    surviving record is keyed by its 'doc' field; if 'doc' is absent or
-    empty, falls back to the filename stem so the dict never loses an entry.
-    A missing or non-directory provenance_dir returns {}.
+    skips any that return None (missing, unreadable, or corrupt JSON — which
+    since #410 includes valid JSON of the wrong shape). Each surviving record
+    is keyed by its 'doc' field; if 'doc' is absent or empty, falls back to the
+    filename stem so the dict never loses an entry. A missing or non-directory
+    provenance_dir returns {}.
 
-    Never raises — filesystem errors and malformed records are silently skipped
-    (this runs on the SessionStart linchpin path).
+    #410: the per-file work sits inside its OWN error boundary. The whole glob
+    loop used to share one try/except, so the first record that raised aborted
+    the scan and every LATER valid record vanished with no diagnostic —
+    SessionStart drift reporting and commit-gate auto-heal then ran against a
+    silently truncated map. One bad file now costs exactly itself.
+
+    `skipped`, when a list is passed, collects the BASENAMES of rejected files
+    (at most MAX_SKIPPED_REPORTED) so a caller that has somewhere to put a
+    warning can name the corrupt record. Names only — never file contents, which
+    may hold paths or claims that do not belong in a log line.
+
+    Never raises — filesystem errors and malformed records are skipped (this
+    runs on the SessionStart linchpin path).
     """
     result = {}
+
+    def note(fpath):
+        if skipped is None or len(skipped) >= MAX_SKIPPED_REPORTED:
+            return
+        try:
+            skipped.append(os.path.basename(fpath))
+        except Exception:  # noqa: BLE001 — a diagnostic must never break the load
+            pass
+
     try:
         if not os.path.isdir(provenance_dir):
             return {}
-        pattern = os.path.join(provenance_dir, "*.json")
-        for fpath in glob.glob(pattern):
+        paths = glob.glob(os.path.join(provenance_dir, "*.json"))
+    except Exception:  # noqa: BLE001 — an unreadable dir is an empty map
+        return {}
+
+    for fpath in paths:
+        try:
             record = read_provenance(fpath)
             if record is None:
+                note(fpath)
                 continue
             doc = record.get("doc") or os.path.splitext(os.path.basename(fpath))[0]
             result[str(doc)] = record
-    except Exception:
-        pass
+        except Exception:  # noqa: BLE001 — per-file boundary: skip THIS file only
+            note(fpath)
     return result
 
 

--- a/plugins/ca/hooks/_subagentslib.py
+++ b/plugins/ca/hooks/_subagentslib.py
@@ -91,7 +91,15 @@ def subagent_dir(data, root, sid):
 def read_subagents(sdir):
     """Return (active, recent, shown[{label,inp,out,age,active}], (tot_in, tot_out)).
     `active` = files touched within ACTIVE_WINDOW (a liveness proxy); `recent` =
-    all files within SHOW_WINDOW (active + recently finished)."""
+    all files within SHOW_WINDOW (active + recently finished).
+
+    ONE result shape on EVERY path (#413). The element types are stable — int,
+    int, list, (int|float, int|float) — so a caller may unpack four names
+    unconditionally. statusline.py does exactly that, OUTSIDE its safe()
+    wrapper, so an error branch returning a shorter tuple was a hard ValueError
+    that erased the entire subagent section on a routine directory race. An
+    unreadable/absent directory is an EMPTY result, not a different result."""
+    empty = (0, 0, [], (0, 0))
     now = time.time()
     files = []
     try:
@@ -106,7 +114,7 @@ def read_subagents(sdir):
             if now - st.st_mtime <= SHOW_WINDOW:
                 files.append((st.st_mtime, st.st_size, fp, nm))
     except OSError:
-        return 0, [], (0, 0)
+        return empty
     files.sort(reverse=True)   # most-recently-touched first
 
     active = sum(1 for mtime, _, _, _ in files if now - mtime <= ACTIVE_WINDOW)
@@ -129,6 +137,13 @@ def read_subagents(sdir):
                         d = json.loads(ln)
                     except ValueError:
                         continue
+                    if not isinstance(d, dict):
+                        # A transcript line may be ANY valid JSON value; only an
+                        # object carries an event. `[]`/`null`/`3`/`"s"` used to
+                        # reach .get() below inside a try that caught OSError
+                        # only, so one such line raised AttributeError out of
+                        # read_subagents and blanked every subagent row (#413).
+                        continue
                     msg = d.get("message")
                     if not isinstance(msg, dict):
                         continue
@@ -147,7 +162,13 @@ def read_subagents(sdir):
                         reqs[d.get("requestId") or msg.get("id") or i] = (
                             num(u.get("input_tokens")) + num(u.get("cache_creation_input_tokens")),
                             num(u.get("output_tokens")))
-        except OSError:
+        except Exception:  # noqa: BLE001 — #413: the error boundary is PER FILE
+            # One unreadable or structurally surprising transcript must cost
+            # only its own row, never the rest of the directory. Widened from
+            # OSError so a shape the reader has not anticipated degrades the
+            # same way malformed JSON already does (the module's standing
+            # "never raise on malformed input" contract) instead of escaping
+            # into the statusline and blanking every subagent row.
             continue
         inp = sum(v[0] for v in reqs.values())
         out = sum(v[1] for v in reqs.values())

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -535,7 +535,7 @@ def _write_dev_session_owner(root, session_id, ts):
 # The fix is a small write-ahead record: the owed line is staged on disk BEFORE
 # the append is attempted, and the record is deleted only once BOTH the append
 # is confirmed AND the marker it settles is gone. That single record therefore
-# carries two facts at once:
+# carries three facts at once:
 #
 #   "lines"        — close lines still owed to overrides.log. Emptied one at a
 #                    time as each append is confirmed.
@@ -544,7 +544,22 @@ def _write_dev_session_owner(root, session_id, ts):
 #                    force-close path knows that marker has already been
 #                    closed in the audit trail and refuses to mint a second
 #                    row for it — which is what makes a failed `os.remove`
-#                    idempotent rather than duplicating the close.
+#                    idempotent rather than duplicating the close. It is
+#                    cleared the moment that marker is gone: an mtime only
+#                    identifies a file that still EXISTS, and a stale one is
+#                    free to collide with an unrelated future marker (2s
+#                    granularity on FAT32/exFAT/SMB/WSL mounts makes that a
+#                    real event, not a theoretical one) and suppress a close
+#                    that is genuinely owed.
+#   "dropped"      — how many owed close lines the bound below has discarded.
+#                    The cap keeps the record small, but the loss must not be
+#                    silent: the count is written to the trail as one
+#                    attributable note the moment overrides.log accepts writes.
+#
+# Replayed lines carry the timestamp they were MINTED with, not the time they
+# land, so a delayed replay leaves overrides.log non-chronological. Enter/exit
+# pairing is by timestamp, so that is correct — but an audit reader must not
+# assume file order is time order.
 #
 # Every boundary is covered:
 #   crash before the append      -> record present, line owed  -> replayed
@@ -553,6 +568,14 @@ def _write_dev_session_owner(root, session_id, ts):
 #                                   drops it instead of appending a duplicate
 #   marker removal fails         -> record present, no line owed -> the next
 #                                   session only retries the removal
+#
+# That tail scan is applied ONLY to lines read back off the record — the ones
+# that might have landed before a crash. A line minted in THIS process cannot
+# already be on the trail, and must never be dedupe-checked: close rows are
+# timestamped to the second, so two distinct closes minted in the same second
+# are byte-identical, and checking the fresh one against an owed copy of itself
+# would silently swallow a close that is genuinely owed.
+#
 # Everything here is best-effort by the module's standing convention: session
 # startup must never be bricked by audit bookkeeping, so nothing raises.
 _DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
@@ -568,11 +591,12 @@ def _overrides_log_path(root):
 
 
 def _read_dev_pending_close(root):
-    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
-    or None when there is nothing usable on disk. A record that exists but
-    carries no replayable line and no marker identity is reported as None so
-    the caller discards it — a corrupt record must never wedge the mechanism
-    shut. Never raises."""
+    """The pending-close record as
+    {"lines": [...], "marker_mtime": float|None, "dropped": int}, or None when
+    there is nothing usable on disk. A record that exists but carries no
+    replayable line, no marker identity and no unreported drop is reported as
+    None so the caller discards it — a corrupt record must never wedge the
+    mechanism shut. Never raises."""
     try:
         with open(_dev_pending_close_path(root), encoding="utf-8") as f:
             data = json.load(f)
@@ -582,9 +606,13 @@ def _read_dev_pending_close(root):
                  if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
         mtime = data.get("marker_mtime")
         mtime = float(mtime) if isinstance(mtime, (int, float)) else None
-        if not lines and mtime is None:
+        dropped = data.get("dropped")
+        # `isinstance(True, int)` is True, so booleans are excluded explicitly.
+        dropped = (int(dropped) if isinstance(dropped, int)
+                   and not isinstance(dropped, bool) and dropped > 0 else 0)
+        if not lines and mtime is None and not dropped:
             return None
-        return {"lines": lines, "marker_mtime": mtime}
+        return {"lines": lines, "marker_mtime": mtime, "dropped": dropped}
     except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
         return None
 
@@ -643,21 +671,37 @@ def _append_override_line(root, line):
         return False
 
 
-def _settle_dev_close(root, marker=None, new_line=None):
+def _dev_dropped_close_note(count, host_name=None):
+    """One audit line accounting for close rows the pending-close cap had to
+    discard. Deliberately NOT a `DEV: exit` row — it closes nothing; it records
+    that N closes can never be written, so a reader of the append-only trail
+    can attribute the unmatched entries instead of finding an unexplained gap.
+    """
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (f"[{ts}] | BY: session-cleanup | HOST: {host_name or 'unknown'} "
+            f"| DEV: close-dropped | NOTE: {count} owed close row(s) discarded - the "
+            f"pending-close cap ({_DEV_PENDING_CLOSE_MAX}) was reached while "
+            f"overrides.log was unwritable; that many maintainer sessions have "
+            f"no matching close row\n")
+
+
+def _settle_dev_close(root, marker=None, new_line=None, host_name=None):
     """Drive the pending-close record to settlement; the single place the owed
     DEV: exit is appended and the retry state is cleared.
 
     `marker` is the dev-active path when one is live (its mtime becomes the
     close identity), None when there is no marker to settle. `new_line` is a
     freshly minted close line to take on, or None when this is a pure replay of
-    whatever is already owed. Returns the number of close lines appended by
-    THIS call. Never raises."""
+    whatever is already owed. `host_name` only attributes the cap-overflow note
+    below; the close lines themselves already carry their own HOST field.
+    Returns the number of close lines appended by THIS call. Never raises."""
     if (marker is None and new_line is None
             and not os.path.isfile(_dev_pending_close_path(root))):
         return 0    # nothing owed, nothing to settle — the overwhelming case
     rec = _read_dev_pending_close(root)
     owed = list(rec["lines"]) if rec else []
     prev_mtime = rec["marker_mtime"] if rec else None
+    dropped = rec["dropped"] if rec else 0
 
     marker_mtime = None
     if marker:
@@ -665,6 +709,11 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_mtime = os.path.getmtime(marker)
         except OSError:
             marker_mtime = None
+
+    # Everything already in `owed` came off disk, so it MAY have reached the
+    # trail before a crash and has to be dedupe-checked. Anything appended
+    # below is minted in this process and cannot possibly be there yet.
+    replays = len(owed)
 
     if new_line is not None:
         # Already closed THIS marker (the append landed, only the removal
@@ -674,21 +723,44 @@ def _settle_dev_close(root, marker=None, new_line=None):
                           and prev_mtime == marker_mtime)
         if not already_closed:
             owed.append(new_line)
-    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+    if len(owed) > _DEV_PENDING_CLOSE_MAX:
+        # Bounded, but never SILENT. A permanently-unwritable overrides.log
+        # would otherwise accumulate owed lines forever, so the oldest are
+        # discarded — and counted, so the loss is itself auditable rather than
+        # reintroducing exactly the unmatched `DEV: enter` this record exists
+        # to prevent.
+        overflow = len(owed) - _DEV_PENDING_CLOSE_MAX
+        dropped += overflow
+        owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+        replays = max(0, replays - overflow)   # the discards come off the front
 
-    if owed or marker_mtime is not None:
+    if owed or dropped or marker_mtime is not None:
         # Write-ahead: the obligation is durable BEFORE the append is tried.
-        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+        _write_dev_pending_close(root, {"lines": owed,
+                                        "marker_mtime": marker_mtime,
+                                        "dropped": dropped})
+
+    # The overflow note goes in FIRST — the rows it accounts for are older than
+    # everything still owed. It is minted fresh each attempt, so it is not
+    # deduped by the tail scan; a crash between this append and the write-back
+    # below can repeat it once, which is the same "a duplicate beats a loss"
+    # trade the close rows themselves make.
+    if dropped and _append_override_line(root, _dev_dropped_close_note(dropped, host_name)):
+        dropped = 0
 
     appended = 0
-    remaining = list(owed)
-    for line in owed:
-        if _overrides_has_line(root, line):
-            remaining.remove(line)   # crash-after-append: already in the trail
-            continue
+    remaining = []
+    stalled = False
+    for idx, line in enumerate(owed):
+        if stalled:
+            remaining.append(line)   # the log is failing — everything after
+            continue                 # the first failure is still owed
+        if idx < replays and _overrides_has_line(root, line):
+            continue                 # crash-after-append: already in the trail
         if not _append_override_line(root, line):
-            break                    # still owed — replay on the next session
-        remaining.remove(line)
+            stalled = True
+            remaining.append(line)   # still owed — replay on the next session
+            continue
         appended += 1
 
     marker_gone = True
@@ -699,11 +771,16 @@ def _settle_dev_close(root, marker=None, new_line=None):
             marker_gone = not os.path.isfile(marker)
 
     # Keep the record ONLY while it still carries information: a line still
-    # owed, or the identity of a marker that survived its own removal (the
-    # tombstone that stops the next session minting a second close for it).
-    if remaining or (not marker_gone and marker_mtime is not None):
+    # owed, an unreported cap overflow, or the identity of a marker that
+    # survived its own removal (the tombstone that stops the next session
+    # minting a second close for it). A marker that IS gone takes its tombstone
+    # with it — a dead marker's mtime identifies nothing, and leaving it behind
+    # lets an unrelated future marker collide with it and lose a real close.
+    if remaining or dropped or (not marker_gone and marker_mtime is not None):
         _write_dev_pending_close(root, {"lines": remaining,
-                                        "marker_mtime": marker_mtime})
+                                        "marker_mtime": (None if marker_gone
+                                                         else marker_mtime),
+                                        "dropped": dropped})
     else:
         _discard_dev_pending_close(root)
     return appended
@@ -754,7 +831,12 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
         # do — there is no marker to clear, but a close owed by an EARLIER
         # session whose append failed is still replayed here (#396); that is
         # precisely the case the old code could never recover from.
-        _settle_dev_close(root)
+        #
+        # `host_name` is passed through as-is (it only attributes the
+        # cap-overflow note) rather than resolved here: main() already hands
+        # the real host name down, and this branch is the overwhelmingly
+        # common one — it must not pay for a host resolution on every startup.
+        _settle_dev_close(root, host_name=host_name)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -809,7 +891,7 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     # #396: stage-then-append-then-clear, all inside one settlement step. The
     # append is no longer a fire-and-forget `except OSError: pass` followed by
     # an unconditional marker delete — the owed line outlives a failed write.
-    _settle_dev_close(root, marker=marker, new_line=line)
+    _settle_dev_close(root, marker=marker, new_line=line, host_name=host_name)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -524,6 +524,191 @@ def _write_dev_session_owner(root, session_id, ts):
         pass
 
 
+# --- #396: a durable, retryable DEV: exit -----------------------------------
+# The synthetic close line is the ONLY thing that keeps the append-only audit
+# trail's DEV: enter/exit pairs matched after an abandoned maintainer session.
+# It used to be written best-effort ("except OSError: pass") and the marker was
+# then removed regardless — so a locked file, a full disk, or a permission blip
+# permanently erased the obligation and left an orphaned DEV: enter that no
+# later session could know about.
+#
+# The fix is a small write-ahead record: the owed line is staged on disk BEFORE
+# the append is attempted, and the record is deleted only once BOTH the append
+# is confirmed AND the marker it settles is gone. That single record therefore
+# carries two facts at once:
+#
+#   "lines"        — close lines still owed to overrides.log. Emptied one at a
+#                    time as each append is confirmed.
+#   "marker_mtime" — the identity of the dev-active marker this close belongs
+#                    to. While the record still names a LIVE marker, the
+#                    force-close path knows that marker has already been
+#                    closed in the audit trail and refuses to mint a second
+#                    row for it — which is what makes a failed `os.remove`
+#                    idempotent rather than duplicating the close.
+#
+# Every boundary is covered:
+#   crash before the append      -> record present, line owed  -> replayed
+#   crash after the append       -> record present, line owed  -> the bounded
+#                                   tail scan sees the line already landed and
+#                                   drops it instead of appending a duplicate
+#   marker removal fails         -> record present, no line owed -> the next
+#                                   session only retries the removal
+# Everything here is best-effort by the module's standing convention: session
+# startup must never be bricked by audit bookkeeping, so nothing raises.
+_DEV_PENDING_CLOSE_MAX = 8        # bounded: never accumulate owed lines forever
+_DEV_PENDING_SCAN_BYTES = 64 * 1024   # bounded tail scan for the dedupe check
+
+
+def _dev_pending_close_path(root):
+    return os.path.join(root, ".codearbiter", ".markers", "dev-close-pending.json")
+
+
+def _overrides_log_path(root):
+    return os.path.join(root, ".codearbiter", "overrides.log")
+
+
+def _read_dev_pending_close(root):
+    """The pending-close record as {"lines": [...], "marker_mtime": float|None},
+    or None when there is nothing usable on disk. A record that exists but
+    carries no replayable line and no marker identity is reported as None so
+    the caller discards it — a corrupt record must never wedge the mechanism
+    shut. Never raises."""
+    try:
+        with open(_dev_pending_close_path(root), encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        lines = [ln for ln in (data.get("lines") or [])
+                 if isinstance(ln, str) and ln.strip()][:_DEV_PENDING_CLOSE_MAX]
+        mtime = data.get("marker_mtime")
+        mtime = float(mtime) if isinstance(mtime, (int, float)) else None
+        if not lines and mtime is None:
+            return None
+        return {"lines": lines, "marker_mtime": mtime}
+    except Exception:  # noqa: BLE001 — absent/corrupt record -> no signal
+        return None
+
+
+def _write_dev_pending_close(root, rec):
+    """Atomically persist the pending-close record. Never raises — a write
+    failure only costs the retry signal this call was trying to create, which
+    is exactly the pre-#396 behavior and still must not brick startup."""
+    try:
+        path = _dev_pending_close_path(root)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, json.dumps(rec), newline="\n")
+    except Exception:  # noqa: BLE001 — must never brick session startup
+        pass
+
+
+def _discard_dev_pending_close(root):
+    try:
+        os.remove(_dev_pending_close_path(root))
+    except OSError:
+        pass
+
+
+def _overrides_has_line(root, line):
+    """True iff `line` already appears in the tail of overrides.log. Bounded to
+    the last _DEV_PENDING_SCAN_BYTES — a replay always happens on the very next
+    SessionStart, so the line it is looking for is at (or near) the end. An
+    unreadable log answers False: re-appending a close row is a far smaller
+    harm than silently dropping one.
+
+    Read in BINARY and decoded here on purpose: a byte offset is only
+    meaningful to seek() on a binary stream, and the comparison is made on the
+    stripped line so the platform EOL the append produced never matters."""
+    needle = line.strip()
+    if not needle:
+        return False
+    try:
+        path = _overrides_log_path(root)
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > _DEV_PENDING_SCAN_BYTES:
+                f.seek(size - _DEV_PENDING_SCAN_BYTES)
+            tail = f.read().decode("utf-8", "replace")
+        return needle in tail
+    except Exception:  # noqa: BLE001 — cannot confirm -> assume not present
+        return False
+
+
+def _append_override_line(root, line):
+    """Append one audit line to overrides.log. True on a confirmed write."""
+    try:
+        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _settle_dev_close(root, marker=None, new_line=None):
+    """Drive the pending-close record to settlement; the single place the owed
+    DEV: exit is appended and the retry state is cleared.
+
+    `marker` is the dev-active path when one is live (its mtime becomes the
+    close identity), None when there is no marker to settle. `new_line` is a
+    freshly minted close line to take on, or None when this is a pure replay of
+    whatever is already owed. Returns the number of close lines appended by
+    THIS call. Never raises."""
+    if (marker is None and new_line is None
+            and not os.path.isfile(_dev_pending_close_path(root))):
+        return 0    # nothing owed, nothing to settle — the overwhelming case
+    rec = _read_dev_pending_close(root)
+    owed = list(rec["lines"]) if rec else []
+    prev_mtime = rec["marker_mtime"] if rec else None
+
+    marker_mtime = None
+    if marker:
+        try:
+            marker_mtime = os.path.getmtime(marker)
+        except OSError:
+            marker_mtime = None
+
+    if new_line is not None:
+        # Already closed THIS marker (the append landed, only the removal
+        # failed) -> do not mint a second row for it; just retry the cleanup.
+        already_closed = (rec is not None and prev_mtime is not None
+                          and marker_mtime is not None
+                          and prev_mtime == marker_mtime)
+        if not already_closed:
+            owed.append(new_line)
+    owed = owed[-_DEV_PENDING_CLOSE_MAX:]
+
+    if owed or marker_mtime is not None:
+        # Write-ahead: the obligation is durable BEFORE the append is tried.
+        _write_dev_pending_close(root, {"lines": owed, "marker_mtime": marker_mtime})
+
+    appended = 0
+    remaining = list(owed)
+    for line in owed:
+        if _overrides_has_line(root, line):
+            remaining.remove(line)   # crash-after-append: already in the trail
+            continue
+        if not _append_override_line(root, line):
+            break                    # still owed — replay on the next session
+        remaining.remove(line)
+        appended += 1
+
+    marker_gone = True
+    if marker:
+        try:
+            os.remove(marker)
+        except OSError:
+            marker_gone = not os.path.isfile(marker)
+
+    # Keep the record ONLY while it still carries information: a line still
+    # owed, or the identity of a marker that survived its own removal (the
+    # tombstone that stops the next session minting a second close for it).
+    if remaining or (not marker_gone and marker_mtime is not None):
+        _write_dev_pending_close(root, {"lines": remaining,
+                                        "marker_mtime": marker_mtime})
+    else:
+        _discard_dev_pending_close(root)
+    return appended
+
+
 def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     """Clear the per-session /dev statusline marker on startup. If the marker is
     LIVE (a prior session entered /ca:dev and ended without /ca:arbiter), append a
@@ -531,6 +716,13 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     (observability-001) — otherwise the audit trail keeps an orphaned DEV: enter
     with no matching close. Append-only (it never rewrites); best-effort — a write
     or remove failure must never brick session startup.
+
+    #396: "best-effort" is no longer "best-effort ONCE". The close is routed
+    through _settle_dev_close, which stages the owed line durably before
+    attempting the append and clears that retry state only after the append is
+    confirmed — so a locked/failing overrides.log leaves a replayable record
+    instead of an orphaned DEV: enter. Startup itself still fails OPEN: this
+    function returns normally on every path, exactly as before.
 
     `host_name` (observability-001/ADR-0012) is the resolved host's `.name`
     ("claude"/"codex"/"unknown"), so the synthetic close line is attributable to
@@ -559,7 +751,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     if not marker_live:
         # No live marker: this record is purely "who could next enter /dev" —
         # any session refreshing it is harmless and correct. Nothing else to
-        # do — there is no marker to clear and no close to log.
+        # do — there is no marker to clear, but a close owed by an EARLIER
+        # session whose append failed is still replayed here (#396); that is
+        # precisely the case the old code could never recover from.
+        _settle_dev_close(root)
         if session_id:
             _write_dev_session_owner(root, session_id, now)
         return
@@ -569,6 +764,14 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
             # The owner itself, resuming/compacting mid-dev — refresh ITS OWN
             # heartbeat (this is the only case where a write is safe while the
             # marker is live) and leave the marker untouched.
+            #
+            # #396: deliberately NO _settle_dev_close here or in the sibling
+            # branch below. Both return with the marker still LIVE, and a
+            # pending record naming a live marker doubles as the "this marker
+            # has already been closed in the trail" tombstone — settling it
+            # against a marker we are not allowed to touch would discard that
+            # tombstone and let a later force-close mint a duplicate row. Any
+            # owed line simply waits for a session that is entitled to act.
             _write_dev_session_owner(root, session_id, now)
             return
         if (now - prev_ts) < DEV_SESSION_LIVENESS_WINDOW:
@@ -603,16 +806,10 @@ def clear_dev_marker(root, host_name=None, session_id=None, now=None):
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = (f"[{ts}] | BY: session-cleanup | HOST: {host_name} | DEV: exit | NOTE: cleared by "
             f"SessionStart (prior session ended mid-dev without {arbiter_ref})\n")
-    try:
-        with open(os.path.join(root, ".codearbiter", "overrides.log"),
-                  "a", encoding="utf-8") as f:
-            f.write(line)
-    except OSError:
-        pass
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
+    # #396: stage-then-append-then-clear, all inside one settlement step. The
+    # append is no longer a fire-and-forget `except OSError: pass` followed by
+    # an unconditional marker delete — the owed line outlives a failed write.
+    _settle_dev_close(root, marker=marker, new_line=line)
 
 
 def provenance_drift_line(root, runner=None):

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -705,6 +705,98 @@ class TestDevExitRetryablePendingClose(unittest.TestCase):
         _mod.clear_dev_marker(self.root)
         self.assertEqual(len(self._exit_lines()), 1)
 
+    def test_a_removed_marker_leaves_no_tombstone_in_the_pending_record(self):
+        # The marker_mtime field is a TOMBSTONE — "this marker has already been
+        # closed in the trail". It is only meaningful while that marker still
+        # EXISTS. When the append fails but the removal succeeds, the record
+        # must keep the owed line and forget the marker: naming a marker that
+        # is gone lets its mtime collide with an unrelated future marker.
+        self._drop_marker()
+        with self._append_fails():
+            _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.marker), "the marker really was removed")
+        with open(self.pending, encoding="utf-8") as f:
+            rec = json.load(f)
+        self.assertTrue(rec.get("lines"), "the owed close must still be staged")
+        self.assertIsNone(rec.get("marker_mtime"),
+                          "a record whose marker is gone must not keep its identity")
+
+    def test_a_stale_tombstone_cannot_suppress_a_later_sessions_close(self):
+        # The consequence of leaking the tombstone: a LATER dev session whose
+        # marker happens to land on the same mtime (2s-granularity FAT32/exFAT/
+        # SMB/WSL mounts do this routinely) is mistaken for the already-closed
+        # one, and its close row is silently dropped — the exact unmatched
+        # `DEV: enter` #396 exists to prevent.
+        self._drop_marker()
+        first_mtime = os.path.getmtime(self.marker)
+        with self._append_fails():
+            _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.marker))
+
+        # A second, unrelated /ca:dev entry whose marker collides on mtime.
+        self._drop_marker()
+        os.utime(self.marker, (first_mtime, first_mtime))
+        _mod.clear_dev_marker(self.root)
+
+        self.assertEqual(len(self._exit_lines()), 2,
+                         "two dev sessions owe two close rows, not one")
+        self.assertFalse(os.path.isfile(self.pending))
+
+    def test_a_freshly_minted_close_is_never_deduped_against_the_trail(self):
+        # The dedupe tail scan compares WHOLE LINES, and a close row is
+        # timestamped only to the second — so two genuinely distinct closes
+        # minted in the same second are byte-identical. The scan exists to stop
+        # a crash-after-append REPLAY from landing twice; it must never be
+        # applied to the freshly minted line, which by construction cannot
+        # already be on the trail. Otherwise the second session's close is
+        # swallowed by the first session's owed copy of it.
+        same_second = ("[2026-01-01T00:00:07Z] | BY: session-cleanup | HOST: claude "
+                       "| DEV: exit | NOTE: cleared by SessionStart\n")
+        self._drop_marker()
+        with self._append_fails():
+            _mod._settle_dev_close(self.root, marker=self.marker, new_line=same_second)
+        self.assertEqual(self._exit_lines(), [], "the first append really did fail")
+
+        self._drop_marker()
+        _mod._settle_dev_close(self.root, marker=self.marker, new_line=same_second)
+        self.assertEqual(len(self._exit_lines()), 2,
+                         "two owed closes must both land even when the second "
+                         "granularity makes their lines identical")
+        self.assertFalse(os.path.isfile(self.pending))
+
+    def test_the_pending_close_cap_never_discards_a_close_silently(self):
+        # The record is bounded to _DEV_PENDING_CLOSE_MAX, so a long-lived
+        # write failure DOES lose the oldest owed rows. That loss must not be
+        # silent: it is counted while the log is unwritable and written to the
+        # trail as one attributable note the moment the log accepts writes.
+        cap = _mod._DEV_PENDING_CLOSE_MAX
+        owed = [
+            f"[2026-01-01T00:00:{i:02d}Z] | BY: session-cleanup | HOST: claude "
+            f"| DEV: exit | NOTE: owed close {i}\n"
+            for i in range(cap + 4)
+        ]
+        with self._append_fails():
+            for line in owed:
+                _mod._settle_dev_close(self.root, new_line=line)
+
+        with open(self.pending, encoding="utf-8") as f:
+            rec = json.load(f)
+        self.assertEqual(len(rec.get("lines") or []), cap, "the record stays bounded")
+        self.assertEqual(rec.get("dropped"), 4,
+                         "every discarded close row must be counted, not forgotten")
+
+        # overrides.log becomes writable again: the owed rows AND the note land.
+        _mod._settle_dev_close(self.root)
+        self.assertEqual(len(self._exit_lines()), cap,
+                         "every retained owed close must land exactly once")
+        notes = [ln for ln in self._read_log().splitlines()
+                 if "DEV: close-dropped" in ln]
+        self.assertEqual(len(notes), 1,
+                         "the discarded closes must be reported once on the trail")
+        self.assertIn("4", notes[0], "the note must carry how many were discarded")
+        self.assertFalse(os.path.isfile(self.pending),
+                         "a fully settled record is cleared")
+
 
 class TestStandupBriefingGating(unittest.TestCase):
     """#61 regression: pin the once-per-LOCAL-day briefing contract so the

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -568,6 +568,144 @@ class TestDevExitAudit(unittest.TestCase):
         self.assertEqual(len(log.splitlines()), 2, "exactly one DEV: exit line appended")
 
 
+class TestDevExitRetryablePendingClose(unittest.TestCase):
+    """#396: a failed overrides.log append must not destroy the only signal that
+    a DEV: exit is still owed. `clear_dev_marker` stages a durable pending-close
+    record BEFORE attempting the append and clears it only once the append (and
+    the marker removal) are confirmed — so a locked/failing log leaves a
+    retryable record instead of an orphaned DEV: enter."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.ca = os.path.join(self.root, ".codearbiter")
+        self.markers = os.path.join(self.ca, ".markers")
+        os.makedirs(self.markers)
+        self.log = os.path.join(self.ca, "overrides.log")
+        self.marker = os.path.join(self.markers, "dev-active")
+        # The durable retry state lives beside the marker it settles.
+        self.pending = os.path.join(self.markers, "dev-close-pending.json")
+        self._seed_log("[2026-01-01T00:00:00Z] | BY: dev | DEV: enter | NOTE: —\n")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _seed_log(self, text):
+        with open(self.log, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def _read_log(self):
+        with open(self.log, encoding="utf-8") as f:
+            return f.read()
+
+    def _drop_marker(self):
+        with open(self.marker, "w", encoding="utf-8") as f:
+            f.write("active\n")
+
+    def _exit_lines(self):
+        return [ln for ln in self._read_log().splitlines() if "DEV: exit" in ln]
+
+    @contextlib.contextmanager
+    def _append_fails(self):
+        """Make ONLY the append-mode open of overrides.log raise OSError."""
+        real_open = open
+
+        def fake_open(file, mode="r", *a, **kw):
+            if "a" in mode and str(file).endswith("overrides.log"):
+                raise OSError("locked")
+            return real_open(file, mode, *a, **kw)
+
+        with mock.patch("builtins.open", fake_open):
+            yield
+
+    def test_append_failure_leaves_a_durable_retryable_close_record(self):
+        # AC-1: returns successfully, but the owed close survives on disk.
+        self._drop_marker()
+        with self._append_fails():
+            _mod.clear_dev_marker(self.root)
+        self.assertEqual(self._exit_lines(), [], "the append really did fail")
+        self.assertTrue(os.path.isfile(self.pending),
+                        "a failed append must leave a durable pending-close record")
+        with open(self.pending, encoding="utf-8") as f:
+            rec = json.load(f)
+        self.assertTrue(any("DEV: exit" in ln for ln in rec.get("lines", [])),
+                        "the pending record must carry the owed DEV: exit line")
+
+    def test_later_session_appends_the_missing_exit_exactly_once(self):
+        # AC-2: the next SessionStart flushes the owed close and clears the
+        # retry state — even though the marker is already gone by then.
+        self._drop_marker()
+        with self._append_fails():
+            _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.marker))
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1,
+                         "the owed DEV: exit must land exactly once on retry")
+        self.assertFalse(os.path.isfile(self.pending),
+                         "a confirmed append must clear the pending-close record")
+        # And a third session must not append it again.
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1, "no duplicate on a later session")
+
+    def test_crash_after_append_before_cleanup_does_not_duplicate(self):
+        # AC-3: an already-landed close line is recognised on retry (bounded
+        # tail scan), so a crash between the append and the record cleanup
+        # yields ONE close row, not two.
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        landed = self._exit_lines()
+        self.assertEqual(len(landed), 1)
+        # Simulate the crash: the record was never cleaned up.
+        with open(self.pending, "w", encoding="utf-8", newline="\n") as f:
+            json.dump({"lines": [landed[0] + "\n"], "marker_mtime": None}, f)
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1,
+                         "an already-appended close must not be appended twice")
+        self.assertFalse(os.path.isfile(self.pending),
+                         "the settled record must be cleared")
+
+    def test_marker_removal_failure_does_not_duplicate_the_close_row(self):
+        # AC-3/AC-4: the append lands, but the marker cleanup fails. The next
+        # SessionStart still sees a live marker and must NOT mint a second
+        # close row for the same marker.
+        self._drop_marker()
+        real_remove = os.remove
+
+        def fake_remove(path, *a, **kw):
+            if str(path).endswith("dev-active"):
+                raise OSError("locked")
+            return real_remove(path, *a, **kw)
+
+        with mock.patch("os.remove", fake_remove):
+            _mod.clear_dev_marker(self.root)
+        self.assertTrue(os.path.isfile(self.marker), "marker cleanup really did fail")
+        self.assertEqual(len(self._exit_lines()), 1)
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1,
+                         "the same marker must not be closed twice in the audit trail")
+        self.assertFalse(os.path.isfile(self.marker), "the retry removes the marker")
+        self.assertFalse(os.path.isfile(self.pending))
+
+    def test_clean_close_leaves_no_pending_record_behind(self):
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1)
+        self.assertFalse(os.path.isfile(self.marker))
+        self.assertFalse(os.path.isfile(self.pending),
+                         "the happy path must not leave retry state on disk")
+
+    def test_corrupt_pending_record_is_discarded_not_jammed(self):
+        # A record that carries no recoverable line must not wedge the
+        # mechanism shut (nothing to replay, so drop it and carry on).
+        with open(self.pending, "w", encoding="utf-8", newline="\n") as f:
+            f.write("{not json")
+        _mod.clear_dev_marker(self.root)
+        self.assertFalse(os.path.isfile(self.pending))
+        self._drop_marker()
+        _mod.clear_dev_marker(self.root)
+        self.assertEqual(len(self._exit_lines()), 1)
+
+
 class TestStandupBriefingGating(unittest.TestCase):
     """#61 regression: pin the once-per-LOCAL-day briefing contract so the
     documented behavior (and the absence of a marker/timezone misfire) cannot

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -891,5 +891,85 @@ class TestSegUpdate(unittest.TestCase):
         self.assertIn("2.10.0", sl.ANSI.sub("", out))
 
 
+class TestSubagentResultContract(unittest.TestCase):
+    """#413: read_subagents() must honor ONE result shape on every path, and a
+    syntactically valid but non-object JSONL record must not escape as an
+    AttributeError. Both defects erase the whole subagent section of the rich
+    statusline (a ValueError on unpack, or an exception swallowed by safe())."""
+
+    def _write(self, td, name, lines):
+        path = os.path.join(td, name)
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            for ln in lines:
+                f.write(ln + "\n")
+        return path
+
+    def test_missing_directory_returns_the_documented_four_item_result(self):
+        with tempfile.TemporaryDirectory() as td:
+            gone = os.path.join(td, "does-not-exist")
+            res = subs.read_subagents(gone)
+        self.assertEqual(len(res), 4,
+                         "every return path must produce the documented 4-item result")
+        active, recent, shown, totals = res
+        self.assertEqual(active, 0)
+        self.assertEqual(recent, 0)
+        self.assertEqual(shown, [])
+        self.assertEqual(totals, (0, 0))
+
+    def test_missing_directory_unpacks_the_same_way_as_a_real_read(self):
+        # The statusline unpacks 4 names OUTSIDE safe() — a 3-item error branch
+        # is a hard ValueError there, not a degraded segment.
+        with tempfile.TemporaryDirectory() as td:
+            gone = os.path.join(td, "raced-away")
+            active, recent, shown, (tin, tout) = subs.read_subagents(gone)
+        self.assertEqual((active, recent, shown, tin, tout), (0, 0, [], 0, 0))
+
+    def test_statusline_renders_through_a_subagent_directory_race(self):
+        with tempfile.TemporaryDirectory() as td:
+            gone = os.path.join(td, "raced-away")
+            with mock.patch.object(sl, "subagent_dir", return_value=gone):
+                out = sl.render(json.dumps({"session_id": "sid"}))
+        self.assertTrue(out, "a directory race must not break the statusline")
+
+    def test_non_object_jsonl_records_are_skipped_not_raised(self):
+        # A valid JSON line that is not an object used to reach d.get() inside
+        # a try that only caught OSError -> AttributeError out of the reader.
+        with tempfile.TemporaryDirectory() as td:
+            self._write(td, "agent-aaaaaa.jsonl", [
+                "[]",
+                "null",
+                "3",
+                '"a bare string"',
+                "{not json at all",
+                json.dumps({"requestId": "r1",
+                            "message": {"role": "user", "content": "Do the thing"}}),
+                json.dumps({"requestId": "r1",
+                            "message": {"role": "assistant",
+                                        "model": "claude-sonnet-4-6-20250514",
+                                        "usage": {"input_tokens": 10,
+                                                  "output_tokens": 4}}}),
+            ])
+            active, recent, shown, (tin, tout) = subs.read_subagents(td)
+        self.assertEqual(recent, 1)
+        self.assertEqual(len(shown), 1, "the valid records after the bad ones must survive")
+        self.assertEqual(shown[0]["label"], "Do the thing")
+        self.assertEqual((tin, tout), (10, 4))
+
+    def test_a_corrupt_file_does_not_suppress_a_later_valid_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._write(td, "agent-000001.jsonl", ["[]", "null"])
+            self._write(td, "agent-000002.jsonl", [
+                json.dumps({"requestId": "r9",
+                            "message": {"role": "user", "content": "Second agent"}}),
+                json.dumps({"requestId": "r9",
+                            "message": {"role": "assistant",
+                                        "usage": {"input_tokens": 7, "output_tokens": 2}}}),
+            ])
+            active, recent, shown, (tin, tout) = subs.read_subagents(td)
+        self.assertEqual(recent, 2)
+        self.assertEqual((tin, tout), (7, 2))
+        self.assertIn("Second agent", [row["label"] for row in shown])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -970,6 +970,39 @@ class TestSubagentResultContract(unittest.TestCase):
         self.assertEqual((tin, tout), (7, 2))
         self.assertIn("Second agent", [row["label"] for row in shown])
 
+    def test_a_non_oserror_from_one_transcript_costs_only_its_own_row(self):
+        # The per-file boundary must be a boundary for EVERY failure, not just
+        # OSError. A transcript whose `requestId` is a JSON array is real,
+        # syntactically valid corruption: the reader uses that value as a dict
+        # key, so the per-file body raises `TypeError: unhashable type: 'list'`
+        # — neither OSError nor ValueError. Under an OSError-only boundary it
+        # escapes read_subagents entirely and blanks every subagent row.
+        with tempfile.TemporaryDirectory() as td:
+            poison = self._write(td, "agent-aaaaaa.jsonl", [
+                json.dumps({"requestId": ["not", "hashable"],
+                            "message": {"role": "assistant",
+                                        "usage": {"input_tokens": 999,
+                                                  "output_tokens": 999}}}),
+            ])
+            self._write(td, "agent-bbbbbb.jsonl", [
+                json.dumps({"requestId": "ok1",
+                            "message": {"role": "user", "content": "Healthy agent"}}),
+                json.dumps({"requestId": "ok1",
+                            "message": {"role": "assistant",
+                                        "usage": {"input_tokens": 6,
+                                                  "output_tokens": 3}}}),
+            ])
+            # Make the poisoned transcript the most recent, so it is processed
+            # first and cannot be reached only after the healthy one.
+            now = time.time()
+            os.utime(poison, (now, now))
+            active, recent, shown, (tin, tout) = subs.read_subagents(td)
+        self.assertEqual(recent, 2)
+        self.assertEqual((tin, tout), (6, 3),
+                         "the poisoned transcript must contribute nothing, and "
+                         "must not take the healthy one down with it")
+        self.assertEqual([row["label"] for row in shown], ["Healthy agent"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three durability defects in the canonical `core/pysrc/` hook layer. Each is the
same shape: the *degradation* path destroys or drops state instead of preserving
it. All edits are in `core/pysrc/`, re-vendored into `plugins/ca`,
`plugins/ca-codex` and `plugins/ca-pi` via `python tools/sync-core.py`.

Closes #396
Closes #413
Closes #410

---

## #396 — a retryable dev-exit record when the audit append fails

`clear_dev_marker` appended the synthetic `DEV: exit` under a fire-and-forget
`except OSError: pass`, then removed `dev-active` from a **separate** try block.
A locked file, full disk, or permission blip therefore permanently erased the
only retry signal and left the append-only trail with an unmatched `DEV: enter`
— contradicting the documented SessionStart self-heal guarantee.

The close now runs through one settlement step (`_settle_dev_close`) built
around a small write-ahead record at `.codearbiter/.markers/dev-close-pending.json`:

```json
{"lines": ["<owed DEV: exit line>"], "marker_mtime": 1753405.2, "dropped": 0}
```

- `lines` — close lines still owed to the audit trail, emptied one at a time as
  each append is **confirmed**. Bounded to 8.
- `marker_mtime` — the identity of the `dev-active` marker the close belongs to.
  While the record names a **live** marker it doubles as a tombstone, so a
  failed `os.remove` cannot make the next session mint a *second* close row. It
  is cleared the instant that marker is gone (see the review-fix section below).
- `dropped` — how many owed lines the bound has had to discard, so a bounded
  record never costs the trail a silent, unexplained gap.

Every crash boundary is covered:

| crash point | state on disk | next SessionStart |
|---|---|---|
| before the append | record present, line owed | replays the append |
| after the append, before cleanup | record present, line owed | bounded 64 KiB tail scan sees the line already landed, drops it instead of duplicating |
| marker removal fails | record present, no line owed | only retries the removal |

Startup still fails **OPEN** — `clear_dev_marker` returns normally on every
path, exactly as before. The two early returns that leave a *live* marker owned
by another session deliberately do **not** settle: discarding a tombstone for a
marker you are not entitled to touch is precisely how a duplicate close gets
minted.

## #413 — one stable result contract for the subagent JSONL reader

Two independent defects, both of which erase the entire subagent section of the
rich statusline with no diagnostic:

1. `read_subagents` returned a **3-item** tuple on its directory-error branch
   while the module docstring, the happy path, and `statusline.py`'s own
   import-failure stub all promise **4**. `statusline.py` unpacks four names
   *outside* `safe()`, so a routine directory race was a hard `ValueError`.
2. `json.loads(ln)` was followed immediately by `d.get("message")` inside a try
   that caught `OSError` only — so one syntactically valid non-object line
   (`[]`, `null`, `3`, `"s"`) raised `AttributeError` out of the reader.

Fixed: one `empty = (0, 0, [], (0, 0))` returned on every error path, an
`isinstance(d, dict)` skip before any field access, and the per-file boundary
widened from `OSError` to `Exception` so file-local corruption costs only its
own row — matching the module's own stated contract ("Never raise on malformed
input — every reader degrades to a safe blank").

## #410 — validate provenance records before admitting them

`read_provenance` documented `dict | None` but returned the raw `json.load`
result, so a file containing `[]` was admitted to the store *as a list*.
`load_provenance_dir` then wrapped the **entire** glob loop in one try/except,
so the first `record.get("doc")` `AttributeError` aborted the scan and silently
dropped every later valid record — SessionStart drift reporting and commit-gate
auto-heal then ran against a truncated provenance map with no indication
anything was missing.

- New `valid_provenance_record()` checks the **top-level** v1 shape only
  (`schema == 1` with `bool` excluded since `True == 1`, plus `doc: str`,
  `created: str`, `interview_derived: bool`, `entries: list`). Entry-level
  tolerance stays where it already lives (`compute_drift`, `provenance_pointer`),
  so one odd claim never costs a doc its whole record.
- `read_provenance` returns `None` for anything that fails it.
- `load_provenance_dir` gets a **per-file** error boundary plus an optional
  `skipped=[]` list collecting up to `MAX_SKIPPED_REPORTED` (5) rejected
  **basenames** — names only, never file contents.

Verified against the real writers: every provenance record in the repo and in
the surface prose is produced by `new_record` / `write_provenance` /
`write_stub` / `rebaseline`, all of which emit the canonical shape. No
hand-authored provenance JSON exists, so the validation admits everything that
was already valid.

---

## Adversarial-review fixes (commit `d2170c1`)

The review found the settlement record could itself lose a close. Every
behavioral item below is reproduced by a test that was RED before its fix.

**1. The tombstone outlived its marker.** The final write-back persisted
`marker_mtime` even when the marker removal had *succeeded* — so after a failed
append the record named a marker that no longer existed. A later `/ca:dev`
marker landing on the same mtime (2s granularity on FAT32/exFAT/SMB/WSL mounts
makes that a real event) matched the stale tombstone, `already_closed` fired,
and the second session's close row was silently dropped: exactly the unmatched
`DEV: enter` #396 exists to prevent. The tombstone is now cleared the moment
the marker it names is gone.

**2. The dedupe tail scan swallowed freshly minted closes.** The scan exists so
a crash-after-append replay does not land twice. It was applied to the *newly
minted* line as well — and close rows are timestamped only to the second, so
two genuinely distinct closes minted in the same second are byte-identical. The
fresh line was matched against the owed copy of itself and dropped. The scan now
runs only against lines read back off the record, which are the only ones that
could already be on the trail. **Found while fixing (1), not raised by the
review.**

**3. The `_DEV_PENDING_CLOSE_MAX` cap discarded silently.** Twelve abandoned dev
sessions against a permanently-unwritable log left 8 owed lines and permanently
dropped 4, with nothing recorded. The overflow is now counted in the record and
written to the trail as one attributable `DEV: close-dropped` note the moment
the log accepts writes again.

**4. Two hunks that no test isolated now have one each.** The review confirmed
that reverting `except OSError` → `except Exception` in `_subagentslib`, and the
per-file boundary in `load_provenance_dir`, each left the whole suite green.
Both are now pinned by a test that fails when *only* that hunk is reverted:
- `_subagentslib`: a transcript line carrying a JSON **array** as `requestId`.
  The reader uses that value as a dict key, so the per-file body raises
  `TypeError: cannot use 'list' as a dict key (unhashable type: 'list')` —
  neither `OSError` nor `ValueError`. Real, syntactically valid corruption.
- `load_provenance_dir`: a read that raises. `read_provenance` only absorbs
  `OSError`/`ValueError`; anything else propagates into the glob loop, which the
  old shared try/except turned into a whole-directory drop.

**5. `load_provenance_dir(skipped=...)` stays return-channel only, and the code
now says why.** Neither production call site can carry the diagnostic:
`startup_drift_line` is bound by AC-08 degrade-to-silence (an all-corrupt
provenance dir MUST return `''`, pinned by `test_degrade_corrupt_json`), and
`build_index` runs on every `PreToolUse:Read`, where a per-call warning is noise
on the hottest path in the hook layer. Surfacing corruption to a *user* belongs
to `/ca:context-check` or `/ca:doctor`, which are surface prose and out of a
`core/pysrc` lane. #410 AC-3 is therefore met **via the return channel only** —
stated plainly here rather than implied.

**6. Changelog heading corrected** from `## [0.1.4] - 2026-07-25` (future-dated)
to `2026-07-24`, and the two stray blank lines removed.

### Not fixed, disclosed

- The 64 KiB bounded tail scan means the crash-after-append dedupe only holds
  while the audit trail grows less than 64 KiB between the crash and the replay.
  Past that, a replay mints a duplicate close. Deliberate: a duplicate is safer
  than a lost close, and the log is 4.4 KB today. A deterministic alternative
  (store the pre-append byte offset and scan forward) is a follow-up.
- A replayed close carries the timestamp it was *minted* with, so a delayed
  replay leaves the trail non-chronological. Enter/exit pairing is by timestamp
  so it still resolves; positional pairing would not. Now called out in the
  module comment so an audit reader does not assume file order is time order.
- `TestDevExitRetryablePendingClose` / `TestSubagentResultContract` load only
  `plugins/ca/hooks/`, not the ca-codex or ca-pi copies (#396 AC-4 asks for
  both). Mitigated by the CI `sync-core.py --check` byte-identity gate, re-run
  green below.

---

## Red-test evidence (verbatim)

### #396 — `plugins/ca/hooks/tests/test_session_start.py::TestDevExitRetryablePendingClose`

```
F.FFFF
======================================================================
FAIL: test_append_failure_leaves_a_durable_retryable_close_record (test_session_start.TestDevExitRetryablePendingClose.test_append_failure_leaves_a_durable_retryable_close_record)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 627, in test_append_failure_leaves_a_durable_retryable_close_record
    self.assertTrue(os.path.isfile(self.pending),
                    "a failed append must leave a durable pending-close record")
AssertionError: False is not true : a failed append must leave a durable pending-close record

======================================================================
FAIL: test_corrupt_pending_record_is_discarded_not_jammed (test_session_start.TestDevExitRetryablePendingClose.test_corrupt_pending_record_is_discarded_not_jammed)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 703, in test_corrupt_pending_record_is_discarded_not_jammed
    self.assertFalse(os.path.isfile(self.pending))
AssertionError: True is not false

======================================================================
FAIL: test_crash_after_append_before_cleanup_does_not_duplicate (test_session_start.TestDevExitRetryablePendingClose.test_crash_after_append_before_cleanup_does_not_duplicate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 664, in test_crash_after_append_before_cleanup_does_not_duplicate
    self.assertFalse(os.path.isfile(self.pending),
                     "the settled record must be cleared")
AssertionError: True is not false : the settled record must be cleared

======================================================================
FAIL: test_later_session_appends_the_missing_exit_exactly_once (test_session_start.TestDevExitRetryablePendingClose.test_later_session_appends_the_missing_exit_exactly_once)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 642, in test_later_session_appends_the_missing_exit_exactly_once
    self.assertEqual(len(self._exit_lines()), 1,
                     "the owed DEV: exit must land exactly once on retry")
AssertionError: 0 != 1 : the owed DEV: exit must land exactly once on retry

======================================================================
FAIL: test_marker_removal_failure_does_not_duplicate_the_close_row (test_session_start.TestDevExitRetryablePendingClose.test_marker_removal_failure_does_not_duplicate_the_close_row)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_session_start.py", line 684, in test_marker_removal_failure_does_not_duplicate_the_close_row
    self.assertEqual(len(self._exit_lines()), 1,
                     "the same marker must not be closed twice in the audit trail")
AssertionError: 2 != 1 : the same marker must not be closed twice in the audit trail

----------------------------------------------------------------------
Ran 6 tests in 0.027s

FAILED (failures=5)
```

`0 != 1` is the defect verbatim: the owed close is gone forever. `2 != 1` is the
duplicate-close mode. The sixth test (`test_clean_close_leaves_no_pending_record_behind`)
passes red — it is the guard proving the happy path was never broken.

### Review fixes 1 and 3 — red against the *pre-fix branch*

```
======================================================================
FAIL: test_a_removed_marker_leaves_no_tombstone_in_the_pending_record (test_session_start.TestDevExitRetryablePendingClose.test_a_removed_marker_leaves_no_tombstone_in_the_pending_record)
----------------------------------------------------------------------
AssertionError: 1784945655.0436485 is not None : a record whose marker is gone must not keep its identity

======================================================================
FAIL: test_a_stale_tombstone_cannot_suppress_a_later_sessions_close (test_session_start.TestDevExitRetryablePendingClose.test_a_stale_tombstone_cannot_suppress_a_later_sessions_close)
----------------------------------------------------------------------
AssertionError: 1 != 2 : two dev sessions owe two close rows, not one

======================================================================
FAIL: test_the_pending_close_cap_never_discards_a_close_silently (test_session_start.TestDevExitRetryablePendingClose.test_the_pending_close_cap_never_discards_a_close_silently)
----------------------------------------------------------------------
AssertionError: None != 4 : every discarded close row must be counted, not forgotten

----------------------------------------------------------------------
Ran 9 tests in 0.142s

FAILED (failures=3)
```

`1 != 2` is the reviewer's own reproduction: two dev sessions, one close row.

### Review fix 2 — the same-second dedupe collapse

```
FAIL: test_a_freshly_minted_close_is_never_deduped_against_the_trail (test_session_start.TestDevExitRetryablePendingClose.test_a_freshly_minted_close_is_never_deduped_against_the_trail)
----------------------------------------------------------------------
AssertionError: 1 != 2 : two owed closes must both land even when the second granularity makes their lines identical
```

### Review fix 4 — each boundary red with ONLY its own hunk reverted

`plugins/ca/hooks/_subagentslib.py`, `except Exception` reverted to `except OSError`:

```
ERROR: test_a_non_oserror_from_one_transcript_costs_only_its_own_row (test_statusline.TestSubagentResultContract.test_a_non_oserror_from_one_transcript_costs_only_its_own_row)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 999, in test_a_non_oserror_from_one_transcript_costs_only_its_own_row
    active, recent, shown, (tin, tout) = subs.read_subagents(td)
  File "...\plugins\ca\hooks\_subagentslib.py", line 162, in read_subagents
    reqs[d.get("requestId") or msg.get("id") or i] = (
TypeError: cannot use 'list' as a dict key (unhashable type: 'list')

----------------------------------------------------------------------
Ran 6 tests in 0.086s

FAILED (errors=1)
```

`plugins/ca/hooks/_provenancelib.py`, per-file boundary reverted to one shared try/except:

```
FAIL: test_a_read_that_raises_costs_only_its_own_file (test_provenancelib.ProvenanceRecordShapeTest.test_a_read_that_raises_costs_only_its_own_file)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2747, in test_a_read_that_raises_costs_only_its_own_file
    self.assertEqual(sorted(loaded), ["code-map", "tech-stack"],
AssertionError: Lists differ: [] != ['code-map', 'tech-stack']

- []
+ ['code-map', 'tech-stack'] : a raising read must not abort the directory scan

----------------------------------------------------------------------
Ran 9 tests in 0.099s

FAILED (failures=1)
```

Both files were restored from git immediately after the probe.

### #413 — `plugins/ca/hooks/tests/test_statusline.py::TestSubagentResultContract`

```
======================================================================
ERROR: test_missing_directory_unpacks_the_same_way_as_a_real_read (test_statusline.TestSubagentResultContract.test_missing_directory_unpacks_the_same_way_as_a_real_read)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 924, in test_missing_directory_unpacks_the_same_way_as_a_real_read
    active, recent, shown, (tin, tout) = subs.read_subagents(gone)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 4, got 3)

======================================================================
ERROR: test_non_object_jsonl_records_are_skipped_not_raised (test_statusline.TestSubagentResultContract.test_non_object_jsonl_records_are_skipped_not_raised)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 952, in test_non_object_jsonl_records_are_skipped_not_raised
    active, recent, shown, (tin, tout) = subs.read_subagents(td)
  File "...\plugins\ca\hooks\_subagentslib.py", line 132, in read_subagents
    msg = d.get("message")
          ^^^^^
AttributeError: 'list' object has no attribute 'get'

======================================================================
ERROR: test_statusline_renders_through_a_subagent_directory_race (test_statusline.TestSubagentResultContract.test_statusline_renders_through_a_subagent_directory_race)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 931, in test_statusline_renders_through_a_subagent_directory_race
    out = sl.render(json.dumps({"session_id": "sid"}))
  File "...\plugins\ca\hooks\statusline.py", line 535, in render
    return _render_active_palette(raw)
  File "...\plugins\ca\hooks\statusline.py", line 653, in _render_active_palette
    active, recent, shown, (tin, tout) = res
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 4, got 3)

======================================================================
FAIL: test_missing_directory_returns_the_documented_four_item_result (test_statusline.TestSubagentResultContract.test_missing_directory_returns_the_documented_four_item_result)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_statusline.py", line 911, in test_missing_directory_returns_the_documented_four_item_result
    self.assertEqual(len(res), 4,
                     "every return path must produce the documented 4-item result")
AssertionError: 3 != 4 : every return path must produce the documented 4-item result

----------------------------------------------------------------------
Ran 5 tests in 0.061s

FAILED (failures=1, errors=4)
```

The third trace is the real-world consequence reproduced end to end: a
`ValueError` thrown from `statusline.py` line 653, exactly the line the issue
names.

### #410 — `.github/scripts/test_provenancelib.py::ProvenanceRecordShapeTest`

```
FFFFFEF.EFF.
======================================================================
ERROR: test_corruption_diagnostic_is_bounded (test_provenancelib.ProvenanceRecordShapeTest.test_corruption_diagnostic_is_bounded)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2716, in test_corruption_diagnostic_is_bounded
    pl.load_provenance_dir(d, skipped=skipped)
TypeError: load_provenance_dir() got an unexpected keyword argument 'skipped'

======================================================================
FAIL: test_a_valid_record_survives_after_every_invalid_top_level_type (test_provenancelib.ProvenanceRecordShapeTest.test_a_valid_record_survives_after_every_invalid_top_level_type) (raw='[]')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2688, in test_a_valid_record_survives_after_every_invalid_top_level_type
    self.assertIn("tech-stack", loaded,
                  f"a valid record after {raw!r} must still load")
AssertionError: 'tech-stack' not found in {} : a valid record after '[]' must still load

======================================================================
FAIL: test_invalid_record_does_not_drop_the_valid_records_after_it (test_provenancelib.ProvenanceRecordShapeTest.test_invalid_record_does_not_drop_the_valid_records_after_it)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2678, in test_invalid_record_does_not_drop_the_valid_records_after_it
    self.assertEqual(sorted(loaded), ["code-map", "tech-stack"],
                     "one invalid record must not abort the directory scan")
AssertionError: Lists differ: [] != ['code-map', 'tech-stack']

======================================================================
FAIL: test_read_provenance_rejects_a_mapping_with_the_wrong_schema (test_provenancelib.ProvenanceRecordShapeTest.test_read_provenance_rejects_a_mapping_with_the_wrong_schema)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts	est_provenancelib.py", line 2661, in test_read_provenance_rejects_a_mapping_with_the_wrong_schema
    self.assertIsNone(
        pl.read_provenance(path),
        f"read_provenance must return None for the {name!r} record",
    )
AssertionError: {} is not None : read_provenance must return None for the 'empty' record

======================================================================
FAIL: test_read_provenance_rejects_every_non_mapping_top_level_type (test_provenancelib.ProvenanceRecordShapeTest.test_read_provenance_rejects_every_non_mapping_top_level_type)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\.github\scripts\test_provenancelib.py", line 2637, in test_read_provenance_rejects_every_non_mapping_top_level_type
    self.assertIsNone(
        pl.read_provenance(path),
        f"read_provenance must return None for a top-level {raw!r}",
    )
AssertionError: [] is not None : read_provenance must return None for a top-level '[]'

----------------------------------------------------------------------
Ran 8 tests in 0.047s

FAILED (failures=8, errors=2)
```

`'tech-stack' not found in {}` is the silent-drop defect: the loader returned an
empty map even though a perfectly valid record sat next to the bad one.

---

## Suite results

Baseline re-measured on this PR's actual merge-base, `origin/main @ 9e8768f`,
in a clean detached worktree. (An earlier revision of this body carried numbers
from the superseded #431 run against base `4ec1a8a` — those were wrong and have
been replaced.)

| suite | before (`origin/main @ 9e8768f`) | after (`d2170c1`) |
|---|---|---|
| `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` | 1057 tests, **OK** | 1073 tests, **OK** (+16) |
| `cd .github/scripts && python -m unittest discover -s . -p "test_*.py"` | 1065 tests, 2 failures / 2 errors / 5 skipped | 1074 tests, **same** 2 failures / 2 errors / 5 skipped (+9) |
| `python tools/sync-core.py --check` | OK | OK — 47 core files x 3 plugins, byte-identical |
| `python tools/build-host-packages.py --check --release-guard-base 9e8768f` | n/a | OK — `Pi payload, version, changelog, and root metadata advanced together: 0.1.3 -> 0.1.4` |
| `check_badge_consistency.py` / `check_docs_contract.py` / `check-plugin-refs.py` | — | all clean (exit 0) |
| `git diff --check origin/main HEAD` | — | exit 0; all 18 touched files `i/lf w/lf` |

The four `.github/scripts` failures are pre-existing on `origin/main` at the
same baseline — identical four test names before and after — and unrelated; see
NEEDS-TRIAGE below.

No TypeScript package was touched, so `plugins/ca/tools` (farm) and
`plugins/ca-sandbox/tools` were not rebuilt — `farm.js` / `sandbox.js` are
unchanged and the staleness gate is unaffected.

### Payload version gate

`plugins/ca-pi/hooks/**` changed (vendored core sync), and the Pi guard is
stricter than ca/ca-codex — it requires the version to advance regardless of
whether a tag is published. So **ca-pi 0.1.3 → 0.1.4**, with the regenerated
root `package.json` (`python tools/build-host-packages.py`) and a
`## [0.1.4] - 2026-07-24` heading. 0.1.4 is unreleased, so the review-fix commit
rides the same version rather than bumping again.

`ca` (2.9.1) and `ca-codex` (0.3.0) need no bump — neither `v2.9.1` nor
`ca-codex-v0.3.0` is published, and both guards only bite once the tag exists.
Confirmed against `git ls-remote --tags origin`.

### Note on branch history

This replaces #431, which was branched from `4ec1a8a` before #427 merged. #427
shipped **ca-pi 0.1.3**, colliding with the version #431 had claimed, so this
branch sits on the current `main` (`9e8768f`) and releases 0.1.4 instead, with
#427's own 0.1.3 section preserved intact.

A new branch rather than a force-push or a merge commit, deliberately:
- H-02 prohibits force-push, so #431's published history could not be rewritten.
- Merging `main` in would have made the merge commit's diff re-present #427's
  SHA-256 correlation lines as *added* crypto, tripping H-09b and asking for a
  crypto-gate pass on another PR's already-reviewed code.

---

## NEEDS-TRIAGE

**1. `test_pi_benchmark` is red on `origin/main` before this branch exists
(environmental, not a regression).** The same four tests fail identically at the
`9e8768f` baseline and after this change:

```
ERROR: test_measurements_use_exact_public_shape_and_100_warm_events
ERROR: test_pi_record_does_not_load_the_generated_python_host_adapter
FAIL:  test_cli_emits_only_three_bounded_json_records
FAIL:  test_cli_real_spawn_flag_adds_a_fourth_labeled_record
```

Root cause is a missing local toolchain, not the code:

```
File ".github/scripts/pi_benchmark.py", line 151, in _production_pi_samples
    raise RuntimeError("Pi benchmark requires the installed pinned esbuild")
```

CI presumably installs the pinned esbuild, so this is likely green there. Worth
a separate look at whether these should skip rather than error when the
toolchain is absent — every local contributor otherwise sees a red
`.github/scripts` suite. Out of scope for this lane; filed here rather than
fixed.

**2. The `dev-close-pending` record is settled only by SessionStart.**
`/ca:arbiter` (the normal dev exit) removes `dev-active` through its own prose
path and does not consult the pending record. That is harmless — the record is
retired by the next SessionStart's no-marker settle — but it means a genuinely
owed close can sit on disk until the next session starts rather than being
flushed at exit time. Deliberate: wiring this into the arbiter prose is a
surface change well outside a `core/pysrc` durability fix.

**3. `load_provenance_dir(skipped=...)` has no production caller, and cannot get
one in this lane.** See review-fix item 5 above: `startup_drift_line` is pinned
to silence by AC-08 and `build_index` is the hot `PreToolUse:Read` path.
#410 AC-3 is met **via the return channel only**. Surfacing it belongs to
`/ca:context-check` or `/ca:doctor` (surface prose), tracked as a follow-up.

**4. `plugins/ca-pi/tools/test/background-jobs.test.ts` is flaky on Windows CI.**
On #431 (identical Python-only diff), the `windows-latest · Pi 0.80.10` cell
failed twice on:

```
FAIL  test/background-jobs.test.ts > session-local background job state
      > launches and disposes a real Git Bash background job
Error: Test timed out in 5000ms.
 ❯ test/background-jobs.test.ts:513:43
```

The test spawns a **real** `bash.exe` and awaits `runtime.settled(...)` under
vitest's default 5s timeout. The same test passed on `windows-latest · Pi 0.80.5`
in the same run, and passed on all six cells for #427 — and no PR in this lane
touches a single line of TypeScript. It is runner-speed dependent, not a
regression. It wants an explicit `testTimeout` (the other real-process tests in
that file are mock-driven and unaffected). Not fixed here: it is a `ca-pi/tools`
TypeScript change, outside a `core/pysrc` durability lane.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
