### PR TITLE
test(ca-pi): budget the live-Pi spawns in package.test.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.9] - 2026-07-25
+
+### Fixed
+
+- The three live-Pi spawns in the package contract test now carry an explicit
+  budget. Each `execFileSync`s a real Node process that imports the installed Pi
+  host, and each inherited Vitest's bare 5000 ms default against cold hosted
+  Windows process creation - the same flat-wall-clock defect as the Job Object
+  admission window, in a file that fix did not reach. Measured 5497 ms and
+  failing on `windows-latest`. Test-only.
+
 ## [0.1.8] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/test/package.test.ts
+++ b/plugins/ca-pi/tools/test/package.test.ts
@@ -26,6 +26,16 @@ const windowsSupervisor = resolve(pluginRoot, "helpers", "windows-supervisor.js"
 // aggregate fixture bound below the platform runner's 180-second command cap.
 const LIVE_DUPLICATE_HOST_TIMEOUT_MS = 120_000;
 
+// Same reasoning as above, for the shorter live-Pi spawns. These execFileSync a
+// real Node process that imports the installed Pi host, so they pay cold hosted
+// Windows process-creation and module-resolution cost that no product operation
+// controls. Measured on windows-latest: the dormant-load case took 5497 ms
+// against Vitest's bare 5000 ms default and failed - the same "a real spawn
+// measured against a flat wall-clock budget" defect as #428, in a file #443 did
+// not touch. Bounded well under the platform runner's 180-second command cap, so
+// a genuine hang still fails closed rather than running to the job deadline.
+const LIVE_PI_SPAWN_TIMEOUT_MS = 60_000;
+
 async function exists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -438,7 +448,7 @@ describe("ca-pi package", () => {
       await rm(projectCwd, { recursive: true, force: true });
       await rm(agentDir, { recursive: true, force: true });
     }
-  });
+  }, LIVE_PI_SPAWN_TIMEOUT_MS);
 
   test("minimal environment replaces poisoned operator homes and configs", async () => {
     const root = await mkdtemp(resolve(tmpdir(), "ca-pi-isolation-red-"));
@@ -1114,7 +1124,7 @@ describe("ca-pi package", () => {
       else process.env.PATH = previousPath;
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }, LIVE_PI_SPAWN_TIMEOUT_MS);
 
   test("installed Pi runtime is admitted by the production boundary", async () => {
     const piRoot = await findPiPackageRoot();
@@ -1128,6 +1138,6 @@ describe("ca-pi package", () => {
       pythonMajor: 3,
     })(api as never);
     expect(apiAccesses).toBe(0);
-  });
+  }, LIVE_PI_SPAWN_TIMEOUT_MS);
 
 });


### PR DESCRIPTION
A third instance of #428's defect class, in a file #443 did not touch. Found blocking #446.

## The defect

Three tests in `plugins/ca-pi/tools/test/package.test.ts` `execFileSync` a real Node process that imports the **installed** Pi host, and none carried an explicit timeout — so each inherited Vitest's bare **5000 ms** default against cold hosted Windows process creation and module resolution:

- `real Pi dormant load never executes a project-cwd Python candidate`
- `installed Pi discovery ignores an adjacent package without a Pi executable`
- `installed Pi runtime is admitted by the production boundary`

Measured on `windows-latest`, the first took **5497 ms** and failed, blocking #446 on both Pi matrix cells:

```
× real Pi dormant load never executes a project-cwd Python candidate  5497ms
Error: Test timed out in 5000ms.
```

Same shape as #428: *a real spawn measured against a flat wall-clock budget*. #443 fixed `background-jobs.test.ts` and `process-tree.test.ts`; this file was out of its scope.

## Why it was easy to miss

The file **already recognised the problem** — `LIVE_DUPLICATE_HOST_TIMEOUT_MS = 120_000` exists, with a comment reading "Cold hosted Windows I/O can exceed Vitest's default without any individual product operation hanging." It was applied to exactly one test. The other three spawn the same live host and were simply never given a budget.

## Fix

A sibling constant, `LIVE_PI_SPAWN_TIMEOUT_MS = 60_000`, applied to all three, with the derivation recorded beside it.

**This is not a flake-hiding raise.** 60s is bounded well under the platform runner's 180-second command cap, so a genuine hang still fails closed inside the job rather than running to the deadline. The alternative — condition-based waiting, which #428 prefers and #443 used — does not apply here: `execFileSync` is synchronous by construction and there is no intermediate signal to poll.

## Verification

| Check | Result |
|---|---|
| `plugins/ca-pi/tools` → `npx vitest run test/package.test.ts` | **19 passed** |
| `npx tsc --noEmit` | clean |
| `git diff --check origin/main HEAD` | exit 0 |

Test-only; no product code, no payload change, so no ca-pi manifest bump.

Related: #428 (the class), #443 (the first two instances).

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L