### PR TITLE
fix(ci): add a pinned secret scan and parse its allowlist instead of scraping it

### DIFF
--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -153,23 +153,74 @@ node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" <file>.
 
 ## CVE gate (supply chain)
 
-The configured CVE gate is `npm audit --omit=dev --audit-level=critical`, run in
-CI (the `tools` job, after `npm ci`) against the shipped dependency set. A
-CRITICAL advisory fails the build; lower severities are intentionally not
-gating, so routine dev-tool advisories don't block unrelated PRs. This enforces
-the supply-chain posture described in `security-controls.md`.
+The configured CVE gate is `npm audit --omit=dev --audit-level=high`, run after
+`npm ci` against every dependency graph the repo ships or publishes:
+
+| graph | workflow / job | production deps today |
+| --- | --- | --- |
+| `plugins/ca/tools` | `ci.yml` — `tools` | none |
+| `plugins/ca-sandbox/tools` | `ci.yml` — `ca-sandbox-tools` | none |
+| `plugins/ca-pi/tools` | `ci.yml` — `ca-pi-checks` | none |
+| `site` (docs site) | `docs.yml` — `site-check`, which `deploy` needs | astro, starlight, markdown-remark |
+
+A HIGH-or-worse advisory fails the build; `--omit=dev` scopes the gate to
+shipped dependencies so routine dev-tool advisories don't block unrelated PRs.
+This enforces the supply-chain posture described in `security-controls.md`.
+
+**What the threshold actually buys, honestly.** Three of the four graphs above
+declare no production dependencies at all, so `--omit=dev` audits an empty graph
+in those jobs and the threshold there is inert at any value — it is a
+*durability* setting that decides what happens the day one of them takes on a
+runtime dependency. The one live graph is `site`, and until issue #403 nothing
+audited it: #400's three HIGH advisories all lived in `site/package-lock.json`,
+which is why the site gate is the part of this change with immediate effect. The
+threshold was lowered from `critical` to `high` across all four so a single rule
+covers the repo — not because the farm or sandbox audits would have caught #400.
+They would not have seen it.
+
+The dev trees, where these packages' advisories actually are, are **not** covered
+by this gate. Measured in `plugins/ca/tools` at the time of writing, `npm audit
+--json` reports `{prod: 1, dev: 104}` — the single prod entry being the root
+package itself — and one **HIGH** advisory (`postcss`) that the shipped
+`--omit=dev` gate never sees. All four graphs pass `npm audit --omit=dev
+--audit-level=high` today. Issue #434 tracks extending the sweep to the dev
+trees, and notes the blast radius: those dev dependencies build `farm.js` and
+`sandbox.js`, which are committed, shipped artifacts.
 
 ## Secrets scan
 
-No dedicated secrets scanner is configured. The gate is two-layered:
+The gate is three-layered — one hosted backstop plus two cooperative local
+layers:
 
-1. Manual sweep of the staged diff for credential patterns
+1. `ci.yml`'s `secret-scan` job (issue #404): gitleaks' full default ruleset,
+   run as a required check for the `ci-passed` merge gate. The scanner is pinned
+   by image digest and runs in a network-isolated, read-only container over a
+   read-only mount. This is the only layer a bot, a fork, a web edit, or a plain
+   `git push` cannot skip — the two below run only inside a contributor's local
+   session. It scans in **two modes**, because each is blind to what the other
+   catches: `gitleaks dir` over the merge-result tree (what would land on main),
+   and, on a pull request, `gitleaks git --log-opts <merge-base>..HEAD` over the
+   PR's own commits. Without the second, a credential added in one commit and
+   deleted in the next passes green and still reaches main's history under a
+   merge or rebase merge, both of which this repo allows. Findings print with
+   `--redact --verbose`, so a red job names the file, line, rule, and commit
+   while the secret itself stays `REDACTED`.
+
+   Its allowlist (`.gitleaks.toml`) waives individual fake fixture literals by
+   value, never a file path — a `paths` waiver drops the whole file from the
+   scan — and every waiver is anchored `\A<literal>\z`. The anchoring is the
+   load-bearing part: gitleaks substring-matches allowlist regexes, so an
+   unanchored literal waives every secret that merely contains it, and no choice
+   of `regexTarget` fixes that. `.github/scripts/test_ci_impact.py` enforces both
+   rules, and the `secret-scan` job re-runs that contract itself, so a path-filter
+   edit can never leave the allowlist unguarded.
+2. Manual sweep of the staged diff for credential patterns
    (`api[_-]?key|token|secret|password|private[_-]?key|passphrase|credential|BEGIN.*PRIVATE|AKIA|ghp_|sk-ant`),
    case-insensitive. This is the convenience layer; the authoritative classifier
    is `_hooklib.SECRET_RE`, pinned against the farm redactor by the shared
    `hooks/secret-detection-corpus.json`, which also matches a secret keyword as
    the trailing segment of a compound name (e.g. `FARM_API_KEY = "..."`).
-2. The plugin's own enforcement hooks: H-09b (crypto/TLS) and H-10b (secrets)
+3. The plugin's own enforcement hooks: H-09b (crypto/TLS) and H-10b (secrets)
    block any commit whose diff touches a crypto or secret line until a diff-bound
    security-gate pass marker covers those exact lines (`hooks/security-pass.py`).
 

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -12,6 +12,7 @@ import json
 import re
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -20,6 +21,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOL = REPO_ROOT / "tools" / "ci-impact.py"
 _DESCRIPTORS_TOOL = REPO_ROOT / "tools" / "host_descriptors.py"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
+GITLEAKS_CONFIG = REPO_ROOT / ".gitleaks.toml"
+# The one audit threshold every dependency graph in this repo is gated at.
+NPM_AUDIT_GATE = "npm audit --omit=dev --audit-level=high"
 PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
 PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
 PI_PLATFORM_CONTRACT = REPO_ROOT / ".github" / "scripts" / "test_pi_platform_contract.py"
@@ -83,6 +88,317 @@ def workflow_jobs(text: str) -> dict[str, str]:
     if current is not None:
         jobs[current] = "".join(body)
     return jobs
+
+
+def push_trigger_paths(workflow: str) -> list[str]:
+    """Quoted globs under the workflow's `on.push.paths:` block.
+
+    Textual like every other contract here.  The block ends at the first line
+    that is not a `      - "<glob>"` entry, which is what makes this sensitive
+    to a deleted path rather than merely to the block's existence.
+    """
+    match = re.search(
+        r'(?ms)^  push:\n(?:.*?)^    paths:\n(?P<body>(?:      (?:- "[^"\n]+"[^\n]*|#[^\n]*)\n)+)',
+        workflow,
+    )
+    if match is None:
+        return []
+    return _globs(match.group("body"), '"')
+
+
+def paths_filter(ci: str, name: str) -> list[str]:
+    """Single-quoted globs under one `filters:` entry of the changes job."""
+    match = re.search(
+        rf"(?ms)^            {re.escape(name)}:\n"
+        rf"(?P<body>(?:              (?:- '[^'\n]+'[^\n]*|#[^\n]*)\n)+)",
+        ci,
+    )
+    if match is None:
+        return []
+    return _globs(match.group("body"), "'")
+
+
+def _globs(body: str, quote: str) -> list[str]:
+    """Quoted list entries in a YAML block, ignoring interleaved comments.
+
+    The value is read out of the quotes rather than by stripping the line,
+    because an entry may carry a TRAILING comment - `- "plugins/ca/**" # the
+    reference is generated from the plugin` is a real line in docs.yml, and
+    stripping quotes off that returns the comment along with the glob.
+    """
+    found: list[str] = []
+    for line in body.splitlines():
+        entry = re.match(rf"-\s*{re.escape(quote)}([^{re.escape(quote)}]*){re.escape(quote)}",
+                         line.strip())
+        if entry is not None:
+            found.append(entry.group(1))
+    return found
+
+
+def npm_audit_invocations(workflow: str) -> list[str]:
+    """Every `npm audit ...` command line in a workflow, whitespace-normalised."""
+    return [
+        " ".join(match.group("command").split())
+        for match in re.finditer(
+            r"(?m)^\s*(?:-\s+)?(?P<command>(?:run: )?npm audit[^\n]*)$", workflow
+        )
+    ]
+
+
+def event_trigger_paths(workflow: str, event: str) -> list[str]:
+    """Double-quoted globs under `on.<event>.paths` of a workflow."""
+    match = re.search(
+        rf'(?ms)^  {re.escape(event)}:\n(?:.*?)^    paths:\n'
+        rf'(?P<body>(?:      (?:- "[^"\n]+"[^\n]*|#[^\n]*)\n)+)',
+        workflow,
+    )
+    if match is None:
+        return []
+    return _globs(match.group("body"), '"')
+
+
+def npm_install_jobs(workflow: str) -> dict[str, str]:
+    """Every job that runs `npm ci`, mapped to the directory it installs into.
+
+    Derived from the workflow rather than listed by hand: a hardcoded job list
+    is exactly how a newly added graph slips in unaudited, which is the defect
+    #403 was.  The directory comes from the job's `defaults.run.working-
+    directory`, which is how every npm job in this repo scopes itself.
+    """
+    installs: dict[str, str] = {}
+    for job_id, body in workflow_jobs(workflow).items():
+        if not re.search(r"(?m)^\s*(?:-\s+)?(?:run: )?npm ci\b", body):
+            continue
+        directory = re.search(
+            r"(?ms)^    defaults:\n      run:\n        working-directory: (?P<dir>\S+)", body
+        )
+        installs[job_id] = directory.group("dir") if directory else "."
+    return installs
+
+
+def unaudited_npm_graphs(workflow: str) -> list[str]:
+    """Every `npm ci` job whose dependency graph no job in `workflow` audits.
+
+    A job may skip the audit itself - what it may NOT do is install a graph
+    nothing audits.  `ca-pi-tools` and docs.yml's `build` are both in that
+    first category today: they run `npm ci` with no audit step, and are benign
+    only because `ca-pi-checks` and `site-check` audit the very same
+    directory.  Deriving the rule this way keeps that fact CHECKED instead of
+    asserted in a comment, and makes a brand-new graph fail on arrival.
+    """
+    jobs = workflow_jobs(workflow)
+    installs = npm_install_jobs(workflow)
+    audited = {
+        directory
+        for job_id, directory in installs.items()
+        if f"run: {NPM_AUDIT_GATE}" in jobs[job_id]
+    }
+    return [
+        f"{job_id} installs {directory}, which nothing audits"
+        for job_id, directory in sorted(installs.items())
+        if directory not in audited
+    ]
+
+
+def _fold_keys(value: object, collisions: list[str]) -> object:
+    """Lower-case every mapping key, the way gitleaks' own config reader does.
+
+    gitleaks loads this file through viper, whose key lookup is case-
+    INSENSITIVE.  Measured against the pinned image: `Paths = ['''.''']`
+    reports `scanned ~0 bytes` exactly as `paths` does, `RegexTarget` rebinds
+    the waiver exactly as `regexTarget` does, and `DISABLEDRULES` deletes a
+    rule exactly as `disabledRules` does.  Every ban below is therefore
+    written against folded keys, so a capitalisation cannot walk past it.
+
+    A fold COLLISION (`paths` and `Paths` in one table) is reported rather
+    than silently resolved: which spelling the scanner would honour is not
+    something this contract should guess at.
+    """
+    if isinstance(value, dict):
+        folded: dict[str, object] = {}
+        for key, item in value.items():
+            lowered = key.lower()
+            if lowered in folded:
+                collisions.append(lowered)
+            folded[lowered] = _fold_keys(item, collisions)
+        return folded
+    if isinstance(value, list):
+        return [_fold_keys(item, collisions) for item in value]
+    return value
+
+
+def parse_gitleaks_config(config: str) -> tuple[dict, list[str]]:
+    """The gitleaks config as gitleaks itself reads it - PARSED, keys folded.
+
+    Reading this file as text was the defect this function exists to end.  A
+    regex has to guess at TOML's spellings and it guessed wrong eleven times:
+    an indented key, an indented table header, a basic string instead of a
+    literal one, a `]` inside a value, a capitalised key.  Every one of those
+    was measured GUARD-GREEN while the pinned scanner swallowed a planted
+    high-entropy key.  TOML has exactly one meaning per document, so the
+    contract now reads that meaning instead of the characters around it.
+
+    Returns the folded document and any key-fold collisions.  Raises
+    `tomllib.TOMLDecodeError` on input gitleaks itself could not load.
+    """
+    collisions: list[str] = []
+    document = _fold_keys(tomllib.loads(config), collisions)
+    assert isinstance(document, dict)
+    return document, collisions
+
+
+def gitleaks_allowlist_blocks(config: str) -> list[dict]:
+    """Every `[[allowlists]]` table in the gitleaks config, keys case-folded."""
+    document, _ = parse_gitleaks_config(config)
+    blocks = document.get("allowlists") or []
+    return [block for block in blocks if isinstance(block, dict)]
+
+
+def gitleaks_allowlist_regexes(config: str) -> list[str]:
+    """Every value inside an allowlist table's `regexes`.
+
+    These are the PARSED values, so the single-entry, multi-line-array,
+    embedded-newline, and alternate-quoting spellings all reduce to the same
+    list - a waiver cannot hide from the narrowness contract by reformatting.
+    The embedded-newline case is real: the one multi-line secret this repo
+    waives is a PEM block whose detected value spans five source lines.
+    """
+    found: list[str] = []
+    for block in gitleaks_allowlist_blocks(config):
+        entries = block.get("regexes")
+        if isinstance(entries, str):
+            entries = [entries]
+        if isinstance(entries, list):
+            found += [entry for entry in entries if isinstance(entry, str)]
+    return found
+
+
+# The characters that would let an anchored waiver match more than the single
+# fixed value it spells out.  `\` is in the set because an escape sequence is a
+# pattern, and this contract admits no patterns at all.
+_REGEX_METACHARACTERS = frozenset(".*+?()[]{}|^$\\")
+# `\A<body>\z` - Go RE2's spelling of "the WHOLE target is exactly <body>".
+_ANCHORED_WAIVER = re.compile(r"(?s)\A\\A(?P<body>.*)\\z\Z")
+# Keys that un-scan a file or a commit rather than waiving one value.
+_UNSCANNING_KEYS = ("paths", "commits", "stopwords")
+# The only keys a waiver in this file may carry.  DEFAULT-DENY: gitleaks keeps
+# adding allowlist knobs, and the next one to widen the haystack must fail this
+# contract on the day it is typed, not on the day someone remembers to ban it.
+_ALLOWED_ALLOWLIST_KEYS = frozenset({"description", "regexes"})
+# `[extend]` selects which rules run.  This file only ever SUBTRACTS fixture
+# values from the default ruleset, so `useDefault` is the only key it may set:
+# `disabledRules` deletes a rule outright, and `path`/`url` pull in allowlists
+# that are not in this file and therefore not covered by anything below.
+_ALLOWED_EXTEND_KEYS = frozenset({"usedefault"})
+
+
+def gitleaks_waiver_violations(config: str) -> list[str]:
+    """Every way `config`'s allowlist could waive more than one fixed value.
+
+    Empty means the allowlist is narrow.  Kept a pure function of the config
+    text so the contract can be exercised against adversarial configs that are
+    never written to disk.
+
+    Each rejected shape below was MEASURED against the pinned scanner image,
+    scanning this repo's tracked tree with a high-entropy key planted in
+    `plugins/ca/tools/.env.example` (the shipped config reports `leaks found: 1`
+    there; every shape below returns it to `no leaks found`):
+
+    * `paths` / `commits` un-scan a whole file or commit rather than waiving a
+      value, leaving a permanent blind spot.  `stopwords` is the same class.
+    * `regexTarget = "line"` widens the haystack to the entire source line, and
+      `regexTarget = "match"` to the rule's whole match text - so a short common
+      substring like `API_KEY` waives every line or match containing it.
+    * an UNANCHORED literal is the deeper bug, and the reason constraining
+      `regexTarget` alone is NOT sufficient: gitleaks tests allowlist regexes
+      with Go's `FindString`, a SUBSTRING search, so even against the default
+      (secret) target the literal `sk-` waives every secret beginning `sk-`.
+
+    Anchoring is what actually buys narrowness: `\\A<literal>\\z` matches only
+    when the ENTIRE detected secret is that exact fixture value.
+
+    The checks run against the PARSED document, not the config text.  Reading
+    it as text is what let eleven measured shapes through - see
+    test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract for
+    each one and the evidence it swallowed a planted key.
+    """
+    try:
+        document, collisions = parse_gitleaks_config(config)
+    except tomllib.TOMLDecodeError as error:
+        # Not "narrow" - unreadable.  gitleaks exits FTL on the same input, so
+        # reporting no violations here would call a config that cannot scan
+        # anything a config that scans everything.
+        return [f"the config is not parseable TOML ({error}), so gitleaks cannot load it"]
+
+    problems: list[str] = []
+    for key in sorted(set(collisions)):
+        problems.append(
+            f"`{key}` is spelled two ways in one table; gitleaks reads keys "
+            "case-insensitively, so which one applies is unknowable from the file"
+        )
+    extend = document.get("extend")
+    if isinstance(extend, dict):
+        for key in sorted(set(extend) - _ALLOWED_EXTEND_KEYS):
+            problems.append(
+                f"`[extend] {key}` changes which rules run instead of waiving one value; "
+                "`useDefault` is the only key this config may set there"
+            )
+    if document.get("rules"):
+        problems.append(
+            "a `[[rules]]` block re-declares the ruleset - one whose id matches a default "
+            "rule REPLACES it - and this file only ever subtracts fixture values"
+        )
+    for position, block in enumerate(document.get("allowlists") or [], start=1):
+        if not isinstance(block, dict):
+            problems.append(f"allowlist #{position} is not a table")
+            continue
+        description = block.get("description")
+        head = str(description).strip().splitlines()[0] if str(description).strip() else ""
+        head = head or f"#{position}"
+        for key in _UNSCANNING_KEYS:
+            if key in block:
+                problems.append(
+                    f"`{key}` un-scans whole files or commits instead of waiving a value"
+                )
+        if "regextarget" in block:
+            problems.append(
+                f"`regexTarget = {block['regextarget']!r}` binds the waiver to surrounding "
+                "source text rather than to the detected secret"
+            )
+        unmodelled = set(block) - _ALLOWED_ALLOWLIST_KEYS - {"regextarget"} - set(_UNSCANNING_KEYS)
+        for key in sorted(unmodelled):
+            problems.append(
+                f"allowlist block at {head!r} sets `{key}`, which this contract cannot "
+                "reason about; a waiver may carry only `description` and `regexes`"
+            )
+        if not str(description or "").strip():
+            problems.append(f"allowlist block at {head!r} carries no rationale")
+        entries = block.get("regexes")
+        if isinstance(entries, str):
+            entries = [entries]
+        if not isinstance(entries, list) or not entries:
+            problems.append(f"allowlist block at {head!r} names no value, so it is unbounded")
+            continue
+        for literal in entries:
+            if not isinstance(literal, str):
+                problems.append(
+                    f"allowlist block at {head!r} waives {literal!r}, which is not a string"
+                )
+                continue
+            anchored = _ANCHORED_WAIVER.match(literal)
+            if anchored is None:
+                problems.append(
+                    f"{literal!r} is not anchored `\\A...\\z`; gitleaks matches allowlist "
+                    "regexes as substrings, so it waives anything merely containing it"
+                )
+                continue
+            stray = sorted(set(anchored.group("body")) & _REGEX_METACHARACTERS)
+            if stray:
+                problems.append(
+                    f"{literal!r} carries regex metacharacter(s) {''.join(stray)!r}; "
+                    "a waiver must spell out one fixed value"
+                )
+    return problems
 
 
 def aggregate_needs(ci: str) -> list[str]:
@@ -406,6 +722,7 @@ class WorkflowContractTest(unittest.TestCase):
             "[CHECK] | [REPO] | License consistency",
             "[CHECK] | [CORE] | Generated surface",
             "[CHECK] | [CDX ] | Reference graph",
+            "[CHECK] | [REPO] | Secret scan",
             "[GATE ] | [REPO] | Merge readiness",
         )
         for name in expected:
@@ -619,6 +936,627 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertIn("GITHUB_STEP_SUMMARY", canary, "the advisory verdict must be visible")
         # And the aggregate gate stays independent of the advisory result.
         self.assertNotIn("ca-pi-latest", aggregate_required_results(ci))
+
+    def test_codex_parity_fixture_edits_reach_their_own_test(self):
+        # Issue #384: `.github/scripts/test_codex_parity_fixture.py` runs inside
+        # the path-scoped `hooks` job, but neither the push trigger nor the
+        # `hooks` filter listed the generator it tests.  A PR editing only
+        # tools/codex-parity-fixture.py therefore skipped its own test, and the
+        # merged push started no workflow at all.  Three registrations must
+        # agree: push trigger, `hooks` filter, and the test invocation.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        generator = "tools/codex-parity-fixture.py"
+        push = push_trigger_paths(ci)
+        self.assertIn(
+            "tools/sync-core.py", push, "the push-trigger scan drifted off the real block"
+        )
+        self.assertIn(generator, push, "a push of the fixture generator starts no CI run")
+        hooks = paths_filter(ci, "hooks")
+        self.assertIn(
+            ".github/scripts/**", hooks, "the hooks-filter scan drifted off the real block"
+        )
+        self.assertIn(
+            generator, hooks, "a PR touching only the fixture generator skips the hooks job"
+        )
+        self.assertIn(
+            "run: python .github/scripts/test_codex_parity_fixture.py",
+            workflow_jobs(ci)["hooks"],
+            "the hooks job no longer runs the fixture generator's own test",
+        )
+
+    def test_every_npm_audit_gate_fails_the_build_on_a_high_advisory(self):
+        # Issue #403: site/package-lock.json - the ONLY graph in this repo that
+        # declares production dependencies (astro, starlight, markdown-remark) -
+        # was audited by nothing, and #400's three HIGH advisories all lived
+        # there.  The farm/sandbox gates were separately pinned at `critical`,
+        # but tightening those two is a DURABILITY change, not a live one:
+        # measured, plugins/ca/tools, plugins/ca-sandbox/tools and
+        # plugins/ca-pi/tools each declare ZERO production dependencies, so
+        # `--omit=dev` audits an empty graph there at any threshold.  It decides
+        # what happens the day one of them takes on a runtime dependency.
+        # Issue #434 tracks extending the sweep to the dev trees, which is where
+        # those packages' advisories actually are.
+        #
+        # One threshold, asserted per invocation, across every graph the repo
+        # ships or publishes.
+        expected = NPM_AUDIT_GATE
+        invocations: list[tuple[str, str]] = []
+        for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
+            invocations += [
+                (workflow.name, command)
+                for command in npm_audit_invocations(workflow.read_text(encoding="utf-8"))
+            ]
+        self.assertEqual(
+            len(invocations),
+            4,
+            "expected exactly the farm, sandbox, ca-pi, and site audit gates",
+        )
+        for name, command in invocations:
+            with self.subTest(workflow=name, command=command):
+                self.assertEqual(command, f"run: {expected}")
+        # EVERY GRAPH THIS REPO INSTALLS IS AUDITED SOMEWHERE.  This used to
+        # iterate the hardcoded triple ("tools", "ca-sandbox-tools",
+        # "ca-pi-checks") under a comment claiming "every job that installs a
+        # lockfile must also audit it" - a claim three job names cannot make.
+        # It was already false: `ca-pi-tools` is a required gate that runs
+        # `npm ci` and never audits, and so does docs.yml's `build`.  Both are
+        # benign only because a SIBLING job audits the same lockfile, and
+        # nothing checked that.  So the list is now DERIVED and the rule is the
+        # one that actually matters: a job may skip the audit only when another
+        # job in the same workflow audits the very directory it installs.  A
+        # genuinely new graph has no such sibling and fails here on arrival -
+        # which is precisely what did not happen when site/package-lock.json
+        # went unguarded through #400 and #403.
+        for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
+            with self.subTest(workflow=workflow.name):
+                text = workflow.read_text(encoding="utf-8")
+                self.assertTrue(
+                    npm_install_jobs(text), f"{workflow.name} installs no lockfile at all"
+                )
+                self.assertEqual(
+                    [],
+                    unaudited_npm_graphs(text),
+                    "a job installs a dependency graph nothing in this workflow audits",
+                )
+        # And the rule BITES.  A derived check that merely happens to be
+        # satisfied is indistinguishable from one that checks nothing, so put
+        # the diff it exists to stop in front of it: a new job installing a
+        # graph no sibling audits.  This is the shape #403 shipped as.
+        newcomer = CI_WORKFLOW.read_text(encoding="utf-8") + (
+            "\n  brand-new-graph:\n"
+            "    name: newcomer\n"
+            "    runs-on: ubuntu-latest\n"
+            "    defaults:\n"
+            "      run:\n"
+            "        working-directory: plugins/ca-brand-new/tools\n"
+            "    steps:\n"
+            "      - run: npm ci\n"
+        )
+        self.assertTrue(
+            unaudited_npm_graphs(newcomer),
+            "a job installing an entirely new graph is accepted without an audit",
+        )
+
+    def test_docs_workflow_gates_the_site_dependency_graph_before_publishing(self):
+        # Issue #403: site-check ran npm ci/typecheck/test and build ran
+        # build/link-audit, but nothing ever audited site/package-lock.json - a
+        # known-vulnerable production dependency could build and deploy to
+        # GitHub Pages with the whole workflow green.
+        docs = DOCS_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(docs)
+        self.assertIn("site-check", sorted(jobs))
+        site_check = jobs["site-check"]
+        self.assertIn("run: npm ci", site_check)
+        self.assertIn("run: npm audit --omit=dev --audit-level=high", site_check)
+        # The audit is only a gate if the publish step waits on the job that
+        # runs it.  `deploy` needs BOTH build and site-check today; assert the
+        # site-check edge specifically so dropping it is caught.
+        deploy = jobs["deploy"]
+        self.assertRegex(
+            deploy,
+            r"(?m)^    needs: \[[^\]]*\bsite-check\b[^\]]*\]",
+            "deploy no longer waits on the audited site-check job",
+        )
+
+    def test_the_docs_workflow_runs_on_changes_to_the_docs_workflow(self):
+        # The SAME defect class this branch exists to fix, one file over.
+        # docs.yml triggered on `site/**` and `plugins/ca/**` only, so it never
+        # ran on itself: the audit step added above did NOT execute in this
+        # PR's own CI - there was no `Site |` check among the 37 that reported.
+        # A PR that deletes the audit step, breaks the deploy edge, or drops a
+        # permission touches docs.yml and nothing else, which is exactly the
+        # diff its own jobs could not see.  #384 and the .gitleaks.toml gap are
+        # the same bug; a workflow that gates something must be reachable by a
+        # change to itself.
+        docs = DOCS_WORKFLOW.read_text(encoding="utf-8")
+        for event in ("push", "pull_request"):
+            with self.subTest(event=event):
+                paths = event_trigger_paths(docs, event)
+                self.assertIn(
+                    "site/**", paths, f"the {event} trigger scan drifted off the real block"
+                )
+                self.assertIn(
+                    ".github/workflows/docs.yml",
+                    paths,
+                    f"a {event} touching only docs.yml never runs docs.yml",
+                )
+
+    def test_ci_runs_a_pinned_read_only_secret_scan_wired_into_the_merge_gate(self):
+        # Issue #404: the repository had NO independent secret scanner - only a
+        # manual staged-diff sweep and the cooperative local H-10b hook, neither
+        # of which a bot, a fork, or a direct push ever runs.  The hosted
+        # backstop must be pinned (no floating tag can be swapped under us),
+        # read-only, and enforced by the aggregate gate.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(ci)
+        self.assertIn("secret-scan", sorted(jobs), "ci.yml has no secret-scan job")
+        job = jobs["secret-scan"]
+        self.assertIn('name: "[CHECK] | [REPO] | Secret scan"', job)
+        # Pinned by image digest, not by a mutable tag.
+        self.assertRegex(
+            job,
+            r"ghcr\.io/gitleaks/gitleaks@sha256:[0-9a-f]{64}",
+            "the scanner image is not pinned by digest",
+        )
+        self.assertNotRegex(
+            job,
+            r"ghcr\.io/gitleaks/gitleaks:[^@\s]",
+            "a floating image tag defeats the pin",
+        )
+        # Read-only: the repository is mounted `:ro` and the scanner gets no
+        # network, so a supply-chain compromise of the image cannot rewrite the
+        # tree it is auditing or exfiltrate what it finds.
+        self.assertIn(":/repo:ro", job, "the scanned tree is not mounted read-only")
+        self.assertIn("--network none", job, "the scanner is not network-isolated")
+        self.assertIn("--redact", job, "a finding would print the credential in public logs")
+        self.assertIn("--exit-code 1", job, "a finding would not fail the job")
+        self.assertIn("--config /repo/.gitleaks.toml", job)
+        # ACTIONABLE WITHOUT LEAKING.  `--redact` alone prints only
+        # `leaks found: N` - no file, no line, no rule id - so a red job tells a
+        # maintainer nothing and the only way to triage it is to re-run the
+        # scanner unredacted.  Measured against the pinned image: adding
+        # `--verbose` prints `File:`/`Line:`/`RuleID:`/`Fingerprint:` (and
+        # `Commit:` in git mode) while still printing `Secret: REDACTED`.  Every
+        # scan step must carry BOTH, so neither mode is a dead end.
+        scan_steps = [step for step in job.split("\n      - name: ") if '"$GITLEAKS_IMAGE"' in step]
+        self.assertEqual(
+            len(scan_steps), 2, "expected exactly the tree scan and the commit-range scan"
+        )
+        for step in scan_steps:
+            with self.subTest(step=step.splitlines()[0]):
+                self.assertIn("--redact", step, "this scan would print credentials in public logs")
+                self.assertIn(
+                    "--verbose",
+                    step,
+                    "a failing scan would print only `leaks found: N` - no file, line, or rule",
+                )
+        # Enforced through BOTH aggregate registrations (the #390 contract).
+        self.assertIn("secret-scan", aggregate_needs(ci), "ci-passed.needs omits secret-scan")
+        self.assertIn(
+            "secret-scan",
+            aggregate_required_results(ci),
+            "ci-passed.required_results omits secret-scan",
+        )
+
+    def test_the_secret_scan_allowlist_stays_narrow_and_value_scoped(self):
+        # A broad ignore defeats the whole job, and in gitleaks the broad ignore
+        # is `paths`: a global `paths = [...]` entry does not waive a finding,
+        # it drops the file from the scan entirely.  Measured against the pinned
+        # image - a config whose sole waiver was
+        # `paths = ['''^test_hooklib\\.py$''']` (condition = "AND", plus a regex
+        # matching nothing) reported `scanned ~189 bytes` and missed a freshly
+        # planted `aws_secret_access_key = "kR3m..."` in that file.  So every
+        # waiver here must be a VALUE waiver naming one fixed adversarial
+        # literal, which leaves every file fully scanned.
+        self.assertTrue(GITLEAKS_CONFIG.is_file(), "no .gitleaks.toml in the repo root")
+        config = GITLEAKS_CONFIG.read_text(encoding="utf-8")
+        document, collisions = parse_gitleaks_config(config)
+        self.assertEqual([], collisions, "a key is spelled two ways in one table")
+        # Read from the PARSE, not from the text: `assertIn("useDefault = true")`
+        # is satisfied by that string appearing in a comment and defeated by a
+        # different spacing, and neither has anything to do with what gitleaks
+        # loads.
+        self.assertIs(
+            document.get("extend", {}).get("usedefault"),
+            True,
+            "the config must extend the default ruleset",
+        )
+        blocks = gitleaks_allowlist_blocks(config)
+        self.assertEqual(
+            len(blocks),
+            len(re.findall(r"(?m)^\s*\[\[\s*allowlists\s*\]\]\s*$", config)),
+            # Text and parse must agree on how many waivers exist.  They can
+            # disagree: `allowlists = [{...}]` is a valid TOML array-of-tables
+            # that a header count cannot see - and, measured against the pinned
+            # image, one gitleaks silently IGNORES.  A waiver the scanner does
+            # not honour and the reader believes in is its own kind of hole.
+            "the allowlist block count disagrees with the table headers in the file",
+        )
+        self.assertTrue(blocks, "no allowlist blocks found")
+        regexes = gitleaks_allowlist_regexes(config)
+        self.assertTrue(regexes, "the allowlist waives no concrete value")
+        # NARROWNESS ITSELF.  Being a fixed literal is NOT enough - that was the
+        # hole in the first version of this contract.  gitleaks substring-matches
+        # allowlist regexes, so the fixed literal `sk-` waives every secret that
+        # starts with it, and `regexTarget = "line"` makes any short literal a
+        # substring test against every scanned line.  Each waiver must be
+        # `\A<literal>\z`, true only when the WHOLE detected secret is that exact
+        # fixture value.  The adversarial shapes this rejects - and the measured
+        # evidence that each one really does swallow a planted credential - are
+        # in test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract.
+        self.assertEqual(
+            gitleaks_waiver_violations(config),
+            [],
+            "the allowlist can waive more than the fixture values it names",
+        )
+        # The two credential-shaped-but-benign payload files the audit named are
+        # covered by the literals they carry, and named in the rationale so a
+        # reviewer can check the claim.
+        self.assertIn("plugins/ca/hooks/secret-detection-corpus.json", config)
+        self.assertIn("plugins/ca/tools/.env.example", config)
+        corpus = json.loads(
+            (REPO_ROOT / "plugins/ca/hooks/secret-detection-corpus.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        # Every waiver is `\A<value>\z`; compare on the anchored body so what is
+        # being checked is "this exact value", not "something resembling it".
+        waived = {_ANCHORED_WAIVER.match(literal).group("body") for literal in regexes}
+        self.assertTrue(
+            {literal for literal in waived if any(literal in row for row in corpus["must_match"])},
+            "no corpus literal is waived - the rationale claims otherwise",
+        )
+        self.assertIn(
+            "sk-REPLACE_ME",
+            waived,
+            "the .env.example placeholder is not the waived value, so the file is waived by "
+            "something broader",
+        )
+
+    def test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract(self):
+        # A contract only means something if it FAILS on the diffs it exists to
+        # stop.  Every adversarial config below was measured against the pinned
+        # scanner image over this repo's tracked tree, with a high-entropy key
+        # planted in plugins/ca/tools/.env.example.  The shipped config reports
+        # `leaks found: 1` there; each shape below returns it to `no leaks
+        # found`, i.e. each one really does swallow a live credential.
+        quote = "'" * 3
+        shipped = GITLEAKS_CONFIG.read_text(encoding="utf-8")
+        self.assertEqual(
+            gitleaks_waiver_violations(shipped), [], "the shipped allowlist is not narrow"
+        )
+
+        def waiver(body: str, *, target: str | None = None) -> str:
+            block = ["", "[[allowlists]]", 'description = "adversarial"']
+            if target is not None:
+                block.append(f'regexTarget = "{target}"')
+            block.append(f"regexes = [{quote}{body}{quote}]")
+            return shipped + "\n".join(block) + "\n"
+
+        # 1. `regexTarget = "line"`: the haystack becomes the whole source line,
+        #    so a short literal is a substring test against every scanned line.
+        #    This is the shape that passed the first version of this contract.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver("API_KEY", target="line")) if "regexTarget" in p],
+            "a line-targeted waiver is accepted - it matches against the entire source line",
+        )
+        # Anchoring does not rescue a `line` target either: the anchors would
+        # then bind to the whole line rather than to the secret.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(waiver(r"\AAPI_KEY\z", target="line"))
+                if "regexTarget" in p
+            ],
+            "an anchored line-targeted waiver is accepted",
+        )
+        # 2. `regexTarget = "match"` is no better - measured: `API_KEY` is a
+        #    substring of the rule's own match text (`FARM_API_KEY=<secret>`).
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver("API_KEY", target="match")) if "regexTarget" in p],
+            "a match-targeted waiver is accepted",
+        )
+        # 3. The deeper bug, and the reason constraining `regexTarget` ALONE is
+        #    insufficient: with the target omitted (the detected secret) an
+        #    unanchored literal is still a SUBSTRING search.  Measured: `sk-`
+        #    waives the planted key outright.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver("sk-")) if "not anchored" in p],
+            "an unanchored waiver is accepted - it waives every secret containing it",
+        )
+        # 4. A pattern smuggled inside the anchors.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(waiver(r"\Ask-.*\z")) if "metacharacter" in p],
+            "a wildcard waiver is accepted",
+        )
+        # 5. The blind-spot directives: these un-scan a whole file or commit.
+        for directive in ("paths", "commits", "stopwords"):
+            with self.subTest(directive=directive):
+                blinded = shipped + f"\n[[allowlists]]\n{directive} = [{quote}x{quote}]\n"
+                self.assertTrue(
+                    [p for p in gitleaks_waiver_violations(blinded) if directive in p],
+                    f"a `{directive}` waiver is accepted - it un-scans whole files",
+                )
+        # 6. A waiver with no rationale, and one with no value at all.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped + f"\n[[allowlists]]\nregexes = [{quote}\\Ax\\z{quote}]\n"
+                )
+                if "no rationale" in p
+            ],
+            "a waiver with no description is accepted",
+        )
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped + '\n[[allowlists]]\ndescription = "x"\n'
+                )
+                if "names no value" in p
+            ],
+            "a waiver naming no value is accepted",
+        )
+
+        # ---- SPELLING BYPASSES OF THE CONTRACT ITSELF -----------------------
+        # Everything above bypasses the RULES.  Every shape below bypassed the
+        # CONTRACT: each was measured GUARD-GREEN against the first version of
+        # this file while the pinned image reported `no leaks found` (exit 0)
+        # over a tree carrying a freshly planted high-entropy key that the
+        # shipped config reports as `leaks found: 1` (exit 1).  They are one
+        # defect with eleven faces - the contract read the config as TEXT, and
+        # TOML (plus viper's case-insensitive key lookup) admits far more
+        # spellings than a regex anticipates.  The contract now PARSES.
+        def block(*lines: str) -> str:
+            return shipped + "\n[[allowlists]]\n" + "\n".join(lines) + "\n"
+
+        # 7. An INDENTED `regexes` key.  `  regexes = [...]` is valid TOML; the
+        #    extractor was anchored at column 0 so it pulled ZERO literals from
+        #    this block, while the `"regexes = [" in block` substring test still
+        #    reported the block as bounded.  Zero literals, zero violations.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    block('description = "adversarial"', f"  regexes = [{quote}sk-{quote}]")
+                )
+                if "not anchored" in p
+            ],
+            "an indented `regexes` key hides its literals from the contract",
+        )
+        # 8. `disabledRules` under `[extend]` turns the highest-value rule off
+        #    outright.  Asserting `useDefault = true` is present says nothing
+        #    about what sits beside it.  Only `useDefault` may live there.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped.replace(
+                        "useDefault = true",
+                        'useDefault = true\ndisabledRules = ["generic-api-key"]',
+                        1,
+                    )
+                )
+                if "disabledrules" in p.lower()
+            ],
+            "`[extend] disabledRules` is accepted - it deletes the rule outright",
+        )
+        # 9. A SINGLE-QUOTED `regexTarget`.  The ban matched double quotes only.
+        #    Measured: `regexTarget = 'match'` plus a whole-match-anchored,
+        #    metacharacter-free literal clears every other check and swallows
+        #    the planted key.
+        #
+        #    The value below is a LOW-ENTROPY stand-in, deliberately.  The
+        #    measurement used a real high-entropy key, but this assertion is a
+        #    pure function of the config TEXT - `regexTarget` is rejected on
+        #    sight, whatever it is paired with - so the entropy buys the test
+        #    nothing and costs it a finding.  Committing the measured key here
+        #    made the secret-scan job red on its own contract, which is the job
+        #    working: a credential-shaped literal in a tracked file is exactly
+        #    what it exists to catch, and the answer to that is to stop
+        #    committing one, never to widen the allowlist around it.
+        planted = "FARM_API_KEY=sk-NOT-A-REAL-KEY"
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    block(
+                        'description = "adversarial"',
+                        "regexTarget = 'match'",
+                        f"regexes = [{quote}\\A{planted}\\z{quote}]",
+                    )
+                )
+                if "regexTarget" in p
+            ],
+            "a single-quoted `regexTarget` evades the ban",
+        )
+        # 10. Any TOML string spelling other than `'''...'''`.  The literal
+        #     extractor matched triple-quoted strings only, so a basic or a
+        #     single-quoted literal string yielded ZERO literals to check.
+        for spelling in ('regexes = ["sk-"]', "regexes = ['sk-']"):
+            with self.subTest(spelling=spelling):
+                self.assertTrue(
+                    [
+                        p
+                        for p in gitleaks_waiver_violations(
+                            block('description = "adversarial"', spelling)
+                        )
+                        if "not anchored" in p
+                    ],
+                    "a waiver spelled with other quotes hides from the contract",
+                )
+        # 11. An INDENTED `[[allowlists]]` header.  The block scan was anchored
+        #     at column 0, so an indented block - and every waiver in it - was
+        #     invisible to every per-block check at once.
+        first_header = re.search(r"(?m)^\[\[allowlists\]\]$", shipped)
+        self.assertIsNotNone(first_header, "the shipped config has no allowlist header")
+        indented = (
+            shipped[: first_header.start()]
+            + f'  [[allowlists]]\n  description = "adversarial"\n  regexes = [{quote}sk-{quote}]\n\n'
+            + shipped[first_header.start() :]
+        )
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations(indented) if "not anchored" in p],
+            "an indented `[[allowlists]]` header hides a whole block",
+        )
+        # 12. CASE-VARIED KEYS.  gitleaks reads its config through viper, whose
+        #     key lookup is case-INSENSITIVE, while every ban here was
+        #     case-sensitive.  Measured: `Paths = ['''.''']` reported
+        #     `scanned ~0 bytes` - the entire repository went unread - with the
+        #     guard green.
+        for line, needle in (
+            (f"Paths = [{quote}.{quote}]", "paths"),
+            ('RegexTarget = "match"', "regexTarget"),
+        ):
+            with self.subTest(line=line):
+                self.assertTrue(
+                    [
+                        p
+                        for p in gitleaks_waiver_violations(
+                            block(
+                                'description = "adversarial"',
+                                line,
+                                f"regexes = [{quote}\\Aunused\\z{quote}]",
+                            )
+                        )
+                        if needle in p
+                    ],
+                    "a case-varied key evades the ban that names it",
+                )
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped.replace(
+                        "useDefault = true",
+                        'useDefault = true\nDISABLEDRULES = ["generic-api-key"]',
+                        1,
+                    )
+                )
+                if "disabledrules" in p.lower()
+            ],
+            "a case-varied `disabledRules` evades the ban",
+        )
+        # 13. A `]` INSIDE a literal.  The array capture was non-greedy to the
+        #     first `]`, so one waiver containing a bracket truncated the scan
+        #     and every later literal in the same array went unchecked.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    block(
+                        'description = "adversarial"',
+                        f"regexes = [{quote}\\Ax]y\\z{quote}, {quote}sk-{quote}]",
+                    )
+                )
+                if "not anchored" in p
+            ],
+            "a `]` in one waiver hides every later waiver in the same array",
+        )
+        # 14. A `[[rules]]` BLOCK.  The contract only ever looked at
+        #     `[[allowlists]]`.  Measured: re-declaring the id `generic-api-key`
+        #     with a never-matching regex REPLACES the default rule, and the
+        #     planted key goes unreported.  This file subtracts fixture values
+        #     from the default ruleset; it declares no rules of its own.
+        self.assertTrue(
+            [
+                p
+                for p in gitleaks_waiver_violations(
+                    shipped
+                    + '\n[[rules]]\nid = "generic-api-key"\ndescription = "adversarial"\n'
+                    + f"regex = {quote}zzzzz-never-matches-zzzzz{quote}\n"
+                )
+                if "rules" in p
+            ],
+            "a `[[rules]]` block is accepted - it can replace a default rule",
+        )
+        # 15. A config gitleaks cannot load is not a passing config.  The
+        #     contract must not silently report "narrow" on TOML it failed to
+        #     read; the scanner exits FTL on the same input.
+        self.assertTrue(
+            [p for p in gitleaks_waiver_violations("regexes = [") if "TOML" in p],
+            "an unparseable config is reported as narrow",
+        )
+
+    def test_secret_scan_config_edits_reach_the_guard_that_constrains_them(self):
+        # The narrowness contract above lives in THIS file, which runs only in
+        # the path-scoped `ci-impact` job.  `.gitleaks.toml` matched no filter
+        # and no push trigger, so a PR whose ONLY change was to widen the
+        # allowlist skipped the single job that guards it - the same defect
+        # class as #384, which this branch fixes for the parity fixture.
+        # `.github/workflows/docs.yml` had the identical gap: it is guarded by
+        # test_docs_workflow_gates_the_site_dependency_graph_before_publishing
+        # (issue #403 AC-3), and a PR deleting the site audit step touches only
+        # docs.yml - exactly the diff the guard could not see.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        impact = paths_filter(ci, "impact")
+        self.assertIn(
+            "tools/ci-impact.py", impact, "the impact-filter scan drifted off the real block"
+        )
+        push = push_trigger_paths(ci)
+        self.assertIn(
+            "tools/sync-core.py", push, "the push-trigger scan drifted off the real block"
+        )
+        for guarded in (".gitleaks.toml", ".github/workflows/docs.yml"):
+            with self.subTest(path=guarded):
+                self.assertIn(
+                    guarded, impact, "a PR touching only this file skips its own contract test"
+                )
+                self.assertIn(guarded, push, "a push of this file starts no CI run")
+
+    def test_the_allowlist_guard_also_runs_unconditionally_in_the_secret_scan_job(self):
+        # Belt AND braces.  A path filter is a promise that has already been
+        # broken twice in this repo (#384, and the .gitleaks.toml gap above), so
+        # registering the config with the filter is necessary but not durable -
+        # a later edit can drop it again.  The `secret-scan` job carries no
+        # `needs: changes` gate, so hosting the narrowness contract there makes
+        # it unskippable: any PR that reaches CI at all re-proves the allowlist
+        # before the scan is allowed to trust it.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        job = workflow_jobs(ci)["secret-scan"]
+        # Job-level keys sit at four spaces; a step's own `if:` is deeper, so
+        # this reads the job's own gating and not the range step's event guard.
+        self.assertNotRegex(job, r"(?m)^    needs:", "the secret scan became path-scoped")
+        self.assertNotRegex(job, r"(?m)^    if:", "the secret scan became conditional")
+        for guard in (
+            "test_the_secret_scan_allowlist_stays_narrow_and_value_scoped",
+            "test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract",
+        ):
+            with self.subTest(guard=guard):
+                self.assertIn(
+                    f"test_ci_impact.WorkflowContractTest.{guard}",
+                    job,
+                    "the always-on job does not re-prove its own allowlist",
+                )
+
+    def test_the_secret_scan_covers_the_pull_requests_commit_range(self):
+        # Issue #404 AC-1 asks for a scan over the relevant commit RANGE.  A
+        # `gitleaks dir` scan of the merge-result tree cannot meet it, and the
+        # gap is not theoretical - measured on a scratch repo, a credential
+        # added in one commit and deleted in the next left the tree scan
+        # reporting `no leaks found` (exit 0) while `gitleaks git --log-opts
+        # <base>..HEAD` reported it with its file, line, rule, and commit sha
+        # (exit 1).  This repository allows merge and rebase merges as well as
+        # squash, so those commits reach main's history verbatim.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        job = workflow_jobs(ci)["secret-scan"]
+        # The `git` subcommand (as opposed to `dir`) is what reads history.
+        self.assertRegex(
+            job, r"(?m)^\s+git \. \\$", "the secret scan never inspects commit history"
+        )
+        self.assertIn("--log-opts", job, "the history scan is not scoped to the PR's range")
+        # History is only there to scan if the checkout actually fetched it.
+        self.assertRegex(
+            job, r"(?m)^          fetch-depth: 0$", "a shallow checkout leaves no range to scan"
+        )
+        # The range scan is a pull_request concern - it is the only event with a
+        # base to diff against, and PR checks are main's enforcement point.
+        self.assertIn(
+            "if: github.event_name == 'pull_request'",
+            job,
+            "the range scan is not scoped to the event that has a base to diff against",
+        )
 
     def test_documentation_contract_is_always_required_by_merge_readiness(self):
         ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ on:
       - "tools/sync-core.py"
       - "tools/build-host-packages.py"
       - "tools/ci-impact.py"
+      # Issue #384: the hooks job runs this generator's own unit tests
+      # (.github/scripts/test_codex_parity_fixture.py), so a push that edits
+      # only the generator must still start a run.
+      - "tools/codex-parity-fixture.py"
+      # Same defect class, same fix: test_ci_impact.py is the ONLY guard on the
+      # secret-scan allowlist (#404) and on docs.yml's site CVE gate (#403), so
+      # a change to either must start a run that can execute it.
+      - ".gitleaks.toml"
+      - ".github/workflows/docs.yml"
 
 permissions:
   contents: read
@@ -122,6 +131,10 @@ jobs:
               - 'plugins/ca-pi/hooks/**'
               - 'core/**'
               - '.github/scripts/**'
+              # Issue #384: test_codex_parity_fixture.py runs in the hooks job
+              # below, so a PR touching only the generator it tests must flag
+              # this filter - otherwise the fixture skips its own test.
+              - 'tools/codex-parity-fixture.py'
               - '.github/workflows/ci.yml'
             impact:
               - '.github/ci-impact-map.json'
@@ -129,6 +142,14 @@ jobs:
               - 'core/hosts.json'
               - 'tools/ci-impact.py'
               - 'tools/host_descriptors.py'
+              # test_ci_impact.py is the only guard on the secret-scan allowlist
+              # (#404) and on docs.yml's site CVE gate (#403). Until these two
+              # were listed, a PR that ONLY weakened .gitleaks.toml - or ONLY
+              # deleted the site audit step - skipped the job that checks them.
+              # The allowlist contract additionally runs unconditionally in the
+              # secret-scan job, so it survives a future edit to this filter.
+              - '.gitleaks.toml'
+              - '.github/workflows/docs.yml'
               - '.github/workflows/ci.yml'
             manifests:
               - '**/*.json'
@@ -197,12 +218,22 @@ jobs:
           cache-dependency-path: plugins/ca/tools/package-lock.json
       - name: Install (locked)
         run: npm ci
-      - name: Audit (CVE gate - fail on CRITICAL)
-        # Supply-chain gate per security-controls.md: a CRITICAL advisory in a
-        # production dependency fails the build. --omit=dev scopes to shipped
-        # deps; --audit-level=critical intentionally ignores lower severities so
-        # routine dev-tool advisories don't block unrelated PRs.
-        run: npm audit --omit=dev --audit-level=critical
+      - name: Audit (CVE gate - fail on HIGH)
+        # Supply-chain gate per security-controls.md: a HIGH-or-worse advisory
+        # in a production dependency fails the build. --omit=dev scopes to
+        # shipped deps so routine dev-tool advisories don't block unrelated PRs.
+        #
+        # HONEST SCOPE: plugins/ca/tools declares ZERO production dependencies,
+        # so `--omit=dev` audits an empty graph here and this step is inert
+        # today at ANY threshold. It is a DURABILITY setting - it decides what
+        # happens the day the farm takes on a runtime dependency. #400's three
+        # HIGH advisories were all in site/package-lock.json, the only graph in
+        # this repo with production deps and one nothing audited until #403;
+        # that gate lives in docs.yml, not here. Issue #434 tracks extending the
+        # sweep to the dev trees, where this package's advisories actually are.
+        # One threshold applies to every audited graph (farm, sandbox, ca-pi,
+        # docs site); test_ci_impact.py asserts that.
+        run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test
@@ -235,8 +266,12 @@ jobs:
           cache-dependency-path: plugins/ca-sandbox/tools/package-lock.json
       - name: Install (locked)
         run: npm ci
-      - name: Audit (CVE gate - fail on CRITICAL)
-        run: npm audit --omit=dev --audit-level=critical
+      - name: Audit (CVE gate - fail on HIGH)
+        # Same threshold as every other audited graph (issue #403), and the same
+        # caveat as the farm: ca-sandbox/tools declares no production
+        # dependencies either, so this audits an empty graph today and is a
+        # durability setting rather than a live gate.
+        run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test
@@ -316,6 +351,16 @@ jobs:
         run: npm install --global @earendil-works/pi-coding-agent@${{ steps.pinned.outputs.version }} --ignore-scripts
       - name: Install reviewed toolchain (scripts disabled)
         run: npm ci --ignore-scripts
+      - name: Audit (CVE gate - fail on HIGH)
+        # plugins/ca-pi/tools is a PUBLISHED host package, so its graph belongs
+        # under the same gate as the farm, sandbox, and docs site - without this
+        # step tech-stack.md's claim to cover "every dependency graph the repo
+        # ships or publishes" was false. Like the first two it declares no
+        # production dependencies today, so this audits an empty graph; it
+        # exists so the gate is already in place when that changes. Hosted here
+        # rather than in the six-cell ca-pi-tools matrix - the verdict does not
+        # depend on OS or Pi version.
+        run: npm audit --omit=dev --audit-level=high
       - name: Check generated root package metadata
         working-directory: .
         run: python tools/build-host-packages.py --check
@@ -983,6 +1028,144 @@ jobs:
       - name: Check cross-reference graph (ca-codex)
         run: python3 .github/scripts/check-plugin-refs.py ca-codex
 
+  secret-scan:
+    name: "[CHECK] | [REPO] | Secret scan"
+    # Issue #404: until this job existed the repository had NO independent
+    # secret scanner. Both existing layers are COOPERATIVE - the H-10b commit
+    # hook and /ca:preview's sweep only run inside a contributor's local
+    # Claude/Codex/Pi session. A bot, a fork, a github.com web edit, or a plain
+    # `git push` runs neither, so a real credential could merge and stay in
+    # history with every hosted check green.
+    #
+    # Repo-wide and always-on, like license-consistency and surface: a
+    # credential can ride any diff, so there is deliberately no `needs: changes`
+    # path gate here. On push the workflow's own path filter still applies -
+    # main's branch protection requires this check on the pull request, which is
+    # the enforcement point.
+    #
+    # PINNED: the scanner is an image digest, not a tag. A tag can be re-pointed
+    # by anyone who compromises the upstream registry account, and a scanner
+    # runs over the entire repository - it is exactly the thing that must not be
+    # swappable. Bump the digest deliberately, the way the SHA-pinned actions
+    # above are bumped.
+    #
+    # READ-ONLY: the tree is mounted `:ro` into a network-isolated, capability-
+    # stripped, read-only-rootfs container running as a non-root uid. The
+    # scanner cannot rewrite what it audits and cannot phone home with what it
+    # finds.
+    #
+    # ACTIONABLE WITHOUT LEAKING: `--redact` replaces every secret with
+    # REDACTED, and `--verbose` is what actually prints the finding. With
+    # `--redact` alone the log contains only `leaks found: N` - no file, no
+    # line, no rule id - which is unactionable and would force a maintainer to
+    # re-run the scanner unredacted to triage it. Measured against the pinned
+    # image: the pair prints `File:`/`Line:`/`RuleID:`/`Fingerprint:` (plus
+    # `Commit:` in git mode) alongside `Secret: REDACTED`.
+    #
+    # TWO SCANS, TWO BLIND SPOTS: the tree scan sees the merge result, so it
+    # catches anything that would LAND on main. It cannot see a credential added
+    # in one PR commit and deleted in the next - measured on a scratch repo,
+    # that tree scan reports `no leaks found` (exit 0) while the history still
+    # carries the key and the range scan reports it with its commit sha
+    # (exit 1). This repo allows merge and rebase merges as well as squash, so
+    # those commits reach main verbatim; #404 AC-1 asks for the commit RANGE and
+    # the second scan step below is what covers it.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      # gitleaks v8.30.1
+      GITLEAKS_IMAGE: ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The range scan below walks the PR's own commits; a shallow checkout
+          # leaves nothing to walk.
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - name: Prove the allowlist is still narrow before trusting it
+        # This scan is only as strong as .gitleaks.toml, and a waiver that
+        # un-scans a file or matches a substring makes a green result
+        # meaningless. That contract lives in test_ci_impact.py, which runs in
+        # the path-scoped `ci-impact` job - and a PR touching only the allowlist
+        # used to skip it entirely. The path filter is now fixed, but a filter
+        # is a promise that has already been broken twice here (#384, and this).
+        # Running the contract HERE - in a job with no `needs: changes` gate -
+        # makes it unskippable: every PR that reaches CI re-proves the allowlist
+        # whatever the filters say.
+        working-directory: .github/scripts
+        run: |
+          python -m unittest -v \
+            test_ci_impact.WorkflowContractTest.test_the_secret_scan_allowlist_stays_narrow_and_value_scoped \
+            test_ci_impact.WorkflowContractTest.test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract
+      - name: Materialize the tracked tree
+        # Scan exactly the committed content: no .git internals, no runner-
+        # generated files, no node_modules. On a pull_request HEAD is the merge
+        # result, which is the tree that would land on main.
+        run: |
+          mkdir -p "$RUNNER_TEMP/secret-scan"
+          git archive --format=tar HEAD | tar -x -C "$RUNNER_TEMP/secret-scan"
+      - name: Scan the tracked tree for credentials
+        run: |
+          docker run --rm \
+            --network none \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
+            --workdir /repo \
+            --volume "$RUNNER_TEMP/secret-scan:/repo:ro" \
+            "$GITLEAKS_IMAGE" \
+            dir . \
+              --config /repo/.gitleaks.toml \
+              --no-banner \
+              --redact \
+              --verbose \
+              --exit-code 1
+      - name: Scan the pull request's commit range for credentials
+        # Issue #404 AC-1. Only meaningful on a pull_request - the only event
+        # with a base to diff against, and the enforcement point main's branch
+        # protection actually requires. On push the tree scan carries the job.
+        #
+        # The repository is mounted read-only WITH its .git, so gitleaks runs
+        # `git log -p` over the range and never writes. `safe.directory` is
+        # passed through GIT_CONFIG_* rather than written to a config file
+        # (nothing here is writable), pre-empting git's dubious-ownership
+        # refusal; /tmp is a small noexec tmpfs so git has scratch space without
+        # the rootfs becoming writable. Verified locally under this exact flag
+        # set, including --user, against a repo whose HEAD had already deleted
+        # the planted credential.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          base="$(git merge-base "$BASE_SHA" HEAD)"
+          echo "scanning commit range ${base}..HEAD"
+          docker run --rm \
+            --network none \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env GIT_CONFIG_COUNT=1 \
+            --env GIT_CONFIG_KEY_0=safe.directory \
+            --env GIT_CONFIG_VALUE_0=/repo \
+            --workdir /repo \
+            --volume "$GITHUB_WORKSPACE:/repo:ro" \
+            "$GITLEAKS_IMAGE" \
+            git . \
+              --config /repo/.gitleaks.toml \
+              --log-opts "${base}..HEAD" \
+              --no-banner \
+              --redact \
+              --verbose \
+              --exit-code 1
+
   documentation-contract:
     name: "[CHECK] | [REPO] | Documentation contract"
     # Repository documentation is a cross-cutting public interface: validate
@@ -1030,11 +1213,12 @@ jobs:
       - license-consistency
       - surface
       - prose-codex
+      - secret-scan
     runs-on: ubuntu-latest
     steps:
       - name: Require every required job to have succeeded or been skipped
         run: |
-          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }}"
+          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }} ${{ needs['secret-scan'].result }}"
           canary_result="${{ needs.ca-pi-latest.result }}"
           echo "upstream required results: $required_results"
           echo "advisory Pi canary result: $canary_result"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,17 +10,25 @@ name: Deploy docs
 # scoped to push: it needs pages:write/id-token:write, which a PR (especially
 # from a fork) can't safely hold.
 
+# This workflow triggers on ITSELF. It gates the site dependency graph (the
+# audit step in site-check) and the deploy edge that makes that audit binding,
+# and a change to any of that touches docs.yml and nothing else - which under
+# the old `site/** + plugins/ca/**` filters started no run at all. Measured:
+# the PR that ADDED the audit step never executed it, with 37 other checks
+# green and no `Site |` check among them. Same defect class as #384.
 on:
   push:
     branches: [main]
     paths:
       - "site/**"
       - "plugins/ca/**" # the reference is generated from the plugin, so rebuild when it changes
+      - ".github/workflows/docs.yml" # this workflow gates the site graph; it must see its own edits
   pull_request:
     branches: [main]
     paths:
       - "site/**"
       - "plugins/ca/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 # Least-privilege: only the deploy job needs pages/id-token:write, granted at
@@ -56,6 +64,14 @@ jobs:
           cache-dependency-path: site/package-lock.json
       - name: Install deps
         run: npm ci
+      - name: Audit (CVE gate - fail on HIGH)
+        # Issue #403: nothing audited site/package-lock.json, so a known-
+        # vulnerable production dependency could build and publish to GitHub
+        # Pages with this whole workflow green. `deploy` needs this job, so a
+        # red audit blocks the publish. Same threshold as the farm and sandbox
+        # gates in ci.yml; --omit=dev scopes it to what the built site actually
+        # ships, keeping routine Astro/vitest dev advisories non-blocking.
+        run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,155 @@
+# Hosted secret-scan configuration (issue #404).
+#
+# codeArbiter's own secret gates are COOPERATIVE: H-10b blocks a commit whose
+# diff touches a secret line, and /ca:preview sweeps the working diff. Both run
+# locally, inside the contributor's Claude/Codex/Pi session. A bot, a fork, a
+# web edit, or a plain `git push` runs neither. The `secret-scan` job in
+# .github/workflows/ci.yml is the independent hosted backstop, and this file is
+# the only thing standing between it and a false positive.
+#
+# WHY THERE IS NO `paths` ALLOWLIST HERE
+# A global `paths = [...]` entry does not waive a finding - it removes the file
+# from the scan altogether. Verified against the pinned image: a config whose
+# only waiver was `paths = ['''^test_hooklib\.py$''']` (with condition = "AND"
+# and a regex that matches nothing) reported `scanned ~189 bytes`, i.e. the
+# 89 KB Python file was never read, and a freshly planted
+# `aws_secret_access_key = "kR3m..."` in it went unreported. Path waivers are
+# therefore permanent blind spots, not narrow exceptions, and this config uses
+# VALUE waivers instead.
+#
+# WHY EVERY WAIVER IS ANCHORED `\A...\z`
+# Being a fixed literal is NOT enough, and assuming otherwise was a real defect
+# in the first version of this file. gitleaks tests an allowlist regex with Go's
+# `FindString`, which is a SUBSTRING search, not a full match. An unanchored
+# literal is therefore exactly as broad as whatever haystack it is tested
+# against, and `regexTarget` only chooses that haystack: omitted = the detected
+# secret, "match" = the rule's whole match text, "line" = the entire source
+# line. Measured against the pinned image over this repo's tracked tree, with a
+# high-entropy key planted in plugins/ca/tools/.env.example (which the shipped
+# config below reports as `leaks found: 1`, exit 1):
+#
+#   regexTarget = "line",   regexes = API_KEY            ->  no leaks found
+#   regexTarget = "match",  regexes = API_KEY            ->  no leaks found
+#   regexTarget omitted,    regexes = sk-                ->  no leaks found
+#   regexTarget omitted,    regexes = \Ask-REPLACE_ME\z  ->  leaks found: 1
+#
+# All three of the first shapes swallow a live credential, so constraining
+# `regexTarget` alone buys NO narrowness - the unanchored-substring case sails
+# through it. Anchoring is what works: `\A<literal>\z` matches only when the
+# ENTIRE detected secret is that exact fixture value. Every waiver below is
+# therefore anchored, and `regexTarget` is omitted everywhere so the anchors
+# bind to the detected secret rather than to surrounding source text.
+#
+# The anchored values are the secrets gitleaks actually reports, not the source
+# text around them - measured with `--report-format json` against the default
+# ruleset, which finds exactly 13 leaks in this tree across 5 distinct values.
+#
+# ADDING AN ENTRY - the rules .github/scripts/test_ci_impact.py enforces:
+#   1. A waiver carries ONLY `description` and `regexes`. Every other key is
+#      rejected, `paths` / `commits` / `stopwords` (which un-scan a file or a
+#      commit) and `regexTarget` (which rebinds the waiver to surrounding source
+#      text) loudest of all. The check is DEFAULT-DENY: a knob gitleaks adds
+#      later fails this contract the day it is typed here, not the day someone
+#      remembers to ban it.
+#   2. `[extend]` sets `useDefault` and nothing else. `disabledRules` deletes a
+#      rule outright - measured, `disabledRules = ["generic-api-key"]` returns a
+#      planted high-entropy key to `no leaks found` - and `path` / `url` pull in
+#      allowlists that are not in this file, so nothing here constrains them.
+#   3. No `[[rules]]` block. This file only ever SUBTRACTS fixture values from
+#      the default ruleset, and a rule whose id matches a default one REPLACES
+#      it - measured, that is the same hole as disabling it.
+#   4. Every `[[allowlists]]` block carries a `description` naming the file the
+#      literal legitimately lives in and why it is benign.
+#   5. Every block waives by `regexes`, every regex is anchored `\A...\z`, and
+#      the anchored body carries no regex metacharacter - no `.*`, no character
+#      class, no escape, nothing that could match an unseen value.
+#
+# REFORMATTING WILL NOT HELP. The contract PARSES this file as TOML and folds
+# keys to lower case, because gitleaks reads its config through viper, whose key
+# lookup is case-INSENSITIVE (measured: `Paths` un-scans the tree exactly as
+# `paths` does). Indenting a key or a table header, spelling a waiver `"x"` or
+# `'x'` instead of `'''x'''`, or capitalising a key changes nothing about what
+# the rules above see. Reading this file as TEXT is what let eleven measured
+# shapes through, each one guard-green while the scanner swallowed a live key.
+
+title = "codeArbiter hosted secret scan"
+
+[extend]
+# Start from gitleaks' full first-party ruleset. This file only ever SUBTRACTS
+# known-fake fixture literals from it; it never adds a rule of its own.
+useDefault = true
+
+[[allowlists]]
+description = """
+Canonical secret-detection corpus literals (architecture-001), which live in
+plugins/ca/hooks/secret-detection-corpus.json and are inlined as test input by
+.github/scripts/test_hooklib.py, plugins/ca/tools/farm.unit.test.ts, and the
+archived .codearbiter/reports/2026-07-14-pi-support-handoff/ review packages.
+Each is a deliberately fake credential SHAPE that both first-party classifiers
+(_hooklib.SECRET_RE and the farm redactor) are required to flag; deleting them
+would delete the adversarial coverage the corpus exists to provide.
+Two of these are live findings under the default ruleset today
+(sk-test-abcd1234 and wJalrXUtnFEMI1234, six occurrences between them); the
+rest sit below its entropy floor and produce no finding, and are waived
+defensively so a future ruleset bump cannot turn the corpus red. Each waiver is
+exact, so a defensive entry cannot waive anything but the value it names.
+"""
+regexes = [
+  '''\Ask-CVlQvxKsecretvalue123\z''',
+  '''\Acorrect-horse-battery\z''',
+  '''\Aabc12345def\z''',
+  '''\AwJalrXUtnFEMIabcd1234\z''',
+  '''\AwJalrXUtnFEMI1234\z''',
+  '''\Ask-test-abcd1234\z''',
+  '''\AAKIAIOSFODNN7EXAMPLE\z''',
+  '''\Aghp_abcdefghijklmnopqrstuvwxyz0123456789\z''',
+  '''\Ask-ant-api03-AbCdEf1234567890abcdef\z''',
+]
+
+[[allowlists]]
+description = """
+The fixed fake value the H-01/H-10b guard-matrix cases assign so the hook is
+proven to block them - .github/scripts/test_hook_guards.py (three occurrences)
+and .github/scripts/test_hooklib.py (two).
+"""
+regexes = ['''\Aabcd1234efgh\z''']
+
+[[allowlists]]
+description = """
+Placeholder in the shipped env template plugins/ca/tools/.env.example:
+FARM_API_KEY carries the literal `sk-REPLACE_ME`, never a value. It sits below
+the generic-api-key entropy floor, so it produces no finding today; it is waived
+by that exact anchored literal anyway, so the waiver can never cover the
+populated-.env.example regression this job exists to catch. Measured: replacing
+it with a high-entropy key gives `leaks found: 1` and exit 1.
+"""
+regexes = ['''\Ask-REPLACE_ME\z''']
+
+[[allowlists]]
+description = """
+The non-real PEM plugins/ca/tools/farm.test.ts plants into a scratch repo. The
+BEGIN/END markers wrap the test-local constants KEY_BODY_1/2/3, whose values are
+the literal strings FAKEKEYBODYLINE{ONE,TWO,THREE} - chosen precisely because
+they carry no trigger word, which is the property that test asserts about the
+per-line redactor. The secret gitleaks reports here is the whole five-line block
+of constant NAMES (the values live on earlier lines), so that block anchored is
+the waiver: any other PEM is a different secret and is not waived. Measured on
+this tree - an inline PEM added anywhere else is reported by `private-key`, and
+pasting real key material into KEY_BODY_1's value is reported by
+`generic-api-key` on the assignment line. Reformatting that array changes the
+secret and turns this job red until the waiver is re-derived, which is the
+correct direction to fail.
+"""
+regexes = ['''\A-----BEGIN RSA PRIVATE KEY-----",
+        KEY_BODY_1,
+        KEY_BODY_2,
+        KEY_BODY_3,
+        "-----END RSA PRIVATE KEY-----\z''']
+
+[[allowlists]]
+description = """
+`highEntropyToken` in plugins/ca-pi/tools/test/dispatch.test.ts: a hand-typed
+high-entropy string with no trigger word, used to assert safeDiagnostic never
+fragments the audit log. Not a credential for any system.
+"""
+regexes = ['''\AZx9qP2mK7vN4wR8tY1uJ6hL3sD5fA0cE\z''']


### PR DESCRIPTION
Closes #404
Closes #384
Closes #403

Replaces #432, which is closed. Same final tree, rebuilt as a single commit — #432's history carried a real high-entropy measurement key, and **the commit-range scan this PR adds caught it**. Force-pushing is prohibited here and a `.gitleaksignore` waiver would have been a twelfth bypass of the class this PR closes eleven of, so the branch was rebuilt clean instead.

## What lands

- A **digest-pinned** gitleaks job, wired into both `ci-passed.needs` and `required_results`, with no job-level `needs:`/`if:` and no `paths:` filter on `on.pull_request` — so no diff can skip the job that guards the allowlist.
- A `pull_request`-scoped **commit-range** scan (`gitleaks git --log-opts <merge-base>..HEAD`). #404 AC-1 asked for the range, not the tree: a secret added and then removed inside a PR is invisible to a tree scan. Proven — a two-commit add-then-`git rm` gives tree scan exit 0, range scan exit 1 naming file, line, rule and commit.
- `--verbose` so a failure names File/Line/RuleID/Entropy/Commit/Fingerprint while the value stays `Secret: REDACTED`.
- `npm audit --omit=dev --audit-level=high` for the docs site, and `tools/codex-parity-fixture.py` added to the push trigger and `hooks` filter so editing the generator runs its own test.

## The contract was itself bypassable — eleven ways

An adversarial recheck found the narrowness contract read `.gitleaks.toml` as **text**. Each case below was measured: contract **GREEN** while the pinned scanner (v8.30.1) reported `no leaks found` on a tree it otherwise flags `leaks found: 1`.

| # | bypass |
|---|---|
| 1 | indented `regexes` — extractor anchored at column 0, guard used a substring test |
| 2 | `[extend] disabledRules = ["generic-api-key"]` — contract checked `useDefault` existed, never what sat beside it |
| 3-4 | `regexTarget = 'line'` — the ban matched double quotes only |
| 5-6 | `regexes = ["sk-"]` / `['sk-']` — only `'''…'''` was ever extracted |
| 7 | indented `[[allowlists]]` — an entire block invisible |
| 8-10 | `Paths`, `RegexTarget`, `DISABLEDRULES` — **gitleaks reads config through viper and is case-insensitive**; every ban was case-sensitive. `Paths` alone produced `scanned ~0 bytes`: the whole repo unread |
| 11 | `[[rules]]` re-declaring `generic-api-key` — replaces the default rule; the contract never looked at `[[rules]]` |

**Fix: parse it, don't scrape it.** `tomllib` + case-folded keys, default-deny on waiver keys, `[extend]` may set only `useDefault`, `[[rules]]` rejected, and unparseable TOML is a violation rather than a silent pass. All eleven now rejected; the shipped config (13 waivers across 5 blocks) still passes and still catches a planted key.

Also confirmed clean: inline `allowlists = [{…}]` (gitleaks ignores it), singular `[allowlist]` and `extend.path` (gitleaks hard-refuses both alongside `[[allowlists]]`), `extend.url` (the job runs `--network none`), no `export-ignore` in `.gitattributes`, and `gitleaks dir` does not skip gitignored files.

## Two more defects fixed

- **`docs.yml` never ran on itself.** Its triggers were `site/**` and `plugins/ca/**` only, so the new site audit step did not execute on the PR that added it — the same defect class this PR exists to fix.
- **The npm-audit contract is now derived from the workflow**, not a hardcoded job list. A list of three names cannot see a fourth dependency graph, which is precisely how `site/package-lock.json` went unguarded. The rule is now "a job may skip the audit only if a sibling audits the directory it installs", proven to bite by a synthetic job. `ca-pi-tools` runs `npm ci` and never audited.

## Verification

| Suite | Result |
|---|---|
| `.github/scripts` (full) | **1084 tests, OK** (skipped=5) |
| `test_ci_impact` alone | **33 tests, OK** |
| `git diff --check origin/main HEAD` | exit 0 |

Crypto gate: the only `sha256` additions are container **image digest pins** — a supply-chain control, and SHA-256 is on the approved list. No banned primitive, nothing disables TLS verification.

Known: `#428`'s Windows Pi flake may redden a matrix cell; it reproduces on `origin/main` and is tracked separately.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L