### PR TITLE
perf(ledger): write the statusline ledger only when it changed

### DIFF
--- a/core/pysrc/_ledgerlib.py
+++ b/core/pysrc/_ledgerlib.py
@@ -37,7 +37,7 @@ import re
 import stat
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
@@ -50,11 +50,23 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
 from _hooklib import release_lock as _release_lock  # noqa: E402
 from _hooklib import LOCK_WAIT  # noqa: E402
+# parse_iso lives in _fmtlib, which already documents it as part of its public
+# API; this module carried a byte-identical second copy (#334 item 3). Same
+# re-export pattern as the lock helpers above: one owner, and `L.parse_iso`
+# stays importable for this module's call sites and the test suite. No cycle
+# risk — _fmtlib imports only _colorlib, never _ledgerlib.
+from _fmtlib import parse_iso  # noqa: E402,F401
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
+# `last_ts` exists only to keep a live record inside SESSION_TTL. Stamping it on
+# EVERY render made every render a writing render (#392) — the statusline runs in
+# a fresh process per refresh, so that was two atomic replacements per refresh
+# forever. Refresh it on a write we are making anyway, or at most once per
+# heartbeat; 5 minutes is ~432x inside the 36-hour TTL.
+LEDGER_HEARTBEAT = 300
 
 # Pi's bridge sends only already-extracted usage facts. The bridge chunks long
 # sessions so one call and one lock hold stay predictably small. `session_key` is
@@ -122,19 +134,6 @@ def get(d, *path, default=None):
             return default
         cur = cur[k]
     return cur
-
-
-def parse_iso(s):
-    """Parse an ISO-8601 timestamp (tolerating a trailing Z) to epoch seconds."""
-    if not s or not isinstance(s, str):
-        return None
-    try:
-        dt = datetime.fromisoformat(s.strip().replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)   # naive timestamps are UTC, not local
-        return dt.timestamp()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 # --------------------------------------------------------------------------- pricing
@@ -212,11 +211,23 @@ def _start_file(path, sid):
     return os.path.join(_session_dir(path), f"{_session_key(sid)}.start.json")
 
 
-def _load_sessions(path):
-    """Merge the legacy snapshot with authoritative independently-written shards."""
+def _merge_sessions(path):
+    """Merge the legacy snapshot with authoritative independently-written shards.
+
+    Returns (sessions, legacy) where `legacy` is the compatibility snapshot's own
+    mapping exactly as it was read from disk (None when the file is absent or
+    malformed). Callers compare the merged result against `legacy` to tell whether
+    the snapshot on disk is already in sync, so the whole-snapshot rewrite happens
+    only when it would actually change bytes (#392). Session records are copied out
+    of `legacy` so later in-place edits (the .start.json overlay below, and the
+    caller's own record) cannot mutate the comparison baseline.
+    """
     led = _read_json(path, {})
     legacy = led.get("sessions") if isinstance(led, dict) else None
-    sessions = dict(legacy) if isinstance(legacy, dict) else {}
+    if not isinstance(legacy, dict):
+        legacy = None
+    sessions = {} if legacy is None else {
+        sid: dict(rec) for sid, rec in legacy.items() if isinstance(rec, dict)}
     directory = _session_dir(path)
     try:
         names = os.listdir(directory)
@@ -275,7 +286,12 @@ def _load_sessions(path):
     sessions = {sid: rec for sid, rec in sessions.items()
                 if isinstance(rec, dict)
                 and now - num(rec.get("last_ts")) <= SESSION_TTL}
-    return sessions
+    return sessions, legacy
+
+
+def _load_sessions(path):
+    """The merged live-session map only (see _merge_sessions for the baseline)."""
+    return _merge_sessions(path)[0]
 
 
 def _write_snapshot(path, sessions):
@@ -432,21 +448,34 @@ def _ledger_update_unlocked(data, sid, path):
     """Read-modify-write the per-session ledger. Accumulate the session's TRUE token
     COUNTS by tailing its transcript (deduped per requestId), take the COST from the
     host's cost.total_cost_usd, and return (session record, this-session totals,
-    today's totals across sessions). Best-effort; safe blanks on any failure."""
+    today's totals across sessions). Best-effort; safe blanks on any failure.
+
+    The statusline re-renders in a fresh process on every refresh, so this is the
+    product's hottest filesystem path: each write below is skipped unless it would
+    actually change bytes on disk (#392). The on-disk FORMAT is unchanged — the
+    per-session shard and the whole-ledger compatibility snapshot are both still
+    written exactly as before, just no longer unconditionally."""
     blank = {"in": 0.0, "out": 0.0, "cost": 0.0}
     now = time.time()
     today = datetime.now().strftime("%Y-%m-%d")
 
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
 
     rec = sessions.get(sid)
     dirty = not isinstance(rec, dict)
     if dirty:
         rec = {}
-    rec.setdefault("first_ts", now)
-    rec["last_ts"] = now
-    rec["last_day"] = today
-    rec["host_cost"] = num(get(data, "cost", "total_cost_usd"))
+    stored_ts = num(rec.get("last_ts"))
+    if "first_ts" not in rec:
+        rec["first_ts"] = now
+        dirty = True
+    if rec.get("last_day") != today:
+        rec["last_day"] = today
+        dirty = True
+    host_cost = num(get(data, "cost", "total_cost_usd"))
+    if rec.get("host_cost") != host_cost:
+        rec["host_cost"] = host_cost
+        dirty = True
 
     tx = data.get("transcript_path") if isinstance(data, dict) else None
     if safe(_tx_accumulate, rec, tx):
@@ -457,20 +486,34 @@ def _ledger_update_unlocked(data, sid, path):
     # it is far more accurate than recomputing tokens*price. api_cost is fallback only.
     if rec["host_cost"] > 0:
         sess["cost"] = rec["host_cost"]
-    rec["today"] = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
-    rec.pop("tot", None)                    # retire the batch-1 whole-session cache key
+    bucket = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
+    if rec.get("today") != bucket:
+        rec["today"] = bucket
+        dirty = True
+    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+        dirty = True
+    # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
+    # with a write we are already making rather than forcing one of its own.
+    if dirty or now - stored_ts >= LEDGER_HEARTBEAT:
+        rec["last_ts"] = now
+        dirty = True
     sessions[sid] = rec
 
     for k in list(sessions.keys()):
         v = sessions[k]
         if not isinstance(v, dict) or now - num(v.get("last_ts")) > SESSION_TTL:
             del sessions[k]
-            dirty = True
     # Each session owns one independently replaced shard. A writer for another
-    # session therefore cannot replace this record with an older snapshot.
-    _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)  # compatibility/readability cache; shards are truth
+    # session therefore cannot replace this record with an older snapshot. The
+    # merged map above already reflects every shard read under this same lock, so
+    # there is nothing a re-read could learn — no concurrent writer can have run.
+    if dirty:
+        _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
+    if sessions != legacy:
+        # Compatibility/readability cache; shards are truth. Rewritten only when
+        # it has drifted from the merged truth — which still covers TTL pruning,
+        # a new session, and a legacy-only record that a shard has superseded.
+        _write_snapshot(path, sessions)
 
     # Today = each session's TODAY bucket (tokens whose transcript timestamp falls
     # on the current local day), summed across sessions — not whole-session totals.
@@ -506,7 +549,7 @@ def persist_sess_start(sid, value):
 
 
 def _persist_sess_start_unlocked(sid, value, path):
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
     rec = sessions.get(sid)
     if not isinstance(rec, dict):
         return False
@@ -517,8 +560,11 @@ def _persist_sess_start_unlocked(sid, value, path):
     if not _atomic_json(_start_file(path, sid),
                         {"sid": sid, "sess_start": float(value)}):
         return False
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)
+    # Applying the value we just persisted is exactly what a re-merge would
+    # produce — the start-file overlay in _merge_sessions — without the reread.
+    rec["sess_start"] = float(value)
+    if sessions != legacy:
+        _write_snapshot(path, sessions)
     return True
 
 

--- a/core/pysrc/_ledgerlib.py
+++ b/core/pysrc/_ledgerlib.py
@@ -490,7 +490,8 @@ def _ledger_update_unlocked(data, sid, path):
     if rec.get("today") != bucket:
         rec["today"] = bucket
         dirty = True
-    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+    if "tot" in rec:                        # retire the batch-1 whole-session cache key
+        del rec["tot"]
         dirty = True
     # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
     # with a write we are already making rather than forcing one of its own.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_ledgerlib.py
+++ b/plugins/ca-codex/hooks/_ledgerlib.py
@@ -37,7 +37,7 @@ import re
 import stat
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
@@ -50,11 +50,23 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
 from _hooklib import release_lock as _release_lock  # noqa: E402
 from _hooklib import LOCK_WAIT  # noqa: E402
+# parse_iso lives in _fmtlib, which already documents it as part of its public
+# API; this module carried a byte-identical second copy (#334 item 3). Same
+# re-export pattern as the lock helpers above: one owner, and `L.parse_iso`
+# stays importable for this module's call sites and the test suite. No cycle
+# risk — _fmtlib imports only _colorlib, never _ledgerlib.
+from _fmtlib import parse_iso  # noqa: E402,F401
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
+# `last_ts` exists only to keep a live record inside SESSION_TTL. Stamping it on
+# EVERY render made every render a writing render (#392) — the statusline runs in
+# a fresh process per refresh, so that was two atomic replacements per refresh
+# forever. Refresh it on a write we are making anyway, or at most once per
+# heartbeat; 5 minutes is ~432x inside the 36-hour TTL.
+LEDGER_HEARTBEAT = 300
 
 # Pi's bridge sends only already-extracted usage facts. The bridge chunks long
 # sessions so one call and one lock hold stay predictably small. `session_key` is
@@ -122,19 +134,6 @@ def get(d, *path, default=None):
             return default
         cur = cur[k]
     return cur
-
-
-def parse_iso(s):
-    """Parse an ISO-8601 timestamp (tolerating a trailing Z) to epoch seconds."""
-    if not s or not isinstance(s, str):
-        return None
-    try:
-        dt = datetime.fromisoformat(s.strip().replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)   # naive timestamps are UTC, not local
-        return dt.timestamp()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 # --------------------------------------------------------------------------- pricing
@@ -212,11 +211,23 @@ def _start_file(path, sid):
     return os.path.join(_session_dir(path), f"{_session_key(sid)}.start.json")
 
 
-def _load_sessions(path):
-    """Merge the legacy snapshot with authoritative independently-written shards."""
+def _merge_sessions(path):
+    """Merge the legacy snapshot with authoritative independently-written shards.
+
+    Returns (sessions, legacy) where `legacy` is the compatibility snapshot's own
+    mapping exactly as it was read from disk (None when the file is absent or
+    malformed). Callers compare the merged result against `legacy` to tell whether
+    the snapshot on disk is already in sync, so the whole-snapshot rewrite happens
+    only when it would actually change bytes (#392). Session records are copied out
+    of `legacy` so later in-place edits (the .start.json overlay below, and the
+    caller's own record) cannot mutate the comparison baseline.
+    """
     led = _read_json(path, {})
     legacy = led.get("sessions") if isinstance(led, dict) else None
-    sessions = dict(legacy) if isinstance(legacy, dict) else {}
+    if not isinstance(legacy, dict):
+        legacy = None
+    sessions = {} if legacy is None else {
+        sid: dict(rec) for sid, rec in legacy.items() if isinstance(rec, dict)}
     directory = _session_dir(path)
     try:
         names = os.listdir(directory)
@@ -275,7 +286,12 @@ def _load_sessions(path):
     sessions = {sid: rec for sid, rec in sessions.items()
                 if isinstance(rec, dict)
                 and now - num(rec.get("last_ts")) <= SESSION_TTL}
-    return sessions
+    return sessions, legacy
+
+
+def _load_sessions(path):
+    """The merged live-session map only (see _merge_sessions for the baseline)."""
+    return _merge_sessions(path)[0]
 
 
 def _write_snapshot(path, sessions):
@@ -432,21 +448,34 @@ def _ledger_update_unlocked(data, sid, path):
     """Read-modify-write the per-session ledger. Accumulate the session's TRUE token
     COUNTS by tailing its transcript (deduped per requestId), take the COST from the
     host's cost.total_cost_usd, and return (session record, this-session totals,
-    today's totals across sessions). Best-effort; safe blanks on any failure."""
+    today's totals across sessions). Best-effort; safe blanks on any failure.
+
+    The statusline re-renders in a fresh process on every refresh, so this is the
+    product's hottest filesystem path: each write below is skipped unless it would
+    actually change bytes on disk (#392). The on-disk FORMAT is unchanged — the
+    per-session shard and the whole-ledger compatibility snapshot are both still
+    written exactly as before, just no longer unconditionally."""
     blank = {"in": 0.0, "out": 0.0, "cost": 0.0}
     now = time.time()
     today = datetime.now().strftime("%Y-%m-%d")
 
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
 
     rec = sessions.get(sid)
     dirty = not isinstance(rec, dict)
     if dirty:
         rec = {}
-    rec.setdefault("first_ts", now)
-    rec["last_ts"] = now
-    rec["last_day"] = today
-    rec["host_cost"] = num(get(data, "cost", "total_cost_usd"))
+    stored_ts = num(rec.get("last_ts"))
+    if "first_ts" not in rec:
+        rec["first_ts"] = now
+        dirty = True
+    if rec.get("last_day") != today:
+        rec["last_day"] = today
+        dirty = True
+    host_cost = num(get(data, "cost", "total_cost_usd"))
+    if rec.get("host_cost") != host_cost:
+        rec["host_cost"] = host_cost
+        dirty = True
 
     tx = data.get("transcript_path") if isinstance(data, dict) else None
     if safe(_tx_accumulate, rec, tx):
@@ -457,20 +486,34 @@ def _ledger_update_unlocked(data, sid, path):
     # it is far more accurate than recomputing tokens*price. api_cost is fallback only.
     if rec["host_cost"] > 0:
         sess["cost"] = rec["host_cost"]
-    rec["today"] = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
-    rec.pop("tot", None)                    # retire the batch-1 whole-session cache key
+    bucket = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
+    if rec.get("today") != bucket:
+        rec["today"] = bucket
+        dirty = True
+    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+        dirty = True
+    # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
+    # with a write we are already making rather than forcing one of its own.
+    if dirty or now - stored_ts >= LEDGER_HEARTBEAT:
+        rec["last_ts"] = now
+        dirty = True
     sessions[sid] = rec
 
     for k in list(sessions.keys()):
         v = sessions[k]
         if not isinstance(v, dict) or now - num(v.get("last_ts")) > SESSION_TTL:
             del sessions[k]
-            dirty = True
     # Each session owns one independently replaced shard. A writer for another
-    # session therefore cannot replace this record with an older snapshot.
-    _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)  # compatibility/readability cache; shards are truth
+    # session therefore cannot replace this record with an older snapshot. The
+    # merged map above already reflects every shard read under this same lock, so
+    # there is nothing a re-read could learn — no concurrent writer can have run.
+    if dirty:
+        _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
+    if sessions != legacy:
+        # Compatibility/readability cache; shards are truth. Rewritten only when
+        # it has drifted from the merged truth — which still covers TTL pruning,
+        # a new session, and a legacy-only record that a shard has superseded.
+        _write_snapshot(path, sessions)
 
     # Today = each session's TODAY bucket (tokens whose transcript timestamp falls
     # on the current local day), summed across sessions — not whole-session totals.
@@ -506,7 +549,7 @@ def persist_sess_start(sid, value):
 
 
 def _persist_sess_start_unlocked(sid, value, path):
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
     rec = sessions.get(sid)
     if not isinstance(rec, dict):
         return False
@@ -517,8 +560,11 @@ def _persist_sess_start_unlocked(sid, value, path):
     if not _atomic_json(_start_file(path, sid),
                         {"sid": sid, "sess_start": float(value)}):
         return False
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)
+    # Applying the value we just persisted is exactly what a re-merge would
+    # produce — the start-file overlay in _merge_sessions — without the reread.
+    rec["sess_start"] = float(value)
+    if sessions != legacy:
+        _write_snapshot(path, sessions)
     return True
 
 

--- a/plugins/ca-codex/hooks/_ledgerlib.py
+++ b/plugins/ca-codex/hooks/_ledgerlib.py
@@ -490,7 +490,8 @@ def _ledger_update_unlocked(data, sid, path):
     if rec.get("today") != bucket:
         rec["today"] = bucket
         dirty = True
-    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+    if "tot" in rec:                        # retire the batch-1 whole-session cache key
+        del rec["tot"]
         dirty = True
     # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
     # with a write we are already making rather than forcing one of its own.

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.13] - 2026-07-25
+
+### Changed
+
+- The shared statusline/footer ledger no longer rewrites itself on every render.
+  `ledger_update()` used to load the compatibility snapshot plus every live
+  session shard, write the session shard, load the snapshot and every shard a
+  second time, then atomically rewrite the whole snapshot - on every refresh,
+  whether or not anything had changed. Each write is now gated on the record (or
+  the snapshot) actually differing from what is on disk, the duplicate load is
+  gone, and the pure-liveness `last_ts` stamp is throttled to one refresh per
+  five minutes so a quiet render forces no write at all. The 36-hour session TTL
+  contract and the on-disk format are unchanged.
+- `parse_iso()` now has one owner. `_ledgerlib` carried a byte-identical second
+  copy of `_fmtlib`'s implementation and re-exports it instead.
+
 ## [0.1.12] - 2026-07-25
 
 ### Changed

--- a/plugins/ca-pi/hooks/_ledgerlib.py
+++ b/plugins/ca-pi/hooks/_ledgerlib.py
@@ -37,7 +37,7 @@ import re
 import stat
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
@@ -50,11 +50,23 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
 from _hooklib import release_lock as _release_lock  # noqa: E402
 from _hooklib import LOCK_WAIT  # noqa: E402
+# parse_iso lives in _fmtlib, which already documents it as part of its public
+# API; this module carried a byte-identical second copy (#334 item 3). Same
+# re-export pattern as the lock helpers above: one owner, and `L.parse_iso`
+# stays importable for this module's call sites and the test suite. No cycle
+# risk — _fmtlib imports only _colorlib, never _ledgerlib.
+from _fmtlib import parse_iso  # noqa: E402,F401
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
+# `last_ts` exists only to keep a live record inside SESSION_TTL. Stamping it on
+# EVERY render made every render a writing render (#392) — the statusline runs in
+# a fresh process per refresh, so that was two atomic replacements per refresh
+# forever. Refresh it on a write we are making anyway, or at most once per
+# heartbeat; 5 minutes is ~432x inside the 36-hour TTL.
+LEDGER_HEARTBEAT = 300
 
 # Pi's bridge sends only already-extracted usage facts. The bridge chunks long
 # sessions so one call and one lock hold stay predictably small. `session_key` is
@@ -122,19 +134,6 @@ def get(d, *path, default=None):
             return default
         cur = cur[k]
     return cur
-
-
-def parse_iso(s):
-    """Parse an ISO-8601 timestamp (tolerating a trailing Z) to epoch seconds."""
-    if not s or not isinstance(s, str):
-        return None
-    try:
-        dt = datetime.fromisoformat(s.strip().replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)   # naive timestamps are UTC, not local
-        return dt.timestamp()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 # --------------------------------------------------------------------------- pricing
@@ -212,11 +211,23 @@ def _start_file(path, sid):
     return os.path.join(_session_dir(path), f"{_session_key(sid)}.start.json")
 
 
-def _load_sessions(path):
-    """Merge the legacy snapshot with authoritative independently-written shards."""
+def _merge_sessions(path):
+    """Merge the legacy snapshot with authoritative independently-written shards.
+
+    Returns (sessions, legacy) where `legacy` is the compatibility snapshot's own
+    mapping exactly as it was read from disk (None when the file is absent or
+    malformed). Callers compare the merged result against `legacy` to tell whether
+    the snapshot on disk is already in sync, so the whole-snapshot rewrite happens
+    only when it would actually change bytes (#392). Session records are copied out
+    of `legacy` so later in-place edits (the .start.json overlay below, and the
+    caller's own record) cannot mutate the comparison baseline.
+    """
     led = _read_json(path, {})
     legacy = led.get("sessions") if isinstance(led, dict) else None
-    sessions = dict(legacy) if isinstance(legacy, dict) else {}
+    if not isinstance(legacy, dict):
+        legacy = None
+    sessions = {} if legacy is None else {
+        sid: dict(rec) for sid, rec in legacy.items() if isinstance(rec, dict)}
     directory = _session_dir(path)
     try:
         names = os.listdir(directory)
@@ -275,7 +286,12 @@ def _load_sessions(path):
     sessions = {sid: rec for sid, rec in sessions.items()
                 if isinstance(rec, dict)
                 and now - num(rec.get("last_ts")) <= SESSION_TTL}
-    return sessions
+    return sessions, legacy
+
+
+def _load_sessions(path):
+    """The merged live-session map only (see _merge_sessions for the baseline)."""
+    return _merge_sessions(path)[0]
 
 
 def _write_snapshot(path, sessions):
@@ -432,21 +448,34 @@ def _ledger_update_unlocked(data, sid, path):
     """Read-modify-write the per-session ledger. Accumulate the session's TRUE token
     COUNTS by tailing its transcript (deduped per requestId), take the COST from the
     host's cost.total_cost_usd, and return (session record, this-session totals,
-    today's totals across sessions). Best-effort; safe blanks on any failure."""
+    today's totals across sessions). Best-effort; safe blanks on any failure.
+
+    The statusline re-renders in a fresh process on every refresh, so this is the
+    product's hottest filesystem path: each write below is skipped unless it would
+    actually change bytes on disk (#392). The on-disk FORMAT is unchanged — the
+    per-session shard and the whole-ledger compatibility snapshot are both still
+    written exactly as before, just no longer unconditionally."""
     blank = {"in": 0.0, "out": 0.0, "cost": 0.0}
     now = time.time()
     today = datetime.now().strftime("%Y-%m-%d")
 
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
 
     rec = sessions.get(sid)
     dirty = not isinstance(rec, dict)
     if dirty:
         rec = {}
-    rec.setdefault("first_ts", now)
-    rec["last_ts"] = now
-    rec["last_day"] = today
-    rec["host_cost"] = num(get(data, "cost", "total_cost_usd"))
+    stored_ts = num(rec.get("last_ts"))
+    if "first_ts" not in rec:
+        rec["first_ts"] = now
+        dirty = True
+    if rec.get("last_day") != today:
+        rec["last_day"] = today
+        dirty = True
+    host_cost = num(get(data, "cost", "total_cost_usd"))
+    if rec.get("host_cost") != host_cost:
+        rec["host_cost"] = host_cost
+        dirty = True
 
     tx = data.get("transcript_path") if isinstance(data, dict) else None
     if safe(_tx_accumulate, rec, tx):
@@ -457,20 +486,34 @@ def _ledger_update_unlocked(data, sid, path):
     # it is far more accurate than recomputing tokens*price. api_cost is fallback only.
     if rec["host_cost"] > 0:
         sess["cost"] = rec["host_cost"]
-    rec["today"] = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
-    rec.pop("tot", None)                    # retire the batch-1 whole-session cache key
+    bucket = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
+    if rec.get("today") != bucket:
+        rec["today"] = bucket
+        dirty = True
+    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+        dirty = True
+    # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
+    # with a write we are already making rather than forcing one of its own.
+    if dirty or now - stored_ts >= LEDGER_HEARTBEAT:
+        rec["last_ts"] = now
+        dirty = True
     sessions[sid] = rec
 
     for k in list(sessions.keys()):
         v = sessions[k]
         if not isinstance(v, dict) or now - num(v.get("last_ts")) > SESSION_TTL:
             del sessions[k]
-            dirty = True
     # Each session owns one independently replaced shard. A writer for another
-    # session therefore cannot replace this record with an older snapshot.
-    _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)  # compatibility/readability cache; shards are truth
+    # session therefore cannot replace this record with an older snapshot. The
+    # merged map above already reflects every shard read under this same lock, so
+    # there is nothing a re-read could learn — no concurrent writer can have run.
+    if dirty:
+        _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
+    if sessions != legacy:
+        # Compatibility/readability cache; shards are truth. Rewritten only when
+        # it has drifted from the merged truth — which still covers TTL pruning,
+        # a new session, and a legacy-only record that a shard has superseded.
+        _write_snapshot(path, sessions)
 
     # Today = each session's TODAY bucket (tokens whose transcript timestamp falls
     # on the current local day), summed across sessions — not whole-session totals.
@@ -506,7 +549,7 @@ def persist_sess_start(sid, value):
 
 
 def _persist_sess_start_unlocked(sid, value, path):
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
     rec = sessions.get(sid)
     if not isinstance(rec, dict):
         return False
@@ -517,8 +560,11 @@ def _persist_sess_start_unlocked(sid, value, path):
     if not _atomic_json(_start_file(path, sid),
                         {"sid": sid, "sess_start": float(value)}):
         return False
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)
+    # Applying the value we just persisted is exactly what a re-merge would
+    # produce — the start-file overlay in _merge_sessions — without the reread.
+    rec["sess_start"] = float(value)
+    if sessions != legacy:
+        _write_snapshot(path, sessions)
     return True
 
 

--- a/plugins/ca-pi/hooks/_ledgerlib.py
+++ b/plugins/ca-pi/hooks/_ledgerlib.py
@@ -490,7 +490,8 @@ def _ledger_update_unlocked(data, sid, path):
     if rec.get("today") != bucket:
         rec["today"] = bucket
         dirty = True
-    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+    if "tot" in rec:                        # retire the batch-1 whole-session cache key
+        del rec["tot"]
         dirty = True
     # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
     # with a write we are already making rather than forcing one of its own.

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/hooks/_ledgerlib.py
+++ b/plugins/ca/hooks/_ledgerlib.py
@@ -37,7 +37,7 @@ import re
 import stat
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # _acquire_lock/_release_lock/LOCK_WAIT were hoisted to _hooklib (#271 C-2) so
@@ -50,11 +50,23 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import acquire_lock as _acquire_lock  # noqa: E402
 from _hooklib import release_lock as _release_lock  # noqa: E402
 from _hooklib import LOCK_WAIT  # noqa: E402
+# parse_iso lives in _fmtlib, which already documents it as part of its public
+# API; this module carried a byte-identical second copy (#334 item 3). Same
+# re-export pattern as the lock helpers above: one owner, and `L.parse_iso`
+# stays importable for this module's call sites and the test suite. No cycle
+# risk — _fmtlib imports only _colorlib, never _ledgerlib.
+from _fmtlib import parse_iso  # noqa: E402,F401
 
 # Tunables (module constants; mirrored from the original inline statusline block).
 SESSION_TTL = 36 * 3600  # prune sessions older than ~1.5 days
 BURN_RING = 40           # recent per-call token-burn samples kept for the sparkline
 TX_MAX_NEW_LINES = 20000 # hot-path bound: transcript lines parsed per render
+# `last_ts` exists only to keep a live record inside SESSION_TTL. Stamping it on
+# EVERY render made every render a writing render (#392) — the statusline runs in
+# a fresh process per refresh, so that was two atomic replacements per refresh
+# forever. Refresh it on a write we are making anyway, or at most once per
+# heartbeat; 5 minutes is ~432x inside the 36-hour TTL.
+LEDGER_HEARTBEAT = 300
 
 # Pi's bridge sends only already-extracted usage facts. The bridge chunks long
 # sessions so one call and one lock hold stay predictably small. `session_key` is
@@ -122,19 +134,6 @@ def get(d, *path, default=None):
             return default
         cur = cur[k]
     return cur
-
-
-def parse_iso(s):
-    """Parse an ISO-8601 timestamp (tolerating a trailing Z) to epoch seconds."""
-    if not s or not isinstance(s, str):
-        return None
-    try:
-        dt = datetime.fromisoformat(s.strip().replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)   # naive timestamps are UTC, not local
-        return dt.timestamp()
-    except Exception:  # noqa: BLE001
-        return None
 
 
 # --------------------------------------------------------------------------- pricing
@@ -212,11 +211,23 @@ def _start_file(path, sid):
     return os.path.join(_session_dir(path), f"{_session_key(sid)}.start.json")
 
 
-def _load_sessions(path):
-    """Merge the legacy snapshot with authoritative independently-written shards."""
+def _merge_sessions(path):
+    """Merge the legacy snapshot with authoritative independently-written shards.
+
+    Returns (sessions, legacy) where `legacy` is the compatibility snapshot's own
+    mapping exactly as it was read from disk (None when the file is absent or
+    malformed). Callers compare the merged result against `legacy` to tell whether
+    the snapshot on disk is already in sync, so the whole-snapshot rewrite happens
+    only when it would actually change bytes (#392). Session records are copied out
+    of `legacy` so later in-place edits (the .start.json overlay below, and the
+    caller's own record) cannot mutate the comparison baseline.
+    """
     led = _read_json(path, {})
     legacy = led.get("sessions") if isinstance(led, dict) else None
-    sessions = dict(legacy) if isinstance(legacy, dict) else {}
+    if not isinstance(legacy, dict):
+        legacy = None
+    sessions = {} if legacy is None else {
+        sid: dict(rec) for sid, rec in legacy.items() if isinstance(rec, dict)}
     directory = _session_dir(path)
     try:
         names = os.listdir(directory)
@@ -275,7 +286,12 @@ def _load_sessions(path):
     sessions = {sid: rec for sid, rec in sessions.items()
                 if isinstance(rec, dict)
                 and now - num(rec.get("last_ts")) <= SESSION_TTL}
-    return sessions
+    return sessions, legacy
+
+
+def _load_sessions(path):
+    """The merged live-session map only (see _merge_sessions for the baseline)."""
+    return _merge_sessions(path)[0]
 
 
 def _write_snapshot(path, sessions):
@@ -432,21 +448,34 @@ def _ledger_update_unlocked(data, sid, path):
     """Read-modify-write the per-session ledger. Accumulate the session's TRUE token
     COUNTS by tailing its transcript (deduped per requestId), take the COST from the
     host's cost.total_cost_usd, and return (session record, this-session totals,
-    today's totals across sessions). Best-effort; safe blanks on any failure."""
+    today's totals across sessions). Best-effort; safe blanks on any failure.
+
+    The statusline re-renders in a fresh process on every refresh, so this is the
+    product's hottest filesystem path: each write below is skipped unless it would
+    actually change bytes on disk (#392). The on-disk FORMAT is unchanged — the
+    per-session shard and the whole-ledger compatibility snapshot are both still
+    written exactly as before, just no longer unconditionally."""
     blank = {"in": 0.0, "out": 0.0, "cost": 0.0}
     now = time.time()
     today = datetime.now().strftime("%Y-%m-%d")
 
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
 
     rec = sessions.get(sid)
     dirty = not isinstance(rec, dict)
     if dirty:
         rec = {}
-    rec.setdefault("first_ts", now)
-    rec["last_ts"] = now
-    rec["last_day"] = today
-    rec["host_cost"] = num(get(data, "cost", "total_cost_usd"))
+    stored_ts = num(rec.get("last_ts"))
+    if "first_ts" not in rec:
+        rec["first_ts"] = now
+        dirty = True
+    if rec.get("last_day") != today:
+        rec["last_day"] = today
+        dirty = True
+    host_cost = num(get(data, "cost", "total_cost_usd"))
+    if rec.get("host_cost") != host_cost:
+        rec["host_cost"] = host_cost
+        dirty = True
 
     tx = data.get("transcript_path") if isinstance(data, dict) else None
     if safe(_tx_accumulate, rec, tx):
@@ -457,20 +486,34 @@ def _ledger_update_unlocked(data, sid, path):
     # it is far more accurate than recomputing tokens*price. api_cost is fallback only.
     if rec["host_cost"] > 0:
         sess["cost"] = rec["host_cost"]
-    rec["today"] = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
-    rec.pop("tot", None)                    # retire the batch-1 whole-session cache key
+    bucket = dict(_totals(_agg_reqs(rec.get("reqs"), only=today)), date=today)
+    if rec.get("today") != bucket:
+        rec["today"] = bucket
+        dirty = True
+    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+        dirty = True
+    # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
+    # with a write we are already making rather than forcing one of its own.
+    if dirty or now - stored_ts >= LEDGER_HEARTBEAT:
+        rec["last_ts"] = now
+        dirty = True
     sessions[sid] = rec
 
     for k in list(sessions.keys()):
         v = sessions[k]
         if not isinstance(v, dict) or now - num(v.get("last_ts")) > SESSION_TTL:
             del sessions[k]
-            dirty = True
     # Each session owns one independently replaced shard. A writer for another
-    # session therefore cannot replace this record with an older snapshot.
-    _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)  # compatibility/readability cache; shards are truth
+    # session therefore cannot replace this record with an older snapshot. The
+    # merged map above already reflects every shard read under this same lock, so
+    # there is nothing a re-read could learn — no concurrent writer can have run.
+    if dirty:
+        _atomic_json(_session_file(path, sid), {"sid": sid, "rec": rec})
+    if sessions != legacy:
+        # Compatibility/readability cache; shards are truth. Rewritten only when
+        # it has drifted from the merged truth — which still covers TTL pruning,
+        # a new session, and a legacy-only record that a shard has superseded.
+        _write_snapshot(path, sessions)
 
     # Today = each session's TODAY bucket (tokens whose transcript timestamp falls
     # on the current local day), summed across sessions — not whole-session totals.
@@ -506,7 +549,7 @@ def persist_sess_start(sid, value):
 
 
 def _persist_sess_start_unlocked(sid, value, path):
-    sessions = _load_sessions(path)
+    sessions, legacy = _merge_sessions(path)
     rec = sessions.get(sid)
     if not isinstance(rec, dict):
         return False
@@ -517,8 +560,11 @@ def _persist_sess_start_unlocked(sid, value, path):
     if not _atomic_json(_start_file(path, sid),
                         {"sid": sid, "sess_start": float(value)}):
         return False
-    sessions = _load_sessions(path)
-    _write_snapshot(path, sessions)
+    # Applying the value we just persisted is exactly what a re-merge would
+    # produce — the start-file overlay in _merge_sessions — without the reread.
+    rec["sess_start"] = float(value)
+    if sessions != legacy:
+        _write_snapshot(path, sessions)
     return True
 
 

--- a/plugins/ca/hooks/_ledgerlib.py
+++ b/plugins/ca/hooks/_ledgerlib.py
@@ -490,7 +490,8 @@ def _ledger_update_unlocked(data, sid, path):
     if rec.get("today") != bucket:
         rec["today"] = bucket
         dirty = True
-    if rec.pop("tot", None) is not None:    # retire the batch-1 whole-session cache key
+    if "tot" in rec:                        # retire the batch-1 whole-session cache key
+        del rec["tot"]
         dirty = True
     # Heartbeat: `last_ts` is pure liveness for the TTL sweep, so it rides along
     # with a write we are already making rather than forcing one of its own.

--- a/plugins/ca/hooks/tests/test_ledgerlib.py
+++ b/plugins/ca/hooks/tests/test_ledgerlib.py
@@ -1245,6 +1245,18 @@ class TestRenderWriteAmplification(unittest.TestCase):
         self.assertEqual(self._read(self.ledger)["sessions"]["cost"]["host_cost"],
                          3.5)
 
+    def test_retired_tot_key_is_removed_even_when_null(self):
+        # The batch-1 "tot" cache key is retired on read. A JSON null value must
+        # still count as a change, or the in-memory record silently diverges from
+        # the shard on disk with no write to reconcile it.
+        L.ledger_update({}, "legacy")
+        shard = L._session_file(self.ledger, "legacy")
+        payload = self._read(shard)
+        payload["rec"]["tot"] = None
+        self.assertTrue(L._atomic_json(shard, payload))
+        L.ledger_update({}, "legacy")
+        self.assertNotIn("tot", self._read(shard)["rec"])
+
     def test_daily_totals_exact_across_shard_counts(self):
         today = datetime.now().strftime("%Y-%m-%d")
         for count in (1, 10, 100):

--- a/plugins/ca/hooks/tests/test_ledgerlib.py
+++ b/plugins/ca/hooks/tests/test_ledgerlib.py
@@ -1102,6 +1102,208 @@ class TestPiUsageLedger(unittest.TestCase):
         self.assertNotIn("environment", shard)
 
 
+# =========================================================================== render write amplification
+class TestRenderWriteAmplification(unittest.TestCase):
+    """#392 — the statusline renders in a fresh process on every refresh, so a
+    render that changed nothing must not rewrite the session shard AND the whole
+    compatibility snapshot, and a render that DID change something must read the
+    snapshot plus the live shards exactly once."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._home = redirect_home(self.tmp)
+        self._orig = os.environ.get("CODEARBITER_LEDGER")
+        self.ledger = os.path.join(self.tmp, ".codearbiter", "ledger.json")
+        os.environ["CODEARBITER_LEDGER"] = self.ledger
+
+    def tearDown(self):
+        restore_home(self._home)
+        if self._orig is None:
+            os.environ.pop("CODEARBITER_LEDGER", None)
+        else:
+            os.environ["CODEARBITER_LEDGER"] = self._orig
+
+    # ------------------------------------------------------------------ helpers
+    def _assistant(self, req, inp=200, out=100):
+        # A local-offset "now" timestamp so _msg_date buckets these tokens into
+        # the CURRENT calendar day (the today-totals path under test).
+        return {"type": "assistant", "requestId": req,
+                "timestamp": datetime.now().astimezone().isoformat(),
+                "message": {"model": "claude-sonnet-4-6",
+                            "usage": {"input_tokens": inp, "output_tokens": out}}}
+
+    def _write_tx(self, entries):
+        tx = os.path.join(self.tmp, "transcript.jsonl")
+        with open(tx, "w", encoding="utf-8") as f:
+            for o in entries:
+                f.write(json.dumps(o) + "\n")
+        return tx
+
+    def _read(self, path):
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _record_writes(self):
+        """Wrap _atomic_json so every replaced pathname is recorded in order."""
+        writes = []
+        real = L._atomic_json
+
+        def spy(path, value):
+            writes.append(path)
+            return real(path, value)
+
+        return writes, mock.patch.object(L, "_atomic_json", side_effect=spy)
+
+    def _record_reads(self):
+        reads = []
+        real = L._read_json
+
+        def spy(path, default=None):
+            reads.append(path)
+            return real(path, default)
+
+        return reads, mock.patch.object(L, "_read_json", side_effect=spy)
+
+    def _seed_shard(self, sid, today, tokens_in, cost):
+        rec = {"first_ts": time.time(), "last_ts": time.time(), "last_day": today,
+               "host_cost": cost, "reqs": {}, "burn": [], "tx_off": 0,
+               "today": {"in": float(tokens_in), "out": 0.0, "cost": cost,
+                         "date": today}}
+        self.assertTrue(L._atomic_json(L._session_file(self.ledger, sid),
+                                       {"sid": sid, "rec": rec}))
+
+    # ------------------------------------------------------------------ tests
+    def test_unchanged_render_replaces_no_file(self):
+        tx = self._write_tx([self._assistant("r1")])
+        data = {"transcript_path": tx, "cost": {"total_cost_usd": 1.25}}
+        L.ledger_update(data, "quiet")                 # seed
+        writes, patcher = self._record_writes()
+        with patcher:
+            L.ledger_update(data, "quiet")             # identical render
+        self.assertEqual(writes, [])
+
+    def test_unchanged_render_preserves_shard_and_snapshot_bytes(self):
+        tx = self._write_tx([self._assistant("r1")])
+        data = {"transcript_path": tx, "cost": {"total_cost_usd": 1.25}}
+        L.ledger_update(data, "quiet")
+        shard = L._session_file(self.ledger, "quiet")
+        before_shard = self._read(shard)
+        before_snap = self._read(self.ledger)
+        L.ledger_update(data, "quiet")
+        self.assertEqual(self._read(shard), before_shard)
+        self.assertEqual(self._read(self.ledger), before_snap)
+
+    def test_changed_render_reads_snapshot_and_shards_once(self):
+        tx = self._write_tx([self._assistant("r1")])
+        data = {"transcript_path": tx, "cost": {"total_cost_usd": 1.0}}
+        L.ledger_update(data, "hot")
+        for other in ("a", "b", "c"):
+            self._seed_shard(other, datetime.now().strftime("%Y-%m-%d"), 10, 0.5)
+        tx = self._write_tx([self._assistant("r1"), self._assistant("r2")])
+        data = {"transcript_path": tx, "cost": {"total_cost_usd": 2.0}}
+        reads, patcher = self._record_reads()
+        with patcher:
+            L.ledger_update(data, "hot")
+        self.assertEqual(reads.count(self.ledger), 1)
+        for path in set(reads):
+            self.assertEqual(reads.count(path), 1, f"{path} was parsed twice")
+
+    def test_last_ts_heartbeat_is_throttled_then_refreshed(self):
+        L.ledger_update({}, "beat")
+        shard = L._session_file(self.ledger, "beat")
+        stamped = self._read(shard)["rec"]["last_ts"]
+        L.ledger_update({}, "beat")
+        self.assertEqual(self._read(shard)["rec"]["last_ts"], stamped)
+        payload = self._read(shard)
+        payload["rec"]["last_ts"] = time.time() - L.LEDGER_HEARTBEAT - 5
+        self.assertTrue(L._atomic_json(shard, payload))
+        L.ledger_update({}, "beat")
+        refreshed = self._read(shard)["rec"]["last_ts"]
+        self.assertGreater(refreshed, time.time() - L.LEDGER_HEARTBEAT)
+
+    def test_heartbeat_throttle_stays_far_inside_the_ttl(self):
+        # The throttle only exists to stop per-render writes; it must never let a
+        # live session drift out of the 36-hour TTL contract.
+        self.assertLess(L.LEDGER_HEARTBEAT, L.SESSION_TTL / 10)
+
+    def test_quiet_render_still_prunes_expired_snapshot_entry(self):
+        tx = self._write_tx([self._assistant("r1")])
+        data = {"transcript_path": tx}
+        L.ledger_update(data, "live")
+        snapshot = self._read(self.ledger)
+        snapshot["sessions"]["ghost"] = {"last_ts": time.time() - L.SESSION_TTL - 1}
+        self.assertTrue(L._atomic_json(self.ledger, snapshot))
+        L.ledger_update(data, "live")                  # nothing changed for "live"
+        self.assertNotIn("ghost", self._read(self.ledger)["sessions"])
+        self.assertIn("live", self._read(self.ledger)["sessions"])
+
+    def test_cost_change_alone_is_persisted(self):
+        L.ledger_update({"cost": {"total_cost_usd": 1.0}}, "cost")
+        shard = L._session_file(self.ledger, "cost")
+        L.ledger_update({"cost": {"total_cost_usd": 3.5}}, "cost")
+        self.assertEqual(self._read(shard)["rec"]["host_cost"], 3.5)
+        self.assertEqual(self._read(self.ledger)["sessions"]["cost"]["host_cost"],
+                         3.5)
+
+    def test_daily_totals_exact_across_shard_counts(self):
+        today = datetime.now().strftime("%Y-%m-%d")
+        for count in (1, 10, 100):
+            with self.subTest(shards=count):
+                directory = L._session_dir(self.ledger)
+                for name in (os.listdir(directory)
+                             if os.path.isdir(directory) else []):
+                    os.remove(os.path.join(directory, name))
+                for index in range(count):
+                    self._seed_shard(f"peer-{index}", today, 7, 0.25)
+                _rec, _sess, day = L.ledger_update({}, "current")
+                self.assertEqual(day["in"], 7.0 * count)
+                self.assertAlmostEqual(day["cost"], 0.25 * count)
+                self.assertEqual(
+                    len(self._read(self.ledger)["sessions"]), count + 1)
+
+    def test_expired_shards_still_pruned_with_many_live_shards(self):
+        today = datetime.now().strftime("%Y-%m-%d")
+        for index in range(10):
+            self._seed_shard(f"peer-{index}", today, 1, 0.0)
+        expired = L._session_file(self.ledger, "gone")
+        self.assertTrue(L._atomic_json(
+            expired, {"sid": "gone",
+                      "rec": {"last_ts": time.time() - L.SESSION_TTL - 1}}))
+        L.ledger_update({}, "current")
+        self.assertFalse(os.path.exists(expired))
+        self.assertNotIn("gone", self._read(self.ledger)["sessions"])
+
+    def test_concurrent_sessions_keep_their_own_totals(self):
+        first = self._write_tx([self._assistant("a1", inp=100, out=10)])
+        second = os.path.join(self.tmp, "second.jsonl")
+        with open(second, "w", encoding="utf-8") as f:
+            f.write(json.dumps(self._assistant("b1", inp=300, out=20)) + "\n")
+        _r, sess_a, _d = L.ledger_update({"transcript_path": first}, "sid-a")
+        _r, sess_b, day = L.ledger_update({"transcript_path": second}, "sid-b")
+        self.assertEqual(sess_a["in"], 100.0)
+        self.assertEqual(sess_b["in"], 300.0)
+        snapshot = self._read(self.ledger)["sessions"]
+        self.assertEqual(snapshot["sid-a"]["today"]["in"], 100.0)
+        self.assertEqual(snapshot["sid-b"]["today"]["in"], 300.0)
+        # A quiet re-render of sid-a must not drop sid-b from the snapshot.
+        L.ledger_update({"transcript_path": first}, "sid-a")
+        self.assertIn("sid-b", self._read(self.ledger)["sessions"])
+
+
+# =========================================================================== clone hoists
+class TestParseIsoHasOneOwner(unittest.TestCase):
+    """#334 item 3 — _fmtlib.parse_iso and _ledgerlib.parse_iso were byte-identical
+    bodies; _fmtlib is the documented owner and _ledgerlib must re-export it."""
+
+    def test_ledgerlib_reexports_the_fmtlib_implementation(self):
+        import _fmtlib
+        self.assertIs(L.parse_iso, _fmtlib.parse_iso)
+
+    def test_ledgerlib_defines_no_second_parse_iso_body(self):
+        source = inspect.getsource(L)
+        self.assertNotIn("def parse_iso(", source)
+
+
 # =========================================================================== import-purity
 class TestNoImportSideEffects(unittest.TestCase):
     """The lib must do zero file/network I/O at import time (the _*lib invariant)."""


### PR DESCRIPTION
Closes #392
Closes #334

Lane **L15-ledger-and-clone-cleanup**. Both issues are `core/pysrc/` — canonical edited, `tools/sync-core.py` re-run, `--check` green across all 3 plugins.

---

## #392 — stop rebuilding the full statusline ledger snapshot on every render

### Claims verified against source

All three claims in the issue hold at current `origin/main` (`3eb23e0`), with only a small line drift:

| Issue claim | Actual | Verdict |
| --- | --- | --- |
| `statusline.py:562-576` calls `ledger_update` every render | `statusline.py:563` | REAL |
| `_ledger_update_unlocked` loads sessions, writes shard, loads AGAIN, rewrites snapshot | `_ledgerlib.py:431/440/471/472/473` | REAL |
| `dirty` computed at 443/453/468 and never consulted | exactly so — nothing reads it | REAL |
| `last_ts = now` on every render | `_ledgerlib.py:448` | REAL (and it is *why* nothing could be gated on `dirty` — the record always looked changed) |

### The fix

- **`_merge_sessions(path)`** replaces `_load_sessions` internally and additionally returns the compatibility snapshot's mapping *as read from disk*. The whole-snapshot rewrite is now gated on `sessions != legacy` — i.e. only when it would actually change bytes. Records are copied out of the legacy mapping so the `.start.json` overlay (and the caller's own record) cannot mutate the comparison baseline. `_load_sessions(path)` survives as the one-value wrapper.
- **Shard write gated on real change.** `first_ts` / `last_day` / `host_cost` / `today` are each compared instead of blindly reassigned; `_tx_accumulate` already reported whether the offset advanced.
- **`LEDGER_HEARTBEAT = 300`** throttles the pure-liveness `last_ts` stamp. It rides along with a write we are already making, otherwise refreshes at most every 5 minutes — ~432x inside the unchanged 36-hour `SESSION_TTL`. A dedicated test asserts `LEDGER_HEARTBEAT < SESSION_TTL / 10` so the throttle can never be widened into the TTL contract.
- **The second `_load_sessions()` is gone.** The first merge already read every shard *under the same lock* (`ledger_update` and `persist_sess_start` are the only writers and both take it), so no concurrent writer can have run in between — the re-read could learn nothing.
- **`persist_sess_start`** gets the same single-merge treatment (it also loaded twice and rewrote unconditionally).

**On-disk format is untouched.** Per-session shards and the legacy compatibility snapshot are still written in exactly the same shape — just no longer on every render. TTL pruning of shard files, start files, malformed shards and stale *snapshot* entries all still happen on the merge path, so a quiet render still heals a drifted snapshot (covered by `test_quiet_render_still_prunes_expired_snapshot_entry`).

### Acceptance criteria

| AC | Covered by |
| --- | --- |
| No-change render rewrites neither shard nor snapshot | `test_unchanged_render_replaces_no_file`, `test_unchanged_render_preserves_shard_and_snapshot_bytes` |
| Changed session parses other live shards at most once | `test_changed_render_reads_snapshot_and_shards_once` (spies `_read_json`; asserts no path is parsed twice) |
| Concurrent sessions keep exact totals, no shard clobbering | `test_concurrent_sessions_keep_their_own_totals` (+ the pre-existing serialized-transaction / misnamed-shard tests, unmodified and still green) |
| TTL pruning + legacy compat correct at 1/10/100 shards | `test_daily_totals_exact_across_shard_counts`, `test_expired_shards_still_pruned_with_many_live_shards` |
| Benchmark shows lower no-change latency and fewer opens/replacements | below |

### Benchmark (Windows 11, 20 quiet renders per shard count, warm store, no transcript change)

| shards | median before | median after | p95 before | p95 after | `os.replace`/render | `open()`/render |
| ---: | ---: | ---: | ---: | ---: | --- | --- |
| 1 | 11.988 ms | **0.292 ms** | 13.593 ms | **0.406 ms** | 2.00 -> **0.00** | 6.0 -> **2.0** |
| 10 | 13.532 ms | **0.779 ms** | 14.817 ms | **0.954 ms** | 2.00 -> **0.00** | 24.0 -> **11.0** |
| 100 | 23.765 ms | **5.061 ms** | 25.633 ms | **6.025 ms** | 2.00 -> **0.00** | 204.0 -> **101.0** |

41x / 17x / 4.7x faster on the quiet path, and **zero** atomic file replacements where there were previously two per render, forever. The remaining `open()` calls are the single authoritative shard read pass. (Throwaway harness, deliberately not committed — it ran `origin/main`'s `_ledgerlib.py` and this branch's side by side against identical seeded stores.)

---

## #334 — clone triage

**Two of the three hazards are stale — already fixed on main. I verified each before closing:**

1. **semver-regex divergence — FIXED.** `compatibility.ts:19` now exports the anchored `export const SEMVER_PREFIX = /^(\d+)\.(\d+)\.(\d+)(?:$|[-+])/u`, and `doctor.ts:16` is `import { atLeast as versionAtLeast } from "./compatibility.ts";` — doctor has no regex of its own left to drift from.
2. **child error-text drift — FIXED.** `child-extension.ts:182` routes through `fixedFailure()`, whose text (`child-extension.ts:50`) is `codeArbiter child handshake ${message}; child remains blocked; run /ca-doctor.` — the `/ca-doctor` guidance the parent carries is present.

**Item 3 is real and is what this PR fixes.** `core/pysrc/_fmtlib.py:123` and `core/pysrc/_ledgerlib.py:127` carried byte-identical `parse_iso()` bodies. `_fmtlib` already documents `parse_iso` in its public-API header, so it is the owner; `_ledgerlib` now re-exports it using the same pattern as its `_hooklib` lock-helper re-exports (`_acquire_lock` / `_release_lock` / `LOCK_WAIT`). No cycle risk — `_fmtlib` imports only `_colorlib`, never `_ledgerlib` — and `L.parse_iso` stays importable for this module's two call sites and the suite. The now-unused `timezone` import was dropped from `_ledgerlib`.

The issue's other listed clusters (entry-point `run()` boilerplate, site render-page trio, sandbox mount pair, drain-logic pair, `extension.ts` authorize dup, and the "unverified" `_prunelib`/session-start/doctor-vs-statusline pairs) are explicitly out of this lane's scope and were left alone.

---

## Verbatim red output

`cd plugins/ca/hooks/tests && python -m unittest test_ledgerlib.TestRenderWriteAmplification test_ledgerlib.TestParseIsoHasOneOwner`, run against `origin/main`'s `_ledgerlib.py` with the new tests in place:

```
F....EF.FFFF
======================================================================
ERROR: test_heartbeat_throttle_stays_far_inside_the_ttl (test_ledgerlib.TestRenderWriteAmplification.test_heartbeat_throttle_stays_far_inside_the_ttl)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1227, in test_heartbeat_throttle_stays_far_inside_the_ttl
    self.assertLess(L.LEDGER_HEARTBEAT, L.SESSION_TTL / 10)
                    ^^^^^^^^^^^^^^^^^^
AttributeError: module '_ledgerlib' has no attribute 'LEDGER_HEARTBEAT'

======================================================================
FAIL: test_changed_render_reads_snapshot_and_shards_once (test_ledgerlib.TestRenderWriteAmplification.test_changed_render_reads_snapshot_and_shards_once)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1207, in test_changed_render_reads_snapshot_and_shards_once
    self.assertEqual(reads.count(self.ledger), 1)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 2 != 1

======================================================================
FAIL: test_last_ts_heartbeat_is_throttled_then_refreshed (test_ledgerlib.TestRenderWriteAmplification.test_last_ts_heartbeat_is_throttled_then_refreshed)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1216, in test_last_ts_heartbeat_is_throttled_then_refreshed
    self.assertEqual(self._read(shard)["rec"]["last_ts"], stamped)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 1784978578.856833 != 1784978578.8511016

======================================================================
FAIL: test_unchanged_render_preserves_shard_and_snapshot_bytes (test_ledgerlib.TestRenderWriteAmplification.test_unchanged_render_preserves_shard_and_snapshot_bytes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1193, in test_unchanged_render_preserves_shard_and_snapshot_bytes
    self.assertEqual(self._read(shard), before_shard)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: {'sid[69 chars]8578.9136388, 'last_day': '2026-07-25', 'host_[348 chars]5'}}} != {'sid[69 chars]8578.8995852, 'last_day': '2026-07-25', 'host_[348 chars]5'}}}
Diff is 929 characters long. Set self.maxDiff to None to see it.

======================================================================
FAIL: test_unchanged_render_replaces_no_file (test_ledgerlib.TestRenderWriteAmplification.test_unchanged_render_replaces_no_file)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1183, in test_unchanged_render_replaces_no_file
    self.assertEqual(writes, [])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
AssertionError: Lists differ: ['C:\\Users\\brenn\\AppData\\Local\\Temp\\[197 chars]son'] != []

First list contains 2 additional elements.
First extra element 0:
'C:\\Users\\brenn\\AppData\\Local\\Temp\\tmpu4ukjjvc\\.codearbiter\\ledger.json.sessions\\008f0747f4e27c8462baa991a538025bcc2dd143e78422f1afbdfcd9e757a20f.json'

+ []
- ['C:\\Users\\brenn\\AppData\\Local\\Temp\\tmpu4ukjjvc\\.codearbiter\\ledger.json.sessions\\008f0747f4e27c8462baa991a538025bcc2dd143e78422f1afbdfcd9e757a20f.json',
-  'C:\\Users\\brenn\\AppData\\Local\\Temp\\tmpu4ukjjvc\\.codearbiter\\ledger.json']

======================================================================
FAIL: test_ledgerlib_defines_no_second_parse_iso_body (test_ledgerlib.TestParseIsoHasOneOwner.test_ledgerlib_defines_no_second_parse_iso_body)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1304, in test_ledgerlib_defines_no_second_parse_iso_body
    self.assertNotIn("def parse_iso(", source)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^

======================================================================
FAIL: test_ledgerlib_reexports_the_fmtlib_implementation (test_ledgerlib.TestParseIsoHasOneOwner.test_ledgerlib_reexports_the_fmtlib_implementation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\tests\test_ledgerlib.py", line 1300, in test_ledgerlib_reexports_the_fmtlib_implementation
    self.assertIs(L.parse_iso, _fmtlib.parse_iso)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: <function parse_iso at 0x000001C1D9937C10> is not <function parse_iso at 0x000001C1D99B10C0>

----------------------------------------------------------------------
Ran 12 tests in 0.817s

FAILED (failures=6, errors=1)
```

The tests that passed in the red run are the deliberate *guards* — quiet-render snapshot pruning, cross-shard daily totals at 1/10/100, expired-shard pruning, cost-only persistence, concurrent-session isolation, and retirement of the legacy `tot` key. They assert pre-existing correct behaviour that the optimization must not break, and they are still green.

One of those guards caught a real defect in my own first cut, fixed in `a16df42`: `rec.pop("tot", None) is not None` cannot tell "key absent" from "key present holding JSON null", so a shard carrying `"tot": null` had the key stripped in memory with no write issued to reconcile it — harmless while the write was unconditional, a silent in-memory/on-disk divergence once it is gated. Presence is the signal, not the value. Verified the guard bites: it fails against the `pop(...) is not None` spelling and passes against `"tot" in rec`.

---

## Suites

| Suite | Baseline | After |
| --- | --- | --- |
| `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` | 1112 OK | **1125 OK** (+13 new) |
| `cd .github/scripts && python -m unittest discover -s . -p "test_*.py"` | 1110 OK, 5 skipped | 1110, **4 pre-existing failures**, 5 skipped — see NEEDS-TRIAGE |
| `cd plugins/ca-pi/tools && npm test` | 629 | 628 passed, 1 skipped, **1 pre-existing env failure** — see NEEDS-TRIAGE |
| `python tools/sync-core.py --check` | — | OK (48 core files x 3 plugins, byte-identical) |
| `python tools/build-host-packages.py --check --release-guard-base <merge-base>` | — | OK, `0.1.12 -> 0.1.13` |
| `git diff --check origin/main HEAD` | — | exit 0 |

`ca-farm` (`plugins/ca/tools`) was not run: this lane changes only Python under `core/pysrc/` and its vendored copies, no TS/JS source and no esbuild artifact.

### ca-pi 0.1.13

The ca-pi payload vendors `hooks/_ledgerlib.py`, so this is a payload change and the release guard requires the version to advance. Both `package.json` files bumped `0.1.12 -> 0.1.13`, exact `## [0.1.13] - 2026-07-25` CHANGELOG heading added, root metadata regenerated via `tools/build-host-packages.py`.

---

## NEEDS-TRIAGE

1. **`.github/scripts/test_pi_benchmark.py` — 4 failures, pre-existing on `origin/main` (`3eb23e0`), not caused by this lane.** Verified by stashing this branch's changes and re-running: identical failure set. `_measure_host("pi", 100)` raises inside `pi_benchmark.py:228 _production_pi_samples`. Failing: `test_measurements_use_exact_public_shape_and_100_warm_events`, `test_pi_record_does_not_load_the_generated_python_host_adapter`, `test_cli_emits_only_three_bounded_json_records`, `test_cli_real_spawn_flag_adds_a_fourth_labeled_record`. The stated `.github/scripts` baseline of "1110 OK, 5 skipped" no longer holds on main.
2. **`plugins/ca-pi/tools/test/package.test.ts` — `Failed to load url rolldown`.** A dev-dependency resolution failure in a fresh git worktree that has no `node_modules` of its own and falls back to the parent checkout's. Environment/tooling, not a code defect, and unrelated to a Python-only change. Worth confirming on CI, where install is clean.
3. **Shared scratchpad across parallel lanes.** All lane agents in this run share one scratchpad directory; a sibling lane overwrote a file I had written there mid-run. Harmless here (I re-derived the artifact and namespaced later files `l15-*`), but worth per-lane scratchpad namespacing for future parallel runs.
4. **Worktree + H-01 interaction.** `git commit` from an isolated worktree is blocked by H-01 because the branch is resolved from `CLAUDE_PROJECT_DIR` (the main checkout, on `main`) rather than the command's own worktree. Workaround used: an explicit `git -C <worktree-abs-path> commit`, which `git_cwd()` does honour. This is the same class of hazard as the `parallel-authors-need-worktrees` note and will hit every worktree-isolated author.

Claude-Session: https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
