### PR TITLE
ci: report merge readiness under merge_group so the gate tests the real base

### DIFF
--- a/.github/scripts/check_branch_protection.py
+++ b/.github/scripts/check_branch_protection.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Read-only audit of main's merge-readiness enforcement (issue #383 AC-3).
+
+Run:  python .github/scripts/check_branch_protection.py --repo owner/name
+Local: GH_TOKEN=$(gh auth token) python .github/scripts/check_branch_protection.py
+
+WHAT IT GUARDS.  main's only required status context is ci.yml's
+`[GATE ] | [REPO] | Merge readiness` aggregate.  On 2026-07-25 that context sat
+behind `required_status_checks.strict=false` and no merge queue, so a pull
+request could merge on a required check computed against an OLDER base - two
+individually green pull requests could interact after one landed while the
+second kept a valid check from its stale merge base.  #383's ruling was a merge
+queue, which synthesises and tests the exact prospective merge commit.  Both
+answers are accepted here: `strict` OR a queue.  Demanding both would fail the
+moment the ruled-on fix landed, because a queue makes `strict` redundant and it
+is expected to stay false.
+
+WHY IT SKIPS RATHER THAN FAILS.  `GET /repos/{owner}/{repo}/branches/{branch}
+/protection` requires Administration:read.  A workflow `permissions:` block has
+no key that grants it - `administration` is not among GITHUB_TOKEN's permission
+scopes - so in ordinary CI this audit CANNOT see the protection document, and a
+check that failed on that would jam every merge for a permission that cannot be
+granted.  Every field is therefore three-valued: True, False, or None for "this
+run could not see it".  A definite False is a violation; a None is a skip that
+prints what it could not check and how to check it.  Only a settings change is
+ever reported, never a transport or permission problem.
+
+READ-ONLY.  Two calls, both queries: a REST GET for the protection document and
+a GraphQL query for `repository.mergeQueue`.  The GraphQL call is an HTTP POST
+because that is the protocol's only verb; it mutates nothing.  The merge-queue
+answer needs plain repository read, so a run without admin rights can still
+prove the queue is on even when the protection document is invisible.
+"""
+import argparse
+import dataclasses
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+# The single stable context #383 requires to REMAIN main's required check.
+# Un-requiring it makes every other guarantee vacuous: there would be nothing
+# whose passing SHA the base has to be current with.
+MERGE_READINESS_CONTEXT = "[GATE ] | [REPO] | Merge readiness"
+
+_API = "https://api.github.com"
+_API_VERSION = "2022-11-28"
+_TIMEOUT_SECONDS = 30
+
+# `mergeQueue` is null until a queue is configured for the branch, and is
+# readable with ordinary repository read - unlike the protection document.
+_MERGE_QUEUE_QUERY = """
+query($owner: String!, $name: String!, $branch: String!) {
+  repository(owner: $owner, name: $name) {
+    mergeQueue(branch: $branch) { id }
+  }
+}
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class Enforcement:
+    """What this run could actually READ about a branch's merge enforcement.
+
+    Every field is three-valued.  `None` means unreadable - no token, a token
+    without Administration:read, or a transport failure - and never means
+    "switched off".  Conflating the two is what would turn a read-only audit
+    into a merge jam.
+    """
+
+    protected: bool | None
+    strict: bool | None
+    merge_queue: bool | None
+    contexts: tuple[str, ...] | None
+
+
+def audit(enforcement: Enforcement) -> list[str]:
+    """Every DEFINITE weakening of merge-readiness enforcement, as findings.
+
+    Silent on anything it could not read.  An empty list means "nothing
+    observed is wrong", which is not the same as "everything was checked" -
+    `unreadable()` reports that half.
+    """
+    if enforcement.protected is False:
+        # GitHub answers 404 for an unprotected branch and 403 when the token
+        # merely lacks rights, so this is a real absence and not a blind spot.
+        # It short-circuits: naming a missing context on an unprotected branch
+        # is noise piled on the one finding that matters.
+        return [
+            "main has no branch protection at all, so nothing requires "
+            f"{MERGE_READINESS_CONTEXT} before a merge (issue #383)."
+        ]
+
+    findings: list[str] = []
+    if enforcement.strict is False and enforcement.merge_queue is False:
+        findings.append(
+            "main can merge a stale-base result: required_status_checks.strict "
+            "is false and no merge queue is enabled, so a green "
+            f"{MERGE_READINESS_CONTEXT} computed against an OLDER base still "
+            "satisfies the gate. Re-enable the merge queue for main, or turn on "
+            '"Require branches to be up to date before merging" (issue #383).'
+        )
+    if enforcement.contexts is not None and MERGE_READINESS_CONTEXT not in enforcement.contexts:
+        # Requiring MORE contexts is a hardening, not a weakening, so only the
+        # absence of the stable one is reported.
+        findings.append(
+            f"main no longer requires the {MERGE_READINESS_CONTEXT} context "
+            f"(required contexts: {list(enforcement.contexts) or 'none'}). "
+            "It is the single stable context every other guarantee hangs off "
+            "(issue #383)."
+        )
+    return findings
+
+
+def unreadable(enforcement: Enforcement) -> list[str]:
+    """The parts of the contract this run could not see, in plain words."""
+    blind: list[str] = []
+    if enforcement.protected is None:
+        blind.append("whether main is protected at all")
+    if enforcement.merge_queue is None:
+        blind.append("whether a merge queue is enabled for main")
+    if enforcement.strict is None and enforcement.merge_queue is not True:
+        # An enabled queue already settles the base-currency question, so the
+        # unreadable `strict` flag is not a gap worth reporting.
+        blind.append("required_status_checks.strict")
+    if enforcement.contexts is None:
+        blind.append("the required status-check contexts")
+    return blind
+
+
+def enforcement_from_protection(
+    document: dict, merge_queue: bool | None = None
+) -> Enforcement:
+    """Read a branch-protection response into an `Enforcement`."""
+    checks = document.get("required_status_checks") or {}
+    contexts = checks.get("contexts")
+    if contexts is None:
+        # `contexts` is deprecated in favour of `checks`; a response carrying
+        # only the newer array must not read as "the context was dropped".
+        contexts = [
+            entry.get("context")
+            for entry in (checks.get("checks") or [])
+            if isinstance(entry, dict) and entry.get("context")
+        ]
+    return Enforcement(
+        protected=True,
+        strict=bool(checks.get("strict", False)),
+        merge_queue=merge_queue,
+        contexts=tuple(contexts),
+    )
+
+
+def read_enforcement(repo: str, branch: str, *, rest, graphql) -> Enforcement:
+    """Gather what the given transports can see. Never raises on an API error."""
+    owner, _, name = repo.partition("/")
+
+    merge_queue: bool | None = None
+    status, payload = graphql(
+        _MERGE_QUEUE_QUERY, {"owner": owner, "name": name, "branch": branch}
+    )
+    if status == 200 and not payload.get("errors"):
+        repository = (payload.get("data") or {}).get("repository")
+        if isinstance(repository, dict) and "mergeQueue" in repository:
+            merge_queue = repository["mergeQueue"] is not None
+
+    status, payload = rest(f"/repos/{repo}/branches/{branch}/protection")
+    if status == 200:
+        return enforcement_from_protection(payload, merge_queue=merge_queue)
+    if status == 404:
+        return Enforcement(protected=False, strict=None, merge_queue=merge_queue, contexts=None)
+    # 401/403 (no Administration:read), 5xx, or a transport failure reported as
+    # status 0 - all unreadable, none of them a finding.
+    return Enforcement(protected=None, strict=None, merge_queue=merge_queue, contexts=None)
+
+
+def _send(request: urllib.request.Request) -> tuple[int, dict]:
+    """One request, reduced to (status, decoded body). Never raises."""
+    try:
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:
+            body = response.read().decode("utf-8")
+            return response.status, (json.loads(body) if body.strip() else {})
+    except urllib.error.HTTPError as error:
+        try:
+            body = error.read().decode("utf-8")
+            payload = json.loads(body) if body.strip() else {}
+        except (ValueError, OSError):
+            payload = {}
+        return error.code, payload
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as error:
+        return 0, {"message": str(error)}
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": _API_VERSION,
+        "User-Agent": "codearbiter-branch-protection-audit",
+    }
+
+
+def _rest_reader(token: str):
+    def rest(path: str) -> tuple[int, dict]:
+        return _send(urllib.request.Request(_API + path, method="GET", headers=_headers(token)))
+
+    return rest
+
+
+def _graphql_reader(token: str):
+    def graphql(query: str, variables: dict) -> tuple[int, dict]:
+        body = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+        headers = _headers(token) | {"Content-Type": "application/json"}
+        return _send(
+            urllib.request.Request(_API + "/graphql", data=body, method="POST", headers=headers)
+        )
+
+    return graphql
+
+
+_SKIP_NOTE = """SKIP: no token, so main's branch protection was NOT audited.
+
+This is expected in ordinary CI. Reading a branch-protection document requires
+Administration:read, and a workflow `permissions:` block has no key that grants
+it, so the default GITHUB_TOKEN can never satisfy this check. It skips instead
+of failing because a merge gate must not depend on a permission that cannot be
+granted.
+
+To actually run the audit, set GH_TOKEN to a token with admin rights on the
+repository - as a repository secret wired into this step, or locally with:
+
+    GH_TOKEN=$(gh auth token) python .github/scripts/check_branch_protection.py
+"""
+
+
+def main(argv=None, *, token=None, rest=None, graphql=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--branch", default="main")
+    arguments = parser.parse_args(argv)
+
+    if token is None:
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not arguments.repo:
+        print("SKIP: no --repo and no GITHUB_REPOSITORY; nothing to audit.")
+        return 0
+    if not token and (rest is None or graphql is None):
+        print(_SKIP_NOTE)
+        print(f"::notice title=Branch protection audit::skipped for {arguments.repo} - no GH_TOKEN")
+        return 0
+
+    enforcement = read_enforcement(
+        arguments.repo,
+        arguments.branch,
+        rest=rest if rest is not None else _rest_reader(token),
+        graphql=graphql if graphql is not None else _graphql_reader(token),
+    )
+    findings = audit(enforcement)
+    blind = unreadable(enforcement)
+
+    for finding in findings:
+        print(f"::error title=Branch protection::{finding}")
+    if blind:
+        print(
+            "SKIP (partial): could not read "
+            + "; ".join(blind)
+            + " - see the note above on Administration:read."
+        )
+    if findings:
+        return 1
+    print(
+        f"OK: {arguments.repo}@{arguments.branch} still enforces merge readiness "
+        f"against the current base (strict={enforcement.strict}, "
+        f"merge_queue={enforcement.merge_queue})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_branch_protection.py
+++ b/.github/scripts/test_branch_protection.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Unit tests for the read-only branch-protection audit (issue #383 AC-3).
+
+Run: python .github/scripts/test_branch_protection.py
+
+The audit answers one question - is main's merge-readiness enforcement still
+switched on? - and it has to answer it WITHOUT a privileged token in ordinary
+CI, because `GET /repos/{owner}/{repo}/branches/{branch}/protection` requires
+Administration:read and the workflow `permissions:` block has no key that
+grants it.  Every field the audit reads is therefore three-valued: True, False,
+or None for "this run could not see it".  A definite False is a violation; a
+None is a SKIP that says so out loud.  These tests pin both halves, plus the
+CLI's no-token exit, entirely offline - no network, no token, no fixtures on
+disk.
+"""
+import importlib.util
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOL = REPO_ROOT / ".github" / "scripts" / "check_branch_protection.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+_spec = importlib.util.spec_from_file_location("check_branch_protection", _TOOL)
+module = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(module)
+
+
+# The live response measured on 2026-07-25, verbatim in shape.  This is the
+# defect #383 reports: one required context, and `strict: false` behind it.
+LIVE_PROTECTION = {
+    "required_status_checks": {
+        "strict": False,
+        "contexts": ["[GATE ] | [REPO] | Merge readiness"],
+        "checks": [{"context": "[GATE ] | [REPO] | Merge readiness", "app_id": 15368}],
+    },
+    "required_pull_request_reviews": {"required_approving_review_count": 0},
+    "enforce_admins": {"enabled": True},
+    "required_linear_history": {"enabled": True},
+    "required_conversation_resolution": {"enabled": True},
+}
+
+
+def enforcement(**overrides):
+    """An Enforcement with everything readable and compliant unless overridden."""
+    fields = {
+        "protected": True,
+        "strict": True,
+        "merge_queue": False,
+        "contexts": (module.MERGE_READINESS_CONTEXT,),
+    }
+    fields.update(overrides)
+    return module.Enforcement(**fields)
+
+
+class AuditTest(unittest.TestCase):
+    def test_strict_required_checks_satisfy_the_current_base_contract(self):
+        # AC-1, first of the two sanctioned answers: an up-to-date branch
+        # cannot carry a required check computed before main advanced.
+        self.assertEqual(module.audit(enforcement(strict=True, merge_queue=False)), [])
+
+    def test_an_enabled_merge_queue_satisfies_the_current_base_contract(self):
+        # AC-1, the ruled-on answer.  The queue synthesises the prospective
+        # merge commit and runs the gate on THAT, so `strict` is redundant and
+        # is expected to stay false once the queue is switched on.  An audit
+        # that demanded both would fail the moment the fix landed.
+        self.assertEqual(module.audit(enforcement(strict=False, merge_queue=True)), [])
+
+    def test_neither_strict_nor_a_queue_is_the_defect_this_audit_exists_for(self):
+        # AC-3.  This is the live state on 2026-07-25 and the exact regression
+        # the audit has to keep detecting after the maintainer's settings
+        # change: enforcement silently switched back off.
+        findings = module.audit(enforcement(strict=False, merge_queue=False))
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("strict", findings[0])
+        self.assertIn("merge queue", findings[0])
+
+    def test_a_dropped_merge_readiness_context_is_reported(self):
+        # #383 asks for the single stable context to REMAIN the required check.
+        # Un-requiring it makes every other guarantee vacuous - there would be
+        # nothing whose passing SHA the base has to be current with.
+        findings = module.audit(enforcement(contexts=()))
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn(module.MERGE_READINESS_CONTEXT, findings[0])
+
+    def test_extra_required_contexts_are_not_a_weakening(self):
+        # Requiring MORE is not the failure this audit hunts, and reporting it
+        # would turn a deliberate hardening into a red merge gate.
+        self.assertEqual(
+            module.audit(
+                enforcement(contexts=(module.MERGE_READINESS_CONTEXT, "[CHECK] | [REPO] | Other"))
+            ),
+            [],
+        )
+
+    def test_deleted_branch_protection_is_reported_on_its_own(self):
+        # A 404 from the protection endpoint means "branch not protected" -
+        # GitHub answers 403 when the token merely lacks rights, so this is a
+        # real finding and not an unreadable field.  It short-circuits: listing
+        # a missing context on an unprotected branch is noise.
+        findings = module.audit(
+            module.Enforcement(protected=False, strict=None, merge_queue=None, contexts=None)
+        )
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("no branch protection", findings[0].lower())
+
+    def test_an_unreadable_field_is_a_skip_and_never_a_violation(self):
+        # The ordinary-CI path.  Without Administration:read nothing is
+        # readable, and a check that failed here would jam every merge for a
+        # permission the default GITHUB_TOKEN cannot be granted.
+        blind = module.Enforcement(protected=None, strict=None, merge_queue=None, contexts=None)
+        self.assertEqual(module.audit(blind), [])
+        self.assertNotEqual(module.unreadable(blind), [])
+
+    def test_a_readable_merge_queue_alone_still_clears_the_base_contract(self):
+        # Partial visibility is still worth something: `mergeQueue` is plain
+        # repository-read in GraphQL, so a run that cannot see `strict` can
+        # still prove the queue is on - and must not be reported as blind.
+        partial = module.Enforcement(
+            protected=None, strict=None, merge_queue=True, contexts=None
+        )
+        self.assertEqual(module.audit(partial), [])
+        self.assertNotIn("strict", " ".join(module.unreadable(partial)))
+
+
+class ProtectionParsingTest(unittest.TestCase):
+    def test_enforcement_is_read_out_of_the_live_protection_document(self):
+        read = module.enforcement_from_protection(LIVE_PROTECTION, merge_queue=False)
+        self.assertIs(read.protected, True)
+        self.assertIs(read.strict, False)
+        self.assertIs(read.merge_queue, False)
+        self.assertEqual(read.contexts, (module.MERGE_READINESS_CONTEXT,))
+        # The whole point: this document is the defect, so it must report one.
+        self.assertEqual(len(module.audit(read)), 1)
+
+    def test_contexts_fall_back_to_the_checks_array(self):
+        # `contexts` is deprecated in favour of `checks`; a response that only
+        # carries the newer array must not read as "the context was dropped".
+        document = json.loads(json.dumps(LIVE_PROTECTION))
+        del document["required_status_checks"]["contexts"]
+        read = module.enforcement_from_protection(document, merge_queue=True)
+        self.assertEqual(read.contexts, (module.MERGE_READINESS_CONTEXT,))
+        self.assertEqual(module.audit(read), [])
+
+    def test_a_protection_document_with_no_required_status_checks_reports(self):
+        document = {"required_linear_history": {"enabled": True}}
+        read = module.enforcement_from_protection(document, merge_queue=False)
+        self.assertIs(read.strict, False)
+        self.assertEqual(read.contexts, ())
+        self.assertEqual(len(module.audit(read)), 2, module.audit(read))
+
+
+class ReadEnforcementTest(unittest.TestCase):
+    """The transport seams, exercised with fakes - never a live request."""
+
+    def test_a_forbidden_protection_read_degrades_to_unreadable(self):
+        def rest(path):
+            return 403, {"message": "Must have admin rights to Repository."}
+
+        def graphql(query, variables):
+            return 200, {"data": {"repository": {"mergeQueue": None}}}
+
+        read = module.read_enforcement("o/n", "main", rest=rest, graphql=graphql)
+        self.assertIsNone(read.protected)
+        self.assertIsNone(read.strict)
+        self.assertIsNone(read.contexts)
+        # The queue answer came from GraphQL, which needs no admin rights.
+        self.assertIs(read.merge_queue, False)
+        self.assertEqual(module.audit(read), [], "a 403 must never be a violation")
+
+    def test_an_unprotected_branch_is_read_as_a_definite_absence(self):
+        def rest(path):
+            return 404, {"message": "Branch not protected"}
+
+        def graphql(query, variables):
+            return 200, {"data": {"repository": {"mergeQueue": None}}}
+
+        read = module.read_enforcement("o/n", "main", rest=rest, graphql=graphql)
+        self.assertIs(read.protected, False)
+        self.assertEqual(len(module.audit(read)), 1)
+
+    def test_an_enabled_queue_is_read_out_of_the_graphql_response(self):
+        def rest(path):
+            return 200, LIVE_PROTECTION
+
+        def graphql(query, variables):
+            return 200, {"data": {"repository": {"mergeQueue": {"id": "MQ_kwDO"}}}}
+
+        read = module.read_enforcement("o/n", "main", rest=rest, graphql=graphql)
+        self.assertIs(read.merge_queue, True)
+        self.assertEqual(module.audit(read), [], "strict is redundant once the queue is on")
+
+    def test_a_graphql_error_leaves_the_queue_unreadable_rather_than_absent(self):
+        # Reporting "no merge queue" because a query errored would fail the
+        # audit for a transport problem, which is how a read-only check turns
+        # into a merge jam.
+        def rest(path):
+            return 200, LIVE_PROTECTION
+
+        def graphql(query, variables):
+            return 200, {"errors": [{"message": "Something went wrong"}]}
+
+        read = module.read_enforcement("o/n", "main", rest=rest, graphql=graphql)
+        self.assertIsNone(read.merge_queue)
+        self.assertEqual(module.audit(read), [])
+        self.assertNotEqual(module.unreadable(read), [])
+
+
+class CommandTest(unittest.TestCase):
+    def test_the_cli_skips_cleanly_and_loudly_without_a_token(self):
+        # The ordinary-CI contract: no token, exit 0, and an explanation of
+        # what was NOT checked plus how to check it.  Silence here would be a
+        # green check that proved nothing.
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = module.main(["--repo", "arbiterForge/codeArbiter", "--branch", "main"], token="")
+        self.assertEqual(code, 0)
+        printed = buffer.getvalue()
+        self.assertIn("SKIP", printed)
+        self.assertIn("GH_TOKEN", printed)
+
+    def test_the_cli_fails_on_a_definite_violation(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = module.main(
+                ["--repo", "arbiterForge/codeArbiter", "--branch", "main"],
+                token="x",
+                rest=lambda path: (200, LIVE_PROTECTION),
+                graphql=lambda query, variables: (
+                    200,
+                    {"data": {"repository": {"mergeQueue": None}}},
+                ),
+            )
+        self.assertEqual(code, 1)
+        self.assertIn(module.MERGE_READINESS_CONTEXT, buffer.getvalue())
+
+    def test_the_cli_passes_once_the_merge_queue_is_enabled(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = module.main(
+                ["--repo", "arbiterForge/codeArbiter", "--branch", "main"],
+                token="x",
+                rest=lambda path: (200, LIVE_PROTECTION),
+                graphql=lambda query, variables: (
+                    200,
+                    {"data": {"repository": {"mergeQueue": {"id": "MQ_kwDO"}}}},
+                ),
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("OK", buffer.getvalue())
+
+
+class WorkflowWiringTest(unittest.TestCase):
+    def test_the_audit_runs_in_a_job_the_merge_gate_actually_waits_for(self):
+        # An audit nothing dispatches is a file, not a control.  The job is
+        # registered in BOTH of ci-passed's registrations, the same way every
+        # other enforced job is (issue #390's contract).
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("  branch-protection:\n", ci)
+        self.assertIn('name: "[CHECK] | [REPO] | Branch protection"', ci)
+        self.assertIn("python .github/scripts/check_branch_protection.py", ci)
+        aggregate = ci.split("  ci-passed:\n", 1)[1]
+        self.assertIn("      - branch-protection\n", aggregate)
+        self.assertIn("${{ needs['branch-protection'].result }}", aggregate)
+
+    def test_the_audit_job_carries_no_path_gate_that_could_skip_it(self):
+        # Enforcement can be switched off in the settings UI with no diff at
+        # all, so a `needs: changes` gate would mean the audit never runs on
+        # the change that mattered - there is none.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        job = ci.split("  branch-protection:\n", 1)[1].split("\n  ", 1)[0]
+        self.assertNotIn("needs: changes", job)
+        self.assertNotIn("needs.changes.outputs", job)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -1710,6 +1710,83 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertIn("      - documentation-contract\n", aggregate)
         self.assertIn("${{ needs['documentation-contract'].result }}", aggregate)
 
+    def test_ci_reports_under_the_merge_group_event_that_tests_the_real_base(self):
+        # Issue #383.  main's ONLY required context is this workflow's
+        # `[GATE ] | [REPO] | Merge readiness` aggregate, and the live
+        # protection response carries `required_status_checks.strict=false`.
+        # A green aggregate computed against an OLDER base is therefore enough
+        # to merge, so two individually green pull requests can interact after
+        # one of them lands while the second keeps a valid required check from
+        # its stale merge base.  The ruling was a merge queue, which
+        # synthesises and tests the exact prospective merge commit - strictly
+        # stronger than mere up-to-dateness, because it catches interactions
+        # that currency alone does not.
+        #
+        # SEQUENCING, and the reason this contract exists in the repository
+        # rather than in the settings UI: a queue whose required context never
+        # reports under `merge_group` stalls EVERY queued merge, with nothing
+        # able to satisfy the gate.  The trigger has to be live on main first.
+        # This test is what keeps it there once it is.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        triggers = ci.split("\njobs:\n", 1)[0]
+        self.assertRegex(
+            triggers,
+            r"(?m)^  merge_group:\n    types: \[checks_requested\]$",
+            "ci.yml never runs on merge_group, so an enabled merge queue would "
+            "have nothing to satisfy the required merge-readiness context",
+        )
+
+    def test_every_enforced_job_is_reachable_and_correctly_based_in_a_merge_group(self):
+        # Issue #383, the half of it a trigger alone does NOT fix.  `ci-passed`
+        # accepts `skipped` as success - that is exactly what ADR-0007 path
+        # scoping needs - so an enforced job gated to `github.event_name ==
+        # 'pull_request'` does not turn a merge group red.  It silently drops
+        # its verdict and the aggregate still reports green on the merge commit,
+        # which is a WEAKER gate than the stale-base one this issue set out to
+        # replace.  The four payload-version guards are the sharpest case:
+        # whether a bump is required is a question about the BASE, so they are
+        # precisely the jobs a merge queue exists to re-run.
+        #
+        # The second scan catches the subtler shape.  A job that RUNS but reads
+        # its base out of a pull_request-only context is worse than one that
+        # skips: `github.base_ref` and `github.event.pull_request.*` are both
+        # EMPTY under merge_group, so the guard would compare against nothing
+        # and conclude green having verified nothing.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(ci)
+        enforced = aggregate_required_results(ci)
+        self.assertIn("version-bump", enforced, "the aggregate scan found no payload guard")
+        unreachable: list[str] = []
+        misbased: list[str] = []
+        for job_id in enforced:
+            block = jobs.get(job_id, "")
+            # Job-level AND step-level conditions: a step gated to
+            # pull_request drops its evidence just as quietly as a job does,
+            # and the secret scan's commit-range step is one of those.
+            for condition in re.findall(r"(?m)^\s+if: (?P<test>[^\n]+)$", block):
+                if "github.event_name" not in condition:
+                    continue
+                if "merge_group" not in condition:
+                    unreachable.append(f"{job_id}: if: {condition}")
+            for expression in re.findall(r"\$\{\{(?P<body>[^}]*)\}\}", block):
+                if (
+                    "github.base_ref" not in expression
+                    and "github.event.pull_request." not in expression
+                ):
+                    continue
+                if "github.event.merge_group." not in expression:
+                    misbased.append(f"{job_id}: ${{{{{expression}}}}}")
+        self.assertEqual(
+            unreachable,
+            [],
+            "enforced jobs a merge queue would silently skip while ci-passed reports green",
+        )
+        self.assertEqual(
+            misbased,
+            [],
+            "enforced jobs whose base context is empty under merge_group",
+        )
+
 
 class ReceiptCommandTest(unittest.TestCase):
     def test_cli_writes_deterministic_json_and_a_markdown_summary(self):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,30 @@ on:
     # campaign merges with zero CI. Drop this once the campaign branch is
     # closed out and merged to main.
     branches: [main, feat/codex-support-m0]
+  # Issue #383. main's ONLY required context is the `[GATE ] | [REPO] | Merge
+  # readiness` aggregate below, and it merges on `strict: false` - so a green
+  # aggregate computed against an OLDER base is enough, and two individually
+  # green PRs can interact after one lands while the second keeps a valid check
+  # from its stale merge base. The ruling was a merge queue: it synthesises the
+  # exact prospective merge commit and runs the gate on THAT, which is stricter
+  # than up-to-dateness because it catches interactions currency does not.
+  #
+  # SEQUENCING - this trigger MUST be live on main BEFORE the queue is enabled.
+  # A queue whose required context never reports under `merge_group` stalls
+  # every queued merge, with nothing able to satisfy the gate. Enabling the
+  # queue is a maintainer settings action that FOLLOWS this workflow landing,
+  # never precedes it. `checks_requested` is the only merge_group activity type
+  # there is; it is named rather than defaulted so a future type cannot silently
+  # join the gate.
+  #
+  # No `paths:` filter here, deliberately. On push a filter only decides whether
+  # to spend runner time on main; in a merge group it would decide whether the
+  # required context reports AT ALL, and a filtered-out merge group waits
+  # forever. The per-job path scoping ADR-0007 asks for still applies - it runs
+  # inside the workflow, via the `changes` job, where a skipped job is a skipped
+  # job and not an absent check run.
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
     paths:
@@ -597,7 +621,12 @@ jobs:
   ca-pi-codeql:
     name: "[CHECK] | [PI  ] | Security analysis  <language: JavaScript/TypeScript>"
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.ca-pi == 'true'
+    # Issue #383: `merge_group` joins `pull_request` here rather than replacing
+    # the event gate. Analysing the prospective merge commit is the whole point
+    # of a queue - the code that actually lands is the merge result, not either
+    # parent - while `push` on main stays excluded, where the analysis would be
+    # a post-mortem of code already merged.
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.ca-pi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -796,7 +825,12 @@ jobs:
     # Pre-publication PRs pass: the rule only bites when tag v<version>
     # already exists. Gated to ca-touching diffs (ADR-0007 path-scoping).
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.ca == 'true'
+    # Issue #383: this guard asks a question ABOUT THE BASE - whether the
+    # payload version on the tip of main is already published - so it is
+    # precisely the check a merge queue exists to re-run against the real base.
+    # Two PRs can each bump ca to the same version and pass individually; only
+    # the second one's merge-group run can see that the first already took it.
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.ca == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -804,8 +838,13 @@ jobs:
           fetch-depth: 0
       - name: Fail if a published version ships a changed payload
         env:
-          BASE: ${{ github.base_ref }}
+          # `github.base_ref` is a pull_request-only context and is EMPTY under
+          # merge_group, which would silently compare against nothing. The merge
+          # group carries its target as a full ref, normalized to a branch name
+          # below so the rest of this script is unchanged.
+          BASE: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
+          BASE="${BASE#refs/heads/}"
           git fetch -q origin "$BASE" --tags
           if git diff --quiet "origin/$BASE"...HEAD -- plugins/ca; then
             echo "no payload change - version bump not required"
@@ -831,7 +870,7 @@ jobs:
     # same silent-staleness trap and is failed here. The sandbox plugin's tags
     # are namespaced (ca-sandbox-v*) so they never collide with ca's v* tags.
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.ca-sandbox == 'true'
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.ca-sandbox == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -839,8 +878,10 @@ jobs:
           fetch-depth: 0
       - name: Fail if a published version ships a changed payload
         env:
-          BASE: ${{ github.base_ref }}
+          # See the ca guard above: `github.base_ref` is empty under merge_group.
+          BASE: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
+          BASE="${BASE#refs/heads/}"
           git fetch -q origin "$BASE" --tags
           if git diff --quiet "origin/$BASE"...HEAD -- plugins/ca-sandbox; then
             echo "no payload change - version bump not required"
@@ -885,7 +926,7 @@ jobs:
     # failed here. Namespaced tags (ca-codex-v*) never collide with ca's bare
     # v* series or ca-sandbox's ca-sandbox-v* series.
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.ca-codex == 'true'
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.ca-codex == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -893,8 +934,10 @@ jobs:
           fetch-depth: 0
       - name: Fail if a published version ships a changed payload
         env:
-          BASE: ${{ github.base_ref }}
+          # See the ca guard above: `github.base_ref` is empty under merge_group.
+          BASE: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
+          BASE="${BASE#refs/heads/}"
           git fetch -q origin "$BASE" --tags
           if git diff --quiet "origin/$BASE"...HEAD -- plugins/ca-codex; then
             echo "no payload change - version bump not required"
@@ -933,7 +976,7 @@ jobs:
   version-bump-pi:
     name: "[GATE ] | [PI  ] | Payload version"
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.ca-pi == 'true'
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.ca-pi == 'true'
     runs-on: ubuntu-latest
     # Issue #399. Observed 4-7s (a full-history fetch plus one Python check);
     # 10 minutes bounds a wedged `git fetch` with three orders of headroom.
@@ -944,7 +987,11 @@ jobs:
           fetch-depth: 0
       - name: Fail if a tagged Pi payload changes without synchronized release metadata
         env:
-          BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          # Issue #383: both spellings are a base COMMIT, so the guard needs no
+          # other change - but the pull_request one is empty in a merge group,
+          # and this is the exact gate whose stale-base pass was observed on
+          # PR #446 after main advanced underneath it.
+          BASE_COMMIT: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: python tools/build-host-packages.py --check --release-guard-base "$BASE_COMMIT"
 
   prose:
@@ -1184,9 +1231,14 @@ jobs:
         # the rootfs becoming writable. Verified locally under this exact flag
         # set, including --user, against a repo whose HEAD had already deleted
         # the planted credential.
-        if: github.event_name == 'pull_request'
+        #
+        # Issue #383: a merge group has a base too - `merge_group.base_sha` is
+        # the tip of main the group was built on - so the range scan runs there
+        # as well. Only `push` is left out, where the commits have already
+        # landed and the tree scan carries the job.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           base="$(git merge-base "$BASE_SHA" HEAD)"
           echo "scanning commit range ${base}..HEAD"
@@ -1225,6 +1277,44 @@ jobs:
       - name: Check repository documentation contract
         run: python3 .github/scripts/check_docs_contract.py
 
+  branch-protection:
+    name: "[CHECK] | [REPO] | Branch protection"
+    # Issue #383 AC-3. Everything else in this workflow guards the CODE; this
+    # guards the setting that makes the workflow binding. Merge-readiness
+    # enforcement lives in repository settings, so it can be switched off with
+    # no diff, no review, and no red check anywhere - which is exactly how the
+    # `strict: false` this issue reports went unnoticed. Repo-wide and
+    # always-on, like license-consistency and surface: there is no diff to
+    # path-scope against, because the regression this detects has no diff.
+    #
+    # IT SKIPS WITHOUT A TOKEN, BY DESIGN AND OUT LOUD. Reading a branch's
+    # protection document requires Administration:read, and GITHUB_TOKEN has no
+    # permission key that grants it - so in ordinary CI this cannot see the
+    # document and says so rather than failing. A merge gate must never depend
+    # on a permission that cannot be granted. Set the optional
+    # BRANCH_PROTECTION_AUDIT_TOKEN repository secret to an admin-scoped token
+    # to turn the audit live; the script's skip note explains the same thing to
+    # whoever reads the log. Read-only either way: two queries, no mutations.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+      - name: Audit main's merge-readiness enforcement (read-only; skips without admin rights)
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_AUDIT_TOKEN }}
+        run: python .github/scripts/check_branch_protection.py --repo "$GITHUB_REPOSITORY" --branch main
+      - name: Test the audit's own logic
+        # The audit itself skips when it cannot see the setting, so its unit
+        # tests are what stay unconditional - they are offline, tokenless, and
+        # pin both the pass and the fail verdict against a recorded copy of the
+        # live protection document.
+        run: python .github/scripts/test_branch_protection.py
+
   ci-passed:
     name: "[GATE ] | [REPO] | Merge readiness"
     # REGISTRATION CONTRACT (issue #390): this gate enforces a job through TWO
@@ -1238,6 +1328,7 @@ jobs:
     if: always()
     needs:
       - documentation-contract
+      - branch-protection
       - changes
       - host-descriptors
       - ci-impact
@@ -1264,7 +1355,7 @@ jobs:
     steps:
       - name: Require every required job to have succeeded or been skipped
         run: |
-          required_results="${{ needs['documentation-contract'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }} ${{ needs['secret-scan'].result }}"
+          required_results="${{ needs['documentation-contract'].result }} ${{ needs['branch-protection'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }} ${{ needs['secret-scan'].result }}"
           canary_result="${{ needs.ca-pi-latest.result }}"
           echo "upstream required results: $required_results"
           echo "advisory Pi canary result: $canary_result"


### PR DESCRIPTION
Closes #383.

## The defect, verified live

```
$ gh api repos/arbiterForge/codeArbiter/branches/main/protection
required_status_checks.strict            false
required_status_checks.contexts          ["[GATE ] | [REPO] | Merge readiness"]
required_linear_history                  true
required_conversation_resolution         true
required_approving_review_count          0
```

One required context, and `strict: false` behind it. A PR can merge on a required check computed against an **older** base, so two individually green PRs can interact after one lands while the second keeps a valid check from its stale merge base. Observed on PR #446: it went green, main advanced, and its Pi adapter cells then failed on a payload-version gate that had nothing to do with its own diff.

Per the maintainer's ruling this implements **Option B (merge queue)** — GitHub synthesises and tests the exact prospective merge commit, which is stricter than mere up-to-dateness.

## ⚠️ This PR is the repository-side half only

**I did not enable the merge queue and did not modify branch protection.** Those are maintainer settings actions, and the sequencing is load-bearing:

1. **Merge this PR** so the `merge_group:` trigger is live on `main`.
2. **Then** enable the merge queue for `main` in branch protection.

Reversing that order jams every merge: a queue whose required context never reports under `merge_group` stalls with nothing able to satisfy the gate. The trigger has to exist on the branch the queue targets *before* the queue is switched on.

One further note for step 2: the new audit job below is **armed but dormant** — it skips because the optional `BRANCH_PROTECTION_AUDIT_TOKEN` secret does not exist. If that secret is provisioned *before* the queue is enabled, the audit will correctly report today's defect and turn CI red. Provision it after, if at all.

---

## TDD: verbatim red output

Both new contracts were written first and run against unmodified `ci.yml`.

### `.github/scripts/test_ci_impact.py`

```
$ cd .github/scripts && python -m unittest -v \
    test_ci_impact.WorkflowContractTest.test_ci_reports_under_the_merge_group_event_that_tests_the_real_base \
    test_ci_impact.WorkflowContractTest.test_every_enforced_job_is_reachable_and_correctly_based_in_a_merge_group

test_ci_reports_under_the_merge_group_event_that_tests_the_real_base ... FAIL
test_every_enforced_job_is_reachable_and_correctly_based_in_a_merge_group ... FAIL

======================================================================
FAIL: test_ci_reports_under_the_merge_group_event_that_tests_the_real_base
----------------------------------------------------------------------
AssertionError: Regex didn't match: '(?m)^  merge_group:\\n    types: \\[checks_requested\\]$' not found in 'name: ci\n...
 : ci.yml never runs on merge_group, so an enabled merge queue would have nothing to satisfy the required merge-readiness context

======================================================================
FAIL: test_every_enforced_job_is_reachable_and_correctly_based_in_a_merge_group
----------------------------------------------------------------------
AssertionError: Lists differ: ["ca-pi-codeql: if: github.event_name == '[521 chars]st'"] != []

First list contains 6 additional elements.
First extra element 0:
"ca-pi-codeql: if: github.event_name == 'pull_request' && needs.changes.outputs.ca-pi == 'true'"

+ []
- ["ca-pi-codeql: if: github.event_name == 'pull_request' && "
-  "needs.changes.outputs.ca-pi == 'true'",
-  "version-bump: if: github.event_name == 'pull_request' && "
-  "needs.changes.outputs.ca == 'true'",
-  "version-bump-sandbox: if: github.event_name == 'pull_request' && "
-  "needs.changes.outputs.ca-sandbox == 'true'",
-  "version-bump-codex: if: github.event_name == 'pull_request' && "
-  "needs.changes.outputs.ca-codex == 'true'",
-  "version-bump-pi: if: github.event_name == 'pull_request' && "
-  "needs.changes.outputs.ca-pi == 'true'",
-  "secret-scan: if: github.event_name == 'pull_request'"] : enforced jobs a merge queue would silently skip while ci-passed reports green

----------------------------------------------------------------------
Ran 2 tests in 0.011s

FAILED (failures=2)
```

The failure list is **derived**, not hardcoded — it walks `ci-passed`'s own `required_results` string, so a future job cannot be added PR-only without failing this.

### `.github/scripts/test_branch_protection.py`

```
$ cd .github/scripts && python -m unittest -v test_branch_protection
...
  File ".github/scripts/test_branch_protection.py", line 31, in <module>
    _spec.loader.exec_module(module)
FileNotFoundError: [Errno 2] No such file or directory:
  'C:\\...\\.github\\scripts\\check_branch_protection.py'
```

---

## Per-job `merge_group` analysis

`ci-passed` treats `skipped` as success — that is exactly what ADR-0007 path scoping needs — so **a job that silently skips under `merge_group` is a dropped verdict with a green aggregate**, i.e. a *weaker* gate than the stale-base one we set out to replace. All 25 jobs enumerated; 24 are awaited by the aggregate and 23 enforced (`ca-pi-latest` is the sanctioned advisory canary).

| job | gate before | behaviour under `merge_group` (before) | action |
| --- | --- | --- | --- |
| `changes` | none | **runs.** `dorny/paths-filter` v4.0.2 handles `merge_group` natively — it reads `merge_group.base_sha`/`head_sha` and diffs those. | none needed ✅ |
| `host-descriptors` | `outputs.host-descriptors` | runs iff flagged, now against the real base | none needed ✅ |
| `ci-impact` | `outputs.impact` | runs iff flagged | none needed ✅ |
| `tools` | `outputs.ca` | runs iff flagged | none needed ✅ |
| `ca-sandbox-tools` | `outputs.ca-sandbox` | runs iff flagged | none needed ✅ |
| `ca-pi-checks` | `outputs.ca-pi` | runs iff flagged | none needed ✅ |
| `ca-pi-tools` | `outputs.ca-pi` | runs iff flagged | none needed ✅ |
| `ca-pi-latest` | `outputs.ca-pi` | runs iff flagged (advisory, never enforced) | none needed ✅ |
| `ca-pi-codeql` | **`event_name == 'pull_request'`** | **SKIPS.** No security analysis of the merge result. | condition now admits `merge_group` 🔧 |
| `hooks` | `outputs.hooks` | runs iff flagged | none needed ✅ |
| `version-bump` | **`event_name == 'pull_request'`** | **SKIPS**, and `BASE: github.base_ref` is **empty** | condition + `merge_group.base_ref` fallback 🔧 |
| `version-bump-sandbox` | **`event_name == 'pull_request'`** | **SKIPS**, same empty `github.base_ref` | condition + `merge_group.base_ref` fallback 🔧 |
| `version-bump-codex` | **`event_name == 'pull_request'`** | **SKIPS**, same empty `github.base_ref` | condition + `merge_group.base_ref` fallback 🔧 |
| `version-bump-pi` | **`event_name == 'pull_request'`** | **SKIPS**, and `github.event.pull_request.base.sha` is **empty** | condition + `merge_group.base_sha` fallback 🔧 |
| `prose` | `outputs.ca` | runs iff flagged | none needed ✅ |
| `badge-consistency` | `outputs.ca` | runs iff flagged | none needed ✅ |
| `prose-sandbox` | `outputs.ca-sandbox` | runs iff flagged | none needed ✅ |
| `manifests` | `outputs.manifests` | runs iff flagged | none needed ✅ |
| `license-consistency` | none | always runs | none needed ✅ |
| `surface` | none | always runs | none needed ✅ |
| `prose-codex` | `outputs.ca-codex` | runs iff flagged | none needed ✅ |
| `secret-scan` | none (job) | job runs; its **commit-range step** is `event_name == 'pull_request'` and its `BASE_SHA` is empty → history scan silently dropped | step condition + `merge_group.base_sha` fallback 🔧 |
| `documentation-contract` | none | always runs | none needed ✅ |
| `branch-protection` | *new* | always runs | new job (AC-3) ➕ |
| `ci-passed` | `always()` | runs | registered the new job in **both** `needs:` and `required_results` |

### The payload guards are the whole point

Whether a version bump is required is a question **about the base**. Two PRs can each bump `ca` to the same version and pass individually; only the second one's merge-group run — computed against a main that already took that version — can see the collision. Those four guards are precisely what a merge queue exists to re-run, and all four were PR-only.

### Empty base contexts are worse than skipping

`github.base_ref` and `github.event.pull_request.*` are **empty** under `merge_group`. A job that runs with an empty base doesn't fail — it passes having verified nothing. Concretely, `tools/build-host-packages.py`:

```python
if not args.release_guard_base:
    return 0
```

With `--release-guard-base ""` the Pi release guard returns **0 without checking anything**. That is why the contract has a second scan asserting every `github.base_ref` / `github.event.pull_request.*` expression inside an enforced job carries a `github.event.merge_group.*` fallback.

### `dorny/paths-filter` needed no change

Verified against the pinned SHA (`7b450fff`, v4.0.2) — `src/main.ts` has an explicit `case 'merge_group'` that sets `base = merge_group.base_sha` and `ref = merge_group.head_sha`, then diffs them. Per-plugin path scoping (ADR-0007) therefore keeps working, against the real base, with no configuration change.

### No `paths:` filter on the trigger, deliberately

On `push` a paths filter only decides whether to spend runner time. In a merge group it would decide whether the required context **reports at all**, and a filtered-out merge group waits forever. Path scoping stays *inside* the workflow via the `changes` job, where a skipped job is a skipped job and not an absent check run.

---

## AC-3: read-only branch-protection audit

`.github/scripts/check_branch_protection.py` — two queries, no mutations:

- REST `GET /repos/{owner}/{repo}/branches/{branch}/protection` → `strict`, required contexts
- GraphQL `repository.mergeQueue(branch:)` → whether a queue is enabled (this one needs only ordinary repository read)

It reports a **definite weakening**: neither `strict` nor a queue; the stable `[GATE ] | [REPO] | Merge readiness` context dropped; or protection deleted outright (a 404, which GitHub distinguishes from the 403 it returns for insufficient rights). Extra required contexts are a hardening and are not reported.

**It accepts either answer.** Demanding `strict` *and* a queue would fail the moment the ruled-on fix landed, because a queue makes `strict` redundant and it is expected to stay `false`.

**Every field is three-valued** — `True` / `False` / `None` for "this run could not see it" — and only a definite `False` is a finding. Reading a protection document requires `Administration:read`, and **no GITHUB_TOKEN `permissions:` key grants it**, so in ordinary CI the audit cannot see the document. It skips cleanly and says so, at length, in the log:

```
$ python .github/scripts/check_branch_protection.py --repo arbiterForge/codeArbiter --branch main
SKIP: no token, so main's branch protection was NOT audited.

This is expected in ordinary CI. Reading a branch-protection document requires
Administration:read, and a workflow `permissions:` block has no key that grants
it, so the default GITHUB_TOKEN can never satisfy this check. It skips instead
of failing because a merge gate must not depend on a permission that cannot be
granted.

To actually run the audit, set GH_TOKEN to a token with admin rights on the
repository - as a repository secret wired into this step, or locally with:

    GH_TOKEN=$(gh auth token) python .github/scripts/check_branch_protection.py

exit=0
```

A merge gate must never depend on a permission that cannot be granted. Given a token, it detects today's live defect:

```
$ GH_TOKEN=$(gh auth token) python .github/scripts/check_branch_protection.py --repo arbiterForge/codeArbiter --branch main
::error title=Branch protection::main can merge a stale-base result: required_status_checks.strict
is false and no merge queue is enabled, so a green [GATE ] | [REPO] | Merge readiness computed
against an OLDER base still satisfies the gate. Re-enable the merge queue for main, or turn on
"Require branches to be up to date before merging" (issue #383).
exit=1
```

The audit's own logic is pinned by 20 offline, tokenless unit tests (against a recorded copy of the live protection document) which run unconditionally in the new job — so the *audit* skipping never means the *contract* went unchecked.

---

## Suite results

Measured in a clean worktree; baseline measured in a second detached worktree at `origin/main` under **identical conditions**, so the comparison is like-for-like.

| suite | before (`origin/main`) | after | delta |
| --- | --- | --- | --- |
| `.github/scripts` | Ran **1179**, 1170 passed, 4 failed, 5 skipped | Ran **1201**, 1192 passed, 4 failed, 5 skipped | **+22 tests**, identical failure set |
| `plugins/ca/hooks/tests` | 1125 OK | **1125 OK** | unchanged (untouched by this PR) |

The 4 failures are **identical before and after** and are environment-only: all four are in `test_pi_benchmark.py`, which needs the pinned `esbuild` from `plugins/ca-pi/tools/node_modules` (`RuntimeError: Pi benchmark requires the installed pinned esbuild`). Proven environmental by running that module in a checkout that *has* the toolchain installed:

```
$ cd .github/scripts && python -m unittest test_pi_benchmark
...........
Ran 11 tests in 1.796s

OK
```

CI installs the toolchain in `ca-pi-checks` before running the benchmark, so this does not reproduce there.

Also green locally: `check_docs_contract.py`, `check_license_consistency.py`, `check_badge_consistency.py`, `tools/build-surface.py --check`, and `git diff --check origin/main HEAD` (exit 0, LF throughout).

---

## Follow-up for the maintainer (after this merges)

1. Enable the merge queue for `main` in branch protection (Settings → Branches → `main` → "Require merge queue").
2. Keep `[GATE ] | [REPO] | Merge readiness` as the single required context — the audit asserts it stays required.
3. Optionally provision `BRANCH_PROTECTION_AUDIT_TOKEN` (admin-scoped) to make the audit live. **Only after step 1**, or it will correctly report the current defect and block merges.

---

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
