### PR TITLE
fix(farm): enforce the plan schema at the runtime boundary and stop reinstalling preserved deps

### DIFF
--- a/core/surface/includes/farm.md
+++ b/core/surface/includes/farm.md
@@ -137,7 +137,7 @@ up-tree module resolution often papers over this for JS because the worktree liv
 root; languages without up-tree resolution get nothing.)
 
 Set **`meta.setup`** in `plan.json` — a list of shell commands the dispatcher runs **in each worktree
-before the worker**, on every attempt:
+before the worker**, **once per worktree**:
 
 ```json
 { "meta": { "name": "my-sprint", "setup": ["npm ci"] }, "tasks": [ … ] }
@@ -148,9 +148,35 @@ before the worker**, on every attempt:
   escalates the task immediately** (it is environmental, not a worker failure) — the worker is not invoked.
 - **Setup-produced files must be gitignored.** Anything setup writes that is *not* ignored and *not* in
   the task's `filesInScope` is correctly flagged as drift and escalates.
-- Cost: setup re-runs each retry (the inter-attempt reset wipes untracked deps), but most tasks pass on
-  attempt 1, so it runs once. For JS, leaving `setup` unset and relying on root `node_modules` up-tree
-  resolution is the cheaper path when it works; `setup` is the portable, explicit alternative.
+- Cost: **`setup` runs once per worktree, not once per retry.** The inter-attempt reset is
+  `git reset --hard` + `git clean -fd` (no `-x`), which *preserves* ignored paths — so the gitignored
+  dependency tree the contract above requires survives the reset and does not need reinstalling. For
+  JS, leaving `setup` unset and relying on root `node_modules` up-tree resolution is the cheaper path
+  when it works; `setup` is the portable, explicit alternative.
+
+### When setup output *does* go stale — `setupEachAttempt`
+
+`setup` is for one-time dependency restore. Commands that regenerate ignored output **from tracked
+source** (codegen, a build step) genuinely do go stale when the reset rolls the tracked files back.
+Declare those separately — they rerun before every attempt, after `setup`:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupEachAttempt": ["npm run codegen"] } }
+```
+
+`task.setupEachAttempt` overrides `meta.setupEachAttempt` the same way. A non-zero command escalates
+the task identically.
+
+### Invalidating the once-per-worktree cache — `setupInputs`
+
+The cache is a fingerprint of the `setup` commands plus the content hashes of any paths listed in
+**`setupInputs`** (relative, no `..`), scoped to exactly one worktree. List your lockfile there when
+a moved baseline must force a reinstall — regenerate-on-conflict resets a task worktree onto a *new*
+integration HEAD, which can carry a different lockfile:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupInputs": ["package-lock.json"] } }
+```
 
 ## Sovereignty note
 

--- a/core/surface/skills/writing-plans/references/farm-plan.md
+++ b/core/surface/skills/writing-plans/references/farm-plan.md
@@ -38,5 +38,13 @@ conforming to `{{PLUGIN_ROOT}}/tools/plan.schema.json`:
 Validate the JSON against the schema before writing (load the schema from
 `{{PLUGIN_ROOT}}/tools/plan.schema.json` and check). A schema-invalid plan BLOCKS.
 
+`plan.schema.json` is the **authoring** contract. The dispatcher enforces its own **runtime** contract
+(`PLAN_SHAPE` / `parsePlan()` in `farm.ts`) on the parsed JSON before it touches a single field, and
+that one is authoritative: a plan that fails it exits before any worktree, branch, report, or network
+call. The two are kept identical key-for-key and type-for-type by a parity test, so a plan that
+satisfies the schema is accepted at runtime — with one deliberate exception, the kebab-case `id`
+pattern, which is stricter here than the runtime path-safety rule. Both objects are closed: an
+undeclared property is an error, not an ignored extra.
+
 Gate: all failing tests written and confirmed failing; `plan.json` written and schema-valid. Both
 artifacts exist before handing off to `subagent-driven-development`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/includes/farm.md
+++ b/plugins/ca-codex/includes/farm.md
@@ -131,7 +131,7 @@ up-tree module resolution often papers over this for JS because the worktree liv
 root; languages without up-tree resolution get nothing.)
 
 Set **`meta.setup`** in `plan.json` — a list of shell commands the dispatcher runs **in each worktree
-before the worker**, on every attempt:
+before the worker**, **once per worktree**:
 
 ```json
 { "meta": { "name": "my-sprint", "setup": ["npm ci"] }, "tasks": [ … ] }
@@ -142,9 +142,35 @@ before the worker**, on every attempt:
   escalates the task immediately** (it is environmental, not a worker failure) — the worker is not invoked.
 - **Setup-produced files must be gitignored.** Anything setup writes that is *not* ignored and *not* in
   the task's `filesInScope` is correctly flagged as drift and escalates.
-- Cost: setup re-runs each retry (the inter-attempt reset wipes untracked deps), but most tasks pass on
-  attempt 1, so it runs once. For JS, leaving `setup` unset and relying on root `node_modules` up-tree
-  resolution is the cheaper path when it works; `setup` is the portable, explicit alternative.
+- Cost: **`setup` runs once per worktree, not once per retry.** The inter-attempt reset is
+  `git reset --hard` + `git clean -fd` (no `-x`), which *preserves* ignored paths — so the gitignored
+  dependency tree the contract above requires survives the reset and does not need reinstalling. For
+  JS, leaving `setup` unset and relying on root `node_modules` up-tree resolution is the cheaper path
+  when it works; `setup` is the portable, explicit alternative.
+
+### When setup output *does* go stale — `setupEachAttempt`
+
+`setup` is for one-time dependency restore. Commands that regenerate ignored output **from tracked
+source** (codegen, a build step) genuinely do go stale when the reset rolls the tracked files back.
+Declare those separately — they rerun before every attempt, after `setup`:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupEachAttempt": ["npm run codegen"] } }
+```
+
+`task.setupEachAttempt` overrides `meta.setupEachAttempt` the same way. A non-zero command escalates
+the task identically.
+
+### Invalidating the once-per-worktree cache — `setupInputs`
+
+The cache is a fingerprint of the `setup` commands plus the content hashes of any paths listed in
+**`setupInputs`** (relative, no `..`), scoped to exactly one worktree. List your lockfile there when
+a moved baseline must force a reinstall — regenerate-on-conflict resets a task worktree onto a *new*
+integration HEAD, which can carry a different lockfile:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupInputs": ["package-lock.json"] } }
+```
 
 ## Sovereignty note
 

--- a/plugins/ca-codex/routines/writing-plans/references/farm-plan.md
+++ b/plugins/ca-codex/routines/writing-plans/references/farm-plan.md
@@ -38,5 +38,13 @@ conforming to `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json`:
 Validate the JSON against the schema before writing (load the schema from
 `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json` and check). A schema-invalid plan BLOCKS.
 
+`plan.schema.json` is the **authoring** contract. The dispatcher enforces its own **runtime** contract
+(`PLAN_SHAPE` / `parsePlan()` in `farm.ts`) on the parsed JSON before it touches a single field, and
+that one is authoritative: a plan that fails it exits before any worktree, branch, report, or network
+call. The two are kept identical key-for-key and type-for-type by a parity test, so a plan that
+satisfies the schema is accepted at runtime — with one deliberate exception, the kebab-case `id`
+pattern, which is stricter here than the runtime path-safety rule. Both objects are closed: an
+undeclared property is an error, not an ignored extra.
+
 Gate: all failing tests written and confirmed failing; `plan.json` written and schema-valid. Both
 artifacts exist before handing off to `subagent-driven-development`.

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.8] - 2026-07-25
+
+### Changed
+
+- The farm plan handoff docs shipped with this host now describe the runtime
+  plan contract (`parsePlan`, authoritative over `plan.schema.json`) and the
+  split setup phases: `setup` runs once per worktree, `setupEachAttempt` reruns
+  per attempt, and `setupInputs` invalidates the once-per-worktree cache.
+
 ## [0.1.7] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/includes/farm.md
+++ b/plugins/ca-pi/includes/farm.md
@@ -130,7 +130,7 @@ up-tree module resolution often papers over this for JS because the worktree liv
 root; languages without up-tree resolution get nothing.)
 
 Set **`meta.setup`** in `plan.json` — a list of shell commands the dispatcher runs **in each worktree
-before the worker**, on every attempt:
+before the worker**, **once per worktree**:
 
 ```json
 { "meta": { "name": "my-sprint", "setup": ["npm ci"] }, "tasks": [ … ] }
@@ -141,9 +141,35 @@ before the worker**, on every attempt:
   escalates the task immediately** (it is environmental, not a worker failure) — the worker is not invoked.
 - **Setup-produced files must be gitignored.** Anything setup writes that is *not* ignored and *not* in
   the task's `filesInScope` is correctly flagged as drift and escalates.
-- Cost: setup re-runs each retry (the inter-attempt reset wipes untracked deps), but most tasks pass on
-  attempt 1, so it runs once. For JS, leaving `setup` unset and relying on root `node_modules` up-tree
-  resolution is the cheaper path when it works; `setup` is the portable, explicit alternative.
+- Cost: **`setup` runs once per worktree, not once per retry.** The inter-attempt reset is
+  `git reset --hard` + `git clean -fd` (no `-x`), which *preserves* ignored paths — so the gitignored
+  dependency tree the contract above requires survives the reset and does not need reinstalling. For
+  JS, leaving `setup` unset and relying on root `node_modules` up-tree resolution is the cheaper path
+  when it works; `setup` is the portable, explicit alternative.
+
+### When setup output *does* go stale — `setupEachAttempt`
+
+`setup` is for one-time dependency restore. Commands that regenerate ignored output **from tracked
+source** (codegen, a build step) genuinely do go stale when the reset rolls the tracked files back.
+Declare those separately — they rerun before every attempt, after `setup`:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupEachAttempt": ["npm run codegen"] } }
+```
+
+`task.setupEachAttempt` overrides `meta.setupEachAttempt` the same way. A non-zero command escalates
+the task identically.
+
+### Invalidating the once-per-worktree cache — `setupInputs`
+
+The cache is a fingerprint of the `setup` commands plus the content hashes of any paths listed in
+**`setupInputs`** (relative, no `..`), scoped to exactly one worktree. List your lockfile there when
+a moved baseline must force a reinstall — regenerate-on-conflict resets a task worktree onto a *new*
+integration HEAD, which can carry a different lockfile:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupInputs": ["package-lock.json"] } }
+```
 
 ## Sovereignty note
 

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/routines/writing-plans/references/farm-plan.md
+++ b/plugins/ca-pi/routines/writing-plans/references/farm-plan.md
@@ -38,5 +38,13 @@ conforming to `<plugin-root>/tools/plan.schema.json`:
 Validate the JSON against the schema before writing (load the schema from
 `<plugin-root>/tools/plan.schema.json` and check). A schema-invalid plan BLOCKS.
 
+`plan.schema.json` is the **authoring** contract. The dispatcher enforces its own **runtime** contract
+(`PLAN_SHAPE` / `parsePlan()` in `farm.ts`) on the parsed JSON before it touches a single field, and
+that one is authoritative: a plan that fails it exits before any worktree, branch, report, or network
+call. The two are kept identical key-for-key and type-for-type by a parity test, so a plan that
+satisfies the schema is accepted at runtime — with one deliberate exception, the kebab-case `id`
+pattern, which is stricter here than the runtime path-safety rule. Both objects are closed: an
+undeclared property is an error, not an ignored extra.
+
 Gate: all failing tests written and confirmed failing; `plan.json` written and schema-valid. Both
 artifacts exist before handing off to `subagent-driven-development`.

--- a/plugins/ca/includes/farm.md
+++ b/plugins/ca/includes/farm.md
@@ -131,7 +131,7 @@ up-tree module resolution often papers over this for JS because the worktree liv
 root; languages without up-tree resolution get nothing.)
 
 Set **`meta.setup`** in `plan.json` — a list of shell commands the dispatcher runs **in each worktree
-before the worker**, on every attempt:
+before the worker**, **once per worktree**:
 
 ```json
 { "meta": { "name": "my-sprint", "setup": ["npm ci"] }, "tasks": [ … ] }
@@ -142,9 +142,35 @@ before the worker**, on every attempt:
   escalates the task immediately** (it is environmental, not a worker failure) — the worker is not invoked.
 - **Setup-produced files must be gitignored.** Anything setup writes that is *not* ignored and *not* in
   the task's `filesInScope` is correctly flagged as drift and escalates.
-- Cost: setup re-runs each retry (the inter-attempt reset wipes untracked deps), but most tasks pass on
-  attempt 1, so it runs once. For JS, leaving `setup` unset and relying on root `node_modules` up-tree
-  resolution is the cheaper path when it works; `setup` is the portable, explicit alternative.
+- Cost: **`setup` runs once per worktree, not once per retry.** The inter-attempt reset is
+  `git reset --hard` + `git clean -fd` (no `-x`), which *preserves* ignored paths — so the gitignored
+  dependency tree the contract above requires survives the reset and does not need reinstalling. For
+  JS, leaving `setup` unset and relying on root `node_modules` up-tree resolution is the cheaper path
+  when it works; `setup` is the portable, explicit alternative.
+
+### When setup output *does* go stale — `setupEachAttempt`
+
+`setup` is for one-time dependency restore. Commands that regenerate ignored output **from tracked
+source** (codegen, a build step) genuinely do go stale when the reset rolls the tracked files back.
+Declare those separately — they rerun before every attempt, after `setup`:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupEachAttempt": ["npm run codegen"] } }
+```
+
+`task.setupEachAttempt` overrides `meta.setupEachAttempt` the same way. A non-zero command escalates
+the task identically.
+
+### Invalidating the once-per-worktree cache — `setupInputs`
+
+The cache is a fingerprint of the `setup` commands plus the content hashes of any paths listed in
+**`setupInputs`** (relative, no `..`), scoped to exactly one worktree. List your lockfile there when
+a moved baseline must force a reinstall — regenerate-on-conflict resets a task worktree onto a *new*
+integration HEAD, which can carry a different lockfile:
+
+```json
+{ "meta": { "name": "my-sprint", "setup": ["npm ci"], "setupInputs": ["package-lock.json"] } }
+```
 
 ## Sovereignty note
 

--- a/plugins/ca/skills/writing-plans/references/farm-plan.md
+++ b/plugins/ca/skills/writing-plans/references/farm-plan.md
@@ -38,5 +38,13 @@ conforming to `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json`:
 Validate the JSON against the schema before writing (load the schema from
 `${CLAUDE_PLUGIN_ROOT}/tools/plan.schema.json` and check). A schema-invalid plan BLOCKS.
 
+`plan.schema.json` is the **authoring** contract. The dispatcher enforces its own **runtime** contract
+(`PLAN_SHAPE` / `parsePlan()` in `farm.ts`) on the parsed JSON before it touches a single field, and
+that one is authoritative: a plan that fails it exits before any worktree, branch, report, or network
+call. The two are kept identical key-for-key and type-for-type by a parity test, so a plan that
+satisfies the schema is accepted at runtime — with one deliberate exception, the kebab-case `id`
+pattern, which is stricter here than the runtime path-safety rule. Both objects are closed: an
+undeclared property is an error, not an ignored extra.
+
 Gate: all failing tests written and confirmed failing; `plan.json` written and schema-valid. Both
 artifacts exist before handing off to `subagent-driven-development`.

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -895,6 +895,29 @@ async function resetWorktree(wt) {
   await git(["reset", "--hard", "HEAD"], wt);
   await git(["clean", "-fd"], wt);
 }
+async function setupFingerprint(wt, t, deps) {
+  const parts = [JSON.stringify(t.setup ?? [])];
+  for (const rel of t.setupInputs ?? [])
+    parts.push(`${rel}=${await deps.fileHash(path3.resolve(wt, rel)) ?? "absent"}`);
+  return createHash("sha256").update(parts.join("\0")).digest("hex");
+}
+async function runSetupPhases(wt, t, deps, state) {
+  if (t.setup && t.setup.length > 0) {
+    const key = await setupFingerprint(wt, t, deps);
+    if (key !== state.key) {
+      const r = await deps.runGate(wt, t.setup);
+      if (!r.ok) return redactSecrets(`setup failed: ${r.failed}
+${r.tail}`);
+      state.key = key;
+    }
+  }
+  if (t.setupEachAttempt && t.setupEachAttempt.length > 0) {
+    const r = await deps.runGate(wt, t.setupEachAttempt);
+    if (!r.ok) return redactSecrets(`setup failed (setupEachAttempt): ${r.failed}
+${r.tail}`);
+  }
+  return null;
+}
 function mintRunId() {
   return randomBytes(8).toString("hex");
 }
@@ -1036,11 +1059,8 @@ async function bestOfN(t, prompt, model, apiBaseUrl, apiKey, sampling, forbidden
     try {
       const prep = await deps.prepareWorktree(branch, wt, taskBranch);
       if (prep) return { ...base, note: prep };
-      if (t.setup && t.setup.length > 0) {
-        const sr = await deps.runGate(wt, t.setup);
-        if (!sr.ok) return { ...base, note: redactSecrets(`setup failed: ${sr.failed}
-${sr.tail}`) };
-      }
+      const setupNote = await runSetupPhases(wt, t, deps, { key: null });
+      if (setupNote) return { ...base, note: setupNote };
       const testHashBefore = await deps.fileHash(path3.resolve(wt, t.test.path));
       const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
       const pt = w.promptTokens ?? 0;
@@ -1100,17 +1120,15 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   let completionTokens = 0;
   let lastWarning;
   let mutationScore = null;
+  const setupState = { key: null };
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
     if (attempt > 1) {
       if (samples <= 1) priorInScope = lastFilesWritten.length > 0 ? await captureInScope(wt, t) : [];
       await deps.resetWorktree(wt);
     }
-    if (t.setup && t.setup.length > 0) {
-      const setupResult = await deps.runGate(wt, t.setup);
-      if (!setupResult.ok)
-        return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: redactSecrets(`setup failed: ${setupResult.failed}
-${setupResult.tail}`), promptTokens, completionTokens };
-    }
+    const setupNote = await runSetupPhases(wt, t, deps, setupState);
+    if (setupNote)
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: setupNote, promptTokens, completionTokens };
     const injected = await buildEnrichment(wt, t, priorInScope);
     const forbiddenExtra = driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0;
     const prompt = buildPrompt(t, injected, priorFailure, forbiddenExtra);
@@ -1261,6 +1279,99 @@ function assertSecureBaseUrl(url) {
   if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname)) return;
   throw new Error("apiBaseUrl must use HTTPS (HTTP is allowed only for bare loopback hosts)");
 }
+var PLAN_SHAPE = {
+  plan: {
+    required: ["meta", "tasks"],
+    props: { meta: "meta", tasks: "task[]" }
+  },
+  meta: {
+    required: ["name"],
+    props: {
+      name: "string",
+      repo: "string",
+      model: "string",
+      apiBaseUrl: "string",
+      setup: "string[]",
+      setupEachAttempt: "string[]",
+      setupInputs: "string[]"
+    }
+  },
+  task: {
+    required: ["id", "description", "filesInScope", "test", "gate"],
+    props: {
+      id: "string",
+      description: "string",
+      deps: "string[]",
+      filesInScope: "string[]",
+      test: "test",
+      gate: "gate",
+      context: "string",
+      model: "string",
+      maxRetries: "integer",
+      setup: "string[]",
+      setupEachAttempt: "string[]",
+      setupInputs: "string[]"
+    }
+  },
+  test: { required: ["path"], props: { path: "string" } },
+  gate: { required: ["commands"], props: { commands: "string[]" } }
+};
+var PLAN_NON_EMPTY = /* @__PURE__ */ new Set(["plan.tasks", "task.filesInScope", "gate.commands"]);
+var PLAN_INT_MIN = { "task.maxRetries": 0 };
+var PLAN_LABEL_MAX = 40;
+var clipLabel = (s) => s.length <= PLAN_LABEL_MAX ? s : `${s.slice(0, PLAN_LABEL_MAX)}\u2026`;
+var jsonTypeName = (v) => v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+var isJsonObject = (v) => typeof v === "object" && v !== null && !Array.isArray(v);
+function checkPlanField(v, type, at, key) {
+  switch (type) {
+    case "string":
+      if (typeof v !== "string") throw new Error(`${at} must be a string (got ${jsonTypeName(v)})`);
+      return;
+    case "integer": {
+      const min = PLAN_INT_MIN[key] ?? 0;
+      if (typeof v !== "number" || !Number.isInteger(v))
+        throw new Error(`${at} must be an integer >= ${min} (got ${jsonTypeName(v)})`);
+      if (v < min) throw new Error(`${at} must be an integer >= ${min}`);
+      return;
+    }
+    case "string[]": {
+      if (!Array.isArray(v)) throw new Error(`${at} must be an array of strings (got ${jsonTypeName(v)})`);
+      if (PLAN_NON_EMPTY.has(key) && v.length === 0)
+        throw new Error(`${at} must list at least one entry`);
+      for (const [i, entry] of v.entries())
+        if (typeof entry !== "string")
+          throw new Error(`${at}[${i}] must be a string (got ${jsonTypeName(entry)})`);
+      return;
+    }
+    case "task[]": {
+      if (!Array.isArray(v)) throw new Error(`${at} must be an array of task objects (got ${jsonTypeName(v)})`);
+      if (PLAN_NON_EMPTY.has(key) && v.length === 0)
+        throw new Error(`${at} must list at least one task`);
+      for (const [i, entry] of v.entries()) checkPlanObject(entry, "task", `${at}[${i}]`);
+      return;
+    }
+    default:
+      checkPlanObject(v, type, at);
+  }
+}
+function checkPlanObject(value, spec, at) {
+  if (!isJsonObject(value)) throw new Error(`${at} must be a JSON object (got ${jsonTypeName(value)})`);
+  const { required, props } = PLAN_SHAPE[spec];
+  const declared = props;
+  for (const key of Object.keys(value))
+    if (!Object.hasOwn(declared, key)) throw new Error(`${at}: unknown property "${clipLabel(key)}"`);
+  for (const key of required)
+    if (value[key] === void 0) throw new Error(`${at}.${key} is required`);
+  for (const [key, type] of Object.entries(declared)) {
+    const v = value[key];
+    if (v === void 0) continue;
+    checkPlanField(v, type, `${at}.${key}`, `${spec}.${key}`);
+  }
+}
+function parsePlan(raw) {
+  checkPlanObject(raw, "plan", "plan");
+  return raw;
+}
 function validate(plan) {
   if (plan.meta.apiBaseUrl) assertSecureBaseUrl(plan.meta.apiBaseUrl);
   const checkSetup = (label, cmds) => {
@@ -1270,7 +1381,17 @@ function validate(plan) {
       if (cmd.length > 1024) throw new Error(`${label}: setup command exceeds 1024 chars`);
     }
   };
+  const checkSetupInputs = (label, inputs) => {
+    for (const rel of inputs) {
+      if (!rel || typeof rel !== "string")
+        throw new Error(`${label}: setupInputs entries must be non-empty strings`);
+      if (rel.includes("..") || path3.isAbsolute(rel))
+        throw new Error(`${label}: setupInputs entry "${rel}" must be a relative path with no ".." segments`);
+    }
+  };
   if (plan.meta.setup) checkSetup("plan.meta.setup", plan.meta.setup);
+  if (plan.meta.setupEachAttempt) checkSetup("plan.meta.setupEachAttempt", plan.meta.setupEachAttempt);
+  if (plan.meta.setupInputs) checkSetupInputs("plan.meta", plan.meta.setupInputs);
   const ids = /* @__PURE__ */ new Set();
   for (const t of plan.tasks) {
     if (!SAFE_TASK_ID.test(t.id))
@@ -1297,6 +1418,8 @@ function validate(plan) {
         throw new Error(`task ${t.id}: gate command exceeds 1024 chars`);
     }
     if (t.setup) checkSetup(`task ${t.id} setup`, t.setup);
+    if (t.setupEachAttempt) checkSetup(`task ${t.id} setupEachAttempt`, t.setupEachAttempt);
+    if (t.setupInputs) checkSetupInputs(`task ${t.id}`, t.setupInputs);
   }
   for (const t of plan.tasks)
     for (const d of t.deps ?? [])
@@ -1438,10 +1561,19 @@ async function main() {
   const args = process.argv.slice(2);
   const canary = args.includes("--canary");
   const planPath = args.find((a) => !a.startsWith("--")) ?? "plan.json";
-  const plan = JSON.parse(await readFile2(planPath, "utf8"));
-  validate(plan);
-  if (plan.meta.setup) {
-    for (const t of plan.tasks) if (t.setup === void 0) t.setup = plan.meta.setup;
+  let plan;
+  try {
+    plan = parsePlan(JSON.parse(await readFile2(planPath, "utf8")));
+    validate(plan);
+  } catch (e) {
+    console.error(`Error: invalid plan ${planPath}: ${msgOf(e).slice(0, 300)}`);
+    return process.exit(1);
+  }
+  for (const t of plan.tasks) {
+    if (plan.meta.setup && t.setup === void 0) t.setup = plan.meta.setup;
+    if (plan.meta.setupEachAttempt && t.setupEachAttempt === void 0)
+      t.setupEachAttempt = plan.meta.setupEachAttempt;
+    if (plan.meta.setupInputs && t.setupInputs === void 0) t.setupInputs = plan.meta.setupInputs;
   }
   if (canary) return runCanary(plan);
   const { model, apiBaseUrl, apiKey } = resolveConfig(plan);
@@ -1731,6 +1863,7 @@ if (_thisFile === _entryFile) {
 }
 export {
   DEFAULT_API_BASE_URL,
+  PLAN_SHAPE,
   SAFE_RUN_ID,
   SAFE_TASK_ID,
   _resetAllowedWorktreeRoot,
@@ -1754,6 +1887,7 @@ export {
   numEnv,
   parseChatCompletion,
   parseMutationHookOutput,
+  parsePlan,
   readSampling,
   redactSecrets,
   run,

--- a/plugins/ca/tools/farm.test.ts
+++ b/plugins/ca/tools/farm.test.ts
@@ -214,6 +214,50 @@ describe("farm.ts smoke tests", () => {
     expect(result.out).toContain("No model configured");
   });
 
+  // #412 — the runtime boundary. A malformed plan must stop at parse time with a
+  // named, bounded, field-specific message and BEFORE any side effect: no
+  // worktree, no branch, no report directory, no network call, no shell process.
+  it.each([
+    ["null root", "null", /plan must be a JSON object/],
+    ["missing meta", '{"tasks":[]}', /plan\.meta/],
+    ["null meta", '{"meta":null,"tasks":[]}', /plan\.meta/],
+    ["numeric task id", '{"meta":{"name":"p"},"tasks":[{"id":1,"description":"d","filesInScope":["a"],"test":{"path":"a"},"gate":{"commands":["c"]}}]}', /plan\.tasks\[0\]\.id must be a string/],
+    ["unknown task field", '{"meta":{"name":"p"},"tasks":[{"id":"a","bogus":1,"description":"d","filesInScope":["a"],"test":{"path":"a"},"gate":{"commands":["c"]}}]}', /unknown property "bogus"/],
+  ])("refuses a malformed plan (%s) with no side effects", async (_label, raw, expected) => {
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, raw);
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_MODEL: "test-model",
+      FARM_API_BASE_URL: "http://127.0.0.1:9",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.out).toMatch(expected);
+    // A raw TypeError/stack is not an acceptable contract failure.
+    expect(result.out).not.toMatch(/Cannot read properties|TypeError|is not iterable/);
+    // No side effects.
+    expect(existsSync(join(tmpDir, ".farm"))).toBe(false);
+    const branches = execSync("git branch --list", { cwd: tmpDir, stdio: "pipe" }).toString();
+    expect(branches).not.toContain("farm/");
+  });
+
+  it("refuses unparseable plan JSON with a bounded message, not a stack", async () => {
+    const planPath = join(tmpDir, "plan.json");
+    writeFileSync(planPath, "{ not json");
+
+    const result = await runFarm(tmpDir, planPath, {
+      FARM_API_KEY: "test-key",
+      FARM_MODEL: "test-model",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.out).toMatch(/plan\.json/);
+    expect(result.out.length).toBeLessThan(500);
+    expect(existsSync(join(tmpDir, ".farm"))).toBe(false);
+  });
+
   it("completes two tasks green when API returns valid file blocks", async () => {
     ({ server: mockServer, port } = await startMockServer((body) => {
       // Return a file block appropriate to the task described in the prompt

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -66,21 +66,49 @@ export type Task = {
   context?: string;
   maxRetries?: number;
   // Optional per-worktree setup commands (#92). Shell commands run IN the task
-  // worktree before the worker, on every attempt (so they survive the
-  // inter-attempt reset that wipes untracked deps). The common case is repo-wide
-  // dependency install (`npm ci`, `pip install -r requirements.txt`); set
-  // plan.meta.setup and it propagates here at dispatch. A per-task value
-  // overrides the meta default. Setup artifacts MUST be gitignored or they trip
-  // drift detection. A failing setup command escalates the task immediately.
+  // worktree before the worker. The common case is repo-wide dependency install
+  // (`npm ci`, `pip install -r requirements.txt`); set plan.meta.setup and it
+  // propagates here at dispatch. A per-task value overrides the meta default.
+  // Setup artifacts MUST be gitignored or they trip drift detection. A failing
+  // setup command escalates the task immediately.
+  //
+  // #391: this phase runs ONCE per worktree, not once per attempt. The
+  // inter-attempt reset is `git reset --hard` + `git clean -fd` (no `-x`), which
+  // deliberately PRESERVES ignored paths — so the very dependency tree the
+  // setup contract requires to be gitignored survives the reset, and
+  // reinstalling it was pure waste (up to 3x the install on the default retry
+  // budget). Commands that genuinely must rerun after a reset go in
+  // `setupEachAttempt`.
   setup?: string[];
+  // Optional per-attempt preparation (#391). Runs in the worktree before EVERY
+  // worker attempt, after `setup`. This is the escape hatch for commands that
+  // rebuild ignored outputs from tracked source (codegen, a build step) and can
+  // therefore go stale once a reset rolls the tracked files back. A failing
+  // command escalates the task exactly like `setup`.
+  setupEachAttempt?: string[];
+  // Optional declared inputs of `setup` (#391) — relative paths (e.g.
+  // "package-lock.json"). Their content hashes join the setup fingerprint, so
+  // the once-per-worktree cache INVALIDATES when the baseline moves under the
+  // worktree. That is a real case, not a hypothetical: regenerate-on-conflict
+  // resets the task worktree onto a NEW integration HEAD, which can carry a
+  // different lockfile.
+  setupInputs?: string[];
   // Optional per-task model override (AC-02). The effective model for a task is
   // `task.model ?? <run-level resolved model>`, layered where runTask invokes
   // the worker; absent → identical current behavior. Model id only — no second
   // provider or per-task apiBaseUrl.
   model?: string;
 };
-type Plan = {
-  meta: { name: string; repo?: string; model?: string; apiBaseUrl?: string; setup?: string[] };
+export type Plan = {
+  meta: {
+    name: string;
+    repo?: string;
+    model?: string;
+    apiBaseUrl?: string;
+    setup?: string[];
+    setupEachAttempt?: string[];
+    setupInputs?: string[];
+  };
   tasks: Task[];
 };
 
@@ -946,9 +974,63 @@ async function fileHash(p: string): Promise<string | null> {
   }
 }
 
+// NOTE (#391): `clean -fd` — deliberately NOT `-fdx`. Ignored paths are
+// PRESERVED, which is what makes a gitignored dependency tree survive the
+// inter-attempt reset (and is why `setup` is once-per-worktree, not
+// once-per-attempt). Tracked changes and non-ignored untracked worker output are
+// still wiped, so nothing stale carries into the next attempt.
 async function resetWorktree(wt: string) {
   await git(["reset", "--hard", "HEAD"], wt);
   await git(["clean", "-fd"], wt);
+}
+
+// --------------------------------------------------------------------------
+// setup phases (#92 / #391)
+// --------------------------------------------------------------------------
+// Two distinct phases, because one `setup` list could not tell a one-time
+// dependency install from a per-attempt rebuild:
+//
+//   setup            — once per worktree. Its output is required to be
+//                      gitignored, and `git clean -fd` preserves ignored paths,
+//                      so it survives every reset. Re-running it was paying the
+//                      full install up to 3x (default budget) for nothing.
+//   setupEachAttempt — before every attempt, for commands that rebuild ignored
+//                      output from tracked source and DO go stale on reset.
+//
+// The `setup` cache is a fingerprint, scoped to exactly one worktree by living
+// in a caller-owned SetupState (no module-level map, so nothing can leak across
+// tasks or runs). It covers the setup commands plus the content hashes of the
+// task's declared `setupInputs`, so a baseline that moves under the worktree —
+// regenerate-on-conflict resets onto a NEW integration HEAD — reinstalls.
+export type SetupState = { key: string | null };
+
+async function setupFingerprint(wt: string, t: Task, deps: RunTaskDeps): Promise<string> {
+  const parts = [JSON.stringify(t.setup ?? [])];
+  for (const rel of t.setupInputs ?? [])
+    parts.push(`${rel}=${(await deps.fileHash(path.resolve(wt, rel))) ?? "absent"}`);
+  return createHash("sha256").update(parts.join(" ")).digest("hex");
+}
+
+/** Runs both setup phases for one attempt. Returns a redacted note on failure, null on success. */
+async function runSetupPhases(
+  wt: string,
+  t: Task,
+  deps: RunTaskDeps,
+  state: SetupState,
+): Promise<string | null> {
+  if (t.setup && t.setup.length > 0) {
+    const key = await setupFingerprint(wt, t, deps);
+    if (key !== state.key) {
+      const r = await deps.runGate(wt, t.setup);
+      if (!r.ok) return redactSecrets(`setup failed: ${r.failed}\n${r.tail}`);
+      state.key = key;
+    }
+  }
+  if (t.setupEachAttempt && t.setupEachAttempt.length > 0) {
+    const r = await deps.runGate(wt, t.setupEachAttempt);
+    if (!r.ok) return redactSecrets(`setup failed (setupEachAttempt): ${r.failed}\n${r.tail}`);
+  }
+  return null;
 }
 
 // --------------------------------------------------------------------------
@@ -1298,10 +1380,10 @@ async function bestOfN(
       try {
         const prep = await deps.prepareWorktree(branch, wt, taskBranch);
         if (prep) return { ...base, note: prep };
-        if (t.setup && t.setup.length > 0) {
-          const sr = await deps.runGate(wt, t.setup);
-          if (!sr.ok) return { ...base, note: redactSecrets(`setup failed: ${sr.failed}\n${sr.tail}`) };
-        }
+        // Each sample gets a FRESH worktree, so its setup cache starts empty and
+        // dies with the sample — a sample never reuses another worktree's install.
+        const setupNote = await runSetupPhases(wt, t, deps, { key: null });
+        if (setupNote) return { ...base, note: setupNote };
         const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
         const w = await deps.worker.apply({ cwd: wt, prompt, model, apiBaseUrl, apiKey, forbidden, sampling });
         const pt = w.promptTokens ?? 0;
@@ -1394,6 +1476,10 @@ export async function runTask(
   let completionTokens = 0;
   let lastWarning: string | undefined;
   let mutationScore: number | null = null;
+  // #391: the setup cache for THIS worktree only — created here, dropped when
+  // the task ends, so a fresh worktree can never inherit a stale "already
+  // installed" verdict from another task.
+  const setupState: SetupState = { key: null };
 
   for (let attempt = 1; attempt <= limit + 1; attempt++) {
     if (attempt > 1) {
@@ -1410,17 +1496,16 @@ export async function runTask(
       await deps.resetWorktree(wt); // never accumulate stale files
     }
 
-    // Per-worktree setup (#92): run dependency-setup commands in the worktree
-    // before the worker. Runs every attempt because the reset above wipes
-    // untracked deps (node_modules etc.); on the happy path (attempt 1 passes)
-    // it runs once. Executed through the same gate machinery (shell + exit
-    // code, redacted tail). A setup failure is environmental, not the worker's
-    // fault, so it escalates immediately rather than burning a worker retry.
-    if (t.setup && t.setup.length > 0) {
-      const setupResult = await deps.runGate(wt, t.setup);
-      if (!setupResult.ok)
-        return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: redactSecrets(`setup failed: ${setupResult.failed}\n${setupResult.tail}`), promptTokens, completionTokens };
-    }
+    // Setup (#92/#391): `setup` runs ONCE per worktree — the reset above is
+    // `clean -fd`, which preserves the ignored dependency tree setup is
+    // contractually required to produce — and re-runs only if its fingerprint
+    // (commands + declared setupInputs) changed. `setupEachAttempt` runs every
+    // attempt. Both go through the same gate machinery (shell + exit code,
+    // redacted tail). A setup failure is environmental, not the worker's fault,
+    // so it escalates immediately rather than burning a worker retry.
+    const setupNote = await runSetupPhases(wt, t, deps, setupState);
+    if (setupNote)
+      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: setupNote, promptTokens, completionTokens };
 
     // Enrichment (AC-03/AC-04): read the per-attempt worktree state — AFTER any
     // reset above — so the test source and existing in-scope file contents
@@ -1674,6 +1759,145 @@ export function assertSecureBaseUrl(url: string) {
   throw new Error("apiBaseUrl must use HTTPS (HTTP is allowed only for bare loopback hosts)");
 }
 
+// --------------------------------------------------------------------------
+// runtime plan contract (#412) — the EXECUTED schema
+// --------------------------------------------------------------------------
+// `main()` reads plan.json off disk, so the plan is untrusted input: it may be
+// hand-edited, half-written, or emitted by a drifted generator. It used to be
+// cast (`JSON.parse(...) as Plan`) and handed straight to validate(), which
+// dereferences `plan.meta` and iterates `plan.tasks` — so `null` and `{}` came
+// out as raw TypeErrors, and a numeric `id`/`description` sailed past checks
+// that assume strings.
+//
+// AUTHORITY. PLAN_SHAPE below (enforced by parsePlan) is the AUTHORITATIVE,
+// executed contract: nothing reaches validate(), resolveConfig(), a worktree, a
+// branch, a report, or the network until a plan satisfies it exactly.
+// `plan.schema.json` is the AUTHORING contract — what writing-plans validates
+// its output against before handing off — and is never consulted at runtime.
+// The two are kept key-for-key and type-for-type identical by the parity test in
+// plan-contract.test.ts; adding a field to one side without the other fails CI.
+// One divergence is deliberate and ratified there: the schema's kebab-case `id`
+// pattern is an authoring rule, while the runtime path-traversal rule is
+// SAFE_TASK_ID in validate() (see the note above it).
+//
+// Messages are bounded and field-specific: they name the JSON path (by task
+// INDEX — the id is not yet trustworthy) and the offending value's TYPE, and
+// never echo plan content back, which could be long or secret-bearing.
+export type PlanFieldType = "string" | "integer" | "string[]" | "task[]" | "meta" | "test" | "gate";
+type PlanObjectSpec = { required: readonly string[]; props: Readonly<Record<string, PlanFieldType>> };
+
+export const PLAN_SHAPE = {
+  plan: {
+    required: ["meta", "tasks"],
+    props: { meta: "meta", tasks: "task[]" },
+  },
+  meta: {
+    required: ["name"],
+    props: {
+      name: "string",
+      repo: "string",
+      model: "string",
+      apiBaseUrl: "string",
+      setup: "string[]",
+      setupEachAttempt: "string[]",
+      setupInputs: "string[]",
+    },
+  },
+  task: {
+    required: ["id", "description", "filesInScope", "test", "gate"],
+    props: {
+      id: "string",
+      description: "string",
+      deps: "string[]",
+      filesInScope: "string[]",
+      test: "test",
+      gate: "gate",
+      context: "string",
+      model: "string",
+      maxRetries: "integer",
+      setup: "string[]",
+      setupEachAttempt: "string[]",
+      setupInputs: "string[]",
+    },
+  },
+  test: { required: ["path"], props: { path: "string" } },
+  gate: { required: ["commands"], props: { commands: "string[]" } },
+} as const satisfies Record<string, PlanObjectSpec>;
+
+type PlanSpecName = keyof typeof PLAN_SHAPE;
+
+// Arrays the schema declares `minItems: 1`, keyed "<spec>.<prop>".
+const PLAN_NON_EMPTY: ReadonlySet<string> = new Set(["plan.tasks", "task.filesInScope", "gate.commands"]);
+// Integer fields and their schema `minimum`.
+const PLAN_INT_MIN: Readonly<Record<string, number>> = { "task.maxRetries": 0 };
+
+const PLAN_LABEL_MAX = 40;
+const clipLabel = (s: string) => (s.length <= PLAN_LABEL_MAX ? s : `${s.slice(0, PLAN_LABEL_MAX)}…`);
+const jsonTypeName = (v: unknown) => (v === null ? "null" : Array.isArray(v) ? "array" : typeof v);
+const isJsonObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+function checkPlanField(v: unknown, type: PlanFieldType, at: string, key: string): void {
+  switch (type) {
+    case "string":
+      if (typeof v !== "string") throw new Error(`${at} must be a string (got ${jsonTypeName(v)})`);
+      return;
+    case "integer": {
+      const min = PLAN_INT_MIN[key] ?? 0;
+      if (typeof v !== "number" || !Number.isInteger(v))
+        throw new Error(`${at} must be an integer >= ${min} (got ${jsonTypeName(v)})`);
+      if (v < min) throw new Error(`${at} must be an integer >= ${min}`);
+      return;
+    }
+    case "string[]": {
+      if (!Array.isArray(v)) throw new Error(`${at} must be an array of strings (got ${jsonTypeName(v)})`);
+      if (PLAN_NON_EMPTY.has(key) && v.length === 0)
+        throw new Error(`${at} must list at least one entry`);
+      for (const [i, entry] of v.entries())
+        if (typeof entry !== "string")
+          throw new Error(`${at}[${i}] must be a string (got ${jsonTypeName(entry)})`);
+      return;
+    }
+    case "task[]": {
+      if (!Array.isArray(v)) throw new Error(`${at} must be an array of task objects (got ${jsonTypeName(v)})`);
+      if (PLAN_NON_EMPTY.has(key) && v.length === 0)
+        throw new Error(`${at} must list at least one task`);
+      for (const [i, entry] of v.entries()) checkPlanObject(entry, "task", `${at}[${i}]`);
+      return;
+    }
+    default:
+      // nested closed object — "meta" | "test" | "gate"
+      checkPlanObject(v, type, at);
+  }
+}
+
+function checkPlanObject(value: unknown, spec: PlanSpecName, at: string): void {
+  if (!isJsonObject(value)) throw new Error(`${at} must be a JSON object (got ${jsonTypeName(value)})`);
+  const { required, props } = PLAN_SHAPE[spec];
+  const declared = props as Readonly<Record<string, PlanFieldType>>;
+  // Closed object: an unknown property is a contract breach, not a courtesy —
+  // it is how a drifted generator or a typo'd hand edit silently loses a field.
+  for (const key of Object.keys(value))
+    if (!Object.hasOwn(declared, key)) throw new Error(`${at}: unknown property "${clipLabel(key)}"`);
+  for (const key of required)
+    if (value[key] === undefined) throw new Error(`${at}.${key} is required`);
+  for (const [key, type] of Object.entries(declared)) {
+    const v = value[key];
+    if (v === undefined) continue;
+    checkPlanField(v, type, `${at}.${key}`, `${spec}.${key}`);
+  }
+}
+
+/**
+ * The runtime boundary (#412). Validates parsed-but-untrusted JSON against
+ * PLAN_SHAPE and returns it typed. Throws a bounded, field-specific Error on the
+ * FIRST violation. Call this before touching any field of a plan.
+ */
+export function parsePlan(raw: unknown): Plan {
+  checkPlanObject(raw, "plan", "plan");
+  return raw as Plan;
+}
+
 export function validate(plan: Plan) {
   // meta-level schema checks — require HTTPS except for loopback (test mocks)
   if (plan.meta.apiBaseUrl) assertSecureBaseUrl(plan.meta.apiBaseUrl);
@@ -1687,7 +1911,20 @@ export function validate(plan: Plan) {
       if (cmd.length > 1024) throw new Error(`${label}: setup command exceeds 1024 chars`);
     }
   };
+  // #391: `setupInputs` are relative paths resolved against the worktree and
+  // read (hashed) by the setup fingerprint, so they get the same relative-path
+  // rule as test.path / filesInScope.
+  const checkSetupInputs = (label: string, inputs: string[]) => {
+    for (const rel of inputs) {
+      if (!rel || typeof rel !== "string")
+        throw new Error(`${label}: setupInputs entries must be non-empty strings`);
+      if (rel.includes("..") || path.isAbsolute(rel))
+        throw new Error(`${label}: setupInputs entry "${rel}" must be a relative path with no ".." segments`);
+    }
+  };
   if (plan.meta.setup) checkSetup("plan.meta.setup", plan.meta.setup);
+  if (plan.meta.setupEachAttempt) checkSetup("plan.meta.setupEachAttempt", plan.meta.setupEachAttempt);
+  if (plan.meta.setupInputs) checkSetupInputs("plan.meta", plan.meta.setupInputs);
 
   const ids = new Set<string>();
   for (const t of plan.tasks) {
@@ -1733,6 +1970,8 @@ export function validate(plan: Plan) {
         throw new Error(`task ${t.id}: gate command exceeds 1024 chars`);
     }
     if (t.setup) checkSetup(`task ${t.id} setup`, t.setup);
+    if (t.setupEachAttempt) checkSetup(`task ${t.id} setupEachAttempt`, t.setupEachAttempt);
+    if (t.setupInputs) checkSetupInputs(`task ${t.id}`, t.setupInputs);
   }
   for (const t of plan.tasks)
     for (const d of t.deps ?? [])
@@ -1931,14 +2170,31 @@ async function main() {
   const args = process.argv.slice(2);
   const canary = args.includes("--canary");
   const planPath = args.find((a) => !a.startsWith("--")) ?? "plan.json";
-  const plan = JSON.parse(await readFile(planPath, "utf8")) as Plan;
-  validate(plan);
+  // #412: plan.json is untrusted input. parsePlan enforces the runtime contract
+  // (PLAN_SHAPE) on the parsed JSON BEFORE any field is dereferenced, and
+  // everything below — validate, resolveConfig, worktrees, branches, reports,
+  // the network — is downstream of it. A malformed plan exits here, with a
+  // bounded field-specific message instead of a raw TypeError and a stack, and
+  // with no side effect of any kind performed.
+  let plan: Plan;
+  try {
+    plan = parsePlan(JSON.parse(await readFile(planPath, "utf8")));
+    validate(plan);
+  } catch (e) {
+    console.error(`Error: invalid plan ${planPath}: ${msgOf(e).slice(0, 300)}`);
+    return process.exit(1);
+  }
 
-  // #92: propagate the repo-wide meta.setup to every task that did not declare
-  // its own (task.setup wins; meta.setup fills the gap). Done once at dispatch,
-  // before main and canary, so runTask only ever reads the effective t.setup.
-  if (plan.meta.setup)
-    for (const t of plan.tasks) if (t.setup === undefined) t.setup = plan.meta.setup;
+  // #92: propagate the repo-wide meta setup fields to every task that did not
+  // declare its own (the task value wins; meta fills the gap). Done once at
+  // dispatch, before main and canary, so runTask only ever reads the effective
+  // task-level values.
+  for (const t of plan.tasks) {
+    if (plan.meta.setup && t.setup === undefined) t.setup = plan.meta.setup;
+    if (plan.meta.setupEachAttempt && t.setupEachAttempt === undefined)
+      t.setupEachAttempt = plan.meta.setupEachAttempt;
+    if (plan.meta.setupInputs && t.setupInputs === undefined) t.setupInputs = plan.meta.setupInputs;
+  }
 
   if (canary) return runCanary(plan);
 

--- a/plugins/ca/tools/plan-contract.test.ts
+++ b/plugins/ca/tools/plan-contract.test.ts
@@ -1,0 +1,471 @@
+/**
+ * plan-contract.test.ts — the farm plan handoff contract.
+ *
+ * Two issues share this surface:
+ *
+ *  #412 — the runtime boundary. `main()` used to do
+ *  `JSON.parse(...) as Plan` and hand the result straight to `validate()`,
+ *  which dereferences `plan.meta` and iterates `plan.tasks` with no shape
+ *  check. `parsePlan()` is the exact runtime validator that closes that hole,
+ *  and PLAN_SHAPE is the single declarative description both it and the
+ *  schema-parity test read.
+ *
+ *  #391 — setup phases. `resetWorktree` is `git reset --hard` + `git clean -fd`
+ *  (no `-x`), which PRESERVES ignored paths, so a gitignored dependency tree
+ *  survives the inter-attempt reset. `setup` must therefore run ONCE per
+ *  worktree, with an explicit `setupEachAttempt` phase for commands that
+ *  genuinely must rerun, and `setupInputs` fingerprinting for the case where
+ *  the baseline moves under the worktree (regenerate-on-conflict).
+ */
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parsePlan, PLAN_SHAPE, validate, runTask } from "./farm.ts";
+import type { Task, RunTaskDeps, Worker, WorkerResult } from "./farm.ts";
+
+const validPlan = () => ({
+  meta: { name: "p" },
+  tasks: [
+    {
+      id: "task-a",
+      description: "make the test pass",
+      filesInScope: ["src/a.ts"],
+      test: { path: "src/a.test.ts" },
+      gate: { commands: ["node -p 0"] },
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// #412 — parsePlan: the runtime schema check at the JSON boundary
+// ---------------------------------------------------------------------------
+describe("#412 parsePlan — rejects malformed plans before any field access", () => {
+  it("accepts a minimal valid plan and returns it", () => {
+    const p = validPlan();
+    expect(parsePlan(p)).toBe(p);
+  });
+
+  it("accepts every optional field declared by the schema", () => {
+    expect(() =>
+      parsePlan({
+        meta: {
+          name: "p",
+          repo: "r",
+          model: "m",
+          apiBaseUrl: "https://api.example/v1",
+          setup: ["npm ci"],
+          setupEachAttempt: ["npm run build"],
+          setupInputs: ["package-lock.json"],
+        },
+        tasks: [
+          {
+            ...validPlan().tasks[0],
+            deps: [],
+            context: "ctx",
+            model: "m2",
+            maxRetries: 0,
+            setup: ["npm ci"],
+            setupEachAttempt: ["npm run build"],
+            setupInputs: ["package-lock.json"],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects null instead of throwing a raw TypeError", () => {
+    expect(() => parsePlan(null)).toThrow(/plan must be a JSON object/);
+  });
+
+  it("rejects an array root", () => {
+    expect(() => parsePlan([])).toThrow(/plan must be a JSON object/);
+  });
+
+  it("rejects a scalar root", () => {
+    expect(() => parsePlan(42)).toThrow(/plan must be a JSON object/);
+  });
+
+  it("rejects {} — meta and tasks are required", () => {
+    expect(() => parsePlan({})).toThrow(/plan\.meta.*required/);
+  });
+
+  it("rejects a missing tasks array", () => {
+    expect(() => parsePlan({ meta: { name: "p" } })).toThrow(/plan\.tasks.*required/);
+  });
+
+  it("rejects a null meta", () => {
+    expect(() => parsePlan({ meta: null, tasks: validPlan().tasks })).toThrow(/plan\.meta/);
+  });
+
+  it("rejects meta without a name", () => {
+    expect(() => parsePlan({ meta: {}, tasks: validPlan().tasks })).toThrow(/plan\.meta\.name.*required/);
+  });
+
+  it("rejects a non-string meta.name", () => {
+    expect(() => parsePlan({ meta: { name: 7 }, tasks: validPlan().tasks })).toThrow(
+      /plan\.meta\.name must be a string/,
+    );
+  });
+
+  it("rejects an empty tasks array (schema minItems: 1)", () => {
+    expect(() => parsePlan({ meta: { name: "p" }, tasks: [] })).toThrow(/plan\.tasks.*at least one/);
+  });
+
+  it("rejects a non-array tasks", () => {
+    expect(() => parsePlan({ meta: { name: "p" }, tasks: {} })).toThrow(/plan\.tasks/);
+  });
+
+  it("rejects a non-object task entry", () => {
+    expect(() => parsePlan({ meta: { name: "p" }, tasks: [null] })).toThrow(/plan\.tasks\[0\]/);
+  });
+
+  it("rejects a numeric task id (SAFE_TASK_ID assumed a string)", () => {
+    const p = validPlan();
+    (p.tasks[0] as Record<string, unknown>).id = 7;
+    expect(() => parsePlan(p)).toThrow(/plan\.tasks\[0\]\.id must be a string/);
+  });
+
+  it("rejects a numeric task description", () => {
+    const p = validPlan();
+    (p.tasks[0] as Record<string, unknown>).description = 7;
+    expect(() => parsePlan(p)).toThrow(/plan\.tasks\[0\]\.description must be a string/);
+  });
+
+  it("rejects an unknown root property", () => {
+    expect(() => parsePlan({ ...validPlan(), bogus: 1 })).toThrow(/plan: unknown property "bogus"/);
+  });
+
+  it("rejects an unknown meta property", () => {
+    expect(() => parsePlan({ meta: { name: "p", bogus: 1 }, tasks: validPlan().tasks })).toThrow(
+      /plan\.meta: unknown property "bogus"/,
+    );
+  });
+
+  it("rejects an unknown task property", () => {
+    const p = validPlan();
+    (p.tasks[0] as Record<string, unknown>).bogus = 1;
+    expect(() => parsePlan(p)).toThrow(/plan\.tasks\[0\]: unknown property "bogus"/);
+  });
+
+  it("rejects an unknown test/gate property (nested closed objects)", () => {
+    const a = validPlan();
+    (a.tasks[0].test as Record<string, unknown>).bogus = 1;
+    expect(() => parsePlan(a)).toThrow(/plan\.tasks\[0\]\.test: unknown property "bogus"/);
+    const b = validPlan();
+    (b.tasks[0].gate as Record<string, unknown>).bogus = 1;
+    expect(() => parsePlan(b)).toThrow(/plan\.tasks\[0\]\.gate: unknown property "bogus"/);
+  });
+
+  it("rejects a non-string entry inside deps / filesInScope / gate.commands / setup", () => {
+    const mk = (patch: Record<string, unknown>) => {
+      const p = validPlan();
+      Object.assign(p.tasks[0], patch);
+      return p;
+    };
+    expect(() => parsePlan(mk({ deps: [7] }))).toThrow(/plan\.tasks\[0\]\.deps/);
+    expect(() => parsePlan(mk({ filesInScope: [7] }))).toThrow(/plan\.tasks\[0\]\.filesInScope/);
+    expect(() => parsePlan(mk({ gate: { commands: [7] } }))).toThrow(/plan\.tasks\[0\]\.gate\.commands/);
+    expect(() => parsePlan(mk({ setup: [7] }))).toThrow(/plan\.tasks\[0\]\.setup/);
+  });
+
+  it("rejects empty filesInScope and empty gate.commands (schema minItems: 1)", () => {
+    const p1 = validPlan();
+    p1.tasks[0].filesInScope = [];
+    expect(() => parsePlan(p1)).toThrow(/plan\.tasks\[0\]\.filesInScope.*at least one/);
+    const p2 = validPlan();
+    p2.tasks[0].gate.commands = [];
+    expect(() => parsePlan(p2)).toThrow(/plan\.tasks\[0\]\.gate\.commands.*at least one/);
+  });
+
+  it("rejects a missing / non-object test and gate", () => {
+    const p1 = validPlan();
+    (p1.tasks[0] as Record<string, unknown>).test = "src/a.test.ts";
+    expect(() => parsePlan(p1)).toThrow(/plan\.tasks\[0\]\.test/);
+    const p2 = validPlan();
+    delete (p2.tasks[0] as Record<string, unknown>).gate;
+    expect(() => parsePlan(p2)).toThrow(/plan\.tasks\[0\]\.gate.*required/);
+  });
+
+  it("rejects a non-integer, fractional, or negative maxRetries", () => {
+    const mk = (v: unknown) => {
+      const p = validPlan();
+      (p.tasks[0] as Record<string, unknown>).maxRetries = v;
+      return p;
+    };
+    expect(() => parsePlan(mk("2"))).toThrow(/plan\.tasks\[0\]\.maxRetries must be an integer/);
+    expect(() => parsePlan(mk(1.5))).toThrow(/plan\.tasks\[0\]\.maxRetries must be an integer/);
+    expect(() => parsePlan(mk(-1))).toThrow(/plan\.tasks\[0\]\.maxRetries must be an integer >= 0/);
+    expect(() => parsePlan(mk(NaN))).toThrow(/plan\.tasks\[0\]\.maxRetries must be an integer/);
+    expect(() => parsePlan(mk(0))).not.toThrow();
+  });
+
+  it("names the offending task by INDEX, not by an unvalidated id", () => {
+    const p = validPlan();
+    p.tasks.push({ ...validPlan().tasks[0], id: "task-b", description: 7 as unknown as string });
+    expect(() => parsePlan(p)).toThrow(/plan\.tasks\[1\]\.description/);
+  });
+
+  it("bounds its messages — an absurd key or value is never echoed whole", () => {
+    const key = "z".repeat(5000);
+    let msg = "";
+    try {
+      parsePlan({ ...validPlan(), [key]: 1 });
+    } catch (e) {
+      msg = e instanceof Error ? e.message : String(e);
+    }
+    expect(msg).toMatch(/unknown property/);
+    expect(msg.length).toBeLessThan(200);
+    expect(msg).not.toContain(key);
+
+    let msg2 = "";
+    try {
+      const p = validPlan();
+      (p.tasks[0] as Record<string, unknown>).description = "q".repeat(5000);
+      (p.tasks[0] as Record<string, unknown>).context = 7;
+      parsePlan(p);
+    } catch (e) {
+      msg2 = e instanceof Error ? e.message : String(e);
+    }
+    expect(msg2.length).toBeLessThan(200);
+  });
+
+  it("hands validate() a plan it can safely dereference (no raw TypeError path left)", () => {
+    // The composition main() performs: parsePlan first, then validate.
+    expect(() => validate(parsePlan(validPlan()))).not.toThrow();
+    expect(() => validate(null as never)).toThrow(); // validate alone is NOT the boundary
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #412 — schema/validator/type parity.
+//
+// AUTHORITY: parsePlan (via PLAN_SHAPE) is the EXECUTED contract. plan.schema.json
+// is the AUTHORING contract writing-plans validates against, and must mirror
+// PLAN_SHAPE key-for-key and type-for-type. This test is what keeps them
+// synchronized: adding a field on one side without the other fails here.
+// ---------------------------------------------------------------------------
+describe("#412 plan.schema.json <-> PLAN_SHAPE parity", () => {
+  const schema = JSON.parse(
+    readFileSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), "plan.schema.json"), "utf8"),
+  );
+
+  // schema sub-object -> PLAN_SHAPE key
+  const pairs: Array<[string, Record<string, unknown>, keyof typeof PLAN_SHAPE]> = [
+    ["root", schema, "plan"],
+    ["meta", schema.properties.meta, "meta"],
+    ["task", schema.$defs.task, "task"],
+    ["task.test", schema.$defs.task.properties.test, "test"],
+    ["task.gate", schema.$defs.task.properties.gate, "gate"],
+  ];
+
+  // How a schema property is spelled as a PLAN_SHAPE field type.
+  function schemaTypeOf(prop: Record<string, any>): string {
+    if (prop.$ref === "#/$defs/task") return "task";
+    if (prop.type === "array") return `${schemaTypeOf(prop.items)}[]`;
+    if (prop.type === "object") return "object";
+    return String(prop.type);
+  }
+
+  for (const [label, node, shapeKey] of pairs) {
+    const spec = PLAN_SHAPE[shapeKey];
+
+    it(`${label}: property sets match exactly`, () => {
+      expect(Object.keys(node.properties as object).sort()).toEqual(Object.keys(spec.props).sort());
+    });
+
+    it(`${label}: required sets match exactly`, () => {
+      expect([...((node.required as string[]) ?? [])].sort()).toEqual([...spec.required].sort());
+    });
+
+    it(`${label}: is a closed object on both sides (additionalProperties:false)`, () => {
+      expect(node.additionalProperties).toBe(false);
+    });
+
+    it(`${label}: every property's declared type matches`, () => {
+      for (const [k, prop] of Object.entries(node.properties as Record<string, any>)) {
+        const runtime = (spec.props as Record<string, string>)[k];
+        // A nested object in PLAN_SHAPE is named by its sub-spec ("meta"/"test"/
+        // "gate"/"task[]"); the schema spells those as object/$ref.
+        const expected =
+          runtime === "meta" || runtime === "test" || runtime === "gate" ? "object" : runtime;
+        expect(`${label}.${k}: ${schemaTypeOf(prop)}`).toBe(`${label}.${k}: ${expected}`);
+      }
+    });
+  }
+
+  it("keeps minItems:1 on exactly the arrays parsePlan requires non-empty", () => {
+    expect(schema.properties.tasks.minItems).toBe(1);
+    expect(schema.$defs.task.properties.filesInScope.minItems).toBe(1);
+    expect(schema.$defs.task.properties.gate.properties.commands.minItems).toBe(1);
+    // …and NOT on the ones it accepts empty.
+    expect(schema.$defs.task.properties.deps.minItems).toBeUndefined();
+    expect(schema.properties.meta.properties.setup.minItems).toBeUndefined();
+  });
+
+  it("documents the one RATIFIED divergence: the id pattern", () => {
+    // The schema's kebab-case `id` pattern is the narrower AUTHORING rule;
+    // SAFE_TASK_ID (checked in validate()) is the broader runtime path-traversal
+    // defense. parsePlan checks the TYPE only and leaves the character rule to
+    // validate(), so a hand-edited plan that never went through the authoring
+    // gate is still refused by the runtime defense — not by a pattern the
+    // authoring layer owns.
+    expect(schema.$defs.task.properties.id.pattern).toBe("^[a-z0-9][a-z0-9-]*$");
+    const p = validPlan();
+    p.tasks[0].id = "my.task_v1"; // schema-invalid, runtime-safe
+    expect(() => validate(parsePlan(p))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #391 — setup phases. `git clean -fd` preserves ignored paths, so the
+// documented dependency-only setup survives the inter-attempt reset.
+// ---------------------------------------------------------------------------
+describe("#391 setup runs once per worktree; setupEachAttempt reruns", () => {
+  const baseTask: Task = {
+    id: "setup-task",
+    description: "make the test pass",
+    filesInScope: ["src/s.ts"],
+    test: { path: "src/s.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  /**
+   * deps that record every runGate command set, fail the GATE for the first
+   * `failGateTimes` attempts (forcing worker retries), and answer fileHash from
+   * a programmable table so setupInputs fingerprinting can be driven.
+   */
+  function retryDeps(opts: {
+    calls: string[][];
+    failGateTimes?: number;
+    hashes?: Record<string, string[]>; // path suffix -> hash per read
+  }): RunTaskDeps {
+    let gateRuns = 0;
+    const reads: Record<string, number> = {};
+    const worker: Worker = {
+      async apply() {
+        return { ok: true, filesWritten: ["src/s.ts"] } satisfies WorkerResult;
+      },
+    };
+    return {
+      worker,
+      prepareWorktree: async () => null,
+      resetWorktree: async () => {},
+      fileHash: async (p: string) => {
+        for (const [suffix, seq] of Object.entries(opts.hashes ?? {})) {
+          if (p.replace(/\\/g, "/").endsWith(suffix)) {
+            const n = reads[suffix] ?? 0;
+            reads[suffix] = n + 1;
+            return seq[Math.min(n, seq.length - 1)];
+          }
+        }
+        return null;
+      },
+      checkDrift: async () => [],
+      runGate: async (_cwd: string, commands: string[]) => {
+        opts.calls.push(commands);
+        const isGate = commands.join(",") === baseTask.gate.commands.join(",");
+        if (isGate) {
+          gateRuns++;
+          if (gateRuns <= (opts.failGateTimes ?? 0))
+            return { ok: false as const, failed: commands[0], tail: "red" };
+        }
+        return { ok: true as const };
+      },
+      antiGamingCheck: async () => ({ risk: "none" as const }),
+      mutationCheck: async () => null,
+      git: async () => ({ code: 0, out: "", stdout: "", stderr: "" }),
+      withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+    };
+  }
+
+  const countOf = (calls: string[][], cmd: string) =>
+    calls.filter((c) => c.join(",") === cmd).length;
+
+  it("invokes a dependency-only `npm ci` setup ONCE across two worker retries", async () => {
+    const calls: string[][] = [];
+    const r = await runTask(
+      { ...baseTask, maxRetries: 2, setup: ["npm ci"] },
+      "m", "https://api.example/v1", "k",
+      retryDeps({ calls, failGateTimes: 2 }),
+    );
+    expect(r.status).toBe("green");
+    expect(r.attempts).toBe(3); // three attempts really happened
+    expect(countOf(calls, "npm ci")).toBe(1); // …and one install
+  });
+
+  it("reruns `setupEachAttempt` before every attempt", async () => {
+    const calls: string[][] = [];
+    const r = await runTask(
+      { ...baseTask, maxRetries: 2, setup: ["npm ci"], setupEachAttempt: ["npm run codegen"] },
+      "m", "https://api.example/v1", "k",
+      retryDeps({ calls, failGateTimes: 2 }),
+    );
+    expect(r.status).toBe("green");
+    expect(countOf(calls, "npm ci")).toBe(1);
+    expect(countOf(calls, "npm run codegen")).toBe(3);
+  });
+
+  it("still runs setup BEFORE the worker on the first attempt", async () => {
+    const calls: string[][] = [];
+    await runTask(
+      { ...baseTask, setup: ["npm ci"], setupEachAttempt: ["npm run codegen"] },
+      "m", "https://api.example/v1", "k",
+      retryDeps({ calls }),
+    );
+    expect(calls[0]).toEqual(["npm ci"]);
+    expect(calls[1]).toEqual(["npm run codegen"]);
+  });
+
+  it("escalates immediately when setupEachAttempt fails", async () => {
+    const calls: string[][] = [];
+    const deps = retryDeps({ calls });
+    const failing: RunTaskDeps = {
+      ...deps,
+      runGate: async (cwd: string, commands: string[]) => {
+        if (commands[0] === "npm run codegen")
+          return { ok: false as const, failed: commands[0], tail: "boom" };
+        return deps.runGate(cwd, commands);
+      },
+    };
+    const r = await runTask(
+      { ...baseTask, setupEachAttempt: ["npm run codegen"] },
+      "m", "https://api.example/v1", "k",
+      failing,
+    );
+    expect(r.status).toBe("escalate");
+    expect(r.note).toMatch(/setup failed/i);
+  });
+
+  it("reruns cached setup when a declared setupInput changes under the worktree", async () => {
+    // The regenerate-on-conflict path resets the worktree onto a NEW integration
+    // HEAD, so a lockfile really can change between attempts. The fingerprint is
+    // what notices.
+    const calls: string[][] = [];
+    const r = await runTask(
+      { ...baseTask, maxRetries: 1, setup: ["npm ci"], setupInputs: ["package-lock.json"] },
+      "m", "https://api.example/v1", "k",
+      retryDeps({ calls, failGateTimes: 1, hashes: { "package-lock.json": ["hash-1", "hash-2"] } }),
+    );
+    expect(r.status).toBe("green");
+    expect(countOf(calls, "npm ci")).toBe(2);
+  });
+
+  it("does NOT rerun setup when the declared setupInput is unchanged", async () => {
+    const calls: string[][] = [];
+    const r = await runTask(
+      { ...baseTask, maxRetries: 1, setup: ["npm ci"], setupInputs: ["package-lock.json"] },
+      "m", "https://api.example/v1", "k",
+      retryDeps({ calls, failGateTimes: 1, hashes: { "package-lock.json": ["hash-1"] } }),
+    );
+    expect(r.status).toBe("green");
+    expect(countOf(calls, "npm ci")).toBe(1);
+  });
+
+  it("is a no-op when neither setup phase is configured", async () => {
+    const calls: string[][] = [];
+    const r = await runTask(baseTask, "m", "https://api.example/v1", "k", retryDeps({ calls }));
+    expect(r.status).toBe("green");
+    expect(calls).toEqual([baseTask.gate.commands]);
+  });
+});

--- a/plugins/ca/tools/plan.schema.json
+++ b/plugins/ca/tools/plan.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://codearbiter/farm/plan.schema.json",
   "title": "codeArbiter farm plan",
-  "description": "The handoff artifact writing-plans emits in --farm mode. Each task is a self-contained work packet a cheap Zen worker can complete. meta.model and meta.apiBaseUrl are written by subagent-driven-development at dispatch time (not at plan-authoring time).",
+  "description": "The handoff artifact writing-plans emits in --farm mode. Each task is a self-contained work packet a cheap Zen worker can complete. meta.model and meta.apiBaseUrl are written by subagent-driven-development at dispatch time (not at plan-authoring time). AUTHORING CONTRACT: this schema is what writing-plans validates its output against; it is never consulted at runtime. The EXECUTED contract is farm.ts's PLAN_SHAPE / parsePlan(), which is authoritative and kept identical to this file key-for-key and type-for-type by the parity test in plan-contract.test.ts. The one ratified divergence is task.id: the kebab-case pattern below is an authoring rule, while the runtime path-traversal rule is SAFE_TASK_ID in validate().",
   "type": "object",
   "required": ["meta", "tasks"],
   "additionalProperties": false,
@@ -10,6 +10,7 @@
     "meta": {
       "type": "object",
       "required": ["name"],
+      "additionalProperties": false,
       "properties": {
         "name": { "type": "string" },
         "repo": { "type": "string" },
@@ -24,7 +25,17 @@
         "setup": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Per-worktree setup shell commands run BEFORE the worker in each task worktree (e.g. `npm ci`). Propagates to every task lacking its own task.setup. Setup-produced files must be gitignored or they trip drift detection."
+          "description": "Per-worktree setup shell commands run BEFORE the worker in each task worktree (e.g. `npm ci`). Runs ONCE per worktree — the inter-attempt reset is `git clean -fd`, which preserves ignored paths, so the dependency tree survives. Propagates to every task lacking its own task.setup. Setup-produced files must be gitignored or they trip drift detection."
+        },
+        "setupEachAttempt": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Setup shell commands rerun before EVERY worker attempt (after `setup`), for commands that rebuild ignored output from tracked source and go stale on reset. Propagates to every task lacking its own task.setupEachAttempt."
+        },
+        "setupInputs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Relative paths whose content hashes join the once-per-worktree `setup` fingerprint (e.g. `package-lock.json`), so setup reruns when the baseline moves under the worktree. Propagates to every task lacking its own task.setupInputs."
         }
       }
     },
@@ -100,7 +111,17 @@
         "setup": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Optional per-task override of meta.setup — per-worktree setup shell commands run before the worker. When set, replaces meta.setup for this task. Must be declared here because the task object is additionalProperties:false."
+          "description": "Optional per-task override of meta.setup — per-worktree setup shell commands run ONCE per worktree before the worker. When set, replaces meta.setup for this task. Must be declared here because the task object is additionalProperties:false."
+        },
+        "setupEachAttempt": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional per-task override of meta.setupEachAttempt — setup commands rerun before EVERY attempt, for output that goes stale when the inter-attempt reset rolls tracked files back."
+        },
+        "setupInputs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional per-task override of meta.setupInputs — relative paths whose content hashes join the `setup` fingerprint, so setup reruns when they change under the worktree."
         }
       }
     }


### PR DESCRIPTION
Closes #412
Closes #391

Lane **L13-farm-plan-contract**. Both issues re-verified against current `origin/main` (27addc8) before any code was written — the audit's line numbers had drifted, the claims had not.

## #412 — enforce the plan schema at the runtime boundary

**Verified.** `main()` did `JSON.parse(await readFile(planPath,"utf8")) as Plan` and handed the result straight to `validate()`, which dereferences `plan.meta.apiBaseUrl` and iterates `plan.tasks` with no shape check. Live: `null` and `{}` came out as raw `TypeError`s, a numeric `id`/`description` sailed past `SAFE_TASK_ID`'s implicit string assumption, and a plan carrying an **unknown task field ran a complete dispatch** (worktrees, branches, network) — the integration test for that case timed out at 5s against the old code because the farm actually started working.

`parsePlan()` is now the boundary: an exact validator over a declarative `PLAN_SHAPE`, applied to parsed-but-untrusted JSON **before any field access**, and therefore before `validate()`, `resolveConfig()`, any worktree, branch, report, shell command, or network call. Messages are bounded and field-specific — they name the JSON path (task by **index**, since the id is not yet trustworthy) and the offending value's **type**, and never echo plan content back.

**Authority (asked for explicitly in the issue).** `PLAN_SHAPE` / `parsePlan()` is the **authoritative, executed** contract. `plan.schema.json` is the **authoring** contract that `writing-plans` validates against and is never consulted at runtime — which is exactly why its `meta` object omitting `additionalProperties` constrained nothing. The two are now key-for-key and type-for-type identical (`meta` gained `additionalProperties: false`), enforced by a parity test that walks the schema and compares property sets, required sets, closedness, per-property types, and `minItems`. Adding a field on one side without the other fails CI. One divergence is deliberate and now **asserted** rather than left implicit: the schema's kebab-case `id` pattern is an authoring rule, while the runtime path-traversal rule is `SAFE_TASK_ID` in `validate()` — the long-standing `[NEEDS-TRIAGE]` note above it is now backed by a test that pins both sides.

This is the enforcement point #439 asks about at the report sink: the plan is validated once, at ingest, rather than projected defensively downstream.

## #391 — stop reinstalling preserved farm dependencies on every retry

**Verified against current source.** `resetWorktree` is `git reset --hard HEAD` + `git clean -fd` — **no `-x`** — so ignored paths are preserved by design. The setup contract simultaneously *requires* setup output to be gitignored (`npm ci` is its canonical example). The comment in `runTask` ("the reset above wipes untracked deps (node_modules etc.)") and the matching line in `farm.md` were simply wrong, and the loop paid the full install on every attempt — 3x on the default retry budget, per task, concurrently.

- `setup` now runs **once per worktree**, behind a fingerprint of its commands plus the content hashes of any declared `setupInputs`. The cache lives in a caller-owned `SetupState` created inside `runTask` (and per sample in best-of-N), so it is scoped to exactly one worktree by construction — no module-level map, nothing to leak across tasks or runs, nothing to invalidate at task end.
- `setupEachAttempt` (new, `meta` + `task`) is the explicit per-attempt phase for commands that rebuild ignored output **from tracked source** and genuinely do go stale when the reset rolls tracked files back.
- `setupInputs` (new, `meta` + `task`) invalidates the cache when the baseline moves under the worktree. That is not hypothetical: regenerate-on-conflict resets the task worktree onto a **new integration HEAD**, which can carry a different lockfile. Entries are relative-path validated (no `..`, no absolute) like `test.path` / `filesInScope`, since they are resolved against the worktree and read.
- Retry behavior is otherwise unchanged: tracked changes and non-ignored untracked worker output are still wiped between attempts.

## Verbatim red output

Tests were written first. `plan-contract.test.ts` as authored fails to even collect (`PLAN_SHAPE` does not exist), so the behavioral red below was captured from a temporary copy with the parity block excised; the copy was deleted before implementing.

```
 RUN  v3.2.6 .../plugins/ca/tools

 ❯ plan-contract.test.ts (0 test)

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  plan-contract.test.ts [ plan-contract.test.ts ]
TypeError: Cannot read properties of undefined (reading 'plan')
 ❯ plan-contract.test.ts:271:18
    269|
    270|   for (const [label, node, shapeKey] of pairs) {
    271|     const spec = PLAN_SHAPE[shapeKey];
       |                  ^
```

```
 RUN  v3.2.6 .../plugins/ca/tools

 ❯ plan-contract.red.test.ts (33 tests | 31 failed) 28ms
   × #412 parsePlan — rejects malformed plans before any field access > accepts a minimal valid plan and returns it 4ms
     → (0 , parsePlan) is not a function
   × #412 parsePlan ... > rejects null instead of throwing a raw TypeError 1ms
     → expected [Function] to throw error matching /plan must be a JSON object/ but got '(0 , parsePlan)…'
   × #412 parsePlan ... > rejects {} — meta and tasks are required 0ms
     → expected [Function] to throw error matching /plan\.meta.*required/ but got '(0 , parsePlan)…'
   × #412 parsePlan ... > rejects a numeric task id (SAFE_TASK_ID assumed a string) 0ms
     → expected [Function] to throw error matching /plan\.tasks\[0\]\.id must be a string/ but got '(0 , parsePlan)…'
   × #412 parsePlan ... > rejects an unknown task property 0ms
     → expected [Function] to throw error matching /plan\.tasks\[0\]: unknown property "b…/ but got '(0 , parsePlan)…'
   × #391 setup runs once per worktree; setupEachAttempt reruns > invokes a dependency-only `npm ci` setup ONCE across two worker retries 4ms
     → expected 3 to be 1 // Object.is equality
   × #391 setup runs once per worktree; setupEachAttempt reruns > reruns `setupEachAttempt` before every attempt 1ms
     → expected 3 to be 1 // Object.is equality
   × #391 setup runs once per worktree; setupEachAttempt reruns > still runs setup BEFORE the worker on the first attempt 1ms
     → expected [ 'node -p 0' ] to deeply equal [ 'npm run codegen' ]
   × #391 setup runs once per worktree; setupEachAttempt reruns > escalates immediately when setupEachAttempt fails 1ms
     → expected 'green' to be 'escalate' // Object.is equality
   × #391 setup runs once per worktree; setupEachAttempt reruns > does NOT rerun setup when the declared setupInput is unchanged 1ms
     → expected 2 to be 1 // Object.is equality
```

`expected 3 to be 1` is #391 stated exactly: three attempts, three `npm ci` runs.

And the end-to-end boundary red (`farm.test.ts`, real subprocess against a temp git repo):

```
 ❯ farm.test.ts (45 tests | 5 failed | 40 skipped) 6753ms
   × farm.ts smoke tests > refuses a malformed plan (null root) with no side effects 430ms
     → expected 'TypeError: Cannot read properties of …' to match /plan must be a JSON object/
   × farm.ts smoke tests > refuses a malformed plan (missing meta) with no side effects 329ms
     → expected 'TypeError: Cannot read properties of …' to match /plan\.meta/
   × farm.ts smoke tests > refuses a malformed plan (null meta) with no side effects 324ms
     → expected 'TypeError: Cannot read properties of …' to match /plan\.meta/
   × farm.ts smoke tests > refuses a malformed plan (numeric task id) with no side effects 432ms
     → expected 'TypeError [ERR_INVALID_ARG_TYPE]: The…' to match /plan\.tasks\[0\]\.id must be a string/
   × farm.ts smoke tests > refuses a malformed plan (unknown task field) with no side effects 5238ms
     → Test timed out in 5000ms.

 FAIL  farm.test.ts > farm.ts smoke tests > refuses a malformed plan (null root) with no side effects
AssertionError: expected 'TypeError: Cannot read properties of …' to match /plan must be a JSON object/

+ Received:
"TypeError: Cannot read properties of null (reading 'meta')
    at validate (.../plugins/ca/tools/farm.ts:1679:12)
    at main (.../plugins/ca/tools/farm.ts:1935:3)
"
```

## Suites — before / after

| Suite | Before (origin/main) | After |
| --- | --- | --- |
| `plugins/ca/tools` — `npx vitest run` | 226 passed, 1 skipped (227), 3 files | **287 passed, 1 skipped (288), 4 files** |
| `plugins/ca/tools` — `npx tsc --noEmit` | exit 0 | exit 0 |
| `plugins/ca/hooks/tests` — unittest | OK (1112) | OK (1112) |
| `.github/scripts` — unittest | 4 env failures (see NEEDS-TRIAGE) | 1074 run, same 4 env failures |
| `python tools/sync-core.py --check` | OK | OK (48 files x 3 plugins, byte-identical) |
| `python tools/build-surface.py --check` | OK | OK (claude, codex, pi in sync) |
| `check-plugin-refs.py ca / ca-pi / ca-codex` | intact | intact |
| `build-host-packages.py --check --release-guard-base` | — | `Pi payload, version, changelog, and root metadata advanced together: 0.1.7 -> 0.1.8` |
| `git diff --check origin/main HEAD` | — | exit 0 |

Net new tests: **+61** (55 in `plan-contract.test.ts`, 6 in `farm.test.ts`).

`farm.js` was rebuilt with `npm run build` and committed (CI's staleness gate). No rebase — branched from current `origin/main` (27addc8), which already carries #430's `writeReport`/`atomicWriteFile` rework and #425's `worktree-fs`; both are preserved untouched.

## NEEDS-TRIAGE

- **`.github/scripts` — 4 pre-existing environmental failures**, all in `test_pi_benchmark.py`, all `RuntimeError: Pi benchmark requires the installed pinned esbuild` (this worktree has no `plugins/ca-pi/tools/node_modules`). Untouched by this lane, identical before and after. Not filed — a local-environment artifact, not a repo defect.
- **`plugins/ca/tools` vitest flakiness on Windows.** The baseline run flaked once with an `EPERM` on a temp `farm-test-*` directory teardown, then passed clean on re-run. Pre-existing, timing-dependent, unrelated to this change — worth an issue if it recurs in CI.
- **ca-pi 0.1.8 bump rides this PR** because `build-surface.py` propagates the `farm.md` / `farm-plan.md` prose into `plugins/ca-pi/**`, which the release guard counts as a payload change. If a sibling lane claims 0.1.8 first, this branch takes the next free version on the merge — no rebase.
- **`SAFE_TASK_ID` vs. the schema `id` pattern remains a deliberate divergence**, now documented and test-pinned rather than a bare comment. Reconciling them into one shared runtime-strict pattern is still a behavior change to id acceptance and still out of scope; the parity test makes the divergence visible instead of silent.
- **#439** (allowlist-projection at the report sink) is now downstream of a validated plan: the `plan.meta` reaching `writeReport` has already been proven closed and typed. Whether #439 still wants a second projection at the sink is a judgment call for that issue, not this one.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
