### PR TITLE
fix(release): fail closed on multi-target, red, and mismatched-tag release dispatches

### DIFF
--- a/.github/scripts/_releaselib.py
+++ b/.github/scripts/_releaselib.py
@@ -19,10 +19,23 @@
 #   release_dates_consistent(changelog_section, tag_message) -> bool
 #   classify_publish_state(tag_exists, tag_sha, head_sha, tag_version,
 #                          manifest_version, release_is_nondraft) -> str
+#   select_release_target(confirm, codex_confirm) -> str
+#   classify_merge_readiness(check_runs, head_sha, check_name) -> str
+#   peel_tag(ls_remote_text, tag) -> str
+#
+# The last three back `.github/workflows/release.yml`'s read-only preflight and
+# its tag-integrity guard (issues #378, #385, #380). The hosted publish path
+# holds `contents: write` and its writes are public and irreversible, so every
+# one of them degrades to the REFUSING answer on malformed input.
 
 import re
 
 NONE_SENTINEL = "<none>"
+
+# The `ci-passed` aggregate in .github/workflows/ci.yml — the single check run
+# that means "every required job for this commit concluded green". Kept in sync
+# with that job's `name:` by test_release_workflow.py.
+MERGE_READINESS_CHECK = "[GATE ] | [REPO] | Merge readiness"
 
 # A `ca` release tag is exactly `vMAJOR.MINOR.PATCH` - no suffix. The anchored
 # form already excludes pre-releases (`v2.6.0-beta.1`) and the namespaced
@@ -108,20 +121,114 @@ def classify_publish_state(tag_exists, tag_sha, head_sha, tag_version,
     publish instead of dead-ending on 'tag exists -> STOP'. Returns one of:
 
       publish_fresh      - no tag yet; the normal Phase 2/3 path.
-      already_published  - a non-draft Release already exists on the tag.
+      already_published  - the tag is at HEAD and a non-draft Release exists.
       resume_publish     - tag is at HEAD and its version matches the manifest,
                            but no non-draft Release exists (tag pushed, Release
                            never created) -> finish Phase 3.
       abort_mismatch     - tag points at a non-HEAD commit, or its version
                            disagrees with the manifest -> STOP, never overwrite.
+
+    Mismatch OUTRANKS publication state (issue #380). An existing Release used
+    to short-circuit to `already_published` before the tag was compared to
+    HEAD, so a resumed publish silently accepted a Release whose tag installs a
+    different snapshot. The tag is what consumers actually fetch; if it does
+    not name this commit, nothing about the Release makes the state safe.
     """
     if not tag_exists:
         return "publish_fresh"
+    if tag_sha != head_sha or tag_version != manifest_version:
+        return "abort_mismatch"
     if release_is_nondraft:
         return "already_published"
-    if tag_sha == head_sha and tag_version == manifest_version:
-        return "resume_publish"
-    return "abort_mismatch"
+    return "resume_publish"
+
+
+def select_release_target(confirm, codex_confirm):
+    """Resolve which single plugin a release dispatch selected. Returns one of:
+
+      ca         - only the `confirm` (ca) version input was supplied.
+      ca-codex   - only the `codex_confirm` input was supplied.
+      none       - neither; there is nothing to publish.
+      multiple   - both; the dispatch is ambiguous and MUST be refused.
+
+    Issue #378: the two publish jobs each tested only their OWN confirmation
+    input, so one dispatch supplying both started two `contents: write`
+    publishers and could create two tags and two public Releases. Selection is
+    one decision, made once, by a job that holds no write token. Blank-ish
+    input (whitespace, non-string) counts as "not selected" so a stray space
+    can never read as a second target."""
+    def _selected(value):
+        return isinstance(value, str) and value.strip() != ""
+
+    ca, codex = _selected(confirm), _selected(codex_confirm)
+    if ca and codex:
+        return "multiple"
+    if ca:
+        return "ca"
+    if codex:
+        return "ca-codex"
+    return "none"
+
+
+def classify_merge_readiness(check_runs, head_sha, check_name=MERGE_READINESS_CHECK):
+    """Classify the merge-readiness evidence for ONE exact commit. `check_runs`
+    is the `check_runs` array from GitHub's
+    `repos/{owner}/{repo}/commits/{sha}/check-runs` response. Returns one of:
+
+      green           - the gate ran for this commit, completed, and succeeded.
+      missing         - no check run by that name is present at all.
+      pending         - present but not `completed` (queued / in_progress / ...).
+      sha_mismatch    - a matching run reports a different `head_sha`.
+      not_successful  - completed with any conclusion other than `success`
+                        (failure, cancelled, skipped, timed_out, neutral, ...).
+
+    Issue #385: the hosted release workflow proved only that it was dispatched
+    from main. Branch protection shows how a commit ENTERED main, not that
+    post-merge evidence exists for the exact commit about to be tagged, and the
+    release skill's hard rules say MUST NOT tag on a red suite.
+
+    Fail-closed throughout: unparseable input is `missing`, and several runs
+    share one name only when a re-run is in flight - we cannot tell which
+    verdict is authoritative, so EVERY matching run must be green."""
+    if not isinstance(check_runs, list):
+        return "missing"
+    matching = [run for run in check_runs
+                if isinstance(run, dict) and run.get("name") == check_name]
+    if not matching:
+        return "missing"
+    if any(run.get("head_sha") != head_sha for run in matching):
+        return "sha_mismatch"
+    if any(run.get("status") != "completed" for run in matching):
+        return "pending"
+    if any(run.get("conclusion") != "success" for run in matching):
+        return "not_successful"
+    return "green"
+
+
+def peel_tag(ls_remote_text, tag):
+    """Resolve the COMMIT a remote tag names, from `git ls-remote --tags`
+    output. Returns "" when the tag is absent.
+
+    An annotated tag's own object id is not the commit it points at; the
+    peeled `refs/tags/<tag>^{}` line is. Issue #380: the workflow treated any
+    remote hit as a resumable publish and skipped tag creation without ever
+    comparing the tag to `GITHUB_SHA`, so a stale tag could be accepted as a
+    successful rerun and a Release published for the wrong commit. Matching is
+    exact on the ref name, so `v2.6.0` is never resolved from `v2.6.0-beta.1`."""
+    if not isinstance(ls_remote_text, str) or not isinstance(tag, str):
+        return ""
+    direct = peeled = ""
+    ref = f"refs/tags/{tag}"
+    for line in ls_remote_text.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        sha, name = parts
+        if name == ref + "^{}":
+            peeled = sha
+        elif name == ref:
+            direct = sha
+    return peeled or direct
 
 
 # --------------------------------------------------------------------------- #
@@ -145,10 +252,20 @@ def main(argv):
       dates-consistent <changelog> <tagmsg>    exit 0 iff the two dates agree
       classify <tag_exists> <tag_sha> <head_sha> <tag_version> <manifest_version> <release_nondraft>
                                                prints the publish-state label (bools: true/false)
+      select-target <confirm> <codex_confirm>  prints ca | ca-codex | none | multiple
+      merge-readiness <head_sha> <checks_json> prints green | missing | pending |
+                                               sha_mismatch | not_successful
+      peel-tag <tag>                           stdin=`git ls-remote --tags` -> commit sha / ""
+
+    The three release.yml subcommands print a LABEL and exit 0; the workflow
+    cases on the label with a fail-closed `*)` arm, so an unrecognised label -
+    or a crash, which yields no label at all - refuses the dispatch either way.
     Returns a process exit code."""
     import sys
     if not argv:
-        sys.stderr.write("usage: _releaselib.py {last-tag|notes-match|dates-consistent|classify} ...\n")
+        sys.stderr.write(
+            "usage: _releaselib.py {last-tag|notes-match|dates-consistent|classify"
+            "|select-target|merge-readiness|peel-tag} ...\n")
         return 2
     cmd, rest = argv[0], argv[1:]
     if cmd == "last-tag":
@@ -163,6 +280,20 @@ def main(argv):
         print(classify_publish_state(
             tag_exists=b(rest[0]), tag_sha=rest[1], head_sha=rest[2],
             tag_version=rest[3], manifest_version=rest[4], release_is_nondraft=b(rest[5])))
+        return 0
+    if cmd == "select-target" and len(rest) == 2:
+        print(select_release_target(rest[0], rest[1]))
+        return 0
+    if cmd == "merge-readiness" and len(rest) == 2:
+        import json
+        try:
+            runs = json.loads(_read(rest[1]))
+        except ValueError:
+            runs = None  # unreadable/unparseable evidence is no evidence
+        print(classify_merge_readiness(runs, rest[0]))
+        return 0
+    if cmd == "peel-tag" and len(rest) == 1:
+        print(peel_tag(sys.stdin.read(), rest[0]))
         return 0
     sys.stderr.write(f"_releaselib.py: bad invocation: {' '.join(argv)}\n")
     return 2

--- a/.github/scripts/test_release_lib.py
+++ b/.github/scripts/test_release_lib.py
@@ -161,6 +161,149 @@ class ClassifyPublishTest(unittest.TestCase):
                 tag_version="2.5.0", manifest_version="2.6.0", release_is_nondraft=False),
             "abort_mismatch")
 
+    def test_nondraft_release_on_a_tag_at_another_commit_is_abort(self):
+        # Issue #380: a published Release used to short-circuit to
+        # `already_published` BEFORE the tag was compared to HEAD, so a
+        # resumed publish accepted a Release sitting on the wrong commit.
+        # Mismatch outranks publication state — the tag identifies what
+        # consumers actually install.
+        self.assertEqual(
+            _releaselib.classify_publish_state(
+                tag_exists=True, tag_sha="xyz", head_sha="abc",
+                tag_version="2.6.0", manifest_version="2.6.0", release_is_nondraft=True),
+            "abort_mismatch")
+
+    def test_nondraft_release_with_a_version_mismatch_is_abort(self):
+        self.assertEqual(
+            _releaselib.classify_publish_state(
+                tag_exists=True, tag_sha="abc", head_sha="abc",
+                tag_version="2.5.0", manifest_version="2.6.0", release_is_nondraft=True),
+            "abort_mismatch")
+
+
+class SelectReleaseTargetTest(unittest.TestCase):
+    """Issue #378: one dispatch selects exactly one plugin, or none at all.
+
+    `confirm` and `codex_confirm` are independent optional strings, so the
+    workflow's two publish jobs used to test only their own input — supplying
+    both started two write-token publishers from one dispatch."""
+
+    def test_ca_only(self):
+        self.assertEqual(_releaselib.select_release_target("2.6.1", ""), "ca")
+
+    def test_codex_only(self):
+        self.assertEqual(_releaselib.select_release_target("", "0.2.4"), "ca-codex")
+
+    def test_neither_is_none(self):
+        self.assertEqual(_releaselib.select_release_target("", ""), "none")
+
+    def test_both_is_multiple(self):
+        self.assertEqual(_releaselib.select_release_target("2.6.1", "0.2.4"), "multiple")
+
+    def test_whitespace_is_not_a_selection(self):
+        # A stray space in a dispatch field must not read as a second target.
+        self.assertEqual(_releaselib.select_release_target("   ", "0.2.4"), "ca-codex")
+        self.assertEqual(_releaselib.select_release_target("  ", "\t"), "none")
+
+    def test_never_raises_on_non_string(self):
+        self.assertEqual(_releaselib.select_release_target(None, None), "none")
+        self.assertEqual(_releaselib.select_release_target(42, "0.2.4"), "ca-codex")
+
+
+class MergeReadinessTest(unittest.TestCase):
+    """Issue #385: the exact commit being tagged must carry green evidence."""
+
+    SHA = "a" * 40
+    OTHER = "b" * 40
+
+    def _run(self, status="completed", conclusion="success", head_sha=None, name=None):
+        return {
+            "name": _releaselib.MERGE_READINESS_CHECK if name is None else name,
+            "status": status,
+            "conclusion": conclusion,
+            "head_sha": self.SHA if head_sha is None else head_sha,
+        }
+
+    def test_completed_success_is_green(self):
+        self.assertEqual(
+            _releaselib.classify_merge_readiness([self._run()], self.SHA), "green")
+
+    def test_unrelated_checks_do_not_stand_in_for_the_gate(self):
+        others = [self._run(name="CA | [Tools] - Vitest"), self._run(name="lint")]
+        self.assertEqual(
+            _releaselib.classify_merge_readiness(others, self.SHA), "missing")
+
+    def test_no_checks_at_all_is_missing(self):
+        self.assertEqual(_releaselib.classify_merge_readiness([], self.SHA), "missing")
+
+    def test_queued_and_in_progress_are_pending(self):
+        for status in ("queued", "in_progress", "waiting", "pending", "requested"):
+            with self.subTest(status=status):
+                run = self._run(status=status, conclusion=None)
+                self.assertEqual(
+                    _releaselib.classify_merge_readiness([run], self.SHA), "pending")
+
+    def test_every_non_success_conclusion_is_rejected(self):
+        for conclusion in ("failure", "cancelled", "skipped", "timed_out",
+                           "action_required", "neutral", "stale", None, ""):
+            with self.subTest(conclusion=conclusion):
+                run = self._run(conclusion=conclusion)
+                self.assertEqual(
+                    _releaselib.classify_merge_readiness([run], self.SHA),
+                    "not_successful")
+
+    def test_success_on_another_commit_is_rejected(self):
+        run = self._run(head_sha=self.OTHER)
+        self.assertEqual(
+            _releaselib.classify_merge_readiness([run], self.SHA), "sha_mismatch")
+
+    def test_a_green_rerun_alongside_a_red_one_is_rejected(self):
+        # Fail closed: with two verdicts on the name we cannot tell which is
+        # authoritative, so we do not get to pick the convenient one.
+        runs = [self._run(), self._run(conclusion="failure")]
+        self.assertEqual(
+            _releaselib.classify_merge_readiness(runs, self.SHA), "not_successful")
+
+    def test_never_raises_on_garbage(self):
+        self.assertEqual(_releaselib.classify_merge_readiness(None, self.SHA), "missing")
+        self.assertEqual(
+            _releaselib.classify_merge_readiness(["nonsense", 7], self.SHA), "missing")
+        self.assertEqual(
+            _releaselib.classify_merge_readiness([self._run()], None), "sha_mismatch")
+
+
+class PeelTagTest(unittest.TestCase):
+    """Issue #380: an annotated tag's object id is not the commit it names."""
+
+    TAG_OBJ = "1" * 40
+    COMMIT = "2" * 40
+
+    def test_annotated_tag_resolves_to_the_peeled_commit(self):
+        text = (f"{self.TAG_OBJ}\trefs/tags/v2.6.0\n"
+                f"{self.COMMIT}\trefs/tags/v2.6.0^{{}}\n")
+        self.assertEqual(_releaselib.peel_tag(text, "v2.6.0"), self.COMMIT)
+
+    def test_lightweight_tag_resolves_to_its_direct_target(self):
+        text = f"{self.COMMIT}\trefs/tags/v2.6.0\n"
+        self.assertEqual(_releaselib.peel_tag(text, "v2.6.0"), self.COMMIT)
+
+    def test_namespaced_tag(self):
+        text = (f"{self.TAG_OBJ}\trefs/tags/ca-codex-v0.2.4\n"
+                f"{self.COMMIT}\trefs/tags/ca-codex-v0.2.4^{{}}\n")
+        self.assertEqual(_releaselib.peel_tag(text, "ca-codex-v0.2.4"), self.COMMIT)
+
+    def test_a_prefix_sharing_tag_is_not_mistaken_for_it(self):
+        # `v2.6.0` must not be resolved from `v2.6.0-beta.1`'s ref line.
+        text = f"{self.COMMIT}\trefs/tags/v2.6.0-beta.1\n"
+        self.assertEqual(_releaselib.peel_tag(text, "v2.6.0"), "")
+
+    def test_absent_tag_is_empty(self):
+        self.assertEqual(_releaselib.peel_tag("", "v2.6.0"), "")
+
+    def test_never_raises_on_non_string(self):
+        self.assertEqual(_releaselib.peel_tag(None, "v2.6.0"), "")
+        self.assertEqual(_releaselib.peel_tag("whatever", None), "")
+
 
 class CLITest(unittest.TestCase):
     """The thin CLI dispatch the release skill shells out to."""
@@ -207,6 +350,51 @@ class CLITest(unittest.TestCase):
     def test_bad_invocation_returns_2(self):
         rc, _ = self._run(["nonsense"])
         self.assertEqual(rc, 2)
+
+    def test_select_target_prints_the_label(self):
+        # The workflow cases on the label, so the label — not the exit code —
+        # is the contract; an unknown label lands on its fail-closed `*` arm.
+        for confirm, codex, expected in (("2.6.1", "", "ca"),
+                                         ("", "0.2.4", "ca-codex"),
+                                         ("", "", "none"),
+                                         ("2.6.1", "0.2.4", "multiple")):
+            with self.subTest(confirm=confirm, codex=codex):
+                rc, out = self._run(["select-target", confirm, codex])
+                self.assertEqual(rc, 0)
+                self.assertEqual(out, expected)
+
+    def test_merge_readiness_reads_check_runs_json(self):
+        import json
+        import tempfile
+        sha = "c" * 40
+        payload = [{"name": _releaselib.MERGE_READINESS_CHECK, "status": "completed",
+                    "conclusion": "success", "head_sha": sha}]
+        with tempfile.NamedTemporaryFile(
+                "w", suffix=".json", delete=False, encoding="utf-8") as f:
+            json.dump(payload, f)
+            path = f.name
+        try:
+            rc_ok, out_ok = self._run(["merge-readiness", sha, path])
+            rc_bad, out_bad = self._run(["merge-readiness", "d" * 40, path])
+        finally:
+            os.unlink(path)
+        self.assertEqual((rc_ok, out_ok), (0, "green"))
+        self.assertEqual((rc_bad, out_bad), (0, "sha_mismatch"))
+
+    def test_merge_readiness_on_unreadable_input_is_missing(self):
+        rc, out = self._run(["merge-readiness", "e" * 40, "no/such/file.json"])
+        self.assertEqual((rc, out), (0, "missing"))
+
+    def test_peel_tag_reads_ls_remote_from_stdin(self):
+        commit = "f" * 40
+        stdin = ("9" * 40 + "\trefs/tags/v2.6.0\n"
+                 + commit + "\trefs/tags/v2.6.0^{}\n")
+        rc, out = self._run(["peel-tag", "v2.6.0"], stdin)
+        self.assertEqual((rc, out), (0, commit))
+
+    def test_peel_tag_prints_nothing_for_an_absent_tag(self):
+        rc, out = self._run(["peel-tag", "v9.9.9"], "")
+        self.assertEqual((rc, out), (0, ""))
 
 
 class SkillProseTest(unittest.TestCase):

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -15,14 +15,26 @@ while every `_releaselib` unit test stays green.
                                    green `[GATE ] | [REPO] | Merge readiness`
   ExistingTagIntegrityTest  #380 — an existing tag is peeled and compared to
                                    GITHUB_SHA through the shared classifier
+  PreflightExecutionTest    #378/#385 — the preflight's own shell, executed
+                                   against fake GitHub responses
+  PublishExecutionTest      #380 — the publisher's own shell, executed against
+                                   fake git/gh responses: fresh, tag-only
+                                   resume, already published, tag at the wrong
+                                   commit, and Release at the wrong commit
   RegistrationTest                 a release.yml-only edit must start the CI
                                    job that runs this file
 
 Stdlib only; the workflow is parsed textually, like every other workflow
-contract in this directory.
+contract in this directory. The two execution classes need a POSIX shell and
+so are skipped on Windows — the structural classes above run everywhere, and
+the hooks job's ubuntu/macos cells run all of it.
 """
+import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -58,6 +70,310 @@ def _job_if(block: str) -> str:
     """The job-level `if:` expression (two-space indent), '' when absent."""
     match = re.search(r"(?m)^    if:[ ]*(.+)$", block)
     return match.group(1).strip() if match else ""
+
+
+def _step_run(job: str, name_fragment: str) -> str:
+    """The dedented body of a named step's `run: |` block, verbatim from the
+    shipped workflow. The execution tests below run exactly this text — no
+    transcription of the logic into the test, which would only assert that a
+    copy behaves, not that the workflow does."""
+    lines = _jobs()[job].splitlines(keepends=True)
+    starts = [i for i, line in enumerate(lines)
+              if line.startswith("      - name:") and name_fragment in line]
+    if len(starts) != 1:
+        raise AssertionError(
+            f"{job}: {len(starts)} steps match {name_fragment!r}, expected exactly 1")
+    index = starts[0] + 1
+    while index < len(lines) and lines[index].strip() != "run: |":
+        if lines[index].startswith("      - "):
+            raise AssertionError(f"{job}/{name_fragment}: step has no `run: |` block")
+        index += 1
+    body = []
+    for line in lines[index + 1:]:
+        if line.strip() and not line.startswith(" " * 10):
+            break
+        body.append(line[10:] if len(line) > 10 else "\n")
+    return "".join(body)
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic execution harness: the real step text, fake `git`/`gh`/`python3`, a
+# temp cwd holding only a copy of _releaselib.py. Nothing touches the network,
+# the repo, or a real tag.
+#
+# The fakes are shell FUNCTIONS rather than scripts on PATH: a function wins
+# over any PATH lookup in every bash, whereas Git Bash re-prepends /usr/bin to
+# an inherited PATH and would silently run the real `git`.
+# --------------------------------------------------------------------------- #
+
+_STUB_PRELUDE = """
+git() {
+  echo "git $*" >> "$STUB_LOG"
+  if [ "$1" = "ls-remote" ]; then cat "$STUB_LS_REMOTE"; fi
+  return 0
+}
+gh() {
+  echo "gh $*" >> "$STUB_LOG"
+  if [ "$1" = "api" ]; then
+    for arg in "$@"; do
+      if [ "$arg" = ".check_runs" ]; then
+        "$STUB_PYTHON" -c 'import json,os;print(json.dumps(json.load(open(os.environ["STUB_CHECKS"]))["check_runs"]))'
+        return 0
+      fi
+    done
+    cat "$STUB_CHECKS"
+    return 0
+  fi
+  if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+    if [ "$STUB_RELEASE" = "none" ]; then return 1; fi
+    if [ "$STUB_RELEASE" = "published" ]; then DRAFT=false; else DRAFT=true; fi
+    for arg in "$@"; do
+      if [ "$arg" = ".isDraft" ]; then echo "$DRAFT"; return 0; fi
+      if [ "$arg" = ".tagName" ]; then echo "$STUB_TAGNAME"; return 0; fi
+    done
+    echo "{\\"isDraft\\": $DRAFT, \\"tagName\\": \\"$STUB_TAGNAME\\"}"
+    return 0
+  fi
+  return 0
+}
+python3() { "$STUB_PYTHON" "$@"; }
+"""
+
+
+def _bash():
+    """A POSIX shell able to run the step bodies. On Windows `bash` on PATH is
+    usually the WSL launcher, whose filesystem view is not the one subprocess
+    hands it, so only Git Bash is accepted there."""
+    if sys.platform != "win32":
+        return shutil.which("bash")
+    for candidate in (r"C:\Program Files\Git\bin\bash.exe",
+                      r"C:\Program Files\Git\usr\bin\bash.exe"):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+BASH = _bash()
+POSIX_ONLY = unittest.skipIf(BASH is None, "no POSIX shell available")
+
+
+class _ShellHarness(unittest.TestCase):
+    """Runs one step body with stubbed `git`/`gh` and reports rc + the call log."""
+
+    HEAD = "1" * 40
+    OTHER = "2" * 40
+
+    def _sandbox(self):
+        root = Path(tempfile.mkdtemp(prefix="ca-release-"))
+        self.addCleanup(shutil.rmtree, root, True)
+        scripts = root / ".github" / "scripts"
+        scripts.mkdir(parents=True)
+        shutil.copy(HERE / "_releaselib.py", scripts / "_releaselib.py")
+        return root
+
+    def _run(self, script, *, env=None, ls_remote="", checks="[]",
+             release="none", tagname="", notes="## [9.9.9] - 2026-07-24\n"):
+        root = self._sandbox()
+        (root / "notes.md").write_text(notes, encoding="utf-8", newline="\n")
+        (root / "ls-remote.txt").write_text(ls_remote, encoding="utf-8", newline="\n")
+        # Deliberately NOT `checks.json`: the step redirects its own `gh api`
+        # output there, and the redirection truncates before the fake reads.
+        (root / "stub-checks.json").write_text(checks, encoding="utf-8", newline="\n")
+        environ = dict(os.environ)
+        environ.update({
+            "STUB_LOG": str(root / "calls.log"),
+            "STUB_LS_REMOTE": str(root / "ls-remote.txt"),
+            "STUB_CHECKS": str(root / "stub-checks.json"),
+            "STUB_RELEASE": release,
+            "STUB_TAGNAME": tagname,
+            "STUB_PYTHON": sys.executable.replace("\\", "/"),
+            "GITHUB_SHA": self.HEAD,
+            "GITHUB_REPOSITORY": "arbiterForge/codeArbiter",
+            "GITHUB_OUTPUT": str(root / "gh-output.txt"),
+            # Nothing authenticating is set here: the fake `gh` never signs in
+            # and never reaches the network.
+        })
+        environ.update(env or {})
+        proc = subprocess.run([BASH, "-c", _STUB_PRELUDE + "\n" + script],
+                              cwd=str(root), env=environ,
+                              capture_output=True, text=True)
+        log_path = root / "calls.log"
+        log = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        output_path = root / "gh-output.txt"
+        step_output = (output_path.read_text(encoding="utf-8")
+                       if output_path.exists() else "")
+        return proc, log, step_output
+
+
+@POSIX_ONLY
+class PreflightExecutionTest(_ShellHarness):
+    """#378 + #385, executed: the preflight's own shell against fake inputs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.branch_step = _step_run("preflight", "Refuse a dispatch off")
+        cls.target_step = _step_run("preflight", "Resolve exactly one release target")
+        cls.readiness_step = _step_run("preflight", "Require green merge readiness")
+
+    def _check_run(self, conclusion="success", status="completed", head=None):
+        head = self.HEAD if head is None else head
+        return ('{"check_runs": [{"name": "[GATE ] | [REPO] | Merge readiness", '
+                f'"status": "{status}", "conclusion": '
+                + ("null" if conclusion is None else f'"{conclusion}"')
+                + f', "head_sha": "{head}"}}]}}')
+
+    # -- #378: the four-cell dispatch truth table ------------------------------
+    def test_ca_only_selects_ca(self):
+        proc, _, out = self._run(self.target_step,
+                                 env={"CONFIRM": "2.6.1", "CODEX_CONFIRM": ""})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("target=ca\n", out)
+
+    def test_codex_only_selects_ca_codex(self):
+        proc, _, out = self._run(self.target_step,
+                                 env={"CONFIRM": "", "CODEX_CONFIRM": "0.2.4"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("target=ca-codex\n", out)
+
+    def test_neither_input_refuses(self):
+        proc, _, out = self._run(self.target_step,
+                                 env={"CONFIRM": "", "CODEX_CONFIRM": ""})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(out, "", "a refused dispatch must publish no target")
+
+    def test_both_inputs_refuse_before_any_publisher_is_eligible(self):
+        proc, _, out = self._run(self.target_step,
+                                 env={"CONFIRM": "2.6.1", "CODEX_CONFIRM": "0.2.4"})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("more than one plugin", proc.stdout + proc.stderr)
+        self.assertEqual(out, "")
+
+    def test_a_dispatch_off_main_is_refused(self):
+        ok, _, _ = self._run(self.branch_step, env={"GITHUB_REF": "refs/heads/main"})
+        self.assertEqual(ok.returncode, 0, ok.stderr)
+        bad, _, _ = self._run(self.branch_step, env={"GITHUB_REF": "refs/heads/feat/x"})
+        self.assertNotEqual(bad.returncode, 0)
+
+    # -- #385: merge-readiness evidence for the exact commit -------------------
+    def test_green_evidence_for_this_commit_proceeds(self):
+        proc, _, _ = self._run(self.readiness_step, checks=self._check_run())
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_missing_pending_and_failed_evidence_all_refuse(self):
+        cases = {
+            "missing": '{"check_runs": []}',
+            "pending": self._check_run(conclusion=None, status="in_progress"),
+            "failure": self._check_run(conclusion="failure"),
+            "cancelled": self._check_run(conclusion="cancelled"),
+            "skipped": self._check_run(conclusion="skipped"),
+        }
+        for label, payload in cases.items():
+            with self.subTest(evidence=label):
+                proc, _, _ = self._run(self.readiness_step, checks=payload)
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("refusing to tag", proc.stdout + proc.stderr)
+
+    def test_green_evidence_for_another_commit_is_refused(self):
+        proc, _, _ = self._run(self.readiness_step,
+                               checks=self._check_run(head=self.OTHER))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("sha_mismatch", proc.stdout + proc.stderr)
+
+
+@POSIX_ONLY
+class PublishExecutionTest(_ShellHarness):
+    """#380, executed: fresh, resume, published, and both wrong-commit states."""
+
+    STEP_NAME = "Create the tag and GitHub Release"
+    VERIFY_NAME = "Verify the published Release"
+
+    def _publish(self, job, tag, version, *, tag_at=None, release="none"):
+        ls_remote = ""
+        if tag_at:
+            ls_remote = (f"9{'0' * 39}\trefs/tags/{tag}\n"
+                         f"{tag_at}\trefs/tags/{tag}^{{}}\n")
+        return self._run(_step_run(job, self.STEP_NAME),
+                         env={"TAG": tag, "VER": version, "SUMMARY": ""},
+                         ls_remote=ls_remote, release=release, tagname=tag)
+
+    def test_fresh_publish_tags_and_releases(self):
+        proc, log, _ = self._publish("release", "v9.9.9", "9.9.9")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("publish state: publish_fresh", proc.stdout)
+        self.assertIn("git tag -a v9.9.9", log)
+        self.assertIn("git push origin refs/tags/v9.9.9", log)
+        self.assertIn("gh release create v9.9.9", log)
+
+    def test_tag_only_resume_creates_the_release_without_retagging(self):
+        proc, log, _ = self._publish("release", "v9.9.9", "9.9.9", tag_at=self.HEAD)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("publish state: resume_publish", proc.stdout)
+        self.assertNotIn("git tag -a", log)
+        self.assertIn("gh release create v9.9.9", log)
+
+    def test_already_published_is_a_no_op(self):
+        proc, log, _ = self._publish("release", "v9.9.9", "9.9.9",
+                                     tag_at=self.HEAD, release="published")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("publish state: already_published", proc.stdout)
+        self.assertNotIn("git tag -a", log)
+        self.assertNotIn("gh release create", log)
+
+    def test_a_tag_at_another_commit_aborts_before_publishing(self):
+        for job, tag, version in (("release", "v9.9.9", "9.9.9"),
+                                  ("release-codex", "ca-codex-v0.9.9", "0.9.9")):
+            with self.subTest(job=job):
+                proc, log, _ = self._publish(job, tag, version, tag_at=self.OTHER)
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("publish state: abort_mismatch", proc.stdout)
+                self.assertNotIn("gh release create", log)
+                self.assertNotIn("git tag -a", log)
+
+    def test_a_published_release_on_a_tag_at_another_commit_aborts(self):
+        # The regression #380 names: a non-draft Release used to short-circuit
+        # the comparison, so a wrong-commit tag reported a clean rerun.
+        for job, tag, version in (("release", "v9.9.9", "9.9.9"),
+                                  ("release-codex", "ca-codex-v0.9.9", "0.9.9")):
+            with self.subTest(job=job):
+                proc, log, _ = self._publish(job, tag, version, tag_at=self.OTHER,
+                                             release="published")
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("abort_mismatch", proc.stdout)
+                self.assertNotIn("gh release create", log)
+
+    def test_the_codex_publisher_never_claims_the_latest_badge(self):
+        proc, log, _ = self._publish("release-codex", "ca-codex-v0.9.9", "0.9.9")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("gh release create ca-codex-v0.9.9", log)
+        self.assertNotIn("--latest", log)
+
+    def test_read_back_rejects_a_tag_that_moved_off_the_dispatched_commit(self):
+        script = _step_run("release", self.VERIFY_NAME)
+        good, _, _ = self._run(script, env={"TAG": "v9.9.9"}, release="published",
+                               tagname="v9.9.9",
+                               ls_remote=f"{self.HEAD}\trefs/tags/v9.9.9\n")
+        self.assertEqual(good.returncode, 0, good.stderr)
+        moved, _, _ = self._run(script, env={"TAG": "v9.9.9"}, release="published",
+                                tagname="v9.9.9",
+                                ls_remote=f"{self.OTHER}\trefs/tags/v9.9.9\n")
+        self.assertNotEqual(moved.returncode, 0)
+        self.assertIn("not the dispatched commit", moved.stdout + moved.stderr)
+
+    def test_read_back_rejects_a_release_naming_another_tag(self):
+        script = _step_run("release", self.VERIFY_NAME)
+        proc, _, _ = self._run(script, env={"TAG": "v9.9.9"}, release="published",
+                               tagname="v9.9.8",
+                               ls_remote=f"{self.HEAD}\trefs/tags/v9.9.9\n")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("names tag", proc.stdout + proc.stderr)
+
+    def test_read_back_rejects_a_draft(self):
+        script = _step_run("release", self.VERIFY_NAME)
+        proc, _, _ = self._run(script, env={"TAG": "v9.9.9"}, release="draft",
+                               tagname="v9.9.9",
+                               ls_remote=f"{self.HEAD}\trefs/tags/v9.9.9\n")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("draft/unpublished", proc.stdout + proc.stderr)
 
 
 class DispatchExclusivityTest(unittest.TestCase):

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""codeArbiter — contract tests for the hosted release workflow.
+
+Run: python .github/scripts/test_release_workflow.py
+
+`.github/workflows/release.yml` holds `contents: write` and publishes tags and
+GitHub Releases — externally visible writes that no later job can roll back.
+`test_release_lib.py` proves the pure helpers; these assertions parse the
+SHIPPED workflow, so removing or weakening a guard turns this suite red even
+while every `_releaselib` unit test stays green.
+
+  DispatchExclusivityTest   #378 — exactly one plugin per dispatch, decided by
+                                   one read-only preflight both publishers need
+  MergeReadinessGateTest    #385 — the exact commit being tagged must carry a
+                                   green `[GATE ] | [REPO] | Merge readiness`
+  ExistingTagIntegrityTest  #380 — an existing tag is peeled and compared to
+                                   GITHUB_SHA through the shared classifier
+  RegistrationTest                 a release.yml-only edit must start the CI
+                                   job that runs this file
+
+Stdlib only; the workflow is parsed textually, like every other workflow
+contract in this directory.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+
+import _releaselib  # noqa: E402 — needs the sys.path mutation above
+from test_ci_impact import paths_filter, push_trigger_paths, workflow_jobs  # noqa: E402
+
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The two write-token publishers, and the read-only job that authorizes them.
+PUBLISH_JOBS = ("release", "release-codex")
+PREFLIGHT_JOB = "preflight"
+
+# A job-level `if:` that uses one of these status functions opts OUT of the
+# implicit "all `needs` succeeded" gate — which would let a publisher run after
+# its own preflight refused the dispatch.
+_STATUS_ESCAPES = ("always()", "!cancelled()", "cancelled()", "failure()")
+
+
+def _release() -> str:
+    return RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+
+def _jobs() -> dict:
+    return workflow_jobs(_release())
+
+
+def _job_if(block: str) -> str:
+    """The job-level `if:` expression (two-space indent), '' when absent."""
+    match = re.search(r"(?m)^    if:[ ]*(.+)$", block)
+    return match.group(1).strip() if match else ""
+
+
+class DispatchExclusivityTest(unittest.TestCase):
+    """#378: one dispatch releases exactly one plugin — enforced, not documented."""
+
+    def test_a_read_only_preflight_job_exists(self):
+        self.assertIn(PREFLIGHT_JOB, _jobs(),
+                      "release.yml has no preflight job to arbitrate the dispatch")
+
+    def test_top_level_permissions_are_read_only(self):
+        # Least privilege: the write token is granted at the publishing jobs,
+        # so the preflight that authorizes them can never hold one.
+        text = _release()
+        header = text.split("jobs:", 1)[0]
+        self.assertRegex(header, r"(?m)^permissions:\n  contents: read$",
+                         "top-level permissions must be `contents: read`")
+
+    def test_only_the_publish_jobs_carry_a_write_token(self):
+        writers = sorted(job for job, block in _jobs().items()
+                         if re.search(r"(?m)^      contents: write$", block))
+        self.assertEqual(writers, sorted(PUBLISH_JOBS),
+                         "exactly the two publishers may declare `contents: write`")
+
+    def test_preflight_holds_no_write_permission(self):
+        block = _jobs()[PREFLIGHT_JOB]
+        self.assertRegex(block, r"(?m)^      contents: read$",
+                         "the preflight job must pin `contents: read`")
+        self.assertNotIn("contents: write", block,
+                         "#385: the preflight job must never receive a write token")
+
+    def test_preflight_resolves_the_target_through_the_shared_helper(self):
+        block = _jobs()[PREFLIGHT_JOB]
+        self.assertIn("_releaselib.py select-target", block,
+                      "#378: the preflight must resolve the target via _releaselib")
+        self.assertIn("target=$TARGET", block,
+                      "the resolved target must be published as a job output")
+
+    def test_every_publish_job_depends_on_the_preflight(self):
+        jobs = _jobs()
+        for job in PUBLISH_JOBS:
+            with self.subTest(job=job):
+                self.assertRegex(
+                    jobs[job], r"(?m)^    needs: preflight$",
+                    f"{job} must not start without the preflight's authorization")
+
+    def test_publish_jobs_gate_on_the_single_resolved_target(self):
+        jobs = _jobs()
+        expected = {"release": "'ca'", "release-codex": "'ca-codex'"}
+        for job, literal in expected.items():
+            with self.subTest(job=job):
+                condition = _job_if(jobs[job])
+                self.assertIn(f"needs.preflight.outputs.target == {literal}", condition,
+                              f"{job} must run only for the resolved target {literal}")
+                # The independent per-input gates are exactly the #378 defect:
+                # each tested only its OWN confirmation, so supplying both
+                # started both write-token publishers.
+                self.assertNotIn("inputs.confirm != ''", condition)
+                self.assertNotIn("inputs.codex_confirm != ''", condition)
+
+    def test_publish_jobs_keep_the_default_branch_guard(self):
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            with self.subTest(job=job):
+                self.assertIn("github.ref == 'refs/heads/main'", _job_if(block))
+
+    def test_no_publish_job_escapes_the_needs_success_gate(self):
+        # A status-check function in a job `if:` overrides the implicit
+        # "all needs succeeded" rule, which would run the publisher anyway.
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            condition = _job_if(block)
+            for escape in _STATUS_ESCAPES:
+                with self.subTest(job=job, escape=escape):
+                    self.assertNotIn(escape, condition)
+
+    def test_the_preflight_refuses_a_dispatch_off_the_default_branch(self):
+        self.assertIn("refs/heads/main", _jobs()[PREFLIGHT_JOB],
+                      "the preflight must refuse a dispatch off the default branch")
+
+
+class MergeReadinessGateTest(unittest.TestCase):
+    """#385: publish only on green merge-readiness evidence for the exact SHA."""
+
+    def test_the_gate_name_matches_the_shipped_ci_aggregate(self):
+        # A rename in ci.yml that this constant does not follow would silently
+        # turn the gate into "no evidence found" — which must stay fail-closed,
+        # but should be caught here rather than at the next release.
+        ci_gate = workflow_jobs(CI_WORKFLOW.read_text(encoding="utf-8"))["ci-passed"]
+        declared = re.search(r'(?m)^    name: "(.+)"$', ci_gate).group(1)
+        self.assertEqual(_releaselib.MERGE_READINESS_CHECK, declared)
+
+    def test_the_preflight_queries_check_runs_for_the_dispatched_sha(self):
+        block = _jobs()[PREFLIGHT_JOB]
+        self.assertIn("commits/${GITHUB_SHA}/check-runs", block,
+                      "#385: merge readiness must be resolved for GITHUB_SHA itself")
+        self.assertIn("_releaselib.py merge-readiness", block,
+                      "the verdict must come from the tested classifier")
+
+    def test_only_a_green_verdict_proceeds(self):
+        block = _jobs()[PREFLIGHT_JOB]
+        # `green` is the one accepting arm; everything else, including an
+        # unrecognised label from a crashed helper, must exit non-zero.
+        self.assertRegex(block, r"(?m)^\s+green\)", "no accepting `green` arm")
+        self.assertRegex(block, r"(?m)^\s+\*\)[\s\S]{0,400}?exit 1",
+                         "the fail-closed default arm must exit 1")
+
+    def test_the_gate_runs_before_any_write_token_job(self):
+        # Structural restatement of the ordering the `needs` edge buys us: no
+        # publisher may resolve merge readiness for itself.
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            with self.subTest(job=job):
+                self.assertNotIn("merge-readiness", block)
+
+
+class ExistingTagIntegrityTest(unittest.TestCase):
+    """#380: never resume onto a tag that names another commit."""
+
+    def test_both_publishers_peel_the_remote_tag(self):
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            with self.subTest(job=job):
+                self.assertIn('"refs/tags/$TAG^{}"', block,
+                              "an annotated tag must be peeled to its commit")
+                self.assertIn("_releaselib.py peel-tag", block,
+                              "peeling must route through the tested helper")
+
+    def test_both_publishers_classify_before_tagging(self):
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            with self.subTest(job=job):
+                self.assertIn("_releaselib.py classify", block,
+                              "#380: the shared publish-state classifier must decide")
+                self.assertIn('"$GITHUB_SHA"', block)
+
+    def test_the_bare_tag_exists_skip_is_gone(self):
+        # The exact defect: any remote hit was treated as resumable and tag
+        # creation was skipped without comparing the tag to GITHUB_SHA.
+        text = _release()
+        self.assertNotIn('if git ls-remote --exit-code --tags origin "$TAG"', text)
+        self.assertNotIn("already on remote — skipping tag creation", text)
+
+    def test_a_mismatch_fails_before_gh_release_create(self):
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            with self.subTest(job=job):
+                case_body = block.split("STATE=", 1)[1]
+                mismatch = case_body.split("*)", 1)[1]
+                self.assertNotIn("gh release create", mismatch.split("esac", 1)[0],
+                                 "the fail-closed arm must not publish")
+                self.assertIn("exit 1", mismatch.split("esac", 1)[0])
+
+    def test_verification_checks_the_tag_and_its_commit_not_only_isdraft(self):
+        for job, block in ((j, _jobs()[j]) for j in PUBLISH_JOBS):
+            with self.subTest(job=job):
+                verify = block.split("Verify the published Release", 1)
+                self.assertEqual(len(verify), 2, f"{job} has no read-back step")
+                body = verify[1]
+                self.assertIn(".tagName", body, "the read-back must compare tagName")
+                self.assertIn("FINAL_SHA", body,
+                              "the read-back must re-peel the tag to its commit")
+                self.assertIn('[ "$FINAL_SHA" = "$GITHUB_SHA" ]', body)
+                self.assertIn(".isDraft", body)
+
+
+class RegistrationTest(unittest.TestCase):
+    """A release.yml-only edit must start the CI job that runs this file."""
+
+    def test_release_workflow_is_in_the_hooks_filter(self):
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(".github/workflows/release.yml", paths_filter(ci, "hooks"),
+                      "the hooks filter must flag a release.yml-only change")
+
+    def test_release_workflow_starts_a_push_run(self):
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(".github/workflows/release.yml", push_trigger_paths(ci),
+                      "a push touching only release.yml must still start CI")
+
+    def test_ci_invokes_this_suite(self):
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("python .github/scripts/test_release_workflow.py", ci,
+                      "this contract suite must run in CI")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ on:
       # a change to either must start a run that can execute it.
       - ".gitleaks.toml"
       - ".github/workflows/docs.yml"
+      # Same defect class again (#378/#380/#385): the hooks job runs
+      # test_release_workflow.py, which is the ONLY guard on the release
+      # workflow's dispatch-exclusivity, merge-readiness, and tag-integrity
+      # gates. A push that weakens only release.yml must still start a run.
+      - ".github/workflows/release.yml"
 
 permissions:
   contents: read
@@ -136,6 +141,9 @@ jobs:
               # this filter - otherwise the fixture skips its own test.
               - 'tools/codex-parity-fixture.py'
               - '.github/workflows/ci.yml'
+              # test_release_workflow.py runs in the hooks job and is the only
+              # guard on the release workflow's publish gates (#378/#380/#385).
+              - '.github/workflows/release.yml'
             impact:
               - '.github/ci-impact-map.json'
               - '.github/scripts/test_ci_impact.py'
@@ -731,6 +739,13 @@ jobs:
         # consistent, classify_publish_state, the CLI dispatch, and the SKILL.md
         # structural wiring (_releaselib).
         run: python .github/scripts/test_release_lib.py
+      - name: Run hosted release-workflow contract tests
+        # #378/#380/#385: release.yml holds `contents: write` and publishes
+        # public, irreversible tags and Releases. This parses the SHIPPED
+        # workflow, so deleting the exactly-one-target preflight, the
+        # merge-readiness gate for GITHUB_SHA, or the peel-and-compare on an
+        # existing tag turns CI red even while _releaselib stays green.
+        run: python .github/scripts/test_release_workflow.py
       - name: Run provenance-store helper unit tests
         # AC-01: write_provenance/read_provenance round-trip, on-disk JSON shape
         # with schema/doc/created/interview_derived/entries[] (_provenancelib).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,11 @@ jobs:
           # Evidence is resolved for GITHUB_SHA itself, and the classifier
           # re-checks each run's head_sha — a green gate on a neighbouring
           # commit is not evidence for this one.
-          gh api --paginate \
+          # One page, deliberately: `--paginate` with `--jq` concatenates one
+          # array per page, which is not valid JSON. A commit here carries a
+          # few dozen check runs, and an over-full first page would land on
+          # `missing` — a refusal, not a silent pass.
+          gh api \
             "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs?per_page=100" \
             --jq '.check_runs' > checks.json
           STATE=$(python3 .github/scripts/_releaselib.py merge-readiness "$GITHUB_SHA" checks.json)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,32 @@ name: release
 # be merged to the default branch (that is the /ca:release skill's Phase 1). The
 # job asserts the requested version equals plugins/ca/.claude-plugin/plugin.json,
 # extracts the matching CHANGELOG section as the notes, and is idempotent — a
-# re-run when the tag/Release already exists is a no-op, not a failure.
+# re-run at the SAME commit is a no-op, not a failure.
 
 # ca-codex (the OpenAI Codex CLI sibling, ADR-0011) versions and releases
 # independently — its own tag namespace (ca-codex-v*), its own manifest
 # (plugins/ca-codex/.codex-plugin/plugin.json), its own CHANGELOG
 # (plugins/ca-codex/CHANGELOG.md). Both plugins share this one dispatched
-# workflow; each job is gated on its own confirm input being non-empty, so a
-# single dispatch releases exactly one plugin (never both, never neither) —
-# an empty `confirm` skips the `release` job entirely, an empty
-# `codex_confirm` skips `release-codex` entirely, and providing neither is an
-# explicit no-op the workflow does not need to special-case.
+# workflow.
+
+# AUTHORIZATION MODEL (issues #378, #385). Everything this workflow publishes is
+# public and irreversible, so the decision to publish is made ONCE, by a job that
+# holds no write token, and both publishers depend on it:
+#
+#   preflight (contents: read, checks: read)
+#     1. refuses a dispatch off the default branch;
+#     2. resolves EXACTLY ONE target from the two confirmation inputs — both
+#        blank, or both filled, is a refusal, not a guess (#378: the two jobs
+#        used to test only their own input, so one dispatch supplying both
+#        started two write-token publishers);
+#     3. requires a green `[GATE ] | [REPO] | Merge readiness` check run for
+#        GITHUB_SHA itself (#385: branch protection proves how a commit ENTERED
+#        main, not that post-merge evidence exists for the exact commit being
+#        tagged; the release skill's hard rules say MUST NOT tag on a red suite).
+#
+# Each publisher then runs only for the one resolved target. Their conditions
+# carry no always()/!cancelled() escape, so a failed preflight skips them.
+# .github/scripts/test_release_workflow.py asserts all of that against this file.
 
 on:
   workflow_dispatch:
@@ -40,16 +55,100 @@ on:
         required: false
         default: ""
 
+# Least privilege by default. Only the two publishing jobs widen this to
+# `contents: write`; the preflight that authorizes them never holds a write
+# token, so the job deciding whether to publish cannot itself publish.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  preflight:
+    name: "[GATE ] | [RELEASE] | Dispatch preflight"
+    # Read-only authorization for the write-token publishers below. Fails
+    # closed on every path: a refusal here skips both of them.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      checks: read
+    outputs:
+      target: ${{ steps.target.outputs.target }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Refuse a dispatch off the default branch
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::release dispatches are only valid on refs/heads/main (got '$GITHUB_REF')"
+            exit 1
+          fi
+
+      - name: Resolve exactly one release target
+        id: target
+        env:
+          CONFIRM: ${{ github.event.inputs.confirm }}
+          CODEX_CONFIRM: ${{ github.event.inputs.codex_confirm }}
+        run: |
+          set -euo pipefail
+          # The helper prints a label and never raises; the '*' arm below is the
+          # fail-closed default, so an unknown label refuses too — and a helper
+          # that crashed prints nothing and trips `set -e` on the assignment.
+          TARGET=$(python3 .github/scripts/_releaselib.py select-target "$CONFIRM" "$CODEX_CONFIRM")
+          case "$TARGET" in
+            ca|ca-codex)
+              echo "resolved release target: $TARGET"
+              ;;
+            multiple)
+              echo "::error::this dispatch selected more than one plugin — supply exactly one of the two version inputs, never both"
+              exit 1
+              ;;
+            none)
+              echo "::error::this dispatch selected no plugin — supply exactly one of the two version inputs"
+              exit 1
+              ;;
+            *)
+              echo "::error::could not resolve a release target (got '$TARGET')"
+              exit 1
+              ;;
+          esac
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Require green merge readiness for this exact commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Evidence is resolved for GITHUB_SHA itself, and the classifier
+          # re-checks each run's head_sha — a green gate on a neighbouring
+          # commit is not evidence for this one.
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs?per_page=100" \
+            --jq '.check_runs' > checks.json
+          STATE=$(python3 .github/scripts/_releaselib.py merge-readiness "$GITHUB_SHA" checks.json)
+          case "$STATE" in
+            green)
+              echo "merge readiness is green for $GITHUB_SHA"
+              ;;
+            *)
+              echo "::error::merge-readiness evidence for $GITHUB_SHA is '$STATE' — refusing to tag (release SKILL.md: MUST NOT tag on a red suite)"
+              exit 1
+              ;;
+          esac
+
   release:
     name: CA | [Release] - Publish
     # Publish only from the default branch, where the merged CHANGELOG section
-    # lives, and only when this dispatch requested a ca release.
-    if: github.ref == 'refs/heads/main' && github.event.inputs.confirm != ''
+    # lives, and only when the read-only preflight resolved `ca` as the single
+    # target of this dispatch. `needs: preflight` IS the authorization: the
+    # condition below carries no status function, so a failed preflight skips
+    # this job rather than letting it run anyway.
+    needs: preflight
+    if: github.ref == 'refs/heads/main' && needs.preflight.outputs.target == 'ca'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -89,7 +188,7 @@ jobs:
           python3 .github/scripts/_releaselib.py notes-match "$TAG" notes.md
           echo "---- notes.md ----"; head -1 notes.md
 
-      - name: Create the tag and GitHub Release (idempotent)
+      - name: Create the tag and GitHub Release (resumable, mismatch-aborting)
         env:
           GH_TOKEN: ${{ github.token }}
           SUMMARY: ${{ github.event.inputs.summary }}
@@ -104,41 +203,93 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
-            echo "tag $TAG already on remote — skipping tag creation"
-          else
-            printf '%s\n\nReleased-at: %s\n' "$(cat notes.md)" "$(date +%F)" > tagmsg.txt
-            git tag -a "$TAG" -F tagmsg.txt "$GITHUB_SHA"
-            git push origin "refs/tags/$TAG"
+          # PEEL the remote tag (#380). An annotated tag's own object id is not
+          # the commit it names, so the `^{}` line is the one that can be
+          # compared against GITHUB_SHA. Empty output = no such tag.
+          TAG_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}" \
+            | python3 .github/scripts/_releaselib.py peel-tag "$TAG")
+          if [ -n "$TAG_SHA" ]; then TAG_EXISTS=true; else TAG_EXISTS=false; fi
+          # The tag name is built from the manifest version, so this is the
+          # version the REMOTE tag claims; the load-bearing comparison here is
+          # TAG_SHA against GITHUB_SHA.
+          TAG_VERSION="${TAG##*v}"
+
+          RELEASE_NONDRAFT=false
+          if gh release view "$TAG" --json isDraft >/dev/null 2>&1; then
+            if [ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "false" ]; then
+              RELEASE_NONDRAFT=true
+            fi
           fi
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release $TAG already exists — nothing to publish"
-          else
-            # This dispatched release is the newest by publish time; mark it latest.
-            gh release create "$TAG" \
-              --title "$TITLE" \
-              --notes-file notes.md \
-              --target "$GITHUB_SHA" \
-              --latest --verify-tag
-          fi
+          # One classifier shared with the /ca:release skill: the hosted and the
+          # local publish path must not disagree about what an existing tag means.
+          STATE=$(python3 .github/scripts/_releaselib.py classify \
+            "$TAG_EXISTS" "$TAG_SHA" "$GITHUB_SHA" "$TAG_VERSION" "$VER" "$RELEASE_NONDRAFT")
+          echo "publish state: $STATE (tag=$TAG tag_sha='$TAG_SHA' head='$GITHUB_SHA')"
 
-          # Verify publication rather than assume it (a create can partially succeed).
+          case "$STATE" in
+            publish_fresh)
+              printf '%s\n\nReleased-at: %s\n' "$(cat notes.md)" "$(date +%F)" > tagmsg.txt
+              git tag -a "$TAG" -F tagmsg.txt "$GITHUB_SHA"
+              git push origin "refs/tags/$TAG"
+              # This dispatched release is the newest by publish time; mark it latest.
+              gh release create "$TAG" \
+                --title "$TITLE" \
+                --notes-file notes.md \
+                --target "$GITHUB_SHA" \
+                --latest --verify-tag
+              ;;
+            resume_publish)
+              echo "tag $TAG is already at $GITHUB_SHA with no published Release — creating the Release only"
+              gh release create "$TAG" \
+                --title "$TITLE" \
+                --notes-file notes.md \
+                --target "$GITHUB_SHA" \
+                --latest --verify-tag
+              ;;
+            already_published)
+              echo "release $TAG is already published at $GITHUB_SHA — nothing to publish"
+              ;;
+            *)
+              echo "::error::refusing to publish $TAG: state '$STATE' — the existing tag resolves to '$TAG_SHA', this dispatch targets '$GITHUB_SHA'"
+              exit 1
+              ;;
+          esac
+
+      - name: Verify the published Release names this tag at this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Verify publication rather than assume it (a create can partially succeed),
+          # and verify WHAT was published: non-draft alone says nothing about which
+          # commit the tag installs (#380).
           gh release view "$TAG" --json url,isDraft,tagName
           DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)
           [ "$DRAFT" = "false" ] || { echo "::error::release $TAG is draft/unpublished"; exit 1; }
+          NAMED=$(gh release view "$TAG" --json tagName --jq .tagName)
+          [ "$NAMED" = "$TAG" ] || { echo "::error::release read back names tag '$NAMED', expected '$TAG'"; exit 1; }
+          FINAL_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}" \
+            | python3 .github/scripts/_releaselib.py peel-tag "$TAG")
+          [ "$FINAL_SHA" = "$GITHUB_SHA" ] || { echo "::error::tag $TAG resolves to '$FINAL_SHA', not the dispatched commit '$GITHUB_SHA'"; exit 1; }
 
   release-codex:
     name: CA-Codex | [Release] - Publish
     # Sibling twin of the `release` job (ADR-0007-style per-plugin
     # independence, ADR-0011 for the Codex host). Publish only from the
-    # default branch, and only when this dispatch requested a ca-codex
-    # release. The tag is namespaced (ca-codex-v*) so it never collides with
-    # ca's bare v* series, and this job never passes --latest to
-    # `gh release create` — ca-codex is an independently versioned sibling, not the
-    # repo's primary release, and must not steal the "Latest" badge from ca.
-    if: github.ref == 'refs/heads/main' && github.event.inputs.codex_confirm != ''
+    # default branch, and only when the read-only preflight resolved
+    # `ca-codex` as the single target of this dispatch. The tag is namespaced
+    # (ca-codex-v*) so it never collides with ca's bare v* series, and this job
+    # never passes --latest to `gh release create` — ca-codex is an
+    # independently versioned sibling, not the repo's primary release, and must
+    # not steal the "Latest" badge from ca.
+    needs: preflight
+    if: github.ref == 'refs/heads/main' && needs.preflight.outputs.target == 'ca-codex'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -178,7 +329,7 @@ jobs:
           python3 .github/scripts/_releaselib.py notes-match "$TAG" notes.md
           echo "---- notes.md ----"; head -1 notes.md
 
-      - name: Create the tag and GitHub Release (idempotent)
+      - name: Create the tag and GitHub Release (resumable, mismatch-aborting)
         env:
           GH_TOKEN: ${{ github.token }}
           SUMMARY: ${{ github.event.inputs.codex_summary }}
@@ -193,27 +344,74 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
-            echo "tag $TAG already on remote — skipping tag creation"
-          else
-            printf '%s\n\nReleased-at: %s\n' "$(cat notes.md)" "$(date +%F)" > tagmsg.txt
-            git tag -a "$TAG" -F tagmsg.txt "$GITHUB_SHA"
-            git push origin "refs/tags/$TAG"
+          # PEEL the remote tag (#380). An annotated tag's own object id is not
+          # the commit it names, so the `^{}` line is the one that can be
+          # compared against GITHUB_SHA. Empty output = no such tag.
+          TAG_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}" \
+            | python3 .github/scripts/_releaselib.py peel-tag "$TAG")
+          if [ -n "$TAG_SHA" ]; then TAG_EXISTS=true; else TAG_EXISTS=false; fi
+          # The tag name is built from the manifest version, so this is the
+          # version the REMOTE tag claims; the load-bearing comparison here is
+          # TAG_SHA against GITHUB_SHA.
+          TAG_VERSION="${TAG##*v}"
+
+          RELEASE_NONDRAFT=false
+          if gh release view "$TAG" --json isDraft >/dev/null 2>&1; then
+            if [ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "false" ]; then
+              RELEASE_NONDRAFT=true
+            fi
           fi
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release $TAG already exists — nothing to publish"
-          else
-            # Not --latest: ca-codex is an independently versioned sibling, not the repo's
-            # primary release; it must never displace ca's "Latest" badge.
-            gh release create "$TAG" \
-              --title "$TITLE" \
-              --notes-file notes.md \
-              --target "$GITHUB_SHA" \
-              --verify-tag
-          fi
+          # One classifier shared with the /ca:release skill: the hosted and the
+          # local publish path must not disagree about what an existing tag means.
+          STATE=$(python3 .github/scripts/_releaselib.py classify \
+            "$TAG_EXISTS" "$TAG_SHA" "$GITHUB_SHA" "$TAG_VERSION" "$VER" "$RELEASE_NONDRAFT")
+          echo "publish state: $STATE (tag=$TAG tag_sha='$TAG_SHA' head='$GITHUB_SHA')"
 
-          # Verify publication rather than assume it (a create can partially succeed).
+          case "$STATE" in
+            publish_fresh)
+              printf '%s\n\nReleased-at: %s\n' "$(cat notes.md)" "$(date +%F)" > tagmsg.txt
+              git tag -a "$TAG" -F tagmsg.txt "$GITHUB_SHA"
+              git push origin "refs/tags/$TAG"
+              # Not --latest: ca-codex is an independently versioned sibling, not the
+              # repo's primary release; it must never displace ca's "Latest" badge.
+              gh release create "$TAG" \
+                --title "$TITLE" \
+                --notes-file notes.md \
+                --target "$GITHUB_SHA" \
+                --verify-tag
+              ;;
+            resume_publish)
+              echo "tag $TAG is already at $GITHUB_SHA with no published Release — creating the Release only"
+              gh release create "$TAG" \
+                --title "$TITLE" \
+                --notes-file notes.md \
+                --target "$GITHUB_SHA" \
+                --verify-tag
+              ;;
+            already_published)
+              echo "release $TAG is already published at $GITHUB_SHA — nothing to publish"
+              ;;
+            *)
+              echo "::error::refusing to publish $TAG: state '$STATE' — the existing tag resolves to '$TAG_SHA', this dispatch targets '$GITHUB_SHA'"
+              exit 1
+              ;;
+          esac
+
+      - name: Verify the published Release names this tag at this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Verify publication rather than assume it (a create can partially succeed),
+          # and verify WHAT was published: non-draft alone says nothing about which
+          # commit the tag installs (#380).
           gh release view "$TAG" --json url,isDraft,tagName
           DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)
           [ "$DRAFT" = "false" ] || { echo "::error::release $TAG is draft/unpublished"; exit 1; }
+          NAMED=$(gh release view "$TAG" --json tagName --jq .tagName)
+          [ "$NAMED" = "$TAG" ] || { echo "::error::release read back names tag '$NAMED', expected '$TAG'"; exit 1; }
+          FINAL_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}" \
+            | python3 .github/scripts/_releaselib.py peel-tag "$TAG")
+          [ "$FINAL_SHA" = "$GITHUB_SHA" ] || { echo "::error::tag $TAG resolves to '$FINAL_SHA', not the dispatched commit '$GITHUB_SHA'"; exit 1; }


### PR DESCRIPTION
Closes #378
Closes #385
Closes #380

`.github/workflows/release.yml` is the only path that creates public tags and
GitHub Releases. Its two jobs hold `contents: write`, and nothing they publish
is reversible. Three defects let a single dispatch publish something it should
not have. All three are now decided **before any write token exists**, by one
read-only `preflight` job both publishers depend on.

## Issue verification

All three issues verified against current `origin/main` (3eb23e0). Line numbers
had drifted only trivially; every claim held.

| Issue | Claim | Verdict |
| --- | --- | --- |
| #378 | `release.yml:51` and `:140` gate independently on their own confirm input; both `required: false`/`default: ""`; top-level `permissions: contents: write` covers both | **Confirmed verbatim**, all four line refs exact |
| #385 | both publish jobs guarded only by `github.ref` + confirm + a manifest-equality step; nothing queries the merge-readiness check for `GITHUB_SHA`; `core/surface/skills/release/SKILL.md` hard rules say MUST NOT tag on a red suite | **Confirmed**; the SKILL.md rule is in the Hard rules block, not lines 62-73 as cited — the only drift found |
| #380 | lines 107-113 / 196-202 skip tag creation on any `git ls-remote` hit without peeling; verification at 127-129 / 217-219 checks only `isDraft`; `_releaselib.classify_publish_state` already returns `abort_mismatch` | **Confirmed verbatim**. One thing the issue did *not* catch: the existing classifier could not have protected this path even if wired in — `release_is_nondraft` was tested *before* the SHA comparison, so a published Release on a wrong-commit tag returned `already_published`. Fixed here. |

## What changed

**#378 — exactly one target per dispatch.** `_releaselib.select_release_target`
resolves `ca` / `ca-codex` / `none` / `multiple` from the two inputs. The
preflight refuses `none` and `multiple` and publishes the single resolved
target as a job output; each publisher's `if:` now reads
`needs.preflight.outputs.target == '<its own>'` instead of testing only its own
confirm input. Whitespace-only input is not a selection, so a stray space can
never read as a second target.

**#385 — green merge readiness for the exact commit.** The preflight resolves
`repos/{owner}/{repo}/commits/${GITHUB_SHA}/check-runs` and classifies it with
`_releaselib.classify_merge_readiness`, which requires every run named
`[GATE ] | [REPO] | Merge readiness` to report `head_sha == GITHUB_SHA`, be
`completed`, and conclude `success`. Missing, pending, cancelled, skipped,
failed, unparseable, or a green run on another commit all refuse. The preflight
holds `contents: read` + `checks: read` only; top-level permissions drop to
`contents: read` and the two publishers declare their own `contents: write`.
`MERGE_READINESS_CHECK` is asserted equal to `ci.yml`'s `ci-passed` job name, so
a rename there cannot silently degrade the gate to "no evidence".

**#380 — abort on a tag at another commit.** Both publishers peel the remote tag
(`git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}"` →
`_releaselib.peel_tag`; an annotated tag's object id is not the commit it names)
and route the decision through the existing shared `classify_publish_state`
rather than a second implementation. That classifier's ordering is corrected:
a mismatched tag now outranks `already_published`. Read-back additionally
asserts `tagName` and re-peels the tag to `GITHUB_SHA` instead of checking only
`isDraft`.

**Registration.** `release.yml` was in no CI paths filter, so a PR weakening it
alone ran nothing. It is now listed in the push trigger and the `hooks` filter,
and the `hooks` job runs the new contract suite — the same defect class as #384.

## Red first

`.github/scripts/test_release_workflow.py` (new) and the new classes in
`test_release_lib.py` were written and run before any implementation.

`python .github/scripts/test_release_lib.py` — the classifier ordering defect,
verbatim:

```
======================================================================
FAIL: test_nondraft_release_on_a_tag_at_another_commit_is_abort (__main__.ClassifyPublishTest.test_nondraft_release_on_a_tag_at_another_commit_is_abort)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\brenn\projects\codeArbiter\.claude\worktrees\wf_7aab526c-bd7-3\.github\scripts\test_release_lib.py", line 170, in test_nondraft_release_on_a_tag_at_another_commit_is_abort
    self.assertEqual(
    ~~~~~~~~~~~~~~~~^
        _releaselib.classify_publish_state(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            tag_exists=True, tag_sha="xyz", head_sha="abc",
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            tag_version="2.6.0", manifest_version="2.6.0", release_is_nondraft=True),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        "abort_mismatch")
        ^^^^^^^^^^^^^^^^^
AssertionError: 'already_published' != 'abort_mismatch'
- already_published
+ abort_mismatch

======================================================================
FAIL: test_select_target_prints_the_label (__main__.CLITest.test_select_target_prints_the_label) (confirm='2.6.1', codex='0.2.4')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\brenn\projects\codeArbiter\.claude\worktrees\wf_7aab526c-bd7-3\.github\scripts\test_release_lib.py", line 363, in test_select_target_prints_the_label
    self.assertEqual(rc, 0)
    ~~~~~~~~~~~~~~~~^^^^^^^
AssertionError: 2 != 0

----------------------------------------------------------------------
Ran 60 tests in 0.012s

FAILED (failures=9, errors=33)
```

`python .github/scripts/test_release_workflow.py` — every gate absent from the
shipped workflow, verbatim:

```
ERROR: test_preflight_holds_no_write_permission (__main__.DispatchExclusivityTest.test_preflight_holds_no_write_permission)
ERROR: test_preflight_resolves_the_target_through_the_shared_helper (__main__.DispatchExclusivityTest.test_preflight_resolves_the_target_through_the_shared_helper)
ERROR: test_the_preflight_refuses_a_dispatch_off_the_default_branch (__main__.DispatchExclusivityTest.test_the_preflight_refuses_a_dispatch_off_the_default_branch)
ERROR: test_a_mismatch_fails_before_gh_release_create (__main__.ExistingTagIntegrityTest.test_a_mismatch_fails_before_gh_release_create) (job='release')
ERROR: test_a_mismatch_fails_before_gh_release_create (__main__.ExistingTagIntegrityTest.test_a_mismatch_fails_before_gh_release_create) (job='release-codex')
ERROR: test_only_a_green_verdict_proceeds (__main__.MergeReadinessGateTest.test_only_a_green_verdict_proceeds)
ERROR: test_the_gate_name_matches_the_shipped_ci_aggregate (__main__.MergeReadinessGateTest.test_the_gate_name_matches_the_shipped_ci_aggregate)
ERROR: test_the_preflight_queries_check_runs_for_the_dispatched_sha (__main__.MergeReadinessGateTest.test_the_preflight_queries_check_runs_for_the_dispatched_sha)
FAIL: test_a_read_only_preflight_job_exists (__main__.DispatchExclusivityTest.test_a_read_only_preflight_job_exists)
FAIL: test_every_publish_job_depends_on_the_preflight (__main__.DispatchExclusivityTest.test_every_publish_job_depends_on_the_preflight) (job='release')
FAIL: test_every_publish_job_depends_on_the_preflight (__main__.DispatchExclusivityTest.test_every_publish_job_depends_on_the_preflight) (job='release-codex')
FAIL: test_only_the_publish_jobs_carry_a_write_token (__main__.DispatchExclusivityTest.test_only_the_publish_jobs_carry_a_write_token)
FAIL: test_publish_jobs_gate_on_the_single_resolved_target (__main__.DispatchExclusivityTest.test_publish_jobs_gate_on_the_single_resolved_target) (job='release')
FAIL: test_publish_jobs_gate_on_the_single_resolved_target (__main__.DispatchExclusivityTest.test_publish_jobs_gate_on_the_single_resolved_target) (job='release-codex')
FAIL: test_top_level_permissions_are_read_only (__main__.DispatchExclusivityTest.test_top_level_permissions_are_read_only)
FAIL: test_both_publishers_classify_before_tagging (__main__.ExistingTagIntegrityTest.test_both_publishers_classify_before_tagging) (job='release')
FAIL: test_both_publishers_classify_before_tagging (__main__.ExistingTagIntegrityTest.test_both_publishers_classify_before_tagging) (job='release-codex')
FAIL: test_both_publishers_peel_the_remote_tag (__main__.ExistingTagIntegrityTest.test_both_publishers_peel_the_remote_tag) (job='release')
FAIL: test_both_publishers_peel_the_remote_tag (__main__.ExistingTagIntegrityTest.test_both_publishers_peel_the_remote_tag) (job='release-codex')
FAIL: test_the_bare_tag_exists_skip_is_gone (__main__.ExistingTagIntegrityTest.test_the_bare_tag_exists_skip_is_gone)
FAIL: test_verification_checks_the_tag_and_its_commit_not_only_isdraft (__main__.ExistingTagIntegrityTest.test_verification_checks_the_tag_and_its_commit_not_only_isdraft) (job='release')
FAIL: test_verification_checks_the_tag_and_its_commit_not_only_isdraft (__main__.ExistingTagIntegrityTest.test_verification_checks_the_tag_and_its_commit_not_only_isdraft) (job='release-codex')
FAIL: test_ci_invokes_this_suite (__main__.RegistrationTest.test_ci_invokes_this_suite)
FAIL: test_release_workflow_is_in_the_hooks_filter (__main__.RegistrationTest.test_release_workflow_is_in_the_hooks_filter)
FAIL: test_release_workflow_starts_a_push_run (__main__.RegistrationTest.test_release_workflow_starts_a_push_run)
Ran 22 tests in 0.009s
FAILED (failures=17, errors=8)
```

### Mutation check

#380's acceptance criterion asks that skipping the commit comparison fail the
release test while `_releaselib`'s unit tests stay green. Reverting only
`classify_publish_state`'s mismatch-first ordering, with everything else intact:

```
FAIL: test_a_published_release_on_a_tag_at_another_commit_aborts (__main__.PublishExecutionTest.test_a_published_release_on_a_tag_at_another_commit_aborts) (job='release')
FAIL: test_a_published_release_on_a_tag_at_another_commit_aborts (__main__.PublishExecutionTest.test_a_published_release_on_a_tag_at_another_commit_aborts) (job='release-codex')
Ran 39 tests in 3.889s
FAILED (failures=2)
```

## Test design

`test_release_workflow.py` has two halves.

*Structural* — parses the shipped `release.yml` and asserts each guard is
present, that only the two publishers carry `contents: write`, and that neither
publisher's `if:` contains a status function (`always()`, `!cancelled()`, …)
that would opt out of the implicit "all `needs` succeeded" rule and let it run
after its own preflight refused.

*Executed* — extracts a named step's `run:` body **verbatim** from the workflow
and runs it in a temp cwd with `git`, `gh` and `python3` replaced by shell
functions. No network, no real tag, no repo mutation. This covers the #378
four-cell truth table, the off-main refusal, every #385 verdict, and the five
#380 states (fresh, tag-only resume, already published, tag at the wrong commit,
published Release at the wrong commit) for both tag namespaces.

Two implementation details, both found by running the real text:

- the fakes are shell **functions**, not scripts on `PATH` — Git Bash
  re-prepends `/usr/bin` to an inherited `PATH` and silently ran the real `git`;
- the `gh api` call drops `--paginate`, which combined with `--jq` emits one
  array per page and is not valid JSON. A commit here carries a few dozen check
  runs, and an over-full single page lands on `missing`, which refuses.

## Suites

| Suite | Before (origin/main 3eb23e0) | After |
| --- | --- | --- |
| `.github/scripts` (primary) | Ran 1110 — 2 failures, 2 errors, 5 skipped | Ran 1176 — same 2 failures, 2 errors, 5 skipped |
| `plugins/ca/hooks/tests` | Ran 1112 — OK | Ran 1112 — OK |
| `git diff --check origin/main HEAD` | — | exit 0 |
| `bash -n` on all 11 `run:` blocks | — | rc 0 each |

`ca-farm` / `ca-pi` not run: no file under `plugins/ca/tools/` or
`plugins/ca-pi/` is touched. No `core/pysrc`, `core/surface`, or bundled
artifact changed, so no `sync-core` / `build-surface` / esbuild rebuild applies.

## NEEDS-TRIAGE

1. **Pre-existing red in the primary suite, unrelated to this lane.**
   `test_pi_benchmark.PiBenchmarkTests` fails 2 / errors 2 on `origin/main`
   before any change here, and identically after. Not touched, not diagnosed:
   `test_measurements_use_exact_public_shape_and_100_warm_events`,
   `test_pi_record_does_not_load_the_generated_python_host_adapter`,
   `test_cli_emits_only_three_bounded_json_records`,
   `test_cli_real_spawn_flag_adds_a_fourth_labeled_record`.

2. **`classify_publish_state` semantics changed for one input.** A non-draft
   Release on a tag pointing at a non-HEAD commit now returns `abort_mismatch`
   instead of `already_published`. `/ca:release`'s local Phase 2 shells out to
   the same classifier, so the local path gets the same tightening. That is the
   intended direction (the prose already lists `abort_mismatch` first and calls
   it STOP), but it is a behavior change to a shared helper, not only to the
   workflow. `plugins/ca/skills/release/SKILL.md` was left unedited — its
   description stays accurate — so no `build-surface` run was needed.

3. **A draft Release now fails loudly instead of being skipped.** With a tag at
   HEAD and a *draft* Release present, the state is `resume_publish` and
   `gh release create` will fail because a release already exists. Previously
   the job skipped creation and then failed the `isDraft` check anyway, so the
   dispatch failed either way — but the error is now a `gh` error rather than
   the workflow's own message. Fail-loud, and not silently accepted.

4. **The installed hook payload cannot see linked worktrees.** Every `git
   commit` from this worktree was blocked `H-01: Direct commit to main` because
   the installed `ca` build is 2.8.11, which predates the `_effective_exec_root`
   fix (#223, merged in b11f337) and has no `_bashguardlib.py` at all — it
   judged the *main* checkout's branch. Worked around with `git -C <worktree>`,
   the hook's own sanctioned `-C` resolution (reliability-004, #190), which
   makes it evaluate the correct repository. No gate was skipped. Every parallel
   worktree lane will hit this until the installed plugin is refreshed.

5. **The `H-10b` block on this branch was a false positive, and was removed
   rather than waived.** The test harness set `"GH_TOKEN": "stub"` for a fake
   `gh` that never authenticates. Rather than record a security-gate pass for a
   line that had no reason to exist, the entry was deleted. No `/override` and
   no marker were used.

6. **Not covered: preflight-to-publisher ordering at the GitHub level.** That
   a failed `preflight` actually skips a `needs`-dependent job is GitHub's
   documented behavior, asserted here structurally (the `needs` edge exists and
   no `if:` escapes it) but not executed. It cannot be without dispatching a
   real release.

Claude-Session: https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
