### PR TITLE
fix(farm): own the child process tree and prove worktree teardown

### DIFF
--- a/plugins/ca/tools/exec.ts
+++ b/plugins/ca/tools/exec.ts
@@ -10,7 +10,7 @@
  * mutation.ts -> exec.ts, never back). This is a move, not a rewrite: behaviour
  * is identical to the prior in-farm.ts definitions.
  */
-import { spawn, type SpawnOptionsWithoutStdio } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptionsWithoutStdio } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -22,7 +22,26 @@ import path from "node:path";
 // a false `drift:` escalation. `timedOut` is set when a per-command wall-clock
 // timeout fired and the child was killed (T-06 / reliability-001) — consumers
 // surface it as a gate/setup/mutation failure rather than a clean exit.
-export type RunResult = { code: number; out: string; stdout: string; stderr: string; timedOut?: true };
+// `cleanupFailed` (#395) is set when the timeout kill fired but the child
+// process TREE could not be confirmed gone. It is a containment failure, not an
+// ordinary timeout: descendants may still be executing model-authored commands
+// against the worktree, so it carries its own exit code (see EXIT_* below) and
+// its own loud note rather than hiding inside a clean-looking 124.
+export type RunResult = {
+  code: number;
+  out: string;
+  stdout: string;
+  stderr: string;
+  timedOut?: true;
+  cleanupFailed?: true;
+};
+
+// #395: two distinguishable timeout outcomes. Both are non-zero, so every
+// existing `code !== 0` consumer branch is unchanged; the split exists so a
+// caller (and an operator reading a report) can tell "we killed it" from "we
+// could not prove we killed it".
+export const EXIT_TIMEOUT = 124; // killed, tree verified gone
+export const EXIT_TIMEOUT_UNCLEAN = 125; // killed, tree NOT verified gone
 
 // gate shell — pure determinism, no model. Use a non-login shell (`-c`, not
 // `-lc`) so user dotfiles don't bleed in. On Windows, fall back to cmd.exe /c.
@@ -72,20 +91,157 @@ export function numEnv(name: string, def: number, opts: { min?: number } = {}): 
 // few minutes; configurable, independent of FARM_REQUEST_TIMEOUT_MS.
 export const GATE_TIMEOUT_MS = numEnv("FARM_GATE_TIMEOUT_MS", 300_000, { min: 1000 });
 
-// Kill a spawned child and its descendants. On Windows a plain child.kill() does
-// not reap the process tree (cmd.exe /c spawns the real command as a grandchild),
-// so use `taskkill /T /F` by PID; elsewhere SIGKILL the child. Best-effort —
-// errors are swallowed (the child may already be gone).
-export function treeKill(child: ReturnType<typeof spawn>): void {
+// #395 — how long treeKill will wait for the tree to be OBSERVABLY gone before
+// it reports the cleanup as unverified. This is a verification budget, not a
+// grace period: the kill is already SIGKILL/`/F`, so the only thing being waited
+// on is the kernel finishing the teardown (and, on Windows, taskkill walking the
+// tree). Generous by default; a run never spends it unless something is wedged.
+const KILL_VERIFY_DEFAULT_MS = 10_000;
+
+// #395: the outcome of a tree kill. `ok` means the process tree was verified
+// ABSENT, not merely that a kill signal was sent. `detail` explains an `ok:false`
+// well enough to act on.
+export type TreeKillResult = { ok: boolean; detail?: string };
+
+// The kill seam run() uses. Defaulted to the real treeKill; injectable so the
+// "cleanup could not be verified" branch is testable without arranging a
+// genuinely unkillable process (which is not portable).
+export type TreeKiller = (child: ChildProcess) => Promise<TreeKillResult>;
+
+// #395: resolve taskkill ABSOLUTELY. An unqualified `spawn("taskkill", ...)` is
+// resolved through %PATH%, so any earlier PATH entry containing a taskkill.exe
+// (or, on some configurations, the current directory) decides what runs during
+// our containment step — a privilege-relevant resolution hazard in exactly the
+// code path whose job is to contain untrusted commands. %SystemRoot% is the
+// canonical, non-user-writable boundary.
+export function taskkillPath(): string {
+  const root = process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows";
+  return path.join(root, "System32", "taskkill.exe");
+}
+
+// A liveness probe. libuv maps signal 0 to "does this exist?" on every platform
+// (on Windows it reports ESRCH for a terminated-but-not-yet-freed process, so a
+// dead pid reads dead). EPERM means the target exists but is not ours to signal
+// — still PRESENT, so it must not read as gone.
+function pidPresent(target: number): boolean {
   try {
-    if (process.platform === "win32" && child.pid !== undefined) {
-      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
-    } else {
-      child.kill("SIGKILL");
-    }
-  } catch {
-    /* already exited / unkillable — best effort */
+    process.kill(target, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
   }
+}
+
+async function waitUntilGone(probe: () => boolean, deadline: number): Promise<boolean> {
+  for (;;) {
+    if (!probe()) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+// Await `taskkill /T /F` to COMPLETION. The prior code spawned it and returned
+// immediately, so run() resolved a "clean timeout" while the tree teardown had
+// not even started. Exit 0 = terminated; exit 128 = "process not found", i.e.
+// already gone, which is success for our purposes.
+function awaitTaskkill(pid: number, budgetMs: number): Promise<TreeKillResult> {
+  return new Promise<TreeKillResult>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const done = (r: TreeKillResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(r);
+    };
+    let tk: ChildProcess;
+    try {
+      tk = spawn(taskkillPath(), ["/pid", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+    } catch (e) {
+      done({ ok: false, detail: `taskkill could not be spawned: ${String(e)}` });
+      return;
+    }
+    timer = setTimeout(() => {
+      try {
+        tk.kill();
+      } catch {
+        /* best effort */
+      }
+      done({ ok: false, detail: `taskkill did not exit within ${budgetMs}ms` });
+    }, Math.max(1000, budgetMs));
+    tk.on("error", (e) => done({ ok: false, detail: `taskkill failed to start: ${e.message}` }));
+    tk.on("close", (code) =>
+      done(code === 0 || code === 128 ? { ok: true } : { ok: false, detail: `taskkill exited ${code}` }),
+    );
+  });
+}
+
+// Kill a spawned child AND ITS DESCENDANTS, then VERIFY the tree is gone (#395).
+//
+// The thing being contained is a grandchild: every gate/setup/mutation command
+// runs as `bash -c <cmd>` / `cmd.exe /c <cmd>`, so the operator-authored (and
+// therefore model-influenced) command is one level below the child we hold. The
+// previous implementation SIGKILLed only that direct child off-Windows — the
+// real command survived, reparented to init, still holding ports, still writing
+// into the worktree the farm had already moved on from.
+//
+//   POSIX  — run() spawns `detached`, so the child LEADS its own process group
+//            and `kill(-pid)` addresses the whole tree at once. The direct
+//            child is also signalled explicitly so a caller that spawned
+//            non-detached (mutation.ts's own spawn predates this) is still
+//            covered. Verification polls both the pid and the group: a group
+//            with any surviving member still answers signal 0.
+//   Windows — `taskkill /T /F` against an ABSOLUTE taskkill.exe, awaited to
+//            completion, then the pid is probed.
+//
+// Resolves ok:false (never throws, never hangs) when the tree cannot be
+// confirmed absent within the verification budget.
+export async function treeKill(child: ChildProcess, opts: { budgetMs?: number } = {}): Promise<TreeKillResult> {
+  const pid = child.pid;
+  // No pid means the spawn itself failed — there is no tree to contain.
+  if (pid === undefined) return { ok: true, detail: "child never started" };
+  const budget = opts.budgetMs ?? numEnv("FARM_KILL_VERIFY_MS", KILL_VERIFY_DEFAULT_MS, { min: 0 });
+  const deadline = Date.now() + budget;
+
+  if (process.platform === "win32") {
+    const tk = await awaitTaskkill(pid, budget);
+    if (!tk.ok) {
+      // taskkill failed outright — fall back to at least killing what we hold,
+      // then still verify rather than assume.
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already exited */
+      }
+    }
+    if (await waitUntilGone(() => pidPresent(pid), deadline)) return { ok: true };
+    return {
+      ok: false,
+      detail: `pid ${pid} and/or its descendants were still present ${budget}ms after taskkill /T /F${tk.detail ? ` (${tk.detail})` : ""}`,
+    };
+  }
+
+  // POSIX. Group first (the detached-leader case: reaches grandchildren), then
+  // the child directly (covers a non-detached caller). A pid is unique, so a
+  // process group whose id equals our child's pid can only be our child's own
+  // group — the negative-pid signal cannot stray onto an unrelated group.
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    /* not a group leader, or already gone */
+  }
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    /* already exited */
+  }
+  // The child is our own, so it lingers as a zombie (and still answers signal 0)
+  // until Node reaps it; the awaits below let the event loop do that.
+  if (await waitUntilGone(() => pidPresent(pid) || pidPresent(-pid), deadline)) return { ok: true };
+  return {
+    ok: false,
+    detail: `process group ${pid} still had a live member ${budget}ms after SIGKILL — descendants may still be running`,
+  };
 }
 
 // Least-privilege child env — the single source of truth for every spawned
@@ -102,29 +258,47 @@ export function scrubbedEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return env;
 }
 
-// `opts` excludes `env`, `cwd`, and `shell` so a caller can never re-introduce
-// a raw env (and thus silently override scrubbedEnv()'s CodeQL #5 scrub),
-// shadow the explicit `cwd` param, or opt into shell interpolation through the
-// spread below — the compiler now enforces the single-scrub-path and
-// argv-array invariants the header comment describes.
-type RunOpts = Omit<SpawnOptionsWithoutStdio, "env" | "cwd" | "shell">;
+// `opts` excludes `env`, `cwd`, `shell`, and `detached` so a caller can never
+// re-introduce a raw env (and thus silently override scrubbedEnv()'s CodeQL #5
+// scrub), shadow the explicit `cwd` param, opt into shell interpolation through
+// the spread below, or opt OUT of the process-group isolation the timeout kill
+// depends on (#395) — the compiler now enforces the single-scrub-path, the
+// argv-array, and the one-group-per-child invariants the header describes.
+type RunOpts = Omit<SpawnOptionsWithoutStdio, "env" | "cwd" | "shell" | "detached">;
 
 // `timeoutMs` (opts) bounds the child's wall-clock; 0/undefined disables the
 // timeout (used by git, which must not be killed mid-operation). On timeout the
-// child tree is killed and a RunResult tagged `timedOut` resolves, so the caller
-// treats it as a non-zero failure instead of awaiting forever.
+// child tree is killed, VERIFIED absent (#395), and a RunResult tagged
+// `timedOut` resolves, so the caller treats it as a non-zero failure instead of
+// awaiting forever. `kill` is the injectable containment seam (defaults to the
+// real treeKill) — see TreeKiller.
 export function run(
   cmd: string,
   args: string[],
   cwd?: string,
   opts: RunOpts = {},
   timeoutMs = 0,
+  kill: TreeKiller = treeKill,
 ): Promise<RunResult> {
   return new Promise<RunResult>((resolve) => {
-    const c = spawn(cmd, args, { cwd, env: scrubbedEnv(), ...opts });
+    const c = spawn(cmd, args, {
+      cwd,
+      env: scrubbedEnv(),
+      ...opts,
+      // #395: off Windows the child leads its OWN process group, so a timeout
+      // kill can address the whole tree (`kill(-pid)`) instead of just the
+      // shell that fronts the operator's command. NOT on Windows, where
+      // `detached` means "new console" and breaks the `cmd.exe /c` contract.
+      detached: process.platform !== "win32",
+    });
     let stdout = "";
     let stderr = "";
     let settled = false;
+    // #395: set the instant the timeout fires, BEFORE the (now awaited) kill.
+    // Without it the child's own `close` — which the kill itself causes — would
+    // win the race and resolve an ordinary exit result, discarding both the
+    // `timedOut` tag and the cleanup verdict.
+    let killing = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const done = (r: RunResult) => {
       if (settled) return;
@@ -134,15 +308,34 @@ export function run(
     };
     if (timeoutMs > 0) {
       timer = setTimeout(() => {
-        treeKill(c);
-        const note = `\n[FARM] command exceeded ${timeoutMs}ms wall-clock timeout — killed (FARM_GATE_TIMEOUT_MS)`;
-        done({ code: 124, out: stdout + stderr + note, stdout, stderr: stderr + note, timedOut: true });
+        killing = true;
+        void (async () => {
+          const k = await kill(c);
+          const base = `\n[FARM] command exceeded ${timeoutMs}ms wall-clock timeout — killed (FARM_GATE_TIMEOUT_MS)`;
+          const note = k.ok
+            ? base
+            : `${base}\n[FARM] CLEANUP UNVERIFIED — the child process tree could not be confirmed gone: ${k.detail ?? "no detail"}. Descendants may still be running against this worktree.`;
+          done({
+            code: k.ok ? EXIT_TIMEOUT : EXIT_TIMEOUT_UNCLEAN,
+            out: stdout + stderr + note,
+            stdout,
+            stderr: stderr + note,
+            timedOut: true,
+            ...(k.ok ? {} : { cleanupFailed: true as const }),
+          });
+        })();
       }, timeoutMs);
     }
     c.stdout.on("data", (d) => (stdout += d));
     c.stderr.on("data", (d) => (stderr += d));
-    c.on("error", (e) => done({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
-    c.on("close", (code) => done({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
+    c.on("error", (e) => {
+      if (killing) return;
+      done({ code: 1, out: String(e), stdout: "", stderr: String(e) });
+    });
+    c.on("close", (code) => {
+      if (killing) return;
+      done({ code: code ?? 1, out: stdout + stderr, stdout, stderr });
+    });
   });
 }
 

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // farm.ts
-import { readFile as readFile2, writeFile, appendFile, mkdir as mkdir2, rm, rename, open as open2 } from "node:fs/promises";
+import { readFile as readFile2, writeFile, appendFile, mkdir as mkdir2, rm, stat, rename, open as open2 } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import path3 from "node:path";
@@ -11,6 +11,8 @@ import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+var EXIT_TIMEOUT = 124;
+var EXIT_TIMEOUT_UNCLEAN = 125;
 var [SHELL_BIN, SHELL_FLAG] = process.platform === "win32" ? ["cmd.exe", "/c"] : ["bash", "-c"];
 var SHELL_OPTS = process.platform === "win32" ? { windowsVerbatimArguments: true } : {};
 function numEnv(name, def, opts = {}) {
@@ -32,15 +34,89 @@ function numEnv(name, def, opts = {}) {
   return n;
 }
 var GATE_TIMEOUT_MS = numEnv("FARM_GATE_TIMEOUT_MS", 3e5, { min: 1e3 });
-function treeKill(child) {
+var KILL_VERIFY_DEFAULT_MS = 1e4;
+function taskkillPath() {
+  const root = process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows";
+  return path.join(root, "System32", "taskkill.exe");
+}
+function pidPresent(target) {
   try {
-    if (process.platform === "win32" && child.pid !== void 0) {
-      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]);
-    } else {
-      child.kill("SIGKILL");
+    process.kill(target, 0);
+    return true;
+  } catch (e) {
+    return e.code === "EPERM";
+  }
+}
+async function waitUntilGone(probe, deadline) {
+  for (; ; ) {
+    if (!probe()) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+function awaitTaskkill(pid, budgetMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer;
+    const done = (r) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(r);
+    };
+    let tk;
+    try {
+      tk = spawn(taskkillPath(), ["/pid", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+    } catch (e) {
+      done({ ok: false, detail: `taskkill could not be spawned: ${String(e)}` });
+      return;
     }
+    timer = setTimeout(() => {
+      try {
+        tk.kill();
+      } catch {
+      }
+      done({ ok: false, detail: `taskkill did not exit within ${budgetMs}ms` });
+    }, Math.max(1e3, budgetMs));
+    tk.on("error", (e) => done({ ok: false, detail: `taskkill failed to start: ${e.message}` }));
+    tk.on(
+      "close",
+      (code) => done(code === 0 || code === 128 ? { ok: true } : { ok: false, detail: `taskkill exited ${code}` })
+    );
+  });
+}
+async function treeKill(child, opts = {}) {
+  const pid = child.pid;
+  if (pid === void 0) return { ok: true, detail: "child never started" };
+  const budget = opts.budgetMs ?? numEnv("FARM_KILL_VERIFY_MS", KILL_VERIFY_DEFAULT_MS, { min: 0 });
+  const deadline = Date.now() + budget;
+  if (process.platform === "win32") {
+    const tk = await awaitTaskkill(pid, budget);
+    if (!tk.ok) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    }
+    if (await waitUntilGone(() => pidPresent(pid), deadline)) return { ok: true };
+    return {
+      ok: false,
+      detail: `pid ${pid} and/or its descendants were still present ${budget}ms after taskkill /T /F${tk.detail ? ` (${tk.detail})` : ""}`
+    };
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
   } catch {
   }
+  try {
+    child.kill("SIGKILL");
+  } catch {
+  }
+  if (await waitUntilGone(() => pidPresent(pid) || pidPresent(-pid), deadline)) return { ok: true };
+  return {
+    ok: false,
+    detail: `process group ${pid} still had a live member ${budget}ms after SIGKILL \u2014 descendants may still be running`
+  };
 }
 function scrubbedEnv(extra) {
   const env = { ...process.env, ...extra ?? {} };
@@ -48,12 +124,22 @@ function scrubbedEnv(extra) {
   delete env.CLAUDE_CODE_OAUTH_TOKEN;
   return env;
 }
-function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
+function run(cmd, args, cwd, opts = {}, timeoutMs = 0, kill = treeKill) {
   return new Promise((resolve) => {
-    const c = spawn(cmd, args, { cwd, env: scrubbedEnv(), ...opts });
+    const c = spawn(cmd, args, {
+      cwd,
+      env: scrubbedEnv(),
+      ...opts,
+      // #395: off Windows the child leads its OWN process group, so a timeout
+      // kill can address the whole tree (`kill(-pid)`) instead of just the
+      // shell that fronts the operator's command. NOT on Windows, where
+      // `detached` means "new console" and breaks the `cmd.exe /c` contract.
+      detached: process.platform !== "win32"
+    });
     let stdout = "";
     let stderr = "";
     let settled = false;
+    let killing = false;
     let timer;
     const done = (r) => {
       if (settled) return;
@@ -63,16 +149,34 @@ function run(cmd, args, cwd, opts = {}, timeoutMs = 0) {
     };
     if (timeoutMs > 0) {
       timer = setTimeout(() => {
-        treeKill(c);
-        const note = `
+        killing = true;
+        void (async () => {
+          const k = await kill(c);
+          const base = `
 [FARM] command exceeded ${timeoutMs}ms wall-clock timeout \u2014 killed (FARM_GATE_TIMEOUT_MS)`;
-        done({ code: 124, out: stdout + stderr + note, stdout, stderr: stderr + note, timedOut: true });
+          const note = k.ok ? base : `${base}
+[FARM] CLEANUP UNVERIFIED \u2014 the child process tree could not be confirmed gone: ${k.detail ?? "no detail"}. Descendants may still be running against this worktree.`;
+          done({
+            code: k.ok ? EXIT_TIMEOUT : EXIT_TIMEOUT_UNCLEAN,
+            out: stdout + stderr + note,
+            stdout,
+            stderr: stderr + note,
+            timedOut: true,
+            ...k.ok ? {} : { cleanupFailed: true }
+          });
+        })();
       }, timeoutMs);
     }
     c.stdout.on("data", (d) => stdout += d);
     c.stderr.on("data", (d) => stderr += d);
-    c.on("error", (e) => done({ code: 1, out: String(e), stdout: "", stderr: String(e) }));
-    c.on("close", (code) => done({ code: code ?? 1, out: stdout + stderr, stdout, stderr }));
+    c.on("error", (e) => {
+      if (killing) return;
+      done({ code: 1, out: String(e), stdout: "", stderr: String(e) });
+    });
+    c.on("close", (code) => {
+      if (killing) return;
+      done({ code: code ?? 1, out: stdout + stderr, stdout, stderr });
+    });
   });
 }
 async function readWorktreeFile(wt, relPath) {
@@ -357,10 +461,15 @@ async function mutationCheck(wt, task) {
       const c = spawn2(SHELL_BIN, [SHELL_FLAG, MUT.cmd], {
         cwd: wt,
         env: scrubbedEnv({ FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd }),
-        ...SHELL_OPTS
+        ...SHELL_OPTS,
+        // #395: process-group isolation, matching run(). The operator-authored
+        // mutation hook is a grandchild behind `bash -c` / `cmd.exe /c`, so the
+        // timeout kill must be able to address the group, not just the shell.
+        detached: process.platform !== "win32"
       });
       let out = "";
       let settled = false;
+      let killing = false;
       const finish = (res) => {
         if (settled) return;
         settled = true;
@@ -368,13 +477,23 @@ async function mutationCheck(wt, task) {
         resolve(res);
       };
       const timer = setTimeout(() => {
-        treeKill(c);
-        finish({ code: 124, out: out + "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout \u2014 killed" });
+        killing = true;
+        void treeKill(c).then((k) => {
+          const note = k.ok ? "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout \u2014 killed" : `
+[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout \u2014 killed, but CLEANUP UNVERIFIED: ${k.detail ?? "no detail"}`;
+          finish({ code: k.ok ? EXIT_TIMEOUT : EXIT_TIMEOUT_UNCLEAN, out: out + note });
+        });
       }, GATE_TIMEOUT_MS);
       c.stdout.on("data", (d) => out += d);
       c.stderr.on("data", (d) => out += d);
-      c.on("error", (e) => finish({ code: 1, out: String(e) }));
-      c.on("close", (code) => finish({ code: code ?? 1, out }));
+      c.on("error", (e) => {
+        if (killing) return;
+        finish({ code: 1, out: String(e) });
+      });
+      c.on("close", (code) => {
+        if (killing) return;
+        finish({ code: code ?? 1, out });
+      });
     });
     const parsed = parseMutationHookOutput(r.out);
     if (parsed !== null) return parsed;
@@ -969,7 +1088,8 @@ function newRunArtifactHealth() {
   return {
     stream: { errors: [] },
     diffs: { unavailable: [], unavailableTotal: 0, latestMirrorErrors: [] },
-    report: { latestMirrorErrors: [] }
+    report: { latestMirrorErrors: [] },
+    cleanup: { failures: [] }
   };
 }
 var MAX_RECORDED_ARTIFACT_ERRORS = 10;
@@ -1009,6 +1129,100 @@ async function prepareWorktree(branch, wt, from) {
   const add = await git(["worktree", "add", "-b", branch, wt, from]);
   if (add.code !== 0) return `worktree add failed: ${add.out.slice(0, 200)}`;
   return null;
+}
+var CLEANUP_ATTEMPTS = 3;
+var CLEANUP_DELAY_MS = 150;
+function samePath(a, b) {
+  const norm = (p) => {
+    const r = path3.resolve(p);
+    return process.platform === "win32" ? r.toLowerCase() : r;
+  };
+  return norm(a) === norm(b);
+}
+async function stillRegistered(gitFn, wt) {
+  const listed = await gitFn(["worktree", "list", "--porcelain"]);
+  if (listed.code !== 0) return true;
+  return listed.stdout.split("\n").filter((l) => l.startsWith("worktree ")).some((l) => samePath(l.slice("worktree ".length).trim(), wt));
+}
+async function pathExists(p) {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+async function removeWorktreeVerified(gitFn, wt, opts = {}) {
+  const attempts = opts.attempts ?? CLEANUP_ATTEMPTS;
+  const delayMs = opts.delayMs ?? CLEANUP_DELAY_MS;
+  let lastErr = "";
+  for (let i = 1; i <= attempts; i++) {
+    const rmR = await gitFn(["worktree", "remove", "--force", wt]);
+    if (rmR.code !== 0) lastErr = rmR.out.trim().split("\n").slice(-1)[0] ?? "";
+    await gitFn(["worktree", "prune"]);
+    const registered = await stillRegistered(gitFn, wt);
+    const present = await pathExists(wt);
+    if (!registered && !present) return { ok: true, target: wt, attempts: i };
+    if (i < attempts) await sleep(delayMs * i);
+    else
+      return {
+        ok: false,
+        target: wt,
+        attempts: i,
+        detail: redactSecrets(
+          [
+            registered ? `still registered as a git worktree after ${i} attempt(s)` : null,
+            present ? `directory still present on disk after ${i} attempt(s)` : null,
+            lastErr ? `last git error: ${lastErr}` : null
+          ].filter(Boolean).join("; ")
+        ).slice(0, 500)
+      };
+  }
+  return { ok: false, target: wt, attempts, detail: "cleanup loop did not settle" };
+}
+async function deleteBranchVerified(gitFn, branch, opts = {}) {
+  const attempts = opts.attempts ?? CLEANUP_ATTEMPTS;
+  const delayMs = opts.delayMs ?? CLEANUP_DELAY_MS;
+  let lastErr = "";
+  for (let i = 1; i <= attempts; i++) {
+    const del = await gitFn(["branch", "-D", branch]);
+    if (del.code !== 0) lastErr = del.out.trim().split("\n").slice(-1)[0] ?? "";
+    const listed = await gitFn(["branch", "--list", branch]);
+    const present = listed.code !== 0 || listed.stdout.trim() !== "";
+    if (!present) return { ok: true, target: branch, attempts: i };
+    if (i < attempts) await sleep(delayMs * i);
+    else
+      return {
+        ok: false,
+        target: branch,
+        attempts: i,
+        detail: redactSecrets(
+          `branch still present after ${i} attempt(s)${lastErr ? `; last git error: ${lastErr}` : ""}`
+        ).slice(0, 500)
+      };
+  }
+  return { ok: false, target: branch, attempts, detail: "cleanup loop did not settle" };
+}
+function runExitCode(o) {
+  return o.escalated || o.blocked || o.aborted || o.cleanupFailures ? 2 : 0;
+}
+function cleanupFailures(health, results) {
+  return [
+    ...results.flatMap(
+      (r) => (r.cleanup ?? []).filter((c) => !c.ok).map((c) => ({ owner: r.id, target: c.target, detail: c.detail ?? "unverified" }))
+    ),
+    ...health.cleanup.failures.map((f) => ({ owner: "run", target: f.target, detail: f.detail }))
+  ];
+}
+function cleanupReportLines(health, results) {
+  const failures = cleanupFailures(health, results);
+  if (failures.length === 0)
+    return [`## Resource cleanup`, `Every farm worktree and scratch branch was removed and re-verified.`];
+  return [
+    `## Resource cleanup`,
+    `> **CLEANUP DEGRADED** \u2014 ${failures.length} resource(s) could not be released and re-verified. They may still be registered with git or present on disk, and the next run will collide with or destructively pre-clean them. Exit code is non-zero for this reason alone.`,
+    ...failures.map((f) => `- \`${f.target}\` (${f.owner}) \u2014 ${f.detail}`)
+  ];
 }
 var defaultRunTaskDeps = () => ({
   worker: httpWorker,
@@ -1089,13 +1303,12 @@ ${gate.tail}`), promptTokens: pt, completionTokens: ct };
   const completionTokens = outcomes.reduce((s, o) => s + o.completionTokens, 0);
   const winner = outcomes.find((o) => o.green) ?? null;
   const bestFailure = outcomes.find((o) => !o.green && o.inScope.length > 0) ?? outcomes.find((o) => !o.green) ?? null;
+  const cleanup = [];
   for (const o of outcomes) {
-    await deps.git(["worktree", "remove", "--force", o.wt]).catch(() => {
-    });
-    await deps.git(["branch", "-D", o.branch]).catch(() => {
-    });
+    cleanup.push(await removeWorktreeVerified(deps.git, o.wt));
+    cleanup.push(await deleteBranchVerified(deps.git, o.branch));
   }
-  return { winner, bestFailure, promptTokens, completionTokens };
+  return { winner, bestFailure, promptTokens, completionTokens, cleanup };
 }
 async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()) {
   const branch = `farm/${t.id}`;
@@ -1106,9 +1319,14 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
   const forbidden = /* @__PURE__ */ new Set([t.test.path]);
   const samples = Math.max(1, Math.floor(numEnv("FARM_SAMPLES", 1, { min: 1 })));
   const sampling = effectiveSampling(samples);
+  const cleanupIssues = [];
+  const noteCleanup = (...outcomes) => {
+    for (const c of outcomes) if (!c.ok) cleanupIssues.push(c);
+  };
+  const finish = (r) => cleanupIssues.length ? { ...r, cleanup: [...cleanupIssues] } : r;
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
-    return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
+    return finish({ id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr });
   const testHashBefore = await deps.fileHash(path3.resolve(wt, t.test.path));
   let priorFailure;
   let driftedOnce = false;
@@ -1128,7 +1346,7 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
     }
     const setupNote = await runSetupPhases(wt, t, deps, setupState);
     if (setupNote)
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: setupNote, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: setupNote, promptTokens, completionTokens });
     const injected = await buildEnrichment(wt, t, priorInScope);
     const forbiddenExtra = driftedOnce ? lastFilesWritten.filter((f) => !allowed.has(f)) : void 0;
     const prompt = buildPrompt(t, injected, priorFailure, forbiddenExtra);
@@ -1148,6 +1366,7 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
       }
     } else {
       const sel = await bestOfN(t, prompt, effectiveModel, apiBaseUrl, apiKey, sampling, forbidden, allowed, samples, deps);
+      noteCleanup(...sel.cleanup);
       promptTokens += sel.promptTokens;
       completionTokens += sel.completionTokens;
       acceptedPromptTokens = sel.winner?.promptTokens ?? 0;
@@ -1162,7 +1381,7 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
         await writeFilesInto(wt, sel.winner.files);
       } catch (error) {
         if (isUnsafeWorktreePathError(error)) {
-          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+          return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens });
         }
         throw error;
       }
@@ -1171,11 +1390,11 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
     }
     const sweepErr = postApplySweep(wt, worker.filesWritten, forbidden);
     if (sweepErr) {
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
     const testHashAfter = await deps.fileHash(path3.resolve(wt, t.test.path));
     if (testHashBefore !== null && testHashAfter !== testHashBefore) {
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
     const driftFiles = await deps.checkDrift(wt, allowed);
     if (driftFiles.length > 0) {
@@ -1184,7 +1403,7 @@ async function runTask(t, model, apiBaseUrl, apiKey, deps = defaultRunTaskDeps()
         priorFailure = `drift: you wrote outside the allowed files: ${driftFiles.join(", ")}`;
         continue;
       }
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
     const gate = await deps.runGate(wt, t.gate.commands);
     if (!gate.ok) {
@@ -1201,7 +1420,7 @@ ${gate.tail}`);
         mut = await deps.mutationCheck(wt, t);
       } catch (error) {
         if (isUnsafeWorktreePathError(error)) {
-          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+          return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens });
         }
         throw error;
       }
@@ -1228,13 +1447,13 @@ ${gate.tail}`);
     if (risk === "high") {
       priorFailure = `${riskNote}. Implement real logic; do not hard-code or special-case the asserted value.`;
       if (attempt <= limit) continue;
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore });
     }
     if (risk === "warn") lastWarning = riskNote;
     await deps.git(["add", "--", ...worker.filesWritten], wt);
     const commit = await deps.git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
     if (commit.code !== 0)
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     const diffstat = (await deps.git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
     const merged = await deps.withMergeLock(async () => {
       const m = await deps.git([...NOSIGN, "merge", "--no-ff", "-m", `merge ${t.id}`, branch], integrationWorktree);
@@ -1255,13 +1474,12 @@ ${gate.tail}`);
 ${String(merged).slice(0, 160)}`);
         continue;
       }
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
-    await deps.git(["worktree", "remove", "--force", wt]).catch(() => {
-    });
-    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore, samples, acceptedPromptTokens, acceptedCompletionTokens };
+    noteCleanup(await removeWorktreeVerified(deps.git, wt));
+    return finish({ id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore, samples, acceptedPromptTokens, acceptedCompletionTokens });
   }
-  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore };
+  return finish({ id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore });
 }
 var SAFE_TASK_ID = /^[A-Za-z0-9._-]{1,64}$/;
 var LOOPBACK_HOSTS = /* @__PURE__ */ new Set(["127.0.0.1", "localhost"]);
@@ -1696,23 +1914,25 @@ ${String(e.stack).slice(0, 1500)}` : ""}`
       blocked.push({ id, reason: aborted ? "run aborted (circuit breaker)" : culprit ? `dependency ${culprit} escalated` : "not scheduled" });
     }
   } finally {
+    if (integrationWorktree) {
+      const c = await removeWorktreeVerified(git, integrationWorktree);
+      if (!c.ok) health.cleanup.failures.push({ target: c.target, detail: c.detail ?? "unverified" });
+    }
     try {
       await writeReport(plan, [...done.values()], blocked, aborted, runId, health);
     } catch (e) {
       publishError = e;
       console.error("report publication failed:", e);
     }
-    if (integrationWorktree)
-      await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {
-      });
   }
   const results = [...done.values()];
   const esc = results.filter((r) => r.status === "escalate").length;
   const green = results.filter((r) => r.status === "green").length;
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
-  const runExitCode = esc || blocked.length || aborted ? 2 : 0;
-  const exitCode = publishError ? 3 : runExitCode;
+  const leaks = cleanupFailures(health, results);
+  const runOutcome = runExitCode({ escalated: esc, blocked: blocked.length, aborted, cleanupFailures: leaks.length });
+  const exitCode = publishError ? 3 : runOutcome;
   const latestReportErrors = health.report.latestMirrorErrors;
   const summary = [
     aborted ? `
@@ -1722,6 +1942,14 @@ Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
     `Run: ${runId}  (artifacts: ${runDir})`,
+    // #398: never let a leak be something the operator has to go looking for.
+    leaks.length ? [
+      `
+CLEANUP DEGRADED \u2014 ${leaks.length} resource(s) could not be released and re-verified:`,
+      ...leaks.map((l) => `  - ${l.target} (${l.owner}): ${l.detail}`),
+      `Git may still register these worktrees, or the directories may still be on disk. The next run's`,
+      `pre-cleanup is destructive and best-effort, so clear them before re-running. Exit is non-zero for this alone.`
+    ].join("\n") : ``,
     // The success breadcrumb is SUPPRESSED when the authoritative publication
     // failed — pointing an operator at a farm-report.md that is not there is
     // the defect. Every claim below has to be true of what is actually on disk:
@@ -1731,10 +1959,10 @@ Done. green=${green} escalate=${esc} blocked=${blocked.length}`,
     publishError ? [
       `
 RECEIPT PUBLICATION FAILED \u2014 run ${runId} could not publish its complete authoritative report under ${runDir}: ${msgOf(publishError)}`,
-      `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but this run's durable receipt is missing or incomplete,`,
+      `The tasks themselves finished ${runOutcome === 0 ? "green" : "with escalations/blocks/unreleased worktrees"}, but this run's durable receipt is missing or incomplete,`,
       `so it cannot be reliably reconciled or audited. Inspect ${runDir} for whatever did land.`,
       `${path3.join(ENV.reportDir, "farm-report.json")} / .md were NOT refreshed and do not describe run ${runId}.`,
-      `Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`
+      `Exiting 3 (receipt failure) rather than ${runOutcome} (task outcome).`
     ].join("\n") : latestReportErrors.length ? (
       // Non-fatal, and stated as such. The authoritative receipt is
       // unaffected; what the operator must not assume is that the shared
@@ -1789,6 +2017,7 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
   }
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
+  const leaks = cleanupFailures(health, results);
   const streamComplete = health.stream.errors.length === 0;
   const artifacts = {
     run_dir: runDir,
@@ -1806,7 +2035,11 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
       unavailable,
       unavailable_total: health.diffs.unavailableTotal,
       latest_mirror_errors: health.diffs.latestMirrorErrors
-    }
+    },
+    // #398: the run's resource-ownership statement. `released` is an explicit
+    // positive claim, so a consumer can distinguish "nothing leaked" from "this
+    // report predates the check" without inferring it from an absent key.
+    cleanup: { released: leaks.length === 0, failures: leaks }
   };
   const json = JSON.stringify(
     { run_id: runId, plan: plan.meta, aborted, tokens: { prompt: pTok, completion: cTok }, results, blocked, artifacts, ts: (/* @__PURE__ */ new Date()).toISOString() },
@@ -1820,6 +2053,8 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
 ` : ``,
     streamComplete ? `` : `> **Streaming rail incomplete** \u2014 ${health.stream.errors.length} write failure(s) on \`farm-results.jsonl\`; this report is authoritative for settled tasks.
 `,
+    leaks.length ? `> **CLEANUP DEGRADED** \u2014 ${leaks.length} worktree/branch could not be released; see Resource cleanup below.
+` : ``,
     `Run: \`${runId}\` \u2014 artifacts under \`${runDir}\``,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     ``,
@@ -1836,6 +2071,8 @@ async function writeReport(plan, results, blocked, aborted, runId, health) {
       `${health.diffs.unavailableTotal} task(s) have no diff evidence${unavailable.length < health.diffs.unavailableTotal ? ` (first ${MAX_RECORDED_ARTIFACT_ERRORS} listed)` : ``}:`,
       ...unavailable.map((u) => `- **${u.id}** \u2014 diff evidence unavailable: ${u.reason}`)
     ] : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`],
+    ``,
+    ...cleanupReportLines(health, results),
     ``,
     `## Warnings \u2014 review during spec-compliance`,
     ...results.filter((r) => r.warning).map((r) => {
@@ -1876,8 +2113,11 @@ export {
   buildPrompt,
   captureInScope,
   checkDrift,
+  cleanupFailures,
+  cleanupReportLines,
   codeLineCount,
   createLimiter,
+  deleteBranchVerified,
   extractFileBlocks,
   extractLiterals,
   httpWorker,
@@ -1890,8 +2130,10 @@ export {
   parsePlan,
   readSampling,
   redactSecrets,
+  removeWorktreeVerified,
   run,
   runArtifactDir,
+  runExitCode,
   runGate,
   runTask,
   screenEntitlements,

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1159,9 +1159,12 @@ async function removeWorktreeVerified(gitFn, wt, opts = {}) {
   for (let i = 1; i <= attempts; i++) {
     const rmR = await gitFn(["worktree", "remove", "--force", wt]);
     if (rmR.code !== 0) lastErr = rmR.out.trim().split("\n").slice(-1)[0] ?? "";
-    await gitFn(["worktree", "prune"]);
-    const registered = await stillRegistered(gitFn, wt);
+    let registered = await stillRegistered(gitFn, wt);
     const present = await pathExists(wt);
+    if (registered && !present) {
+      await gitFn(["worktree", "prune"]);
+      registered = await stillRegistered(gitFn, wt);
+    }
     if (!registered && !present) return { ok: true, target: wt, attempts: i };
     if (i < attempts) await sleep(delayMs * i);
     else
@@ -1915,8 +1918,12 @@ ${String(e.stack).slice(0, 1500)}` : ""}`
     }
   } finally {
     if (integrationWorktree) {
-      const c = await removeWorktreeVerified(git, integrationWorktree);
-      if (!c.ok) health.cleanup.failures.push({ target: c.target, detail: c.detail ?? "unverified" });
+      try {
+        const c = await removeWorktreeVerified(git, integrationWorktree);
+        if (!c.ok) health.cleanup.failures.push({ target: c.target, detail: c.detail ?? "unverified" });
+      } catch (e) {
+        health.cleanup.failures.push({ target: integrationWorktree, detail: `teardown threw: ${msgOf(e)}` });
+      }
     }
     try {
       await writeReport(plan, [...done.values()], blocked, aborted, runId, health);

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -1351,11 +1351,18 @@ export async function removeWorktreeVerified(
   for (let i = 1; i <= attempts; i++) {
     const rmR = await gitFn(["worktree", "remove", "--force", wt]);
     if (rmR.code !== 0) lastErr = rmR.out.trim().split("\n").slice(-1)[0] ?? "";
+    let registered = await stillRegistered(gitFn, wt);
+    const present = await pathExists(wt);
     // Prune clears a stale registration whose directory is already gone — the
     // exact state a partially-failed removal or an external delete leaves.
-    await gitFn(["worktree", "prune"]);
-    const registered = await stillRegistered(gitFn, wt);
-    const present = await pathExists(wt);
+    // Run it ONLY in that state: `git worktree prune` is repo-wide, and a
+    // blanket call would also deregister an unrelated worktree whose path is
+    // merely unreachable right now (an unmounted volume, a temporarily denied
+    // directory). Narrow it to the condition it is actually needed for.
+    if (registered && !present) {
+      await gitFn(["worktree", "prune"]);
+      registered = await stillRegistered(gitFn, wt);
+    }
     if (!registered && !present) return { ok: true, target: wt, attempts: i };
     if (i < attempts) await sleep(delayMs * i);
     else
@@ -2632,8 +2639,16 @@ async function main() {
     // writeReport reads the integration worktree (its `git diff` runs against
     // the main checkout), so the reordering is safe.
     if (integrationWorktree) {
-      const c = await removeWorktreeVerified(git, integrationWorktree);
-      if (!c.ok) health.cleanup.failures.push({ target: c.target, detail: c.detail ?? "unverified" });
+      try {
+        const c = await removeWorktreeVerified(git, integrationWorktree);
+        if (!c.ok) health.cleanup.failures.push({ target: c.target, detail: c.detail ?? "unverified" });
+      } catch (e) {
+        // Belt and braces: nothing in removeWorktreeVerified is expected to
+        // throw (git() resolves rather than rejects, stat is guarded), but a
+        // throw HERE would propagate out of the finally and mask an in-flight
+        // exception — the exact failure mode reliability-004 fixed above.
+        health.cleanup.failures.push({ target: integrationWorktree, detail: `teardown threw: ${msgOf(e)}` });
+      }
     }
     // #387: the report is still written from the `finally` (so an abort or a
     // mid-run throw still produces a receipt), but its failure is no longer

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -1069,6 +1069,11 @@ type Result = {
   // writing to the same .farm/ directory produce distinguishable lines that tie
   // back to a single farm-report.json header.
   runId?: string;
+  // #398: teardown outcomes for the resources this task owned — its worktree and
+  // any best-of-N sample worktrees/branches. Present only when at least one
+  // could not be verified released, so a green status is never unqualified:
+  // the leak travels with the result, into the receipt, and into the exit code.
+  cleanup?: CleanupOutcome[];
 };
 
 // observability-003 (T-07c): a run-id minted once at main() startup.
@@ -1199,6 +1204,11 @@ export type RunArtifactHealth = {
   // inside the report itself (the payload is already serialized by the time the
   // pointers are written), so main() surfaces them on the summary instead.
   report: { latestMirrorErrors: string[] };
+  // #398: RUN-level resource teardown that could not be verified — today the
+  // integration worktree, which no task owns. Task-owned leaks ride on the
+  // Result; these have nowhere else to live, so they are collected here and
+  // folded into the same report section and exit code.
+  cleanup: { failures: { target: string; detail: string }[] };
 };
 
 export function newRunArtifactHealth(): RunArtifactHealth {
@@ -1206,6 +1216,7 @@ export function newRunArtifactHealth(): RunArtifactHealth {
     stream: { errors: [] },
     diffs: { unavailable: [], unavailableTotal: 0, latestMirrorErrors: [] },
     report: { latestMirrorErrors: [] },
+    cleanup: { failures: [] },
   };
 }
 
@@ -1260,6 +1271,191 @@ async function prepareWorktree(branch: string, wt: string, from: string): Promis
   const add = await git(["worktree", "add", "-b", branch, wt, from]);
   if (add.code !== 0) return `worktree add failed: ${add.out.slice(0, 200)}`;
   return null;
+}
+
+// --------------------------------------------------------------------------
+// #398 — verified resource teardown.
+//
+// Every teardown site in this file used to be `git(...).catch(() => {})`, and
+// the task's success path returned `status: "green"` on the very next line. A
+// Windows file lock, an antivirus scan holding a handle, or any git failure
+// therefore left a worktree registered and on disk while the run reported
+// success — and the NEXT run's best-effort destructive pre-cleanup was the only
+// thing standing between that leak and an ambiguous re-registration.
+//
+// #430 established the tiering rule this follows: an authoritative outcome
+// fails the run, a convenience mirror warns. Releasing ownership of a worktree
+// is authoritative — it is the farm's claim on a directory and a branch — so a
+// teardown that cannot be VERIFIED is reported on the result, printed on the
+// summary, persisted in the receipt, and lifts the run's exit code. The
+// operations below are non-destructive beyond what git itself does: they retry
+// and then TELL you, rather than escalating to an unbounded rm.
+// --------------------------------------------------------------------------
+
+// The outcome of one bounded, verified teardown. `ok` means the resource is
+// verifiably GONE — not merely that a removal command was issued.
+export type CleanupOutcome = { ok: boolean; target: string; attempts: number; detail?: string };
+
+// Bounded backoff for a transient Windows lock (a scanner or an editor holding a
+// handle usually clears in tens of milliseconds). Deliberately small: the point
+// is to ride out a race, not to wait out a genuinely stuck resource.
+const CLEANUP_ATTEMPTS = 3;
+const CLEANUP_DELAY_MS = 150;
+
+// Path comparison for `git worktree list --porcelain` output. git prints
+// forward slashes even on Windows, and Windows paths are case-insensitive, so
+// compare RESOLVED, normalized forms rather than raw strings.
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string) => {
+    const r = path.resolve(p);
+    return process.platform === "win32" ? r.toLowerCase() : r;
+  };
+  return norm(a) === norm(b);
+}
+
+// Does git still register `wt` as a worktree? This — not the removal command's
+// exit code — is the authority: a removal that "failed" but left git with no
+// registration and no directory has still released ownership, and a removal
+// that "succeeded" while git keeps the registration has not.
+async function stillRegistered(gitFn: GitRunner, wt: string): Promise<boolean> {
+  const listed = await gitFn(["worktree", "list", "--porcelain"]);
+  if (listed.code !== 0) return true; // cannot verify ⇒ do not claim success
+  return listed.stdout
+    .split("\n")
+    .filter((l) => l.startsWith("worktree "))
+    .some((l) => samePath(l.slice("worktree ".length).trim(), wt));
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Remove a farm worktree and PROVE it is gone: `worktree remove --force`, then
+// `worktree prune` (which clears a registration whose directory already went
+// away), then re-verify against `worktree list --porcelain` AND the filesystem.
+// Retries a bounded number of times so a transient lock does not become a
+// permanent leak, and returns a diagnosable ok:false when it cannot be cleared.
+export async function removeWorktreeVerified(
+  gitFn: GitRunner,
+  wt: string,
+  opts: { attempts?: number; delayMs?: number } = {},
+): Promise<CleanupOutcome> {
+  const attempts = opts.attempts ?? CLEANUP_ATTEMPTS;
+  const delayMs = opts.delayMs ?? CLEANUP_DELAY_MS;
+  let lastErr = "";
+  for (let i = 1; i <= attempts; i++) {
+    const rmR = await gitFn(["worktree", "remove", "--force", wt]);
+    if (rmR.code !== 0) lastErr = rmR.out.trim().split("\n").slice(-1)[0] ?? "";
+    // Prune clears a stale registration whose directory is already gone — the
+    // exact state a partially-failed removal or an external delete leaves.
+    await gitFn(["worktree", "prune"]);
+    const registered = await stillRegistered(gitFn, wt);
+    const present = await pathExists(wt);
+    if (!registered && !present) return { ok: true, target: wt, attempts: i };
+    if (i < attempts) await sleep(delayMs * i);
+    else
+      return {
+        ok: false,
+        target: wt,
+        attempts: i,
+        detail: redactSecrets(
+          [
+            registered ? `still registered as a git worktree after ${i} attempt(s)` : null,
+            present ? `directory still present on disk after ${i} attempt(s)` : null,
+            lastErr ? `last git error: ${lastErr}` : null,
+          ]
+            .filter(Boolean)
+            .join("; "),
+        ).slice(0, 500),
+      };
+  }
+  /* istanbul ignore next — the loop always returns */
+  return { ok: false, target: wt, attempts, detail: "cleanup loop did not settle" };
+}
+
+// Delete a farm scratch branch and PROVE it is gone. `branch --list` is used for
+// verification rather than `rev-parse` because an empty listing unambiguously
+// means "absent", whereas rev-parse's exit code also encodes other failures.
+export async function deleteBranchVerified(
+  gitFn: GitRunner,
+  branch: string,
+  opts: { attempts?: number; delayMs?: number } = {},
+): Promise<CleanupOutcome> {
+  const attempts = opts.attempts ?? CLEANUP_ATTEMPTS;
+  const delayMs = opts.delayMs ?? CLEANUP_DELAY_MS;
+  let lastErr = "";
+  for (let i = 1; i <= attempts; i++) {
+    const del = await gitFn(["branch", "-D", branch]);
+    if (del.code !== 0) lastErr = del.out.trim().split("\n").slice(-1)[0] ?? "";
+    const listed = await gitFn(["branch", "--list", branch]);
+    const present = listed.code !== 0 || listed.stdout.trim() !== "";
+    if (!present) return { ok: true, target: branch, attempts: i };
+    if (i < attempts) await sleep(delayMs * i);
+    else
+      return {
+        ok: false,
+        target: branch,
+        attempts: i,
+        detail: redactSecrets(
+          `branch still present after ${i} attempt(s)${lastErr ? `; last git error: ${lastErr}` : ""}`,
+        ).slice(0, 500),
+      };
+  }
+  /* istanbul ignore next — the loop always returns */
+  return { ok: false, target: branch, attempts, detail: "cleanup loop did not settle" };
+}
+
+// The run's exit code from its two independent failure axes. #387 established
+// 0/2/3; #398 adds a third input on the "2" side — a run that leaked a worktree
+// or a branch has not come out clean, whatever the tasks did, because the next
+// run inherits ambiguous state. (3, the authoritative-receipt failure, still
+// outranks it and is applied by the caller.)
+export function runExitCode(o: {
+  escalated: number;
+  blocked: number;
+  aborted: boolean;
+  cleanupFailures: number;
+}): 0 | 2 {
+  return o.escalated || o.blocked || o.aborted || o.cleanupFailures ? 2 : 0;
+}
+
+// Every unreleased resource this run is responsible for, from both places they
+// can be recorded: the task results (worktrees and sample branches a task owned)
+// and the run-level health (the integration worktree, owned by no task).
+export function cleanupFailures(
+  health: RunArtifactHealth,
+  results: Result[],
+): { owner: string; target: string; detail: string }[] {
+  return [
+    ...results.flatMap((r) =>
+      (r.cleanup ?? [])
+        .filter((c) => !c.ok)
+        .map((c) => ({ owner: r.id, target: c.target, detail: c.detail ?? "unverified" })),
+    ),
+    ...health.cleanup.failures.map((f) => ({ owner: "run", target: f.target, detail: f.detail })),
+  ];
+}
+
+// The report's cleanup section. Stated in both directions on purpose: silence is
+// not evidence of a clean teardown, so the clean case says so explicitly rather
+// than omitting the section (an operator must be able to tell "nothing leaked"
+// from "this report predates the check").
+export function cleanupReportLines(health: RunArtifactHealth, results: Result[]): string[] {
+  const failures = cleanupFailures(health, results);
+  if (failures.length === 0)
+    return [`## Resource cleanup`, `Every farm worktree and scratch branch was removed and re-verified.`];
+  return [
+    `## Resource cleanup`,
+    `> **CLEANUP DEGRADED** — ${failures.length} resource(s) could not be released and re-verified. ` +
+      `They may still be registered with git or present on disk, and the next run will collide with or ` +
+      `destructively pre-clean them. Exit code is non-zero for this reason alone.`,
+    ...failures.map((f) => `- \`${f.target}\` (${f.owner}) — ${f.detail}`),
+  ];
 }
 
 // Injectable dependencies for runTask. Every field defaults to the real
@@ -1359,6 +1555,8 @@ async function bestOfN(
   bestFailure: SampleOutcome | null;
   promptTokens: number;
   completionTokens: number;
+  // #398: one entry per sample resource torn down, ok or not.
+  cleanup: CleanupOutcome[];
 }> {
   // All sample worktrees are cut from the same integration HEAD as the task
   // worktree, so they share the baseline the single `prompt` was enriched
@@ -1420,11 +1618,17 @@ async function bestOfN(
   // in-scope output for F2), else any failure.
   const bestFailure = outcomes.find((o) => !o.green && o.inScope.length > 0) ?? outcomes.find((o) => !o.green) ?? null;
   // Discard every sample worktree — the winner's files are already captured.
+  // #398: verified, and EVERY sample is attempted even after one fails. The old
+  // loop swallowed each failure, so one stuck sample was indistinguishable from
+  // a clean sweep; worse, a leaked sample worktree keeps its branch checked out,
+  // which then makes the branch delete fail too. Both outcomes are returned so
+  // the task result can carry the full list of what is still on disk.
+  const cleanup: CleanupOutcome[] = [];
   for (const o of outcomes) {
-    await deps.git(["worktree", "remove", "--force", o.wt]).catch(() => {});
-    await deps.git(["branch", "-D", o.branch]).catch(() => {});
+    cleanup.push(await removeWorktreeVerified(deps.git, o.wt));
+    cleanup.push(await deleteBranchVerified(deps.git, o.branch));
   }
-  return { winner, bestFailure, promptTokens, completionTokens };
+  return { winner, bestFailure, promptTokens, completionTokens, cleanup };
 }
 
 export async function runTask(
@@ -1457,9 +1661,21 @@ export async function runTask(
   const samples = Math.max(1, Math.floor(numEnv("FARM_SAMPLES", 1, { min: 1 })));
   const sampling = effectiveSampling(samples);
 
+  // #398: resources this task owned that could NOT be verified released —
+  // sample worktrees/branches from best-of-N, and the task worktree on the
+  // success path. Attached to whatever Result the task returns, so a leak is
+  // never dropped on the floor between the teardown and `status: "green"`.
+  const cleanupIssues: CleanupOutcome[] = [];
+  const noteCleanup = (...outcomes: CleanupOutcome[]) => {
+    for (const c of outcomes) if (!c.ok) cleanupIssues.push(c);
+  };
+  // Every return below routes through finish() so the cleanup record rides
+  // along regardless of which exit the task takes.
+  const finish = (r: Result): Result => (cleanupIssues.length ? { ...r, cleanup: [...cleanupIssues] } : r);
+
   const prepErr = await deps.prepareWorktree(branch, wt, ENV.integration);
   if (prepErr)
-    return { id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr };
+    return finish({ id: t.id, status: "escalate", attempts: 0, branch, worktree: wt, note: prepErr });
 
   const testHashBefore = await deps.fileHash(path.resolve(wt, t.test.path));
 
@@ -1505,7 +1721,7 @@ export async function runTask(
     // so it escalates immediately rather than burning a worker retry.
     const setupNote = await runSetupPhases(wt, t, deps, setupState);
     if (setupNote)
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: setupNote, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: setupNote, promptTokens, completionTokens });
 
     // Enrichment (AC-03/AC-04): read the per-attempt worktree state — AFTER any
     // reset above — so the test source and existing in-scope file contents
@@ -1539,6 +1755,7 @@ export async function runTask(
       // (its in-scope output, per F2) and loop (AC-F1.5). Token spend across ALL
       // samples is summed; the winner's own tokens are recorded separately (AC-F1.6).
       const sel = await bestOfN(t, prompt, effectiveModel, apiBaseUrl, apiKey, sampling, forbidden, allowed, samples, deps);
+      noteCleanup(...sel.cleanup); // #398: sample worktrees/branches left behind
       promptTokens += sel.promptTokens;
       completionTokens += sel.completionTokens;
       acceptedPromptTokens = sel.winner?.promptTokens ?? 0;
@@ -1553,7 +1770,7 @@ export async function runTask(
         await writeFilesInto(wt, sel.winner.files);
       } catch (error) {
         if (isUnsafeWorktreePathError(error)) {
-          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+          return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens });
         }
         throw error;
       }
@@ -1571,14 +1788,14 @@ export async function runTask(
     // inline guards remain defense-in-depth.
     const sweepErr = postApplySweep(wt, worker.filesWritten, forbidden);
     if (sweepErr) {
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: sweepErr, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
 
     // The failing test must be untouched (defence in depth — the write path
     // already refuses test.path, this catches a sneaky in-scope edit too).
     const testHashAfter = await deps.fileHash(path.resolve(wt, t.test.path));
     if (testHashBefore !== null && testHashAfter !== testHashBefore) {
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `tampered test: ${t.test.path}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
 
     // Drift: on the FIRST drift, retry once with a hardened prompt naming the
@@ -1591,7 +1808,7 @@ export async function runTask(
         priorFailure = `drift: you wrote outside the allowed files: ${driftFiles.join(", ")}`;
         continue;
       }
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `drift: ${driftFiles.join(", ")}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
 
     const gate = await deps.runGate(wt, t.gate.commands);
@@ -1617,7 +1834,7 @@ export async function runTask(
         mut = await deps.mutationCheck(wt, t);
       } catch (error) {
         if (isUnsafeWorktreePathError(error)) {
-          return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens };
+          return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: error.message, filesWritten: [], promptTokens, completionTokens });
         }
         throw error;
       }
@@ -1651,7 +1868,7 @@ export async function runTask(
     if (risk === "high") {
       priorFailure = `${riskNote}. Implement real logic; do not hard-code or special-case the asserted value.`;
       if (attempt <= limit) continue; // give it a chance to fix
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: riskNote, filesWritten: worker.filesWritten, promptTokens, completionTokens, mutationScore });
     }
     if (risk === "warn") lastWarning = riskNote;
 
@@ -1661,7 +1878,7 @@ export async function runTask(
     await deps.git(["add", "--", ...worker.filesWritten], wt);
     const commit = await deps.git([...NOSIGN, "commit", "-m", `farm(${t.id}): ${t.description}`], wt);
     if (commit.code !== 0)
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `commit failed: ${commit.out.slice(0, 200)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
 
     const diffstat = (await deps.git(["diff", "--stat", `${ENV.base}...${branch}`], wt)).out.trim();
 
@@ -1694,16 +1911,22 @@ export async function runTask(
         continue;
       }
       // retries exhausted — escalate exactly as before (worktree left for inspection)
-      return { id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens };
+      return finish({ id: t.id, status: "escalate", attempts: attempt, branch, worktree: wt, note: `merge failed vs integration: ${String(merged).slice(0, 160)}`, filesWritten: worker.filesWritten, promptTokens, completionTokens });
     }
 
-    // success — drop the worktree (branch stays, merged into integration)
-    await deps.git(["worktree", "remove", "--force", wt]).catch(() => {});
-    return { id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore, samples, acceptedPromptTokens, acceptedCompletionTokens };
+    // success — drop the worktree (branch stays, merged into integration).
+    // #398: verified. This teardown used to be a bare `.catch(() => {})` one
+    // line above `status: "green"`, so a locked or otherwise unremovable
+    // worktree produced an unqualified green result and a silent leak. Now the
+    // outcome travels on the Result (and from there into the receipt, the
+    // summary, and the exit code) — green still means the work merged, but it
+    // can no longer also mean "and we quietly abandoned a worktree".
+    noteCleanup(await removeWorktreeVerified(deps.git, wt));
+    return finish({ id: t.id, status: "green", attempts: attempt, branch, worktree: wt, warning: lastWarning, filesWritten: worker.filesWritten, diffstat, promptTokens, completionTokens, mutationScore, samples, acceptedPromptTokens, acceptedCompletionTokens });
   }
 
   // worktree intentionally left in place for inspection
-  return { id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore };
+  return finish({ id: t.id, status: "escalate", attempts: limit + 1, branch, worktree: wt, note: priorFailure?.split("\n")[0], filesWritten: lastFilesWritten, promptTokens, completionTokens, mutationScore });
 }
 
 // --------------------------------------------------------------------------
@@ -2394,6 +2617,24 @@ async function main() {
       blocked.push({ id, reason: aborted ? "run aborted (circuit breaker)" : culprit ? `dependency ${culprit} escalated` : "not scheduled" });
     }
   } finally {
+    // reliability-004 (T-07a): only remove the integration worktree if it was
+    // actually assigned. An early throw (e.g. the integration branch could not
+    // be created) leaves `integrationWorktree` undefined; passing undefined as an
+    // argv element into spawn throws a synchronous TypeError out of this finally,
+    // masking the real, actionable error. Guard it so the original error
+    // surfaces.
+    //
+    // #398: this now runs BEFORE writeReport, not after. The teardown outcome
+    // has to be IN the receipt — a leak an operator only learns about from a
+    // console line they scrolled past is exactly the silent-green failure this
+    // fixes — and the report payload is serialized inside writeReport, so any
+    // teardown performed afterwards could never appear in it. Nothing in
+    // writeReport reads the integration worktree (its `git diff` runs against
+    // the main checkout), so the reordering is safe.
+    if (integrationWorktree) {
+      const c = await removeWorktreeVerified(git, integrationWorktree);
+      if (!c.ok) health.cleanup.failures.push({ target: c.target, detail: c.detail ?? "unverified" });
+    }
     // #387: the report is still written from the `finally` (so an abort or a
     // mid-run throw still produces a receipt), but its failure is no longer
     // absorbed by a console.error. It is captured and turned into a distinct
@@ -2405,14 +2646,6 @@ async function main() {
       publishError = e;
       console.error("report publication failed:", e);
     }
-    // reliability-004 (T-07a): only remove the integration worktree if it was
-    // actually assigned. An early throw (e.g. the integration branch could not
-    // be created) leaves `integrationWorktree` undefined; passing undefined as an
-    // argv element into spawn throws a synchronous TypeError out of this finally,
-    // masking the real, actionable error. Guard it so the original error
-    // surfaces.
-    if (integrationWorktree)
-      await git(["worktree", "remove", "--force", integrationWorktree]).catch(() => {});
   }
 
   const results = [...done.values()];
@@ -2434,8 +2667,15 @@ async function main() {
   // last-writer-wins; failing the run on them would over-report failure in
   // exactly the concurrent-run case this design exists to make safe. They are
   // reported as a warning below instead.
-  const runExitCode = esc || blocked.length || aborted ? 2 : 0;
-  const exitCode = publishError ? 3 : runExitCode;
+  //
+  // #398 adds a fourth input on the "2" side: an unreleased worktree or branch.
+  // That is NOT a convenience-mirror failure — it is the farm still holding a
+  // claim on a directory and a ref that the next run will collide with or
+  // destructively pre-clean, so it belongs with "the run did not come out
+  // clean" rather than in a warning line.
+  const leaks = cleanupFailures(health, results);
+  const runOutcome = runExitCode({ escalated: esc, blocked: blocked.length, aborted, cleanupFailures: leaks.length });
+  const exitCode = publishError ? 3 : runOutcome;
   const latestReportErrors = health.report.latestMirrorErrors;
   const summary = [
     aborted ? `\nABORTED by circuit breaker — escalation rate exceeded ${ENV.abortEscalationRate}. The model may not be capable of this plan; consider the premium path or a different FARM_MODEL.` : ``,
@@ -2443,6 +2683,15 @@ async function main() {
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     `Integration: ${ENV.integration}  ->  review & PR to ${ENV.base}`,
     `Run: ${runId}  (artifacts: ${runDir})`,
+    // #398: never let a leak be something the operator has to go looking for.
+    leaks.length
+      ? [
+          `\nCLEANUP DEGRADED — ${leaks.length} resource(s) could not be released and re-verified:`,
+          ...leaks.map((l) => `  - ${l.target} (${l.owner}): ${l.detail}`),
+          `Git may still register these worktrees, or the directories may still be on disk. The next run's`,
+          `pre-cleanup is destructive and best-effort, so clear them before re-running. Exit is non-zero for this alone.`,
+        ].join("\n")
+      : ``,
     // The success breadcrumb is SUPPRESSED when the authoritative publication
     // failed — pointing an operator at a farm-report.md that is not there is
     // the defect. Every claim below has to be true of what is actually on disk:
@@ -2452,10 +2701,10 @@ async function main() {
     publishError
       ? [
           `\nRECEIPT PUBLICATION FAILED — run ${runId} could not publish its complete authoritative report under ${runDir}: ${msgOf(publishError)}`,
-          `The tasks themselves finished ${runExitCode === 0 ? "green" : "with escalations/blocks"}, but this run's durable receipt is missing or incomplete,`,
+          `The tasks themselves finished ${runOutcome === 0 ? "green" : "with escalations/blocks/unreleased worktrees"}, but this run's durable receipt is missing or incomplete,`,
           `so it cannot be reliably reconciled or audited. Inspect ${runDir} for whatever did land.`,
           `${path.join(ENV.reportDir, "farm-report.json")} / .md were NOT refreshed and do not describe run ${runId}.`,
-          `Exiting 3 (receipt failure) rather than ${runExitCode} (task outcome).`,
+          `Exiting 3 (receipt failure) rather than ${runOutcome} (task outcome).`,
         ].join("\n")
       : latestReportErrors.length
         ? // Non-fatal, and stated as such. The authoritative receipt is
@@ -2529,6 +2778,7 @@ async function writeReport(
 
   const pTok = results.reduce((n, r) => n + (r.promptTokens ?? 0), 0);
   const cTok = results.reduce((n, r) => n + (r.completionTokens ?? 0), 0);
+  const leaks = cleanupFailures(health, results);
 
   // #387: the report carries its own integrity statement, so a consumer never
   // has to guess whether a short stream or a missing patch is real or a
@@ -2551,6 +2801,10 @@ async function writeReport(
       unavailable_total: health.diffs.unavailableTotal,
       latest_mirror_errors: health.diffs.latestMirrorErrors,
     },
+    // #398: the run's resource-ownership statement. `released` is an explicit
+    // positive claim, so a consumer can distinguish "nothing leaked" from "this
+    // report predates the check" without inferring it from an absent key.
+    cleanup: { released: leaks.length === 0, failures: leaks },
   };
 
   const json = JSON.stringify(
@@ -2564,6 +2818,7 @@ async function writeReport(
     ``,
     aborted ? `> **ABORTED by circuit breaker** — escalation rate exceeded threshold.\n` : ``,
     streamComplete ? `` : `> **Streaming rail incomplete** — ${health.stream.errors.length} write failure(s) on \`farm-results.jsonl\`; this report is authoritative for settled tasks.\n`,
+    leaks.length ? `> **CLEANUP DEGRADED** — ${leaks.length} worktree/branch could not be released; see Resource cleanup below.\n` : ``,
     `Run: \`${runId}\` — artifacts under \`${runDir}\``,
     `Worker tokens: prompt=${pTok} completion=${cTok}`,
     ``,
@@ -2584,6 +2839,8 @@ async function writeReport(
           ...unavailable.map((u) => `- **${u.id}** — diff evidence unavailable: ${u.reason}`),
         ]
       : [`Every settled task with a non-empty diff has a patch under \`${diffsDir}\`.`]),
+    ``,
+    ...cleanupReportLines(health, results),
     ``,
     `## Warnings — review during spec-compliance`,
     ...results.filter((r) => r.warning).map((r) => {

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -11,7 +11,10 @@ import { tmpdir } from "node:os";
 import { extractFileBlocks, extractLiterals, codeLineCount, validate, assertSecureBaseUrl, runTask, httpWorker, DEFAULT_API_BASE_URL, parseChatCompletion, checkDrift, screenEntitlements, makeEntitlementProbe, redactSecrets, run, runGate, mintRunId, parseMutationHookOutput, buildChatBody, readSampling, buildPrompt, captureInScope, createLimiter, validateWorktreeRoot, assertContainedWorktree, allowedWorktreeRoot, _resetAllowedWorktreeRoot, numEnv, atomicWriteFile, assertSafeRunId } from "./farm.ts";
 import type { InjectedFile, Sampling } from "./farm.ts";
 import type { Worker, WorkerResult, RunTaskDeps, Task } from "./farm.ts";
-import { scrubbedEnv } from "./exec.ts";
+import { removeWorktreeVerified, deleteBranchVerified, runExitCode, newRunArtifactHealth, cleanupReportLines } from "./farm.ts";
+import { scrubbedEnv, treeKill, taskkillPath } from "./exec.ts";
+import type { RunResult } from "./exec.ts";
+import { spawn } from "node:child_process";
 import { mutationCheck as realMutationCheck } from "./mutation.ts";
 
 // ---------------------------------------------------------------------------
@@ -2265,5 +2268,267 @@ describe("assertSafeRunId — run id is a path segment (#397)", () => {
   it("rejects traversal, separators, dot ids and empty/oversized ids", () => {
     for (const bad of ["..", ".", "../escape", "a/b", "a\\b", "", "x".repeat(65), "a b"])
       expect(() => assertSafeRunId(bad)).toThrow(/FARM_RUN_ID/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #395 — farm timeout cleanup must own the ENTIRE child process tree.
+//
+// A gate/setup/mutation command that times out is killed, but the kill has to
+// reach the GRANDCHILDREN too: every gate command is `bash -c <cmd>` /
+// `cmd.exe /c <cmd>`, so the thing the operator actually named is a grandchild.
+// Before this fix `treeKill` SIGKILLed only the direct child off-Windows (the
+// grandchild survived, reparented to init) and on Windows fire-and-forgot an
+// unqualified `spawn("taskkill", ...)` whose exit was never awaited — `run()`
+// resolved exit 124 while the tree was still being torn down, or not at all.
+// ---------------------------------------------------------------------------
+describe("#395 — timeout kills and VERIFIES the whole child process tree", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "farm-tree-"));
+  });
+  afterEach(async () => {
+    await fsRm(dir, { recursive: true, force: true });
+  });
+
+  // libuv maps signal 0 to a liveness probe on every platform (on Windows it
+  // reports ESRCH for a terminated-but-not-yet-freed process), so this is a
+  // faithful cross-platform "is this pid still running?".
+  const alive = (pid: number) => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  // A direct child that hangs forever AND spawns a hanging GRANDCHILD, writing
+  // the grandchild's pid where the test can read it. `node -e` runs as CJS.
+  const parentSrc = (pidFile: string) => `
+    const { spawn } = require("node:child_process");
+    const fs = require("node:fs");
+    const gc = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], { stdio: "ignore" });
+    fs.writeFileSync(${JSON.stringify(pidFile)}, String(gc.pid));
+    setInterval(() => {}, 1000);
+  `;
+
+  const waitForPid = async (file: string, budgetMs: number): Promise<number> => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < budgetMs) {
+      try {
+        const raw = (await fsReadFile(file, "utf8")).trim();
+        if (raw) return Number(raw);
+      } catch {
+        /* not written yet */
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error("grandchild pid file never appeared");
+  };
+
+  it("leaves NO grandchild behind — the tree is verified gone before run() resolves", async () => {
+    const pidFile = path.join(dir, "gc.pid");
+    const pending = run(process.execPath, ["-e", parentSrc(pidFile)], undefined, {}, 4000);
+    const gcPid = await waitForPid(pidFile, 3000);
+    expect(alive(gcPid)).toBe(true); // the grandchild really exists
+    const r = await pending;
+    expect(r.timedOut).toBe(true);
+    // The containment claim: when run() resolves, the descendant is GONE.
+    expect(alive(gcPid)).toBe(false);
+    // A clean kill stays the ordinary timeout result.
+    expect(r.code).toBe(124);
+    expect(r.cleanupFailed).toBeUndefined();
+  }, 30000);
+
+  it("treeKill resolves a verification result instead of firing and forgetting", async () => {
+    const c = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+      detached: process.platform !== "win32",
+      stdio: "ignore",
+    });
+    const k = await treeKill(c);
+    expect(k.ok).toBe(true);
+    expect(alive(c.pid!)).toBe(false);
+  }, 30000);
+
+  it("resolves taskkill absolutely from SystemRoot (an unqualified name is a PATH hazard)", () => {
+    const saved = process.env.SystemRoot;
+    try {
+      process.env.SystemRoot = path.join(path.sep, "WinDirForTest");
+      const p = taskkillPath();
+      expect(p).not.toBe("taskkill");
+      expect(path.isAbsolute(p)).toBe(true);
+      expect(p).toBe(path.join(path.sep, "WinDirForTest", "System32", "taskkill.exe"));
+    } finally {
+      if (saved === undefined) delete process.env.SystemRoot;
+      else process.env.SystemRoot = saved;
+    }
+  });
+
+  it("reports an UNVERIFIED cleanup distinctly from an ordinary timeout", async () => {
+    const r = await run(
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000);"],
+      undefined,
+      {},
+      200,
+      // Kill for real (no leak from the test), but report the kill as unverified.
+      async (child) => {
+        await treeKill(child);
+        return { ok: false, detail: "descendant pid 4242 still alive" };
+      },
+    );
+    expect(r.timedOut).toBe(true);
+    expect(r.cleanupFailed).toBe(true);
+    // Distinct from the ordinary 124 timeout: the caller can tell "killed" from
+    // "we could not prove it was killed".
+    expect(r.code).toBe(125);
+    expect(r.out).toMatch(/CLEANUP UNVERIFIED/);
+    expect(r.out).toMatch(/descendant pid 4242 still alive/);
+    expect(r.stderr).toMatch(/CLEANUP UNVERIFIED/);
+  }, 30000);
+});
+
+// ---------------------------------------------------------------------------
+// #398 — worktree teardown must be verified, retried, and REPORTED. Before this
+// fix every teardown site ended in a bare `.catch(() => {})` and the task
+// returned status "green" one line later, so a Windows lock / AV race left a
+// live worktree registration behind under a clean green report.
+// ---------------------------------------------------------------------------
+describe("#398 — verified, retried, reported worktree teardown", () => {
+  const res = (code: number, out = ""): RunResult => ({ code, out, stdout: out, stderr: "" });
+  const wt = path.resolve(".farm/worktrees/tt-398");
+
+  it("retries a transient remove failure and confirms git no longer registers the worktree", async () => {
+    const calls: string[][] = [];
+    let removes = 0;
+    const git = async (args: string[]): Promise<RunResult> => {
+      calls.push(args);
+      if (args[0] === "worktree" && args[1] === "remove") {
+        removes++;
+        return removes < 2 ? res(1, "fatal: failed to delete: Directory not empty") : res(0);
+      }
+      if (args[0] === "worktree" && args[1] === "list") return res(0, removes < 2 ? `worktree ${wt}\n` : "");
+      return res(0);
+    };
+    const r = await removeWorktreeVerified(git, wt, { attempts: 4, delayMs: 1 });
+    expect(r.ok).toBe(true);
+    expect(r.attempts).toBe(2);
+    // Re-verification actually happened — a list AND a prune are on the wire.
+    expect(calls.some((a) => a[0] === "worktree" && a[1] === "list")).toBe(true);
+    expect(calls.some((a) => a[0] === "worktree" && a[1] === "prune")).toBe(true);
+  });
+
+  it("returns ok:false with diagnostics when git still registers the worktree after every attempt", async () => {
+    const git = async (args: string[]): Promise<RunResult> => {
+      if (args[0] === "worktree" && args[1] === "remove") return res(1, "fatal: '.farm/worktrees/tt-398' is locked");
+      if (args[0] === "worktree" && args[1] === "list") return res(0, `worktree ${wt}\n`);
+      return res(0);
+    };
+    const r = await removeWorktreeVerified(git, wt, { attempts: 2, delayMs: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.attempts).toBe(2);
+    expect(r.target).toBe(wt);
+    expect(r.detail).toMatch(/still registered/i);
+    expect(r.detail).toMatch(/is locked/);
+  });
+
+  it("deleteBranchVerified reports a branch git still lists", async () => {
+    const git = async (args: string[]): Promise<RunResult> => {
+      if (args[0] === "branch" && args[1] === "-D") return res(1, "error: Cannot delete branch 'farm/x' checked out at ...");
+      if (args[0] === "branch" && args[1] === "--list") return res(0, "  farm/x\n");
+      return res(0);
+    };
+    const r = await deleteBranchVerified(git, "farm/x", { attempts: 2, delayMs: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.target).toBe("farm/x");
+    expect(r.detail).toMatch(/still present/i);
+  });
+
+  // ---- wiring: the failures reach the task result and the run's exit code ----
+  const task: Task = {
+    id: "tt-398",
+    description: "make the test pass",
+    filesInScope: ["src/x.ts"],
+    test: { path: "src/x.test.ts" },
+    gate: { commands: ["node -p 0"] },
+  };
+
+  const stubDeps = (git: RunTaskDeps["git"]): RunTaskDeps => ({
+    worker: {
+      async apply(ctx) {
+        const k = ctx.cwd.match(/__s(\d+)$/)?.[1] ?? "main";
+        return { ok: true, filesWritten: [`src/s${k}.ts`] } satisfies WorkerResult;
+      },
+    },
+    prepareWorktree: async () => null,
+    resetWorktree: async () => {},
+    fileHash: async () => null,
+    checkDrift: async () => [],
+    runGate: async () => ({ ok: true as const }),
+    antiGamingCheck: async () => ({ risk: "none" as const }),
+    mutationCheck: async () => null,
+    git,
+    withMergeLock: async <T,>(fn: () => Promise<T>) => fn(),
+  });
+
+  it("a task whose worktree removal cannot be verified carries the failure — green is never unqualified", async () => {
+    const git: RunTaskDeps["git"] = async (args) => {
+      if (args[0] === "worktree" && args[1] === "remove") return res(1, "fatal: is locked");
+      if (args[0] === "worktree" && args[1] === "list") return res(0, `worktree ${wt}\n`);
+      return res(0);
+    };
+    const r = await runTask({ ...task, maxRetries: 0 }, "m", "https://api.example/v1", "k", stubDeps(git));
+    expect(r.status).toBe("green");
+    const failed = (r.cleanup ?? []).filter((c) => !c.ok);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].target).toBe(wt);
+    expect(runExitCode({ escalated: 0, blocked: 0, aborted: false, cleanupFailures: failed.length })).toBe(2);
+  });
+
+  it("best-of-N attempts EVERY sample's teardown even when an earlier one fails, and reports all leftovers", async () => {
+    const savedSamples = process.env.FARM_SAMPLES;
+    process.env.FARM_SAMPLES = "3";
+    try {
+      const removed: string[] = [];
+      const git: RunTaskDeps["git"] = async (args) => {
+        if (args[0] === "worktree" && args[1] === "remove") {
+          removed.push(args[3]);
+          return args[3].endsWith("__s0") ? res(1, "fatal: is locked") : res(0);
+        }
+        if (args[0] === "worktree" && args[1] === "list")
+          return res(0, removed.some((p) => p.endsWith("__s0")) ? `worktree ${wt}__s0\n` : "");
+        return res(0);
+      };
+      const r = await runTask({ ...task, maxRetries: 0 }, "m", "https://api.example/v1", "k", stubDeps(git));
+      expect(r.status).toBe("green");
+      // Every sample was attempted — the first failure did not abort the loop.
+      for (const k of [0, 1, 2]) expect(removed).toContain(`${wt}__s${k}`);
+      const failed = (r.cleanup ?? []).filter((c) => !c.ok);
+      expect(failed.some((c) => c.target.endsWith("__s0"))).toBe(true);
+    } finally {
+      if (savedSamples === undefined) delete process.env.FARM_SAMPLES;
+      else process.env.FARM_SAMPLES = savedSamples;
+    }
+  });
+
+  it("run exit code is non-zero when ownership could not be released, zero otherwise", () => {
+    expect(runExitCode({ escalated: 0, blocked: 0, aborted: false, cleanupFailures: 0 })).toBe(0);
+    expect(runExitCode({ escalated: 0, blocked: 0, aborted: false, cleanupFailures: 1 })).toBe(2);
+    expect(runExitCode({ escalated: 1, blocked: 0, aborted: false, cleanupFailures: 0 })).toBe(2);
+  });
+
+  it("integration-worktree teardown failure is carried on the run health and lands in the receipt", () => {
+    const health = newRunArtifactHealth();
+    expect(health.cleanup.failures).toEqual([]);
+    expect(cleanupReportLines(health, [])).toEqual([
+      `## Resource cleanup`,
+      `Every farm worktree and scratch branch was removed and re-verified.`,
+    ]);
+    health.cleanup.failures.push({ target: "/repo/.farm/integration-wt", detail: "still registered after 3 attempt(s)" });
+    const lines = cleanupReportLines(health, []);
+    expect(lines.join("\n")).toMatch(/CLEANUP DEGRADED/);
+    expect(lines.join("\n")).toMatch(/integration-wt/);
+    expect(lines.join("\n")).toMatch(/still registered after 3 attempt\(s\)/);
   });
 });

--- a/plugins/ca/tools/mutation.ts
+++ b/plugins/ca/tools/mutation.ts
@@ -21,6 +21,8 @@ import {
   SHELL_FLAG,
   SHELL_OPTS,
   GATE_TIMEOUT_MS,
+  EXIT_TIMEOUT,
+  EXIT_TIMEOUT_UNCLEAN,
 } from "./exec.ts";
 import { redactSecrets } from "./redactor.ts";
 import { isUnsafeWorktreePathError, writeWorktreeFile } from "./worktree-fs.ts";
@@ -202,9 +204,14 @@ export async function mutationCheck(wt: string, task: Task): Promise<MutationChe
         cwd: wt,
         env: scrubbedEnv({ FARM_MUTATION_FILES: impl.join(","), FARM_MUTATION_TEST_PATH: task.test.path, FARM_MUTATION_TEST_CMD: testCmd }),
         ...SHELL_OPTS,
+        // #395: process-group isolation, matching run(). The operator-authored
+        // mutation hook is a grandchild behind `bash -c` / `cmd.exe /c`, so the
+        // timeout kill must be able to address the group, not just the shell.
+        detached: process.platform !== "win32",
       });
       let out = "";
       let settled = false;
+      let killing = false;
       const finish = (res: { code: number; out: string }) => {
         if (settled) return;
         settled = true;
@@ -215,14 +222,29 @@ export async function mutationCheck(wt: string, task: Task): Promise<MutationChe
       // timeout. A hung mutation framework would otherwise wedge the worker; on
       // timeout the child tree is killed and the result is treated as
       // unparseable (score skipped leniently — no false escalation).
+      // #395: the kill is now AWAITED and verified, and an unverified cleanup is
+      // reported in `out` — which observability-002 turns into the "configured
+      // but failed" detail, so a leaked mutation-hook tree is visible on the
+      // task result instead of being swallowed by a lenient score skip.
       const timer = setTimeout(() => {
-        treeKill(c);
-        finish({ code: 124, out: out + "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout — killed" });
+        killing = true;
+        void treeKill(c).then((k) => {
+          const note = k.ok
+            ? "\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout — killed"
+            : `\n[FARM] FARM_MUTATION_CMD exceeded the wall-clock timeout — killed, but CLEANUP UNVERIFIED: ${k.detail ?? "no detail"}`;
+          finish({ code: k.ok ? EXIT_TIMEOUT : EXIT_TIMEOUT_UNCLEAN, out: out + note });
+        });
       }, GATE_TIMEOUT_MS);
       c.stdout.on("data", (d) => (out += d));
       c.stderr.on("data", (d) => (out += d));
-      c.on("error", (e) => finish({ code: 1, out: String(e) }));
-      c.on("close", (code) => finish({ code: code ?? 1, out }));
+      c.on("error", (e) => {
+        if (killing) return;
+        finish({ code: 1, out: String(e) });
+      });
+      c.on("close", (code) => {
+        if (killing) return;
+        finish({ code: code ?? 1, out });
+      });
     });
     // dx-002 (T-08b): shape-guarded parse of the hook's trailing score line.
     const parsed = parseMutationHookOutput(r.out);


### PR DESCRIPTION
Closes #395
Closes #398

Lane **L01-farm-process-boundary**. Two containment defects with the same shape: a cleanup step was issued, never verified, and the run reported success one line later.

---

## Claim verification (line numbers had drifted — 19 PRs landed since filing)

| Issue claim | Verdict |
| --- | --- |
| #395 `exec.ts:75-89` / `123-145` | **REAL**, drifted to `exec.ts:79-89` (`treeKill`) and `116-147` (`run`). Every sub-claim held: spawn without `detached` (124), `child.kill("SIGKILL")` only off-Windows (84), unqualified fire-and-forget `spawn("taskkill", …)` (82), timer resolving 124 with no descendant check (136-140). |
| #398 `farm.ts:1154-1167` (sample teardown) | **REAL**, drifted to `farm.ts:1423-1426`. |
| #398 `farm.ts:1422-1424` (success path) | **REAL**, drifted to `farm.ts:1700-1702` — `.catch(() => {})` immediately followed by `status: "green"` on 1702. |
| #398 `farm.ts:1900-1910` (run `finally`) | **REAL**, drifted to `farm.ts:2414-2415`. |
| #398 "no `git worktree list`/`prune` re-verification anywhere" | **REAL** — confirmed by grep across `farm.ts`. |

**Deliberately NOT changed:** `prepareWorktree` (`farm.ts:1257-1259`) has the identical `.catch(() => {})` trio. That is stale-leftover **pre**-cleanup before a `git worktree add` that already fails loudly on its own (`worktree add failed: …` → escalate), not a teardown claim. Swallowing there is correct and is left alone.

---

## #395 — the timeout kill did not own the process tree

Every gate, setup and mutation command runs as `bash -c <cmd>` / `cmd.exe /c <cmd>`, so **the operator-authored (model-influenced) command is a grandchild**. The old kill reached only the shell.

- `run()` now spawns `detached` off Windows, so the child leads its own process group and `kill(-pid)` addresses the whole tree at once. Not on Windows, where `detached` means "new console" and breaks `cmd.exe /c`.
- `treeKill` is `async` and **verifies absence** — pid probe plus process-group probe via signal 0, polled to a budget (`FARM_KILL_VERIFY_MS`, default 10s) — before it reports success. `EPERM` reads as *present*, never as gone.
- Windows resolves `taskkill.exe` **absolutely** from `%SystemRoot%` (an unqualified name is resolved through `%PATH%` — a resolution hazard inside the containment step itself) and **awaits it to completion**. Exit 128 ("process not found") counts as success.
- A cleanup that cannot be verified is a **distinct outcome**: exit `125` + `cleanupFailed: true` + a `CLEANUP UNVERIFIED` note on both `out` and `stderr`, instead of a clean-looking 124. Both codes are non-zero, so every existing `code !== 0` consumer branch is untouched.
- `detached` is now in `RunOpts`'s `Omit` list, so the group-isolation invariant is compiler-enforced alongside the existing env-scrub and argv-array invariants.
- `run()` sets a `killing` flag *before* the (now awaited) kill — otherwise the child's own `close`, which the kill itself causes, wins the race and resolves an ordinary exit result, discarding both the `timedOut` tag and the cleanup verdict.
- `mutation.ts`'s own `spawn` gets the same treatment, and surfaces `CLEANUP UNVERIFIED` into the observability-002 "configured but failed" detail.

## #398 — teardown was best-effort and unreported

- `removeWorktreeVerified` / `deleteBranchVerified`: bounded retry with backoff (3 × 150ms, Windows lock/AV race), then re-verify against `git worktree list --porcelain` **and** the filesystem (`git branch --list` for branches — an empty listing unambiguously means absent, whereas `rev-parse`'s exit code also encodes other failures). The **verification**, not the removal command's exit code, is the authority.
- `git worktree prune` runs **only** when git still registers the target but the directory is already gone. It is repo-wide, and a blanket call would deregister an unrelated worktree whose path is merely unreachable.
- Best-of-N attempts **every** sample even after one fails — one stuck sample no longer hides the ones behind it (and a leaked sample worktree keeps its branch checked out, so the branch delete fails too; both are now reported).
- Task-owned leaks ride on the `Result` (`cleanup: CleanupOutcome[]`, present only when something failed); the run-level integration worktree rides on `RunArtifactHealth.cleanup`.
- Integration teardown now runs **before** `writeReport`, not after, so it lands in the authoritative receipt rather than a console line the operator scrolled past. Nothing in `writeReport` reads that worktree (`git diff` runs against the main checkout), so the reorder is safe.
- Following #430's tiering: releasing worktree ownership is **authoritative**, not a convenience mirror. A leak lifts the run to **exit 2** via the new pure `runExitCode()` and prints a `CLEANUP DEGRADED` block naming every unreleased resource. Exit 3 (receipt failure) still outranks it.
- The report gains a `## Resource cleanup` section and an `artifacts.cleanup.released` boolean, stated in **both** directions on purpose — silence is not evidence of a clean teardown, so an operator can tell "nothing leaked" from "this report predates the check".

`status` stays `"green"` for a task whose work genuinely merged; flipping it to `escalate` would wrongly block dependent tasks. Green now means "the work merged" and can no longer *also* mean "and we quietly abandoned a worktree" — the leak travels on the result, into the receipt, onto the summary, and into the exit code.

---

## Verbatim red (before implementation)

```
⎯⎯⎯⎯⎯⎯ Failed Tests 11 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  farm.unit.test.ts > #395 — timeout kills and VERIFIES the whole child process tree > leaves NO grandchild behind — the tree is verified gone before run() resolves
AssertionError: expected true to be false // Object.is equality
 FAIL  farm.unit.test.ts > #395 — timeout kills and VERIFIES the whole child process tree > treeKill resolves a verification result instead of firing and forgetting
TypeError: Cannot read properties of undefined (reading 'ok')
 FAIL  farm.unit.test.ts > #395 — timeout kills and VERIFIES the whole child process tree > resolves taskkill absolutely from SystemRoot (an unqualified name is a PATH hazard)
TypeError: taskkillPath is not a function
 FAIL  farm.unit.test.ts > #395 — timeout kills and VERIFIES the whole child process tree > reports an UNVERIFIED cleanup distinctly from an ordinary timeout
AssertionError: expected undefined to be true // Object.is equality
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > retries a transient remove failure and confirms git no longer registers the worktree
TypeError: removeWorktreeVerified is not a function
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > returns ok:false with diagnostics when git still registers the worktree after every attempt
TypeError: removeWorktreeVerified is not a function
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > deleteBranchVerified reports a branch git still lists
TypeError: deleteBranchVerified is not a function
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > a task whose worktree removal cannot be verified carries the failure — green is never unqualified
AssertionError: expected [] to have a length of 1 but got +0
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > best-of-N attempts EVERY sample's teardown even when an earlier one fails, and reports all leftovers
AssertionError: expected false to be true // Object.is equality
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > run exit code is non-zero when ownership could not be released, zero otherwise
TypeError: runExitCode is not a function
 FAIL  farm.unit.test.ts > #398 — verified, retried, reported worktree teardown > integration-worktree teardown failure is carried on the run health and lands in the receipt
TypeError: Cannot read properties of undefined (reading 'failures')
 Test Files  1 failed (1)
      Tests  11 failed | 182 passed (193)
```

The load-bearing one is the first: `expected true to be false` on `alive(gcPid)` **after `run()` resolved**. That is the live fixture (a hanging child that spawns a hanging grandchild, recording its pid) reproducing the actual containment defect on Windows — the grandchild was still running while the run reported a clean timeout. Every other failure is a "right reason" red: the symbol under test does not exist yet, or the field the fix introduces is absent.

## Suites — before / after

| Suite | Baseline | After |
| --- | --- | --- |
| `plugins/ca/tools` — `npx vitest run` | 287 passed, 1 skipped | **298 passed, 1 skipped** (+11 new) |
| `plugins/ca/tools` — `npx tsc --noEmit` | clean | **clean** |
| `plugins/ca/hooks/tests` | 1112 OK | **Ran 1112 tests — OK** |
| `.github/scripts` | 1110 OK, 5 skipped | **Ran 1110 tests — OK (skipped=5)** |

The whole `plugins/ca/tools` suite (including `farm.test.ts`'s real-git, real-worktree smoke tests such as *"best-of-N … cleans up scratch worktrees"* and *"is safe to run twice in a row (stale branches cleaned)"*) passes against real git with the new verified teardown in place.

`plugins/ca/tools/farm.js` — the committed esbuild artifact — is rebuilt and committed.

## NEEDS-TRIAGE

1. **Ctrl-C no longer reaches a running gate command (off Windows).** `detached: true` puts the child in its own process group, so a terminal `SIGINT` sent to farm's foreground group no longer propagates to it. Farm has no `SIGINT`/`SIGTERM` handler today, so an interrupted run now leaves the in-flight gate command running where it previously died with the terminal. This is the same leak class this PR fixes, on a path the issue did not cover; the fix is a signal handler in `main()` that tree-kills every in-flight child, which is a separate change. Windows is unaffected (`detached` is not set there).
2. **Descendant verification is a group/pid probe, not a PID census.** #395's AC says "all recorded PIDs are verified absent". We verify the process *group* is empty (POSIX) and that `taskkill /T /F` completed and the root pid is gone (Windows) — behaviourally equivalent for a tree we own, and proven by the live grandchild fixture, but it is not an enumeration of individually recorded pids. A double-fork daemon that calls `setsid()` escapes the group and would not be detected on either platform.
3. **`FARM_KILL_VERIFY_MS` is a new knob** (default 10 000ms, min 0) and is not yet documented in `.env.example` or the farm docs.
4. **`worktree list --porcelain` is re-read once per removal attempt.** On a repo with very many worktrees this is O(worktrees) per teardown. Negligible at farm's scale; noted so it is not a surprise later.
5. **Environment, not this branch:** the `.github/scripts` suite fails 4 `test_pi_benchmark` cases in a fresh worktree until `plugins/ca-pi/tools` deps are installed (`RuntimeError: Pi benchmark requires the installed pinned esbuild`). After `npm ci` there it is 1110 OK / 5 skipped. Worth a clearer skip-vs-fail decision in that test.
6. **Tooling friction (no repo change needed):** the installed plugin payload in this environment is `ca@2.8.11`, which predates #223's linked-worktree fix, so `H-01` judged the branch from `CLAUDE_PROJECT_DIR` (the main checkout, on `main`) and blocked every commit from this worktree. Worked around by addressing the repo explicitly — `git -C <worktree> commit …` — which is what `git_cwd` composes against, so the gate ran and passed on the real branch. No `--no-verify`, no override. The repo's own current hooks resolve this correctly; only the installed 2.8.11 payload is stale.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
