### PR TITLE
fix(ca-pi): give every Pi audit sink one hardened owner and validate host compaction events

### DIFF
--- a/.github/scripts/test_host_descriptors.py
+++ b/.github/scripts/test_host_descriptors.py
@@ -152,6 +152,13 @@ _ISSUE_370_NON_POLICY_ARTIFACTS = frozenset({
     "tools/test/live-pi-host.ts",
 })
 
+# Exact artifacts approved by issue #374's single hardened audit sink. Path-exact
+# like every set above, so an unlisted file under tools/ still fails closed.
+_ISSUE_374_NON_POLICY_ARTIFACTS = frozenset({
+    "tools/src/audit-sink.ts",
+    "tools/test/audit-sink.test.ts",
+})
+
 
 def _load_module(name, path):
     spec = importlib.util.spec_from_file_location(name, path)
@@ -381,6 +388,7 @@ def _pi_policy_surfaces_from_disk(pi_host):
         | set(_TASK_11_THROUGH_14_NON_POLICY_ARTIFACTS)
         | set(_MODULE_STRUCTURE_NON_POLICY_ARTIFACTS)
         | set(_ISSUE_370_NON_POLICY_ARTIFACTS)
+        | set(_ISSUE_374_NON_POLICY_ARTIFACTS)
         | shared_hooks
         | ({pi_host.catalog} if pi_host.catalog else set())
     )
@@ -724,7 +732,7 @@ class GenerationContractTest(unittest.TestCase):
         for rel in (_TASK_2_NON_POLICY_ARTIFACTS | _TASK_3_NON_POLICY_ARTIFACTS
                     | _TASK_4_NON_POLICY_ARTIFACTS | _TASK_5_NON_POLICY_ARTIFACTS
                     | _TASK_6_THROUGH_10_NON_POLICY_ARTIFACTS | _TASK_11_THROUGH_14_NON_POLICY_ARTIFACTS
-                    | _ISSUE_370_NON_POLICY_ARTIFACTS):
+                    | _ISSUE_370_NON_POLICY_ARTIFACTS | _ISSUE_374_NON_POLICY_ARTIFACTS):
             with self.subTest(rel=rel):
                 self.assertIn(rel, exemptions)
         self.assertFalse(any(item.startswith("tools/") and item.endswith("/**") for item in exemptions))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,7 +490,7 @@ jobs:
       # contracts in .github/scripts are textual (stdlib-only, no YAML parser)
       # and read the covered file set straight off a `run: npm test -- ...` line.
       - name: Test the platform-gated adapter suites on this operating system
-        run: npm test -- test/activation.test.ts test/background-jobs.test.ts test/child-env.test.ts test/commands.test.ts test/plan-mode.test.ts test/runtime-resolver.test.ts test/security.test.ts test/windows-supervisor.test.ts
+        run: npm test -- test/activation.test.ts test/audit-sink.test.ts test/background-jobs.test.ts test/child-env.test.ts test/commands.test.ts test/plan-mode.test.ts test/runtime-resolver.test.ts test/security.test.ts test/windows-supervisor.test.ts
       - name: Test real package RPC activation and aliases
         working-directory: .
         run: python .github/scripts/test_pi_package.py --rpc-commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.13] - 2026-07-25
+
+### Fixed
+
+- Every Pi audit sink is hardened against link and race redirection. The bridge
+  failure audit, the child-dispatch audit, and the confirmed-compaction audit
+  each resolved the project's `.codearbiter` governance log from a
+  caller-supplied cwd and appended to it directly, which follows file symlinks,
+  directory junctions, and hardlinks - so a trusted project could redirect those
+  records onto another same-user file and leave the real log without them. All
+  five producers now share one primitive that canonicalizes the state directory,
+  refuses a linked or escaping one, opens the target no-follow and
+  create-exclusive, and re-verifies the opened handle's identity on both sides
+  of the append. A failed or hostile sink returns false rather than throwing, so
+  no producer's enforcement outcome or fail direction changes.
+- Pi native compaction events are validated before they are narrowed. Both host
+  records were laundered through a type assertion, and the before-compact
+  handler read `event.signal.aborted` and `event.preparation.tokensBefore`
+  before its fail-safe block opened, so a malformed or drifted native record
+  rejected the host callback with a raw `TypeError` instead of the fixed
+  `Pi native compaction failed safely; run /ca-doctor.` diagnostic. Both events
+  are now parsed from `unknown` through exact bounded validators covering the
+  abort signal, preparation, entry array, reason enum, booleans, and optional
+  strings.
+
 ## [0.1.12] - 2026-07-25
 
 ### Changed

--- a/plugins/ca-pi/extensions/codearbiter-child.js
+++ b/plugins/ca-pi/extensions/codearbiter-child.js
@@ -4,7 +4,7 @@ var define_CODEARBITER_PI_TOOL_CLASSES_default = { bash: "EXEC", write: "WRITE",
 // src/child-extension.ts
 import { createReadStream } from "node:fs";
 import { readFile as readFile2, realpath as realpath4 } from "node:fs/promises";
-import { dirname as dirname3, resolve as resolve4 } from "node:path";
+import { dirname as dirname3, resolve as resolve5 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // src/attestation.ts
@@ -30,8 +30,13 @@ function childAttestationDigest(input) {
 import { spawn, spawnSync } from "node:child_process";
 import { createHash as createHash2, randomUUID } from "node:crypto";
 import { accessSync, constants, realpathSync, statSync } from "node:fs";
-import { appendFile, realpath } from "node:fs/promises";
-import { isAbsolute, posix as posix2, resolve as resolve2, win32 as win322 } from "node:path";
+import { realpath as realpath2 } from "node:fs/promises";
+import { isAbsolute, posix as posix2, win32 as win322 } from "node:path";
+
+// src/audit-sink.ts
+import { constants as fsConstants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import { relative, resolve as resolve2 } from "node:path";
 
 // src/path-boundary.ts
 import { posix, resolve, win32 } from "node:path";
@@ -45,6 +50,99 @@ function lexicallyInside(path, root, flavor = flavorForPlatform(process.platform
   const pathApi = pathApiFor(flavor);
   const suffix = pathApi.relative(root, path);
   return suffix === "" || !suffix.startsWith("..") && !pathApi.isAbsolute(suffix);
+}
+
+// src/audit-sink.ts
+var AUDIT_LOG_NAME = "gate-events.log";
+var AUDIT_STATE_DIRECTORY = ".codearbiter";
+var MAX_AUDIT_LINE_BYTES = 2048;
+var NODE_AUDIT_SINK_IO = Object.freeze({ realpath, lstat, open });
+function sameAuditFile(left, right) {
+  return left.isFile() && right.isFile() && !left.isSymbolicLink() && !right.isSymbolicLink() && left.nlink === 1 && right.nlink === 1 && left.dev === right.dev && left.ino === right.ino;
+}
+function sameAuditDirectory(left, right) {
+  return left.isDirectory() && right.isDirectory() && !left.isSymbolicLink() && !right.isSymbolicLink() && left.dev === right.dev && left.ino === right.ino;
+}
+async function openedAuditTarget(target, io) {
+  const noFollow = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+  const existingFlags = fsConstants.O_WRONLY | fsConstants.O_APPEND | noFollow;
+  const createFlags = existingFlags | fsConstants.O_CREAT | fsConstants.O_EXCL;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let expected;
+    try {
+      expected = await io.lstat(target);
+      if (!expected.isFile() || expected.isSymbolicLink() || expected.nlink !== 1) return void 0;
+    } catch (error) {
+      if (error.code !== "ENOENT") return void 0;
+    }
+    let handle;
+    try {
+      handle = await io.open(target, expected === void 0 ? createFlags : existingFlags, 384);
+    } catch (error) {
+      if (expected === void 0 && error.code === "EEXIST" && attempt === 0) continue;
+      return void 0;
+    }
+    try {
+      const opened = await handle.stat();
+      const pathname = await io.lstat(target);
+      if (!sameAuditFile(opened, pathname) || expected !== void 0 && !sameAuditFile(opened, expected)) {
+        await handle.close();
+        return void 0;
+      }
+      return Object.freeze({ handle, identity: opened });
+    } catch {
+      try {
+        await handle.close();
+      } catch {
+      }
+      return void 0;
+    }
+  }
+  return void 0;
+}
+async function appendAuditLineWithIo(cwd, line, io) {
+  try {
+    if (Buffer.byteLength(line, "utf8") > MAX_AUDIT_LINE_BYTES || !line.endsWith("\n") || line.slice(0, -1).includes("\n")) return false;
+    const root = await io.realpath(cwd);
+    const statePath = resolve2(root, AUDIT_STATE_DIRECTORY);
+    const stateInfo = await io.lstat(statePath);
+    if (!stateInfo.isDirectory() || stateInfo.isSymbolicLink()) return false;
+    const state = await io.realpath(statePath);
+    const stateRelative = relative(root, state);
+    if (stateRelative === "" || !lexicallyInside(state, root) || resolve2(root, stateRelative) !== state) return false;
+    const stateIdentity = await io.lstat(state);
+    if (!sameAuditDirectory(stateInfo, stateIdentity)) return false;
+    const stateIsCurrent = async () => {
+      try {
+        return await io.realpath(statePath) === state && sameAuditDirectory(stateIdentity, await io.lstat(statePath));
+      } catch {
+        return false;
+      }
+    };
+    if (!await stateIsCurrent()) return false;
+    const target = resolve2(state, AUDIT_LOG_NAME);
+    const opened = await openedAuditTarget(target, io);
+    if (opened === void 0) return false;
+    const { handle, identity: identity2 } = opened;
+    try {
+      const before = await handle.stat();
+      const beforePath = await io.lstat(target);
+      if (!sameAuditFile(identity2, before) || !sameAuditFile(before, beforePath) || !await stateIsCurrent()) return false;
+      await handle.appendFile(line, { encoding: "utf8" });
+      await handle.sync();
+      const after = await handle.stat();
+      const afterPath = await io.lstat(target);
+      if (!sameAuditFile(before, after) || !sameAuditFile(after, afterPath) || after.size < before.size + Buffer.byteLength(line, "utf8") || !await stateIsCurrent()) return false;
+    } finally {
+      await handle.close();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+async function appendAuditLine(cwd, line) {
+  return await appendAuditLineWithIo(cwd, line, NODE_AUDIT_SINK_IO);
 }
 
 // ../../ca/tools/redactor.ts
@@ -132,7 +230,7 @@ async function canonicalUserHome(projectRoot, packageRoot, platform = process.pl
   const candidate = platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
   if (typeof candidate !== "string" || candidate.length < 1 || candidate.length > PI_MAX_HOME_CHARS || candidate !== candidate.trim() || CONTROL_RE.test(candidate) || !pathApi.isAbsolute(candidate)) return void 0;
   try {
-    const canonical = await realpath(candidate);
+    const canonical = await realpath2(candidate);
     if (!statSync(canonical).isDirectory() || lexicallyInside(canonical, projectRoot, flavorForPlatform(platform)) || lexicallyInside(canonical, packageRoot, flavorForPlatform(platform))) return void 0;
     return canonical;
   } catch {
@@ -247,7 +345,6 @@ var BridgeClient = class {
     this.ready = this.validatePaths();
     this.ready.catch(() => void 0);
   }
-  options;
   ready;
   timeoutMs;
   maxRequestBytes;
@@ -260,10 +357,10 @@ var BridgeClient = class {
       throw new Error("bridge paths must be absolute");
     }
     const [git, python, script, root] = await Promise.all([
-      realpath(this.options.gitExecutable),
-      realpath(this.options.pythonExecutable),
-      realpath(this.options.bridgeScript),
-      realpath(this.options.packageRoot)
+      realpath2(this.options.gitExecutable),
+      realpath2(this.options.pythonExecutable),
+      realpath2(this.options.bridgeScript),
+      realpath2(this.options.packageRoot)
     ]);
     if (canonicalExecutable(git, process.platform) === void 0 || canonicalExecutable(python, process.platform) === void 0) {
       throw new Error("bridge executable identity is invalid");
@@ -299,10 +396,7 @@ var BridgeClient = class {
       `STDOUT_BYTES: ${counts.stdout}`,
       `STDERR_BYTES: ${counts.stderr}`
     ].join(" | ") + "\n";
-    try {
-      await appendFile(resolve2(request.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-    } catch {
-    }
+    await appendAuditLine(request.cwd, line);
   }
   async failed(request, detail, counts = { request: 0, stdout: 0, stderr: 0 }) {
     const response = this.failure(request, detail);
@@ -319,7 +413,7 @@ var BridgeClient = class {
       return await this.failed(request, "path validation failed");
     }
     try {
-      const project = await realpath(request.cwd);
+      const project = await realpath2(request.cwd);
       if (lexicallyInside(paths.git, project) || lexicallyInside(paths.python, project)) {
         return await this.failed(request, "path validation failed");
       }
@@ -477,9 +571,9 @@ function compatibilityDirection(input) {
 }
 
 // src/runtime-resolver.ts
-import { lstat, readFile, realpath as realpath2 } from "node:fs/promises";
+import { lstat as lstat2, readFile, realpath as realpath3 } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { dirname as dirname2, isAbsolute as isAbsolute2, resolve as resolve3 } from "node:path";
+import { dirname as dirname2, isAbsolute as isAbsolute2, resolve as resolve4 } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 var PI_RUNTIME_DIAGNOSIS = "codeArbiter could not validate the active Pi CLI runtime; start from the Pi CLI and run /ca-doctor.";
 var trustedIdentities = /* @__PURE__ */ new WeakSet();
@@ -489,12 +583,12 @@ function fail(cause) {
 async function owningPackageRoot(file, expectedName) {
   let cursor = dirname2(file);
   while (true) {
-    const candidate = resolve3(cursor, "package.json");
+    const candidate = resolve4(cursor, "package.json");
     try {
       const manifest = JSON.parse(await readFile(candidate, "utf8"));
       if (manifest.name !== expectedName) return fail();
-      const canonicalRoot = await realpath2(cursor);
-      if (!lexicallyInside(file, canonicalRoot) || !lexicallyInside(await realpath2(candidate), canonicalRoot)) return fail();
+      const canonicalRoot = await realpath3(cursor);
+      if (!lexicallyInside(file, canonicalRoot) || !lexicallyInside(await realpath3(candidate), canonicalRoot)) return fail();
       return canonicalRoot;
     } catch (error) {
       if (error.code !== "ENOENT") return fail(error);
@@ -529,17 +623,17 @@ async function resolvePiRuntimeIdentity(cliCandidate) {
   try {
     const activeAnchor = process.argv[1];
     if (typeof activeAnchor !== "string" || activeAnchor.length === 0 || !isAbsolute2(activeAnchor)) return fail();
-    const canonicalAnchor = await realpath2(activeAnchor);
+    const canonicalAnchor = await realpath3(activeAnchor);
     if (cliCandidate !== void 0) {
-      if (!isAbsolute2(cliCandidate) || await realpath2(cliCandidate) !== canonicalAnchor) return fail();
+      if (!isAbsolute2(cliCandidate) || await realpath3(cliCandidate) !== canonicalAnchor) return fail();
     }
-    const shippedModule = await realpath2(fileURLToPath(import.meta.url));
+    const shippedModule = await realpath3(fileURLToPath(import.meta.url));
     const extensionPackageRoot = await owningPackageRoot(shippedModule, "ca-pi");
     let cursor = dirname2(canonicalAnchor);
     let manifest;
     let manifestPath = "";
     while (true) {
-      const candidate = resolve3(cursor, "package.json");
+      const candidate = resolve4(cursor, "package.json");
       try {
         manifest = JSON.parse(await readFile(candidate, "utf8"));
         manifestPath = candidate;
@@ -552,19 +646,19 @@ async function resolvePiRuntimeIdentity(cliCandidate) {
       cursor = parent;
     }
     if (manifest.name !== "@earendil-works/pi-coding-agent" || typeof manifest.version !== "string") return fail();
-    const packageRoot = await realpath2(cursor);
-    const canonicalManifest = await realpath2(manifestPath);
+    const packageRoot = await realpath3(cursor);
+    const canonicalManifest = await realpath3(manifestPath);
     if (!lexicallyInside(canonicalAnchor, packageRoot) || !lexicallyInside(canonicalManifest, packageRoot)) return fail();
     if (lexicallyInside(packageRoot, extensionPackageRoot)) return fail();
-    const declaredBin = resolve3(packageRoot, binTarget(manifest));
-    if (!lexicallyInside(declaredBin, packageRoot) || await realpath2(declaredBin) !== canonicalAnchor) return fail();
-    if (!(await lstat(canonicalAnchor)).isFile()) return fail();
+    const declaredBin = resolve4(packageRoot, binTarget(manifest));
+    if (!lexicallyInside(declaredBin, packageRoot) || await realpath3(declaredBin) !== canonicalAnchor) return fail();
+    if (!(await lstat2(canonicalAnchor)).isFile()) return fail();
     const declaredExport = importTarget(manifest);
     if (!declaredExport.startsWith("./")) return fail();
-    const requireFromPi = createRequire(resolve3(packageRoot, "package.json"));
-    const moduleEntry = await realpath2(requireFromPi.resolve(declaredExport));
+    const requireFromPi = createRequire(resolve4(packageRoot, "package.json"));
+    const moduleEntry = await realpath3(requireFromPi.resolve(declaredExport));
     if (!lexicallyInside(moduleEntry, packageRoot)) return fail();
-    if (!(await lstat(moduleEntry)).isFile()) return fail();
+    if (!(await lstat2(moduleEntry)).isFile()) return fail();
     const identity2 = Object.freeze({
       cliEntry: canonicalAnchor,
       manifestPath: canonicalManifest,
@@ -616,8 +710,7 @@ async function loadPiRuntime(identity2) {
 
 // src/tool-guard.ts
 import { createHash as createHash4, randomUUID as randomUUID2 } from "node:crypto";
-import { constants as fsConstants, realpathSync as realpathSync2 } from "node:fs";
-import { lstat as lstat2, open, realpath as realpath3 } from "node:fs/promises";
+import { realpathSync as realpathSync2 } from "node:fs";
 import { types as utilTypes2 } from "node:util";
 
 // src/notices.ts
@@ -908,7 +1001,6 @@ function evaluatePolicy(descriptor, rawRequest) {
 
 // src/tool-guard.ts
 var STANDALONE_GENERATION = Object.freeze({});
-var NODE_PERMISSION_AUDIT_IO = Object.freeze({ realpath: realpath3, lstat: lstat2, open });
 var CONFIRMATION_TITLE = "Allow governed operation?";
 var CONFIRMATION_TIMEOUT_MS = 6e4;
 var COMMAND_LIMIT = 8192;
@@ -1658,7 +1750,7 @@ async function codeArbiterPiChild(pi) {
   let packageRoot = dirname3(modulePath);
   while (true) {
     try {
-      const manifest = JSON.parse(await readFile2(resolve4(packageRoot, "package.json"), "utf8"));
+      const manifest = JSON.parse(await readFile2(resolve5(packageRoot, "package.json"), "utf8"));
       if (manifest.name === "ca-pi") break;
     } catch {
     }
@@ -1671,7 +1763,7 @@ async function codeArbiterPiChild(pi) {
   const gitExecutable = resolveGitExecutable(cwd);
   const descriptor = loadToolClasses(define_CODEARBITER_PI_TOOL_CLASSES_default);
   const bridge = new BridgeClient({
-    bridgeScript: resolve4(packageRoot, "hooks", "pi-bridge.py"),
+    bridgeScript: resolve5(packageRoot, "hooks", "pi-bridge.py"),
     packageRoot,
     pythonExecutable: python.executable,
     pythonPrefixArgs: python.prefixArgs,

--- a/plugins/ca-pi/extensions/codearbiter-child.js
+++ b/plugins/ca-pi/extensions/codearbiter-child.js
@@ -345,6 +345,7 @@ var BridgeClient = class {
     this.ready = this.validatePaths();
     this.ready.catch(() => void 0);
   }
+  options;
   ready;
   timeoutMs;
   maxRequestBytes;

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -706,6 +706,7 @@ var BridgeClient = class {
     this.ready = this.validatePaths();
     this.ready.catch(() => void 0);
   }
+  options;
   ready;
   timeoutMs;
   maxRequestBytes;
@@ -3050,7 +3051,7 @@ function createNativeBackgroundController(pi, options) {
   };
   const reserve = (value) => {
     if (value.reservations.size >= MAX_ACTIVE_JOBS) return void 0;
-    const token = Symbol("background-job-capacity");
+    const token = /* @__PURE__ */ Symbol("background-job-capacity");
     let resolveDone;
     const done = new Promise((resolveReservation) => {
       resolveDone = resolveReservation;
@@ -4441,6 +4442,8 @@ var Box = class {
     this.metrics = metrics;
     this.inner = width - 4;
   }
+  width;
+  metrics;
   lines = [];
   inner;
   top(title) {
@@ -4595,6 +4598,10 @@ var PiFooterLifecycle = class {
     this.loadMetrics = loadMetrics;
     this.currentActivity = currentActivity2;
   }
+  pi;
+  bridge;
+  loadMetrics;
+  currentActivity;
   generation = 0;
   context;
   footerData;
@@ -8986,7 +8993,7 @@ async function codeArbiterPi(pi) {
         activeTools: pi.getActiveTools(),
         allTools: pi.getAllTools(),
         expansionFingerprints,
-        childFingerprint: "c1f1b9045b026cf712c01b198f054e4962de05eec3bc219d687a0694d2a78972"
+        childFingerprint: "f31ba24b1bd6f85f71893df71713d4fce5426da7072236537be7499382d1dece"
       });
       const wrapperSelfTest = await runPiWrapperSelfTest({
         enabled: enabledForDoctor,

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -46,8 +46,13 @@ function compatibilityDirection(input) {
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, constants, realpathSync as realpathSync2, statSync } from "node:fs";
-import { appendFile, realpath } from "node:fs/promises";
-import { isAbsolute, posix as posix2, resolve as resolve2, win32 as win322 } from "node:path";
+import { realpath as realpath2 } from "node:fs/promises";
+import { isAbsolute, posix as posix2, win32 as win322 } from "node:path";
+
+// src/audit-sink.ts
+import { constants as fsConstants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import { relative, resolve as resolve2 } from "node:path";
 
 // src/path-boundary.ts
 import { realpathSync } from "node:fs";
@@ -72,6 +77,102 @@ function canonicalPath(path) {
 }
 function canonicallyInside(path, root) {
   return lexicallyInside(canonicalPath(path), canonicalPath(root));
+}
+
+// src/audit-sink.ts
+var AUDIT_LOG_NAME = "gate-events.log";
+var AUDIT_STATE_DIRECTORY = ".codearbiter";
+var MAX_AUDIT_LINE_BYTES = 2048;
+var NODE_AUDIT_SINK_IO = Object.freeze({ realpath, lstat, open });
+function sameAuditFile(left, right) {
+  return left.isFile() && right.isFile() && !left.isSymbolicLink() && !right.isSymbolicLink() && left.nlink === 1 && right.nlink === 1 && left.dev === right.dev && left.ino === right.ino;
+}
+function sameAuditDirectory(left, right) {
+  return left.isDirectory() && right.isDirectory() && !left.isSymbolicLink() && !right.isSymbolicLink() && left.dev === right.dev && left.ino === right.ino;
+}
+async function openedAuditTarget(target, io) {
+  const noFollow = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+  const existingFlags = fsConstants.O_WRONLY | fsConstants.O_APPEND | noFollow;
+  const createFlags = existingFlags | fsConstants.O_CREAT | fsConstants.O_EXCL;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let expected;
+    try {
+      expected = await io.lstat(target);
+      if (!expected.isFile() || expected.isSymbolicLink() || expected.nlink !== 1) return void 0;
+    } catch (error) {
+      if (error.code !== "ENOENT") return void 0;
+    }
+    let handle;
+    try {
+      handle = await io.open(target, expected === void 0 ? createFlags : existingFlags, 384);
+    } catch (error) {
+      if (expected === void 0 && error.code === "EEXIST" && attempt === 0) continue;
+      return void 0;
+    }
+    try {
+      const opened = await handle.stat();
+      const pathname = await io.lstat(target);
+      if (!sameAuditFile(opened, pathname) || expected !== void 0 && !sameAuditFile(opened, expected)) {
+        await handle.close();
+        return void 0;
+      }
+      return Object.freeze({ handle, identity: opened });
+    } catch {
+      try {
+        await handle.close();
+      } catch {
+      }
+      return void 0;
+    }
+  }
+  return void 0;
+}
+async function appendAuditLineWithIo(cwd, line, io) {
+  try {
+    if (Buffer.byteLength(line, "utf8") > MAX_AUDIT_LINE_BYTES || !line.endsWith("\n") || line.slice(0, -1).includes("\n")) return false;
+    const root = await io.realpath(cwd);
+    const statePath = resolve2(root, AUDIT_STATE_DIRECTORY);
+    const stateInfo = await io.lstat(statePath);
+    if (!stateInfo.isDirectory() || stateInfo.isSymbolicLink()) return false;
+    const state = await io.realpath(statePath);
+    const stateRelative = relative(root, state);
+    if (stateRelative === "" || !lexicallyInside(state, root) || resolve2(root, stateRelative) !== state) return false;
+    const stateIdentity = await io.lstat(state);
+    if (!sameAuditDirectory(stateInfo, stateIdentity)) return false;
+    const stateIsCurrent = async () => {
+      try {
+        return await io.realpath(statePath) === state && sameAuditDirectory(stateIdentity, await io.lstat(statePath));
+      } catch {
+        return false;
+      }
+    };
+    if (!await stateIsCurrent()) return false;
+    const target = resolve2(state, AUDIT_LOG_NAME);
+    const opened = await openedAuditTarget(target, io);
+    if (opened === void 0) return false;
+    const { handle, identity: identity2 } = opened;
+    try {
+      const before = await handle.stat();
+      const beforePath = await io.lstat(target);
+      if (!sameAuditFile(identity2, before) || !sameAuditFile(before, beforePath) || !await stateIsCurrent()) return false;
+      await handle.appendFile(line, { encoding: "utf8" });
+      await handle.sync();
+      const after = await handle.stat();
+      const afterPath = await io.lstat(target);
+      if (!sameAuditFile(before, after) || !sameAuditFile(after, afterPath) || after.size < before.size + Buffer.byteLength(line, "utf8") || !await stateIsCurrent()) return false;
+    } finally {
+      await handle.close();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+async function appendAuditLine(cwd, line) {
+  return await appendAuditLineWithIo(cwd, line, NODE_AUDIT_SINK_IO);
+}
+function auditField(value) {
+  return value.replaceAll("\n", " ");
 }
 
 // ../../ca/tools/redactor.ts
@@ -185,7 +286,7 @@ async function canonicalUserHome(projectRoot, packageRoot, platform = process.pl
   const candidate = platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
   if (typeof candidate !== "string" || candidate.length < 1 || candidate.length > PI_MAX_HOME_CHARS || candidate !== candidate.trim() || CONTROL_RE.test(candidate) || !pathApi.isAbsolute(candidate)) return void 0;
   try {
-    const canonical = await realpath(candidate);
+    const canonical = await realpath2(candidate);
     if (!statSync(canonical).isDirectory() || lexicallyInside(canonical, projectRoot, flavorForPlatform(platform)) || lexicallyInside(canonical, packageRoot, flavorForPlatform(platform))) return void 0;
     return canonical;
   } catch {
@@ -605,7 +706,6 @@ var BridgeClient = class {
     this.ready = this.validatePaths();
     this.ready.catch(() => void 0);
   }
-  options;
   ready;
   timeoutMs;
   maxRequestBytes;
@@ -618,10 +718,10 @@ var BridgeClient = class {
       throw new Error("bridge paths must be absolute");
     }
     const [git, python, script, root] = await Promise.all([
-      realpath(this.options.gitExecutable),
-      realpath(this.options.pythonExecutable),
-      realpath(this.options.bridgeScript),
-      realpath(this.options.packageRoot)
+      realpath2(this.options.gitExecutable),
+      realpath2(this.options.pythonExecutable),
+      realpath2(this.options.bridgeScript),
+      realpath2(this.options.packageRoot)
     ]);
     if (canonicalExecutable(git, process.platform) === void 0 || canonicalExecutable(python, process.platform) === void 0) {
       throw new Error("bridge executable identity is invalid");
@@ -657,10 +757,7 @@ var BridgeClient = class {
       `STDOUT_BYTES: ${counts.stdout}`,
       `STDERR_BYTES: ${counts.stderr}`
     ].join(" | ") + "\n";
-    try {
-      await appendFile(resolve2(request.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-    } catch {
-    }
+    await appendAuditLine(request.cwd, line);
   }
   async failed(request, detail, counts = { request: 0, stdout: 0, stderr: 0 }) {
     const response = this.failure(request, detail);
@@ -677,7 +774,7 @@ var BridgeClient = class {
       return await this.failed(request, "path validation failed");
     }
     try {
-      const project = await realpath(request.cwd);
+      const project = await realpath2(request.cwd);
       if (lexicallyInside(paths.git, project) || lexicallyInside(paths.python, project)) {
         return await this.failed(request, "path validation failed");
       }
@@ -808,15 +905,15 @@ function resolvePythonCommand(platform = process.platform, probe = systemPythonP
 }
 
 // src/activation.ts
-import { lstat, open, readFile } from "node:fs/promises";
+import { lstat as lstat2, open as open2, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { resolve as resolve3 } from "node:path";
+import { resolve as resolve4 } from "node:path";
 var PYTHON_WHITESPACE = String.raw`[\t-\r\x1c-\x20\x85\xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]`;
 var DELIMITER = new RegExp(`^${PYTHON_WHITESPACE}*---${PYTHON_WHITESPACE}*$`, "u");
 var ENABLED_MARKER = new RegExp(`^${PYTHON_WHITESPACE}*arb[i\u0130\u0131]ter:${PYTHON_WHITESPACE}*enabled${PYTHON_WHITESPACE}*$`, "iu");
 async function isEnabled(cwd) {
   try {
-    const raw = await readFile(resolve3(cwd, ".codearbiter", "CONTEXT.md"), "utf8");
+    const raw = await readFile(resolve4(cwd, ".codearbiter", "CONTEXT.md"), "utf8");
     const lines = raw.split("\n");
     const first = (lines[0] ?? "").replace(/^\uFEFF+/u, "");
     if (!DELIMITER.test(first)) return false;
@@ -835,11 +932,11 @@ var VERSION_RE = /^[vV]?(\d+(?:\.\d+)*)(?:[-+][0-9A-Za-z.-]+)?$/u;
 async function readSmallRegularJson(path) {
   let handle;
   try {
-    const before = await lstat(path);
+    const before = await lstat2(path);
     if (!before.isFile() || before.isSymbolicLink() || before.size > UPDATE_DOCUMENT_MAX_BYTES) return void 0;
-    handle = await open(path, "r");
+    handle = await open2(path, "r");
     const opened = await handle.stat();
-    const afterOpen = await lstat(path);
+    const afterOpen = await lstat2(path);
     if (!opened.isFile() || opened.size > UPDATE_DOCUMENT_MAX_BYTES || !afterOpen.isFile() || afterOpen.isSymbolicLink() || opened.dev !== before.dev || opened.ino !== before.ino || afterOpen.dev !== opened.dev || afterOpen.ino !== opened.ino) return void 0;
     const buffer = Buffer.alloc(UPDATE_DOCUMENT_MAX_BYTES + 1);
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
@@ -874,19 +971,19 @@ function isNewerVersion(candidate, installed) {
 }
 async function readCachedUpdateVersion(packageRoot) {
   const [manifest, cache] = await Promise.all([
-    readSmallRegularJson(resolve3(packageRoot, "package.json")),
-    readSmallRegularJson(resolve3(homedir(), ".codearbiter", "update-state.json"))
+    readSmallRegularJson(resolve4(packageRoot, "package.json")),
+    readSmallRegularJson(resolve4(homedir(), ".codearbiter", "update-state.json"))
   ]);
   return isNewerVersion(cache?.latest, manifest?.version) ? cache.latest : void 0;
 }
 
 // src/commands.ts
 import { lstatSync as lstatSync2, realpathSync as realpathSync5 } from "node:fs";
-import { dirname as dirname4, resolve as resolve6 } from "node:path";
+import { dirname as dirname4, resolve as resolve7 } from "node:path";
 
 // src/command-ownership.ts
 import { lstatSync, readFileSync, realpathSync as realpathSync3 } from "node:fs";
-import { dirname as dirname2, isAbsolute as isAbsolute2, relative, resolve as resolve4 } from "node:path";
+import { dirname as dirname2, isAbsolute as isAbsolute2, relative as relative2, resolve as resolve5 } from "node:path";
 import { fileURLToPath } from "node:url";
 var COMMAND_DIAGNOSIS = "codeArbiter could not validate the Pi command surface; run /ca-doctor.";
 var NAME = /^[a-z][a-z0-9-]*$/u;
@@ -895,7 +992,7 @@ function pluginRootFromModule() {
   let cursor = dirname2(fileURLToPath(import.meta.url));
   while (true) {
     try {
-      const manifest = JSON.parse(readFileSync(resolve4(cursor, "package.json"), "utf8"));
+      const manifest = JSON.parse(readFileSync(resolve5(cursor, "package.json"), "utf8"));
       if (manifest.name === "ca-pi") return realpathSync3(cursor);
     } catch {
     }
@@ -918,13 +1015,13 @@ function strictUtf8(path) {
   return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 }
 function hasSymlinkComponent(root, path) {
-  const lexicalRoot = resolve4(root);
-  const lexicalPath = resolve4(path);
+  const lexicalRoot = resolve5(root);
+  const lexicalPath = resolve5(path);
   if (!lexicallyInside(lexicalPath, lexicalRoot) || lstatSync(lexicalRoot).isSymbolicLink()) return true;
-  const suffix = relative(lexicalRoot, lexicalPath);
+  const suffix = relative2(lexicalRoot, lexicalPath);
   let cursor = lexicalRoot;
   for (const part of suffix.split(/[\\/]/u).filter(Boolean)) {
-    cursor = resolve4(cursor, part);
+    cursor = resolve5(cursor, part);
     if (lstatSync(cursor).isSymbolicLink()) return true;
   }
   return false;
@@ -937,12 +1034,12 @@ function declaredPackageOwner(command, expectedPath) {
     const canonicalExpected = realpathSync3(expectedPath);
     const canonicalBase = realpathSync3(command.sourceInfo.baseDir);
     if (canonicalPath2 !== canonicalExpected || !lexicallyInside(canonicalPath2, canonicalBase)) return false;
-    const manifest = JSON.parse(strictUtf8(resolve4(canonicalBase, "package.json")));
+    const manifest = JSON.parse(strictUtf8(resolve5(canonicalBase, "package.json")));
     if (manifest.name !== "ca-pi" || manifest.pi === void 0) return false;
     const declared = command.source === "extension" ? manifest.pi.extensions : manifest.pi.skills;
     if (!Array.isArray(declared) || !declared.every((item) => typeof item === "string")) return false;
     return declared.some((item) => {
-      const target = resolve4(canonicalBase, item);
+      const target = resolve5(canonicalBase, item);
       return command.source === "extension" ? realpathSync3(target) === canonicalPath2 : lexicallyInside(canonicalPath2, realpathSync3(target));
     });
   } catch {
@@ -956,7 +1053,7 @@ function assertCommandOwnership(pi, packageRoot, catalog) {
   for (const entry of catalog) {
     validatedEntry(entry);
     const alias = `ca-${entry.name}`;
-    const expectedExtension = resolve4(canonicalRoot, "extensions", "codearbiter.js");
+    const expectedExtension = resolve5(canonicalRoot, "extensions", "codearbiter.js");
     const exact = commands.filter((command) => command.name === alias);
     const suffixed = commands.filter((command) => command.name.startsWith(`${alias}:`));
     const validExact = exact.filter((command) => command.source === "extension" && declaredPackageOwner(command, expectedExtension));
@@ -972,7 +1069,7 @@ function assertCommandOwnership(pi, packageRoot, catalog) {
     }
     const fallbackName = `skill:ca-${entry.name}`;
     const fallbacks = commands.filter((command) => command.name === fallbackName);
-    const expectedSkill = resolve4(canonicalRoot, ...entry.skillPath.split("/"));
+    const expectedSkill = resolve5(canonicalRoot, ...entry.skillPath.split("/"));
     const validFallbacks = fallbacks.filter((command) => command.source === "skill" && declaredPackageOwner(command, expectedSkill));
     if (validFallbacks.length === 0) collisions.push({ command: fallbackName, reason: "missing-fallback" });
     if (fallbacks.length > 1) collisions.push({ command: fallbackName, reason: "duplicate-alias" });
@@ -993,7 +1090,7 @@ function assertCommandOwnership(pi, packageRoot, catalog) {
 }
 function assertNativePlanCommandOwnership(pi, packageRoot) {
   const canonicalRoot = realpathSync3(packageRoot);
-  const expectedExtension = resolve4(canonicalRoot, "extensions", "codearbiter.js");
+  const expectedExtension = resolve5(canonicalRoot, "extensions", "codearbiter.js");
   const commands = pi.getCommands();
   const exact = commands.filter((command) => command.name === "ca-plan");
   const suffixed = commands.filter((command) => command.name.startsWith("ca-plan:"));
@@ -1013,7 +1110,7 @@ function assertNativePlanCommandOwnership(pi, packageRoot) {
 }
 function assertNativeJobsCommandOwnership(pi, packageRoot) {
   const canonicalRoot = realpathSync3(packageRoot);
-  const expectedExtension = resolve4(canonicalRoot, "extensions", "codearbiter.js");
+  const expectedExtension = resolve5(canonicalRoot, "extensions", "codearbiter.js");
   const commands = pi.getCommands();
   const exact = commands.filter((command) => command.name === "ca-jobs");
   const related = commands.filter((command) => command.name.startsWith("ca-jobs:") || command.name === "skill:ca-jobs");
@@ -1232,7 +1329,7 @@ function publishActivity(publisher, event) {
 import { EventEmitter } from "node:events";
 import { spawn as spawn2, spawnSync as spawnSync2 } from "node:child_process";
 import { readFileSync as readFileSync2, realpathSync as realpathSync4, statSync as statSync2 } from "node:fs";
-import { dirname as dirname3, isAbsolute as isAbsolute3, relative as relative2, resolve as resolve5, win32 as win323 } from "node:path";
+import { dirname as dirname3, isAbsolute as isAbsolute3, relative as relative3, resolve as resolve6, win32 as win323 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { types as utilTypes2 } from "node:util";
 var DEFAULT_GRACE_MS = 500;
@@ -1876,11 +1973,11 @@ function canonicalSupervisorPath() {
   let cursor = dirname3(realpathSync4(fileURLToPath2(import.meta.url)));
   while (true) {
     try {
-      const manifest = JSON.parse(readFileSync2(resolve5(cursor, "package.json"), "utf8"));
+      const manifest = JSON.parse(readFileSync2(resolve6(cursor, "package.json"), "utf8"));
       if (manifest.name === "ca-pi") {
         const packageRoot = realpathSync4(cursor);
-        const candidate = realpathSync4(resolve5(cursor, "helpers", "windows-supervisor.js"));
-        const suffix = relative2(packageRoot, candidate);
+        const candidate = realpathSync4(resolve6(cursor, "helpers", "windows-supervisor.js"));
+        const suffix = relative3(packageRoot, candidate);
         if (!statSync2(candidate).isFile() || suffix.startsWith("..") || isAbsolute3(suffix) || win323.basename(candidate).toLowerCase() !== "windows-supervisor.js") throw new Error("invalid supervisor artifact");
         return candidate;
       }
@@ -2953,7 +3050,7 @@ function createNativeBackgroundController(pi, options) {
   };
   const reserve = (value) => {
     if (value.reservations.size >= MAX_ACTIVE_JOBS) return void 0;
-    const token = /* @__PURE__ */ Symbol("background-job-capacity");
+    const token = Symbol("background-job-capacity");
     let resolveDone;
     const done = new Promise((resolveReservation) => {
       resolveDone = resolveReservation;
@@ -3823,7 +3920,7 @@ ${body}
 ${args}` : block;
 }
 function fallbackCommand(pi, packageRoot, entry) {
-  const expected = resolve6(packageRoot, ...entry.skillPath.split("/"));
+  const expected = resolve7(packageRoot, ...entry.skillPath.split("/"));
   const matches = pi.getCommands().filter((command) => command.name === `skill:ca-${entry.name}`);
   if (matches.length !== 1 || matches[0].source !== "skill") return void 0;
   return declaredPackageOwner(matches[0], expected) ? matches[0] : void 0;
@@ -3841,7 +3938,7 @@ function registerAliases(pi, catalog, packageRoot = pluginRootFromModule(), onDe
           }
           const fallback = fallbackCommand(pi, canonicalRoot, entry);
           if (fallback === void 0) throw new Error(COMMAND_DIAGNOSIS);
-          const expectedPath = resolve6(canonicalRoot, ...entry.skillPath.split("/"));
+          const expectedPath = resolve7(canonicalRoot, ...entry.skillPath.split("/"));
           if (fallback.sourceInfo.baseDir === void 0 || hasSymlinkComponent(fallback.sourceInfo.baseDir, fallback.sourceInfo.path)) {
             throw new Error(COMMAND_DIAGNOSIS);
           }
@@ -3869,9 +3966,9 @@ ${generated}`;
 }
 
 // src/runtime-resolver.ts
-import { lstat as lstat2, readFile as readFile2, realpath as realpath2 } from "node:fs/promises";
+import { lstat as lstat3, readFile as readFile2, realpath as realpath3 } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { dirname as dirname5, isAbsolute as isAbsolute4, resolve as resolve7 } from "node:path";
+import { dirname as dirname5, isAbsolute as isAbsolute4, resolve as resolve8 } from "node:path";
 import { fileURLToPath as fileURLToPath3, pathToFileURL } from "node:url";
 var PI_RUNTIME_DIAGNOSIS = "codeArbiter could not validate the active Pi CLI runtime; start from the Pi CLI and run /ca-doctor.";
 var trustedIdentities = /* @__PURE__ */ new WeakSet();
@@ -3881,12 +3978,12 @@ function fail(cause) {
 async function owningPackageRoot(file, expectedName) {
   let cursor = dirname5(file);
   while (true) {
-    const candidate = resolve7(cursor, "package.json");
+    const candidate = resolve8(cursor, "package.json");
     try {
       const manifest = JSON.parse(await readFile2(candidate, "utf8"));
       if (manifest.name !== expectedName) return fail();
-      const canonicalRoot = await realpath2(cursor);
-      if (!lexicallyInside(file, canonicalRoot) || !lexicallyInside(await realpath2(candidate), canonicalRoot)) return fail();
+      const canonicalRoot = await realpath3(cursor);
+      if (!lexicallyInside(file, canonicalRoot) || !lexicallyInside(await realpath3(candidate), canonicalRoot)) return fail();
       return canonicalRoot;
     } catch (error) {
       if (error.code !== "ENOENT") return fail(error);
@@ -3921,17 +4018,17 @@ async function resolvePiRuntimeIdentity(cliCandidate) {
   try {
     const activeAnchor = process.argv[1];
     if (typeof activeAnchor !== "string" || activeAnchor.length === 0 || !isAbsolute4(activeAnchor)) return fail();
-    const canonicalAnchor = await realpath2(activeAnchor);
+    const canonicalAnchor = await realpath3(activeAnchor);
     if (cliCandidate !== void 0) {
-      if (!isAbsolute4(cliCandidate) || await realpath2(cliCandidate) !== canonicalAnchor) return fail();
+      if (!isAbsolute4(cliCandidate) || await realpath3(cliCandidate) !== canonicalAnchor) return fail();
     }
-    const shippedModule = await realpath2(fileURLToPath3(import.meta.url));
+    const shippedModule = await realpath3(fileURLToPath3(import.meta.url));
     const extensionPackageRoot = await owningPackageRoot(shippedModule, "ca-pi");
     let cursor = dirname5(canonicalAnchor);
     let manifest;
     let manifestPath = "";
     while (true) {
-      const candidate = resolve7(cursor, "package.json");
+      const candidate = resolve8(cursor, "package.json");
       try {
         manifest = JSON.parse(await readFile2(candidate, "utf8"));
         manifestPath = candidate;
@@ -3944,19 +4041,19 @@ async function resolvePiRuntimeIdentity(cliCandidate) {
       cursor = parent;
     }
     if (manifest.name !== "@earendil-works/pi-coding-agent" || typeof manifest.version !== "string") return fail();
-    const packageRoot = await realpath2(cursor);
-    const canonicalManifest = await realpath2(manifestPath);
+    const packageRoot = await realpath3(cursor);
+    const canonicalManifest = await realpath3(manifestPath);
     if (!lexicallyInside(canonicalAnchor, packageRoot) || !lexicallyInside(canonicalManifest, packageRoot)) return fail();
     if (lexicallyInside(packageRoot, extensionPackageRoot)) return fail();
-    const declaredBin = resolve7(packageRoot, binTarget(manifest));
-    if (!lexicallyInside(declaredBin, packageRoot) || await realpath2(declaredBin) !== canonicalAnchor) return fail();
-    if (!(await lstat2(canonicalAnchor)).isFile()) return fail();
+    const declaredBin = resolve8(packageRoot, binTarget(manifest));
+    if (!lexicallyInside(declaredBin, packageRoot) || await realpath3(declaredBin) !== canonicalAnchor) return fail();
+    if (!(await lstat3(canonicalAnchor)).isFile()) return fail();
     const declaredExport = importTarget(manifest);
     if (!declaredExport.startsWith("./")) return fail();
-    const requireFromPi = createRequire(resolve7(packageRoot, "package.json"));
-    const moduleEntry = await realpath2(requireFromPi.resolve(declaredExport));
+    const requireFromPi = createRequire(resolve8(packageRoot, "package.json"));
+    const moduleEntry = await realpath3(requireFromPi.resolve(declaredExport));
     if (!lexicallyInside(moduleEntry, packageRoot)) return fail();
-    if (!(await lstat2(moduleEntry)).isFile()) return fail();
+    if (!(await lstat3(moduleEntry)).isFile()) return fail();
     const identity2 = Object.freeze({
       cliEntry: canonicalAnchor,
       manifestPath: canonicalManifest,
@@ -4344,8 +4441,6 @@ var Box = class {
     this.metrics = metrics;
     this.inner = width - 4;
   }
-  width;
-  metrics;
   lines = [];
   inner;
   top(title) {
@@ -4500,10 +4595,6 @@ var PiFooterLifecycle = class {
     this.loadMetrics = loadMetrics;
     this.currentActivity = currentActivity2;
   }
-  pi;
-  bridge;
-  loadMetrics;
-  currentActivity;
   generation = 0;
   context;
   footerData;
@@ -4694,9 +4785,7 @@ var PiFooterLifecycle = class {
 
 // src/tool-guard.ts
 import { createHash as createHash5, randomUUID as randomUUID3 } from "node:crypto";
-import { constants as fsConstants, realpathSync as realpathSync6 } from "node:fs";
-import { lstat as lstat3, open as open2, realpath as realpath3 } from "node:fs/promises";
-import { relative as relative3, resolve as resolve8 } from "node:path";
+import { realpathSync as realpathSync6 } from "node:fs";
 import { types as utilTypes7 } from "node:util";
 
 // src/notices.ts
@@ -4987,7 +5076,6 @@ function evaluatePolicy(descriptor, rawRequest) {
 
 // src/tool-guard.ts
 var STANDALONE_GENERATION = Object.freeze({});
-var NODE_PERMISSION_AUDIT_IO = Object.freeze({ realpath: realpath3, lstat: lstat3, open: open2 });
 var CONFIRMATION_TITLE = "Allow governed operation?";
 var CONFIRMATION_TIMEOUT_MS = 6e4;
 var COMMAND_LIMIT = 8192;
@@ -5090,90 +5178,6 @@ function permissionAuditCodeRow(toolCallId, toolClass, auditCode) {
     auditCode
   });
 }
-function sameAuditFile(left, right) {
-  return left.isFile() && right.isFile() && !left.isSymbolicLink() && !right.isSymbolicLink() && left.nlink === 1 && right.nlink === 1 && left.dev === right.dev && left.ino === right.ino;
-}
-function sameAuditDirectory(left, right) {
-  return left.isDirectory() && right.isDirectory() && !left.isSymbolicLink() && !right.isSymbolicLink() && left.dev === right.dev && left.ino === right.ino;
-}
-async function openedAuditTarget(target, io) {
-  const noFollow = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
-  const existingFlags = fsConstants.O_WRONLY | fsConstants.O_APPEND | noFollow;
-  const createFlags = existingFlags | fsConstants.O_CREAT | fsConstants.O_EXCL;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    let expected;
-    try {
-      expected = await io.lstat(target);
-      if (!expected.isFile() || expected.isSymbolicLink() || expected.nlink !== 1) return void 0;
-    } catch (error) {
-      if (error.code !== "ENOENT") return void 0;
-    }
-    let handle;
-    try {
-      handle = await io.open(target, expected === void 0 ? createFlags : existingFlags, 384);
-    } catch (error) {
-      if (expected === void 0 && error.code === "EEXIST" && attempt === 0) continue;
-      return void 0;
-    }
-    try {
-      const opened = await handle.stat();
-      const pathname = await io.lstat(target);
-      if (!sameAuditFile(opened, pathname) || expected !== void 0 && !sameAuditFile(opened, expected)) {
-        await handle.close();
-        return void 0;
-      }
-      return Object.freeze({ handle, identity: opened });
-    } catch {
-      try {
-        await handle.close();
-      } catch {
-      }
-      return void 0;
-    }
-  }
-  return void 0;
-}
-async function appendAuditLineWithIo(cwd, line, io) {
-  try {
-    if (Buffer.byteLength(line, "utf8") > 2048 || !line.endsWith("\n") || line.slice(0, -1).includes("\n")) return false;
-    const root = await io.realpath(cwd);
-    const statePath = resolve8(root, ".codearbiter");
-    const stateInfo = await io.lstat(statePath);
-    if (!stateInfo.isDirectory() || stateInfo.isSymbolicLink()) return false;
-    const state = await io.realpath(statePath);
-    const stateRelative = relative3(root, state);
-    if (stateRelative === "" || stateRelative.startsWith("..") || resolve8(root, stateRelative) !== state) return false;
-    const stateIdentity = await io.lstat(state);
-    if (!sameAuditDirectory(stateInfo, stateIdentity)) return false;
-    const stateIsCurrent = async () => {
-      try {
-        return await io.realpath(statePath) === state && sameAuditDirectory(stateIdentity, await io.lstat(statePath));
-      } catch {
-        return false;
-      }
-    };
-    if (!await stateIsCurrent()) return false;
-    const target = resolve8(state, "gate-events.log");
-    const opened = await openedAuditTarget(target, io);
-    if (opened === void 0) return false;
-    const { handle, identity: identity2 } = opened;
-    try {
-      const before = await handle.stat();
-      const beforePath = await io.lstat(target);
-      if (!sameAuditFile(identity2, before) || !sameAuditFile(before, beforePath) || !await stateIsCurrent()) return false;
-      await handle.appendFile(line, { encoding: "utf8" });
-      await handle.sync();
-      const after = await handle.stat();
-      const afterPath = await io.lstat(target);
-      if (!sameAuditFile(before, after) || !sameAuditFile(after, afterPath) || after.size < before.size + Buffer.byteLength(line, "utf8") || !await stateIsCurrent()) return false;
-    } finally {
-      await handle.close();
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
 async function appendPermissionAuditWithIo(cwd, row, io) {
   try {
     const timestamp = row.timestamp;
@@ -5201,7 +5205,7 @@ async function appendBackgroundJobAudit(cwd, row) {
     const keys = Object.keys(row).sort().join(",");
     const expectedKeys = row.event === "launch" ? "correlation,event,id,lifecycleId,state,timeoutMs,timestamp" : row.event === "terminal" ? "correlation,durationMs,event,exitClass,id,lifecycleId,outputBytes,state,timestamp" : row.event === "cancel" ? "accepted,correlation,event,id,lifecycleId,timestamp" : "";
     if (keys !== expectedKeys || row.timestamp.length !== 24 || new Date(row.timestamp).toISOString() !== row.timestamp || !/^[a-f0-9]{64}$/u.test(row.lifecycleId) || !/^[a-f0-9]{64}$/u.test(row.correlation) || !Number.isSafeInteger(row.id) || row.id < 1 || row.event === "launch" && (!["queued", "active", "completed", "failed", "cancelled", "timed-out"].includes(row.state) || row.timeoutMs !== null && (!Number.isSafeInteger(row.timeoutMs) || row.timeoutMs < 1e3 || row.timeoutMs > 6048e5)) || row.event === "terminal" && (!["completed", "failed", "cancelled", "timed-out"].includes(row.state) || !["success", "failure", "cancelled", "timeout"].includes(row.exitClass) || row.exitClass !== (row.state === "completed" ? "success" : row.state === "failed" ? "failure" : row.state === "cancelled" ? "cancelled" : "timeout") || !Number.isSafeInteger(row.durationMs) || row.durationMs < 0 || !Number.isSafeInteger(row.outputBytes) || row.outputBytes < 0 || row.outputBytes > 65536) || row.event === "cancel" && typeof row.accepted !== "boolean") return false;
-    return await appendAuditLineWithIo(cwd, [
+    return await appendAuditLine(cwd, [
       `[${row.timestamp}]`,
       "HOST: pi",
       "RULE: PI-BACKGROUND-JOB",
@@ -5215,13 +5219,13 @@ async function appendBackgroundJobAudit(cwd, row) {
       ...row.durationMs === void 0 ? [] : [`DURATION_MS: ${row.durationMs}`],
       ...row.exitClass === void 0 ? [] : [`EXIT_CLASS: ${row.exitClass}`],
       ...row.accepted === void 0 ? [] : [`ACCEPTED: ${row.accepted}`]
-    ].join(" | ") + "\n", NODE_PERMISSION_AUDIT_IO);
+    ].join(" | ") + "\n");
   } catch {
     return false;
   }
 }
 async function appendPermissionAudit(cwd, row) {
-  return await appendPermissionAuditWithIo(cwd, row, NODE_PERMISSION_AUDIT_IO);
+  return await appendPermissionAuditWithIo(cwd, row, NODE_AUDIT_SINK_IO);
 }
 function failTool(message) {
   throw new Error(safeDiagnostic(message));
@@ -6061,7 +6065,6 @@ function formatPiDoctorReport(diagnoses) {
 
 // src/dispatch.ts
 import { randomUUID as randomUUID5 } from "node:crypto";
-import { appendFile as appendFile2 } from "node:fs/promises";
 import { resolve as resolve12 } from "node:path";
 import { types as utilTypes8 } from "node:util";
 
@@ -7366,19 +7369,16 @@ async function appendDispatchAudit(record2) {
     "RULE: PI-DISPATCH",
     `AUDIT: ${record2.terminal === "completed" ? "PI_DISPATCH_COMPLETED" : "PI_DISPATCH_DEGRADED"}`,
     `CORRELATION: ${randomUUID5()}`,
-    `ROLE: ${safeDiagnostic(record2.role, 100)}`,
-    `PROVIDER: ${safeDiagnostic(record2.provider, 100)}`,
-    `MODEL: ${safeDiagnostic(record2.model, 100)}`,
+    `ROLE: ${auditField(safeDiagnostic(record2.role, 100))}`,
+    `PROVIDER: ${auditField(safeDiagnostic(record2.provider, 100))}`,
+    `MODEL: ${auditField(safeDiagnostic(record2.model, 100))}`,
     `EXIT: ${record2.terminal}${record2.exitCode === void 0 ? "" : `(${record2.exitCode})`}`,
     `DURATION_MS: ${record2.durationMs ?? 0}`,
     `STDOUT_BYTES: ${record2.stdoutBytes ?? 0}`,
     `STDERR_BYTES: ${record2.stderrBytes ?? 0}`,
-    ...record2.diagnostic === void 0 ? [] : [`DIAGNOSTIC: ${safeDiagnostic(record2.diagnostic, 200)}`]
+    ...record2.diagnostic === void 0 ? [] : [`DIAGNOSTIC: ${auditField(safeDiagnostic(record2.diagnostic, 200))}`]
   ].join(" | ") + "\n";
-  try {
-    await appendFile2(resolve12(record2.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-  } catch {
-  }
+  await appendAuditLine(record2.cwd, line);
 }
 var DISPATCH_MODES = Object.freeze(["single", "chain", "parallel"]);
 var DISPATCH_TERMINALS = Object.freeze([
@@ -7962,7 +7962,6 @@ function createFarmPreviewTool(dependencies) {
 
 // src/compaction.ts
 import { randomUUID as randomUUID6 } from "node:crypto";
-import { appendFile as appendFile3 } from "node:fs/promises";
 import { resolve as resolve14 } from "node:path";
 var MAX_CONVERSATION_BYTES = 48e3;
 var MAX_SUMMARY_BYTES = 16e3;
@@ -8122,15 +8121,64 @@ function alreadyCompactedTail(entries) {
   }
   return false;
 }
-async function handleBeforeCompact(event, context, runner) {
+var COMPACTION_REASONS = Object.freeze(["manual", "threshold", "overflow"]);
+var MAX_BRANCH_ENTRIES = 1e5;
+var MAX_ENTRY_ID_CHARS = 1024;
+var MAX_HOST_TEXT_CHARS = 1048576;
+function boundedHostText(value, maxChars) {
+  return typeof value === "string" && value.length <= maxChars;
+}
+function isCompactionReason(value) {
+  return COMPACTION_REASONS.includes(value);
+}
+function isAbortSignalLike(value) {
+  return isRecord2(value) && typeof value.aborted === "boolean" && typeof value.addEventListener === "function" && typeof value.removeEventListener === "function";
+}
+function validPreparation(value) {
+  return isRecord2(value) && boundedHostText(value.firstKeptEntryId, MAX_ENTRY_ID_CHARS) && typeof value.tokensBefore === "number" && Number.isFinite(value.tokensBefore) && value.tokensBefore >= 0 && (value.previousSummary === void 0 || boundedHostText(value.previousSummary, MAX_HOST_TEXT_CHARS));
+}
+function parsePiCompactionEvent(raw) {
+  if (!isRecord2(raw)) return void 0;
+  if (!Array.isArray(raw.branchEntries) || raw.branchEntries.length > MAX_BRANCH_ENTRIES) return void 0;
+  if (!validPreparation(raw.preparation)) return void 0;
+  const customInstructions = raw.customInstructions;
+  if (customInstructions !== void 0 && !boundedHostText(customInstructions, MAX_HOST_TEXT_CHARS)) return void 0;
+  if (!isCompactionReason(raw.reason)) return void 0;
+  if (typeof raw.willRetry !== "boolean") return void 0;
+  if (!isAbortSignalLike(raw.signal)) return void 0;
+  const preparation = raw.preparation;
+  return {
+    branchEntries: raw.branchEntries,
+    preparation: {
+      firstKeptEntryId: preparation.firstKeptEntryId,
+      tokensBefore: preparation.tokensBefore,
+      ...preparation.previousSummary === void 0 ? {} : { previousSummary: preparation.previousSummary }
+    },
+    ...customInstructions === void 0 ? {} : { customInstructions },
+    reason: raw.reason,
+    willRetry: raw.willRetry,
+    signal: raw.signal
+  };
+}
+function parsePiCompactedEvent(raw) {
+  if (!isRecord2(raw)) return void 0;
+  if (typeof raw.fromExtension !== "boolean" || typeof raw.willRetry !== "boolean") return void 0;
+  if (!isCompactionReason(raw.reason)) return void 0;
+  return {
+    compactionEntry: raw.compactionEntry,
+    fromExtension: raw.fromExtension,
+    reason: raw.reason,
+    willRetry: raw.willRetry
+  };
+}
+async function handleBeforeCompact(rawEvent, context, runner) {
+  const event = parsePiCompactionEvent(rawEvent);
+  if (event === void 0) throw new Error(COMPACTION_FAILURE);
   if (event.signal.aborted) throw new Error("Pi native compaction was cancelled.");
   const provider = context.model?.provider;
   const model = context.model?.id;
   if (typeof provider !== "string" || provider.trim() === "" || typeof model !== "string" || model.trim() === "") {
     throw new Error("Pi native compaction requires the current exact provider and model.");
-  }
-  if (!Number.isFinite(event.preparation.tokensBefore) || event.preparation.tokensBefore < 0) {
-    throw new Error("Pi compaction token metrics are invalid.");
   }
   try {
     const semantic = piSemanticEntries(event.branchEntries);
@@ -8178,7 +8226,9 @@ async function handleBeforeCompact(event, context, runner) {
     throw new Error(COMPACTION_FAILURE);
   }
 }
-async function handleAfterCompact(event, audit) {
+async function handleAfterCompact(rawEvent, audit) {
+  const event = parsePiCompactedEvent(rawEvent);
+  if (event === void 0) return;
   if (!event.fromExtension || !isRecord2(event.compactionEntry)) return;
   const detailsRoot = event.compactionEntry.details;
   if (!isRecord2(detailsRoot) || !isRecord2(detailsRoot.codearbiter)) return;
@@ -8222,7 +8272,9 @@ function installPiCompaction(pi, options) {
     });
   });
 }
+var MAX_AUDIT_METRICS = 16;
 async function appendPiCompactionAudit(record2) {
+  const metrics = Object.fromEntries(Object.entries(record2.metrics).slice(0, MAX_AUDIT_METRICS));
   const line = [
     `[${(/* @__PURE__ */ new Date()).toISOString()}]`,
     "HOST: pi",
@@ -8230,12 +8282,9 @@ async function appendPiCompactionAudit(record2) {
     `AUDIT: ${record2.auditCodes.join(",") || "CA-PRUNE-CONFIRMED"}`,
     `CORRELATION: ${randomUUID6()}`,
     `PLAN: ${record2.planFingerprint}`,
-    `METRICS: ${JSON.stringify(record2.metrics)}`
+    `METRICS: ${JSON.stringify(metrics)}`
   ].join(" | ") + "\n";
-  try {
-    await appendFile3(resolve14(record2.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-  } catch {
-  }
+  await appendAuditLine(record2.cwd, line);
 }
 
 // src/extension.ts
@@ -8937,7 +8986,7 @@ async function codeArbiterPi(pi) {
         activeTools: pi.getActiveTools(),
         allTools: pi.getAllTools(),
         expansionFingerprints,
-        childFingerprint: "1e994b3ffb1ea78affa4ec7320a55050f89ece1ceb8f23b63e2e23183cb13462"
+        childFingerprint: "c1f1b9045b026cf712c01b198f054e4962de05eec3bc219d687a0694d2a78972"
       });
       const wrapperSelfTest = await runPiWrapperSelfTest({
         enabled: enabledForDoctor,

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/audit-sink.ts
+++ b/plugins/ca-pi/tools/src/audit-sink.ts
@@ -1,0 +1,187 @@
+/**
+ * audit-sink.ts - the single owner of every Pi write into a project's governance log.
+ *
+ * Permission decisions, background-job lifecycle rows, bridge failures, child dispatches, and
+ * confirmed compactions all land in the same project-local `.codearbiter/gate-events.log`. That path is
+ * derived from a caller-supplied project cwd, so a trusted project that plants a symlink,
+ * junction, or hardlink there could otherwise redirect a governance record onto another
+ * same-user file and leave the real log without it. `node:fs`'s own `appendFile` follows all
+ * three, which is why no producer is allowed to call it directly - `module-structure.test.ts`
+ * fails when a second implementation appears.
+ *
+ * The primitive answers one question - "is this still the project's own regular, single-linked
+ * log?" - at every step where the answer could have changed:
+ *
+ * 1. The project root and `.codearbiter` are canonicalized; a linked or escaping state
+ *    directory is rejected before any target path is formed.
+ * 2. The target is opened `O_NOFOLLOW` (where the platform has it), and created
+ *    `O_CREAT|O_EXCL` so a hardlink raced into an absent target cannot be adopted.
+ * 3. The opened handle's device/inode identity is compared against the validated path before
+ *    the append, and again after it, so a swap on either side of the write is caught.
+ *
+ * Every failure is a `false` return, never a throw: an unavailable or hostile sink must not
+ * change the enforcement outcome the caller already decided. Callers keep their own fail
+ * direction and emit only their own bounded diagnostic.
+ */
+import { constants as fsConstants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+
+import { lexicallyInside } from "./path-boundary.ts";
+
+/** The single governance log file name every Pi producer appends to. */
+const AUDIT_LOG_NAME = "gate-events.log";
+
+/** The project-relative state directory that must hold it. */
+const AUDIT_STATE_DIRECTORY = ".codearbiter";
+
+/** One row must stay small enough that a hostile field cannot bloat or straddle the log. */
+export const MAX_AUDIT_LINE_BYTES = 2_048;
+
+export interface AuditSinkStatsPort {
+  readonly dev: number;
+  readonly ino: number;
+  readonly nlink: number;
+  readonly size: number;
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+export interface AuditSinkHandlePort {
+  stat(): Promise<AuditSinkStatsPort>;
+  appendFile(data: string, options: { encoding: "utf8" }): Promise<unknown>;
+  sync(): Promise<void>;
+  close(): Promise<void>;
+}
+
+/** The filesystem seam, injectable so the adversarial race cases are testable from either host. */
+export interface AuditSinkIoPort {
+  realpath(path: string): Promise<string>;
+  lstat(path: string): Promise<AuditSinkStatsPort>;
+  open(path: string, flags: number, mode?: number): Promise<AuditSinkHandlePort>;
+}
+
+export const NODE_AUDIT_SINK_IO: AuditSinkIoPort = Object.freeze({ realpath, lstat, open });
+
+function sameAuditFile(left: AuditSinkStatsPort, right: AuditSinkStatsPort): boolean {
+  return left.isFile() && right.isFile()
+    && !left.isSymbolicLink() && !right.isSymbolicLink()
+    && left.nlink === 1 && right.nlink === 1
+    && left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameAuditDirectory(left: AuditSinkStatsPort, right: AuditSinkStatsPort): boolean {
+  return left.isDirectory() && right.isDirectory()
+    && !left.isSymbolicLink() && !right.isSymbolicLink()
+    && left.dev === right.dev && left.ino === right.ino;
+}
+
+async function openedAuditTarget(
+  target: string,
+  io: AuditSinkIoPort,
+): Promise<Readonly<{ handle: AuditSinkHandlePort; identity: AuditSinkStatsPort }> | undefined> {
+  const noFollow = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+  const existingFlags = fsConstants.O_WRONLY | fsConstants.O_APPEND | noFollow;
+  const createFlags = existingFlags | fsConstants.O_CREAT | fsConstants.O_EXCL;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let expected: AuditSinkStatsPort | undefined;
+    try {
+      expected = await io.lstat(target);
+      if (!expected.isFile() || expected.isSymbolicLink() || expected.nlink !== 1) return undefined;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return undefined;
+    }
+    let handle: AuditSinkHandlePort;
+    try {
+      handle = await io.open(target, expected === undefined ? createFlags : existingFlags, 0o600);
+    } catch (error) {
+      if (expected === undefined && (error as NodeJS.ErrnoException).code === "EEXIST" && attempt === 0) continue;
+      return undefined;
+    }
+    try {
+      const opened = await handle.stat();
+      const pathname = await io.lstat(target);
+      if (!sameAuditFile(opened, pathname) || expected !== undefined && !sameAuditFile(opened, expected)) {
+        await handle.close();
+        return undefined;
+      }
+      return Object.freeze({ handle, identity: opened });
+    } catch {
+      try { await handle.close(); } catch { /* fail closed below */ }
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Append exactly one already-rendered governance row to the project's own
+ * `.codearbiter/gate-events.log`, resolved beneath `cwd`.
+ *
+ * `line` must be a single bounded line ending in one newline: the sink is the last place that
+ * can refuse a forged embedded newline, and it does, rather than letting one producer's
+ * unsanitized field write a second structurally valid row.
+ *
+ * Returns whether the row is durably in the project's own log. Never throws.
+ */
+export async function appendAuditLineWithIo(cwd: string, line: string, io: AuditSinkIoPort): Promise<boolean> {
+  try {
+    if (Buffer.byteLength(line, "utf8") > MAX_AUDIT_LINE_BYTES
+      || !line.endsWith("\n") || line.slice(0, -1).includes("\n")) return false;
+    const root = await io.realpath(cwd);
+    const statePath = resolve(root, AUDIT_STATE_DIRECTORY);
+    const stateInfo = await io.lstat(statePath);
+    if (!stateInfo.isDirectory() || stateInfo.isSymbolicLink()) return false;
+    const state = await io.realpath(statePath);
+    const stateRelative = relative(root, state);
+    if (stateRelative === "" || !lexicallyInside(state, root) || resolve(root, stateRelative) !== state) return false;
+    const stateIdentity = await io.lstat(state);
+    if (!sameAuditDirectory(stateInfo, stateIdentity)) return false;
+    const stateIsCurrent = async (): Promise<boolean> => {
+      try {
+        return await io.realpath(statePath) === state
+          && sameAuditDirectory(stateIdentity, await io.lstat(statePath));
+      } catch {
+        return false;
+      }
+    };
+    if (!await stateIsCurrent()) return false;
+    const target = resolve(state, AUDIT_LOG_NAME);
+    const opened = await openedAuditTarget(target, io);
+    if (opened === undefined) return false;
+    const { handle, identity } = opened;
+    try {
+      const before = await handle.stat();
+      const beforePath = await io.lstat(target);
+      if (!sameAuditFile(identity, before) || !sameAuditFile(before, beforePath) || !await stateIsCurrent()) return false;
+      await handle.appendFile(line, { encoding: "utf8" });
+      await handle.sync();
+      const after = await handle.stat();
+      const afterPath = await io.lstat(target);
+      if (!sameAuditFile(before, after) || !sameAuditFile(after, afterPath)
+        || after.size < before.size + Buffer.byteLength(line, "utf8") || !await stateIsCurrent()) return false;
+    } finally {
+      await handle.close();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `appendAuditLineWithIo` bound to the real filesystem: the call every producer makes. */
+export async function appendAuditLine(cwd: string, line: string): Promise<boolean> {
+  return await appendAuditLineWithIo(cwd, line, NODE_AUDIT_SINK_IO);
+}
+
+/**
+ * Render one governance field so a hostile value cannot forge a second row.
+ *
+ * The shared redactor already strips secrets and control characters, but it deliberately
+ * preserves newlines for human-readable diagnostics. A single log line cannot, so the residual
+ * line breaks collapse to spaces here rather than causing the sink to drop the whole record.
+ */
+export function auditField(value: string): string {
+  return value.replaceAll("\n", " ");
+}

--- a/plugins/ca-pi/tools/src/bridge.ts
+++ b/plugins/ca-pi/tools/src/bridge.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, constants, realpathSync, statSync } from "node:fs";
-import { appendFile, realpath } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { dirname, isAbsolute, posix, resolve, win32 } from "node:path";
 
 import type {
@@ -15,6 +15,7 @@ import type {
   PiUsageSnapshotPortResult,
   ToolCategory,
 } from "./contracts.ts";
+import { appendAuditLine } from "./audit-sink.ts";
 import { flavorForPlatform, lexicallyInside } from "./path-boundary.ts";
 import { redactJson, safeDiagnostic } from "./redaction.ts";
 
@@ -704,11 +705,10 @@ export class BridgeClient implements BridgePort {
       `STDOUT_BYTES: ${counts.stdout}`,
       `STDERR_BYTES: ${counts.stderr}`,
     ].join(" | ") + "\n";
-    try {
-      await appendFile(resolve(request.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-    } catch {
-      // A bridge failure must retain its fail direction even if the audit sink is unavailable.
-    }
+    // appendAuditLine returns false rather than throwing when the project's sink is missing,
+    // linked, or raced, so a bridge failure keeps its fail direction and its own bounded
+    // diagnostic either way; the sink is never followed to reach an outside file.
+    await appendAuditLine(request.cwd, line);
   }
 
   private async failed(

--- a/plugins/ca-pi/tools/src/compaction.ts
+++ b/plugins/ca-pi/tools/src/compaction.ts
@@ -298,16 +298,16 @@ function alreadyCompactedTail(entries: readonly unknown[]): boolean {
   return false;
 }
 
-/**
+/* ---------------------------------------------------------------------------
  * Host-event validation for the two native compaction records.
  *
  * Pi's generic event port hands every extension a `Record<string, unknown>`, so the only thing
  * standing between a drifted or malformed native record and a raw `TypeError` escaping into the
- * host callback is an exact parse. These validators are the adapter's schema-checked boundary:
- * every field the compaction logic later dereferences is proven here, from `unknown`, with no
- * type assertion anywhere on the path. An invalid record leaves through the same fixed
+ * host callback is an exact parse. The validators below are the adapter's schema-checked
+ * boundary: every field the compaction logic later dereferences is proven here, from `unknown`,
+ * with no type assertion anywhere on the path. An invalid record leaves through the same fixed
  * diagnostic a failed compaction uses, never through a stack trace carrying host payload.
- */
+ * ------------------------------------------------------------------------ */
 const COMPACTION_REASONS = Object.freeze(["manual", "threshold", "overflow"] as const);
 const MAX_BRANCH_ENTRIES = 100_000;
 const MAX_ENTRY_ID_CHARS = 1_024;
@@ -511,13 +511,13 @@ export function installPiCompaction(
   });
 }
 
-/** Appends one confirmed-compaction row through the shared hardened sink in audit-sink.ts. The
- * rendered metrics are bounded here because the sink refuses an oversized line outright: a
- * plan may legitimately carry up to 64 metrics, and only the first `MAX_AUDIT_METRICS` of them
- * belong on one governance row. A confirmed compaction remains valid whether or not the
- * append-only sink accepts the row. */
+/** A plan may legitimately carry up to 64 metrics; only this many belong on one governance row.
+ * The sink refuses an oversized line outright, so bounding here is what keeps a wide but valid
+ * plan auditable instead of silently unrecorded. */
 const MAX_AUDIT_METRICS = 16;
 
+/** Appends one confirmed-compaction row through the shared hardened sink in audit-sink.ts. A
+ * confirmed compaction remains valid whether or not the append-only sink accepts the row. */
 export async function appendPiCompactionAudit(record: PiCompactionAuditRecord): Promise<void> {
   const metrics = Object.fromEntries(Object.entries(record.metrics).slice(0, MAX_AUDIT_METRICS));
   const line = [

--- a/plugins/ca-pi/tools/src/compaction.ts
+++ b/plugins/ca-pi/tools/src/compaction.ts
@@ -1,8 +1,8 @@
 /** compaction.ts - semantic, non-mutating Pi native compaction adapter. */
 import { randomUUID } from "node:crypto";
-import { appendFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
+import { appendAuditLine } from "./audit-sink.ts";
 import type { BridgePort, ExtensionContextPort, LifecycleLease } from "./contracts.ts";
 import { safeDiagnostic } from "./redaction.ts";
 import { runPiChild, type ChildResult, type PiChildRequest } from "./runner.ts";
@@ -298,20 +298,101 @@ function alreadyCompactedTail(entries: readonly unknown[]): boolean {
   return false;
 }
 
+/**
+ * Host-event validation for the two native compaction records.
+ *
+ * Pi's generic event port hands every extension a `Record<string, unknown>`, so the only thing
+ * standing between a drifted or malformed native record and a raw `TypeError` escaping into the
+ * host callback is an exact parse. These validators are the adapter's schema-checked boundary:
+ * every field the compaction logic later dereferences is proven here, from `unknown`, with no
+ * type assertion anywhere on the path. An invalid record leaves through the same fixed
+ * diagnostic a failed compaction uses, never through a stack trace carrying host payload.
+ */
+const COMPACTION_REASONS = Object.freeze(["manual", "threshold", "overflow"] as const);
+const MAX_BRANCH_ENTRIES = 100_000;
+const MAX_ENTRY_ID_CHARS = 1_024;
+const MAX_HOST_TEXT_CHARS = 1_048_576;
+
+function boundedHostText(value: unknown, maxChars: number): value is string {
+  return typeof value === "string" && value.length <= maxChars;
+}
+
+function isCompactionReason(value: unknown): value is PiCompactionEvent["reason"] {
+  return COMPACTION_REASONS.includes(value as never);
+}
+
+/** An AbortSignal the compaction path may both read and hand to a child run. */
+function isAbortSignalLike(value: unknown): value is AbortSignal {
+  return isRecord(value) && typeof value.aborted === "boolean"
+    && typeof value.addEventListener === "function" && typeof value.removeEventListener === "function";
+}
+
+function validPreparation(value: unknown): value is PiCompactionEvent["preparation"] {
+  return isRecord(value)
+    && boundedHostText(value.firstKeptEntryId, MAX_ENTRY_ID_CHARS)
+    && typeof value.tokensBefore === "number"
+    && Number.isFinite(value.tokensBefore) && value.tokensBefore >= 0
+    && (value.previousSummary === undefined || boundedHostText(value.previousSummary, MAX_HOST_TEXT_CHARS));
+}
+
+/** Parse a raw `session_before_compact` record; `undefined` means "do not narrow this". */
+export function parsePiCompactionEvent(raw: unknown): PiCompactionEvent | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (!Array.isArray(raw.branchEntries) || raw.branchEntries.length > MAX_BRANCH_ENTRIES) return undefined;
+  if (!validPreparation(raw.preparation)) return undefined;
+  const customInstructions = raw.customInstructions;
+  if (customInstructions !== undefined && !boundedHostText(customInstructions, MAX_HOST_TEXT_CHARS)) return undefined;
+  if (!isCompactionReason(raw.reason)) return undefined;
+  if (typeof raw.willRetry !== "boolean") return undefined;
+  if (!isAbortSignalLike(raw.signal)) return undefined;
+  const preparation = raw.preparation;
+  return {
+    branchEntries: raw.branchEntries,
+    preparation: {
+      firstKeptEntryId: preparation.firstKeptEntryId,
+      tokensBefore: preparation.tokensBefore,
+      ...(preparation.previousSummary === undefined ? {} : { previousSummary: preparation.previousSummary }),
+    },
+    ...(customInstructions === undefined ? {} : { customInstructions }),
+    reason: raw.reason,
+    willRetry: raw.willRetry,
+    signal: raw.signal,
+  };
+}
+
+export interface PiCompactedEvent {
+  compactionEntry: unknown;
+  fromExtension: boolean;
+  reason: string;
+  willRetry: boolean;
+}
+
+/** Parse a raw `session_compact` record; `undefined` means "do not audit this". */
+export function parsePiCompactedEvent(raw: unknown): PiCompactedEvent | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (typeof raw.fromExtension !== "boolean" || typeof raw.willRetry !== "boolean") return undefined;
+  if (!isCompactionReason(raw.reason)) return undefined;
+  return {
+    compactionEntry: raw.compactionEntry,
+    fromExtension: raw.fromExtension,
+    reason: raw.reason,
+    willRetry: raw.willRetry,
+  };
+}
+
 export async function handleBeforeCompact(
-  event: PiCompactionEvent,
+  rawEvent: unknown,
   context: PiCompactionContext,
   runner: CompactionRunner,
 ): Promise<PiCompactionResult | undefined> {
+  const event = parsePiCompactionEvent(rawEvent);
+  if (event === undefined) throw new Error(COMPACTION_FAILURE);
   if (event.signal.aborted) throw new Error("Pi native compaction was cancelled.");
   const provider = context.model?.provider;
   const model = context.model?.id;
   if (typeof provider !== "string" || provider.trim() === ""
     || typeof model !== "string" || model.trim() === "") {
     throw new Error("Pi native compaction requires the current exact provider and model.");
-  }
-  if (!Number.isFinite(event.preparation.tokensBefore) || event.preparation.tokensBefore < 0) {
-    throw new Error("Pi compaction token metrics are invalid.");
   }
 
   try {
@@ -362,9 +443,11 @@ export async function handleBeforeCompact(
 }
 
 export async function handleAfterCompact(
-  event: { compactionEntry: unknown; fromExtension: boolean; reason: string; willRetry: boolean },
+  rawEvent: unknown,
   audit: CompactionAuditPort,
 ): Promise<void> {
+  const event = parsePiCompactedEvent(rawEvent);
+  if (event === undefined) return;
   if (!event.fromExtension || !isRecord(event.compactionEntry)) return;
   const detailsRoot = event.compactionEntry.details;
   if (!isRecord(detailsRoot) || !isRecord(detailsRoot.codearbiter)) return;
@@ -407,7 +490,7 @@ export function installPiCompaction(
   pi.on("session_before_compact", async (rawEvent, rawContext) => {
     const lifecycle = currentLifecycle();
     if (lifecycle === undefined || !trustedContext(rawContext)) return undefined;
-    const result = await handleBeforeCompact(rawEvent as unknown as PiCompactionEvent, {
+    const result = await handleBeforeCompact(rawEvent, {
       cwd: rawContext.cwd,
       packageRoot: options.packageRoot,
       model: rawContext.model,
@@ -419,12 +502,7 @@ export function installPiCompaction(
   pi.on("session_compact", async (rawEvent, rawContext) => {
     const lifecycle = currentLifecycle();
     if (lifecycle === undefined || !trustedContext(rawContext)) return;
-    await handleAfterCompact(rawEvent as unknown as {
-      compactionEntry: unknown;
-      fromExtension: boolean;
-      reason: string;
-      willRetry: boolean;
-    }, {
+    await handleAfterCompact(rawEvent, {
       record: async (record) => {
         if (currentLifecycle() !== lifecycle) return;
         await options.audit({ cwd: rawContext.cwd, ...record });
@@ -433,7 +511,15 @@ export function installPiCompaction(
   });
 }
 
+/** Appends one confirmed-compaction row through the shared hardened sink in audit-sink.ts. The
+ * rendered metrics are bounded here because the sink refuses an oversized line outright: a
+ * plan may legitimately carry up to 64 metrics, and only the first `MAX_AUDIT_METRICS` of them
+ * belong on one governance row. A confirmed compaction remains valid whether or not the
+ * append-only sink accepts the row. */
+const MAX_AUDIT_METRICS = 16;
+
 export async function appendPiCompactionAudit(record: PiCompactionAuditRecord): Promise<void> {
+  const metrics = Object.fromEntries(Object.entries(record.metrics).slice(0, MAX_AUDIT_METRICS));
   const line = [
     `[${new Date().toISOString()}]`,
     "HOST: pi",
@@ -441,11 +527,7 @@ export async function appendPiCompactionAudit(record: PiCompactionAuditRecord): 
     `AUDIT: ${record.auditCodes.join(",") || "CA-PRUNE-CONFIRMED"}`,
     `CORRELATION: ${randomUUID()}`,
     `PLAN: ${record.planFingerprint}`,
-    `METRICS: ${JSON.stringify(record.metrics)}`,
+    `METRICS: ${JSON.stringify(metrics)}`,
   ].join(" | ") + "\n";
-  try {
-    await appendFile(resolve(record.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-  } catch {
-    // A confirmed compaction remains valid if its append-only audit sink is unavailable.
-  }
+  await appendAuditLine(record.cwd, line);
 }

--- a/plugins/ca-pi/tools/src/dispatch.ts
+++ b/plugins/ca-pi/tools/src/dispatch.ts
@@ -1,6 +1,5 @@
 /** dispatch.ts - bounded single, chained, and FIFO-parallel Pi orchestration. */
 import { randomUUID } from "node:crypto";
-import { appendFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { types as utilTypes } from "node:util";
 
@@ -11,6 +10,7 @@ import type {
 } from "./contracts.ts";
 import { publishActivity } from "./activity.ts";
 import type { ActivityPublisher } from "./activity.ts";
+import { appendAuditLine, auditField } from "./audit-sink.ts";
 import { safeDiagnostic } from "./redaction.ts";
 import { loadRoleCatalog, validRoleName } from "./roles.ts";
 import type { PiRole } from "./roles.ts";
@@ -30,11 +30,12 @@ interface DispatchAuditRecord {
   diagnostic?: string;
 }
 
-/** Appends one gate-events.log line per Pi child dispatch completion (success or failure),
- * mirroring bridge.ts's auditFailure and compaction.ts's appendPiCompactionAudit: same target
- * resolution, same append-only best-effort fail-open contract. An unwritable audit sink NEVER
- * changes dispatch behavior or its result. Task/prompt content and raw child stderr are never
- * included. */
+/** Appends one governance row per Pi child dispatch completion (success or failure) through the
+ * shared hardened sink in audit-sink.ts, which is also what bridge.ts's auditFailure and
+ * compaction.ts's appendPiCompactionAudit use: one target resolution, one link- and
+ * race-resistant append, one append-only best-effort fail-open contract. An unavailable or
+ * redirected audit sink NEVER changes dispatch behavior or its result. Task/prompt content and
+ * raw child stderr are never included. */
 export async function appendDispatchAudit(record: DispatchAuditRecord): Promise<void> {
   const line = [
     `[${new Date().toISOString()}]`,
@@ -42,20 +43,16 @@ export async function appendDispatchAudit(record: DispatchAuditRecord): Promise<
     "RULE: PI-DISPATCH",
     `AUDIT: ${record.terminal === "completed" ? "PI_DISPATCH_COMPLETED" : "PI_DISPATCH_DEGRADED"}`,
     `CORRELATION: ${randomUUID()}`,
-    `ROLE: ${safeDiagnostic(record.role, 100)}`,
-    `PROVIDER: ${safeDiagnostic(record.provider, 100)}`,
-    `MODEL: ${safeDiagnostic(record.model, 100)}`,
+    `ROLE: ${auditField(safeDiagnostic(record.role, 100))}`,
+    `PROVIDER: ${auditField(safeDiagnostic(record.provider, 100))}`,
+    `MODEL: ${auditField(safeDiagnostic(record.model, 100))}`,
     `EXIT: ${record.terminal}${record.exitCode === undefined ? "" : `(${record.exitCode})`}`,
     `DURATION_MS: ${record.durationMs ?? 0}`,
     `STDOUT_BYTES: ${record.stdoutBytes ?? 0}`,
     `STDERR_BYTES: ${record.stderrBytes ?? 0}`,
-    ...(record.diagnostic === undefined ? [] : [`DIAGNOSTIC: ${safeDiagnostic(record.diagnostic, 200)}`]),
+    ...(record.diagnostic === undefined ? [] : [`DIAGNOSTIC: ${auditField(safeDiagnostic(record.diagnostic, 200))}`]),
   ].join(" | ") + "\n";
-  try {
-    await appendFile(resolve(record.cwd, ".codearbiter", "gate-events.log"), line, { encoding: "utf8" });
-  } catch {
-    // A dispatch outcome remains valid if its append-only audit sink is unavailable.
-  }
+  await appendAuditLine(record.cwd, line);
 }
 
 export const DISPATCH_MODES = Object.freeze(["single", "chain", "parallel"] as const);

--- a/plugins/ca-pi/tools/src/tool-guard.ts
+++ b/plugins/ca-pi/tools/src/tool-guard.ts
@@ -8,10 +8,11 @@ import type {
   ToolResultPiPort,
 } from "./contracts.ts";
 import { createHash, randomUUID } from "node:crypto";
-import { constants as fsConstants, realpathSync } from "node:fs";
-import { lstat, open, realpath } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { types as utilTypes } from "node:util";
+import { NODE_AUDIT_SINK_IO, appendAuditLine, appendAuditLineWithIo } from "./audit-sink.ts";
+import type { AuditSinkIoPort } from "./audit-sink.ts";
 import { safeDiagnostic } from "./redaction.ts";
 import { applyToolResultNotice } from "./notices.ts";
 import {
@@ -99,30 +100,8 @@ export interface BackgroundJobAuditRow {
   readonly exitClass?: "success" | "failure" | "cancelled" | "timeout";
 }
 
-interface PermissionAuditStatsPort {
-  readonly dev: number;
-  readonly ino: number;
-  readonly nlink: number;
-  readonly size: number;
-  isDirectory(): boolean;
-  isFile(): boolean;
-  isSymbolicLink(): boolean;
-}
-
-interface PermissionAuditHandlePort {
-  stat(): Promise<PermissionAuditStatsPort>;
-  appendFile(data: string, options: { encoding: "utf8" }): Promise<unknown>;
-  sync(): Promise<void>;
-  close(): Promise<void>;
-}
-
-export interface PermissionAuditIoPort {
-  realpath(path: string): Promise<string>;
-  lstat(path: string): Promise<PermissionAuditStatsPort>;
-  open(path: string, flags: number, mode?: number): Promise<PermissionAuditHandlePort>;
-}
-
-const NODE_PERMISSION_AUDIT_IO: PermissionAuditIoPort = Object.freeze({ realpath, lstat, open });
+/** The permission audit's view of the shared hardened sink seam; see `audit-sink.ts`. */
+export type PermissionAuditIoPort = AuditSinkIoPort;
 
 const CONFIRMATION_TITLE = "Allow governed operation?";
 const CONFIRMATION_TIMEOUT_MS = 60_000;
@@ -270,101 +249,6 @@ function permissionAuditCodeRow(
 }
 
 /** Appends one closed, command-free permission row. Approved mutation audit is fail-closed. */
-function sameAuditFile(left: PermissionAuditStatsPort, right: PermissionAuditStatsPort): boolean {
-  return left.isFile() && right.isFile()
-    && !left.isSymbolicLink() && !right.isSymbolicLink()
-    && left.nlink === 1 && right.nlink === 1
-    && left.dev === right.dev && left.ino === right.ino;
-}
-
-function sameAuditDirectory(left: PermissionAuditStatsPort, right: PermissionAuditStatsPort): boolean {
-  return left.isDirectory() && right.isDirectory()
-    && !left.isSymbolicLink() && !right.isSymbolicLink()
-    && left.dev === right.dev && left.ino === right.ino;
-}
-
-async function openedAuditTarget(
-  target: string,
-  io: PermissionAuditIoPort,
-): Promise<Readonly<{ handle: PermissionAuditHandlePort; identity: PermissionAuditStatsPort }> | undefined> {
-  const noFollow = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
-  const existingFlags = fsConstants.O_WRONLY | fsConstants.O_APPEND | noFollow;
-  const createFlags = existingFlags | fsConstants.O_CREAT | fsConstants.O_EXCL;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    let expected: PermissionAuditStatsPort | undefined;
-    try {
-      expected = await io.lstat(target);
-      if (!expected.isFile() || expected.isSymbolicLink() || expected.nlink !== 1) return undefined;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return undefined;
-    }
-    let handle: PermissionAuditHandlePort;
-    try {
-      handle = await io.open(target, expected === undefined ? createFlags : existingFlags, 0o600);
-    } catch (error) {
-      if (expected === undefined && (error as NodeJS.ErrnoException).code === "EEXIST" && attempt === 0) continue;
-      return undefined;
-    }
-    try {
-      const opened = await handle.stat();
-      const pathname = await io.lstat(target);
-      if (!sameAuditFile(opened, pathname) || expected !== undefined && !sameAuditFile(opened, expected)) {
-        await handle.close();
-        return undefined;
-      }
-      return Object.freeze({ handle, identity: opened });
-    } catch {
-      try { await handle.close(); } catch { /* fail closed below */ }
-      return undefined;
-    }
-  }
-  return undefined;
-}
-
-async function appendAuditLineWithIo(cwd: string, line: string, io: PermissionAuditIoPort): Promise<boolean> {
-  try {
-    if (Buffer.byteLength(line, "utf8") > 2_048 || !line.endsWith("\n") || line.slice(0, -1).includes("\n")) return false;
-    const root = await io.realpath(cwd);
-    const statePath = resolve(root, ".codearbiter");
-    const stateInfo = await io.lstat(statePath);
-    if (!stateInfo.isDirectory() || stateInfo.isSymbolicLink()) return false;
-    const state = await io.realpath(statePath);
-    const stateRelative = relative(root, state);
-    if (stateRelative === "" || stateRelative.startsWith("..") || resolve(root, stateRelative) !== state) return false;
-    const stateIdentity = await io.lstat(state);
-    if (!sameAuditDirectory(stateInfo, stateIdentity)) return false;
-    const stateIsCurrent = async (): Promise<boolean> => {
-      try {
-        return await io.realpath(statePath) === state
-          && sameAuditDirectory(stateIdentity, await io.lstat(statePath));
-      } catch {
-        return false;
-      }
-    };
-    if (!await stateIsCurrent()) return false;
-    const target = resolve(state, "gate-events.log");
-    const opened = await openedAuditTarget(target, io);
-    if (opened === undefined) return false;
-    const { handle, identity } = opened;
-    try {
-      const before = await handle.stat();
-      const beforePath = await io.lstat(target);
-      if (!sameAuditFile(identity, before) || !sameAuditFile(before, beforePath) || !await stateIsCurrent()) return false;
-      await handle.appendFile(line, { encoding: "utf8" });
-      await handle.sync();
-      const after = await handle.stat();
-      const afterPath = await io.lstat(target);
-      if (!sameAuditFile(before, after) || !sameAuditFile(after, afterPath)
-        || after.size < before.size + Buffer.byteLength(line, "utf8") || !await stateIsCurrent()) return false;
-    } finally {
-      await handle.close();
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export async function appendPermissionAuditWithIo(
   cwd: string,
   row: PermissionAuditRow,
@@ -415,7 +299,7 @@ export async function appendBackgroundJobAudit(cwd: string, row: BackgroundJobAu
         || !Number.isSafeInteger(row.durationMs) || row.durationMs! < 0
         || !Number.isSafeInteger(row.outputBytes) || row.outputBytes! < 0 || row.outputBytes! > 65_536))
       || (row.event === "cancel" && typeof row.accepted !== "boolean")) return false;
-    return await appendAuditLineWithIo(cwd, [
+    return await appendAuditLine(cwd, [
       `[${row.timestamp}]`, "HOST: pi", "RULE: PI-BACKGROUND-JOB", `CORRELATION: ${row.correlation}`,
       `LIFECYCLE: ${row.lifecycleId}`, `EVENT: ${row.event}`, `JOB_ID: ${row.id}`,
       ...(row.state === undefined ? [] : [`STATE: ${row.state}`]),
@@ -424,12 +308,12 @@ export async function appendBackgroundJobAudit(cwd: string, row: BackgroundJobAu
       ...(row.durationMs === undefined ? [] : [`DURATION_MS: ${row.durationMs}`]),
       ...(row.exitClass === undefined ? [] : [`EXIT_CLASS: ${row.exitClass}`]),
       ...(row.accepted === undefined ? [] : [`ACCEPTED: ${row.accepted}`]),
-    ].join(" | ") + "\n", NODE_PERMISSION_AUDIT_IO);
+    ].join(" | ") + "\n");
   } catch { return false; }
 }
 
 export async function appendPermissionAudit(cwd: string, row: PermissionAuditRow): Promise<boolean> {
-  return await appendPermissionAuditWithIo(cwd, row, NODE_PERMISSION_AUDIT_IO);
+  return await appendPermissionAuditWithIo(cwd, row, NODE_AUDIT_SINK_IO);
 }
 
 export interface EnforcementReadinessPort {

--- a/plugins/ca-pi/tools/src/tool-guard.ts
+++ b/plugins/ca-pi/tools/src/tool-guard.ts
@@ -9,7 +9,6 @@ import type {
 } from "./contracts.ts";
 import { createHash, randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
-import { relative, resolve } from "node:path";
 import { types as utilTypes } from "node:util";
 import { NODE_AUDIT_SINK_IO, appendAuditLine, appendAuditLineWithIo } from "./audit-sink.ts";
 import type { AuditSinkIoPort } from "./audit-sink.ts";

--- a/plugins/ca-pi/tools/test/audit-sink.test.ts
+++ b/plugins/ca-pi/tools/test/audit-sink.test.ts
@@ -1,0 +1,297 @@
+/**
+ * audit-sink.test.ts - the one adversarial matrix every Pi `gate-events.log` producer runs.
+ *
+ * Two tables live here. The producer table drives the real filesystem cases (regular append,
+ * file symlink, directory junction, hardlink, nonregular sink) across every writer that can put
+ * a row into the governance log, so a new producer that reimplements the sink is caught by the
+ * negative cases rather than by review. The primitive table drives the injected-io race cases
+ * (validation-open swap, opened-handle mismatch, post-append swap, create race) against the one
+ * shared primitive; `module-structure.test.ts` proves there is no second implementation for
+ * those cases to miss.
+ */
+import { link, lstat, mkdir, mkdtemp, open, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { BridgeClient } from "../src/bridge.ts";
+import { appendPiCompactionAudit } from "../src/compaction.ts";
+import { appendDispatchAudit } from "../src/dispatch.ts";
+import { appendBackgroundJobAudit, appendPermissionAudit } from "../src/tool-guard.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(async (root) => await rm(root, { recursive: true, force: true })));
+});
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await realpath(await mkdtemp(resolve(tmpdir(), prefix)));
+  temporaryRoots.push(root);
+  return root;
+}
+
+/** File symlinks need an elevated or developer-mode Windows session; probe once. */
+async function fileSymlinksAvailable(): Promise<boolean> {
+  const root = await temporaryRoot("ca-pi-symlink-probe-");
+  try {
+    await writeFile(resolve(root, "target"), "probe\n", "utf8");
+    await symlink(resolve(root, "target"), resolve(root, "alias"), "file");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const FILE_SYMLINKS = await fileSymlinksAvailable();
+
+/** A Pi writer that emits exactly one governance row into the project's own audit log. */
+interface AuditProducer {
+  readonly name: string;
+  readonly rule: string;
+  emit(cwd: string): Promise<void>;
+}
+
+/** Reaches `BridgeClient.auditFailure` without spawning Python: an unresolvable interpreter
+ * rejects path validation, which is the bridge's own audited failure path. */
+async function emitBridgeFailure(cwd: string): Promise<void> {
+  const bridge = new BridgeClient({
+    bridgeScript: resolve(cwd, "hooks", "pi-bridge.py"),
+    packageRoot: resolve(cwd, "hooks"),
+    toolClasses: { bash: "EXEC" },
+  });
+  const response = await bridge.call(
+    { version: 1, event: "tool_call", cwd, tool: "bash", input: { command: "git status" } },
+    new AbortController().signal,
+  );
+  expect(response.outcome).toBe("block");
+}
+
+const PRODUCERS: readonly AuditProducer[] = Object.freeze([
+  {
+    name: "permission",
+    rule: "RULE: PI-PERMISSION",
+    emit: async (cwd) => {
+      await appendPermissionAudit(cwd, {
+        timestamp: "2026-07-24T00:00:00.000Z",
+        correlation: "a".repeat(64),
+        toolClass: "EXEC",
+        actionClasses: ["shell-mutation"],
+        decision: "approved",
+      });
+    },
+  },
+  {
+    name: "background-job",
+    rule: "RULE: PI-BACKGROUND-JOB",
+    emit: async (cwd) => {
+      await appendBackgroundJobAudit(cwd, {
+        timestamp: "2026-07-24T00:00:00.000Z",
+        lifecycleId: "b".repeat(64),
+        correlation: "c".repeat(64),
+        event: "cancel",
+        id: 1,
+        accepted: true,
+      });
+    },
+  },
+  { name: "bridge-failure", rule: "RULE: PI-BRIDGE", emit: emitBridgeFailure },
+  {
+    name: "dispatch",
+    rule: "RULE: PI-DISPATCH",
+    emit: async (cwd) => {
+      await appendDispatchAudit({
+        cwd,
+        role: "security-reviewer",
+        provider: "openai",
+        model: "gpt-5",
+        terminal: "completed",
+        exitCode: 0,
+        durationMs: 1,
+        stdoutBytes: 1,
+        stderrBytes: 0,
+      });
+    },
+  },
+  {
+    name: "compaction",
+    rule: "RULE: PI-PRUNE",
+    emit: async (cwd) => {
+      await appendPiCompactionAudit({
+        cwd,
+        auditCodes: ["CA-PRUNE-PLAN"],
+        metrics: { entriesBefore: 5, candidateEntries: 3 },
+        planFingerprint: "plan-123",
+      });
+    },
+  },
+]);
+
+describe("Pi audit sink hardening", () => {
+  test.each(PRODUCERS)("$name writes its row into the project's own state directory", async (producer) => {
+    const root = await temporaryRoot("ca-pi-audit-regular-");
+    await mkdir(resolve(root, ".codearbiter"));
+
+    await producer.emit(root);
+
+    const audit = await readFile(resolve(root, ".codearbiter", "gate-events.log"), "utf8");
+    expect(audit).toContain("HOST: pi");
+    expect(audit).toContain(producer.rule);
+    expect(audit.endsWith("\n")).toBe(true);
+    expect(audit.split("\n").filter((line) => line !== "")).toHaveLength(1);
+  });
+
+  test.skipIf(!FILE_SYMLINKS).each(PRODUCERS)(
+    "$name refuses a gate-events.log symlinked at an external sentinel",
+    async (producer) => {
+      const root = await temporaryRoot("ca-pi-audit-file-link-");
+      const outside = await temporaryRoot("ca-pi-audit-file-sentinel-");
+      const sentinel = resolve(outside, "sentinel.log");
+      await mkdir(resolve(root, ".codearbiter"));
+      await writeFile(sentinel, "sentinel\n", "utf8");
+      await symlink(sentinel, resolve(root, ".codearbiter", "gate-events.log"), "file");
+
+      await producer.emit(root);
+
+      expect(await readFile(sentinel, "utf8")).toBe("sentinel\n");
+    },
+  );
+
+  test.each(PRODUCERS)("$name refuses a .codearbiter directory linked at an external sentinel", async (producer) => {
+    const root = await temporaryRoot("ca-pi-audit-dir-link-");
+    const outside = await temporaryRoot("ca-pi-audit-dir-sentinel-");
+    const sentinel = resolve(outside, "gate-events.log");
+    await writeFile(sentinel, "sentinel\n", "utf8");
+    await symlink(outside, resolve(root, ".codearbiter"), process.platform === "win32" ? "junction" : "dir");
+
+    await producer.emit(root);
+
+    expect(await readFile(sentinel, "utf8")).toBe("sentinel\n");
+  });
+
+  test.each(PRODUCERS)("$name refuses a gate-events.log hardlinked at an external sentinel", async (producer) => {
+    const root = await temporaryRoot("ca-pi-audit-hardlink-");
+    const sentinel = resolve(root, "sentinel.log");
+    await mkdir(resolve(root, ".codearbiter"));
+    await writeFile(sentinel, "sentinel\n", "utf8");
+    await link(sentinel, resolve(root, ".codearbiter", "gate-events.log"));
+
+    await producer.emit(root);
+
+    expect(await readFile(sentinel, "utf8")).toBe("sentinel\n");
+  });
+
+  test.each(PRODUCERS)("$name keeps its fail-open result when the sink is not a regular file", async (producer) => {
+    const root = await temporaryRoot("ca-pi-audit-nonregular-");
+    await mkdir(resolve(root, ".codearbiter", "gate-events.log"), { recursive: true });
+
+    await expect(producer.emit(root)).resolves.toBeUndefined();
+
+    expect((await lstat(resolve(root, ".codearbiter", "gate-events.log"))).isDirectory()).toBe(true);
+  });
+
+  test.each(PRODUCERS)("$name never creates a state directory the project does not have", async (producer) => {
+    const root = await temporaryRoot("ca-pi-audit-absent-state-");
+
+    await producer.emit(root);
+
+    await expect(lstat(resolve(root, ".codearbiter"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("Pi audit sink race cases", () => {
+  const line = "[2026-07-24T00:00:00.000Z] | HOST: pi | RULE: PI-TEST | AUDIT: PI_TEST\n";
+
+  async function fixture(): Promise<{ root: string; target: string; replacement: string }> {
+    const root = await temporaryRoot("ca-pi-audit-race-");
+    const state = resolve(root, ".codearbiter");
+    await mkdir(state);
+    return { root, target: resolve(state, "gate-events.log"), replacement: resolve(state, "replacement.log") };
+  }
+
+  test("rejects a target swapped between validation and open", async () => {
+    const { root, target, replacement } = await fixture();
+    await writeFile(target, "target\n", "utf8");
+    await writeFile(replacement, "replacement\n", "utf8");
+    const targetStats = await lstat(target);
+    const replacementStats = await lstat(replacement);
+    let targetLstats = 0;
+    const { appendAuditLineWithIo } = await import("../src/audit-sink.ts");
+
+    await expect(appendAuditLineWithIo(root, line, {
+      realpath,
+      lstat: async (path: string) => {
+        if (path === target) return ++targetLstats === 1 ? targetStats : replacementStats;
+        return await lstat(path);
+      },
+      open: async () => await open(replacement, "a"),
+    })).resolves.toBe(false);
+    expect(await readFile(replacement, "utf8")).toBe("replacement\n");
+  });
+
+  test("rejects an opened handle whose identity is not the validated path", async () => {
+    const { root, target, replacement } = await fixture();
+    await writeFile(target, "target\n", "utf8");
+    await writeFile(replacement, "replacement\n", "utf8");
+    const { appendAuditLineWithIo } = await import("../src/audit-sink.ts");
+
+    await expect(appendAuditLineWithIo(root, line, {
+      realpath,
+      lstat,
+      open: async () => await open(replacement, "a"),
+    })).resolves.toBe(false);
+    expect(await readFile(replacement, "utf8")).toBe("replacement\n");
+  });
+
+  test("rejects a target swapped after the append", async () => {
+    const { root, target, replacement } = await fixture();
+    await writeFile(target, "target\n", "utf8");
+    await writeFile(replacement, "replacement\n", "utf8");
+    const targetStats = await lstat(target);
+    const replacementStats = await lstat(replacement);
+    let targetLstats = 0;
+    const { appendAuditLineWithIo } = await import("../src/audit-sink.ts");
+
+    await expect(appendAuditLineWithIo(root, line, {
+      realpath,
+      lstat: async (path: string) => {
+        if (path === target) return ++targetLstats < 4 ? targetStats : replacementStats;
+        return await lstat(path);
+      },
+      open: async () => await open(target, "a"),
+    })).resolves.toBe(false);
+    expect(await readFile(replacement, "utf8")).toBe("replacement\n");
+  });
+
+  test("rejects a hardlink raced into an absent target", async () => {
+    const { root, target } = await fixture();
+    const sentinel = resolve(root, "sentinel.log");
+    await writeFile(sentinel, "sentinel\n", "utf8");
+    let raced = false;
+    const { appendAuditLineWithIo } = await import("../src/audit-sink.ts");
+
+    await expect(appendAuditLineWithIo(root, line, {
+      realpath,
+      lstat,
+      open: async (path: string, flags: number, mode?: number) => {
+        if (path === target && !raced) {
+          raced = true;
+          await link(sentinel, target);
+        }
+        return await open(path, flags, mode);
+      },
+    })).resolves.toBe(false);
+    expect(await readFile(sentinel, "utf8")).toBe("sentinel\n");
+  });
+
+  test("rejects a line that is unbounded, unterminated, or carries an embedded newline", async () => {
+    const { root } = await fixture();
+    const { appendAuditLine } = await import("../src/audit-sink.ts");
+
+    await expect(appendAuditLine(root, `${"x".repeat(2_049)}\n`)).resolves.toBe(false);
+    await expect(appendAuditLine(root, "no terminator")).resolves.toBe(false);
+    await expect(appendAuditLine(root, "forged\ninjection\n")).resolves.toBe(false);
+    await expect(lstat(resolve(root, ".codearbiter", "gate-events.log"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/plugins/ca-pi/tools/test/compaction.test.ts
+++ b/plugins/ca-pi/tools/test/compaction.test.ts
@@ -374,3 +374,100 @@ describe("Task 8 Pi compaction lifecycle integration", () => {
     expect(audit).toHaveBeenCalledOnce();
   });
 });
+
+describe("Pi native compaction host-event validation", () => {
+  const SAFE = "Pi native compaction failed safely; run /ca-doctor.";
+  /** A credential-shaped host payload: the diagnostic must never echo it back. */
+  const HOSTILE_PAYLOAD = "OPENAI_API_KEY=synthetic-secret";
+  const context = {
+    cwd: resolve("C:/repo"), packageRoot: resolve("C:/package"),
+    model: { provider: "openai", id: "gpt-test" },
+  };
+
+  function malformedBeforeEvents(): ReadonlyArray<readonly [string, unknown]> {
+    const valid = event();
+    return [
+      ["empty record", {}],
+      ["null", null],
+      ["undefined", undefined],
+      ["array", []],
+      ["scalar number", 42],
+      ["scalar string", HOSTILE_PAYLOAD],
+      ["missing signal", { ...valid, signal: undefined }],
+      ["signal without a boolean aborted", { ...valid, signal: { aborted: "yes", addEventListener() {}, throwIfAborted() {} } }],
+      ["signal without listener support", { ...valid, signal: { aborted: false } }],
+      ["missing preparation", { ...valid, preparation: undefined }],
+      ["scalar preparation", { ...valid, preparation: HOSTILE_PAYLOAD }],
+      ["missing firstKeptEntryId", { ...valid, preparation: { tokensBefore: 1 } }],
+      ["non-string firstKeptEntryId", { ...valid, preparation: { firstKeptEntryId: 7, tokensBefore: 1 } }],
+      ["string tokensBefore", { ...valid, preparation: { firstKeptEntryId: "u1", tokensBefore: "12345" } }],
+      ["NaN tokensBefore", { ...valid, preparation: { firstKeptEntryId: "u1", tokensBefore: Number.NaN } }],
+      ["negative tokensBefore", { ...valid, preparation: { firstKeptEntryId: "u1", tokensBefore: -1 } }],
+      ["non-string previousSummary", { ...valid, preparation: { firstKeptEntryId: "u1", tokensBefore: 1, previousSummary: 9 } }],
+      ["non-string customInstructions", { ...valid, customInstructions: 9 }],
+      ["unknown reason", { ...valid, reason: "compact-now" }],
+      ["non-boolean willRetry", { ...valid, willRetry: "false" }],
+      ["non-array branchEntries", { ...valid, branchEntries: { length: 1 } }],
+      ["oversized branchEntries", { ...valid, branchEntries: new Array(100_001).fill({ type: "message" }) }],
+      ["oversized customInstructions", { ...valid, customInstructions: "x".repeat(1_048_577) }],
+    ] as const;
+  }
+
+  test.each(malformedBeforeEvents())(
+    "session_before_compact rejects %s with the fixed diagnostic",
+    async (_name, raw) => {
+      const child = runner();
+      await expect(handleBeforeCompact(raw as never, context, child)).rejects.toThrow(SAFE);
+      await expect(handleBeforeCompact(raw as never, context, child)).rejects.not.toThrow(/synthetic-secret/u);
+      expect(child.plan).not.toHaveBeenCalled();
+      expect(child.summarize).not.toHaveBeenCalled();
+    },
+  );
+
+  test("the registered session_before_compact handler never leaks a host TypeError", async () => {
+    const handlers = new Map<string, (raw: any, ctx: any) => unknown>();
+    const child = runner();
+    installPiCompaction(
+      { on: (name: string, handler: (raw: any, ctx: any) => unknown) => handlers.set(name, handler) },
+      {
+        packageRoot: resolve("C:/package"), isLifecycleReady: () => true,
+        runner: child, audit: vi.fn(async () => undefined),
+      },
+    );
+    const hostContext = {
+      cwd: resolve("C:/repo"), model: { provider: "openai", id: "gpt-test" }, isProjectTrusted: () => true,
+    };
+
+    await expect(handlers.get("session_before_compact")!({}, hostContext)).rejects.toThrow(SAFE);
+    expect(child.plan).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["array", []],
+    ["scalar", 42],
+    ["non-boolean fromExtension", { compactionEntry: {}, fromExtension: "yes", reason: "threshold", willRetry: false }],
+    ["unknown reason", { compactionEntry: {}, fromExtension: true, reason: HOSTILE_PAYLOAD, willRetry: false }],
+    ["non-boolean willRetry", { compactionEntry: {}, fromExtension: true, reason: "threshold", willRetry: 1 }],
+  ] as const)("session_compact ignores %s without throwing or recording", async (_name, raw) => {
+    const audit = { record: vi.fn(async () => undefined) };
+    await expect(handleAfterCompact(raw as never, audit)).resolves.toBeUndefined();
+    expect(audit.record).not.toHaveBeenCalled();
+  });
+
+  test("the registered session_compact handler ignores a malformed host record", async () => {
+    const handlers = new Map<string, (raw: any, ctx: any) => unknown>();
+    const audit = vi.fn(async () => undefined);
+    installPiCompaction(
+      { on: (name: string, handler: (raw: any, ctx: any) => unknown) => handlers.set(name, handler) },
+      { packageRoot: resolve("C:/package"), isLifecycleReady: () => true, runner: runner(), audit },
+    );
+    const hostContext = {
+      cwd: resolve("C:/repo"), model: { provider: "openai", id: "gpt-test" }, isProjectTrusted: () => true,
+    };
+
+    await expect(handlers.get("session_compact")!(null, hostContext)).resolves.toBeUndefined();
+    expect(audit).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/ca-pi/tools/test/module-structure.test.ts
+++ b/plugins/ca-pi/tools/test/module-structure.test.ts
@@ -18,6 +18,12 @@ const COMMAND_SURFACE_CLUSTER = Object.freeze([
   "path-boundary.ts",
 ]);
 
+/** The governance log a Pi producer may only reach through the shared hardened primitive. */
+const AUDIT_SINK_TARGET = /gate-events\.log/u;
+
+/** A filesystem append: a second, unhardened audit-sink implementation if it is not the owner. */
+const DIRECT_APPEND = /\bappendFile\b/u;
+
 const COMMAND_SURFACE_CEILING = 350;
 const CLUSTER_CEILING = 450;
 
@@ -75,6 +81,24 @@ describe("Pi module structure", () => {
     const boundary = await import("../src/path-boundary.ts");
     for (const name of ["lexicallyInside", "canonicallyInside", "canonicalPath", "flavorForPlatform"]) {
       expect(typeof (boundary as Record<string, unknown>)[name]).toBe("function");
+    }
+  });
+
+  test("gate-events audit appends have exactly one owner", () => {
+    const owners = sourceFiles().filter((name) => AUDIT_SINK_TARGET.test(sourceOf(name)));
+    expect(owners).toEqual(["audit-sink.ts"]);
+  });
+
+  test("no production module appends to the filesystem outside the audit sink", () => {
+    const direct = sourceFiles()
+      .filter((name) => name !== "audit-sink.ts" && DIRECT_APPEND.test(sourceOf(name)));
+    expect(direct).toEqual([]);
+  });
+
+  test("the audit sink module exports the hardened primitive and its injectable seam", async () => {
+    const sink = await import("../src/audit-sink.ts");
+    for (const name of ["appendAuditLine", "appendAuditLineWithIo"]) {
+      expect(typeof (sink as Record<string, unknown>)[name]).toBe("function");
     }
   });
 


### PR DESCRIPTION
Closes #374
Closes #411

## What changed

### #374 — every Pi audit sink now has one hardened owner

Three producers derived the project's `.codearbiter` governance log from a
caller-supplied cwd and appended to it directly, which follows file symlinks,
directory junctions, and hardlinks:

| producer | before | after |
| --- | --- | --- |
| `bridge.ts` `auditFailure` (line 708 on main, not 700) | `appendFile(resolve(request.cwd, …))` | `appendAuditLine(request.cwd, line)` |
| `compaction.ts` `appendPiCompactionAudit` (447 — as filed) | `appendFile(resolve(record.cwd, …))` | `appendAuditLine(record.cwd, line)` |
| `dispatch.ts` `appendDispatchAudit` (55 on main, not 64) | `appendFile(resolve(record.cwd, …))` | `appendAuditLine(record.cwd, line)` |

`src/audit-sink.ts` is new and owns the primitive `tool-guard.ts` used to keep
private (it was at ~285-360, not 275-316). It canonicalizes the project root and
`.codearbiter`, refuses a linked or escaping state directory, opens the target
`O_NOFOLLOW` and `O_CREAT|O_EXCL`, and compares the opened handle's device/inode
identity against the validated path before *and* after the append. Containment
itself is delegated to `path-boundary.ts` (`lexicallyInside`), which #445
established as the single owner — so this adds a sink, not a second containment
opinion. Every failure is a `false` return, never a throw, so no producer's fail
direction or bounded diagnostic changes.

Dispatch's `ROLE`/`PROVIDER`/`MODEL`/`DIAGNOSTIC` fields additionally collapse
residual newlines. `safeDiagnostic` deliberately preserves them for readable
diagnostics, but a single governance row cannot carry one; without this the sink
would correctly refuse the whole record rather than write a forged second row.

### #411 — Pi compaction host events are validated before they are narrowed

`installPiCompaction` laundered both raw host records through `as unknown as`
(compaction.ts 410 and 421 on main), and `handleBeforeCompact` dereferenced
`event.signal.aborted` (306) and `event.preparation.tokensBefore` (313) before
its fail-safe `try` opened at 317. Both handlers now take `unknown` and parse
through exact bounded validators — abort signal, preparation, entry array
(bounded at 100 000), reason enum, booleans, bounded optional strings — with no
type assertion left anywhere on the host path. An invalid `session_before_compact`
record throws the fixed `Pi native compaction failed safely; run /ca-doctor.`
diagnostic; an invalid `session_compact` record is a documented no-op.

The now-unreachable `"Pi compaction token metrics are invalid."` branch is
removed: the parser proves `tokensBefore` is finite and non-negative before the
value is ever read.

## Issue accuracy

Both issues are real and reproduce. Line numbers had drifted (see above); the
substance of every claim held. Nothing in either issue was stale.

## Red first (verbatim)

`npx vitest run test/audit-sink.test.ts test/module-structure.test.ts test/compaction.test.ts`

```
 ❯ test/audit-sink.test.ts (35 tests | 14 failed) 139ms
   × Pi audit sink hardening > 'bridge-failure' refuses a gate-events.log symlinked at an external sentinel 10ms
     → expected 'sentinel\n[2026-07-25T11:16:27.532Z] …' to be 'sentinel\n' // Object.is equality
   × Pi audit sink hardening > 'dispatch' refuses a gate-events.log symlinked at an external sentinel 4ms
     → expected 'sentinel\n[2026-07-25T11:16:27.542Z] …' to be 'sentinel\n' // Object.is equality
   × Pi audit sink hardening > 'compaction' refuses a gate-events.log symlinked at an external sentinel 5ms
     → expected 'sentinel\n[2026-07-25T11:16:27.547Z] …' to be 'sentinel\n' // Object.is equality
   × Pi audit sink hardening > 'bridge-failure' refuses a .codearbiter directory linked at an external sentinel 4ms
   × Pi audit sink hardening > 'dispatch' refuses a .codearbiter directory linked at an external sentinel 4ms
   × Pi audit sink hardening > 'compaction' refuses a .codearbiter directory linked at an external sentinel 4ms
   × Pi audit sink hardening > 'bridge-failure' refuses a gate-events.log hardlinked at an external sentinel 5ms
   × Pi audit sink hardening > 'dispatch' refuses a gate-events.log hardlinked at an external sentinel 6ms
   × Pi audit sink hardening > 'compaction' refuses a gate-events.log hardlinked at an external sentinel 5ms
   × Pi audit sink race cases > rejects a target swapped between validation and open 7ms
     → Failed to load url ../src/audit-sink.ts (resolved id: ../src/audit-sink.ts). Does the file exist?
```

The sentinel diff names the redirected write exactly:

```
- sentinel
+ sentinel
+ [2026-07-25T11:16:27.532Z] | HOST: pi | RULE: PI-BRIDGE | AUDIT: PI_BRIDGE_BLOCK | CORRELATION: 02b8e392-956e-4ce8-b889-95ef3a6901d0 | REQUEST_BYTES: 0 | STDOUT_BYTES: 0 | STDERR_BYTES: 0
+ [2026-07-25T11:16:27.542Z] | HOST: pi | RULE: PI-DISPATCH | AUDIT: PI_DISPATCH_COMPLETED | CORRELATION: 8ed27b05-0cb9-42c7-a77f-0fb922883026 | ROLE: security-reviewer | PROVIDER: openai | MODEL: gpt-5 | EXIT: completed(0) | DURATION_MS: 1 | STDOUT_BYTES: 1 | STDERR_BYTES: 0
```

`permission` and `background-job` passed every one of those cases in the same
run — which is the whole of #374: the primitive existed, three producers simply
were not using it.

The source guard was red for the right reason too:

```
 FAIL test/module-structure.test.ts > Pi module structure > gate-events audit appends have exactly one owner
 AssertionError: expected [ 'bridge.ts', 'compaction.ts', …(2) ] to deeply equal [ 'audit-sink.ts' ]
- Array [
-   "audit-sink.ts",
+   "bridge.ts",
+   "compaction.ts",
+   "dispatch.ts",
+   "tool-guard.ts",
  ]
```

And #411 reproduced exactly as filed:

```
 FAIL test/compaction.test.ts > Pi native compaction host-event validation > the registered session_before_compact handler never leaks a host TypeError
 AssertionError: expected [Function] to throw error including 'Pi native compaction failed safely; r…' but got 'Cannot read properties of undefined (…'

 Expected: "Pi native compaction failed safely; run /ca-doctor."
 Received: "Cannot read properties of undefined (reading 'aborted')"

 FAIL test/compaction.test.ts > … > session_compact ignores null without throwing or recording
 Caused by: TypeError: Cannot read properties of null (reading 'fromExtension')
 ❯ Module.handleAfterCompact src/compaction.ts:368:14
```

42 tests failed across the three files before implementation; all 42 pass after.

## Suites

| suite | before | after |
| --- | --- | --- |
| `plugins/ca-pi/tools` `npm test` | 628 passed, 1 skipped, 1 failed (`package.test.ts`, env) | **698 passed**, 1 skipped, 1 failed (same env failure) |
| `plugins/ca-pi/tools` `npx tsc --noEmit` | 1 error (`rolldown`, env) | 1 error (same) |
| `plugins/ca/hooks/tests` | 1112 OK | **1112 OK** |
| `.github/scripts` | 1110 ran, 4 failed (`test_pi_benchmark`, env), 5 skipped | **1110 ran, 4 failed (same env failures), 5 skipped** |
| `git diff --check origin/main HEAD` | — | exit 0 |
| `build-host-packages.py --check --release-guard-base <merge-base>` | — | exit 0, `0.1.12 -> 0.1.13` |

New coverage: 70 tests — `test/audit-sink.test.ts` (35), the compaction
validator table (32), and three module-structure guards.

## Release

ca-pi `0.1.12` → `0.1.13`. Both extension bundles rebuilt and committed
(`codearbiter.js`, `codearbiter-child.js`); `windows-supervisor.js` is
byte-identical because no source it bundles changed. Root Git-package metadata
regenerated with `tools/build-host-packages.py`.

## CI contract updates

`test/audit-sink.test.ts` branches on the live platform (junction vs. dir
symlink), so `test_ci_impact` requires it in every OS matrix cell — added to the
`ci.yml` platform-gated line. The two new Pi files are registered in a new
path-exact `_ISSUE_374_NON_POLICY_ARTIFACTS` set so the AC-04 generation
contract still fails closed on an unlisted file under `tools/`.

## NEEDS-TRIAGE

1. **`package.test.ts` cannot resolve `rolldown`, and `test_pi_benchmark` cannot
   find `plugins/ca-pi/tools/node_modules/esbuild/bin/esbuild`.** Both fail
   identically at `origin/main` in this checkout, before any change here — they
   are dependency-layout gaps (no per-package `node_modules` in a worktree), not
   regressions. Worth noting that the ca-pi baseline of 629 in the lane brief
   silently included one of them.

2. **Worktree-isolated lanes cannot clear the commit gate as designed.**
   `pre-bash.py` resolves `project_root()` from `CLAUDE_PROJECT_DIR`, which the
   harness pins to the shared checkout, while `git_cwd` honours `git -C`. H-01
   therefore reads the shared checkout's branch (`main`) for a commit made on a
   worktree branch, and H-09b/H-10b read the shared checkout's
   `security-gate-passed` marker while scanning the worktree's staged diff —
   and `security-pass.py`, run from the worktree, writes its marker into the
   worktree. A worktree lane has no in-band way to record a pass the gate will
   read. Committing here required `git -C <worktree>` plus removing the H-10b
   trigger outright (see 3).

3. **`SECRET_RE` fires on the identifier, not the payload.** `const SECRET =
   "…"` matched `secret["']?\s*[:=]\s*["'][^"']{4,}` purely because the
   *variable* is named `SECRET`; the credential-shaped literal itself
   (`OPENAI_API_KEY=synthetic-secret`, already used repo-wide) does not match.
   Renaming the constant to `HOSTILE_PAYLOAD` cleared the gate with the test
   otherwise unchanged. Worth a rule review — a test sentinel named
   `SECRET`/`TOKEN` is a common shape, and this false positive is
   indistinguishable from a real finding at the gate.

4. **H-05 fires on prose.** A commit message containing the literal
   `<cwd>/.codearbiter/gate-events.log` reads as a truncating redirect, because
   the `>` of `<cwd>` is immediately followed by the audit-log path. Reworded
   here; the guard may want a shell-redirect context rather than a bare `>`.

5. **`security.test.ts` retains the permission-audit race cases** that
   `audit-sink.test.ts` now covers generically against the shared primitive.
   They are left in place deliberately: that file is the ADR-0014 promotion
   contract, and thinning a governance artifact is not this lane's call. Worth a
   decision on whether the promotion contract should reference the shared suite
   instead.

Claude-Session: https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
