### PR TITLE
test(ci): assert actions are SHA-pinned structurally, not by literal value

### DIFF
--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -724,6 +724,39 @@ class DescriptorSurfaceTest(unittest.TestCase):
 
 
 class WorkflowContractTest(unittest.TestCase):
+    def test_every_third_party_action_is_pinned_to_a_commit_sha(self):
+        """A `uses:` on a movable tag re-points under us.
+
+        `@v4` and `@main` are branch/tag refs the upstream owner can move at any
+        time, so a compromised or merely careless upstream silently changes what
+        runs against this repo's checkout with write-capable tokens in scope.
+        The repo pins every action by SHA, but nothing asserted it — the
+        convention was held up by dependabot plus human review, and a
+        hand-edited `@v7` would have passed CI. Local `./...` composites are
+        exempt: they are this repo's own tracked files.
+        """
+        floating = []
+        for workflow in sorted((REPO_ROOT / ".github/workflows").glob("*.yml")):
+            for number, line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), 1):
+                match = re.search(r"^\s*(?:-\s*)?uses:\s*(\S+)", line)
+                if match is None:
+                    continue
+                ref = match.group(1)
+                if ref.startswith("./"):
+                    continue
+                # `- uses: security-extended` inside a `config: |` literal is a
+                # CodeQL query-suite entry, not an Actions reference. An Actions
+                # `uses:` always names owner/repo; a bare word never does.
+                if "/" not in ref:
+                    continue
+                if re.search(r"@[0-9a-f]{40}$", ref):
+                    continue
+                floating.append(f"{workflow.name}:{number}: {ref}")
+        self.assertEqual(
+            floating, [],
+            "every third-party `uses:` must pin a 40-hex commit SHA, never a movable tag",
+        )
+
     def test_ci_runs_impact_planner_without_replacing_existing_job_conditions(self):
         ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
         self.assertIn(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.14] - 2026-07-25
+
+### Fixed
+
+- The Pi security contract asserted the exact CodeQL action SHA, so dependabot
+  could never land a codeql-action bump on its own - it cannot edit a test, and
+  every upgrade failed there until a human hand-edited the literal. The
+  assertion now checks the property that matters: both refs are 40-hex commit
+  SHAs, and init and analyze pin the same commit, so a split pair cannot
+  silently analyse with a different CodeQL than it initialised.
+
 ## [0.1.13] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/test/security.test.ts
+++ b/plugins/ca-pi/tools/test/security.test.ts
@@ -382,8 +382,19 @@ describe("ADR-0014 adversarial promotion contract", () => {
 
   test("pins CodeQL and scans both TypeScript sources and shipped JavaScript", async () => {
     const workflow = await readFile(resolve(import.meta.dirname, "../../../../.github/workflows/codeql.yml"), "utf8");
-    expect(workflow).toContain("github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a");
-    expect(workflow).toContain("github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a");
+    // Assert the PIN, not its current value. Naming one SHA meant dependabot
+    // could never land a codeql-action bump on its own — it cannot edit a test,
+    // so every upgrade failed here until a human hand-edited the literal. That
+    // is not a security control, it is a merge tax that pressures reviewers to
+    // "just update the string". What actually matters is that both refs are
+    // 40-hex SHAs (never a movable tag) and that init and analyze resolve to the
+    // SAME commit — a split pair silently analyses with a different CodeQL than
+    // it initialised.
+    const initPin = workflow.match(/github\/codeql-action\/init@([0-9a-f]{40})\b/u);
+    const analyzePin = workflow.match(/github\/codeql-action\/analyze@([0-9a-f]{40})\b/u);
+    expect(initPin, "codeql-action/init must be pinned to a 40-hex commit SHA").not.toBeNull();
+    expect(analyzePin, "codeql-action/analyze must be pinned to a 40-hex commit SHA").not.toBeNull();
+    expect(analyzePin![1], "codeql-action init and analyze must pin the same commit").toBe(initPin![1]);
     expect(workflow).toContain("languages: javascript-typescript");
     expect(workflow).toContain("plugins/ca-pi/tools/src");
     expect(workflow).toContain("plugins/ca-pi/extensions");


### PR DESCRIPTION
Unblocks #452 and #454, which were unmergeable through no fault of their own.

## Two guards, wrong about the same thing in opposite directions

**Over-specified.** `plugins/ca-pi/tools/test/security.test.ts` asserted the *exact* CodeQL SHA:

```
AssertionError: expected 'name: CodeQL…' to contain 'github/codeql-action/init@7188fc36363…'
```

Dependabot cannot edit a test, so **every** codeql-action bump failed there until a human hand-edited the literal. That is not a security control — it is a merge tax, and its predictable effect is to train reviewers into "just update the string" on a pinned security action.

The assertion now checks what the test actually meant: both refs are 40-hex commit SHAs, **and init and analyze pin the same commit**. A split pair silently analyses with a different CodeQL than it initialised — a real hazard the value-pin never checked.

**Under-specified.** Nothing asserted that any *other* action was pinned at all. A hand-edited `@v7` would have passed CI; the convention was upheld by dependabot plus human review. A movable tag is a ref the upstream owner can re-point at any time, and these workflows run against this repo's checkout with write-capable tokens in scope.

`test_ci_impact.WorkflowContractTest.test_every_third_party_action_is_pinned_to_a_commit_sha` now walks every workflow and fails on any third-party `uses:` that is not a 40-hex SHA. Local `./…` composites are exempt — they are this repo's own tracked files.

## Proven to bite, and one false positive caught

Planting a single `@v4` on an existing pinned action turns the guard red. Restored after.

While writing it the guard flagged `- uses: security-extended` in `ci.yml:618` and `codeql.yml:35` — those are CodeQL **query-suite** entries inside a `config: |` literal, not action references. Discriminator tightened: an Actions `uses:` always names `owner/repo`, so a bare word with no slash is skipped.

## Verification

| Check | Result |
|---|---|
| `.github/scripts` full suite | **1177 tests, OK** (skipped=5) |
| ca-pi `security.test.ts` | 15 passed |
| `git diff --check origin/main HEAD` | exit 0 |

ca-pi advanced 0.1.13 → 0.1.14; the Pi payload guard requires a bump for any `plugins/ca-pi/**` change, test-only included.

## Related

Two NEEDS-TRIAGE items from the `setup-python` v7 review (#453) motivated the repo-wide half: that review found no contract test asserting SHA pinning, and noted `pi-promotion.yml` pins Pi versions and action SHAs exactly while leaving Python as the floating spec `"3.x"` — that second one is untouched here and still worth its own issue.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
