### PR TITLE
test(ca-sandbox): fail CI when the Docker integration prerequisite is unavailable

### DIFF
--- a/.github/scripts/check_sandbox_docker_layers.py
+++ b/.github/scripts/check_sandbox_docker_layers.py
@@ -62,13 +62,19 @@ def sandbox_test_files(repo_root: Path) -> list[Path]:
     return sorted(found)
 
 
-def declared_layers(repo_root: Path) -> set[str]:
-    """Layer names the committed ca-sandbox sources gate a real-container suite on."""
-    layers: set[str] = set()
+def declared_layer_sites(repo_root: Path) -> dict[str, list[str]]:
+    """Layer name -> the files declaring it.  A layer must have exactly one site."""
+    sites: dict[str, list[str]] = {}
     for path in sandbox_test_files(repo_root):
         text = path.read_text(encoding="utf-8")
-        layers.update(match.group("layer") for match in _GATE_CALL.finditer(text))
-    return layers
+        for layer in {match.group("layer") for match in _GATE_CALL.finditer(text)}:
+            sites.setdefault(layer, []).append(path.name)
+    return {layer: sorted(files) for layer, files in sites.items()}
+
+
+def declared_layers(repo_root: Path) -> set[str]:
+    """Layer names the committed ca-sandbox sources gate a real-container suite on."""
+    return set(declared_layer_sites(repo_root))
 
 
 def recorded_layers(sentinel: Path) -> set[str]:
@@ -82,7 +88,15 @@ def recorded_layers(sentinel: Path) -> set[str]:
 
 def verify(repo_root: Path, sentinel: Path) -> tuple[int, str]:
     """Return (exit code, human report)."""
-    declared = declared_layers(repo_root)
+    sites = declared_layer_sites(repo_root)
+    shared = {layer: files for layer, files in sites.items() if len(files) > 1}
+    if shared:
+        # Two suites behind one sentinel key: either one alone recording makes
+        # both look executed, so the coverage check silently loses a layer.
+        return 1, "layer names shared by more than one suite: " + "; ".join(
+            f"{layer} <- {', '.join(files)}" for layer, files in sorted(shared.items())
+        )
+    declared = set(sites)
     if not declared:
         return 1, (
             "no dockerGate() layer declarations found under "

--- a/.github/scripts/check_sandbox_docker_layers.py
+++ b/.github/scripts/check_sandbox_docker_layers.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Assert every ca-sandbox real-container layer actually EXECUTED (issue #406).
+
+`docker info` answering once at the top of the CI job proves the daemon was
+alive for one probe.  It does not prove that the isolation, mount, network,
+lifecycle and teardown suites ran - and those suites are the only evidence that
+ca-sandbox, the driver that clones UNTRUSTED repositories, actually contains
+them.  Before this gate a runner Docker outage turned all 31 of them into skips
+and the required job still exited 0.
+
+The mechanism has two halves:
+
+  * `plugins/ca-sandbox/tools/docker-gate.ts` appends one line per gated layer
+    to $CA_SANDBOX_DOCKER_SENTINEL when that layer's suite STARTS;
+  * this script scans the same directory for the layers the sources DECLARE and
+    fails unless the recorded set matches.
+
+Both directions are enforced.  A declared layer that never recorded means a
+suite silently stopped running; a recorded layer nothing declares means the
+sentinel and the scanner have drifted apart, which makes the first check
+untrustworthy.
+
+Usage:
+    python .github/scripts/check_sandbox_docker_layers.py --sentinel <path>
+                                                         [--repo-root <path>]
+
+Stdlib-only, like the rest of .github/scripts.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SANDBOX_TOOLS = ("plugins", "ca-sandbox", "tools")
+
+# `const d = dockerGate("isolation", { linux: true });`
+_GATE_CALL = re.compile(r'dockerGate\(\s*"(?P<layer>[A-Za-z0-9][A-Za-z0-9._-]*)"')
+
+# Files whose `dockerGate("...")` occurrences are NOT layer declarations:
+#   docker-gate.test.ts  - the gate's own unit test, which drives it with
+#                          throwaway layer names that no suite ever records;
+#   __fixtures__/**      - the #406 reproduction fixture, deliberately run only
+#                          as a failing child process.
+_SCAN_SKIP_NAMES = frozenset({"docker-gate.test.ts"})
+_SCAN_SKIP_DIRS = frozenset({"__fixtures__", "node_modules"})
+
+
+def sandbox_test_files(repo_root: Path) -> list[Path]:
+    """Every ca-sandbox Vitest file that may declare a docker-gated layer."""
+    tools = repo_root.joinpath(*SANDBOX_TOOLS)
+    if not tools.is_dir():
+        return []
+    found = [
+        path
+        for path in tools.rglob("*.test.ts")
+        if not _SCAN_SKIP_DIRS.intersection(path.relative_to(tools).parts)
+        and path.name not in _SCAN_SKIP_NAMES
+    ]
+    return sorted(found)
+
+
+def declared_layers(repo_root: Path) -> set[str]:
+    """Layer names the committed ca-sandbox sources gate a real-container suite on."""
+    layers: set[str] = set()
+    for path in sandbox_test_files(repo_root):
+        text = path.read_text(encoding="utf-8")
+        layers.update(match.group("layer") for match in _GATE_CALL.finditer(text))
+    return layers
+
+
+def recorded_layers(sentinel: Path) -> set[str]:
+    """Layer names the gate appended at runtime.  Repeats collapse."""
+    return {
+        line.strip()
+        for line in sentinel.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+
+
+def verify(repo_root: Path, sentinel: Path) -> tuple[int, str]:
+    """Return (exit code, human report)."""
+    declared = declared_layers(repo_root)
+    if not declared:
+        return 1, (
+            "no dockerGate() layer declarations found under "
+            f"{'/'.join(SANDBOX_TOOLS)} - the scan drifted off the sources, so a "
+            "green sentinel would prove nothing."
+        )
+    if not sentinel.is_file():
+        return 1, (
+            f"the execution sentinel {sentinel} does not exist. Not one docker-gated "
+            "ca-sandbox layer recorded that it ran, which is exactly the silent-skip "
+            "failure this gate exists to catch (issue #406)."
+        )
+    recorded = recorded_layers(sentinel)
+    if not recorded:
+        return 1, (
+            f"the execution sentinel {sentinel} is empty - no docker-gated ca-sandbox "
+            "layer recorded that it ran."
+        )
+    missing = sorted(declared - recorded)
+    unknown = sorted(recorded - declared)
+    problems: list[str] = []
+    if missing:
+        problems.append(
+            "real-container layers that never executed: "
+            + ", ".join(missing)
+            + ". Docker was reachable at preflight but these suites did not run; "
+            "the containment guarantees they own are unproven."
+        )
+    if unknown:
+        problems.append(
+            "sentinel layers no source declares: "
+            + ", ".join(unknown)
+            + ". The runtime gate and this scanner disagree, so the coverage check "
+            "above cannot be trusted."
+        )
+    if problems:
+        return 1, "\n".join(problems)
+    return 0, "every declared real-container layer executed: " + ", ".join(sorted(declared))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sentinel",
+        required=True,
+        help="path of the append-only file written by CA_SANDBOX_DOCKER_SENTINEL",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="repository root to scan for layer declarations",
+    )
+    args = parser.parse_args(argv)
+    code, report = verify(Path(args.repo_root), Path(args.sentinel))
+    if code == 0:
+        print(report)
+    else:
+        print(f"::error::ca-sandbox docker layer sentinel: {report}", file=sys.stderr)
+        print(report, file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -23,6 +23,21 @@ CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
 PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
 PI_PLATFORM_CONTRACT = REPO_ROOT / ".github" / "scripts" / "test_pi_platform_contract.py"
+SANDBOX_LAYERS_TOOL = REPO_ROOT / ".github" / "scripts" / "check_sandbox_docker_layers.py"
+
+# Issue #406: a ca-sandbox suite that spins REAL containers used to carry its
+# own private `dockerAvailable()` probe and degrade to `describe.skip` when the
+# probe failed - on the REQUIRED CI job too.  The only sanctioned spelling is
+# now the shared `dockerGate("<layer>")` helper, which fails hard in required
+# mode and records an execution sentinel.  These two shapes are what a
+# re-introduced private self-skip looks like.
+_PRIVATE_DOCKER_PROBE = re.compile(
+    r"(?m)^\s*(?:(?:async\s+)?function\s+dockerAvailable\b"
+    r"|const\s+\w+\s*=\s*(?:HAS_DOCKER|dockerAvailable\(\))\s*\?)"
+)
+# A `docker info` PROBE, as an executed shell command - not the word "docker
+# info" inside a YAML comment, which is all the job used to contain.
+_DOCKER_PREFLIGHT = re.compile(r"(?m)^\s+(?:if\s+!\s+)?docker info\b")
 
 # `needs.<id>.result` and `needs['<id>'].result` are the two spellings GitHub
 # accepts; the aggregate gate uses both depending on whether the job id has a
@@ -205,6 +220,31 @@ _spec = importlib.util.spec_from_file_location("ci_impact", _TOOL)
 module = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = module
 _spec.loader.exec_module(module)
+
+
+def sandbox_layers_module():
+    """The ca-sandbox docker-layer sentinel verifier, loaded by path."""
+    spec = importlib.util.spec_from_file_location(
+        "check_sandbox_docker_layers_ci_impact", SANDBOX_LAYERS_TOOL
+    )
+    loaded = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = loaded
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+def privately_gated_sandbox_suites() -> dict[str, list[str]]:
+    """ca-sandbox test files that still hand-roll their own docker self-skip."""
+    layers = sandbox_layers_module()
+    offenders: dict[str, list[str]] = {}
+    for path in layers.sandbox_test_files(REPO_ROOT):
+        found = [
+            match.group(0).strip()
+            for match in _PRIVATE_DOCKER_PROBE.finditer(path.read_text(encoding="utf-8"))
+        ]
+        if found:
+            offenders[path.relative_to(REPO_ROOT).as_posix()] = found
+    return offenders
 
 
 def hosts():
@@ -410,6 +450,77 @@ class WorkflowContractTest(unittest.TestCase):
         )
         for name in expected:
             self.assertIn(f'name: "{name}"', ci)
+
+    def test_the_required_sandbox_job_fails_when_docker_is_unavailable(self):
+        # Issue #406 AC-1/AC-2.  ca-sandbox is the driver that clones UNTRUSTED
+        # repositories, and every real-container suite used to convert a failed
+        # `docker info` probe into `describe.skip` - on the required merge-gate
+        # job too.  A runner Docker outage therefore removed the ONLY isolation,
+        # mount, network, lifecycle and teardown evidence while the board went
+        # green off pure argv-builder tests.  The required job must now (a)
+        # preflight the daemon BEFORE the suite and exit non-zero without it,
+        # and (b) run the suite in docker-REQUIRED mode so a daemon that dies
+        # mid-run fails the file instead of skipping it.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("ca-sandbox-tools", aggregate_required_results(ci))
+        job = workflow_jobs(ci)["ca-sandbox-tools"]
+        suite = job.find("run: npm test")
+        self.assertNotEqual(suite, -1, "the sandbox job no longer runs `npm test`")
+        probe = _DOCKER_PREFLIGHT.search(job)
+        self.assertIsNotNone(probe, "the sandbox job runs no `docker info` preflight command")
+        self.assertLess(
+            probe.start(), suite, "the docker preflight must run BEFORE the sandbox suite"
+        )
+        self.assertIn(
+            "exit 1",
+            job[probe.start():suite],
+            "the docker preflight does not fail the job when the daemon is unavailable",
+        )
+        self.assertIn(
+            'CA_SANDBOX_REQUIRE_DOCKER: "1"',
+            job,
+            "the required sandbox suite does not run in docker-REQUIRED mode",
+        )
+
+    def test_the_required_sandbox_job_asserts_a_real_container_execution_sentinel(self):
+        # Issue #406 AC-3.  A preflight only proves the daemon answered once.
+        # The required job must additionally prove that every docker-gated
+        # layer actually EXECUTED, so a suite that silently stops registering
+        # (a bad filter, a renamed file, a gate left inert) cannot pass.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        job = workflow_jobs(ci)["ca-sandbox-tools"]
+        suite = job.find("run: npm test")
+        self.assertIn(
+            "CA_SANDBOX_DOCKER_SENTINEL",
+            job,
+            "the sandbox suite records no machine-checkable execution sentinel",
+        )
+        verifier = job.find("check_sandbox_docker_layers.py")
+        self.assertNotEqual(verifier, -1, "the sandbox job never asserts the layer sentinel")
+        self.assertGreater(
+            verifier, suite, "the layer sentinel must be asserted AFTER the suite runs"
+        )
+
+    def test_every_real_container_sandbox_suite_routes_through_the_shared_docker_gate(self):
+        # The contract above is only worth as much as the gate's reach: a suite
+        # keeping its own `dockerAvailable()` + `describe.skip` pair opts itself
+        # back out of required mode AND contributes no sentinel line, which is
+        # exactly the #406 hole one file at a time.
+        self.assertEqual(
+            privately_gated_sandbox_suites(),
+            {},
+            "ca-sandbox suites still self-skipping outside the shared docker gate",
+        )
+        layers = sandbox_layers_module().declared_layers(REPO_ROOT)
+        self.assertTrue(layers, "no dockerGate() layers found - the scan is wrong")
+        # The containment guarantees the sandbox actually advertises. Each is a
+        # real-container suite, so each must be a sentinel-bearing layer.
+        for required in ("isolation", "lifecycle", "network", "run"):
+            self.assertIn(
+                required,
+                layers,
+                f"the {required!r} real-container layer is not behind the shared docker gate",
+            )
 
     def test_every_committed_pi_test_file_runs_in_a_required_merge_gate_job(self):
         # Issue #405: the six-cell matrix named 6 of the 23 committed Vitest

--- a/.github/scripts/test_sandbox_docker_layers.py
+++ b/.github/scripts/test_sandbox_docker_layers.py
@@ -127,6 +127,24 @@ class VerifyTest(unittest.TestCase):
             self.assertEqual(code, 1)
             self.assertIn("ghost", report)
 
+    def test_two_suites_sharing_one_layer_name_is_rejected(self):
+        # One sentinel key for two suites means either suite alone recording
+        # makes both look executed - the coverage check would lose a layer.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fake_tree(
+                Path(tmp),
+                {
+                    "run.test.ts": 'const d = dockerGate("run");\n',
+                    "rerun.test.ts": 'const d = dockerGate("run");\n',
+                },
+            )
+            sentinel = Path(tmp) / "sentinel.txt"
+            sentinel.write_text("run\n", encoding="utf-8", newline="\n")
+            code, report = layers.verify(root, sentinel)
+            self.assertEqual(code, 1)
+            self.assertIn("run.test.ts", report)
+            self.assertIn("rerun.test.ts", report)
+
     def test_a_tree_declaring_no_layers_fails_instead_of_vacuously_passing(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = fake_tree(Path(tmp), {"mounts.test.ts": "describe('unit', () => {});\n"})

--- a/.github/scripts/test_sandbox_docker_layers.py
+++ b/.github/scripts/test_sandbox_docker_layers.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Unit tests for the ca-sandbox real-container execution sentinel verifier.
+
+Run: python .github/scripts/test_sandbox_docker_layers.py
+
+Issue #406.  `docker info` answering once at the top of the job proves the
+daemon was alive for one probe; it does not prove that the isolation, mount,
+network, lifecycle and teardown suites - the only evidence ca-sandbox really
+contains an untrusted repository - actually executed.  The gate appends one
+line per layer that STARTED, and this verifier is what turns that append-only
+file into a merge-blocking verdict.
+"""
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / ".github" / "scripts" / "check_sandbox_docker_layers.py"
+
+_spec = importlib.util.spec_from_file_location("check_sandbox_docker_layers", TOOL)
+layers = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = layers
+_spec.loader.exec_module(layers)
+
+
+def fake_tree(root: Path, files: dict[str, str]) -> Path:
+    tools = root / "plugins" / "ca-sandbox" / "tools"
+    for name, body in files.items():
+        path = tools / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8", newline="\n")
+    tools.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+class ScanTest(unittest.TestCase):
+    def test_declared_layers_come_from_the_shared_gate_call_sites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fake_tree(
+                Path(tmp),
+                {
+                    "run.test.ts": 'const d = dockerGate("run");\n',
+                    "network.test.ts": 'const d = dockerGate("network", { linux: true });\n',
+                    "mounts.test.ts": 'describe("pure unit", () => {});\n',
+                },
+            )
+            self.assertEqual(layers.declared_layers(root), {"run", "network"})
+
+    def test_the_gates_own_unit_test_is_not_scanned_as_a_declared_layer(self):
+        # docker-gate.test.ts exercises the gate with literal layer names of its
+        # own; counting those would demand sentinel lines no suite ever writes.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fake_tree(
+                Path(tmp),
+                {
+                    "run.test.ts": 'const d = dockerGate("run");\n',
+                    "docker-gate.test.ts": 'expect(dockerGate("probe-fixture"));\n',
+                    "__fixtures__/docker-required/gate.fixture.test.ts": (
+                        'const d = dockerGate("fixture");\n'
+                    ),
+                },
+            )
+            self.assertEqual(layers.declared_layers(root), {"run"})
+
+    def test_nested_test_directories_are_scanned(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fake_tree(
+                Path(tmp),
+                {"__tests__/isolation.test.ts": 'const d = dockerGate("isolation");\n'},
+            )
+            self.assertEqual(layers.declared_layers(root), {"isolation"})
+
+
+class VerifyTest(unittest.TestCase):
+    def _root(self, tmp: str) -> Path:
+        return fake_tree(
+            Path(tmp),
+            {
+                "run.test.ts": 'const d = dockerGate("run");\n',
+                "network.test.ts": 'const d = dockerGate("network", { linux: true });\n',
+            },
+        )
+
+    def test_a_sentinel_covering_every_layer_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._root(tmp)
+            sentinel = Path(tmp) / "sentinel.txt"
+            sentinel.write_text("run\nnetwork\nrun\n", encoding="utf-8", newline="\n")
+            code, report = layers.verify(root, sentinel)
+            self.assertEqual(code, 0, report)
+
+    def test_a_layer_that_never_executed_fails_and_is_named(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._root(tmp)
+            sentinel = Path(tmp) / "sentinel.txt"
+            sentinel.write_text("run\n", encoding="utf-8", newline="\n")
+            code, report = layers.verify(root, sentinel)
+            self.assertEqual(code, 1)
+            self.assertIn("network", report)
+
+    def test_a_missing_sentinel_fails_rather_than_reading_as_success(self):
+        # The exact #406 failure shape one level up: "nothing recorded" must
+        # never be indistinguishable from "everything passed".
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._root(tmp)
+            code, report = layers.verify(root, Path(tmp) / "absent.txt")
+            self.assertEqual(code, 1)
+            self.assertIn("absent.txt", report)
+
+    def test_an_empty_sentinel_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._root(tmp)
+            sentinel = Path(tmp) / "sentinel.txt"
+            sentinel.write_text("\n  \n", encoding="utf-8", newline="\n")
+            code, report = layers.verify(root, sentinel)
+            self.assertEqual(code, 1)
+
+    def test_a_sentinel_layer_no_source_declares_is_drift_and_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._root(tmp)
+            sentinel = Path(tmp) / "sentinel.txt"
+            sentinel.write_text("run\nnetwork\nghost\n", encoding="utf-8", newline="\n")
+            code, report = layers.verify(root, sentinel)
+            self.assertEqual(code, 1)
+            self.assertIn("ghost", report)
+
+    def test_a_tree_declaring_no_layers_fails_instead_of_vacuously_passing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = fake_tree(Path(tmp), {"mounts.test.ts": "describe('unit', () => {});\n"})
+            sentinel = Path(tmp) / "sentinel.txt"
+            sentinel.write_text("run\n", encoding="utf-8", newline="\n")
+            code, report = layers.verify(root, sentinel)
+            self.assertEqual(code, 1)
+            self.assertIn("no dockerGate", report)
+
+
+class RepositoryTest(unittest.TestCase):
+    def test_the_committed_sandbox_tree_declares_the_containment_layers(self):
+        declared = layers.declared_layers(REPO_ROOT)
+        self.assertTrue(declared, "the committed ca-sandbox tree declares no docker layers")
+        for expected in ("isolation", "lifecycle", "network", "run"):
+            self.assertIn(expected, declared)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,24 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ca-sandbox == 'true'
     runs-on: ubuntu-latest
+    # Issue #406. Docker is a REQUIRED prerequisite for this job, not a nicety.
+    # ca-sandbox is the driver that clones UNTRUSTED repositories into a
+    # container, and every real-container suite used to convert a failed
+    # `docker info` probe into `describe.skip` - here too. A runner Docker
+    # outage, a daemon that failed to start, a permissions regression or a
+    # runtime incompatibility therefore deleted the ONLY isolation, mount,
+    # network, lifecycle and teardown evidence while this job exited 0 off the
+    # pure argv-builder specs. CA_SANDBOX_REQUIRE_DOCKER makes an unavailable
+    # daemon throw from module scope instead; CA_SANDBOX_DOCKER_SENTINEL is the
+    # append-only record of which gated layers actually STARTED, asserted below.
+    # Developer machines set neither and keep the old self-skipping behavior.
+    #
+    # OPERATIONAL CONSEQUENCE, accepted deliberately: a runner-side Docker
+    # outage is now a merge blocker for every ca-sandbox PR. That is the point -
+    # a sandbox contract that cannot be exercised has not been verified.
+    env:
+      CA_SANDBOX_REQUIRE_DOCKER: "1"
+      CA_SANDBOX_DOCKER_SENTINEL: ${{ github.workspace }}/sandbox-docker-layers.sentinel
     defaults:
       run:
         working-directory: plugins/ca-sandbox/tools
@@ -233,18 +251,31 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: plugins/ca-sandbox/tools/package-lock.json
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
       - name: Install (locked)
         run: npm ci
       - name: Audit (CVE gate - fail on CRITICAL)
         run: npm audit --omit=dev --audit-level=critical
       - name: Typecheck
         run: npm run typecheck
-      - name: Test
-        # Docker-gated. The bulk of the ca-sandbox suite spins real containers;
-        # those specs probe `docker info` and skip themselves when Docker is
-        # absent. The GitHub ubuntu-latest runner ships Docker, so they run for
-        # real here; the pure-unit specs (mounts, dephash) always run.
+      - name: Docker preflight (REQUIRED prerequisite - fail, never skip)
+        # Fails the job BEFORE the suite rather than letting it degrade into a
+        # green run of argv-builder tests only.
+        run: |
+          if ! docker info --format '{{.OSType}}'; then
+            echo "::error::The ca-sandbox contract job requires a working Docker daemon. Without one the real isolation, mount, network, lifecycle and teardown suites cannot run, and this job would otherwise report green having exercised none of the container behaviour that contains an untrusted repository (issue #406)."
+            exit 1
+          fi
+      - name: Test (Docker required - a missing daemon fails the run)
         run: npm test
+      - name: Assert every real-container layer executed
+        # The preflight only proves the daemon answered once. This proves each
+        # docker-gated layer actually ran, so a suite that silently stops
+        # registering cannot pass on an exit code alone.
+        working-directory: ${{ github.workspace }}
+        run: python3 .github/scripts/check_sandbox_docker_layers.py --sentinel "$CA_SANDBOX_DOCKER_SENTINEL"
       - name: Rebuild sandbox.js
         run: npm run build
       - name: Fail if committed sandbox.js is stale

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ site/src/content/docs/changelog.md
 plugins/ca-sandbox/tools/node_modules/
 plugins/ca-sandbox/tools/**/.nixpacks/
 plugins/ca-sandbox/tools/**/.ca-sandbox.nixpacks.Dockerfile
+
+# ca-sandbox real-container execution sentinel (issue #406) — the append-only
+# record of which docker-gated layers actually ran. Written per-run by
+# docker-gate.ts when CA_SANDBOX_DOCKER_SENTINEL is set (required CI does; a
+# developer may set it locally too). Run output, never project state.
+*.sentinel

--- a/plugins/ca-sandbox/README.md
+++ b/plugins/ca-sandbox/README.md
@@ -87,3 +87,21 @@ npm run typecheck
 npm test          # docker-gated suites run serially (fileParallelism off)
 npm run build     # rebuilds sandbox.js; the shipped artifact must be in sync
 ```
+
+### Docker-required mode
+
+Most of this suite spins real containers. Without a Docker daemon those suites
+skip themselves, which is right on a laptop and wrong on CI: a green run that
+exercised none of the container behaviour proves nothing about a driver whose
+whole job is containing an **untrusted** repository. Two environment variables
+make that explicit (issue #406):
+
+| Variable | Effect |
+| --- | --- |
+| `CA_SANDBOX_REQUIRE_DOCKER=1` | An unavailable daemon **fails** the run instead of skipping. Set by the required CI job. |
+| `CA_SANDBOX_DOCKER_SENTINEL=<path>` | Each real-container layer appends its name to `<path>` when it starts. |
+
+CI sets both, then runs
+`python .github/scripts/check_sandbox_docker_layers.py --sentinel <path>`, which
+fails unless every layer the sources declare actually recorded a run. Locally,
+leave both unset for the usual self-skipping behaviour.

--- a/plugins/ca-sandbox/tools/__fixtures__/docker-required/gate.fixture.test.ts
+++ b/plugins/ca-sandbox/tools/__fixtures__/docker-required/gate.fixture.test.ts
@@ -1,0 +1,24 @@
+/**
+ * The #406 reproduction, as a real Vitest file.
+ *
+ * `docker-gate.test.ts` runs this through a child Vitest whose PATH has been
+ * masked of docker, with CA_SANDBOX_REQUIRE_DOCKER=1, and asserts the child
+ * exits NON-ZERO. That is the acceptance criterion the issue names: masking
+ * Docker from PATH must reproduce a non-zero required-mode result rather than
+ * the "exit 0, 31 tests skipped" the audit reproduced.
+ *
+ * It is excluded from the normal suite by the root vitest.config.ts and runs
+ * ONLY under this directory's own config.
+ */
+import { it, expect } from "vitest";
+import { dockerGate } from "../../docker-gate.ts";
+
+// Module scope on purpose: this is exactly how every gated suite declares
+// itself, so the throw has to happen during collection.
+const d = dockerGate("fixture-layer");
+
+d("a layer that must never be silently skipped in required mode", () => {
+  it("would have proven containment", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/plugins/ca-sandbox/tools/__fixtures__/docker-required/vitest.config.ts
+++ b/plugins/ca-sandbox/tools/__fixtures__/docker-required/vitest.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const TOOLS = fileURLToPath(new URL("../../", import.meta.url));
+
+/**
+ * Config for the #406 reproduction fixture ONLY.
+ *
+ * The root vitest.config.ts excludes `__fixtures__/**`, so `gate.fixture.test.ts`
+ * never runs in the normal suite — it exists to be launched as a child process
+ * by docker-gate.test.ts with docker masked from PATH, where it is SUPPOSED to
+ * fail. `root` is pinned to this directory so the fixture is the only file
+ * collected, and `cacheDir` is pushed back up to the real node_modules so a
+ * pinned root does not litter the fixture tree with a Vite cache.
+ */
+export default defineConfig({
+  cacheDir: `${TOOLS}node_modules/.vite`,
+  test: {
+    root: HERE,
+    include: ["*.fixture.test.ts"],
+    testTimeout: 30_000,
+  },
+});

--- a/plugins/ca-sandbox/tools/__tests__/isolation.test.ts
+++ b/plugins/ca-sandbox/tools/__tests__/isolation.test.ts
@@ -25,6 +25,7 @@
  * task id and the `ca.sandbox.build=1` label, and torn down in afterAll.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { dockerGate } from "../docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -36,12 +37,7 @@ import { runContainer } from "../run.ts";
 // mangled by MSYS path conversion; MSYS_NO_PATHCONV=1 disables it (Spike A/B).
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
 
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("isolation");
 
 const NS = "ca-sbx-t08";
 

--- a/plugins/ca-sandbox/tools/__tests__/isolation.test.ts
+++ b/plugins/ca-sandbox/tools/__tests__/isolation.test.ts
@@ -20,9 +20,12 @@
  *   5. Structural cross-check: `docker inspect` on the running container shows no
  *      "Type":"bind" mount (the structural reason the canary is unreachable).
  *
- * Docker-gated: the whole suite guards behind a `docker info` probe and skips
- * cleanly on a host without Docker. Every object created is namespaced with this
- * task id and the `ca.sandbox.build=1` label, and torn down in afterAll.
+ * Docker-gated through `dockerGate()` (docker-gate.ts): the suite skips cleanly
+ * on a developer host without Docker, but under CA_SANDBOX_REQUIRE_DOCKER — the
+ * mode required CI runs in — an absent daemon FAILS the run instead, because
+ * "the isolation canary did not run" must never read as "isolation holds"
+ * (issue #406). Every object created is namespaced with this task id and the
+ * `ca.sandbox.build=1` label, and torn down in afterAll.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { dockerGate } from "../docker-gate.ts";

--- a/plugins/ca-sandbox/tools/build.test.ts
+++ b/plugins/ca-sandbox/tools/build.test.ts
@@ -23,6 +23,7 @@
  *      and cleans up every docker object it creates.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -216,13 +217,7 @@ describe("dephash drives the tag — unchanged vs manifest-changed (AC-04/AC-05)
 // Builds a real image; proves cache-hit = no build; manifest change = rebuild;
 // baked deps resolve from /deps. Namespaced + cleaned up.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("build");
 
 d("buildOrReuseImage [docker] — real build, cache, rebuild (AC-04/AC-05)", () => {
   const created: string[] = []; // image tags to clean up

--- a/plugins/ca-sandbox/tools/claude-inside.test.ts
+++ b/plugins/ca-sandbox/tools/claude-inside.test.ts
@@ -23,6 +23,7 @@
  *      DUMMY token only — never a real credential.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import {
   CLAUDE_CODE_VERSION,
@@ -206,12 +207,7 @@ function collectEnv(argv: string[]): Record<string, string> {
 // --------------------------------------------------------------------------
 // DOCKER-GATED integration layer (AC-12) — DUMMY token only.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0 && /linux/i.test(r.stdout);
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("claude-inside", { linux: true });
 
 const NS = "ca-sbx-t14";
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };

--- a/plugins/ca-sandbox/tools/cli-resolve.test.ts
+++ b/plugins/ca-sandbox/tools/cli-resolve.test.ts
@@ -15,6 +15,7 @@
  *      resolve and run (AC-09 / AC-10 through the create-shaped naming).
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { readFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -44,11 +45,7 @@ describe("resolveContainerId — sandbox id -> container id (label registry)", (
 // --------------------------------------------------------------------------
 // DOCKER-GATED — the real seam: container NAME != sandbox id.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const d = dockerAvailable() ? describe : describe.skip;
+const d = dockerGate("cli-resolve");
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
 
 d("CLI exec/cp resolve a sandbox id whose container name != id [docker] (AC-09/AC-10 regression)", () => {

--- a/plugins/ca-sandbox/tools/cp.test.ts
+++ b/plugins/ca-sandbox/tools/cp.test.ts
@@ -20,6 +20,7 @@
  *      bytes match. Namespaced + cleaned up.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { readFileSync, mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -81,12 +82,7 @@ describe("assertNoCopyInBind — host->container bind is impossible (AC-10)", ()
 // DOCKER-GATED integration layer (AC-10).
 // cpOut copies a real file out of a real container to the host.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("cp");
 
 const NS = "ca-sbx-t12";
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };

--- a/plugins/ca-sandbox/tools/create.test.ts
+++ b/plugins/ca-sandbox/tools/create.test.ts
@@ -9,6 +9,7 @@
  * no docker; runs everywhere. The end-to-end clone is exercised by lifecycle.test.ts.
  */
 import { describe, it, expect } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import {
   validateRepoUrl,
@@ -168,12 +169,7 @@ describe("createSandbox failure teardown — containers before volume (reliabili
 // prune() purely because it carries the ca.sandbox=1 label, even though it is
 // not a registered sandbox object.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("create");
 
 d("orphaned helper containers [docker] — prune() reclaims them (reliability-015)", () => {
   it("a labeled, detached clone-shaped orphan is removed by prune()", () => {

--- a/plugins/ca-sandbox/tools/docker-gate.test.ts
+++ b/plugins/ca-sandbox/tools/docker-gate.test.ts
@@ -1,0 +1,167 @@
+/**
+ * docker-gate.test.ts — #406. Docker is a REQUIRED prerequisite in CI.
+ *
+ * Every real-container ca-sandbox suite used to carry its own `docker info`
+ * probe and degrade to `describe.skip` when the probe failed — including on the
+ * REQUIRED merge-gate job. A runner Docker outage therefore deleted the only
+ * isolation / mount / network / lifecycle / teardown evidence this plugin has
+ * while the board reported green off pure argv-builder tests. ca-sandbox is the
+ * driver that clones UNTRUSTED repositories; "the containment tests did not run"
+ * must never be indistinguishable from "the containment tests passed".
+ *
+ * The obligations locked in here:
+ *   1. self-skip survives on a developer machine (no CA_SANDBOX_REQUIRE_DOCKER);
+ *   2. in required mode an unavailable daemon THROWS, so the file fails to
+ *      collect and Vitest exits non-zero;
+ *   3. a daemon of the wrong OSType is "unavailable" for a suite that needs a
+ *      linux daemon — a Windows-container daemon cannot attest linux isolation;
+ *   4. a suite that really executes appends its layer to the sentinel file, so
+ *      required CI can assert the layer set rather than trust an exit code;
+ *   5. end-to-end: a Vitest child whose PATH has been masked of docker exits
+ *      NON-ZERO in required mode (this is the reproduction from the issue).
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  REQUIRE_ENV,
+  SENTINEL_ENV,
+  decideGate,
+  defaultProbe,
+  dockerGate,
+  recordLayer,
+  requiredMode,
+  type DockerProbe,
+} from "./docker-gate.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** A probe standing in for a daemon that is simply not there. */
+const absent: DockerProbe = () => ({ status: null, stdout: "" });
+/** A probe standing in for `docker info` answering with an error. */
+const broken: DockerProbe = () => ({ status: 1, stdout: "" });
+/** A healthy linux daemon. */
+const linux: DockerProbe = () => ({ status: 0, stdout: "linux\n" });
+/** A healthy daemon serving WINDOWS containers. */
+const windows: DockerProbe = () => ({ status: 0, stdout: "windows\n" });
+
+/** An env with every case-spelling of PATH pointed at an empty directory. */
+function maskDockerFromPath(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const empty = mkdtempSync(join(tmpdir(), "ca-sbx-nopath-"));
+  const env: NodeJS.ProcessEnv = { ...process.env, ...extra };
+  for (const key of Object.keys(env)) {
+    if (/^path$/i.test(key)) env[key] = empty;
+  }
+  return env;
+}
+
+describe("requiredMode — the explicit local/required switch (AC-2)", () => {
+  it("is off when the variable is unset, empty, 0 or false", () => {
+    expect(requiredMode({})).toBe(false);
+    expect(requiredMode({ [REQUIRE_ENV]: "" })).toBe(false);
+    expect(requiredMode({ [REQUIRE_ENV]: "   " })).toBe(false);
+    expect(requiredMode({ [REQUIRE_ENV]: "0" })).toBe(false);
+    expect(requiredMode({ [REQUIRE_ENV]: "false" })).toBe(false);
+  });
+
+  it("is on for the spellings CI actually uses", () => {
+    expect(requiredMode({ [REQUIRE_ENV]: "1" })).toBe(true);
+    expect(requiredMode({ [REQUIRE_ENV]: "true" })).toBe(true);
+  });
+});
+
+describe("decideGate — what counts as an available daemon", () => {
+  it("runs on a healthy daemon", () => {
+    expect(decideGate({ probe: linux })).toMatchObject({ run: true });
+  });
+
+  it("does not run when docker is not on PATH at all", () => {
+    const decision = decideGate({ probe: absent });
+    expect(decision.run).toBe(false);
+    expect(decision.run === false && decision.reason).toMatch(/PATH/i);
+  });
+
+  it("does not run when `docker info` exits non-zero", () => {
+    const decision = decideGate({ probe: broken });
+    expect(decision.run).toBe(false);
+    expect(decision.run === false && decision.reason).toMatch(/exited 1/);
+  });
+
+  it("treats a windows-container daemon as unavailable for a linux-only layer", () => {
+    expect(decideGate({ probe: windows, linux: true }).run).toBe(false);
+    // ...and as fine for a layer that does not care.
+    expect(decideGate({ probe: windows }).run).toBe(true);
+  });
+});
+
+describe("dockerGate — required mode fails instead of skipping (AC-1)", () => {
+  it("throws, naming the layer and the switch, when the daemon is unavailable", () => {
+    expect(() =>
+      dockerGate("isolation", { probe: absent, env: { [REQUIRE_ENV]: "1" } }),
+    ).toThrow(new RegExp(`${REQUIRE_ENV}[\\s\\S]*isolation|isolation[\\s\\S]*${REQUIRE_ENV}`));
+  });
+
+  it("throws when a linux-only layer meets a windows daemon", () => {
+    expect(() =>
+      dockerGate("network", { probe: windows, linux: true, env: { [REQUIRE_ENV]: "1" } }),
+    ).toThrow(/windows/i);
+  });
+
+  it("still self-skips on a developer machine with the switch off", () => {
+    expect(() => dockerGate("isolation", { probe: absent, env: {} })).not.toThrow();
+  });
+
+  it("does not throw when the daemon is healthy", () => {
+    expect(() =>
+      dockerGate("isolation", { probe: linux, env: { [REQUIRE_ENV]: "1" } }),
+    ).not.toThrow();
+  });
+});
+
+describe("recordLayer — the machine-checkable execution sentinel (AC-3)", () => {
+  it("appends one line per executed layer", () => {
+    const sentinel = join(mkdtempSync(join(tmpdir(), "ca-sbx-sentinel-")), "layers.txt");
+    recordLayer("isolation", { [SENTINEL_ENV]: sentinel });
+    recordLayer("lifecycle", { [SENTINEL_ENV]: sentinel });
+    expect(readFileSync(sentinel, "utf8").trim().split(/\r?\n/)).toEqual([
+      "isolation",
+      "lifecycle",
+    ]);
+  });
+
+  it("is inert when no sentinel path is configured", () => {
+    expect(() => recordLayer("isolation", {})).not.toThrow();
+  });
+});
+
+describe("PATH-masked reproduction — the issue's own repro (AC-4)", () => {
+  it("the real probe reports unavailable when docker is masked from PATH", () => {
+    const result = defaultProbe(maskDockerFromPath());
+    expect(result.status).not.toBe(0);
+  });
+
+  it("a required-mode Vitest child with docker masked from PATH exits NON-ZERO", () => {
+    const env = maskDockerFromPath({ [REQUIRE_ENV]: "1" });
+    delete env[SENTINEL_ENV];
+    const child = spawnSync(
+      process.execPath,
+      [
+        join(HERE, "node_modules", "vitest", "vitest.mjs"),
+        "run",
+        "--config",
+        join("__fixtures__", "docker-required", "vitest.config.ts"),
+      ],
+      { cwd: HERE, env, encoding: "utf8" },
+    );
+    const output = `${child.stdout ?? ""}${child.stderr ?? ""}`;
+    expect(child.status, `expected a non-zero run, got:\n${output}`).not.toBe(0);
+    // ...and non-zero for the RIGHT reason: the gate refused, naming its layer.
+    // Without this the assertion above would also accept "Vitest failed to
+    // start", which is not the contract under test.
+    expect(output).toContain(REQUIRE_ENV);
+    expect(output).toContain("fixture-layer");
+  }, 120_000);
+});

--- a/plugins/ca-sandbox/tools/docker-gate.ts
+++ b/plugins/ca-sandbox/tools/docker-gate.ts
@@ -1,0 +1,163 @@
+/**
+ * docker-gate.ts — the ONE docker-integration gate for the ca-sandbox suite
+ * (issue #406).
+ *
+ * Every real-container spec in this plugin used to paste in its own copy of
+ *
+ *     function dockerAvailable() { ...spawnSync("docker", ["info", ...]) }
+ *     const d = dockerAvailable() ? describe : describe.skip;
+ *
+ * which is exactly right on a developer machine and exactly wrong on the
+ * REQUIRED merge gate: a runner Docker outage, a daemon that failed to start, a
+ * permissions regression or a runtime incompatibility silently converted the
+ * isolation, mount, network, lifecycle and teardown layers into skips, and the
+ * job still exited 0 off the pure argv-builder specs. ca-sandbox is the driver
+ * that clones UNTRUSTED repositories into a container — "the containment tests
+ * did not run" must never be indistinguishable from "the containment tests
+ * passed".
+ *
+ * This module keeps the developer-machine behavior and adds an explicit
+ * REQUIRED mode plus an execution sentinel:
+ *
+ *   CA_SANDBOX_REQUIRE_DOCKER=1
+ *       Docker is a prerequisite, not a nicety. An unavailable daemon throws
+ *       from module scope, so Vitest fails to collect the file and the run
+ *       exits non-zero. CI sets this; developer machines do not.
+ *
+ *   CA_SANDBOX_DOCKER_SENTINEL=<path>
+ *       Each gated layer appends its name to this file when its suite actually
+ *       STARTS. `.github/scripts/check_sandbox_docker_layers.py` then asserts
+ *       the recorded set against the layers declared in this directory's
+ *       sources, so "green" has to mean "every real-container layer executed"
+ *       rather than merely "the process exited 0".
+ *
+ * The gate deliberately makes NO network/daemon assumption of its own beyond a
+ * `docker info` probe: the suites themselves own the real container work.
+ */
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { beforeAll, describe } from "vitest";
+
+/** Set to a truthy value to make an unavailable daemon fatal instead of a skip. */
+export const REQUIRE_ENV = "CA_SANDBOX_REQUIRE_DOCKER";
+/** Path of the append-only file recording which gated layers actually ran. */
+export const SENTINEL_ENV = "CA_SANDBOX_DOCKER_SENTINEL";
+
+/** The `docker info` result the gate reasons about — the injectable seam. */
+export type ProbeResult = { status: number | null; stdout: string };
+export type DockerProbe = () => ProbeResult;
+
+export type GateOptions = {
+  /**
+   * The layer needs a daemon serving LINUX containers. A Windows-container
+   * daemon answers `docker info` happily but cannot attest anything this
+   * plugin claims about linux isolation or egress policy.
+   */
+  linux?: boolean;
+  /** Environment to read the mode switches from (defaults to `process.env`). */
+  env?: NodeJS.ProcessEnv;
+  /** Docker probe override — tests inject a daemon that is up, down or wrong. */
+  probe?: DockerProbe;
+};
+
+export type GateDecision =
+  | { run: true; ostype: string }
+  | { run: false; reason: string };
+
+/** A gated suite declaration: `d("name", () => { ... })`, and nothing else. */
+export type GatedDescribe = (name: string, body: () => void) => void;
+
+/** The real `docker info` probe. `env` is a parameter so a test can mask PATH. */
+export function defaultProbe(env: NodeJS.ProcessEnv = process.env): ProbeResult {
+  const result = spawnSync("docker", ["info", "--format", "{{.OSType}}"], {
+    encoding: "utf8",
+    env,
+  });
+  return { status: result.status, stdout: result.stdout ?? "" };
+}
+
+/**
+ * Is Docker a REQUIRED prerequisite for this run?
+ *
+ * Unset / empty / `0` / `false` mean "local mode, self-skipping is fine".
+ * Anything else means required. The permissive spelling is deliberate: the cost
+ * of misreading a typo as "required" is a loud failure, while misreading it as
+ * "local" is the silent green this whole module exists to abolish.
+ */
+export function requiredMode(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env[REQUIRE_ENV] ?? "").trim().toLowerCase();
+  return raw !== "" && raw !== "0" && raw !== "false";
+}
+
+/** Probe the daemon and decide whether a gated layer can run against it. */
+export function decideGate(options: GateOptions = {}): GateDecision {
+  const probe = options.probe ?? (() => defaultProbe(options.env ?? process.env));
+  const result = probe();
+  const ostype = result.stdout.trim();
+  if (result.status !== 0) {
+    const detail =
+      result.status === null
+        ? "`docker info` never ran (docker is not on PATH)"
+        : `\`docker info\` exited ${result.status}`;
+    return { run: false, reason: detail };
+  }
+  if (options.linux === true && !/linux/i.test(ostype)) {
+    return {
+      run: false,
+      reason:
+        `the docker daemon serves OSType "${ostype || "<empty>"}", ` +
+        "but this layer needs a daemon serving linux containers",
+    };
+  }
+  return { run: true, ostype };
+}
+
+/**
+ * Append `layer` to the sentinel file, if one is configured. Inert otherwise,
+ * so a developer run writes nothing. `appendFileSync` on an O_APPEND handle is
+ * the whole mechanism — Vitest runs these files serially (`fileParallelism:
+ * false` in vitest.config.ts) precisely because they contend for the daemon.
+ */
+export function recordLayer(layer: string, env: NodeJS.ProcessEnv = process.env): void {
+  const target = env[SENTINEL_ENV];
+  if (target === undefined || target.trim() === "") return;
+  appendFileSync(target, `${layer}\n`, { encoding: "utf8" });
+}
+
+/**
+ * The gate every real-container suite declares itself with:
+ *
+ *     const d = dockerGate("isolation");
+ *     d("host-FS isolation canary [docker] (AC-03)", () => { ... });
+ *
+ * `layer` is the sentinel key and must be unique across this directory; the
+ * convention is the test file's stem.
+ *
+ * In required mode an unavailable daemon throws HERE, at module scope, which is
+ * what turns a missing prerequisite into a non-zero Vitest exit instead of a
+ * quiet skip.
+ */
+export function dockerGate(layer: string, options: GateOptions = {}): GatedDescribe {
+  const env = options.env ?? process.env;
+  const decision = decideGate(options);
+  if (decision.run === false) {
+    if (requiredMode(env)) {
+      throw new Error(
+        `${REQUIRE_ENV} is set, but the "${layer}" real-container layer cannot run: ` +
+          `${decision.reason}. Docker is a REQUIRED prerequisite in this mode — a missing ` +
+          "daemon fails the run rather than silently deleting the only evidence that " +
+          "ca-sandbox contains an untrusted repository (issue #406). Unset " +
+          `${REQUIRE_ENV} to restore developer self-skipping.`,
+      );
+    }
+    return (name, body) => {
+      describe.skip(name, body);
+    };
+  }
+  return (name, body) => {
+    describe(name, () => {
+      beforeAll(() => recordLayer(layer, env));
+      body();
+    });
+  };
+}

--- a/plugins/ca-sandbox/tools/exec.test.ts
+++ b/plugins/ca-sandbox/tools/exec.test.ts
@@ -17,6 +17,7 @@
  *      Namespaced (ca-sbx-t11), labeled, and cleaned up.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { execInSandbox, buildExecArgs, type ExecResult } from "./exec.ts";
 
@@ -126,12 +127,7 @@ describe("execInSandbox — JSON contract (AC-09)", () => {
 // Starts a real container, execs a real command, asserts the JSON contract.
 // Namespaced with the task id; every object is cleaned up.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("exec");
 
 const NS = "ca-sbx-t11";
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };

--- a/plugins/ca-sandbox/tools/layering.test.ts
+++ b/plugins/ca-sandbox/tools/layering.test.ts
@@ -34,6 +34,7 @@
  * ca.sandbox.build=1 and torn down in afterAll.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -70,12 +71,7 @@ describe("layering precondition — /deps is outside the /work/repo mount (AC-06
 // --------------------------------------------------------------------------
 // DOCKER-GATED layer — the real end-to-end proof (AC-06).
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("layering");
 
 const NS = "ca-sbx-t07";
 const BUILD_LABEL = "ca.sandbox.build=1";

--- a/plugins/ca-sandbox/tools/lifecycle.test.ts
+++ b/plugins/ca-sandbox/tools/lifecycle.test.ts
@@ -20,6 +20,7 @@
  *      hand-leaked labeled volume. Namespaced + fully cleaned up.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import {
   listSandboxes,
@@ -245,12 +246,7 @@ describe("createSandbox — clones into a named volume + runs (AC-01)", () => {
 // cleaned up. Uses a LOCAL fake repo served by a throwaway git container so the
 // clone needs no external network.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("lifecycle");
 
 const NS = "ca-sbx-t09";
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };

--- a/plugins/ca-sandbox/tools/multistack.test.ts
+++ b/plugins/ca-sandbox/tools/multistack.test.ts
@@ -36,6 +36,7 @@
  * fortiori.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -127,13 +128,7 @@ describe("multistack fixtures — present + deterministic dephash (AC-07)", () =
 // DOCKER-GATED layer — each fixture builds a runnable image; two builds of the
 // same fixture are deterministic (identical tag, second build is a cache reuse).
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("multistack");
 const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1" };
 
 /** Namespace every dephash for this task so tags never collide with other tasks. */
@@ -154,7 +149,11 @@ d("multistack [docker] — each fixture builds a runnable image; deterministic a
 
   for (const stack of STACKS) {
     const present = fixturePresent(stack);
-    const t = present && HAS_DOCKER ? it : it.skip;
+    // Docker is already proven by the enclosing `d(...)` gate (and, in required
+    // mode, would have thrown at collection). Only fixture presence is left —
+    // and a MISSING fixture is failed outright by the pure-unit
+    // "multistack fixtures — present" suite above, so skipping here cannot hide it.
+    const t = present ? it : it.skip;
 
     t(
       `[${stack.dir}] builds a runnable image, and a second build with the same dephash reuses it (no rebuild)`,

--- a/plugins/ca-sandbox/tools/network.test.ts
+++ b/plugins/ca-sandbox/tools/network.test.ts
@@ -26,6 +26,7 @@
  *      (ca-sbx-t10-*) + labeled (ca.sandbox.build=1) + cleaned up.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import {
   applyNetworkPolicy,
@@ -146,12 +147,7 @@ describe("applyNetworkPolicy — unknown policy", () => {
 // --------------------------------------------------------------------------
 // DOCKER-GATED integration layer (AC-08) — real containers, real curl.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0 && /linux/i.test(r.stdout);
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("network", { linux: true });
 
 const NS = "ca-sbx-t10";
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };

--- a/plugins/ca-sandbox/tools/run.test.ts
+++ b/plugins/ca-sandbox/tools/run.test.ts
@@ -23,6 +23,7 @@
  *      read-only root, non-root user. Namespaced + cleaned up.
  */
 import { describe, it, expect, afterAll } from "vitest";
+import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { buildRunArgs, runContainer } from "./run.ts";
 
@@ -120,12 +121,7 @@ function networkValues(argv: string[]): string[] {
 // Starts a real container and inspects it for the structural guarantees.
 // Namespaced with the task id; every object is cleaned up.
 // --------------------------------------------------------------------------
-function dockerAvailable(): boolean {
-  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
-  return r.status === 0;
-}
-const HAS_DOCKER = dockerAvailable();
-const d = HAS_DOCKER ? describe : describe.skip;
+const d = dockerGate("run");
 
 const NS = "ca-sbx-t06";
 const DENV = { ...process.env, MSYS_NO_PATHCONV: "1" };

--- a/plugins/ca-sandbox/tools/vitest.config.ts
+++ b/plugins/ca-sandbox/tools/vitest.config.ts
@@ -1,19 +1,34 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 /**
- * ca-sandbox driver test harness. Docker-gated tests guard themselves behind a
- * `docker info` probe at runtime (see individual *.test.ts), so the default run
- * stays green on a host without Docker. testTimeout is generous because the
- * docker-backed suites build/run real ephemeral containers.
+ * ca-sandbox driver test harness.
+ *
+ * Docker-gated suites declare themselves through `dockerGate()` in
+ * docker-gate.ts. On a developer machine an absent daemon still self-skips, so
+ * the default run stays green on a host without Docker. Under
+ * CA_SANDBOX_REQUIRE_DOCKER=1 — which required CI sets (issue #406) — an absent
+ * daemon instead THROWS from module scope, so the run exits non-zero rather
+ * than quietly deleting the isolation / mount / network / lifecycle / teardown
+ * evidence for a plugin that clones UNTRUSTED repositories.
+ *
+ * testTimeout is generous because the docker-backed suites build/run real
+ * ephemeral containers.
  *
  * fileParallelism is disabled: the docker-gated suites each build/run containers,
  * and running multiple suites concurrently overloads the host and gets containers
  * OOM-killed (exit 137) non-deterministically. Serial files trade wall-clock for a
  * deterministic, green suite — the right call for a docker integration harness.
+ * It also keeps the append-only execution sentinel a serial write.
+ *
+ * `__fixtures__/**` is excluded: it holds the multistack build fixtures and the
+ * #406 reproduction (`__fixtures__/docker-required/`), a test file that is
+ * SUPPOSED to fail and is launched only as a child process by
+ * docker-gate.test.ts.
  */
 export default defineConfig({
   test: {
     include: ["**/*.test.ts"],
+    exclude: [...configDefaults.exclude, "**/__fixtures__/**"],
     testTimeout: 300_000,
     hookTimeout: 300_000,
     fileParallelism: false,


### PR DESCRIPTION
Closes #406

## The hole

`ca-sandbox` is the driver that clones **untrusted** repositories into a container. Every real-container suite carried its own copy of

```ts
function dockerAvailable(): boolean {
  const r = spawnSync("docker", ["info", "--format", "{{.OSType}}"], { encoding: "utf8" });
  return r.status === 0;
}
const HAS_DOCKER = dockerAvailable();
const d = HAS_DOCKER ? describe : describe.skip;
```

— twelve times — and the required `ca-sandbox-tools` job ran a bare `npm test` with no preflight and no executed-integration sentinel. A runner Docker outage, a daemon that failed to start, a permissions regression or a runtime incompatibility therefore turned the isolation, mount, network, lifecycle and teardown layers into skips, and the job still exited 0 off the pure argv-builder specs. "The containment tests did not run" was indistinguishable from "the containment tests passed".

## Verified against source first

The issue's line numbers had drifted (#424 and #429 landed here today), so every claim was re-checked before acting:

| Issue claim | Verified |
| --- | --- |
| `ci.yml:221-247` required job has no Docker preflight | Confirmed — `npm ci` -> `audit` -> `typecheck` -> `npm test`, with only a comment asserting Docker was present |
| `vitest.config.ts:3-18` keeps no-Docker hosts green | Confirmed verbatim: *"so the default run stays green on a host without Docker"* |
| `run.test.ts` / `lifecycle.test.ts` / `__tests__/isolation.test.ts` self-skip | Confirmed, plus **nine more the issue did not list**: `build`, `claude-inside`, `cli-resolve`, `cp`, `create`, `exec`, `layering`, `multistack`, `network` |
| 31 integration tests skipped without Docker | Confirmed exactly — see run B below |

Two corrections to the issue's framing, both worth recording:

- `mounts.test.ts` and `teardown.test.ts` are **pure-unit** files on an injected docker runner; they were never docker-gated. The real-container mount evidence lives in `__tests__/isolation.test.ts` and the real teardown evidence in `lifecycle.test.ts`, so those are the layers the sentinel pins.
- `network.test.ts` and `claude-inside.test.ts` additionally required `OSType == linux`. That check is preserved and is *also* fatal in required mode — a Windows-container daemon answers `docker info` happily and can attest nothing this plugin claims.

## What changed

- **`plugins/ca-sandbox/tools/docker-gate.ts`** (new) is now the one gate. Developer machines keep self-skipping. Under `CA_SANDBOX_REQUIRE_DOCKER` an unavailable daemon **throws from module scope**, so Vitest fails to collect the file and exits non-zero. When `CA_SANDBOX_DOCKER_SENTINEL` is set, each layer appends its name in a `beforeAll` — proving the suite *started*, not merely that a probe once answered.
- **All twelve gated suites** migrated off their private probes.
- **`.github/scripts/check_sandbox_docker_layers.py`** (new) scans the sources for declared layers and asserts them against the sentinel **in both directions**: a declared layer that never recorded is a silent skip; a recorded layer nothing declares means scanner and runtime have drifted, which makes the first check untrustworthy. A missing sentinel, an empty sentinel, a tree declaring no layers, and two suites sharing one layer name are all failures.
- **`ci.yml`** `ca-sandbox-tools`: `docker info` preflight **before** the suite (exit 1 without it), the suite in required mode, then the sentinel assertion.
- **`WorkflowContractTest`** pins all three, plus that no suite reintroduces a private self-skip.

## Operational consequence — please read

**Once this merges, every ca-sandbox PR needs a working Docker daemon on the runner. A runner-side Docker outage becomes a merge blocker for the `ca-sandbox` lane.**

That is the point of #406 — a sandbox contract that cannot be exercised has not been verified — but it is a real availability trade. It is called out inline in `ci.yml` so nobody rediscovers it mid-incident. Two notes for whoever hits it:

- Only `ca-sandbox-tools` is affected, and it is gated on `needs.changes.outputs.ca-sandbox`; PRs touching nothing under `plugins/ca-sandbox/**` are unaffected.
- The escape hatch is a deliberate, logged `/ca:override`, not an env tweak — required mode is set in the workflow, not in a config file a PR can quietly edit.

## Red tests first

### 1. Workflow contract — `.github/scripts/test_ci_impact.py`, before `ci.yml` changed

```
ERROR: test_every_real_container_sandbox_suite_routes_through_the_shared_docker_gate (test_ci_impact.WorkflowContractTest.test_every_real_container_sandbox_suite_routes_through_the_shared_docker_gate)
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\brenn\\projects\\codeArbiter\\.claude\\worktrees\\wf_75f7ed0b-d79-4\\.github\\scripts\\check_sandbox_docker_layers.py'

FAIL: test_the_required_sandbox_job_asserts_a_real_container_execution_sentinel (test_ci_impact.WorkflowContractTest.test_the_required_sandbox_job_asserts_a_real_container_execution_sentinel)
AssertionError: 'CA_SANDBOX_DOCKER_SENTINEL' not found in '  ca-sandbox-tools:\n    name: "[CHECK] | [SBX ] | Sandbox driver contract"\n ... ' : the sandbox suite records no machine-checkable execution sentinel

FAIL: test_the_required_sandbox_job_fails_when_docker_is_unavailable (test_ci_impact.WorkflowContractTest.test_the_required_sandbox_job_fails_when_docker_is_unavailable)
AssertionError: unexpectedly None : the sandbox job runs no `docker info` preflight command

Ran 15 tests in 0.024s
FAILED (failures=2, errors=1)
```

Worth flagging: the first draft of the preflight assertion used `job.find("docker info")`, and it **passed against the pre-existing comment** *"those specs probe `docker info` and skip themselves"*. It was tightened to `^\s+(?:if\s+!\s+)?docker info\b` — an executed shell command, not prose — and only then went red for the right reason, as shown above.

### 2. The gate itself — `plugins/ca-sandbox/tools/docker-gate.test.ts`

```
 ❯ docker-gate.test.ts (0 test)

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  docker-gate.test.ts [ docker-gate.test.ts ]
Error: Cannot find module './docker-gate.ts' imported from C:/Users/brenn/projects/codeArbiter/.claude/worktrees/wf_75f7ed0b-d79-4/plugins/ca-sandbox/tools/docker-gate.test.ts
 ❯ docker-gate.test.ts:29:1

 Test Files  1 failed (1)
      Tests  no tests
```

### 3. The reproduction, both modes — real Docker masked from `PATH`

Run on a host with a live linux daemon, with every case-spelling of `PATH` pointed at an empty directory so `docker` cannot resolve.

**A — `CA_SANDBOX_REQUIRE_DOCKER=1`, what required CI now sets:**

```
 FAIL  __tests__/isolation.test.ts [ __tests__/isolation.test.ts ]
Error: CA_SANDBOX_REQUIRE_DOCKER is set, but the "isolation" real-container layer cannot run: `docker info` never ran (docker is not on PATH). Docker is a REQUIRED prerequisite in this mode — a missing daemon fails the run rather than silently deleting the only evidence that ca-sandbox contains an untrusted repository (issue #406). Unset CA_SANDBOX_REQUIRE_DOCKER to restore developer self-skipping.
 ❯ dockerGate docker-gate.ts:145:13
 ❯ __tests__/isolation.test.ts:40:11

 Test Files  12 failed | 7 passed (19)
      Tests  104 passed (104)

EXIT_A=1
```

**B — switch unset, developer mode, deliberately preserved — and exactly what CI used to do:**

```
 Test Files  18 passed | 1 skipped (19)
      Tests  208 passed | 31 skipped (239)

EXIT_B=0
```

B reproduces the issue's own finding — **31 integration tests skipped, exit 0** — matching the audit's number exactly. Before this PR that was the *required job's* behaviour; now it is only the laptop's.

### 4. Sentinel, end to end, real Docker, full suite

```
$ CA_SANDBOX_REQUIRE_DOCKER=1 CA_SANDBOX_DOCKER_SENTINEL=... npm test
 Test Files  19 passed (19)
      Tests  239 passed (239)
   Duration  164.20s
SUITE_EXIT=0

$ python .github/scripts/check_sandbox_docker_layers.py --sentinel ...
every declared real-container layer executed: build, claude-inside, cli-resolve, cp,
create, exec, isolation, layering, lifecycle, multistack, network, run
EXIT=0

$ python .github/scripts/check_sandbox_docker_layers.py --sentinel /nonexistent/layers.sentinel
::error::ca-sandbox docker layer sentinel: the execution sentinel ...\layers.sentinel does not
exist. Not one docker-gated ca-sandbox layer recorded that it ran, which is exactly the
silent-skip failure this gate exists to catch (issue #406).
EXIT=1
```

## Acceptance criteria

| # | Criterion | Where |
| --- | --- | --- |
| 1 | Job fails before tests when `docker info` is unavailable | `ci.yml` preflight step; pinned by `test_the_required_sandbox_job_fails_when_docker_is_unavailable` |
| 2 | Same command stays self-skipping in an explicit local mode | Run B above; `requiredMode` truthiness table in `docker-gate.test.ts` |
| 3 | Machine-checkable sentinel proves the isolation / lifecycle / mount / network / teardown layer executed | `check_sandbox_docker_layers.py`, both directions; `test_..._asserts_a_real_container_execution_sentinel` |
| 4 | A test masking Docker from `PATH` reproduces a non-zero required-mode result | `docker-gate.test.ts` -> child Vitest over `__fixtures__/docker-required/`, asserting non-zero **and** that it failed naming its layer, so "Vitest failed to start" cannot satisfy it |

## Suites

| Suite | Before | After |
| --- | --- | --- |
| `.github/scripts` (primary) | 1074 tests, 4 failures (all `test_pi_benchmark`, pre-existing) | **1088 tests**, same 4 `test_pi_benchmark` failures, 0 new |
| `ca-sandbox` vitest, real Docker, required mode | n/a (mode did not exist) | **19 files / 239 passed / 0 skipped**, exit 0, 164s |
| `ca-sandbox` vitest, Docker masked, local mode | 208 passed / 31 skipped, exit 0 | 208 passed / 31 skipped, exit 0 — unchanged |
| `ca-sandbox` vitest, Docker masked, required mode | n/a | 12 files failed, **exit 1** |
| `npx tsc --noEmit` (ca-sandbox) | clean | clean |
| `check-plugin-refs.py ca-sandbox` | pass | pass |
| `check_docs_contract.py` / `check_badge_consistency.py` | pass | pass |
| `npm run build` -> `sandbox.js` | in sync | in sync — the gate is test-only, the shipped bundle is byte-identical |
| `git diff --check origin/main HEAD` | 0 | 0 |

The four `test_pi_benchmark` failures are environmental and untouched by this branch: `plugins/ca-pi/tools/node_modules` is absent on this machine, so the benchmark raises `RuntimeError: Pi benchmark requires the installed pinned esbuild`. Neither `pi_benchmark.py` nor `test_pi_benchmark.py` differs from `origin/main`.

## NEEDS-TRIAGE

1. **`ca-sandbox-tools` has no `timeout-minutes`.** Now that Docker is required rather than optional, a hung `docker pull` or a wedged daemon burns the full 6-hour hosted cap instead of skipping in seconds. The existing bounded-timeout contract (`test_every_pi_ci_and_promotion_job_declares_a_bounded_timeout`) covers Pi jobs only. Deliberately out of scope — it is a separate behavioural change to a job this PR already alters — but it is the natural follow-up and this PR makes it matter more.
2. **`multistack.test.ts` still skips per-fixture on `present`.** `const t = present ? it : it.skip` (was `present && HAS_DOCKER`). A *missing* fixture is failed outright by the pure-unit `"multistack fixtures — present"` suite above it, so nothing hides, but the inner skip is a second, unrelated self-skip idiom that survives required mode. Noted inline; left alone as out of scope.
3. **No `plugin.json` bump.** `ca-sandbox` is on `0.1.5` with no `ca-sandbox-v0.1.5` tag, so the payload-version gate's unpublished-version branch applies. This PR changes only test files, harness config, and the README; `sandbox.js` is byte-identical after a rebuild.
4. **This PR's own CI is the first real proof of the CI half.** Runs 1-4 above were executed locally on a live linux daemon plus a masked-PATH reproduction; the preflight step and the sentinel assertion step themselves have only ever run on a GitHub runner in this PR. Please read the `ca-sandbox-tools` job log rather than trusting the table.

Claude-Session: https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
