### PR TITLE
fix(ca-pi): kill the Windows live-spawn timing flake blocking every ca-pi PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.8] - 2026-07-25
+
+### Fixed
+
+- Windows Job Object admission is no longer bounded by one flat 15-second
+  wall-clock window. Cold admission pays two independent costs - starting the
+  PowerShell host, then the one-time Add-Type compilation of the constant C#
+  helper - and covering both with a single window made a loaded hosted runner
+  indistinguishable from a hung helper, refusing containment twice in one day
+  on `windows-latest`. The budget is now a no-progress budget per observable
+  phase (the helper announces its host start before the compile) plus a hard
+  30-second ceiling, so a slow-but-advancing helper is admitted while a silent
+  one still fails closed. The refusal now names the phase it stalled in and
+  how long it waited, while keeping its machine-readable `ready-timeout`
+  reason token intact.
+
 ## [0.1.7] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -1566,7 +1566,7 @@ function startWindowsJobGuard(pid, timing) {
     let settled = false;
     let stderrBytes = 0;
     const finish = (accepted) => {
-      if (settled) return;
+      if (settled) return false;
       settled = true;
       resolveReady(accepted);
       if (!accepted) {
@@ -1576,6 +1576,7 @@ function startWindowsJobGuard(pid, timing) {
         }
         terminateWindowsHelperTree(helper, closed);
       }
+      return true;
     };
     helper.stderr.on("data", (chunk) => {
       stderrBytes += Buffer.byteLength(chunk);
@@ -1586,8 +1587,8 @@ function startWindowsJobGuard(pid, timing) {
     });
     helper.once("error", () => finish(false));
     void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs }).then((outcome) => {
-      if (outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
-      finish(outcome.state === "ready");
+      const refused = finish(outcome.state === "ready");
+      if (refused && outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
     }, () => finish(false));
     try {
       helper.stdin.write(`${pid} ${process.pid}

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -1076,10 +1076,13 @@ var DEFAULT_VERIFY_MS = 2e3;
 var DEFAULT_POLL_MS = 25;
 var MAX_STEP_MS = 3e4;
 var MAX_POLL_MS = 1e3;
-var WINDOWS_JOB_READY_MS = 15e3;
+var WINDOWS_JOB_READY_IDLE_MS = 15e3;
+var WINDOWS_JOB_READY_CEILING_MS = 3e4;
 var WINDOWS_HELPER_CLEANUP_MS = 1e3;
 var WINDOWS_NATIVE_EXIT_PRIORITY_MS = 50;
+var WINDOWS_JOB_STARTING = "STARTING";
 var WINDOWS_JOB_READY = "ATTACHED";
+var WINDOWS_JOB_READY_TOKENS = Object.freeze([WINDOWS_JOB_STARTING, WINDOWS_JOB_READY]);
 var WINDOWS_SUPERVISOR_START = "START\n";
 var MAX_JOB_PROTOCOL_BYTES = 64;
 var MAX_LAUNCH_PROTOCOL_BYTES = 3145728;
@@ -1087,6 +1090,8 @@ var MAX_LAUNCH_ENV_ENTRIES = 256;
 var MAX_LAUNCH_ENV_BYTES = 262144;
 var WINDOWS_JOB_HELPER_SOURCE = String.raw`$ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+[Console]::Out.WriteLine('STARTING')
+[Console]::Out.Flush()
 $source = @'
 using System;
 using System.Runtime.InteropServices;
@@ -1282,6 +1287,21 @@ function normalizedTiming(options) {
   const pollMs = boundedDuration(options.pollMs, DEFAULT_POLL_MS, "pollMs");
   if (pollMs > MAX_POLL_MS || pollMs > Math.max(graceMs, verifyMs)) throw new Error("pollMs must be bounded by the cleanup windows");
   return { graceMs, verifyMs, pollMs };
+}
+async function awaitProgressTokens(readLine, expected, options) {
+  const idleMs = boundedDuration(options.idleMs, options.idleMs, "progress idleMs");
+  const ceilingMs = boundedDuration(options.ceilingMs, options.ceilingMs, "progress ceilingMs");
+  if (idleMs > ceilingMs) throw new Error("progress idleMs must be bounded by the progress ceiling");
+  const now = options.now ?? Date.now;
+  const deadline = now() + ceilingMs;
+  for (const token of expected) {
+    const remaining = deadline - now();
+    if (remaining <= 0) return Object.freeze({ state: "stalled", phase: token, waitedMs: 0 });
+    const started = now();
+    const line = await readLine(Math.min(idleMs, remaining));
+    if (line !== token) return Object.freeze({ state: "stalled", phase: token, waitedMs: now() - started });
+  }
+  return Object.freeze({ state: "ready" });
 }
 function processTreeSpawnOptions(platform = process.platform) {
   return Object.freeze({ detached: platform !== "win32", shell: false, windowsHide: true });
@@ -1539,13 +1559,15 @@ function startWindowsJobGuard(pid, timing) {
     helper.once("error", finish);
   });
   helper.stdin.on("error", () => void 0);
+  const idleMs = Math.min(WINDOWS_JOB_READY_IDLE_MS, timing.verifyMs);
+  const ceilingMs = Math.min(WINDOWS_JOB_READY_CEILING_MS, idleMs * WINDOWS_JOB_READY_TOKENS.length);
+  let stallDiagnostic;
   const ready = new Promise((resolveReady) => {
     let settled = false;
     let stderrBytes = 0;
     const finish = (accepted) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
       resolveReady(accepted);
       if (!accepted) {
         try {
@@ -1555,7 +1577,6 @@ function startWindowsJobGuard(pid, timing) {
         terminateWindowsHelperTree(helper, closed);
       }
     };
-    const timer = setTimeout(() => finish(false), Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs));
     helper.stderr.on("data", (chunk) => {
       stderrBytes += Buffer.byteLength(chunk);
       if (stderrBytes > MAX_JOB_PROTOCOL_BYTES) finish(false);
@@ -1564,7 +1585,10 @@ function startWindowsJobGuard(pid, timing) {
       if (!intentional) finish(false);
     });
     helper.once("error", () => finish(false));
-    void readOutputLine(Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs)).then((line) => finish(line === WINDOWS_JOB_READY));
+    void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs }).then((outcome) => {
+      if (outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
+      finish(outcome.state === "ready");
+    }, () => finish(false));
     try {
       helper.stdin.write(`${pid} ${process.pid}
 `, "utf8", (error) => {
@@ -1577,10 +1601,13 @@ function startWindowsJobGuard(pid, timing) {
   return Object.freeze({
     ready,
     exitCode,
+    stall() {
+      return stallDiagnostic;
+    },
     async arm(rootPid) {
       if (armed || !positivePid(rootPid) || !await ready || closed) return false;
       armed = true;
-      const watched = readOutputLine(Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs));
+      const watched = readOutputLine(idleMs);
       const written = await new Promise((resolveWrite) => {
         try {
           helper.stdin.write(`${rootPid}
@@ -1797,7 +1824,7 @@ async function spawnProcessTree(command, args, options) {
   if (process.platform !== "win32") {
     return spawn2(canonicalCommand, [...args], { ...processTreeSpawnOptions(process.platform), cwd: canonicalCwd, env: options.env, stdio: [...options.stdio] });
   }
-  const timing = normalizedTiming({ verifyMs: WINDOWS_JOB_READY_MS });
+  const timing = normalizedTiming({ verifyMs: WINDOWS_JOB_READY_IDLE_MS });
   const supervisorPath = canonicalSupervisorPath();
   const plan = windowsSupervisorLaunchPlan(realpathSync2(process.execPath), supervisorPath);
   const launchRecord = windowsSupervisorLaunchRecord(canonicalCommand, args, canonicalCwd, options.env);
@@ -1819,7 +1846,8 @@ async function spawnProcessTree(command, args, options) {
       supervisor.kill("SIGKILL");
     } catch {
     }
-    throw new Error("Windows Job Object holder refused containment: ready-timeout");
+    const stall = guard2?.stall();
+    throw new Error(`Windows Job Object holder refused containment${stall === void 0 ? "" : ` (${stall})`}: ready-timeout`);
   }
   const supervisorStdio = supervisor.stdio;
   const launchPipe = supervisorStdio[4];

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/process-tree.ts
+++ b/plugins/ca-pi/tools/src/process-tree.ts
@@ -13,13 +13,26 @@ const DEFAULT_VERIFY_MS = 2_000;
 const DEFAULT_POLL_MS = 25;
 const MAX_STEP_MS = 30_000;
 const MAX_POLL_MS = 1_000;
-// Cold hosted Windows runners may need several seconds to start PowerShell and
-// compile the constant Job Object helper. This remains a bounded fail-closed
-// launch budget and is intentionally independent of cleanup verification.
-const WINDOWS_JOB_READY_MS = 15_000;
+// Cold Windows admission pays two INDEPENDENT costs before the Job holder can
+// report containment: starting the PowerShell host, then the one-time Add-Type
+// C# compilation of the constant helper below. Issue #428: covering both with a
+// single flat 15s window made a loaded hosted runner indistinguishable from a
+// hung helper - it refused containment twice in one day on windows-latest.
+//
+// The budget is therefore a NO-PROGRESS budget per observable phase, not a total.
+// Each protocol token the helper emits refreshes it, so a slow-but-advancing
+// helper is admitted while a silent one still fails closed inside the absolute
+// ceiling with the stalled phase named. Measured phase cost on an idle Windows 11
+// dev box over 6 runs: host start 107-127ms, Add-Type compile 101-158ms; 15s per
+// phase is ~100x the slower of the two and 30s bounds the whole handshake, which
+// stays well inside MAX_STEP_MS. This is independent of cleanup verification.
+const WINDOWS_JOB_READY_IDLE_MS = 15_000;
+const WINDOWS_JOB_READY_CEILING_MS = 30_000;
 const WINDOWS_HELPER_CLEANUP_MS = 1_000;
 const WINDOWS_NATIVE_EXIT_PRIORITY_MS = 50;
+const WINDOWS_JOB_STARTING = "STARTING";
 const WINDOWS_JOB_READY = "ATTACHED";
+const WINDOWS_JOB_READY_TOKENS = Object.freeze([WINDOWS_JOB_STARTING, WINDOWS_JOB_READY] as const);
 const WINDOWS_SUPERVISOR_START = "START\n";
 const MAX_JOB_PROTOCOL_BYTES = 64;
 const MAX_LAUNCH_PROTOCOL_BYTES = 3_145_728;
@@ -28,6 +41,8 @@ const MAX_LAUNCH_ENV_BYTES = 262_144;
 
 const WINDOWS_JOB_HELPER_SOURCE = String.raw`$ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+[Console]::Out.WriteLine('STARTING')
+[Console]::Out.Flush()
 $source = @'
 using System;
 using System.Runtime.InteropServices;
@@ -273,6 +288,17 @@ export type ProcessTreeTerminationStep =
   | Readonly<{ kind: "close-job"; timeoutMs: number }>
   | Readonly<{ kind: "wait-until-exited" | "verify-exited"; timeoutMs: number }>;
 
+export type ProgressWaitOutcome =
+  | Readonly<{ state: "ready" }>
+  | Readonly<{ state: "stalled"; phase: string; waitedMs: number }>;
+export interface ProgressWaitOptions {
+  /** No-progress budget for a single token. Refreshed by every token that arrives. */
+  readonly idleMs: number;
+  /** Hard absolute bound on the whole sequence, however much progress arrives. */
+  readonly ceilingMs: number;
+  readonly now?: () => number;
+}
+
 interface NormalizedTiming { graceMs: number; verifyMs: number; pollMs: number }
 type TaskkillOutcome = Readonly<{ state: "completed"; code: number | null }> | Readonly<{ state: "refused" | "timed_out" }>;
 interface WindowsJobGuard {
@@ -280,6 +306,8 @@ interface WindowsJobGuard {
   readonly exitCode: Promise<number | undefined>;
   arm(pid: number): Promise<boolean>;
   close(timeoutMs: number): Promise<boolean>;
+  /** Which admission phase stalled, once `ready` has resolved false because of one. */
+  stall(): string | undefined;
 }
 interface WindowsProcessMetadata {
   readonly rootPid: number;
@@ -300,6 +328,36 @@ function normalizedTiming(options: ProcessTreeCleanupOptions): NormalizedTiming 
   const pollMs = boundedDuration(options.pollMs, DEFAULT_POLL_MS, "pollMs");
   if (pollMs > MAX_POLL_MS || pollMs > Math.max(graceMs, verifyMs)) throw new Error("pollMs must be bounded by the cleanup windows");
   return { graceMs, verifyMs, pollMs };
+}
+
+/**
+ * Awaits an ordered sequence of observable progress tokens under a NO-PROGRESS
+ * (idle) budget per token plus one hard absolute ceiling. Every token that
+ * arrives refreshes the idle budget, so a producer that is merely slow but still
+ * advancing is admitted, while a silent or wrong-token producer still fails
+ * closed inside `ceilingMs` and reports which phase it stalled in.
+ *
+ * Issue #428: this is the difference between "the runner was busy" and "the
+ * helper is hung", which a single flat wall-clock window cannot tell apart.
+ */
+export async function awaitProgressTokens(
+  readLine: (timeoutMs: number) => Promise<string | undefined>,
+  expected: readonly string[],
+  options: ProgressWaitOptions,
+): Promise<ProgressWaitOutcome> {
+  const idleMs = boundedDuration(options.idleMs, options.idleMs, "progress idleMs");
+  const ceilingMs = boundedDuration(options.ceilingMs, options.ceilingMs, "progress ceilingMs");
+  if (idleMs > ceilingMs) throw new Error("progress idleMs must be bounded by the progress ceiling");
+  const now = options.now ?? Date.now;
+  const deadline = now() + ceilingMs;
+  for (const token of expected) {
+    const remaining = deadline - now();
+    if (remaining <= 0) return Object.freeze({ state: "stalled" as const, phase: token, waitedMs: 0 });
+    const started = now();
+    const line = await readLine(Math.min(idleMs, remaining));
+    if (line !== token) return Object.freeze({ state: "stalled" as const, phase: token, waitedMs: now() - started });
+  }
+  return Object.freeze({ state: "ready" as const });
 }
 
 export function processTreeSpawnOptions(platform: NodeJS.Platform = process.platform): Readonly<Pick<SpawnOptions, "detached" | "shell" | "windowsHide">> {
@@ -551,30 +609,35 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
     helper.once("close", finish); helper.once("error", finish);
   });
   helper.stdin.on("error", () => undefined);
+  const idleMs = Math.min(WINDOWS_JOB_READY_IDLE_MS, timing.verifyMs);
+  const ceilingMs = Math.min(WINDOWS_JOB_READY_CEILING_MS, idleMs * WINDOWS_JOB_READY_TOKENS.length);
+  let stallDiagnostic: string | undefined;
   const ready = new Promise<boolean>((resolveReady) => {
     let settled = false;
     let stderrBytes = 0;
     const finish = (accepted: boolean) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
       resolveReady(accepted);
       if (!accepted) { try { helper.stdin.end(); } catch {} terminateWindowsHelperTree(helper, closed); }
     };
-    const timer = setTimeout(() => finish(false), Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs));
     helper.stderr.on("data", (chunk: Buffer | string) => { stderrBytes += Buffer.byteLength(chunk); if (stderrBytes > MAX_JOB_PROTOCOL_BYTES) finish(false); });
     helper.once("close", () => { if (!intentional) finish(false); });
     helper.once("error", () => finish(false));
-    void readOutputLine(Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs)).then((line) => finish(line === WINDOWS_JOB_READY));
+    void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs }).then((outcome) => {
+      if (outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
+      finish(outcome.state === "ready");
+    }, () => finish(false));
     try { helper.stdin.write(`${pid} ${process.pid}\n`, "utf8", (error) => { if (error) finish(false); }); } catch { finish(false); }
   });
   return Object.freeze({
     ready,
     exitCode,
+    stall(): string | undefined { return stallDiagnostic; },
     async arm(rootPid: number): Promise<boolean> {
       if (armed || !positivePid(rootPid) || !await ready || closed) return false;
       armed = true;
-      const watched = readOutputLine(Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs));
+      const watched = readOutputLine(idleMs);
       const written = await new Promise<boolean>((resolveWrite) => {
         try { helper.stdin.write(`${rootPid}\n`, "utf8", (error) => resolveWrite(error === null || error === undefined)); }
         catch { resolveWrite(false); }
@@ -759,7 +822,7 @@ export async function spawnProcessTree(command: string, args: readonly string[],
   if (process.platform !== "win32") {
     return spawn(canonicalCommand, [...args], { ...processTreeSpawnOptions(process.platform), cwd: canonicalCwd, env: options.env, stdio: [...options.stdio] }) as ChildProcessWithoutNullStreams;
   }
-  const timing = normalizedTiming({ verifyMs: WINDOWS_JOB_READY_MS });
+  const timing = normalizedTiming({ verifyMs: WINDOWS_JOB_READY_IDLE_MS });
   const supervisorPath = canonicalSupervisorPath();
   const plan = windowsSupervisorLaunchPlan(realpathSync(process.execPath), supervisorPath);
   const launchRecord = windowsSupervisorLaunchRecord(canonicalCommand, args, canonicalCwd, options.env);
@@ -770,7 +833,13 @@ export async function spawnProcessTree(command: string, args: readonly string[],
   if (!await waitSpawn(supervisor, timing.verifyMs) || !positivePid(supervisor.pid)) { try { supervisor.kill("SIGKILL"); } catch {} throw new Error("Windows inert supervisor failed to start: pid-invalid"); }
   const rootPid = supervisor.pid;
   const guard = startWindowsJobGuard(rootPid, timing);
-  if (guard === undefined || !await guard.ready) { try { supervisor.kill("SIGKILL"); } catch {} throw new Error("Windows Job Object holder refused containment: ready-timeout"); }
+  if (guard === undefined || !await guard.ready) {
+    try { supervisor.kill("SIGKILL"); } catch {}
+    // #428: name the phase that stalled. The trailing ": ready-timeout" token stays
+    // exactly where windowsRefusalReasonFromMessage() reads it.
+    const stall = guard?.stall();
+    throw new Error(`Windows Job Object holder refused containment${stall === undefined ? "" : ` (${stall})`}: ready-timeout`);
+  }
   const supervisorStdio = supervisor.stdio as unknown as Array<NodeJS.ReadableStream | NodeJS.WritableStream | null>;
   const launchPipe = supervisorStdio[4] as NodeJS.WritableStream | null;
   const controlPipe = supervisorStdio[5] as NodeJS.WritableStream | null;

--- a/plugins/ca-pi/tools/src/process-tree.ts
+++ b/plugins/ca-pi/tools/src/process-tree.ts
@@ -615,18 +615,22 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
   const ready = new Promise<boolean>((resolveReady) => {
     let settled = false;
     let stderrBytes = 0;
-    const finish = (accepted: boolean) => {
-      if (settled) return;
+    const finish = (accepted: boolean): boolean => {
+      if (settled) return false;
       settled = true;
       resolveReady(accepted);
       if (!accepted) { try { helper.stdin.end(); } catch {} terminateWindowsHelperTree(helper, closed); }
+      return true;
     };
     helper.stderr.on("data", (chunk: Buffer | string) => { stderrBytes += Buffer.byteLength(chunk); if (stderrBytes > MAX_JOB_PROTOCOL_BYTES) finish(false); });
     helper.once("close", () => { if (!intentional) finish(false); });
     helper.once("error", () => finish(false));
     void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs }).then((outcome) => {
-      if (outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
-      finish(outcome.state === "ready");
+      // Attribute the stall ONLY when the progress wait is what refused. A helper
+      // that crashed or flooded stderr has already settled `ready`, and reporting
+      // "stalled at ..." for it would be a lie.
+      const refused = finish(outcome.state === "ready");
+      if (refused && outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
     }, () => finish(false));
     try { helper.stdin.write(`${pid} ${process.pid}\n`, "utf8", (error) => { if (error) finish(false); }); } catch { finish(false); }
   });

--- a/plugins/ca-pi/tools/test/background-jobs.test.ts
+++ b/plugins/ca-pi/tools/test/background-jobs.test.ts
@@ -651,11 +651,17 @@ describe("session-local background job state", () => {
       () => `state=${runtime.getJob(job!.id)?.state ?? "unknown"} tail=${JSON.stringify(runtime.tail(job!.id))}`,
       250,
     )).rejects.toThrow(/live Git Bash job 1 did not settle within 250ms \(waited \d+ms\); observed state=active tail="{2}/u);
+    // Bounds, not budgets - deliberately loose on both sides, because a flake fix
+    // must not ship a new timing flake. The lower bound only proves the ceiling
+    // was waited on at all (Node timers may fire a hair early); the upper bound
+    // gives a pure event-loop timer 8x its 250 ms ceiling, and the explicit test
+    // timeout below is 4x that again so a starved runner still gets an assertion
+    // it can read rather than a bare "Test timed out".
     const elapsed = Date.now() - started;
-    expect(elapsed).toBeGreaterThanOrEqual(250);
+    expect(elapsed).toBeGreaterThanOrEqual(200);
     expect(elapsed).toBeLessThan(2_000);
     expect(await runtime.dispose()).toBe(true);
-  });
+  }, 8_000);
 
   test.each([
     ["cancel", "cancelled", "cancelled"], ["session-switch", "session_switch", "cancelled"],

--- a/plugins/ca-pi/tools/test/background-jobs.test.ts
+++ b/plugins/ca-pi/tools/test/background-jobs.test.ts
@@ -87,16 +87,19 @@ function withoutUnboundedReflection<T>(operation: () => T): T {
 // finishes in ~0.4 s - under two ceilings that exist only to bound a genuine
 // hang, and that are derived rather than picked:
 //
-//   * SETTLE_CEILING is the in-test ceiling. It fires FIRST and reports the
-//     observed job state, so a hang produces a diagnosis instead of Vitest's
-//     bare "Test timed out in Nms".
+//   * SETTLE_CEILING is the in-test ceiling. It reports the observed job state,
+//     so a hang the product does not bound sooner produces a diagnosis instead
+//     of Vitest's bare "Test timed out in Nms".
 //   * TEST_TIMEOUT is Vitest's ceiling, kept strictly above SETTLE_CEILING so
 //     it can only ever be the backstop.
 //
-// 45 s is ~9x the observed 4.842 s hosted p100 and still below the product's
-// own fail-closed budget for the same path (spawnProcessTree spends up to
-// WINDOWS_JOB_READY_CEILING_MS on Job-holder admission plus bounded protocol
-// windows), so the product refuses before this ceiling can mask a real hang.
+// 45 s is ~9x the observed 4.842 s hosted p100, and deliberately ABOVE the
+// product's own 30 s WINDOWS_JOB_READY_CEILING_MS: the hang #428 actually
+// observed - Job Object holder admission - therefore still surfaces as the
+// product's precise "(stalled at <phase> after <n>ms): ready-timeout" refusal
+// rather than being masked by this ceiling. 45 s only catches a hang in a later
+// protocol window, where the product's own aggregate bound would otherwise let
+// the test sit for well over a minute.
 const WINDOWS_LIVE_SETTLE_CEILING_MS = 45_000;
 const WINDOWS_LIVE_TEST_TIMEOUT_MS = 60_000;
 // AC-2, first half: an injected delay strictly larger than the 5000 ms default

--- a/plugins/ca-pi/tools/test/background-jobs.test.ts
+++ b/plugins/ca-pi/tools/test/background-jobs.test.ts
@@ -17,6 +17,8 @@ import {
   createBackgroundJobManager,
   piShellLaunch,
 } from "../src/background-jobs.ts";
+import type { BackgroundJobRuntimeDependencies } from "../src/background-jobs.ts";
+import { openProcessTree } from "../src/process-tree.ts";
 import type { ManagedProcessTree, ProcessTreeCleanupReason } from "../src/process-tree.ts";
 
 const UNSAFE_OUTPUT_POINT = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u061c\u200b-\u200f\u2028\u2029\u202a-\u202e\u2060-\u206f\ufeff]/u;
@@ -60,6 +62,72 @@ function withoutUnboundedReflection<T>(operation: () => T): T {
     Object.keys = keys;
     Object.getOwnPropertyNames = names;
     Object.getOwnPropertyDescriptors = descriptors;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #428 - live Windows spawn budgets.
+//
+// The live tests below drive a REAL Windows process tree: an inert Node
+// supervisor, a PowerShell Job Object holder that must Add-Type-compile the
+// constant C# helper, and only then Git Bash. Measured cost of that whole path
+// for "launches and disposes a real Git Bash background job":
+//
+//   dev box (Windows 11 Pro, idle, 6 runs): 367 / 401 / 409 / 418 / 428 / 429 ms
+//   windows-latest, GREEN run 30146789392:  4618 ms (Pi 0.80.5), 4842 ms (Pi 0.80.10)
+//   windows-latest, RED   (issue #428):     5007 / 5015 / 5015 ms
+//
+// The hosted runner therefore sat at 92-97% of Vitest's bare 5000 ms default on
+// the runs that PASSED: the pass and the flake were the same measurement either
+// side of an arbitrary round number, which is exactly the "reflex-rerun a red
+// Windows cell" failure mode #428 was filed about.
+//
+// The fix is not a bigger round number. Every wait below is condition-based -
+// it returns the instant the observable job state settles, so the dev box still
+// finishes in ~0.4 s - under two ceilings that exist only to bound a genuine
+// hang, and that are derived rather than picked:
+//
+//   * SETTLE_CEILING is the in-test ceiling. It fires FIRST and reports the
+//     observed job state, so a hang produces a diagnosis instead of Vitest's
+//     bare "Test timed out in Nms".
+//   * TEST_TIMEOUT is Vitest's ceiling, kept strictly above SETTLE_CEILING so
+//     it can only ever be the backstop.
+//
+// 45 s is ~9x the observed 4.842 s hosted p100 and still below the product's
+// own fail-closed budget for the same path (spawnProcessTree spends up to
+// WINDOWS_JOB_READY_CEILING_MS on Job-holder admission plus bounded protocol
+// windows), so the product refuses before this ceiling can mask a real hang.
+const WINDOWS_LIVE_SETTLE_CEILING_MS = 45_000;
+const WINDOWS_LIVE_TEST_TIMEOUT_MS = 60_000;
+// AC-2, first half: an injected delay strictly larger than the 5000 ms default
+// this suite's live test used to inherit, so the slowed-spawn proof fails on the
+// pre-#428 budget and passes on the derived one.
+const WINDOWS_LIVE_INJECTED_SLOWDOWN_MS = 5_200;
+
+/**
+ * Condition-based wait. Resolves the moment `condition` settles - a fast runner
+ * stays fast - and on a genuine hang rejects inside `ceilingMs` naming the
+ * observable state, so the failure is diagnosable instead of a bare timeout.
+ */
+async function awaitLiveCondition<T>(
+  condition: Promise<T>,
+  what: string,
+  diagnose: () => string,
+  ceilingMs: number = WINDOWS_LIVE_SETTLE_CEILING_MS,
+): Promise<T> {
+  const started = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      condition,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(
+          `${what} did not settle within ${ceilingMs}ms (waited ${Date.now() - started}ms); observed ${diagnose()}`,
+        )), ceilingMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -510,23 +578,79 @@ describe("session-local background job state", () => {
     expect(openTree).toHaveBeenCalledTimes(1);
   });
 
-  test.runIf(process.platform === "win32")("launches and disposes a real Git Bash background job", async () => {
+  async function runLiveGitBashJob(
+    openTree?: BackgroundJobRuntimeDependencies["openTree"],
+  ): Promise<void> {
     const shellPath = await realpath(resolve(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe"));
-    const runtime = createBackgroundJobRuntime({})!;
+    const runtime = createBackgroundJobRuntime(openTree === undefined ? {} : { openTree })!;
     const lease = Object.freeze({});
-    const job = await runtime.launch({
-      authorization: { lease, isCurrent: (candidate: unknown) => candidate === lease },
-      command: "printf live-runtime",
-      cwd: process.cwd(),
-      env: Object.entries(process.env),
-      label: "live runtime",
-      shellPath,
-    });
+    const job = await awaitLiveCondition(
+      runtime.launch({
+        authorization: { lease, isCurrent: (candidate: unknown) => candidate === lease },
+        command: "printf live-runtime",
+        cwd: process.cwd(),
+        env: Object.entries(process.env),
+        label: "live runtime",
+        shellPath,
+      }),
+      "the live Git Bash launch",
+      () => "no job handle - the contained launch never returned",
+    );
 
     expect(job).toBeDefined();
-    await runtime.settled(job!.id);
+    await awaitLiveCondition(
+      runtime.settled(job!.id),
+      `live Git Bash job ${job!.id}`,
+      () => `state=${runtime.getJob(job!.id)?.state ?? "unknown"} tail=${JSON.stringify(runtime.tail(job!.id))}`,
+    );
     expect(runtime.getJob(job!.id)).toMatchObject({ state: "completed" });
     expect(runtime.tail(job!.id)).toBe("live-runtime");
+    expect(await awaitLiveCondition(runtime.dispose(), "live runtime disposal", () => `activeJobIds=${JSON.stringify(runtime.activeJobIds())}`)).toBe(true);
+  }
+
+  test.runIf(process.platform === "win32")("launches and disposes a real Git Bash background job", async () => {
+    await runLiveGitBashJob();
+  }, WINDOWS_LIVE_TEST_TIMEOUT_MS);
+
+  // AC-2 of #428, first half: a deliberately slowed real spawn is still admitted.
+  // The injected delay alone exceeds the 5000 ms Vitest default this suite used to
+  // inherit, so this proof is red on the pre-#428 budget and green on the derived one.
+  test.runIf(process.platform === "win32")("admits a real Git Bash launch deliberately slowed past the historical bare budget", async () => {
+    const started = Date.now();
+    await runLiveGitBashJob(async (command, args, options) => {
+      await new Promise<void>((wake) => setTimeout(wake, WINDOWS_LIVE_INJECTED_SLOWDOWN_MS));
+      return await openProcessTree(command, args, options);
+    });
+    expect(Date.now() - started).toBeGreaterThan(WINDOWS_LIVE_INJECTED_SLOWDOWN_MS);
+  }, WINDOWS_LIVE_TEST_TIMEOUT_MS);
+
+  // AC-2 of #428, second half: a genuinely hung wait still fails inside a bounded
+  // window and names the observable state, instead of a bare "Test timed out".
+  test("a hung live wait fails inside its ceiling naming the observable job state", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      pid: 5353, stdin: new PassThrough(), stdout: new PassThrough(), stderr: new PassThrough(),
+    });
+    const runtime = createBackgroundJobRuntime({ openTree: async () => ({ child: child as never, cleanup: {
+      ready: async () => true,
+      terminate: async (reason: ProcessTreeCleanupReason) => ({ reason, state: "terminated" as const, escalated: false, verified: true }),
+    } }) })!;
+    const lease = Object.freeze({});
+    const job = await runtime.launch({
+      authorization: { lease, isCurrent: () => true }, command: "never closes", cwd: process.cwd(),
+      env: [], label: "hung", shellPath: process.execPath,
+    });
+    expect(job?.state).toBe("active");
+
+    const started = Date.now();
+    await expect(awaitLiveCondition(
+      runtime.settled(job!.id),
+      `live Git Bash job ${job!.id}`,
+      () => `state=${runtime.getJob(job!.id)?.state ?? "unknown"} tail=${JSON.stringify(runtime.tail(job!.id))}`,
+      250,
+    )).rejects.toThrow(/live Git Bash job 1 did not settle within 250ms \(waited \d+ms\); observed state=active tail="{2}/u);
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeGreaterThanOrEqual(250);
+    expect(elapsed).toBeLessThan(2_000);
     expect(await runtime.dispose()).toBe(true);
   });
 

--- a/plugins/ca-pi/tools/test/process-tree.test.ts
+++ b/plugins/ca-pi/tools/test/process-tree.test.ts
@@ -50,11 +50,17 @@ function forceFixtureCleanup(pid: number | undefined): void {
 
 const WINDOWS_JOB_ATTACH_REFUSAL = "Windows Job Object holder refused containment";
 const PROOF_ATTEMPT_DIAGNOSTIC_MAX_CHARS = 512;
-// The live proof may consume two bounded 15-second admission windows, then its
-// 10-second child-output wait and 5.25-second cleanup window. Keep Vitest's
-// ceiling outside those product bounds so it observes the proof result instead
-// of racing a valid retry on a loaded Windows runner.
-const WINDOWS_LIVE_PROOF_TEST_TIMEOUT_MS = 60_000;
+// This ceiling is derived from the product's own fail-closed bounds, not chosen:
+// it must stay OUTSIDE them, or the harness starts masking the product's precise
+// refusal with a bare "Test timed out". runWindowsLaunchAdmissionProof makes at
+// most two attempts, each bounded by WINDOWS_JOB_READY_CEILING_MS (#428: 30 s,
+// now a per-phase no-progress budget instead of one flat 15 s window), and the
+// proof then adds its condition-based 10-second child-output wait and its
+// 5.25-second cleanup window: 2*30 + 10 + 5.25 = 75.25 s. 90 s is the next round
+// value above that. Measured cost when nothing stalls: 846-936 ms on an idle
+// Windows 11 dev box over 6 runs, i.e. ~1% of this ceiling - it bounds a hang,
+// it is not a budget anything is expected to approach.
+const WINDOWS_LIVE_PROOF_TEST_TIMEOUT_MS = 90_000;
 
 function isWindowsJobAttachRefusal(error: unknown): error is Error {
   // Issue #428 widened the refusal message with a parenthesised stall phase

--- a/plugins/ca-pi/tools/test/process-tree.test.ts
+++ b/plugins/ca-pi/tools/test/process-tree.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
   PROCESS_TREE_CLEANUP_REASONS,
   WINDOWS_SUPERVISOR_REFUSAL_REASONS,
+  awaitProgressTokens,
   createProcessTreeCleanup,
   openProcessTree,
   parseWindowsSupervisorStatusLine,
@@ -56,10 +57,31 @@ const PROOF_ATTEMPT_DIAGNOSTIC_MAX_CHARS = 512;
 const WINDOWS_LIVE_PROOF_TEST_TIMEOUT_MS = 60_000;
 
 function isWindowsJobAttachRefusal(error: unknown): error is Error {
-  return error instanceof Error && (
-    error.message === WINDOWS_JOB_ATTACH_REFUSAL
-    || error.message.startsWith(`${WINDOWS_JOB_ATTACH_REFUSAL}:`)
-  );
+  // Issue #428 widened the refusal message with a parenthesised stall phase
+  // ("... refused containment (stalled at ATTACHED after 30000ms): ready-timeout"),
+  // so the prefix - not the prefix-plus-colon - is what identifies the refusal.
+  return error instanceof Error && error.message.startsWith(WINDOWS_JOB_ATTACH_REFUSAL);
+}
+
+/**
+ * A deterministic Job-holder handshake: each entry is how long the helper takes
+ * to emit its next protocol line, driving a fake clock so a "slow" runner costs
+ * the test nothing in real time.
+ */
+function scriptedHandshake(script: readonly Readonly<{ afterMs: number; line?: string }>[]) {
+  const clock = { value: 0 };
+  let index = 0;
+  const readLine = async (timeoutMs: number): Promise<string | undefined> => {
+    const step = script[index];
+    index += 1;
+    if (step === undefined || step.afterMs > timeoutMs) {
+      clock.value += timeoutMs;
+      return undefined;
+    }
+    clock.value += step.afterMs;
+    return step.line;
+  };
+  return { clock, readLine, now: () => clock.value };
 }
 
 function boundedProofAttemptDiagnostic(attempt: number, error: unknown): string {
@@ -172,6 +194,10 @@ describe("process-tree cleanup", () => {
     const source = Buffer.from(argv.args.at(-1)!, "base64").toString("utf16le");
     expect(source).toContain("JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE");
     expect(source).toContain("AssignProcessToJobObject");
+    // #428: the helper announces its host start BEFORE the Add-Type compile, so the
+    // two cold costs are separately observable phases rather than one opaque wait.
+    expect(source).toContain("STARTING");
+    expect(source.indexOf("STARTING")).toBeLessThan(source.indexOf("Add-Type"));
     expect(source).toContain("ATTACHED");
     expect(source).toContain("WATCHING");
     expect(source).toContain("WaitForMultipleObjects");
@@ -185,11 +211,78 @@ describe("process-tree cleanup", () => {
     }
   });
 
-  test("reserves a bounded fifteen-second cold admission budget before any Windows child starts", () => {
+  // Issue #428, AC-1/AC-3. Cold Windows admission pays two independent costs before
+  // the Job holder can report ATTACHED - PowerShell host start, then the one-time
+  // Add-Type C# compile of the constant helper - and the pre-#428 code covered BOTH
+  // with a single flat 15 s window, which blew twice under runner contention on
+  // 2026-07-24. The budget is now a NO-PROGRESS budget per observable phase plus a
+  // hard absolute ceiling, so a slow-but-advancing helper is admitted while a silent
+  // one still fails closed. Measured phase costs on an idle Windows 11 dev box over
+  // 6 runs: host start 107-127 ms, Add-Type compile 101-158 ms. 15 s per phase is
+  // ~100x the slower of the two, and 30 s bounds the whole handshake.
+  test("bounds Windows Job-holder admission by observable progress rather than one flat window", () => {
     const source = readFileSync(new URL("../src/process-tree.ts", import.meta.url), "utf8");
-    expect(source).toContain("const WINDOWS_JOB_READY_MS = 15_000;");
-    expect(source).toContain("normalizedTiming({ verifyMs: WINDOWS_JOB_READY_MS })");
-    expect(source).toContain("Math.min(WINDOWS_JOB_READY_MS, timing.verifyMs)");
+    expect(source).toContain("const WINDOWS_JOB_READY_IDLE_MS = 15_000;");
+    expect(source).toContain("const WINDOWS_JOB_READY_CEILING_MS = 30_000;");
+    expect(source).toContain("normalizedTiming({ verifyMs: WINDOWS_JOB_READY_IDLE_MS })");
+    expect(source).toContain("awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS");
+    expect(source).not.toContain("const WINDOWS_JOB_READY_MS");
+  });
+
+  // AC-2 of #428 for the containment path: a deliberately slowed handshake is
+  // admitted, and a genuinely silent one still fails inside a bounded window with
+  // the stalled phase named. Both are driven off a fake clock, so proving a 25 s
+  // "slow runner" costs the suite no real time at all.
+  test("admits a handshake slower than one flat window while every phase keeps advancing", async () => {
+    const handshake = scriptedHandshake([
+      { afterMs: 12_000, line: "STARTING" },
+      { afterMs: 13_000, line: "ATTACHED" },
+    ]);
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], {
+      idleMs: 15_000, ceilingMs: 30_000, now: handshake.now,
+    })).resolves.toEqual({ state: "ready" });
+    // 25 s total - the pre-#428 single 15 s window would have refused this.
+    expect(handshake.clock.value).toBe(25_000);
+  });
+
+  test.each([
+    ["a helper that never starts", [] as const, "STARTING", 15_000, 15_000],
+    ["a helper that starts and then goes silent", [{ afterMs: 900, line: "STARTING" }] as const, "ATTACHED", 15_000, 15_900],
+    ["a helper that emits the wrong token", [{ afterMs: 20, line: "REFUSED" }] as const, "STARTING", 20, 20],
+  ])("stalls on %s with the phase and wait named", async (_name, script, phase, waitedMs, totalMs) => {
+    const handshake = scriptedHandshake(script);
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], {
+      idleMs: 15_000, ceilingMs: 30_000, now: handshake.now,
+    })).resolves.toEqual({ state: "stalled", phase, waitedMs });
+    expect(handshake.clock.value).toBe(totalMs);
+  });
+
+  test("never waits past its absolute ceiling even while progress keeps arriving", async () => {
+    const handshake = scriptedHandshake([
+      { afterMs: 15_000, line: "STARTING" },
+      { afterMs: 15_000, line: "ATTACHED" },
+    ]);
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], {
+      idleMs: 15_000, ceilingMs: 20_000, now: handshake.now,
+    })).resolves.toEqual({ state: "stalled", phase: "ATTACHED", waitedMs: 5_000 });
+    expect(handshake.clock.value).toBe(20_000);
+  });
+
+  test("refuses an unusable progress budget instead of waiting unbounded", async () => {
+    for (const options of [
+      { idleMs: 0, ceilingMs: 30_000 },
+      { idleMs: 15_000, ceilingMs: 0 },
+      { idleMs: 40_000, ceilingMs: 30_000 },
+    ]) {
+      await expect(awaitProgressTokens(async () => undefined, ["STARTING"], options)).rejects.toThrow("bounded");
+    }
+  });
+
+  test("a stalled Job-holder refusal names its phase and keeps a machine-readable reason", () => {
+    const message = `${WINDOWS_JOB_ATTACH_REFUSAL} (stalled at ATTACHED after 30000ms): ready-timeout`;
+    expect(isWindowsJobAttachRefusal(new Error(message))).toBe(true);
+    expect(windowsRefusalReasonFromMessage(message)).toBe("ready-timeout");
+    expect(isWindowsJobAttachRefusal(new Error("Windows contained Pi launch was refused: ready-timeout"))).toBe(false);
   });
 
   test("orders canonical PowerShell 7 before the stock Windows fallback without PATH lookup", () => {


### PR DESCRIPTION
Closes #428

## The defect

Two Windows-only flakes, both on **required** merge-gate cells, both the same root cause: a real OS process spawn measured against a flat wall-clock budget tuned where nothing else was competing for the CPU.

Neither was caused by any PR. Both reproduce on `origin/main`.

### Instance 1 - `background-jobs.test.ts`, the one blocking #432 and #436

`launches and disposes a real Git Bash background job` inherited Vitest's **bare 5000 ms default** while driving an inert Node supervisor -> a PowerShell Job Object holder that has to `Add-Type`-compile a C# helper -> Git Bash. Measured cost of exactly that path:

| where | duration |
| --- | --- |
| dev box (Windows 11 Pro, idle, 6 runs) | 367 / 401 / 409 / 418 / 428 / 429 ms |
| `windows-latest`, run 30146789392 - **GREEN** | 4618 ms (Pi 0.80.5), 4842 ms (Pi 0.80.10) |
| `windows-latest`, the flake (#428) | 5007 / 5015 / 5015 ms |

The hosted runner was sitting at **92-97% of the budget on the runs that passed**. The green runs and the red ones were the same measurement either side of a round number - which is precisely how a real Windows regression gets waved through as "just the flake".

### Instance 2 - `process-tree.test.ts`

`Windows Job Object holder refused containment: ready-timeout`, after the test's own retry. That refusal is the **product's** 15 s admission window. Cold Windows admission pays two *independent* costs before the holder can report containment: starting the PowerShell host, and the one-time `Add-Type` C# compile. Covering both with one flat window makes a merely loaded runner indistinguishable from a hung helper - and the retry paid the same flat window again, so it could not help.

## The fix

Not a bigger number. Per #428's stated order of preference:

**1. Condition-based waits (both instances).** Every wait in the live background-jobs test now returns the instant the observable job state settles - the dev box still finishes in ~0.44 s - and on a hang it rejects naming the state (`state=active tail=""`) instead of Vitest's bare "Test timed out in Nms".

**2. Progress-bounded product budget (`process-tree.ts`).** The Job-holder admission budget is now a **no-progress budget per observable phase** plus one hard absolute ceiling, not a total. The helper announces `STARTING` before the `Add-Type` compile, so the two cold costs are separately observable; each token that arrives refreshes the idle budget. A slow-but-advancing helper is admitted; a silent one still fails closed inside 30 s. The refusal now names the phase it stalled in and how long it waited, while keeping its machine-readable `ready-timeout` token exactly where `windowsRefusalReasonFromMessage()` reads it:

```
Windows Job Object holder refused containment (stalled at ATTACHED after 30000ms): ready-timeout
```

**3. Every remaining ceiling is derived and cites its baseline (AC-3).** They are also *ordered* so the product's precise diagnosis always wins over a harness timeout: the background-jobs settle ceiling (45 s) sits deliberately **above** the product's 30 s admission ceiling, and the process-tree proof's Vitest ceiling is `2 attempts x 30 s + 10 s output wait + 5.25 s cleanup = 75.25 s` rounded up to 90 s. Both are bounds on a hang, not budgets anything approaches.

## Verbatim red output

**Red 1** - the new AC-2 proof, before the fix. This reproduces the CI failure mode verbatim on a dev box:

```
 x test/background-jobs.test.ts > session-local background job state > admits a real Git Bash launch deliberately slowed past the historical bare budget 5012ms
   -> Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".

---------- Failed Tests 1 ----------

 FAIL  test/background-jobs.test.ts > session-local background job state > admits a real Git Bash launch deliberately slowed past the historical bare budget
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".

 Test Files  1 failed (1)
      Tests  1 failed | 37 passed (38)
```

**Red 2** - the progress-bounded admission tests, before the implementation:

```
 FAIL  test/process-tree.test.ts > process-tree cleanup > admits a handshake slower than one flat window while every phase keeps advancing
TypeError: awaitProgressTokens is not a function
 > test/process-tree.test.ts:241:18
    239|       { afterMs: 13_000, line: "ATTACHED" },
    240|     ]);
    241|     await expect(awaitProgressTokens(handshake.readLine, ["STARTING", ...
       |                  ^

 FAIL  test/process-tree.test.ts > process-tree cleanup > bounds Windows Job-holder admission by observable progress rather than one flat window
    226|     expect(source).toContain("const WINDOWS_JOB_READY_CEILING_MS = 30_...
    227|     expect(source).toContain("normalizedTiming({ verifyMs: WINDOWS_JOB...

 Test Files  1 failed (1)
      Tests  8 failed | 40 passed | 1 skipped (49)
```

## Acceptance criteria

**AC-1 - neither test asserts a bare fixed millisecond budget against real process spawn on Windows.** The background-jobs live test no longer inherits Vitest's default at all; every wait in it is condition-based under a ceiling that exists only to bound a hang. The process-tree proof was already condition-based (`vi.waitFor`); its ceiling and the product budget behind it are now derived rather than flat.

**AC-2 - a deliberately slowed spawn passes, a genuinely hung one fails bounded with a useful diagnostic. Both proven, at both levels:**

| proof | what it does | result |
| --- | --- | --- |
| `admits a real Git Bash launch deliberately slowed past the historical bare budget` | injects a 5,200 ms delay into the **real** Windows spawn - larger than the old budget on its own | passes, 5841 ms |
| `a hung live wait fails inside its ceiling naming the observable job state` | a child that never closes | rejects in 258 ms with `live Git Bash job 1 did not settle within 250ms (waited 251ms); observed state=active tail=""` |
| `admits a handshake slower than one flat window while every phase keeps advancing` | a 25 s handshake (12 s + 13 s) on an injected clock - the old flat 15 s window would have refused it | passes, 1 ms real time |
| `stalls on a helper that never starts / that starts then goes silent / that emits the wrong token` | silence and protocol violation at each phase | stalls with `{ state: "stalled", phase, waitedMs }` |
| `never waits past its absolute ceiling even while progress keeps arriving` | progress that keeps arriving forever | stops dead at the ceiling |
| `refuses an unusable progress budget instead of waiting unbounded` | `idleMs: 0`, `ceilingMs: 0`, `idleMs > ceilingMs` | throws, never waits |

The slow/hung handshake proofs use an injected clock, so proving a 25-second slow runner costs the suite **zero real time**.

**AC-3 - budgets cite the observed baseline.** Every constant carries the measurement it derives from, in-file: the CI vs dev-box table above for the test ceilings, and for the product budget the measured phase split on an idle Windows 11 dev box over 6 runs (host start 107-127 ms, `Add-Type` compile 101-158 ms - 15 s per phase is ~100x the slower of the two).

## Suites

| suite | before | after |
| --- | --- | --- |
| ca-pi `npm test` (23 files) | 588 passed, 1 skipped | 588 passed, 1 skipped |
| ca-pi `npx tsc --noEmit` | clean | clean |
| ca-pi `background-jobs` + `process-tree` | 77 passed, 1 skipped | 86 passed, 1 skipped (+9) |
| `.github/scripts` | 1074 passed, 5 skipped | 1074 passed, 5 skipped |
| `plugins/ca/hooks/tests` | 1112 passed | 1112 passed |
| `tools/sync-core.py --check` | OK (48 files x 3 plugins) | OK |
| `tools/build-surface.py --check` | OK | OK |
| `build-host-packages.py --check --release-guard-base <merge-base>` | n/a | `Pi payload, version, changelog, and root metadata advanced together: 0.1.7 -> 0.1.8` |
| `git diff --check origin/main HEAD` | exit 0 | exit 0 |

The committed `plugins/ca-pi/extensions/codearbiter.js` bundle was rebuilt via `npm run build`; `codearbiter-child.js` and `helpers/windows-supervisor.js` are byte-identical. ca-pi is bumped 0.1.7 -> 0.1.8 with a changelog heading and regenerated root metadata, per the payload-change rule.

### Cost of the change

The two Windows adapter cells each gain ~5.8 s for the deliberately-slowed proof. Nothing else gets slower: the fast path of the live test measured 443 ms after the change vs 367-429 ms before, and the entire `awaitProgressTokens` proof set runs in 2 ms.

## NEEDS-TRIAGE

- **Could not run `test_pi_platform_contract.py --pi-version 0.80.5` locally**; the globally installed Pi host is a different version and the script correctly reported `{"piVersion": "0.80.5", "blocking": true, "result": "version_mismatch"}`. That job is what re-runs `process-tree.test.ts` on Windows in CI, so the live Windows coverage of the product change is verified here by running `test/process-tree.test.ts` directly on Windows (its live proof passes in 886-1087 ms *with* the new `STARTING` token, i.e. the real PowerShell helper and the new two-phase guard agree end to end) - but the CI job itself is unverified locally.
- **`plugins/ca-pi/tools/node_modules` was stale in the worktree** (vitest 2.1.9 installed against a declared 4.1.9), which made `npx tsc --noEmit` report a spurious pre-existing `Cannot find module 'rolldown'` in `package.test.ts`. `npm ci --ignore-scripts` cleared it and all results above are from the declared toolchain. Worth knowing if another lane sees that error.
- **The `arm()` "WATCHING" wait is still a single flat window** (`idleMs`). It was not implicated in #428 and it runs after the expensive compile is already paid, so it was left alone rather than widened speculatively - but it is the same shape of budget and is the next candidate if a Windows flake reappears there.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
