### PR TITLE
chore(deps): bump codeql-action init and analyze to 4.37.3 together

### DIFF
--- a/.github/scripts/test_pi_security.py
+++ b/.github/scripts/test_pi_security.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 import shutil
 import subprocess
@@ -16,7 +17,15 @@ from verify_pi_support import strict_promotion
 REPO = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO / ".github" / "workflows" / "codeql.yml"
 CI_WORKFLOW = REPO / ".github" / "workflows" / "ci.yml"
-CODEQL_SHA = "7188fc363630916deb702c7fdcf4e481b751f97a"
+# Match the PIN, not its current value. A literal SHA here means dependabot can
+# never land a codeql-action bump on its own -- it cannot edit a test, so every
+# upgrade fails until a human hand-edits the constant, which trains reviewers to
+# "just update the string" on a security-critical pin. What matters is that both
+# refs are 40-hex commit SHAs (never a movable tag) and that init and analyze
+# resolve to the SAME commit: a split pair silently analyses with a different
+# CodeQL than it initialised. Dependabot files those two bumps as SEPARATE PRs,
+# so this is a live hazard, not a theoretical one.
+CODEQL_PIN = re.compile(r"github/codeql-action/(init|analyze)@([0-9a-f]{40})\b")
 SCHEMA = "codearbiter-pi-security-v1"
 PREVIEW_ENTRYPOINTS = (
     REPO / "core" / "pysrc" / "preview.py",
@@ -46,9 +55,10 @@ def workflow_results() -> list[dict[str, object]]:
             result("PI-SEC-CODEQL-SCOPE", False),
             result("PI-SEC-CODEQL-PR-JOB", False),
         ]
+    found = {role: sha for role, sha in CODEQL_PIN.findall(text)}
     pins = (
-        f"github/codeql-action/init@{CODEQL_SHA}" in text
-        and f"github/codeql-action/analyze@{CODEQL_SHA}" in text
+        set(found) == {"init", "analyze"}
+        and len(set(found.values())) == 1
         and "@v4" not in text
     )
     scope = all(
@@ -69,8 +79,7 @@ def workflow_results() -> list[dict[str, object]]:
             'name: "[CHECK] | [PI  ] | Security analysis  <language: JavaScript/TypeScript>"',
             "github.event_name == 'pull_request'",
             "needs.changes.outputs.ca-pi == 'true'",
-            f"github/codeql-action/init@{CODEQL_SHA}",
-            f"github/codeql-action/analyze@{CODEQL_SHA}",
+            *(f"github/codeql-action/{role}@{sha}" for role, sha in sorted(found.items())),
             "upload: never",
             "test_pi_security.py --sarif codeql-results",
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,7 +608,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Initialize scoped Pi CodeQL database
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript-typescript
           build-mode: none
@@ -622,7 +622,7 @@ jobs:
             paths-ignore:
               - plugins/ca-pi/tools/node_modules
       - name: Analyze Pi without duplicating default code-scanning uploads
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:javascript-typescript"
           output: codeql-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript-typescript
           build-mode: none
@@ -39,7 +39,7 @@ jobs:
             paths-ignore:
               - plugins/ca-pi/tools/node_modules
       - name: Analyze Pi without duplicating default code-scanning uploads
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:javascript-typescript"
           output: codeql-results


### PR DESCRIPTION
Closes #452
Closes #454

Replaces #452 and #454, which **could not merge separately**.

## Why they had to be combined

Dependabot files `codeql-action/init` and `codeql-action/analyze` as two independent PRs. Merging either alone leaves the pair on different commits — CodeQL then **analyses with a different version than it initialised**. #461's new assertion caught exactly that:

```
AssertionError: codeql-action init and analyze must pin the same commit:
expected '7188fc36363…' to be 'e4fba868fa4b…'
```

That is the hazard the previous value-pin never checked, and it is a live one rather than theoretical — dependabot will split this pair again on every future release.

## Provenance

`refs/tags/v4.37.3` is an **annotated** tag: its ref object is `c54b30b7…`, and peeling it yields commit **`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`** — exactly dependabot's pin. The first ref lookup appearing to disagree was the annotated-tag indirection, not a mismatch. Worth stating because "the pin does not match the tag" is the right thing to be alarmed by, and here it was a lookup artefact.

## A third hardcoded pin, which #461 missed

#461 replaced the literal SHA in `plugins/ca-pi/tools/test/security.test.ts`, but `.github/scripts/test_pi_security.py` carried its **own** `CODEQL_SHA` constant. So `PI-SEC-ACTIONS-PIN` and `PI-SEC-CODEQL-PR-JOB` still failed on any bump — the same defect, one file over. My earlier fix was incomplete.

That check now matches the property instead of the value: both roles present, both 40-hex, both resolving to a single commit, and no movable `@v4` anywhere in the workflow.

## Mutation-tested

| Mutation | `PI-SEC-ACTIONS-PIN` |
|---|---|
| paired bump (this PR) | **pass** |
| revert `analyze` only — split pair | **fail** |
| rewrite `init` to `@v4` — movable tag | **fail** |
| restored | **pass** |

## Verification

| Check | Result |
|---|---|
| `.github/scripts` full suite | **1177 tests, OK** (skipped=5) |
| ca-pi `security.test.ts` | 15 passed |
| `test_pi_security.py --contract-only` | all 6 checks pass |
| `git diff --check origin/main HEAD` | exit 0 |

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
