### PR TITLE
fix(hooks): never pin a non-durable plugin root into global settings.json

### DIFF
--- a/core/pysrc/_durabilitylib.py
+++ b/core/pysrc/_durabilitylib.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# codeArbiter — durable-vs-ephemeral install-root detection.
+#
+# WHY THIS EXISTS (found in-session on 2026-07-25, after it broke the
+# maintainer's statusline three times in one day):
+#
+# A plugin cannot own a statusLine and ${CLAUDE_PLUGIN_ROOT} is NOT expanded
+# inside settings.json, so codeArbiter has to write an ABSOLUTE, version-pinned
+# renderer path into the user's GLOBAL ~/.claude/settings.json — and re-point it
+# on every SessionStart so a plugin update does not leave the old version wired.
+# That refresh had no notion of a root that will not survive the session. When a
+# session starts inside a git worktree (subagents routinely run in
+# <repo>/.claude/worktrees/<id>/), the plugin root IS the worktree's plugins/ca,
+# and the heal happily pinned the user's global config there:
+#
+#   "...\.claude\worktrees\wf_58ee3fa6-de1-8\plugins\ca\hooks\statusline.py"
+#
+# The worktree is then pruned — that is what worktrees are FOR — and the
+# statusline renders nothing until someone notices and re-runs /ca:statusline.
+#
+# This module answers exactly one question, for callers about to write a path
+# into a long-lived config: may this path be trusted to still be there?
+#
+# TWO INDEPENDENT SIGNALS, because each alone has a blind spot:
+#   1. LEXICAL (has_worktree_segment) — a `worktrees` or `*-worktrees` path
+#      segment. Free, no I/O at all, works even when the checkout is already
+#      gone. Covers the confirmed `.claude/worktrees/<id>/` case and the
+#      `../.codearbiter-worktrees/<slug>` layout the using-git-worktrees skill
+#      creates.
+#   2. GIT (in_linked_worktree) — the path lives in a LINKED worktree, read
+#      straight off git's own on-disk marker. Generalizes to a worktree parked
+#      anywhere under any name, which the lexical rule cannot see.
+#
+# NO SUBPROCESS, DELIBERATELY. This predicate is consulted on EVERY SessionStart,
+# before the dormant gate, in every repo on the machine. An earlier draft shelled
+# out to `git rev-parse --git-dir --git-common-dir`; that probe fails by design
+# in the ordinary plugin-cache install (which is not a git repository at all), so
+# it bought nothing in the common case while charging every session a process
+# spawn plus a timeout hazard. Git writes the answer to disk anyway: a LINKED
+# worktree's `.git` is a FILE reading `gitdir: <common>/.git/worktrees/<name>`,
+# while a normal checkout's `.git` is a DIRECTORY. A handful of stat() calls
+# gives the same answer, with no dependency on git being installed at all.
+#
+# FAILURE DIRECTION IS "DURABLE", DELIBERATELY. Anything unreadable, unparseable
+# or absent reads as durable. Reading uncertainty as "ephemeral" would silently
+# disable the self-heal for users whose installs are perfectly fine — a far worse
+# outcome than the residual it protects against.
+#
+# The lexical rule is deliberately a little broad (any `worktrees` segment, not
+# only one under `.claude`). The asymmetry justifies it: a false positive costs
+# an un-refreshed pin the user fixes with one explicit /ca:statusline run, while
+# a false negative corrupts their global config.
+#
+# Design principles (mirroring _gitexec.py / _gitlib.py):
+#   - Stdlib only; no third-party imports ever (ADR-0004).
+#   - Zero side effects at import time.
+#   - NEVER raises. This sits on the SessionStart path; it must not be the thing
+#     that crashes startup, whatever it is handed.
+#
+# Public API:
+#   has_worktree_segment(path) -> bool   lexical signal, no I/O
+#   in_linked_worktree(path) -> bool     git's on-disk marker, no subprocess
+#   is_ephemeral_path(path) -> bool      either signal
+
+import os
+import re
+
+# The walk from a plugin root to the filesystem root is a handful of levels; the
+# bound exists only so a pathological path can never spin this on the hot path.
+MAX_ANCESTOR_WALK = 64
+
+# A `.git` FILE is at most a line or two. Reading a bounded prefix means a
+# directory entry that is unexpectedly enormous cannot stall startup.
+GITFILE_READ_BYTES = 4096
+
+_SEP_RE = re.compile(r"[\\/]+")
+
+
+def _segments(path):
+    """Path segments of `path`, split on BOTH separators (a Windows path may be
+    read from a POSIX host and vice versa). Empty tuple on any non-string."""
+    if not isinstance(path, str) or not path:
+        return ()
+    return tuple(part for part in _SEP_RE.split(path) if part)
+
+
+def has_worktree_segment(path):
+    """True iff `path` contains a segment named `worktrees` or `*-worktrees`
+    (case-insensitive). Purely lexical — no filesystem access, no subprocess.
+
+    Matches `<repo>/.claude/worktrees/<id>/...` (Claude Code's own subagent
+    worktrees) and `../.codearbiter-worktrees/<slug>/...` (the
+    using-git-worktrees skill). Compares whole SEGMENTS, never substrings: a
+    directory literally called `worktrees-archive` is a name of its own, not a
+    container of worktrees, and matching it would decline to heal a perfectly
+    durable root."""
+    for part in _segments(path):
+        low = part.lower()
+        if low == "worktrees" or low.endswith("-worktrees"):
+            return True
+    return False
+
+
+def _ancestors(path):
+    """`path` (or its directory, if it names a file) and every parent above it,
+    nearest first, bounded by MAX_ANCESTOR_WALK. Yields nothing for junk."""
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        cur = os.path.abspath(path)
+        if not os.path.isdir(cur):
+            cur = os.path.dirname(cur)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return
+    for _ in range(MAX_ANCESTOR_WALK):
+        if not cur:
+            return
+        yield cur
+        parent = os.path.dirname(cur)
+        if parent == cur:  # filesystem root: dirname is a fixed point
+            return
+        cur = parent
+
+
+def _gitfile_points_at_worktree(gitfile):
+    """True iff the `.git` FILE at `gitfile` is a LINKED WORKTREE pointer.
+
+    Git writes `gitdir: <path>` into `.git` for both linked worktrees and
+    submodules, and the two must not be confused: a worktree points into
+    `<common>/.git/worktrees/<name>` (disposable), a submodule into
+    `<super>/.git/modules/<name>` (an ordinary long-lived checkout). The
+    `worktrees` segment in the TARGET is what separates them."""
+    try:
+        with open(gitfile, "rb") as f:
+            head = f.read(GITFILE_READ_BYTES)
+        lines = head.decode("utf-8", "replace").splitlines()
+        if not lines:
+            return False
+        first = lines[0].strip()
+        if not first.lower().startswith("gitdir:"):
+            return False
+        # split(":", 1) — the FIRST colon only, so a Windows target like
+        # `C:/Users/...` survives intact.
+        return has_worktree_segment(first.split(":", 1)[1].strip())
+    except Exception:  # noqa: BLE001 — unreadable reads as durable, by design
+        return False
+
+
+def in_linked_worktree(path):
+    """True iff `path` sits inside a LINKED git worktree.
+
+    Walks up from `path` to the first `.git` it meets — the boundary of the
+    repository the path actually belongs to — and decides there:
+      - `.git` is a DIRECTORY -> the main worktree. Durable. Stop.
+      - `.git` is a FILE      -> a linked worktree or a submodule; the pointer's
+                                 target says which. Stop either way.
+      - no `.git` at any level -> not in a repository at all (the ordinary
+                                 plugin-cache install). Durable.
+    Stopping at the NEAREST boundary is load-bearing: a real checkout nested
+    below some unrelated worktree marker must read as durable.
+
+    `path` may name a file (its directory is walked) or a directory, and need
+    not exist. Never raises."""
+    try:
+        for cur in _ancestors(path):
+            gitpath = os.path.join(cur, ".git")
+            if os.path.isdir(gitpath):
+                return False
+            if os.path.isfile(gitpath):
+                return _gitfile_points_at_worktree(gitpath)
+        return False
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False
+
+
+def is_ephemeral_path(path):
+    """True iff `path` must NOT be pinned into a long-lived global config.
+
+    Checks the free lexical signal FIRST and short-circuits on it, so the
+    confirmed production case is decided with zero I/O. Never raises."""
+    try:
+        if has_worktree_segment(path):
+            return True
+        return in_linked_worktree(path)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -32,6 +32,7 @@ from _gitexec import git_executable
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
+from _durabilitylib import is_ephemeral_path  # noqa: E402
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
     write_text_atomic,
@@ -411,13 +412,36 @@ def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None)
     Narrow that window by reloading the file fresh immediately before writing:
     if it differs from what we loaded, some other writer touched it in the
     interim, so we SKIP this heal entirely (never overwrite that write with
-    our now-stale snapshot) — a later session's heal simply retries."""
+    our now-stale snapshot) — a later session's heal simply retries.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). This hook runs on EVERY
+    SessionStart and pins an ABSOLUTE path into the user's GLOBAL settings.json.
+    A session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolves `plugin` to that worktree, and the
+    heal pinned the global config at a directory whose entire purpose is to be
+    pruned. When the root is not durable we leave the existing pin exactly as it
+    is — not healed, not cleared, no error.
+
+    wire-statusline.refresh_if_stale enforces the same rule (it is the producer,
+    and also reachable by a human running `--plugin-root <worktree>`), so this
+    check is deliberately REDUNDANT — but not decoratively so. `_load_wire_
+    statusline` loads that producer OUT OF `plugin` itself: a worktree cut from a
+    pre-fix branch supplies a pre-fix, unguarded producer, while THIS file may
+    have been loaded from somewhere else entirely (main() honours
+    $CLAUDE_PLUGIN_ROOT independently of where session-start.py came from). The
+    highest-consequence write on the machine gets to refuse on its own account
+    rather than on the good behaviour of whatever version it happened to load.
+    Both call sites share the one predicate, so there is no second policy to
+    drift."""
     try:
+        script_abs = os.path.join(plugin, "hooks", "statusline.py")
+        if is_ephemeral_path(script_abs):
+            return False
         ws = (loader or _load_wire_statusline)(plugin)
         if ws is None:
             return False
         spath = settings_path or ws.settings_path(None)
-        script_abs = os.path.join(plugin, "hooks", "statusline.py")
         interp = interp or ws.default_interp(None)
         settings, exists = ws.load_settings(spath)
         if not exists:

--- a/core/pysrc/wire-statusline.py
+++ b/core/pysrc/wire-statusline.py
@@ -33,6 +33,7 @@ import sys
 # session-start.py and the test suite both do) — always resolve _hooklib
 # relative to THIS file rather than relying on the caller's sys.path state.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _durabilitylib  # noqa: E402 — "may this path be pinned?" (see below)
 import _hooklib  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
 
@@ -230,6 +231,19 @@ def cmd_status(settings, exists, script_abs):
 
 
 def cmd_install(settings, path, script_abs, interp):
+    # Never pin a root that will not outlive the session (see refresh_if_stale's
+    # docstring for the defect). `install` is EXPLICIT — a human ran
+    # /ca:statusline, or passed `--plugin-root <worktree>` by hand — so this
+    # refuses LOUDLY where `refresh` degrades silently: a quiet no-op would leave
+    # that human believing the statusline was wired.
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        raise SystemExit(
+            f"REFUSING TO WIRE: {script_abs} is inside a git worktree (or another "
+            "root that will not survive being pruned).\n"
+            "~/.claude/settings.json is GLOBAL and holds an ABSOLUTE path, so "
+            "pinning it here breaks your statusline the moment this checkout goes "
+            "away.\nRe-run from your real install (the plugin cache, or your main "
+            "checkout), or pass --plugin-root pointing at it.")
     if not os.path.exists(script_abs):
         raise SystemExit(f"ERROR: renderer not found at {script_abs}; nothing wired.")
     new_cmd = build_command(interp, script_abs)
@@ -272,7 +286,30 @@ def refresh_if_stale(settings, script_abs, interp):
       - statusLine is a third-party line, or absent                       -> never touched, False
 
     Returning a changed-flag lets the caller persist ONLY on a real change, so a
-    steady-state session start never churns settings.json."""
+    steady-state session start never churns settings.json.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). settings.json is GLOBAL and
+    the pin is ABSOLUTE, but the running plugin root need not be long-lived: a
+    session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolved the root to that worktree and this
+    function cheerfully re-pointed the user's global config at it. The worktree
+    is then pruned — its entire purpose — and the statusline renders nothing.
+
+    So: when `script_abs` is not durable, LEAVE THE EXISTING PIN ALONE. Not
+    healed, not cleared, no error — the same silent degrade the rest of this path
+    already performs. It is emphatically NOT a kill-switch: a genuinely stale pin
+    from a real plugin-cache update still heals, because that root IS durable.
+    Clearing instead of skipping was considered and rejected — a user whose only
+    session that day is a worktree session would lose a working statusline over a
+    condition that resolves itself the next time they start from a real install.
+
+    The guard lives HERE, at the mutation itself, rather than only in
+    `cmd_refresh`: `session-start.heal_statusline_wiring` calls this function
+    DIRECTLY and never goes through `cmd_refresh`, so a guard one level up would
+    have left the confirmed corruption path wide open."""
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        return False
     current = settings.get("statusLine")
     if not is_ours(current, settings):
         return False

--- a/core/surface/commands/statusline.md
+++ b/core/surface/commands/statusline.md
@@ -46,7 +46,13 @@ colors.
    show the user the resolved command and the prior line it will back up, and confirm.** Editing the
    user's global settings is their call, not yours.
 
+   The script REFUSES to wire a plugin root that will not outlive the session — a git worktree, for
+   instance. `settings.json` is global and the pin is absolute, so a worktree path breaks the
+   statusline the moment that checkout is pruned. On a refusal, report it verbatim and re-run from
+   the real install (the plugin cache, or the main checkout) rather than working around it.
+
 3. **uninstall** — restore the backed-up line, or remove `statusLine` entirely if none existed.
+   Never blocked, wherever it is run from — a user stuck with a dead pin must be able to clear it.
 
 4. **status** — report the current `statusLine.command`, whether it is codeArbiter's, and any backup
    on file. Changes nothing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_durabilitylib.py
+++ b/plugins/ca-codex/hooks/_durabilitylib.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# codeArbiter — durable-vs-ephemeral install-root detection.
+#
+# WHY THIS EXISTS (found in-session on 2026-07-25, after it broke the
+# maintainer's statusline three times in one day):
+#
+# A plugin cannot own a statusLine and ${CLAUDE_PLUGIN_ROOT} is NOT expanded
+# inside settings.json, so codeArbiter has to write an ABSOLUTE, version-pinned
+# renderer path into the user's GLOBAL ~/.claude/settings.json — and re-point it
+# on every SessionStart so a plugin update does not leave the old version wired.
+# That refresh had no notion of a root that will not survive the session. When a
+# session starts inside a git worktree (subagents routinely run in
+# <repo>/.claude/worktrees/<id>/), the plugin root IS the worktree's plugins/ca,
+# and the heal happily pinned the user's global config there:
+#
+#   "...\.claude\worktrees\wf_58ee3fa6-de1-8\plugins\ca\hooks\statusline.py"
+#
+# The worktree is then pruned — that is what worktrees are FOR — and the
+# statusline renders nothing until someone notices and re-runs /ca:statusline.
+#
+# This module answers exactly one question, for callers about to write a path
+# into a long-lived config: may this path be trusted to still be there?
+#
+# TWO INDEPENDENT SIGNALS, because each alone has a blind spot:
+#   1. LEXICAL (has_worktree_segment) — a `worktrees` or `*-worktrees` path
+#      segment. Free, no I/O at all, works even when the checkout is already
+#      gone. Covers the confirmed `.claude/worktrees/<id>/` case and the
+#      `../.codearbiter-worktrees/<slug>` layout the using-git-worktrees skill
+#      creates.
+#   2. GIT (in_linked_worktree) — the path lives in a LINKED worktree, read
+#      straight off git's own on-disk marker. Generalizes to a worktree parked
+#      anywhere under any name, which the lexical rule cannot see.
+#
+# NO SUBPROCESS, DELIBERATELY. This predicate is consulted on EVERY SessionStart,
+# before the dormant gate, in every repo on the machine. An earlier draft shelled
+# out to `git rev-parse --git-dir --git-common-dir`; that probe fails by design
+# in the ordinary plugin-cache install (which is not a git repository at all), so
+# it bought nothing in the common case while charging every session a process
+# spawn plus a timeout hazard. Git writes the answer to disk anyway: a LINKED
+# worktree's `.git` is a FILE reading `gitdir: <common>/.git/worktrees/<name>`,
+# while a normal checkout's `.git` is a DIRECTORY. A handful of stat() calls
+# gives the same answer, with no dependency on git being installed at all.
+#
+# FAILURE DIRECTION IS "DURABLE", DELIBERATELY. Anything unreadable, unparseable
+# or absent reads as durable. Reading uncertainty as "ephemeral" would silently
+# disable the self-heal for users whose installs are perfectly fine — a far worse
+# outcome than the residual it protects against.
+#
+# The lexical rule is deliberately a little broad (any `worktrees` segment, not
+# only one under `.claude`). The asymmetry justifies it: a false positive costs
+# an un-refreshed pin the user fixes with one explicit /ca:statusline run, while
+# a false negative corrupts their global config.
+#
+# Design principles (mirroring _gitexec.py / _gitlib.py):
+#   - Stdlib only; no third-party imports ever (ADR-0004).
+#   - Zero side effects at import time.
+#   - NEVER raises. This sits on the SessionStart path; it must not be the thing
+#     that crashes startup, whatever it is handed.
+#
+# Public API:
+#   has_worktree_segment(path) -> bool   lexical signal, no I/O
+#   in_linked_worktree(path) -> bool     git's on-disk marker, no subprocess
+#   is_ephemeral_path(path) -> bool      either signal
+
+import os
+import re
+
+# The walk from a plugin root to the filesystem root is a handful of levels; the
+# bound exists only so a pathological path can never spin this on the hot path.
+MAX_ANCESTOR_WALK = 64
+
+# A `.git` FILE is at most a line or two. Reading a bounded prefix means a
+# directory entry that is unexpectedly enormous cannot stall startup.
+GITFILE_READ_BYTES = 4096
+
+_SEP_RE = re.compile(r"[\\/]+")
+
+
+def _segments(path):
+    """Path segments of `path`, split on BOTH separators (a Windows path may be
+    read from a POSIX host and vice versa). Empty tuple on any non-string."""
+    if not isinstance(path, str) or not path:
+        return ()
+    return tuple(part for part in _SEP_RE.split(path) if part)
+
+
+def has_worktree_segment(path):
+    """True iff `path` contains a segment named `worktrees` or `*-worktrees`
+    (case-insensitive). Purely lexical — no filesystem access, no subprocess.
+
+    Matches `<repo>/.claude/worktrees/<id>/...` (Claude Code's own subagent
+    worktrees) and `../.codearbiter-worktrees/<slug>/...` (the
+    using-git-worktrees skill). Compares whole SEGMENTS, never substrings: a
+    directory literally called `worktrees-archive` is a name of its own, not a
+    container of worktrees, and matching it would decline to heal a perfectly
+    durable root."""
+    for part in _segments(path):
+        low = part.lower()
+        if low == "worktrees" or low.endswith("-worktrees"):
+            return True
+    return False
+
+
+def _ancestors(path):
+    """`path` (or its directory, if it names a file) and every parent above it,
+    nearest first, bounded by MAX_ANCESTOR_WALK. Yields nothing for junk."""
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        cur = os.path.abspath(path)
+        if not os.path.isdir(cur):
+            cur = os.path.dirname(cur)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return
+    for _ in range(MAX_ANCESTOR_WALK):
+        if not cur:
+            return
+        yield cur
+        parent = os.path.dirname(cur)
+        if parent == cur:  # filesystem root: dirname is a fixed point
+            return
+        cur = parent
+
+
+def _gitfile_points_at_worktree(gitfile):
+    """True iff the `.git` FILE at `gitfile` is a LINKED WORKTREE pointer.
+
+    Git writes `gitdir: <path>` into `.git` for both linked worktrees and
+    submodules, and the two must not be confused: a worktree points into
+    `<common>/.git/worktrees/<name>` (disposable), a submodule into
+    `<super>/.git/modules/<name>` (an ordinary long-lived checkout). The
+    `worktrees` segment in the TARGET is what separates them."""
+    try:
+        with open(gitfile, "rb") as f:
+            head = f.read(GITFILE_READ_BYTES)
+        lines = head.decode("utf-8", "replace").splitlines()
+        if not lines:
+            return False
+        first = lines[0].strip()
+        if not first.lower().startswith("gitdir:"):
+            return False
+        # split(":", 1) — the FIRST colon only, so a Windows target like
+        # `C:/Users/...` survives intact.
+        return has_worktree_segment(first.split(":", 1)[1].strip())
+    except Exception:  # noqa: BLE001 — unreadable reads as durable, by design
+        return False
+
+
+def in_linked_worktree(path):
+    """True iff `path` sits inside a LINKED git worktree.
+
+    Walks up from `path` to the first `.git` it meets — the boundary of the
+    repository the path actually belongs to — and decides there:
+      - `.git` is a DIRECTORY -> the main worktree. Durable. Stop.
+      - `.git` is a FILE      -> a linked worktree or a submodule; the pointer's
+                                 target says which. Stop either way.
+      - no `.git` at any level -> not in a repository at all (the ordinary
+                                 plugin-cache install). Durable.
+    Stopping at the NEAREST boundary is load-bearing: a real checkout nested
+    below some unrelated worktree marker must read as durable.
+
+    `path` may name a file (its directory is walked) or a directory, and need
+    not exist. Never raises."""
+    try:
+        for cur in _ancestors(path):
+            gitpath = os.path.join(cur, ".git")
+            if os.path.isdir(gitpath):
+                return False
+            if os.path.isfile(gitpath):
+                return _gitfile_points_at_worktree(gitpath)
+        return False
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False
+
+
+def is_ephemeral_path(path):
+    """True iff `path` must NOT be pinned into a long-lived global config.
+
+    Checks the free lexical signal FIRST and short-circuits on it, so the
+    confirmed production case is decided with zero I/O. Never raises."""
+    try:
+        if has_worktree_segment(path):
+            return True
+        return in_linked_worktree(path)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -32,6 +32,7 @@ from _gitexec import git_executable
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
+from _durabilitylib import is_ephemeral_path  # noqa: E402
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
     write_text_atomic,
@@ -411,13 +412,36 @@ def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None)
     Narrow that window by reloading the file fresh immediately before writing:
     if it differs from what we loaded, some other writer touched it in the
     interim, so we SKIP this heal entirely (never overwrite that write with
-    our now-stale snapshot) — a later session's heal simply retries."""
+    our now-stale snapshot) — a later session's heal simply retries.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). This hook runs on EVERY
+    SessionStart and pins an ABSOLUTE path into the user's GLOBAL settings.json.
+    A session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolves `plugin` to that worktree, and the
+    heal pinned the global config at a directory whose entire purpose is to be
+    pruned. When the root is not durable we leave the existing pin exactly as it
+    is — not healed, not cleared, no error.
+
+    wire-statusline.refresh_if_stale enforces the same rule (it is the producer,
+    and also reachable by a human running `--plugin-root <worktree>`), so this
+    check is deliberately REDUNDANT — but not decoratively so. `_load_wire_
+    statusline` loads that producer OUT OF `plugin` itself: a worktree cut from a
+    pre-fix branch supplies a pre-fix, unguarded producer, while THIS file may
+    have been loaded from somewhere else entirely (main() honours
+    $CLAUDE_PLUGIN_ROOT independently of where session-start.py came from). The
+    highest-consequence write on the machine gets to refuse on its own account
+    rather than on the good behaviour of whatever version it happened to load.
+    Both call sites share the one predicate, so there is no second policy to
+    drift."""
     try:
+        script_abs = os.path.join(plugin, "hooks", "statusline.py")
+        if is_ephemeral_path(script_abs):
+            return False
         ws = (loader or _load_wire_statusline)(plugin)
         if ws is None:
             return False
         spath = settings_path or ws.settings_path(None)
-        script_abs = os.path.join(plugin, "hooks", "statusline.py")
         interp = interp or ws.default_interp(None)
         settings, exists = ws.load_settings(spath)
         if not exists:

--- a/plugins/ca-codex/hooks/wire-statusline.py
+++ b/plugins/ca-codex/hooks/wire-statusline.py
@@ -33,6 +33,7 @@ import sys
 # session-start.py and the test suite both do) — always resolve _hooklib
 # relative to THIS file rather than relying on the caller's sys.path state.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _durabilitylib  # noqa: E402 — "may this path be pinned?" (see below)
 import _hooklib  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
 
@@ -230,6 +231,19 @@ def cmd_status(settings, exists, script_abs):
 
 
 def cmd_install(settings, path, script_abs, interp):
+    # Never pin a root that will not outlive the session (see refresh_if_stale's
+    # docstring for the defect). `install` is EXPLICIT — a human ran
+    # /ca:statusline, or passed `--plugin-root <worktree>` by hand — so this
+    # refuses LOUDLY where `refresh` degrades silently: a quiet no-op would leave
+    # that human believing the statusline was wired.
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        raise SystemExit(
+            f"REFUSING TO WIRE: {script_abs} is inside a git worktree (or another "
+            "root that will not survive being pruned).\n"
+            "~/.claude/settings.json is GLOBAL and holds an ABSOLUTE path, so "
+            "pinning it here breaks your statusline the moment this checkout goes "
+            "away.\nRe-run from your real install (the plugin cache, or your main "
+            "checkout), or pass --plugin-root pointing at it.")
     if not os.path.exists(script_abs):
         raise SystemExit(f"ERROR: renderer not found at {script_abs}; nothing wired.")
     new_cmd = build_command(interp, script_abs)
@@ -272,7 +286,30 @@ def refresh_if_stale(settings, script_abs, interp):
       - statusLine is a third-party line, or absent                       -> never touched, False
 
     Returning a changed-flag lets the caller persist ONLY on a real change, so a
-    steady-state session start never churns settings.json."""
+    steady-state session start never churns settings.json.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). settings.json is GLOBAL and
+    the pin is ABSOLUTE, but the running plugin root need not be long-lived: a
+    session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolved the root to that worktree and this
+    function cheerfully re-pointed the user's global config at it. The worktree
+    is then pruned — its entire purpose — and the statusline renders nothing.
+
+    So: when `script_abs` is not durable, LEAVE THE EXISTING PIN ALONE. Not
+    healed, not cleared, no error — the same silent degrade the rest of this path
+    already performs. It is emphatically NOT a kill-switch: a genuinely stale pin
+    from a real plugin-cache update still heals, because that root IS durable.
+    Clearing instead of skipping was considered and rejected — a user whose only
+    session that day is a worktree session would lose a working statusline over a
+    condition that resolves itself the next time they start from a real install.
+
+    The guard lives HERE, at the mutation itself, rather than only in
+    `cmd_refresh`: `session-start.heal_statusline_wiring` calls this function
+    DIRECTLY and never goes through `cmd_refresh`, so a guard one level up would
+    have left the confirmed corruption path wide open."""
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        return False
     current = settings.get("statusLine")
     if not is_ours(current, settings):
         return False

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.4] - 2026-07-25
+
+### Fixed
+
+- The SessionStart statusline self-heal no longer pins a NON-DURABLE plugin
+  root into the user's global `~/.claude/settings.json`. A session started
+  inside a git worktree resolved the plugin root to that worktree and rewrote
+  the global pin there; once the worktree was pruned the statusline rendered
+  nothing. A non-durable root is now inert - the existing pin is left exactly
+  as it is - while a genuinely stale pin from a real plugin-cache update still
+  heals. Explicit `wire-statusline.py install` from such a root refuses loudly
+  instead of writing a doomed path.
+
 ## [0.1.3] - 2026-07-24
 
 ### Security

--- a/plugins/ca-pi/hooks/_durabilitylib.py
+++ b/plugins/ca-pi/hooks/_durabilitylib.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# codeArbiter — durable-vs-ephemeral install-root detection.
+#
+# WHY THIS EXISTS (found in-session on 2026-07-25, after it broke the
+# maintainer's statusline three times in one day):
+#
+# A plugin cannot own a statusLine and ${CLAUDE_PLUGIN_ROOT} is NOT expanded
+# inside settings.json, so codeArbiter has to write an ABSOLUTE, version-pinned
+# renderer path into the user's GLOBAL ~/.claude/settings.json — and re-point it
+# on every SessionStart so a plugin update does not leave the old version wired.
+# That refresh had no notion of a root that will not survive the session. When a
+# session starts inside a git worktree (subagents routinely run in
+# <repo>/.claude/worktrees/<id>/), the plugin root IS the worktree's plugins/ca,
+# and the heal happily pinned the user's global config there:
+#
+#   "...\.claude\worktrees\wf_58ee3fa6-de1-8\plugins\ca\hooks\statusline.py"
+#
+# The worktree is then pruned — that is what worktrees are FOR — and the
+# statusline renders nothing until someone notices and re-runs /ca:statusline.
+#
+# This module answers exactly one question, for callers about to write a path
+# into a long-lived config: may this path be trusted to still be there?
+#
+# TWO INDEPENDENT SIGNALS, because each alone has a blind spot:
+#   1. LEXICAL (has_worktree_segment) — a `worktrees` or `*-worktrees` path
+#      segment. Free, no I/O at all, works even when the checkout is already
+#      gone. Covers the confirmed `.claude/worktrees/<id>/` case and the
+#      `../.codearbiter-worktrees/<slug>` layout the using-git-worktrees skill
+#      creates.
+#   2. GIT (in_linked_worktree) — the path lives in a LINKED worktree, read
+#      straight off git's own on-disk marker. Generalizes to a worktree parked
+#      anywhere under any name, which the lexical rule cannot see.
+#
+# NO SUBPROCESS, DELIBERATELY. This predicate is consulted on EVERY SessionStart,
+# before the dormant gate, in every repo on the machine. An earlier draft shelled
+# out to `git rev-parse --git-dir --git-common-dir`; that probe fails by design
+# in the ordinary plugin-cache install (which is not a git repository at all), so
+# it bought nothing in the common case while charging every session a process
+# spawn plus a timeout hazard. Git writes the answer to disk anyway: a LINKED
+# worktree's `.git` is a FILE reading `gitdir: <common>/.git/worktrees/<name>`,
+# while a normal checkout's `.git` is a DIRECTORY. A handful of stat() calls
+# gives the same answer, with no dependency on git being installed at all.
+#
+# FAILURE DIRECTION IS "DURABLE", DELIBERATELY. Anything unreadable, unparseable
+# or absent reads as durable. Reading uncertainty as "ephemeral" would silently
+# disable the self-heal for users whose installs are perfectly fine — a far worse
+# outcome than the residual it protects against.
+#
+# The lexical rule is deliberately a little broad (any `worktrees` segment, not
+# only one under `.claude`). The asymmetry justifies it: a false positive costs
+# an un-refreshed pin the user fixes with one explicit /ca:statusline run, while
+# a false negative corrupts their global config.
+#
+# Design principles (mirroring _gitexec.py / _gitlib.py):
+#   - Stdlib only; no third-party imports ever (ADR-0004).
+#   - Zero side effects at import time.
+#   - NEVER raises. This sits on the SessionStart path; it must not be the thing
+#     that crashes startup, whatever it is handed.
+#
+# Public API:
+#   has_worktree_segment(path) -> bool   lexical signal, no I/O
+#   in_linked_worktree(path) -> bool     git's on-disk marker, no subprocess
+#   is_ephemeral_path(path) -> bool      either signal
+
+import os
+import re
+
+# The walk from a plugin root to the filesystem root is a handful of levels; the
+# bound exists only so a pathological path can never spin this on the hot path.
+MAX_ANCESTOR_WALK = 64
+
+# A `.git` FILE is at most a line or two. Reading a bounded prefix means a
+# directory entry that is unexpectedly enormous cannot stall startup.
+GITFILE_READ_BYTES = 4096
+
+_SEP_RE = re.compile(r"[\\/]+")
+
+
+def _segments(path):
+    """Path segments of `path`, split on BOTH separators (a Windows path may be
+    read from a POSIX host and vice versa). Empty tuple on any non-string."""
+    if not isinstance(path, str) or not path:
+        return ()
+    return tuple(part for part in _SEP_RE.split(path) if part)
+
+
+def has_worktree_segment(path):
+    """True iff `path` contains a segment named `worktrees` or `*-worktrees`
+    (case-insensitive). Purely lexical — no filesystem access, no subprocess.
+
+    Matches `<repo>/.claude/worktrees/<id>/...` (Claude Code's own subagent
+    worktrees) and `../.codearbiter-worktrees/<slug>/...` (the
+    using-git-worktrees skill). Compares whole SEGMENTS, never substrings: a
+    directory literally called `worktrees-archive` is a name of its own, not a
+    container of worktrees, and matching it would decline to heal a perfectly
+    durable root."""
+    for part in _segments(path):
+        low = part.lower()
+        if low == "worktrees" or low.endswith("-worktrees"):
+            return True
+    return False
+
+
+def _ancestors(path):
+    """`path` (or its directory, if it names a file) and every parent above it,
+    nearest first, bounded by MAX_ANCESTOR_WALK. Yields nothing for junk."""
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        cur = os.path.abspath(path)
+        if not os.path.isdir(cur):
+            cur = os.path.dirname(cur)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return
+    for _ in range(MAX_ANCESTOR_WALK):
+        if not cur:
+            return
+        yield cur
+        parent = os.path.dirname(cur)
+        if parent == cur:  # filesystem root: dirname is a fixed point
+            return
+        cur = parent
+
+
+def _gitfile_points_at_worktree(gitfile):
+    """True iff the `.git` FILE at `gitfile` is a LINKED WORKTREE pointer.
+
+    Git writes `gitdir: <path>` into `.git` for both linked worktrees and
+    submodules, and the two must not be confused: a worktree points into
+    `<common>/.git/worktrees/<name>` (disposable), a submodule into
+    `<super>/.git/modules/<name>` (an ordinary long-lived checkout). The
+    `worktrees` segment in the TARGET is what separates them."""
+    try:
+        with open(gitfile, "rb") as f:
+            head = f.read(GITFILE_READ_BYTES)
+        lines = head.decode("utf-8", "replace").splitlines()
+        if not lines:
+            return False
+        first = lines[0].strip()
+        if not first.lower().startswith("gitdir:"):
+            return False
+        # split(":", 1) — the FIRST colon only, so a Windows target like
+        # `C:/Users/...` survives intact.
+        return has_worktree_segment(first.split(":", 1)[1].strip())
+    except Exception:  # noqa: BLE001 — unreadable reads as durable, by design
+        return False
+
+
+def in_linked_worktree(path):
+    """True iff `path` sits inside a LINKED git worktree.
+
+    Walks up from `path` to the first `.git` it meets — the boundary of the
+    repository the path actually belongs to — and decides there:
+      - `.git` is a DIRECTORY -> the main worktree. Durable. Stop.
+      - `.git` is a FILE      -> a linked worktree or a submodule; the pointer's
+                                 target says which. Stop either way.
+      - no `.git` at any level -> not in a repository at all (the ordinary
+                                 plugin-cache install). Durable.
+    Stopping at the NEAREST boundary is load-bearing: a real checkout nested
+    below some unrelated worktree marker must read as durable.
+
+    `path` may name a file (its directory is walked) or a directory, and need
+    not exist. Never raises."""
+    try:
+        for cur in _ancestors(path):
+            gitpath = os.path.join(cur, ".git")
+            if os.path.isdir(gitpath):
+                return False
+            if os.path.isfile(gitpath):
+                return _gitfile_points_at_worktree(gitpath)
+        return False
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False
+
+
+def is_ephemeral_path(path):
+    """True iff `path` must NOT be pinned into a long-lived global config.
+
+    Checks the free lexical signal FIRST and short-circuits on it, so the
+    confirmed production case is decided with zero I/O. Never raises."""
+    try:
+        if has_worktree_segment(path):
+            return True
+        return in_linked_worktree(path)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False

--- a/plugins/ca-pi/hooks/session-start.py
+++ b/plugins/ca-pi/hooks/session-start.py
@@ -32,6 +32,7 @@ from _gitexec import git_executable
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
+from _durabilitylib import is_ephemeral_path  # noqa: E402
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
     write_text_atomic,
@@ -411,13 +412,36 @@ def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None)
     Narrow that window by reloading the file fresh immediately before writing:
     if it differs from what we loaded, some other writer touched it in the
     interim, so we SKIP this heal entirely (never overwrite that write with
-    our now-stale snapshot) — a later session's heal simply retries."""
+    our now-stale snapshot) — a later session's heal simply retries.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). This hook runs on EVERY
+    SessionStart and pins an ABSOLUTE path into the user's GLOBAL settings.json.
+    A session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolves `plugin` to that worktree, and the
+    heal pinned the global config at a directory whose entire purpose is to be
+    pruned. When the root is not durable we leave the existing pin exactly as it
+    is — not healed, not cleared, no error.
+
+    wire-statusline.refresh_if_stale enforces the same rule (it is the producer,
+    and also reachable by a human running `--plugin-root <worktree>`), so this
+    check is deliberately REDUNDANT — but not decoratively so. `_load_wire_
+    statusline` loads that producer OUT OF `plugin` itself: a worktree cut from a
+    pre-fix branch supplies a pre-fix, unguarded producer, while THIS file may
+    have been loaded from somewhere else entirely (main() honours
+    $CLAUDE_PLUGIN_ROOT independently of where session-start.py came from). The
+    highest-consequence write on the machine gets to refuse on its own account
+    rather than on the good behaviour of whatever version it happened to load.
+    Both call sites share the one predicate, so there is no second policy to
+    drift."""
     try:
+        script_abs = os.path.join(plugin, "hooks", "statusline.py")
+        if is_ephemeral_path(script_abs):
+            return False
         ws = (loader or _load_wire_statusline)(plugin)
         if ws is None:
             return False
         spath = settings_path or ws.settings_path(None)
-        script_abs = os.path.join(plugin, "hooks", "statusline.py")
         interp = interp or ws.default_interp(None)
         settings, exists = ws.load_settings(spath)
         if not exists:

--- a/plugins/ca-pi/hooks/wire-statusline.py
+++ b/plugins/ca-pi/hooks/wire-statusline.py
@@ -33,6 +33,7 @@ import sys
 # session-start.py and the test suite both do) — always resolve _hooklib
 # relative to THIS file rather than relying on the caller's sys.path state.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _durabilitylib  # noqa: E402 — "may this path be pinned?" (see below)
 import _hooklib  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
 
@@ -230,6 +231,19 @@ def cmd_status(settings, exists, script_abs):
 
 
 def cmd_install(settings, path, script_abs, interp):
+    # Never pin a root that will not outlive the session (see refresh_if_stale's
+    # docstring for the defect). `install` is EXPLICIT — a human ran
+    # /ca:statusline, or passed `--plugin-root <worktree>` by hand — so this
+    # refuses LOUDLY where `refresh` degrades silently: a quiet no-op would leave
+    # that human believing the statusline was wired.
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        raise SystemExit(
+            f"REFUSING TO WIRE: {script_abs} is inside a git worktree (or another "
+            "root that will not survive being pruned).\n"
+            "~/.claude/settings.json is GLOBAL and holds an ABSOLUTE path, so "
+            "pinning it here breaks your statusline the moment this checkout goes "
+            "away.\nRe-run from your real install (the plugin cache, or your main "
+            "checkout), or pass --plugin-root pointing at it.")
     if not os.path.exists(script_abs):
         raise SystemExit(f"ERROR: renderer not found at {script_abs}; nothing wired.")
     new_cmd = build_command(interp, script_abs)
@@ -272,7 +286,30 @@ def refresh_if_stale(settings, script_abs, interp):
       - statusLine is a third-party line, or absent                       -> never touched, False
 
     Returning a changed-flag lets the caller persist ONLY on a real change, so a
-    steady-state session start never churns settings.json."""
+    steady-state session start never churns settings.json.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). settings.json is GLOBAL and
+    the pin is ABSOLUTE, but the running plugin root need not be long-lived: a
+    session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolved the root to that worktree and this
+    function cheerfully re-pointed the user's global config at it. The worktree
+    is then pruned — its entire purpose — and the statusline renders nothing.
+
+    So: when `script_abs` is not durable, LEAVE THE EXISTING PIN ALONE. Not
+    healed, not cleared, no error — the same silent degrade the rest of this path
+    already performs. It is emphatically NOT a kill-switch: a genuinely stale pin
+    from a real plugin-cache update still heals, because that root IS durable.
+    Clearing instead of skipping was considered and rejected — a user whose only
+    session that day is a worktree session would lose a working statusline over a
+    condition that resolves itself the next time they start from a real install.
+
+    The guard lives HERE, at the mutation itself, rather than only in
+    `cmd_refresh`: `session-start.heal_statusline_wiring` calls this function
+    DIRECTLY and never goes through `cmd_refresh`, so a guard one level up would
+    have left the confirmed corruption path wide open."""
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        return False
     current = settings.get("statusLine")
     if not is_ours(current, settings):
         return False

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/commands/statusline.md
+++ b/plugins/ca/commands/statusline.md
@@ -46,7 +46,13 @@ colors.
    show the user the resolved command and the prior line it will back up, and confirm.** Editing the
    user's global settings is their call, not yours.
 
+   The script REFUSES to wire a plugin root that will not outlive the session — a git worktree, for
+   instance. `settings.json` is global and the pin is absolute, so a worktree path breaks the
+   statusline the moment that checkout is pruned. On a refusal, report it verbatim and re-run from
+   the real install (the plugin cache, or the main checkout) rather than working around it.
+
 3. **uninstall** — restore the backed-up line, or remove `statusLine` entirely if none existed.
+   Never blocked, wherever it is run from — a user stuck with a dead pin must be able to clear it.
 
 4. **status** — report the current `statusLine.command`, whether it is codeArbiter's, and any backup
    on file. Changes nothing.

--- a/plugins/ca/hooks/_durabilitylib.py
+++ b/plugins/ca/hooks/_durabilitylib.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# codeArbiter — durable-vs-ephemeral install-root detection.
+#
+# WHY THIS EXISTS (found in-session on 2026-07-25, after it broke the
+# maintainer's statusline three times in one day):
+#
+# A plugin cannot own a statusLine and ${CLAUDE_PLUGIN_ROOT} is NOT expanded
+# inside settings.json, so codeArbiter has to write an ABSOLUTE, version-pinned
+# renderer path into the user's GLOBAL ~/.claude/settings.json — and re-point it
+# on every SessionStart so a plugin update does not leave the old version wired.
+# That refresh had no notion of a root that will not survive the session. When a
+# session starts inside a git worktree (subagents routinely run in
+# <repo>/.claude/worktrees/<id>/), the plugin root IS the worktree's plugins/ca,
+# and the heal happily pinned the user's global config there:
+#
+#   "...\.claude\worktrees\wf_58ee3fa6-de1-8\plugins\ca\hooks\statusline.py"
+#
+# The worktree is then pruned — that is what worktrees are FOR — and the
+# statusline renders nothing until someone notices and re-runs /ca:statusline.
+#
+# This module answers exactly one question, for callers about to write a path
+# into a long-lived config: may this path be trusted to still be there?
+#
+# TWO INDEPENDENT SIGNALS, because each alone has a blind spot:
+#   1. LEXICAL (has_worktree_segment) — a `worktrees` or `*-worktrees` path
+#      segment. Free, no I/O at all, works even when the checkout is already
+#      gone. Covers the confirmed `.claude/worktrees/<id>/` case and the
+#      `../.codearbiter-worktrees/<slug>` layout the using-git-worktrees skill
+#      creates.
+#   2. GIT (in_linked_worktree) — the path lives in a LINKED worktree, read
+#      straight off git's own on-disk marker. Generalizes to a worktree parked
+#      anywhere under any name, which the lexical rule cannot see.
+#
+# NO SUBPROCESS, DELIBERATELY. This predicate is consulted on EVERY SessionStart,
+# before the dormant gate, in every repo on the machine. An earlier draft shelled
+# out to `git rev-parse --git-dir --git-common-dir`; that probe fails by design
+# in the ordinary plugin-cache install (which is not a git repository at all), so
+# it bought nothing in the common case while charging every session a process
+# spawn plus a timeout hazard. Git writes the answer to disk anyway: a LINKED
+# worktree's `.git` is a FILE reading `gitdir: <common>/.git/worktrees/<name>`,
+# while a normal checkout's `.git` is a DIRECTORY. A handful of stat() calls
+# gives the same answer, with no dependency on git being installed at all.
+#
+# FAILURE DIRECTION IS "DURABLE", DELIBERATELY. Anything unreadable, unparseable
+# or absent reads as durable. Reading uncertainty as "ephemeral" would silently
+# disable the self-heal for users whose installs are perfectly fine — a far worse
+# outcome than the residual it protects against.
+#
+# The lexical rule is deliberately a little broad (any `worktrees` segment, not
+# only one under `.claude`). The asymmetry justifies it: a false positive costs
+# an un-refreshed pin the user fixes with one explicit /ca:statusline run, while
+# a false negative corrupts their global config.
+#
+# Design principles (mirroring _gitexec.py / _gitlib.py):
+#   - Stdlib only; no third-party imports ever (ADR-0004).
+#   - Zero side effects at import time.
+#   - NEVER raises. This sits on the SessionStart path; it must not be the thing
+#     that crashes startup, whatever it is handed.
+#
+# Public API:
+#   has_worktree_segment(path) -> bool   lexical signal, no I/O
+#   in_linked_worktree(path) -> bool     git's on-disk marker, no subprocess
+#   is_ephemeral_path(path) -> bool      either signal
+
+import os
+import re
+
+# The walk from a plugin root to the filesystem root is a handful of levels; the
+# bound exists only so a pathological path can never spin this on the hot path.
+MAX_ANCESTOR_WALK = 64
+
+# A `.git` FILE is at most a line or two. Reading a bounded prefix means a
+# directory entry that is unexpectedly enormous cannot stall startup.
+GITFILE_READ_BYTES = 4096
+
+_SEP_RE = re.compile(r"[\\/]+")
+
+
+def _segments(path):
+    """Path segments of `path`, split on BOTH separators (a Windows path may be
+    read from a POSIX host and vice versa). Empty tuple on any non-string."""
+    if not isinstance(path, str) or not path:
+        return ()
+    return tuple(part for part in _SEP_RE.split(path) if part)
+
+
+def has_worktree_segment(path):
+    """True iff `path` contains a segment named `worktrees` or `*-worktrees`
+    (case-insensitive). Purely lexical — no filesystem access, no subprocess.
+
+    Matches `<repo>/.claude/worktrees/<id>/...` (Claude Code's own subagent
+    worktrees) and `../.codearbiter-worktrees/<slug>/...` (the
+    using-git-worktrees skill). Compares whole SEGMENTS, never substrings: a
+    directory literally called `worktrees-archive` is a name of its own, not a
+    container of worktrees, and matching it would decline to heal a perfectly
+    durable root."""
+    for part in _segments(path):
+        low = part.lower()
+        if low == "worktrees" or low.endswith("-worktrees"):
+            return True
+    return False
+
+
+def _ancestors(path):
+    """`path` (or its directory, if it names a file) and every parent above it,
+    nearest first, bounded by MAX_ANCESTOR_WALK. Yields nothing for junk."""
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        cur = os.path.abspath(path)
+        if not os.path.isdir(cur):
+            cur = os.path.dirname(cur)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return
+    for _ in range(MAX_ANCESTOR_WALK):
+        if not cur:
+            return
+        yield cur
+        parent = os.path.dirname(cur)
+        if parent == cur:  # filesystem root: dirname is a fixed point
+            return
+        cur = parent
+
+
+def _gitfile_points_at_worktree(gitfile):
+    """True iff the `.git` FILE at `gitfile` is a LINKED WORKTREE pointer.
+
+    Git writes `gitdir: <path>` into `.git` for both linked worktrees and
+    submodules, and the two must not be confused: a worktree points into
+    `<common>/.git/worktrees/<name>` (disposable), a submodule into
+    `<super>/.git/modules/<name>` (an ordinary long-lived checkout). The
+    `worktrees` segment in the TARGET is what separates them."""
+    try:
+        with open(gitfile, "rb") as f:
+            head = f.read(GITFILE_READ_BYTES)
+        lines = head.decode("utf-8", "replace").splitlines()
+        if not lines:
+            return False
+        first = lines[0].strip()
+        if not first.lower().startswith("gitdir:"):
+            return False
+        # split(":", 1) — the FIRST colon only, so a Windows target like
+        # `C:/Users/...` survives intact.
+        return has_worktree_segment(first.split(":", 1)[1].strip())
+    except Exception:  # noqa: BLE001 — unreadable reads as durable, by design
+        return False
+
+
+def in_linked_worktree(path):
+    """True iff `path` sits inside a LINKED git worktree.
+
+    Walks up from `path` to the first `.git` it meets — the boundary of the
+    repository the path actually belongs to — and decides there:
+      - `.git` is a DIRECTORY -> the main worktree. Durable. Stop.
+      - `.git` is a FILE      -> a linked worktree or a submodule; the pointer's
+                                 target says which. Stop either way.
+      - no `.git` at any level -> not in a repository at all (the ordinary
+                                 plugin-cache install). Durable.
+    Stopping at the NEAREST boundary is load-bearing: a real checkout nested
+    below some unrelated worktree marker must read as durable.
+
+    `path` may name a file (its directory is walked) or a directory, and need
+    not exist. Never raises."""
+    try:
+        for cur in _ancestors(path):
+            gitpath = os.path.join(cur, ".git")
+            if os.path.isdir(gitpath):
+                return False
+            if os.path.isfile(gitpath):
+                return _gitfile_points_at_worktree(gitpath)
+        return False
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False
+
+
+def is_ephemeral_path(path):
+    """True iff `path` must NOT be pinned into a long-lived global config.
+
+    Checks the free lexical signal FIRST and short-circuits on it, so the
+    confirmed production case is decided with zero I/O. Never raises."""
+    try:
+        if has_worktree_segment(path):
+            return True
+        return in_linked_worktree(path)
+    except Exception:  # noqa: BLE001 — a probe must never crash its caller
+        return False

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -32,6 +32,7 @@ from _gitexec import git_executable
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin root + capability flags
+from _durabilitylib import is_ephemeral_path  # noqa: E402
 from _hooklib import (  # noqa: E402
     frontmatter_enabled, get_host, project_root, set_host, utf8_stdio,
     write_text_atomic,
@@ -411,13 +412,36 @@ def heal_statusline_wiring(plugin, settings_path=None, interp=None, loader=None)
     Narrow that window by reloading the file fresh immediately before writing:
     if it differs from what we loaded, some other writer touched it in the
     interim, so we SKIP this heal entirely (never overwrite that write with
-    our now-stale snapshot) — a later session's heal simply retries."""
+    our now-stale snapshot) — a later session's heal simply retries.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). This hook runs on EVERY
+    SessionStart and pins an ABSOLUTE path into the user's GLOBAL settings.json.
+    A session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolves `plugin` to that worktree, and the
+    heal pinned the global config at a directory whose entire purpose is to be
+    pruned. When the root is not durable we leave the existing pin exactly as it
+    is — not healed, not cleared, no error.
+
+    wire-statusline.refresh_if_stale enforces the same rule (it is the producer,
+    and also reachable by a human running `--plugin-root <worktree>`), so this
+    check is deliberately REDUNDANT — but not decoratively so. `_load_wire_
+    statusline` loads that producer OUT OF `plugin` itself: a worktree cut from a
+    pre-fix branch supplies a pre-fix, unguarded producer, while THIS file may
+    have been loaded from somewhere else entirely (main() honours
+    $CLAUDE_PLUGIN_ROOT independently of where session-start.py came from). The
+    highest-consequence write on the machine gets to refuse on its own account
+    rather than on the good behaviour of whatever version it happened to load.
+    Both call sites share the one predicate, so there is no second policy to
+    drift."""
     try:
+        script_abs = os.path.join(plugin, "hooks", "statusline.py")
+        if is_ephemeral_path(script_abs):
+            return False
         ws = (loader or _load_wire_statusline)(plugin)
         if ws is None:
             return False
         spath = settings_path or ws.settings_path(None)
-        script_abs = os.path.join(plugin, "hooks", "statusline.py")
         interp = interp or ws.default_interp(None)
         settings, exists = ws.load_settings(spath)
         if not exists:

--- a/plugins/ca/hooks/tests/_helpers.py
+++ b/plugins/ca/hooks/tests/_helpers.py
@@ -36,6 +36,38 @@ def fixture(name):
         return f.read()
 
 
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def durable_plugin_copy(tmpdir):
+    """Copy the real plugin's top-level `hooks/*.py` payload into `tmpdir` and
+    return the copy's plugin root.
+
+    Since 2026-07-25 the statusline pin writers REFUSE a non-durable plugin root
+    (a git worktree), and codeArbiter's own checkout is very often exactly that:
+    subagents run in `<repo>/.claude/worktrees/<id>/`. A test that drove the REAL
+    plugin root would therefore heal or decline depending on where the suite
+    happened to be run from — green in CI, red on a maintainer's machine, for
+    reasons having nothing to do with the behaviour under test.
+
+    Copying into a plain temp dir makes "durable" a property of the FIXTURE
+    rather than of the developer's checkout. Only top-level `.py` files are
+    copied: that is the whole import surface `wire-statusline.py` needs
+    (`_hooklib`, `hostapi`, `_gitexec`, `_durabilitylib`, `_host`), and it keeps
+    the copy cheap enough to run in setUp."""
+    root = os.path.join(tmpdir, "durable-plugin", "ca")
+    hooks = os.path.join(root, "hooks")
+    os.makedirs(hooks, exist_ok=True)
+    for name in os.listdir(HOOKS):
+        src = os.path.join(HOOKS, name)
+        if name.endswith(".py") and os.path.isfile(src):
+            with open(src, "rb") as f:
+                data = f.read()
+            with open(os.path.join(hooks, name), "wb") as f:
+                f.write(data)
+    return root
+
+
 def _line(obj):
     return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
 

--- a/plugins/ca/hooks/tests/test_atomic_writes.py
+++ b/plugins/ca/hooks/tests/test_atomic_writes.py
@@ -28,7 +28,7 @@ sys.path.insert(0, _TESTS_DIR)
 
 import _githooks  # noqa: E402
 import _prunelib as P  # noqa: E402
-from _helpers import redirect_home, restore_home  # noqa: E402
+from _helpers import durable_plugin_copy, redirect_home, restore_home  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +209,11 @@ class HealReloadBeforeSaveTest(unittest.TestCase):
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
-        self.plugin = os.path.dirname(os.path.dirname(os.path.abspath(_ss.__file__)))
+        # A DURABLE plugin root (see _helpers.durable_plugin_copy): the heal now
+        # refuses a non-durable one, and codeArbiter's own checkout is very often
+        # a git worktree — which would make these reliability-009 assertions
+        # depend on where the suite was run from.
+        self.plugin = durable_plugin_copy(self.tmp.name)
         d = os.path.join(self.tmp.name, ".claude")
         os.makedirs(d)
         self.settings = os.path.join(d, "settings.json")

--- a/plugins/ca/hooks/tests/test_durabilitylib.py
+++ b/plugins/ca/hooks/tests/test_durabilitylib.py
@@ -1,0 +1,217 @@
+"""Unit tests for _durabilitylib — "may this path be pinned into a long-lived
+global config?".
+
+Found in-session on 2026-07-25, after `heal_statusline_wiring()` rewrote the
+maintainer's GLOBAL ~/.claude/settings.json to a git-worktree path three times
+in one day. The worktree is then pruned — that is what worktrees are FOR — and
+the statusline renders nothing.
+
+Two independent signals, because each alone has a blind spot:
+  * LEXICAL  — a `worktrees` / `*-worktrees` path segment. Covers the confirmed
+               `<repo>/.claude/worktrees/<id>/` shape and the
+               `../.codearbiter-worktrees/<slug>` layout, with zero I/O.
+  * GIT      — the path lives inside a LINKED git worktree, detected by git's
+               own on-disk marker: a linked worktree's `.git` is a FILE reading
+               `gitdir: <common>/.git/worktrees/<name>`, never a directory.
+               Catches a worktree parked anywhere under any name.
+
+Both directions matter, so both are pinned here: a false positive costs one
+un-refreshed pin the user fixes with a single /ca:statusline run, while a false
+negative corrupts their global config.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if HOOKS not in sys.path:
+    sys.path.insert(0, HOOKS)
+
+import _durabilitylib as dl
+
+
+def _mkdirs(*parts):
+    path = os.path.join(*parts)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _write(path, text):
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
+
+
+class TestHasWorktreeSegment(unittest.TestCase):
+    """The zero-I/O lexical signal. Segment equality, never substring."""
+
+    def test_claude_subagent_worktree_matches(self):
+        # The exact shape observed on the maintainer's machine.
+        self.assertTrue(dl.has_worktree_segment(
+            r"C:\Users\me\repo\.claude\worktrees\wf_58ee3fa6-de1-8"
+            r"\plugins\ca\hooks\statusline.py"))
+
+    def test_codearbiter_worktrees_layout_matches(self):
+        # The layout the using-git-worktrees skill creates.
+        self.assertTrue(dl.has_worktree_segment(
+            "/home/me/.codearbiter-worktrees/add-widget/plugins/ca/hooks/statusline.py"))
+
+    def test_plugin_cache_install_does_not_match(self):
+        self.assertFalse(dl.has_worktree_segment(
+            r"C:\Users\me\.claude\plugins\cache\codearbiter\ca\2.8.13"
+            r"\hooks\statusline.py"))
+
+    def test_source_checkout_does_not_match(self):
+        self.assertFalse(dl.has_worktree_segment(
+            "/home/me/projects/codeArbiter/plugins/ca/hooks/statusline.py"))
+
+    def test_substring_is_not_a_segment(self):
+        # `worktrees-archive` is a directory of its own name, not a container of
+        # worktrees. Matching it would decline to heal a perfectly durable root.
+        self.assertFalse(dl.has_worktree_segment(
+            "/srv/worktrees-archive/ca/hooks/statusline.py"))
+        self.assertFalse(dl.has_worktree_segment(
+            "/srv/myworktreesbackup/ca/hooks/statusline.py"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(dl.has_worktree_segment(r"C:\repo\.claude\WorkTrees\x\y"))
+
+    def test_mixed_separators(self):
+        # A Windows path can be read out of a POSIX-written config and vice versa.
+        self.assertTrue(dl.has_worktree_segment("C:/repo/.claude\\worktrees/x/y"))
+
+    def test_junk_input_is_false_never_raises(self):
+        for junk in (None, "", 17, [], {}, object()):
+            self.assertFalse(dl.has_worktree_segment(junk))
+
+
+class TestInLinkedWorktree(unittest.TestCase):
+    """The git signal, read straight off disk — no subprocess.
+
+    Git's own marker: in a LINKED worktree `.git` is a FILE containing
+    `gitdir: <common>/.git/worktrees/<name>`; in the main worktree `.git` is a
+    DIRECTORY. A submodule also uses a `.git` file, but its gitdir points at
+    `<super>/.git/modules/<name>` — durable, and must not be confused for one.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_linked_worktree_gitfile_is_ephemeral(self):
+        repo = _mkdirs(self.root, "ca-feature")
+        _write(os.path.join(repo, ".git"),
+               "gitdir: C:/Users/me/projects/codeArbiter/.git/worktrees/ca-feature\n")
+        deep = _mkdirs(repo, "plugins", "ca", "hooks")
+        self.assertTrue(dl.in_linked_worktree(deep))
+
+    def test_signal_survives_a_file_argument(self):
+        repo = _mkdirs(self.root, "ca-feature")
+        _write(os.path.join(repo, ".git"),
+               "gitdir: /home/me/codeArbiter/.git/worktrees/ca-feature\n")
+        hooks = _mkdirs(repo, "plugins", "ca", "hooks")
+        script = os.path.join(hooks, "statusline.py")
+        _write(script, "")
+        self.assertTrue(dl.in_linked_worktree(script))
+
+    def test_main_checkout_gitdir_is_durable(self):
+        repo = _mkdirs(self.root, "codeArbiter")
+        _mkdirs(repo, ".git")
+        deep = _mkdirs(repo, "plugins", "ca", "hooks")
+        self.assertFalse(dl.in_linked_worktree(deep))
+
+    def test_submodule_gitfile_is_durable(self):
+        # A submodule is a normal, long-lived checkout: `.git` is a file, but it
+        # points into `modules/`, not `worktrees/`.
+        sub = _mkdirs(self.root, "super", "vendor", "ca")
+        _write(os.path.join(sub, ".git"),
+               "gitdir: ../../.git/modules/vendor/ca\n")
+        self.assertFalse(dl.in_linked_worktree(_mkdirs(sub, "hooks")))
+
+    def test_no_git_anywhere_is_durable(self):
+        # The ordinary install: the plugin cache is not a git repository at all.
+        cache = _mkdirs(self.root, ".claude", "plugins", "cache",
+                        "codearbiter", "ca", "2.8.13", "hooks")
+        self.assertFalse(dl.in_linked_worktree(cache))
+
+    def test_unreadable_or_garbage_gitfile_is_durable(self):
+        repo = _mkdirs(self.root, "weird")
+        _write(os.path.join(repo, ".git"), "this is not a gitdir pointer\n")
+        self.assertFalse(dl.in_linked_worktree(_mkdirs(repo, "hooks")))
+
+    def test_nearest_boundary_wins(self):
+        # A real main checkout that merely SITS somewhere below an unrelated
+        # linked-worktree marker must read as durable: the walk stops at the
+        # first `.git` it meets, which is the repository the path belongs to.
+        outer = _mkdirs(self.root, "outer")
+        _write(os.path.join(outer, ".git"), "gitdir: /x/.git/worktrees/outer\n")
+        inner = _mkdirs(outer, "nested", "codeArbiter")
+        _mkdirs(inner, ".git")
+        self.assertFalse(dl.in_linked_worktree(_mkdirs(inner, "plugins", "ca")))
+
+    def test_junk_input_is_false_never_raises(self):
+        for junk in (None, "", 17, [], {}):
+            self.assertFalse(dl.in_linked_worktree(junk))
+
+
+class TestIsEphemeralPath(unittest.TestCase):
+    """The combined predicate the pin writers actually call."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_lexical_signal_alone_is_enough(self):
+        # No git anywhere near it — the confirmed case, decided for free.
+        self.assertTrue(dl.is_ephemeral_path(
+            os.path.join(self.tmp.name, "repo", ".claude", "worktrees",
+                         "wf_58ee3fa6-de1-8", "plugins", "ca", "hooks",
+                         "statusline.py")))
+
+    def test_git_signal_alone_is_enough(self):
+        # A worktree parked under an ordinary name: the lexical rule cannot see
+        # it, so this is exactly what the git signal is here to catch.
+        repo = _mkdirs(self.tmp.name, "ca-feature")
+        _write(os.path.join(repo, ".git"), "gitdir: /x/.git/worktrees/ca-feature\n")
+        script = os.path.join(_mkdirs(repo, "plugins", "ca", "hooks"),
+                              "statusline.py")
+        self.assertFalse(dl.has_worktree_segment(script))
+        self.assertTrue(dl.is_ephemeral_path(script))
+
+    def test_plugin_cache_install_is_durable(self):
+        cache = os.path.join(self.tmp.name, ".claude", "plugins", "cache",
+                             "codearbiter", "ca", "2.8.13", "hooks",
+                             "statusline.py")
+        _mkdirs(os.path.dirname(cache))
+        self.assertFalse(dl.is_ephemeral_path(cache))
+
+    def test_junk_input_is_false_never_raises(self):
+        for junk in (None, "", 17, [], {}):
+            self.assertFalse(dl.is_ephemeral_path(junk))
+
+
+class TestHotPathCost(unittest.TestCase):
+    """This predicate is consulted on EVERY SessionStart, before the dormant
+    gate, in every repo on the machine. It must not spawn a process.
+
+    An earlier draft shelled out to `git rev-parse --git-dir --git-common-dir`.
+    That probe fails by design in the ordinary plugin-cache install (not a git
+    repo at all), so it bought nothing there while charging every session a
+    process spawn plus a timeout hazard. Git's on-disk marker gives the same
+    answer from a handful of stat() calls."""
+
+    def test_module_does_not_import_subprocess(self):
+        self.assertFalse(
+            hasattr(dl, "subprocess"),
+            "_durabilitylib must stay subprocess-free: it runs on the "
+            "SessionStart hot path in every repo.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -30,6 +30,17 @@ local_date_iso = _mod.local_date_iso
 write_standup_marker = _mod.write_standup_marker
 provenance_drift_line = _mod.provenance_drift_line
 
+from _helpers import durable_plugin_copy  # noqa: E402
+
+# The real plugin payload root (parent of the hooks/ dir holding session-start.py).
+_REAL_PLUGIN = os.path.dirname(os.path.dirname(os.path.abspath(_mod.__file__)))
+
+# A ca-owned pin left behind by an OLD plugin-cache version — the genuine
+# stale-pin condition the heal exists to repair.
+STALE_CACHE_PIN = (
+    '"python" "C:\\Users\\me\\.claude\\plugins\\cache\\codearbiter\\ca\\2.0.1'
+    '\\hooks\\statusline.py"')
+
 
 class TestHasSource(unittest.TestCase):
     def setUp(self):
@@ -163,9 +174,10 @@ class TestHealStatuslineWiring(unittest.TestCase):
 
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
-        # Real plugin root = parent of the hooks/ dir holding session-start.py.
-        self.plugin = os.path.dirname(
-            os.path.dirname(os.path.abspath(_mod.__file__)))
+        # A DURABLE copy of the real plugin payload — see durable_plugin_copy().
+        # (Was the real plugin root; that made the outcome depend on whether the
+        # suite was run from a git worktree, once the heal started refusing one.)
+        self.plugin = durable_plugin_copy(self._tmp.name)
         self.real_script = os.path.join(self.plugin, "hooks", "statusline.py")
         d = os.path.join(self._tmp.name, ".claude")
         os.makedirs(d)
@@ -227,6 +239,157 @@ class TestHealStatuslineWiring(unittest.TestCase):
                 loader=lambda _p: None))
 
 
+class TestHealRefusesNonDurableRoot(unittest.TestCase):
+    """Found in-session on 2026-07-25, after it broke the maintainer's
+    statusline three times in one day.
+
+    `heal_statusline_wiring()` runs on EVERY SessionStart and rewrites the
+    GLOBAL `~/.claude/settings.json` to the CURRENT plugin root. When the
+    session starts inside a git worktree (subagents routinely run in
+    `<repo>/.claude/worktrees/<id>/`) that root is the worktree's own
+    `plugins/ca`, so the heal pinned the user's global statusline at a directory
+    whose entire purpose is to be pruned:
+
+        "...\\.claude\\worktrees\\wf_58ee3fa6-de1-8\\plugins\\ca\\hooks\\statusline.py"
+
+    Contract: a session rooted in a non-durable checkout is INERT with respect
+    to the user's global config — the existing pin is left exactly as it is
+    (not healed, not cleared, no error). A genuinely stale pin from a real
+    plugin-cache update must still heal, so BOTH directions are proven here."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        # One real wire-statusline module, loaded once from the real payload and
+        # injected through the `loader=` seam, so `plugin` is free to be any
+        # shape at all — including one that does not exist on disk.
+        self.ws = _mod._load_wire_statusline(_REAL_PLUGIN)
+        self.assertIsNotNone(self.ws, "wire-statusline.py must load")
+        d = os.path.join(self._tmp.name, ".claude")
+        os.makedirs(d)
+        self.settings = os.path.join(d, "settings.json")
+        self._write({"statusLine": {"type": "command", "command": STALE_CACHE_PIN}})
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, obj):
+        with open(self.settings, "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2)
+        self.before = self._bytes()
+
+    def _bytes(self):
+        with open(self.settings, "rb") as f:
+            return f.read()
+
+    def _heal(self, plugin, loader=None):
+        return _mod.heal_statusline_wiring(
+            plugin, settings_path=self.settings, interp="python",
+            loader=loader or (lambda _p: self.ws))
+
+    def _worktree_root(self):
+        """The confirmed shape: a Claude Code subagent worktree checkout."""
+        return os.path.join(self._tmp.name, "repo", ".claude", "worktrees",
+                            "wf_58ee3fa6-de1-8", "plugins", "ca")
+
+    def _durable_root(self):
+        """The ordinary shape: an updated plugin-cache install."""
+        return os.path.join(self._tmp.name, "home", ".claude", "plugins",
+                            "cache", "codearbiter", "ca", "9.9.9")
+
+    # --- proof 1: a worktree-rooted heal changes nothing -------------------
+
+    def test_worktree_root_leaves_settings_byte_identical(self):
+        self.assertFalse(self._heal(self._worktree_root()))
+        self.assertEqual(self._bytes(), self.before)
+
+    def test_worktree_root_pin_never_appears_in_settings(self):
+        self._heal(self._worktree_root())
+        with open(self.settings, encoding="utf-8") as f:
+            raw = f.read()
+        self.assertNotIn("worktrees", raw)
+        self.assertEqual(json.loads(raw)["statusLine"]["command"], STALE_CACHE_PIN)
+
+    def test_worktree_root_does_not_repair_an_already_worktree_pin(self):
+        # The maintainer's observed corrupted state, re-entered from ANOTHER
+        # worktree: leave it alone rather than swap one doomed pin for another.
+        # A later session from a durable root is what repairs it.
+        pinned = ('"python" "C:\\Users\\me\\repo\\.claude\\worktrees'
+                  '\\wf_b7160646-041-2\\plugins\\ca\\hooks\\statusline.py"')
+        self._write({"statusLine": {"type": "command", "command": pinned},
+                     self.ws.OWNER_KEY: pinned})
+        self.assertFalse(self._heal(self._worktree_root()))
+        self.assertEqual(self._bytes(), self.before)
+
+    def test_caller_refuses_even_an_unguarded_producer(self):
+        # WHY THE CALLER GUARDS TOO. `heal_statusline_wiring` loads
+        # wire-statusline.py FROM `plugin` — i.e. out of the very worktree it is
+        # about to pin. A worktree cut from a pre-fix branch therefore supplies a
+        # pre-fix, UNGUARDED producer, while session-start.py itself may have
+        # been loaded from elsewhere (main() honours $CLAUDE_PLUGIN_ROOT
+        # independently of where this file came from). The heal must refuse on
+        # its own account, not on the loaded module's good behaviour.
+        unguarded = _Unguarded(self.ws)
+        self.assertFalse(self._heal(self._worktree_root(),
+                                    loader=lambda _p: unguarded))
+        self.assertEqual(self._bytes(), self.before)
+        self.assertFalse(unguarded.refresh_called,
+                         "the heal must bail BEFORE reaching the producer")
+
+    # --- proof 2: a stale-but-durable pin still heals ----------------------
+
+    def test_durable_stale_pin_still_heals(self):
+        # The feature is NOT disabled: a real plugin-cache update still
+        # re-points the pin at the new version's renderer.
+        self.assertTrue(self._heal(self._durable_root()))
+        cmd = json.loads(self._bytes().decode("utf-8"))["statusLine"]["command"]
+        self.assertIn(os.path.join(self._durable_root(), "hooks", "statusline.py"), cmd)
+        self.assertNotIn("2.0.1", cmd)
+
+    def test_durable_root_repairs_a_worktree_pin_left_by_the_bug(self):
+        # Forward fix: the corruption already on the maintainer's disk self-heals
+        # the next time a session starts from a durable root.
+        pinned = ('"python" "C:\\Users\\me\\repo\\.claude\\worktrees'
+                  '\\wf_b7160646-041-2\\plugins\\ca\\hooks\\statusline.py"')
+        self._write({"statusLine": {"type": "command", "command": pinned},
+                     self.ws.OWNER_KEY: pinned})
+        self.assertTrue(self._heal(self._durable_root()))
+        cmd = json.loads(self._bytes().decode("utf-8"))["statusLine"]["command"]
+        self.assertNotIn("worktrees", cmd)
+
+    # --- proof 3: a third-party line is still never touched ----------------
+
+    def test_worktree_root_still_never_touches_a_third_party_line(self):
+        self._write({"statusLine": {"type": "command", "command": "theirs --x"}})
+        self.assertFalse(self._heal(self._worktree_root()))
+        self.assertEqual(self._bytes(), self.before)
+
+    def test_durable_root_still_never_touches_a_third_party_line(self):
+        # The pre-existing contract, re-proven on the path that DOES write.
+        self._write({"statusLine": {"type": "command", "command": "theirs --x"}})
+        self.assertFalse(self._heal(self._durable_root()))
+        self.assertEqual(self._bytes(), self.before)
+
+
+class _Unguarded:
+    """A stand-in for a PRE-FIX vendored wire-statusline.py: every real function
+    except `refresh_if_stale`, which unconditionally rewrites the pin exactly as
+    the module did before 2026-07-25."""
+
+    def __init__(self, real):
+        self._real = real
+        self.refresh_called = False
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def refresh_if_stale(self, settings, script_abs, interp):
+        self.refresh_called = True
+        desired = self._real.build_command(interp, script_abs)
+        settings["statusLine"] = self._real.owned_statusline(desired)
+        settings[self._real.OWNER_KEY] = desired
+        return True
+
+
 class TestMainHealsBeforeDormantGate(unittest.TestCase):
     """Regression (#fix): the heal must run from main() BEFORE the dormant early
     return, so a plugin update re-points the pin in EVERY session — even a
@@ -245,8 +408,9 @@ class TestMainHealsBeforeDormantGate(unittest.TestCase):
         self.settings = os.path.join(self.home, ".claude", "settings.json")
         with open(self.settings, "w", encoding="utf-8") as f:
             json.dump({"statusLine": {"type": "command",
-                       "command": '"python" "C:\\Users\\me\\.claude\\plugins\\cache\\codearbiter\\ca\\2.0.1\\hooks\\statusline.py"'}}, f)
-        self.plugin = os.path.dirname(os.path.dirname(os.path.abspath(_mod.__file__)))
+                       "command": STALE_CACHE_PIN}}, f)
+        # A DURABLE copy of the real payload — see durable_plugin_copy().
+        self.plugin = durable_plugin_copy(self._tmp.name)
         self.real_script = os.path.join(self.plugin, "hooks", "statusline.py")
 
     def tearDown(self):
@@ -292,11 +456,13 @@ class TestMainSkipsHealUnderNoStatuslineHost(unittest.TestCase):
         self.home = os.path.join(self._tmp.name, "home")
         os.makedirs(os.path.join(self.home, ".claude"))
         self.settings = os.path.join(self.home, ".claude", "settings.json")
-        self.stale_command = '"python" "C:\\Users\\me\\.claude\\plugins\\cache\\codearbiter\\ca\\2.0.1\\hooks\\statusline.py"'
+        self.stale_command = STALE_CACHE_PIN
         with open(self.settings, "w", encoding="utf-8") as f:
             json.dump({"statusLine": {"type": "command",
                        "command": self.stale_command}}, f)
-        self.plugin = os.path.dirname(os.path.dirname(os.path.abspath(_mod.__file__)))
+        # A DURABLE copy of the real payload, so this test proves the
+        # has_statusline gate specifically — not the durability guard.
+        self.plugin = durable_plugin_copy(self._tmp.name)
 
     def tearDown(self):
         self._tmp.cleanup()

--- a/plugins/ca/hooks/tests/test_wire_statusline.py
+++ b/plugins/ca/hooks/tests/test_wire_statusline.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib.util
 import io
 import json
@@ -43,9 +44,30 @@ def _make_source_plugin_root(tmp):
     return root
 
 
+def _make_worktree_plugin_root(tmp):
+    """A plugin root inside a Claude Code subagent worktree —
+    `<repo>/.claude/worktrees/<id>/plugins/ca` — the exact shape that corrupted
+    the maintainer's global settings.json on 2026-07-25. Non-durable by
+    construction: the whole purpose of the directory is that it gets pruned.
+
+    Deliberately built with NO git metadata, so it pins the LEXICAL signal on
+    its own — the shape confirmed in production must be caught for free."""
+    root = os.path.join(tmp, "repo", ".claude", "worktrees",
+                        "wf_58ee3fa6-de1-8", "plugins", "ca")
+    hooks_dir = os.path.join(root, "hooks")
+    os.makedirs(hooks_dir, exist_ok=True)
+    open(os.path.join(hooks_dir, "statusline.py"), "w").close()
+    return root
+
+
 def _read(path):
     with open(path, encoding="utf-8") as f:
         return json.load(f)
+
+
+def _read_bytes(path):
+    with open(path, "rb") as f:
+        return f.read()
 
 
 class TestFreshInstall(unittest.TestCase):
@@ -700,6 +722,127 @@ class TestRefreshStalePathOnSessionStart(unittest.TestCase):
         cmd = sl.get("command") if isinstance(sl, dict) else sl
         self.assertIn(self.script_abs, cmd)
         self.assertNotIn("2.0.1", cmd)
+
+
+class TestNonDurableRootIsNeverPinned(unittest.TestCase):
+    """Found in-session on 2026-07-25, after it broke the maintainer's
+    statusline three times in one day.
+
+    `~/.claude/settings.json` is GLOBAL and long-lived; a git-worktree plugin
+    root is neither. Writing one into the other yields a statusline that
+    renders nothing the moment the worktree is pruned — which is the entire
+    point of a worktree.
+
+    The guard lives HERE, in the producer, because every write to the pin flows
+    through this module: `cmd_install`, `cmd_refresh`, AND
+    `session-start.heal_statusline_wiring`, which calls `refresh_if_stale`
+    directly. The two writing paths get DIFFERENT treatment, because their
+    audiences differ:
+      - `refresh` is AUTOMATIC (SessionStart) -> silent no-op, matching the
+        surrounding degrade-silently contract.
+      - `install` is EXPLICIT (a human ran /ca:statusline, or passed
+        `--plugin-root <worktree>` by hand) -> LOUD refusal, because a silent
+        no-op would leave that human believing it worked.
+    Read-only and removal paths (`status`, `uninstall`) are never blocked."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.worktree_root = _make_worktree_plugin_root(self.tmp.name)
+        self.durable_root = _make_plugin_root(self.tmp.name)
+        self.stale_cmd = (
+            '"python" "C:\\Users\\me\\.claude\\plugins\\cache\\codearbiter\\ca'
+            '\\2.0.1\\hooks\\statusline.py"')
+        self.settings = _make_settings(
+            self.tmp.name,
+            {"statusLine": {"type": "command", "command": self.stale_cmd}})
+        self.before = _read_bytes(self.settings)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # --- refresh: the automatic path (silent) ------------------------------
+
+    def test_refresh_from_worktree_root_leaves_settings_byte_identical(self):
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", self.worktree_root, "--interp", "python"])
+        self.assertEqual(_read_bytes(self.settings), self.before)
+
+    def test_refresh_from_worktree_root_never_writes_a_worktree_path(self):
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", self.worktree_root, "--interp", "python"])
+        with open(self.settings, encoding="utf-8") as f:
+            raw = f.read()
+        self.assertNotIn("worktrees", raw)
+        self.assertEqual(json.loads(raw)["statusLine"]["command"], self.stale_cmd)
+
+    def test_refresh_from_durable_root_still_heals(self):
+        # NOT a feature kill-switch: a genuine plugin-cache update still
+        # re-points the pin at the new version's renderer.
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", self.durable_root, "--interp", "python"])
+        cmd = _read(self.settings)["statusLine"]["command"]
+        self.assertIn(os.path.join(self.durable_root, "hooks", "statusline.py"), cmd)
+        self.assertNotIn("2.0.1", cmd)
+
+    def test_refresh_if_stale_declines_an_ephemeral_script_without_mutating(self):
+        # The choke point session-start.heal_statusline_wiring calls DIRECTLY —
+        # pinned separately from cmd_refresh so the heal cannot regress if
+        # cmd_refresh is ever restructured.
+        settings = {"statusLine": {"type": "command", "command": self.stale_cmd}}
+        snapshot = json.dumps(settings, sort_keys=True)
+        script = os.path.join(self.worktree_root, "hooks", "statusline.py")
+        self.assertFalse(ws.refresh_if_stale(settings, script, "python"))
+        self.assertEqual(json.dumps(settings, sort_keys=True), snapshot)
+
+    def test_refresh_declines_a_linked_worktree_with_no_worktrees_segment(self):
+        # The git signal earning its place: a worktree parked under an ordinary
+        # name, which the lexical rule cannot see.
+        root = os.path.join(self.tmp.name, "ca-feature")
+        os.makedirs(os.path.join(root, "hooks"), exist_ok=True)
+        open(os.path.join(root, "hooks", "statusline.py"), "w").close()
+        with open(os.path.join(root, ".git"), "w", encoding="utf-8",
+                  newline="\n") as f:
+            f.write("gitdir: C:/Users/me/codeArbiter/.git/worktrees/ca-feature\n")
+        ws.main(["refresh", "--settings", self.settings,
+                 "--plugin-root", root, "--interp", "python"])
+        self.assertEqual(_read_bytes(self.settings), self.before)
+
+    # --- install: the explicit path (loud) ---------------------------------
+
+    def test_install_from_worktree_root_refuses_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            ws.main(["install", "--settings", self.settings,
+                     "--plugin-root", self.worktree_root, "--interp", "python"])
+        self.assertIn("REFUSING", str(ctx.exception))
+
+    def test_install_from_worktree_root_leaves_settings_byte_identical(self):
+        with contextlib.suppress(SystemExit):
+            ws.main(["install", "--settings", self.settings,
+                     "--plugin-root", self.worktree_root, "--interp", "python"])
+        self.assertEqual(_read_bytes(self.settings), self.before)
+
+    def test_install_from_durable_root_still_wires(self):
+        ws.main(["install", "--settings", self.settings,
+                 "--plugin-root", self.durable_root, "--interp", "python"])
+        cmd = _read(self.settings)["statusLine"]["command"]
+        self.assertIn(os.path.join(self.durable_root, "hooks", "statusline.py"), cmd)
+
+    # --- read-only / removal: never blocked --------------------------------
+
+    def test_uninstall_from_worktree_root_is_never_blocked(self):
+        # Removal is always safe, and a user stuck with a worktree pin must be
+        # able to get rid of it from wherever they happen to be.
+        ws.main(["uninstall", "--settings", self.settings,
+                 "--plugin-root", self.worktree_root])
+        self.assertNotIn("statusLine", _read(self.settings))
+
+    def test_status_from_worktree_root_still_reports_and_writes_nothing(self):
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured):
+            ws.main(["status", "--settings", self.settings,
+                     "--plugin-root", self.worktree_root])
+        self.assertIn("settings.json", captured.getvalue())
+        self.assertEqual(_read_bytes(self.settings), self.before)
 
 
 if __name__ == "__main__":

--- a/plugins/ca/hooks/wire-statusline.py
+++ b/plugins/ca/hooks/wire-statusline.py
@@ -33,6 +33,7 @@ import sys
 # session-start.py and the test suite both do) — always resolve _hooklib
 # relative to THIS file rather than relying on the caller's sys.path state.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _durabilitylib  # noqa: E402 — "may this path be pinned?" (see below)
 import _hooklib  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011): plugin-root resolution
 
@@ -230,6 +231,19 @@ def cmd_status(settings, exists, script_abs):
 
 
 def cmd_install(settings, path, script_abs, interp):
+    # Never pin a root that will not outlive the session (see refresh_if_stale's
+    # docstring for the defect). `install` is EXPLICIT — a human ran
+    # /ca:statusline, or passed `--plugin-root <worktree>` by hand — so this
+    # refuses LOUDLY where `refresh` degrades silently: a quiet no-op would leave
+    # that human believing the statusline was wired.
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        raise SystemExit(
+            f"REFUSING TO WIRE: {script_abs} is inside a git worktree (or another "
+            "root that will not survive being pruned).\n"
+            "~/.claude/settings.json is GLOBAL and holds an ABSOLUTE path, so "
+            "pinning it here breaks your statusline the moment this checkout goes "
+            "away.\nRe-run from your real install (the plugin cache, or your main "
+            "checkout), or pass --plugin-root pointing at it.")
     if not os.path.exists(script_abs):
         raise SystemExit(f"ERROR: renderer not found at {script_abs}; nothing wired.")
     new_cmd = build_command(interp, script_abs)
@@ -272,7 +286,30 @@ def refresh_if_stale(settings, script_abs, interp):
       - statusLine is a third-party line, or absent                       -> never touched, False
 
     Returning a changed-flag lets the caller persist ONLY on a real change, so a
-    steady-state session start never churns settings.json."""
+    steady-state session start never churns settings.json.
+
+    NON-DURABLE ROOTS ARE INERT (found in-session 2026-07-25, after it broke the
+    maintainer's statusline three times in one day). settings.json is GLOBAL and
+    the pin is ABSOLUTE, but the running plugin root need not be long-lived: a
+    session started inside a git worktree (subagents run in
+    `<repo>/.claude/worktrees/<id>/`) resolved the root to that worktree and this
+    function cheerfully re-pointed the user's global config at it. The worktree
+    is then pruned — its entire purpose — and the statusline renders nothing.
+
+    So: when `script_abs` is not durable, LEAVE THE EXISTING PIN ALONE. Not
+    healed, not cleared, no error — the same silent degrade the rest of this path
+    already performs. It is emphatically NOT a kill-switch: a genuinely stale pin
+    from a real plugin-cache update still heals, because that root IS durable.
+    Clearing instead of skipping was considered and rejected — a user whose only
+    session that day is a worktree session would lose a working statusline over a
+    condition that resolves itself the next time they start from a real install.
+
+    The guard lives HERE, at the mutation itself, rather than only in
+    `cmd_refresh`: `session-start.heal_statusline_wiring` calls this function
+    DIRECTLY and never goes through `cmd_refresh`, so a guard one level up would
+    have left the confirmed corruption path wide open."""
+    if _durabilitylib.is_ephemeral_path(script_abs):
+        return False
     current = settings.get("statusLine")
     if not is_ours(current, settings):
         return False


### PR DESCRIPTION
## The defect

`heal_statusline_wiring()` in `core/pysrc/session-start.py` runs on **every** SessionStart and refreshes a ca-OWNED `statusLine` pin to the current renderer path. The purpose is legitimate: a plugin cannot own a `statusLine` and `${CLAUDE_PLUGIN_ROOT}` is not expanded inside `settings.json`, so an **absolute, version-pinned** path must be written — and nothing re-ran it after a plugin update, so an updated install kept invoking the *old* version's `statusline.py` until that cache dir was pruned.

What it had no notion of is a **non-durable root**. A session started inside a git worktree (subagents run in `<repo>/.claude/worktrees/<id>/`) resolves the plugin root to that worktree, and the heal rewrote the user's **global** `~/.claude/settings.json` to point there. The worktree is then pruned — its entire purpose — and the statusline renders nothing.

Found in-session on **2026-07-25**, after it broke the maintainer's statusline three times in one day:

```
...\.claude\worktrees\wf_58ee3fa6-de1-8\plugins\ca\hooks\statusline.py   (pruned -> broken)
...\.claude\worktrees\wf_b7160646-041-2\plugins\ca\hooks\statusline.py   (recurred)
...\.claude\worktrees\wf_04e3c2f6-f27-1\plugins\ca\hooks\statusline.py   (recurred again)
```

Not agent-specific: any user running codeArbiter from a worktree hits it. There is no issue number — this was found and fixed in the same session.

### How a healthy pin degraded into a doomed one

Worth spelling out, because the entry point is not obvious. `is_ours()` recognises a legitimate cache pin via `_owned_command()`. So from a perfectly healthy `…/plugins/cache/codearbiter/ca/<ver>/hooks/statusline.py`, a worktree session took the *heal* branch, rewrote the command to the worktree path, and stamped `_codearbiterStatuslineOwner` with it. From that point the worktree pin is "ours" by owner-key match, so every later session kept re-pointing it at whatever worktree it happened to be in. **The bug fed itself.**

## Required behaviour, and what this implements

When the current root is non-durable: **leave the existing pin alone.** Do not heal, do not clear, do not error — degrade silently, as the surrounding code already does.

The feature is **not** disabled. A genuinely stale pin from a real plugin-cache update still heals, because that root *is* durable. Both directions are proven at both layers (see Tests).

Clearing instead of skipping was considered and rejected: a user whose only session that day is a worktree session would lose a working statusline over a condition that resolves itself the next time they start from a real install.

## Placement — argued

The task asked whether the guard belongs in the caller, the producer, or both. **Both**, sharing one predicate, and the reasoning differs per site:

| Site | Treatment | Why there |
|---|---|---|
| `wire-statusline.refresh_if_stale` | silent `return False` | **The mutation itself.** `heal_statusline_wiring` calls this function *directly* and never goes through `cmd_refresh`, so a guard one level up (in `cmd_refresh`) would have left the confirmed corruption path wide open. Silence matches the automatic/degrade-silently contract of the SessionStart path. |
| `wire-statusline.cmd_install` | loud `SystemExit` | **Explicit human action** — someone ran `/ca:statusline`, or passed `--plugin-root <worktree>` by hand. A silent no-op here would leave that human believing the statusline was wired. This is the reachable-by-a-human path the task flagged. |
| `session-start.heal_statusline_wiring` | early `return False` | **Deliberately redundant, and not decoratively so.** `_load_wire_statusline` loads the producer *out of `plugin` itself*. A worktree cut from a pre-fix branch therefore supplies a pre-fix, **unguarded** producer — while `session-start.py` may have been loaded from somewhere else entirely, since `main()` honours `$CLAUDE_PLUGIN_ROOT` independently of where the file came from (exactly the split the pre-existing `TestMainHealsBeforeDormantGate` harness already exercises). The highest-consequence write on the machine gets to refuse on its own account rather than on the good behaviour of whatever version it happened to load. |
| `cmd_status`, `cmd_uninstall` | **never blocked** | Reporting changes nothing, and a user stuck with a dead worktree pin must be able to clear it from wherever they are. |

Both call sites invoke the same `is_ephemeral_path()`, so there is one policy and nothing to drift.

## Salvage: what was reused, what was rejected

A prior agent (killed mid-task by a session limit) left an uncommitted `_durabilitylib.py` plus test drafts. Its branch existed but carried **zero commits** — nothing to rebase onto. I verified rather than trusted; the judgement calls:

**Kept.** The two-signal design, the fail-durable direction, the "false positive costs one `/ca:statusline` run, false negative corrupts global config" asymmetry argument, the loud-install/silent-refresh split, and the observation that fixtures driving the *real* plugin root become checkout-dependent once the guard exists. All sound, all retained (largely rewritten in wording, same substance).

**Rejected — the `git rev-parse` subprocess.** The salvaged `in_linked_git_worktree()` shelled out to `git rev-parse --git-dir --git-common-dir` with a 2s timeout and an injectable runner. Its own module header conceded the probe "fails there every single time" for the ordinary plugin-cache install — which is not a git repo at all. But the lexical check short-circuits only on a *positive*, so the common, negative, everybody-every-session case fell straight through to the subprocess. That is **a process spawn on every SessionStart, before the dormant gate, in every repo on the machine, to learn nothing.** Plus a timeout hazard and a dependency on git being installed.

Git already writes the answer to disk: a linked worktree's `.git` is a **file** reading `gitdir: <common>/.git/worktrees/<name>`; a normal checkout's `.git` is a **directory**. Walking up to the first `.git` and reading a bounded prefix gives the identical answer from a handful of `stat()` calls, with no git dependency, no timeout, and no injected-runner seam in the tests. It is also *more* precise: a submodule also uses a `.git` file, but its target is `modules/`, not `worktrees/` — so submodules stay durable, which the subprocess version got right only incidentally. `test_module_does_not_import_subprocess` pins the constraint so it cannot creep back.

**Judged, per the task's prompt — is a whole new module over-architecture?** I kept it, but only after stripping it to ~2 public predicates. The deciding factor is house style, not speculation: `core/pysrc/` already carries small single-concept libs, `_gitexec.py` among them at **45 lines**. "Is this path durable enough to pin?" is a topology question, not a statusline question, and folding it into the 1200-line `_hooklib.py` junk drawer or inlining it in `wire-statusline.py` would hide it from the *next* caller. (One is visible already and deliberately **out of scope here**: `_githooks.install(root)` installs git hooks pointing at the current plugin path, and linked worktrees share `$GIT_COMMON_DIR/hooks` — the same bug class, unreported, not touched by this PR.)

## Tests — TDD, red first

Red was captured before any implementation existed, and reproduced the production corruption verbatim in the failure message:

```
FAIL: test_worktree_root_pin_never_appears_in_settings
AssertionError: 'worktrees' unexpectedly found in '{\n  "statusLine": {\n    "type": "command",
  "command": "\\"python\\" \\"C:\\\\...\\\\repo\\\\.claude\\\\worktrees\\\\wf_58ee3fa6-de1-8\\\\
  plugins\\\\ca\\\\hooks\\\\statusline.py\\"", ...

FAIL: test_refresh_if_stale_declines_an_ephemeral_script_without_mutating
AssertionError: True is not false
FAIL: test_worktree_root_leaves_settings_byte_identical
AssertionError: True is not false
...
Ran 18 tests in 0.150s
FAILED (failures=10)
```

plus `ModuleNotFoundError: No module named '_durabilitylib'` for the new unit suite. **+39 tests**, all three required directions pinned at *both* layers:

1. **A worktree-rooted heal leaves settings.json byte-identical** — `test_worktree_root_leaves_settings_byte_identical` (caller), `test_refresh_from_worktree_root_leaves_settings_byte_identical` (producer), plus `test_worktree_root_pin_never_appears_in_settings` asserting the literal string `worktrees` is absent from the file afterward.
2. **A stale-but-durable pin still heals** — `test_durable_stale_pin_still_heals`, `test_refresh_from_durable_root_still_heals`, `test_install_from_durable_root_still_wires`.
3. **A non-ca-owned statusLine is still never touched** — re-proven under the new guard *and* on the durable path that does write.

Beyond the three: `test_worktree_root_does_not_repair_an_already_worktree_pin` (the maintainer's observed corrupt state, re-entered from another worktree — leave it, don't swap one doomed pin for another); `test_durable_root_repairs_a_worktree_pin_left_by_the_bug` (**the forward fix** — the corruption already on disk self-heals next time a session starts from a real install); `test_caller_refuses_even_an_unguarded_producer` (injects a pre-fix producer stub and asserts the heal bails *before* reaching it, which is the whole reason the caller guards); `test_refresh_declines_a_linked_worktree_with_no_worktrees_segment` (the git signal earning its place — a worktree the lexical rule cannot see); `test_uninstall_from_worktree_root_is_never_blocked` and `test_status_from_worktree_root_still_reports_and_writes_nothing`.

Every test passes an explicit temp `--settings` / `settings_path`. **Nothing touches real home settings.**

### Fixture change worth reviewing

`TestHealStatuslineWiring`, `TestMainHealsBeforeDormantGate`, `TestMainSkipsHealUnderNoStatuslineHost` and `HealReloadBeforeSaveTest` drove the **real** plugin root. codeArbiter's own checkout is very often a worktree, so once the guard exists those tests would heal or decline **depending on where the suite was run** — green in CI, red on a maintainer's machine, for reasons unrelated to what they test. They now use `_helpers.durable_plugin_copy()`, which copies the top-level `hooks/*.py` into a temp dir, making "durable" a property of the fixture. (Placed in the existing shared `_helpers.py` rather than triplicated across three test modules as the salvage draft had it.)

## Live-fire verification

Predicate evaluated against the maintainer's **real** paths, and the CLI driven end-to-end against a temp settings file:

```
THIS worktree renderer: ...\.claude\worktrees\wf_5892fde9-a3b-4\plugins\ca\hooks\statusline.py
  has_worktree_segment -> True     in_linked_worktree -> True     is_ephemeral_path -> True
MAIN checkout renderer: C:\Users\brenn\projects\codeArbiter\plugins\ca\hooks\statusline.py
  is_ephemeral_path    -> False
REAL plugin cache:      ~\.claude\plugins\cache\codearbiter\ca\2.8.11\hooks\statusline.py
  is_ephemeral_path    -> False
```

```
--- refresh from WORKTREE (the defect vector)
    rc=0  stdout=''
    settings byte-identical: True
    command now: "python" "C:\Users\me\.claude\plugins\cache\codearbiter\ca\2.0.1\hooks\statusline.py"

--- refresh from PLUGIN CACHE (durable, must still heal)
    rc=0  stdout='REFRESHED stale codeArbiter statusline path -> ...\ca\2.8.11\hooks\statusline.py'
    settings byte-identical: False

--- install from WORKTREE (explicit -> must refuse LOUDLY)
    rc=1
    REFUSING TO WIRE: ...\worktrees\wf_5892fde9-a3b-4\plugins\ca\hooks\statusline.py is inside a
    git worktree (or another root that will not survive being pruned).
    ~/.claude/settings.json is GLOBAL and holds an ABSOLUTE path, so pinning it here breaks your
    statusline the moment this checkout goes away.
    Re-run from your real install (the plugin cache, or your main checkout), or pass --plugin-root
    pointing at it.
    settings byte-identical: True
```

Both signals fire on the real defect vector; both the maintainer's main checkout and their actual `2.8.13`-era cache install read durable, so the self-heal they depend on is intact.

## Gates

| Gate | Result |
|---|---|
| `python -m unittest discover -s plugins/ca/hooks/tests` | **OK, 1096 tests** (baseline before this change: 1057) |
| `python tools/sync-core.py --check` | OK — 48 core files x 3 plugins, byte-identical |
| `python tools/build-surface.py --check` | OK — claude, codex, pi in sync |
| `python tools/build-host-packages.py --check --release-guard-base <merge-base>` | OK — `Pi payload, version, changelog, and root metadata advanced together: 0.1.5 -> 0.1.6` |
| `python .github/scripts/check-plugin-refs.py ca` | Reference graph intact |
| `python .github/scripts/check_docs_contract.py` | rc=0 |
| `git diff --check origin/main HEAD` | exit 0 |
| Line endings | LF on every changed file; 0 CRLF |
| Version bump | `ca` unpublished `2.9.1` (no tag) and `ca-codex` unpublished `0.3.0` — not required. **`ca-pi` bumped to `0.1.6`** — see below. |

### One correction, caught by CI rather than by me

My first push failed `[GATE ] | [PI ] | Payload version`. The Pi guard is stricter than ca's: **any** change under `plugins/ca-pi` must ship a strictly advancing version *plus* regenerated root `package.json` *plus* a new exact `## [X.Y.Z]` changelog heading. Vendoring `_durabilitylib.py` into `plugins/ca-pi/hooks` is such a change.

I had run that exact command locally and it printed `no Pi payload change - version bump not required`. The reason it lied: `pi_release_guard` diffs `base...HEAD` — **commits**, not the working tree — and I ran it before committing, when `HEAD` was still the base. Worth knowing for anyone verifying this gate locally: run it *after* committing, or it proves nothing.

Fixed in `f03d08d`: ca-pi `0.1.3 -> 0.1.4`, root metadata regenerated via `python tools/build-host-packages.py`, changelog entry added.

That number then had to move twice more. **#430** landed on main taking `0.1.4`, and **#426** landed taking `0.1.5` — several ca-pi PRs are racing for the next patch. Each time I merged `origin/main` (never rebased), split the shared changelog heading so **both** entries survive, and moved this branch up: `0.1.4` -> `0.1.5` -> **`0.1.6`**. No code ever conflicted — #430 is farm TypeScript, #426 is `plugins/ca-pi/tools/**`, this branch is python hooks — only the version line and its changelog heading. Final verification against the current merge base:

```
package.json matches plugins/ca-pi/package.json and the Pi descriptor
Pi payload, version, changelog, and root metadata advanced together: 0.1.5 -> 0.1.6
RC=0
```

### CI status

**34 checks pass, 0 fail; PR is CLEAN / MERGEABLE.** One flake on the way: `[CHECK] | [PI ] | Adapter contract <windows-latest · Pi 0.80.5>` hit `Error: Test timed out in 5000ms` at `plugins/ca-pi/tools/test/background-jobs.test.ts:513`. That file is not in this diff — the branch contains **zero TypeScript** — and the same job passed on the preceding commit against an identical TS tree. It passed on re-run (6m18s; that matrix cell is the slowest in the run). Not investigated further as unrelated to this change.

**Pre-existing, unrelated:** `.github/scripts` has 4 failures in `test_pi_benchmark.py`, all `RuntimeError: Pi benchmark requires the installed pinned esbuild` — an environment prerequisite (no `node_modules` in this fresh worktree), untouched by this change. The other 1061 tests in that suite pass.

`farm.js` / `sandbox.js` / `codearbiter*.js` were not rebuilt: this diff contains no TypeScript.

## Files

- **new** `core/pysrc/_durabilitylib.py` — the predicate (vendored to `ca`, `ca-codex`, `ca-pi` via `sync-core`)
- `core/pysrc/wire-statusline.py` — guard in `refresh_if_stale` (silent) and `cmd_install` (loud)
- `core/pysrc/session-start.py` — guard in `heal_statusline_wiring`
- `core/surface/commands/statusline.md` — documents the refusal and that `uninstall` is never blocked (built to `plugins/ca/commands/`)
- **new** `plugins/ca/hooks/tests/test_durabilitylib.py`; `test_wire_statusline.py`, `test_session_start.py`, `test_atomic_writes.py`, `_helpers.py`

### A note on the two merge commits

Both merges tripped the local `H-10b` secret gate, and both were cleared by actually reviewing rather than bypassing:

- **Merge 1** flagged 14 lines, all `FARM_API_KEY: "test-key"` in `plugins/ca/tools/farm.test.ts` / `farm.unit.test.ts` — already present 40x on `origin/main` from #430. Product code reads the real value from the approved source (`process.env.FARM_API_KEY`, `farm.ts:102`).
- **Merge 2** flagged 13 lines in `plugins/ca-pi/tools/**` and `plugins/ca-pi/extensions/codearbiter.js` from #426 — synthetic **negative**-test fixtures (`sk-literal-operator-secret`, `dummy-*-value`) that exist so the tests can assert a literal `apiKey` **fails the launch closed**; the `$OPENAI_API_KEY` forms are whole-value environment references, the shape that feature permits precisely because they carry no secret.

This branch's own commits touch **no** file under `plugins/ca/tools/` or `plugins/ca-pi/tools/`. The gate fires only because a merge commit's staged diff re-presents the other branch's added lines. Both reviewed PASS with no findings and recorded through `hooks/security-pass.py`; the rationale is written into each merge commit message.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
