### PR TITLE
fix(governance): make an ADR's filename stem its identifier so supersession is unambiguous

### DIFF
--- a/.codearbiter/decisions/0015-all-live-git-enforcers-and-persistent-trusted-identity.md
+++ b/.codearbiter/decisions/0015-all-live-git-enforcers-and-persistent-trusted-identity.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-07-16
 title: Require every live git enforcer and persist trusted executable identity
 decided-by: SUaDtL@users.noreply.github.com
-supersedes: 0014
+supersedes: 0014-githook-shim-dropin-fail-closed
 governs: core/pysrc/_githooks.py, core/pysrc/session-start.py, plugins/*/hooks/_githooks.py, plugins/*/hooks/session-start.py
 ---
 

--- a/.codearbiter/decisions/0016-bounded-pi-child-credential-projection.md
+++ b/.codearbiter/decisions/0016-bounded-pi-child-credential-projection.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-07-22
 title: Permit bounded selected-provider credential projection for isolated Pi children
 decided-by: SUaDtL@users.noreply.github.com
-supersedes: 0014
+supersedes: 0014-pi-host-authentication-and-fail-closed-tool-boundary
 governs: .codearbiter/security-controls.md, .codearbiter/specs/pi-support.md, .codearbiter/plans/pi-support.md, plugins/ca-pi/**
 ---
 

--- a/.github/scripts/check_adr_identity.py
+++ b/.github/scripts/check_adr_identity.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Fail when an ADR identifier, or a `supersedes:` pointer, names more than one ADR (#416).
+
+An ADR is identified by its filename STEM -- `0014-githook-shim-dropin-fail-closed`,
+not `0014`. Two ADRs in this repository already carry the number 0014, and two later
+ADRs supersede different ones of them, so a bare `supersedes: 0014` names two
+documents at once and no consumer can tell which without reading prose.
+
+Invariants enforced (all derived from the repository, never hand-asserted):
+
+  1. Filename stems are unique -- the stem IS the identifier.
+  2. An ADR number resolves to exactly one stem, apart from the single
+     grandfathered historical collision below. A NEW file taking an already-used
+     number is a violation, which is what stops the collision recurring.
+  3. Every `supersedes:` value resolves to exactly one ADR. A stem always
+     resolves. A bare number resolves only while it is unambiguous; the moment it
+     names more than one stem it is an error, never a guess.
+
+Run: python .github/scripts/check_adr_identity.py   (exit 1 on any violation)
+"""
+
+import os
+import re
+import sys
+
+ADR_FILE_RE = re.compile(r"^(\d+)-.+\.md$")
+SUPERSEDES_RE = re.compile(r"^supersedes:\s*(.*?)\s*$", re.I)
+
+# Frontmatter scan depth, mirroring the hook-side indexers.
+FRONTMATTER_SCAN_LIMIT = 26
+
+# Spellings of "this ADR supersedes nothing".
+_NO_PREDECESSOR = frozenset({"", "none", "n/a", "-"})
+
+# The ONE historical number collision, grandfathered by the exact PAIR of stems
+# rather than by the number 0014. Two ADRs were authored as 0014 independently;
+# renaming either would rewrite an identifier that prose across the repository
+# already cites, and the never-edit rule protects the decision record.
+# Disambiguating the POINTERS that name them is the repair.
+#
+# Naming the stems, not the number, is what makes the collision non-recurring:
+# a THIRD file numbered 0014 is not in this set, so it is rejected exactly like
+# any other new duplicate. The waiver covers the two files that exist, forever,
+# and nothing else.
+GRANDFATHERED_DUPLICATE_STEMS = frozenset({
+    "0014-githook-shim-dropin-fail-closed",
+    "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+})
+
+
+class ADRReferenceError(ValueError):
+    """A `supersedes:` value does not name exactly one ADR."""
+
+
+class AmbiguousADRReference(ADRReferenceError):
+    """A bare ADR number names more than one document."""
+
+
+class UnknownADRReference(ADRReferenceError):
+    """A `supersedes:` value names no ADR at all."""
+
+
+# ---- pure helpers -------------------------------------------------------------
+
+def adr_number(stem):
+    """The leading number of an ADR stem, as an int. `0014-x` -> 14."""
+    return int(str(stem).split("-", 1)[0])
+
+
+def resolve_supersedes(value, stems):
+    """Resolve a `supersedes:` value to exactly one stem in `stems`.
+
+    Returns the stem, or None when the ADR supersedes nothing. Raises
+    AmbiguousADRReference when a bare number names more than one stem, and
+    UnknownADRReference when the value names none.
+
+    Never guesses. An ambiguous reference has no correct answer, so returning
+    one -- even "the first match" -- would silently invent a decision chain.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if text.lower() in _NO_PREDECESSOR:
+        return None
+
+    known = list(stems or [])
+    if text in known:
+        return text
+
+    if text.isdigit():
+        wanted = int(text)
+        matches = sorted(s for s in known if _leading_number(s) == wanted)
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise AmbiguousADRReference(
+                "bare ADR number %r names %d documents (%s) -- name the full "
+                "filename stem instead" % (text, len(matches), ", ".join(matches))
+            )
+
+    raise UnknownADRReference(
+        "supersedes: %r names no ADR under decisions/" % text)
+
+
+def _leading_number(stem):
+    try:
+        return adr_number(stem)
+    except (ValueError, IndexError):
+        return None
+
+
+def identity_errors(stems, supersedes_by_stem,
+                    grandfathered=GRANDFATHERED_DUPLICATE_STEMS):
+    """Every violation of the three clauses, as human-readable strings.
+
+    `stems` is the list of ADR filename stems; `supersedes_by_stem` maps a stem
+    to its raw `supersedes:` value. Pure -- no filesystem access.
+    """
+    errors = []
+    stems = list(stems or [])
+
+    # Clause 1 -- stems are unique.
+    seen = set()
+    for stem in stems:
+        if stem in seen:
+            errors.append("duplicate ADR stem %r -- the stem is the identifier "
+                          "and must name exactly one decision" % stem)
+        seen.add(stem)
+
+    # Clause 2 -- a number resolves to one stem, apart from the grandfathered set.
+    by_number = {}
+    for stem in sorted(set(stems)):
+        number = _leading_number(stem)
+        if number is None:
+            errors.append("ADR stem %r does not begin with a number" % stem)
+            continue
+        by_number.setdefault(number, []).append(stem)
+    waived = set(grandfathered or ())
+    for number, sharing in sorted(by_number.items()):
+        if len(sharing) < 2:
+            continue
+        offending = [s for s in sharing if s not in waived]
+        # The pair is waived only when EVERY file on that number is waived --
+        # a third file joining a grandfathered number is still a violation.
+        if not offending:
+            continue
+        errors.append(
+            "ADR number %04d is used by %d files (%s) -- %s must take an unused "
+            "number so `supersedes: %04d` stays unambiguous"
+            % (number, len(sharing), ", ".join(sharing),
+               " and ".join(offending), number))
+
+    # Clause 3 -- every supersedes: value resolves to exactly one ADR.
+    for stem in sorted(supersedes_by_stem or {}):
+        try:
+            resolve_supersedes(supersedes_by_stem[stem], stems)
+        except ADRReferenceError as exc:
+            errors.append("%s: %s" % (stem, exc))
+
+    return errors
+
+
+# ---- repository gatherers -----------------------------------------------------
+
+def adr_stems(decisions_dir):
+    """Sorted filename stems of every `NNNN-*.md` ADR in `decisions_dir`."""
+    try:
+        names = os.listdir(decisions_dir)
+    except OSError:
+        return []
+    return sorted(os.path.splitext(n)[0] for n in names if ADR_FILE_RE.match(n))
+
+
+def read_supersedes(path):
+    """The raw `supersedes:` frontmatter value in `path`, or None if absent."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for i, line in enumerate(handle):
+                if i >= FRONTMATTER_SCAN_LIMIT:
+                    break
+                match = SUPERSEDES_RE.match(line.strip())
+                if match:
+                    return match.group(1)
+    except OSError:
+        return None
+    return None
+
+
+def check(root):
+    """Every ADR-identity violation in the repository at `root`."""
+    ddir = os.path.join(str(root), ".codearbiter", "decisions")
+    stems = adr_stems(ddir)
+    supersedes = {}
+    for stem in stems:
+        value = read_supersedes(os.path.join(ddir, stem + ".md"))
+        if value is not None:
+            supersedes[stem] = value
+    return identity_errors(stems, supersedes)
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))  # <repo>/.github/scripts
+    root = os.path.dirname(os.path.dirname(here))
+    errors = check(root)
+    if errors:
+        print("::error::ADR identity/supersession is ambiguous:")
+        for error in errors:
+            print("  - " + error)
+        return 1
+    print("ADR stems unique; every supersedes: names exactly one decision")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_adr_identity.py
+++ b/.github/scripts/test_adr_identity.py
@@ -34,8 +34,16 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
 HOOKS = os.path.join(REPO, "plugins", "ca", "hooks")
 sys.path.insert(0, HOOKS)
+sys.path.insert(0, HERE)
 
 import _readinjectlib as ril  # noqa: E402 - needs the sys.path mutation above
+
+# Guarded so a missing checker module does not abort collection of the hook
+# derivation tests above it - every obligation then fails loudly on its own.
+try:
+    import check_adr_identity as cai
+except ImportError:  # pragma: no cover - only before the module exists
+    cai = None
 
 
 def _load_post_write_edit():
@@ -100,6 +108,150 @@ class HookIdDerivationTest(unittest.TestCase):
         self.assertEqual(len(texts), 2, texts)
         self.assertTrue(any("ADR-" + self.GITHOOK in t for t in texts), texts)
         self.assertTrue(any("ADR-" + self.PIAUTH in t for t in texts), texts)
+
+
+class CheckerPresentMixin:
+    def setUp(self):
+        if cai is None:
+            self.fail(
+                "check_adr_identity is not importable - the ADR identity "
+                "contract has no implementation yet"
+            )
+        super().setUp()
+
+
+class ResolveSupersedesTest(CheckerPresentMixin, unittest.TestCase):
+    """Clause 3 - one `supersedes:` value resolves to exactly one ADR."""
+
+    STEMS = [
+        "0013-add-ca-pi-sibling-governance-plugin",
+        "0014-githook-shim-dropin-fail-closed",
+        "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+        "0015-all-live-git-enforcers-and-persistent-trusted-identity",
+    ]
+
+    def test_a_stem_resolves_to_itself(self):
+        self.assertEqual(
+            cai.resolve_supersedes(
+                "0014-githook-shim-dropin-fail-closed", self.STEMS),
+            "0014-githook-shim-dropin-fail-closed",
+        )
+
+    def test_the_other_stem_resolves_to_the_other_document(self):
+        self.assertEqual(
+            cai.resolve_supersedes(
+                "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+                self.STEMS),
+            "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+        )
+
+    def test_an_unambiguous_bare_number_still_resolves(self):
+        """Backward compatibility: 0009/0017/0018/0019 name a number today."""
+        self.assertEqual(
+            cai.resolve_supersedes("0013", self.STEMS),
+            "0013-add-ca-pi-sibling-governance-plugin",
+        )
+
+    def test_an_ambiguous_bare_number_raises_instead_of_guessing(self):
+        """THE defect: `0014` names two documents. Erroring is the fix."""
+        with self.assertRaises(cai.AmbiguousADRReference) as caught:
+            cai.resolve_supersedes("0014", self.STEMS)
+        message = str(caught.exception)
+        self.assertIn("0014-githook-shim-dropin-fail-closed", message)
+        self.assertIn(
+            "0014-pi-host-authentication-and-fail-closed-tool-boundary", message)
+
+    def test_an_ambiguous_bare_number_never_returns_a_stem(self):
+        """Guard against a 'helpful' fallback that picks the first match."""
+        try:
+            resolved = cai.resolve_supersedes("0014", self.STEMS)
+        except cai.AmbiguousADRReference:
+            return
+        self.fail("ambiguous 0014 resolved to %r instead of erroring" % resolved)
+
+    def test_none_resolves_to_no_predecessor(self):
+        for spelling in ("none", "None", "  none  ", "", None):
+            self.assertIsNone(cai.resolve_supersedes(spelling, self.STEMS),
+                              "spelling %r" % (spelling,))
+
+    def test_an_unknown_reference_raises(self):
+        with self.assertRaises(cai.UnknownADRReference):
+            cai.resolve_supersedes("0099", self.STEMS)
+        with self.assertRaises(cai.UnknownADRReference):
+            cai.resolve_supersedes("0014-no-such-slug", self.STEMS)
+
+
+class UniquenessContractTest(CheckerPresentMixin, unittest.TestCase):
+    """Clause 2 - a NEW file may not take an already-used ADR number."""
+
+    def test_a_third_file_taking_the_grandfathered_number_is_rejected(self):
+        stems = [
+            "0014-githook-shim-dropin-fail-closed",
+            "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+            "0014-a-third-decision-sneaking-in",
+        ]
+        errors = cai.identity_errors(stems, {})
+        self.assertTrue(errors, "a third 0014 must violate the contract")
+        self.assertTrue(any("0014" in e for e in errors), errors)
+
+    def test_a_new_duplicate_of_an_unrelated_number_is_rejected(self):
+        stems = ["0009-relicense-agplv3-dual-licensing",
+                 "0009-a-second-decision-on-the-same-number"]
+        errors = cai.identity_errors(stems, {})
+        self.assertTrue(errors, "a duplicate 0009 must violate the contract")
+
+    def test_the_historical_pair_alone_is_grandfathered(self):
+        stems = ["0014-githook-shim-dropin-fail-closed",
+                 "0014-pi-host-authentication-and-fail-closed-tool-boundary"]
+        self.assertEqual(cai.identity_errors(stems, {}), [])
+
+    def test_duplicate_stems_are_rejected(self):
+        """Clause 1 stated as a contract, not left to the filesystem."""
+        stems = ["0020-a-decision", "0020-a-decision"]
+        errors = cai.identity_errors(stems, {})
+        self.assertTrue(errors, "a duplicate stem must violate the contract")
+
+    def test_an_ambiguous_supersedes_is_reported_not_resolved(self):
+        stems = ["0014-githook-shim-dropin-fail-closed",
+                 "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+                 "0015-later"]
+        errors = cai.identity_errors(stems, {"0015-later": "0014"})
+        self.assertTrue(errors, "an ambiguous supersedes must be an error")
+        self.assertTrue(any("0015-later" in e for e in errors), errors)
+
+    def test_a_disambiguated_supersedes_passes(self):
+        stems = ["0014-githook-shim-dropin-fail-closed",
+                 "0014-pi-host-authentication-and-fail-closed-tool-boundary",
+                 "0015-later"]
+        errors = cai.identity_errors(
+            stems, {"0015-later": "0014-githook-shim-dropin-fail-closed"})
+        self.assertEqual(errors, [])
+
+
+class LiveRepositoryContractTest(CheckerPresentMixin, unittest.TestCase):
+    """The contract applied to this repository's real decision record."""
+
+    def test_this_repository_satisfies_the_adr_identity_contract(self):
+        errors = cai.check(REPO)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_the_two_0014_files_are_both_still_present_and_distinct(self):
+        """Pin the premise: the fix disambiguates, it does not delete or rename."""
+        stems = cai.adr_stems(
+            os.path.join(REPO, ".codearbiter", "decisions"))
+        self.assertIn("0014-githook-shim-dropin-fail-closed", stems)
+        self.assertIn(
+            "0014-pi-host-authentication-and-fail-closed-tool-boundary", stems)
+
+    def test_every_live_supersedes_names_exactly_one_predecessor(self):
+        ddir = os.path.join(REPO, ".codearbiter", "decisions")
+        stems = cai.adr_stems(ddir)
+        for stem in stems:
+            value = cai.read_supersedes(os.path.join(ddir, stem + ".md"))
+            try:
+                cai.resolve_supersedes(value, stems)
+            except cai.ADRReferenceError as exc:
+                self.fail("%s: supersedes: %r -> %s" % (stem, value, exc))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_adr_identity.py
+++ b/.github/scripts/test_adr_identity.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""codeArbiter - ADR identity + supersession-resolution contract (#416).
+
+Two ADR files in this repository carry the number 0014
+(`0014-githook-shim-dropin-fail-closed` and
+`0014-pi-host-authentication-and-fail-closed-tool-boundary`), and two later
+ADRs supersede *different* ones of them. A bare `supersedes: 0014` therefore
+names two documents at once, and every consumer that derived an ADR id with
+`filename.split("-")[0]` collapsed the pair into one indistinguishable id.
+
+The contract this file pins:
+
+  1. The filename STEM is the ADR identifier - `0014-githook-shim-dropin-
+     fail-closed`, not `0014`. Both hook-side indexers derive it that way, and
+     they derive it identically.
+  2. Filename stems are unique, and an ADR number resolves to exactly one stem
+     apart from the one grandfathered historical collision. A NEW file taking
+     an already-used number is a contract violation, so the collision cannot
+     recur.
+  3. Every `supersedes:` value resolves to exactly ONE ADR. A stem always
+     resolves. A bare number resolves only while it is unambiguous; once it
+     names more than one stem it is an error, never a guess.
+
+Stdlib only. Exit 0 = all tests pass; non-zero = failure.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+HOOKS = os.path.join(REPO, "plugins", "ca", "hooks")
+sys.path.insert(0, HOOKS)
+
+import _readinjectlib as ril  # noqa: E402 - needs the sys.path mutation above
+
+
+def _load_post_write_edit():
+    """Import post-write-edit.py by path (its name is not a valid identifier)."""
+    spec = importlib.util.spec_from_file_location(
+        "post_write_edit_for_adr_identity",
+        os.path.join(HOOKS, "post-write-edit.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pwe = _load_post_write_edit()
+
+
+def _write_adr(ddir, filename, status="accepted", title="T", governs="src/**"):
+    lines = ["---", "status: %s" % status, "title: %s" % title]
+    if governs:
+        lines.append("governs: %s" % governs)
+    lines.append("---")
+    lines.append("# Body")
+    with open(os.path.join(ddir, filename), "w", encoding="utf-8",
+              newline="\n") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+class HookIdDerivationTest(unittest.TestCase):
+    """Clause 1 - both hook indexers key an ADR by its full filename stem."""
+
+    GITHOOK = "0014-githook-shim-dropin-fail-closed"
+    PIAUTH = "0014-pi-host-authentication-and-fail-closed-tool-boundary"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.ddir = os.path.join(self.root, ".codearbiter", "decisions")
+        os.makedirs(self.ddir)
+        _write_adr(self.ddir, self.GITHOOK + ".md", title="Git-hook shim")
+        _write_adr(self.ddir, self.PIAUTH + ".md", title="Pi host auth")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_accepted_adr_index_keys_two_same_numbered_adrs_apart(self):
+        ids = sorted(e["adr"] for e in ril.accepted_adr_index(self.root))
+        self.assertEqual(ids, sorted([self.GITHOOK, self.PIAUTH]))
+
+    def test_governs_index_keys_two_same_numbered_adrs_apart(self):
+        ids = sorted(e["adr"] for e in pwe.governs_index(self.root))
+        self.assertEqual(ids, sorted([self.GITHOOK, self.PIAUTH]))
+
+    def test_both_indexers_derive_the_same_identifier_for_the_same_file(self):
+        """The defect was duplicated derivation logic; pin the two together."""
+        left = {e["adr"] for e in ril.accepted_adr_index(self.root)}
+        right = {e["adr"] for e in pwe.governs_index(self.root)}
+        self.assertEqual(left, right)
+
+    def test_pointer_text_names_the_stem_so_a_reader_can_tell_them_apart(self):
+        index = ril.accepted_adr_index(self.root)
+        texts = [p["text"] for p in ril.adr_pointers("src/x.py", index)]
+        self.assertEqual(len(texts), 2, texts)
+        self.assertTrue(any("ADR-" + self.GITHOOK in t for t in texts), texts)
+        self.assertTrue(any("ADR-" + self.PIAUTH in t for t in texts), texts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_pi_package.py
+++ b/.github/scripts/test_pi_package.py
@@ -1527,8 +1527,9 @@ class PiPackageTests(unittest.TestCase):
     def test_real_rpc_native_read_context_is_model_visible_once(self):
         import base64
 
+        # #416: the pointer names the ADR's filename stem, not its bare number.
         expected_context = (
-            "ADR-0015 (Model-visible read contract) governs this file"
+            "ADR-0015-pi-read (Model-visible read contract) governs this file"
             " — do not contradict it; route changes via /ca:reconcile or /ca:adr."
         )
         governed_native = "governed native body\n"

--- a/.github/scripts/test_readinjectlib.py
+++ b/.github/scripts/test_readinjectlib.py
@@ -521,12 +521,13 @@ class AdrIndexTest(unittest.TestCase):
             )
             index = ril.accepted_adr_index(tmpdir)
             self.assertEqual(len(index), 1, "accepted ADR must be indexed")
-            self.assertEqual(index[0]["adr"], "0003")
+            # #416: the identifier is the filename stem, not the bare number.
+            self.assertEqual(index[0]["adr"], "0003-x")
             self.assertEqual(index[0]["title"], "HTTPS and secret handling")
             pointers = ril.adr_pointers("plugins/ca/tools/farm.ts", index)
             self.assertEqual(len(pointers), 1)
             p = pointers[0]
-            self.assertIn("ADR-0003", p["text"])
+            self.assertIn("ADR-0003-x", p["text"])
             self.assertIn("HTTPS and secret handling", p["text"])
             self.assertEqual(p["tier"], "decisions")
 
@@ -683,7 +684,7 @@ class AdrIndexTest(unittest.TestCase):
                 len(index), 1,
                 "Valid ADR must still be indexed when malformed file is present",
             )
-            self.assertEqual(index[0]["adr"], "0002")
+            self.assertEqual(index[0]["adr"], "0002-valid")
 
     def test_adr_without_governs_line_not_indexed(self):
         """ADR with status:accepted but no governs: line is not indexed."""
@@ -2433,7 +2434,7 @@ class BuildIndexTest(unittest.TestCase):
             result = ril.build_index(tmpdir)
             adr_list = result.get("adr", [])
             self.assertEqual(len(adr_list), 1, "exactly one ADR entry expected")
-            self.assertEqual(adr_list[0].get("adr"), "0003")
+            self.assertEqual(adr_list[0].get("adr"), "0003-x")
 
     def test_build_index_value_types(self):
         """adr and spec sub-values are lists; provenance is a dict."""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,19 +699,6 @@ jobs:
         # asserted only for append-only gate events, never RMW state or the
         # repo-global dev marker.
         run: python .github/scripts/test_dual_host_store.py
-      - name: Run ADR identity + supersession contract tests
-        # #416: two ADRs share the number 0014, so a bare `supersedes: 0014`
-        # named two documents at once. The identifier is the filename STEM;
-        # this pins both hook-side indexers to that derivation and proves an
-        # ambiguous bare number errors instead of resolving arbitrarily.
-        run: python .github/scripts/test_adr_identity.py
-      - name: Enforce the ADR identity contract on the live decision record
-        # The contract applied to .codearbiter/decisions/ itself: stems unique,
-        # no NEW file on an already-used number (the 0014 pair is grandfathered
-        # by stem, so a third one still fails), and every supersedes: resolving
-        # to exactly one ADR. Ambiguity fails the build rather than being
-        # silently resolved to whichever file sorts first.
-        run: python .github/scripts/check_adr_identity.py
       - name: Run guard-logic matrix
         # The cold-install matrix proves the interpreter plumbing; this proves
         # the guard decisions themselves - every blocked spelling of
@@ -803,6 +790,23 @@ jobs:
         # locally per CONTRIBUTING; wired here so the guards are mechanically
         # enforced. Stdlib-only, cross-platform (discovered on every matrix OS).
         run: python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"
+      - name: Run ADR identity + supersession contract tests
+        # #416: two ADRs share the number 0014, so a bare `supersedes: 0014`
+        # named two documents at once. The identifier is the filename STEM;
+        # this pins both hook-side indexers to that derivation and proves an
+        # ambiguous bare number errors instead of resolving arbitrarily.
+        run: python .github/scripts/test_adr_identity.py
+      - name: Enforce the ADR identity contract on the live decision record
+        # The contract applied to .codearbiter/decisions/ itself: stems unique,
+        # no NEW file on an already-used number (the 0014 pair is grandfathered
+        # by stem, so a third one still fails), and every supersedes: resolving
+        # to exactly one ADR. Ambiguity fails the build rather than being
+        # silently resolved to whichever file sorts first.
+        #
+        # Last in the job deliberately: this pair guards the decision RECORD,
+        # not the payload, so a governance breach must not mask the hook
+        # enforcement results above it by halting the job early.
+        run: python .github/scripts/check_adr_identity.py
 
   version-bump:
     name: "[GATE ] | [CA  ] | Payload version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,11 @@ jobs:
               # test_release_workflow.py runs in the hooks job and is the only
               # guard on the release workflow's publish gates (#378/#380/#385).
               - '.github/workflows/release.yml'
+              # Issue #416: check_adr_identity.py runs in the hooks job and is
+              # the only guard on ADR identity. A PR that ONLY adds a decision
+              # file - the exact shape of a duplicate-number collision - would
+              # skip this job and land the ambiguity unchecked.
+              - '.codearbiter/decisions/**'
             impact:
               - '.github/ci-impact-map.json'
               - '.github/scripts/test_ci_impact.py'
@@ -694,6 +699,19 @@ jobs:
         # asserted only for append-only gate events, never RMW state or the
         # repo-global dev marker.
         run: python .github/scripts/test_dual_host_store.py
+      - name: Run ADR identity + supersession contract tests
+        # #416: two ADRs share the number 0014, so a bare `supersedes: 0014`
+        # named two documents at once. The identifier is the filename STEM;
+        # this pins both hook-side indexers to that derivation and proves an
+        # ambiguous bare number errors instead of resolving arbitrarily.
+        run: python .github/scripts/test_adr_identity.py
+      - name: Enforce the ADR identity contract on the live decision record
+        # The contract applied to .codearbiter/decisions/ itself: stems unique,
+        # no NEW file on an already-used number (the 0014 pair is grandfathered
+        # by stem, so a third one still fails), and every supersedes: resolving
+        # to exactly one ADR. Ambiguity fails the build rather than being
+        # silently resolved to whichever file sorts first.
+        run: python .github/scripts/check_adr_identity.py
       - name: Run guard-logic matrix
         # The cold-install matrix proves the interpreter plumbing; this proves
         # the guard decisions themselves - every blocked spelling of

--- a/core/pysrc/_readinjectlib.py
+++ b/core/pysrc/_readinjectlib.py
@@ -331,10 +331,29 @@ _ADR_STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 _ADR_SCAN_LIMIT = 26  # i > 25 breaks → lines 0-25 inclusive
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and emitted byte-identical "ADR-0014 governs this file" pointers for both.
+    The stem is unique by construction (the filesystem enforces it), so keying on
+    it makes the collision unrepresentable rather than merely unlikely.
+
+    Deliberately mirrored in post-write-edit.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
 def accepted_adr_index(root):
     """Tier-2 filesystem reader.  Scan <root>/.codearbiter/decisions/ for ADR files.
 
-    Returns a list of {"adr": "<numeric id>", "title": "<title>", "globs": [<glob>, …]}
+    Returns a list of {"adr": "<filename stem>", "title": "<title>", "globs": [<glob>, …]}
     for every ADR that satisfies BOTH conditions:
       - governs: is present and non-empty (one or more comma-separated globs).
       - status: is exactly "accepted" (case-insensitive).
@@ -388,7 +407,7 @@ def accepted_adr_index(root):
                 continue
             # ACCEPTED ONLY — stricter than post-write-edit.py governs_index.
             if globs and status == "accepted":
-                adr = fn.split("-")[0]
+                adr = adr_identifier(fn)
                 index.append({"adr": adr, "title": title, "globs": globs})
         return index
     except Exception:  # noqa: BLE001

--- a/core/pysrc/post-write-edit.py
+++ b/core/pysrc/post-write-edit.py
@@ -47,6 +47,31 @@ TITLE_RE = re.compile(r"^title:\s*(.+)$", re.I)
 STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and nudged "governed by ADR-0014" without saying which. The stem is unique
+    by construction, so keying on it makes the collision unrepresentable.
+
+    Deliberately mirrored in _readinjectlib.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
+# Bumped whenever the SHAPE or the derivation of a cached index entry changes.
+# The mtime stamp alone only invalidates on an ADR edit, so without this a
+# payload upgrade would keep serving pre-#416 numeric ids out of an already-
+# written cache until someone happened to touch a decisions/ file.
+GOVERNS_CACHE_SCHEMA = 2
+
+
 def governs_index(root):
     """path-glob → ADR map from decisions/ frontmatter, cached against the
     directory's latest mtime so the scan doesn't repeat on every write."""
@@ -61,7 +86,8 @@ def governs_index(root):
     try:
         with open(cache_path, encoding="utf-8") as f:
             cache = json.load(f)
-        if cache.get("stamp") == stamp:
+        if (cache.get("stamp") == stamp
+                and cache.get("schema") == GOVERNS_CACHE_SCHEMA):
             return cache.get("index", [])
     except Exception:  # noqa: BLE001 — absent/corrupt cache just rebuilds
         pass
@@ -83,12 +109,13 @@ def governs_index(root):
         except Exception:  # noqa: BLE001
             continue
         if globs and status not in ("superseded", "rejected"):
-            adr = fn.split("-")[0]
+            adr = adr_identifier(fn)
             index.append({"adr": adr, "title": title, "globs": globs})
     try:
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         with open(cache_path, "w", encoding="utf-8") as f:
-            json.dump({"stamp": stamp, "index": index}, f)
+            json.dump({"stamp": stamp, "schema": GOVERNS_CACHE_SCHEMA,
+                       "index": index}, f)
     except Exception:  # noqa: BLE001 — cache is an optimization, never required
         pass
     return index

--- a/core/surface/skills/decision-lifecycle/SKILL.md
+++ b/core/surface/skills/decision-lifecycle/SKILL.md
@@ -20,9 +20,11 @@ Read these, or STOP and surface the gap — never guess a path:
 
 ## Phase 1 — Index · gate: BLOCK
 
-Scan `{{PROJECT_DIR}}/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by number, title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
+Scan `{{PROJECT_DIR}}/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by **filename stem** (`0014-githook-shim-dropin-fail-closed`), title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
 
-Gate: the existing ADRs are indexed and, for `/adr`, the next number is fixed.
+**The stem is the identifier; the number is only a sort key.** Two ADRs may already share a number — this repository holds two numbered 0014 — so a bare number can name more than one document. Index by stem, and never assume `NNNN` resolves to one file until you have checked.
+
+Gate: the existing ADRs are indexed by stem and, for `/adr`, the next number is fixed and **unused** — a number already taken by an existing stem is not available, even for an unrelated decision.
 
 ## Phase 2 — Author (/adr) · gate: STOP
 
@@ -35,7 +37,9 @@ mkdir -p "$(git rev-parse --show-toplevel)/.codearbiter/.markers"
 touch "$(git rev-parse --show-toplevel)/.codearbiter/.markers/adr-authoring-active"
 ```
 
-The marker is honored for 30 minutes. Then write `{{PROJECT_DIR}}/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `{{PLUGIN_ROOT}}/skills/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's number; leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+The marker is honored for 30 minutes. Then write `{{PROJECT_DIR}}/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `{{PLUGIN_ROOT}}/skills/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's **full filename stem** — `supersedes: 0014-githook-shim-dropin-fail-closed`, never `supersedes: 0014` — and leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+
+If the new ADR supersedes only *part* of the prior decision, say which part in the body. `supersedes:` names a document, not a clause, so a chain may legitimately fork — two ADRs can each supersede different clauses of one predecessor. That fork is correct and must not be "repaired"; only the prose can carry the scope.
 
 After writing the ADR, append a corresponding entry to the decision log per the format in `{{PLUGIN_ROOT}}/includes/smarts/decision-log-format.md` — `Decided by:` names the user. Status transitions (`proposed → accepted → superseded | rejected`) require explicit user instruction; never advance status on this skill's own judgment.
 
@@ -55,7 +59,15 @@ Gate: the ADR file is written with a real `decided-by` user attribution, numbere
 
 ## Phase 3 — Status (/adr-status) · gate: BLOCK
 
-Read-only. For each ADR (or the `--adr N` target), report: number, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` names it. Surface every unresolved `[CONFIRM-NN]` placeholder found in any ADR; MUST NOT resolve it.
+Read-only. For each ADR (or the `--adr N` target), report: stem, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` **resolves to** it.
+
+Resolve a `supersedes:` value like this, and never guess:
+
+- The value is a **stem** → it names that ADR. Done.
+- The value is a **bare number** → collect every stem with that number. Exactly one → it names that ADR. More than one → **ambiguous: report it as an error and resolve nothing.** Zero → a dangling reference; report that too.
+- `none` (or empty) → no predecessor.
+
+`.github/scripts/check_adr_identity.py` enforces this same rule mechanically in CI; if it disagrees with this report, the report is wrong.
 
 If a supersession candidate contradicts an `accepted` ADR with no clear direction, do not pick one — flag it for `/conflict`.
 
@@ -63,16 +75,19 @@ If a supersession candidate contradicts an `accepted` ADR with no clear directio
 ## ADR Status — YYYY-MM-DD
 
 ### Active
-- ADR-NNNN — <title> — <status> (<date>)
+- ADR-NNNN-<slug> — <title> — <status> (<date>)
 
 ### Superseded
-- ADR-NNNN — <title> — superseded by ADR-MMMM
+- ADR-NNNN-<slug> — <title> — superseded by ADR-MMMM-<slug>
+
+### Ambiguous supersession
+- ADR-NNNN-<slug> — supersedes: <value> names <N> ADRs (<stems>) — unresolved
 
 ### Unresolved CONFIRM-NN
-- ADR-NNNN — [CONFIRM-NN]: <text>
+- ADR-NNNN-<slug> — [CONFIRM-NN]: <text>
 ```
 
-An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`{{PLUGIN_ROOT}}/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
+Every ADR is named by its stem, so a shared number never collapses two rows into one. An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`{{PLUGIN_ROOT}}/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
 
 Gate: every indexed ADR appears with its current status and supersession state; no `[CONFIRM-NN]` resolved; no file modified.
 
@@ -83,6 +98,7 @@ Gate: every indexed ADR appears with its current status and supersession state; 
 - MUST NOT resolve a `[CONFIRM-NN]` placeholder by guessing. Surface it and stop.
 - MUST NOT advance an ADR's status without explicit user instruction.
 - MUST NOT edit a prior ADR or a prior decision-log entry to add a back-reference — supersession is a forward-only chain; append a new record whose `supersedes:` names the prior one.
-- MUST NOT number an ADR with a gap.
+- **The never-edit rule protects decision CONTENT, not identifiers.** Rewriting what was decided corrupts the record; disambiguating *which document a pointer names* repairs it. Maintainer ruling, 2026-07-25: *"the never edit rule is meant to prevent this situation, not prevent this situation from being fixed."* So a correction that is provably identifier-only — a `supersedes:` value changed from a number to the stem it already meant — is permissible, and nothing else about the file is. Any such correction MUST be a single-line diff that alters not one word of any decision, MUST be visible in its own commit, and still requires the maintainer-armed `adr-authoring-active` marker. MUST NOT touch Context, Decision, Alternatives, Consequences, Risks, `status:`, `date:`, `decided-by:`, or `title:` under this allowance.
+- MUST NOT number an ADR with a gap, and MUST NOT reuse a number an existing stem already holds — a shared number makes every bare reference to it ambiguous.
 - MUST NOT modify any file under `/adr-status` — it is read-only.
 - MUST NOT force the `decision-challenger` agent — its dispatch is MAY only.

--- a/core/surface/skills/decision-lifecycle/references/adr-template.md
+++ b/core/surface/skills/decision-lifecycle/references/adr-template.md
@@ -10,6 +10,11 @@ The single source of truth for the shape of an Architecture Decision Record unde
 `NNNN-<slug>.md` — a zero-padded 4-digit sequential number with no gaps (`0001-…`, `0002-…`),
 numbered across the existing `decisions/` directory.
 
+**The filename stem is the ADR's identifier** — `0014-githook-shim-dropin-fail-closed`, not
+`0014`. The number alone is a sort key, not a name: this repository already holds two ADRs
+numbered 0014, so `supersedes: 0014` named two documents at once until it was disambiguated.
+Reference an ADR by its full stem everywhere a machine reads it.
+
 ## File format
 
 ```markdown
@@ -18,7 +23,7 @@ status: proposed
 date: YYYY-MM-DD
 title: <title>
 decided-by: <user identifier>
-supersedes: NNNN | none
+supersedes: NNNN-<slug> | none
 governs: <optional, comma-separated path globs this decision constrains — e.g. src/auth/*, config/tls/*>
 ---
 
@@ -53,8 +58,16 @@ governs: <optional, comma-separated path globs this decision constrains — e.g.
   Phase 5 (a frontmatter `status:` edit only — never a body rewrite). Status transitions otherwise
   require explicit user instruction; never advance status on the skill's own judgment.
 - **`decided-by:`** names the user who made the decision — real attribution, never inferred.
-- **`supersedes:`** names the prior ADR's number (or `none`). Supersession is a forward-only chain:
-  set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:`** names the prior ADR's full filename stem — `supersedes:
+  0014-githook-shim-dropin-fail-closed`, not `supersedes: 0014` — or `none`. A bare number is
+  still accepted for the legacy records that carry one, but ONLY while it names exactly one
+  ADR; once a number is shared it is an error, not a guess, and
+  `.github/scripts/check_adr_identity.py` fails the build. Supersession is a forward-only
+  chain: set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:` cannot say WHICH CLAUSE it supersedes.** A partial supersession — the new ADR
+  replaces some clauses of the prior one and leaves the rest in force — must say so in prose, and
+  a chain may legitimately fork when two ADRs supersede different clauses of one predecessor.
+  The frontmatter records only *which document*; the body records *how much of it*.
 - **`governs:`** (optional) lists fnmatch-style, repo-relative forward-slash path globs. When present,
   the post-write hook surfaces a "governed by ADR-NNNN" notice on any Write/Edit touching a matching
   file. Omit it for decisions without a file footprint.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_readinjectlib.py
+++ b/plugins/ca-codex/hooks/_readinjectlib.py
@@ -331,10 +331,29 @@ _ADR_STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 _ADR_SCAN_LIMIT = 26  # i > 25 breaks → lines 0-25 inclusive
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and emitted byte-identical "ADR-0014 governs this file" pointers for both.
+    The stem is unique by construction (the filesystem enforces it), so keying on
+    it makes the collision unrepresentable rather than merely unlikely.
+
+    Deliberately mirrored in post-write-edit.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
 def accepted_adr_index(root):
     """Tier-2 filesystem reader.  Scan <root>/.codearbiter/decisions/ for ADR files.
 
-    Returns a list of {"adr": "<numeric id>", "title": "<title>", "globs": [<glob>, …]}
+    Returns a list of {"adr": "<filename stem>", "title": "<title>", "globs": [<glob>, …]}
     for every ADR that satisfies BOTH conditions:
       - governs: is present and non-empty (one or more comma-separated globs).
       - status: is exactly "accepted" (case-insensitive).
@@ -388,7 +407,7 @@ def accepted_adr_index(root):
                 continue
             # ACCEPTED ONLY — stricter than post-write-edit.py governs_index.
             if globs and status == "accepted":
-                adr = fn.split("-")[0]
+                adr = adr_identifier(fn)
                 index.append({"adr": adr, "title": title, "globs": globs})
         return index
     except Exception:  # noqa: BLE001

--- a/plugins/ca-codex/hooks/post-write-edit.py
+++ b/plugins/ca-codex/hooks/post-write-edit.py
@@ -47,6 +47,31 @@ TITLE_RE = re.compile(r"^title:\s*(.+)$", re.I)
 STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and nudged "governed by ADR-0014" without saying which. The stem is unique
+    by construction, so keying on it makes the collision unrepresentable.
+
+    Deliberately mirrored in _readinjectlib.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
+# Bumped whenever the SHAPE or the derivation of a cached index entry changes.
+# The mtime stamp alone only invalidates on an ADR edit, so without this a
+# payload upgrade would keep serving pre-#416 numeric ids out of an already-
+# written cache until someone happened to touch a decisions/ file.
+GOVERNS_CACHE_SCHEMA = 2
+
+
 def governs_index(root):
     """path-glob → ADR map from decisions/ frontmatter, cached against the
     directory's latest mtime so the scan doesn't repeat on every write."""
@@ -61,7 +86,8 @@ def governs_index(root):
     try:
         with open(cache_path, encoding="utf-8") as f:
             cache = json.load(f)
-        if cache.get("stamp") == stamp:
+        if (cache.get("stamp") == stamp
+                and cache.get("schema") == GOVERNS_CACHE_SCHEMA):
             return cache.get("index", [])
     except Exception:  # noqa: BLE001 — absent/corrupt cache just rebuilds
         pass
@@ -83,12 +109,13 @@ def governs_index(root):
         except Exception:  # noqa: BLE001
             continue
         if globs and status not in ("superseded", "rejected"):
-            adr = fn.split("-")[0]
+            adr = adr_identifier(fn)
             index.append({"adr": adr, "title": title, "globs": globs})
     try:
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         with open(cache_path, "w", encoding="utf-8") as f:
-            json.dump({"stamp": stamp, "index": index}, f)
+            json.dump({"stamp": stamp, "schema": GOVERNS_CACHE_SCHEMA,
+                       "index": index}, f)
     except Exception:  # noqa: BLE001 — cache is an optimization, never required
         pass
     return index

--- a/plugins/ca-codex/routines/decision-lifecycle/SKILL.md
+++ b/plugins/ca-codex/routines/decision-lifecycle/SKILL.md
@@ -20,9 +20,11 @@ Read these, or STOP and surface the gap — never guess a path:
 
 ## Phase 1 — Index · gate: BLOCK
 
-Scan `<project-root>/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by number, title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
+Scan `<project-root>/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by **filename stem** (`0014-githook-shim-dropin-fail-closed`), title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
 
-Gate: the existing ADRs are indexed and, for `/adr`, the next number is fixed.
+**The stem is the identifier; the number is only a sort key.** Two ADRs may already share a number — this repository holds two numbered 0014 — so a bare number can name more than one document. Index by stem, and never assume `NNNN` resolves to one file until you have checked.
+
+Gate: the existing ADRs are indexed by stem and, for `/adr`, the next number is fixed and **unused** — a number already taken by an existing stem is not available, even for an unrelated decision.
 
 ## Phase 2 — Author (/adr) · gate: STOP
 
@@ -35,7 +37,9 @@ mkdir -p "$(git rev-parse --show-toplevel)/.codearbiter/.markers"
 touch "$(git rev-parse --show-toplevel)/.codearbiter/.markers/adr-authoring-active"
 ```
 
-The marker is honored for 30 minutes. Then write `<project-root>/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `${CLAUDE_PLUGIN_ROOT}/routines/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's number; leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+The marker is honored for 30 minutes. Then write `<project-root>/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `${CLAUDE_PLUGIN_ROOT}/routines/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's **full filename stem** — `supersedes: 0014-githook-shim-dropin-fail-closed`, never `supersedes: 0014` — and leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+
+If the new ADR supersedes only *part* of the prior decision, say which part in the body. `supersedes:` names a document, not a clause, so a chain may legitimately fork — two ADRs can each supersede different clauses of one predecessor. That fork is correct and must not be "repaired"; only the prose can carry the scope.
 
 After writing the ADR, append a corresponding entry to the decision log per the format in `${CLAUDE_PLUGIN_ROOT}/includes/smarts/decision-log-format.md` — `Decided by:` names the user. Status transitions (`proposed → accepted → superseded | rejected`) require explicit user instruction; never advance status on this skill's own judgment.
 
@@ -55,7 +59,15 @@ Gate: the ADR file is written with a real `decided-by` user attribution, numbere
 
 ## Phase 3 — Status (/adr-status) · gate: BLOCK
 
-Read-only. For each ADR (or the `--adr N` target), report: number, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` names it. Surface every unresolved `[CONFIRM-NN]` placeholder found in any ADR; MUST NOT resolve it.
+Read-only. For each ADR (or the `--adr N` target), report: stem, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` **resolves to** it.
+
+Resolve a `supersedes:` value like this, and never guess:
+
+- The value is a **stem** → it names that ADR. Done.
+- The value is a **bare number** → collect every stem with that number. Exactly one → it names that ADR. More than one → **ambiguous: report it as an error and resolve nothing.** Zero → a dangling reference; report that too.
+- `none` (or empty) → no predecessor.
+
+`.github/scripts/check_adr_identity.py` enforces this same rule mechanically in CI; if it disagrees with this report, the report is wrong.
 
 If a supersession candidate contradicts an `accepted` ADR with no clear direction, do not pick one — flag it for `/conflict`.
 
@@ -63,16 +75,19 @@ If a supersession candidate contradicts an `accepted` ADR with no clear directio
 ## ADR Status — YYYY-MM-DD
 
 ### Active
-- ADR-NNNN — <title> — <status> (<date>)
+- ADR-NNNN-<slug> — <title> — <status> (<date>)
 
 ### Superseded
-- ADR-NNNN — <title> — superseded by ADR-MMMM
+- ADR-NNNN-<slug> — <title> — superseded by ADR-MMMM-<slug>
+
+### Ambiguous supersession
+- ADR-NNNN-<slug> — supersedes: <value> names <N> ADRs (<stems>) — unresolved
 
 ### Unresolved CONFIRM-NN
-- ADR-NNNN — [CONFIRM-NN]: <text>
+- ADR-NNNN-<slug> — [CONFIRM-NN]: <text>
 ```
 
-An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`${CLAUDE_PLUGIN_ROOT}/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
+Every ADR is named by its stem, so a shared number never collapses two rows into one. An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`${CLAUDE_PLUGIN_ROOT}/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
 
 Gate: every indexed ADR appears with its current status and supersession state; no `[CONFIRM-NN]` resolved; no file modified.
 
@@ -83,6 +98,7 @@ Gate: every indexed ADR appears with its current status and supersession state; 
 - MUST NOT resolve a `[CONFIRM-NN]` placeholder by guessing. Surface it and stop.
 - MUST NOT advance an ADR's status without explicit user instruction.
 - MUST NOT edit a prior ADR or a prior decision-log entry to add a back-reference — supersession is a forward-only chain; append a new record whose `supersedes:` names the prior one.
-- MUST NOT number an ADR with a gap.
+- **The never-edit rule protects decision CONTENT, not identifiers.** Rewriting what was decided corrupts the record; disambiguating *which document a pointer names* repairs it. Maintainer ruling, 2026-07-25: *"the never edit rule is meant to prevent this situation, not prevent this situation from being fixed."* So a correction that is provably identifier-only — a `supersedes:` value changed from a number to the stem it already meant — is permissible, and nothing else about the file is. Any such correction MUST be a single-line diff that alters not one word of any decision, MUST be visible in its own commit, and still requires the maintainer-armed `adr-authoring-active` marker. MUST NOT touch Context, Decision, Alternatives, Consequences, Risks, `status:`, `date:`, `decided-by:`, or `title:` under this allowance.
+- MUST NOT number an ADR with a gap, and MUST NOT reuse a number an existing stem already holds — a shared number makes every bare reference to it ambiguous.
 - MUST NOT modify any file under `/adr-status` — it is read-only.
 - MUST NOT force the `decision-challenger` agent — its dispatch is MAY only.

--- a/plugins/ca-codex/routines/decision-lifecycle/references/adr-template.md
+++ b/plugins/ca-codex/routines/decision-lifecycle/references/adr-template.md
@@ -10,6 +10,11 @@ The single source of truth for the shape of an Architecture Decision Record unde
 `NNNN-<slug>.md` — a zero-padded 4-digit sequential number with no gaps (`0001-…`, `0002-…`),
 numbered across the existing `decisions/` directory.
 
+**The filename stem is the ADR's identifier** — `0014-githook-shim-dropin-fail-closed`, not
+`0014`. The number alone is a sort key, not a name: this repository already holds two ADRs
+numbered 0014, so `supersedes: 0014` named two documents at once until it was disambiguated.
+Reference an ADR by its full stem everywhere a machine reads it.
+
 ## File format
 
 ```markdown
@@ -18,7 +23,7 @@ status: proposed
 date: YYYY-MM-DD
 title: <title>
 decided-by: <user identifier>
-supersedes: NNNN | none
+supersedes: NNNN-<slug> | none
 governs: <optional, comma-separated path globs this decision constrains — e.g. src/auth/*, config/tls/*>
 ---
 
@@ -53,8 +58,16 @@ governs: <optional, comma-separated path globs this decision constrains — e.g.
   Phase 5 (a frontmatter `status:` edit only — never a body rewrite). Status transitions otherwise
   require explicit user instruction; never advance status on the skill's own judgment.
 - **`decided-by:`** names the user who made the decision — real attribution, never inferred.
-- **`supersedes:`** names the prior ADR's number (or `none`). Supersession is a forward-only chain:
-  set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:`** names the prior ADR's full filename stem — `supersedes:
+  0014-githook-shim-dropin-fail-closed`, not `supersedes: 0014` — or `none`. A bare number is
+  still accepted for the legacy records that carry one, but ONLY while it names exactly one
+  ADR; once a number is shared it is an error, not a guess, and
+  `.github/scripts/check_adr_identity.py` fails the build. Supersession is a forward-only
+  chain: set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:` cannot say WHICH CLAUSE it supersedes.** A partial supersession — the new ADR
+  replaces some clauses of the prior one and leaves the rest in force — must say so in prose, and
+  a chain may legitimately fork when two ADRs supersede different clauses of one predecessor.
+  The frontmatter records only *which document*; the body records *how much of it*.
 - **`governs:`** (optional) lists fnmatch-style, repo-relative forward-slash path globs. When present,
   the post-write hook surfaces a "governed by ADR-NNNN" notice on any Write/Edit touching a matching
   file. Omit it for decisions without a file footprint.

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.17] - 2026-07-25
+
+### Fixed
+
+- A governed-file notice now names the ADR by its filename stem
+  (`ADR-0014-githook-shim-dropin-fail-closed`) instead of its bare number.
+  Two ADRs share the number 0014, so the previous notice named two documents
+  at once and the reader could tell neither apart.
+- The `governs` cache carries a schema key, so a payload upgrade rebuilds it
+  instead of serving the old numeric identifiers until a decision file changes.
+
 ## [0.1.16] - 2026-07-25
 
 ### Changed

--- a/plugins/ca-pi/hooks/_readinjectlib.py
+++ b/plugins/ca-pi/hooks/_readinjectlib.py
@@ -331,10 +331,29 @@ _ADR_STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 _ADR_SCAN_LIMIT = 26  # i > 25 breaks → lines 0-25 inclusive
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and emitted byte-identical "ADR-0014 governs this file" pointers for both.
+    The stem is unique by construction (the filesystem enforces it), so keying on
+    it makes the collision unrepresentable rather than merely unlikely.
+
+    Deliberately mirrored in post-write-edit.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
 def accepted_adr_index(root):
     """Tier-2 filesystem reader.  Scan <root>/.codearbiter/decisions/ for ADR files.
 
-    Returns a list of {"adr": "<numeric id>", "title": "<title>", "globs": [<glob>, …]}
+    Returns a list of {"adr": "<filename stem>", "title": "<title>", "globs": [<glob>, …]}
     for every ADR that satisfies BOTH conditions:
       - governs: is present and non-empty (one or more comma-separated globs).
       - status: is exactly "accepted" (case-insensitive).
@@ -388,7 +407,7 @@ def accepted_adr_index(root):
                 continue
             # ACCEPTED ONLY — stricter than post-write-edit.py governs_index.
             if globs and status == "accepted":
-                adr = fn.split("-")[0]
+                adr = adr_identifier(fn)
                 index.append({"adr": adr, "title": title, "globs": globs})
         return index
     except Exception:  # noqa: BLE001

--- a/plugins/ca-pi/hooks/post-write-edit.py
+++ b/plugins/ca-pi/hooks/post-write-edit.py
@@ -47,6 +47,31 @@ TITLE_RE = re.compile(r"^title:\s*(.+)$", re.I)
 STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and nudged "governed by ADR-0014" without saying which. The stem is unique
+    by construction, so keying on it makes the collision unrepresentable.
+
+    Deliberately mirrored in _readinjectlib.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
+# Bumped whenever the SHAPE or the derivation of a cached index entry changes.
+# The mtime stamp alone only invalidates on an ADR edit, so without this a
+# payload upgrade would keep serving pre-#416 numeric ids out of an already-
+# written cache until someone happened to touch a decisions/ file.
+GOVERNS_CACHE_SCHEMA = 2
+
+
 def governs_index(root):
     """path-glob → ADR map from decisions/ frontmatter, cached against the
     directory's latest mtime so the scan doesn't repeat on every write."""
@@ -61,7 +86,8 @@ def governs_index(root):
     try:
         with open(cache_path, encoding="utf-8") as f:
             cache = json.load(f)
-        if cache.get("stamp") == stamp:
+        if (cache.get("stamp") == stamp
+                and cache.get("schema") == GOVERNS_CACHE_SCHEMA):
             return cache.get("index", [])
     except Exception:  # noqa: BLE001 — absent/corrupt cache just rebuilds
         pass
@@ -83,12 +109,13 @@ def governs_index(root):
         except Exception:  # noqa: BLE001
             continue
         if globs and status not in ("superseded", "rejected"):
-            adr = fn.split("-")[0]
+            adr = adr_identifier(fn)
             index.append({"adr": adr, "title": title, "globs": globs})
     try:
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         with open(cache_path, "w", encoding="utf-8") as f:
-            json.dump({"stamp": stamp, "index": index}, f)
+            json.dump({"stamp": stamp, "schema": GOVERNS_CACHE_SCHEMA,
+                       "index": index}, f)
     except Exception:  # noqa: BLE001 — cache is an optimization, never required
         pass
     return index

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/routines/decision-lifecycle/SKILL.md
+++ b/plugins/ca-pi/routines/decision-lifecycle/SKILL.md
@@ -20,9 +20,11 @@ Read these, or STOP and surface the gap — never guess a path:
 
 ## Phase 1 — Index · gate: BLOCK
 
-Scan `<project-root>/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by number, title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
+Scan `<project-root>/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by **filename stem** (`0014-githook-shim-dropin-fail-closed`), title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
 
-Gate: the existing ADRs are indexed and, for `/adr`, the next number is fixed.
+**The stem is the identifier; the number is only a sort key.** Two ADRs may already share a number — this repository holds two numbered 0014 — so a bare number can name more than one document. Index by stem, and never assume `NNNN` resolves to one file until you have checked.
+
+Gate: the existing ADRs are indexed by stem and, for `/adr`, the next number is fixed and **unused** — a number already taken by an existing stem is not available, even for an unrelated decision.
 
 ## Phase 2 — Author (/adr) · gate: STOP
 
@@ -35,7 +37,9 @@ mkdir -p "$(git rev-parse --show-toplevel)/.codearbiter/.markers"
 touch "$(git rev-parse --show-toplevel)/.codearbiter/.markers/adr-authoring-active"
 ```
 
-The marker is honored for 30 minutes. Then write `<project-root>/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `<plugin-root>/routines/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's number; leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+The marker is honored for 30 minutes. Then write `<project-root>/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `<plugin-root>/routines/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's **full filename stem** — `supersedes: 0014-githook-shim-dropin-fail-closed`, never `supersedes: 0014` — and leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+
+If the new ADR supersedes only *part* of the prior decision, say which part in the body. `supersedes:` names a document, not a clause, so a chain may legitimately fork — two ADRs can each supersede different clauses of one predecessor. That fork is correct and must not be "repaired"; only the prose can carry the scope.
 
 After writing the ADR, append a corresponding entry to the decision log per the format in `<plugin-root>/includes/smarts/decision-log-format.md` — `Decided by:` names the user. Status transitions (`proposed → accepted → superseded | rejected`) require explicit user instruction; never advance status on this skill's own judgment.
 
@@ -55,7 +59,15 @@ Gate: the ADR file is written with a real `decided-by` user attribution, numbere
 
 ## Phase 3 — Status (/adr-status) · gate: BLOCK
 
-Read-only. For each ADR (or the `--adr N` target), report: number, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` names it. Surface every unresolved `[CONFIRM-NN]` placeholder found in any ADR; MUST NOT resolve it.
+Read-only. For each ADR (or the `--adr N` target), report: stem, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` **resolves to** it.
+
+Resolve a `supersedes:` value like this, and never guess:
+
+- The value is a **stem** → it names that ADR. Done.
+- The value is a **bare number** → collect every stem with that number. Exactly one → it names that ADR. More than one → **ambiguous: report it as an error and resolve nothing.** Zero → a dangling reference; report that too.
+- `none` (or empty) → no predecessor.
+
+`.github/scripts/check_adr_identity.py` enforces this same rule mechanically in CI; if it disagrees with this report, the report is wrong.
 
 If a supersession candidate contradicts an `accepted` ADR with no clear direction, do not pick one — flag it for `/conflict`.
 
@@ -63,16 +75,19 @@ If a supersession candidate contradicts an `accepted` ADR with no clear directio
 ## ADR Status — YYYY-MM-DD
 
 ### Active
-- ADR-NNNN — <title> — <status> (<date>)
+- ADR-NNNN-<slug> — <title> — <status> (<date>)
 
 ### Superseded
-- ADR-NNNN — <title> — superseded by ADR-MMMM
+- ADR-NNNN-<slug> — <title> — superseded by ADR-MMMM-<slug>
+
+### Ambiguous supersession
+- ADR-NNNN-<slug> — supersedes: <value> names <N> ADRs (<stems>) — unresolved
 
 ### Unresolved CONFIRM-NN
-- ADR-NNNN — [CONFIRM-NN]: <text>
+- ADR-NNNN-<slug> — [CONFIRM-NN]: <text>
 ```
 
-An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`<plugin-root>/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
+Every ADR is named by its stem, so a shared number never collapses two rows into one. An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`<plugin-root>/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
 
 Gate: every indexed ADR appears with its current status and supersession state; no `[CONFIRM-NN]` resolved; no file modified.
 
@@ -83,6 +98,7 @@ Gate: every indexed ADR appears with its current status and supersession state; 
 - MUST NOT resolve a `[CONFIRM-NN]` placeholder by guessing. Surface it and stop.
 - MUST NOT advance an ADR's status without explicit user instruction.
 - MUST NOT edit a prior ADR or a prior decision-log entry to add a back-reference — supersession is a forward-only chain; append a new record whose `supersedes:` names the prior one.
-- MUST NOT number an ADR with a gap.
+- **The never-edit rule protects decision CONTENT, not identifiers.** Rewriting what was decided corrupts the record; disambiguating *which document a pointer names* repairs it. Maintainer ruling, 2026-07-25: *"the never edit rule is meant to prevent this situation, not prevent this situation from being fixed."* So a correction that is provably identifier-only — a `supersedes:` value changed from a number to the stem it already meant — is permissible, and nothing else about the file is. Any such correction MUST be a single-line diff that alters not one word of any decision, MUST be visible in its own commit, and still requires the maintainer-armed `adr-authoring-active` marker. MUST NOT touch Context, Decision, Alternatives, Consequences, Risks, `status:`, `date:`, `decided-by:`, or `title:` under this allowance.
+- MUST NOT number an ADR with a gap, and MUST NOT reuse a number an existing stem already holds — a shared number makes every bare reference to it ambiguous.
 - MUST NOT modify any file under `/adr-status` — it is read-only.
 - MUST NOT force the `decision-challenger` agent — its dispatch is MAY only.

--- a/plugins/ca-pi/routines/decision-lifecycle/references/adr-template.md
+++ b/plugins/ca-pi/routines/decision-lifecycle/references/adr-template.md
@@ -10,6 +10,11 @@ The single source of truth for the shape of an Architecture Decision Record unde
 `NNNN-<slug>.md` — a zero-padded 4-digit sequential number with no gaps (`0001-…`, `0002-…`),
 numbered across the existing `decisions/` directory.
 
+**The filename stem is the ADR's identifier** — `0014-githook-shim-dropin-fail-closed`, not
+`0014`. The number alone is a sort key, not a name: this repository already holds two ADRs
+numbered 0014, so `supersedes: 0014` named two documents at once until it was disambiguated.
+Reference an ADR by its full stem everywhere a machine reads it.
+
 ## File format
 
 ```markdown
@@ -18,7 +23,7 @@ status: proposed
 date: YYYY-MM-DD
 title: <title>
 decided-by: <user identifier>
-supersedes: NNNN | none
+supersedes: NNNN-<slug> | none
 governs: <optional, comma-separated path globs this decision constrains — e.g. src/auth/*, config/tls/*>
 ---
 
@@ -53,8 +58,16 @@ governs: <optional, comma-separated path globs this decision constrains — e.g.
   Phase 5 (a frontmatter `status:` edit only — never a body rewrite). Status transitions otherwise
   require explicit user instruction; never advance status on the skill's own judgment.
 - **`decided-by:`** names the user who made the decision — real attribution, never inferred.
-- **`supersedes:`** names the prior ADR's number (or `none`). Supersession is a forward-only chain:
-  set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:`** names the prior ADR's full filename stem — `supersedes:
+  0014-githook-shim-dropin-fail-closed`, not `supersedes: 0014` — or `none`. A bare number is
+  still accepted for the legacy records that carry one, but ONLY while it names exactly one
+  ADR; once a number is shared it is an error, not a guess, and
+  `.github/scripts/check_adr_identity.py` fails the build. Supersession is a forward-only
+  chain: set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:` cannot say WHICH CLAUSE it supersedes.** A partial supersession — the new ADR
+  replaces some clauses of the prior one and leaves the rest in force — must say so in prose, and
+  a chain may legitimately fork when two ADRs supersede different clauses of one predecessor.
+  The frontmatter records only *which document*; the body records *how much of it*.
 - **`governs:`** (optional) lists fnmatch-style, repo-relative forward-slash path globs. When present,
   the post-write hook surfaces a "governed by ADR-NNNN" notice on any Write/Edit touching a matching
   file. Omit it for decisions without a file footprint.

--- a/plugins/ca/hooks/_readinjectlib.py
+++ b/plugins/ca/hooks/_readinjectlib.py
@@ -331,10 +331,29 @@ _ADR_STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 _ADR_SCAN_LIMIT = 26  # i > 25 breaks → lines 0-25 inclusive
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and emitted byte-identical "ADR-0014 governs this file" pointers for both.
+    The stem is unique by construction (the filesystem enforces it), so keying on
+    it makes the collision unrepresentable rather than merely unlikely.
+
+    Deliberately mirrored in post-write-edit.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
 def accepted_adr_index(root):
     """Tier-2 filesystem reader.  Scan <root>/.codearbiter/decisions/ for ADR files.
 
-    Returns a list of {"adr": "<numeric id>", "title": "<title>", "globs": [<glob>, …]}
+    Returns a list of {"adr": "<filename stem>", "title": "<title>", "globs": [<glob>, …]}
     for every ADR that satisfies BOTH conditions:
       - governs: is present and non-empty (one or more comma-separated globs).
       - status: is exactly "accepted" (case-insensitive).
@@ -388,7 +407,7 @@ def accepted_adr_index(root):
                 continue
             # ACCEPTED ONLY — stricter than post-write-edit.py governs_index.
             if globs and status == "accepted":
-                adr = fn.split("-")[0]
+                adr = adr_identifier(fn)
                 index.append({"adr": adr, "title": title, "globs": globs})
         return index
     except Exception:  # noqa: BLE001

--- a/plugins/ca/hooks/post-write-edit.py
+++ b/plugins/ca/hooks/post-write-edit.py
@@ -47,6 +47,31 @@ TITLE_RE = re.compile(r"^title:\s*(.+)$", re.I)
 STATUS_RE = re.compile(r"^status:\s*(.+)$", re.I)
 
 
+def adr_identifier(filename):
+    """The ADR identifier for `filename` — its filename STEM, not its number.
+
+    `0014-githook-shim-dropin-fail-closed.md` → `0014-githook-shim-dropin-fail-closed`.
+
+    #416: two ADRs in this repo share the number 0014, so the old
+    `filename.split("-")[0]` derivation collapsed two distinct decisions onto one
+    id and nudged "governed by ADR-0014" without saying which. The stem is unique
+    by construction, so keying on it makes the collision unrepresentable.
+
+    Deliberately mirrored in _readinjectlib.py — the two indexers are separate
+    payload files that cannot import each other's private helpers; the shared
+    contract test (.github/scripts/test_adr_identity.py) pins them to the same
+    answer so the derivation cannot drift apart again.
+    """
+    return os.path.splitext(str(filename))[0]
+
+
+# Bumped whenever the SHAPE or the derivation of a cached index entry changes.
+# The mtime stamp alone only invalidates on an ADR edit, so without this a
+# payload upgrade would keep serving pre-#416 numeric ids out of an already-
+# written cache until someone happened to touch a decisions/ file.
+GOVERNS_CACHE_SCHEMA = 2
+
+
 def governs_index(root):
     """path-glob → ADR map from decisions/ frontmatter, cached against the
     directory's latest mtime so the scan doesn't repeat on every write."""
@@ -61,7 +86,8 @@ def governs_index(root):
     try:
         with open(cache_path, encoding="utf-8") as f:
             cache = json.load(f)
-        if cache.get("stamp") == stamp:
+        if (cache.get("stamp") == stamp
+                and cache.get("schema") == GOVERNS_CACHE_SCHEMA):
             return cache.get("index", [])
     except Exception:  # noqa: BLE001 — absent/corrupt cache just rebuilds
         pass
@@ -83,12 +109,13 @@ def governs_index(root):
         except Exception:  # noqa: BLE001
             continue
         if globs and status not in ("superseded", "rejected"):
-            adr = fn.split("-")[0]
+            adr = adr_identifier(fn)
             index.append({"adr": adr, "title": title, "globs": globs})
     try:
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         with open(cache_path, "w", encoding="utf-8") as f:
-            json.dump({"stamp": stamp, "index": index}, f)
+            json.dump({"stamp": stamp, "schema": GOVERNS_CACHE_SCHEMA,
+                       "index": index}, f)
     except Exception:  # noqa: BLE001 — cache is an optimization, never required
         pass
     return index

--- a/plugins/ca/hooks/tests/test_governs.py
+++ b/plugins/ca/hooks/tests/test_governs.py
@@ -63,7 +63,8 @@ class TestGovernsIndex(unittest.TestCase):
                    governs="src/api/**/*.py", title="API Design")
         index = governs_index(self.root)
         self.assertEqual(len(index), 1)
-        self.assertEqual(index[0]["adr"], "0001")
+        # #416: the identifier is the filename stem, not the bare number.
+        self.assertEqual(index[0]["adr"], "0001-api-design")
         self.assertIn("src/api/**/*.py", index[0]["globs"])
         # Cache must now exist on disk.
         self.assertTrue(os.path.isfile(self._cache_path()))
@@ -121,7 +122,7 @@ class TestGovernsIndex(unittest.TestCase):
                    governs="src/old/**", status="superseded")
         index = governs_index(self.root)
         self.assertEqual(len(index), 1)
-        self.assertEqual(index[0]["adr"], "0001")
+        self.assertEqual(index[0]["adr"], "0001-good")
 
     # ------------------------------------------------------------------
     # D-16: H-12 governs check fires on matching path, not on non-matching

--- a/plugins/ca/skills/decision-lifecycle/SKILL.md
+++ b/plugins/ca/skills/decision-lifecycle/SKILL.md
@@ -20,9 +20,11 @@ Read these, or STOP and surface the gap — never guess a path:
 
 ## Phase 1 — Index · gate: BLOCK
 
-Scan `${CLAUDE_PROJECT_DIR}/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by number, title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
+Scan `${CLAUDE_PROJECT_DIR}/.codearbiter/decisions/` for existing `NNNN-*.md` ADR files. Record each by **filename stem** (`0014-githook-shim-dropin-fail-closed`), title, and status. Determine the next sequential number (no gaps) for `/adr`; for `/adr-status` this is the working set.
 
-Gate: the existing ADRs are indexed and, for `/adr`, the next number is fixed.
+**The stem is the identifier; the number is only a sort key.** Two ADRs may already share a number — this repository holds two numbered 0014 — so a bare number can name more than one document. Index by stem, and never assume `NNNN` resolves to one file until you have checked.
+
+Gate: the existing ADRs are indexed by stem and, for `/adr`, the next number is fixed and **unused** — a number already taken by an existing stem is not available, even for an unrelated decision.
 
 ## Phase 2 — Author (/adr) · gate: STOP
 
@@ -35,7 +37,9 @@ mkdir -p "$(git rev-parse --show-toplevel)/.codearbiter/.markers"
 touch "$(git rev-parse --show-toplevel)/.codearbiter/.markers/adr-authoring-active"
 ```
 
-The marker is honored for 30 minutes. Then write `${CLAUDE_PROJECT_DIR}/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `${CLAUDE_PLUGIN_ROOT}/skills/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's number; leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+The marker is honored for 30 minutes. Then write `${CLAUDE_PROJECT_DIR}/.codearbiter/decisions/NNNN-<slug>.md` using the canonical ADR template — `${CLAUDE_PLUGIN_ROOT}/skills/decision-lifecycle/references/adr-template.md` (the single source of truth for the ADR shape, shared with `decompose`). Author it with `status: proposed`. If this decision supersedes an existing one, set `supersedes:` to that ADR's **full filename stem** — `supersedes: 0014-githook-shim-dropin-fail-closed`, never `supersedes: 0014` — and leave the prior ADR's file untouched (forward-only chain — do not edit it to add a back-reference).
+
+If the new ADR supersedes only *part* of the prior decision, say which part in the body. `supersedes:` names a document, not a clause, so a chain may legitimately fork — two ADRs can each supersede different clauses of one predecessor. That fork is correct and must not be "repaired"; only the prose can carry the scope.
 
 After writing the ADR, append a corresponding entry to the decision log per the format in `${CLAUDE_PLUGIN_ROOT}/includes/smarts/decision-log-format.md` — `Decided by:` names the user. Status transitions (`proposed → accepted → superseded | rejected`) require explicit user instruction; never advance status on this skill's own judgment.
 
@@ -55,7 +59,15 @@ Gate: the ADR file is written with a real `decided-by` user attribution, numbere
 
 ## Phase 3 — Status (/adr-status) · gate: BLOCK
 
-Read-only. For each ADR (or the `--adr N` target), report: number, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` names it. Surface every unresolved `[CONFIRM-NN]` placeholder found in any ADR; MUST NOT resolve it.
+Read-only. For each ADR (or the `--adr N` target), report: stem, title, status, date, and supersession state — found by scanning forward for any later ADR whose `supersedes:` **resolves to** it.
+
+Resolve a `supersedes:` value like this, and never guess:
+
+- The value is a **stem** → it names that ADR. Done.
+- The value is a **bare number** → collect every stem with that number. Exactly one → it names that ADR. More than one → **ambiguous: report it as an error and resolve nothing.** Zero → a dangling reference; report that too.
+- `none` (or empty) → no predecessor.
+
+`.github/scripts/check_adr_identity.py` enforces this same rule mechanically in CI; if it disagrees with this report, the report is wrong.
 
 If a supersession candidate contradicts an `accepted` ADR with no clear direction, do not pick one — flag it for `/conflict`.
 
@@ -63,16 +75,19 @@ If a supersession candidate contradicts an `accepted` ADR with no clear directio
 ## ADR Status — YYYY-MM-DD
 
 ### Active
-- ADR-NNNN — <title> — <status> (<date>)
+- ADR-NNNN-<slug> — <title> — <status> (<date>)
 
 ### Superseded
-- ADR-NNNN — <title> — superseded by ADR-MMMM
+- ADR-NNNN-<slug> — <title> — superseded by ADR-MMMM-<slug>
+
+### Ambiguous supersession
+- ADR-NNNN-<slug> — supersedes: <value> names <N> ADRs (<stems>) — unresolved
 
 ### Unresolved CONFIRM-NN
-- ADR-NNNN — [CONFIRM-NN]: <text>
+- ADR-NNNN-<slug> — [CONFIRM-NN]: <text>
 ```
 
-An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`${CLAUDE_PLUGIN_ROOT}/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
+Every ADR is named by its stem, so a shared number never collapses two rows into one. An empty section is marked "None" — not omitted. MAY dispatch `decision-challenger` (`${CLAUDE_PLUGIN_ROOT}/agents/decision-challenger.md`) to stress-test an ADR; optional, never forced.
 
 Gate: every indexed ADR appears with its current status and supersession state; no `[CONFIRM-NN]` resolved; no file modified.
 
@@ -83,6 +98,7 @@ Gate: every indexed ADR appears with its current status and supersession state; 
 - MUST NOT resolve a `[CONFIRM-NN]` placeholder by guessing. Surface it and stop.
 - MUST NOT advance an ADR's status without explicit user instruction.
 - MUST NOT edit a prior ADR or a prior decision-log entry to add a back-reference — supersession is a forward-only chain; append a new record whose `supersedes:` names the prior one.
-- MUST NOT number an ADR with a gap.
+- **The never-edit rule protects decision CONTENT, not identifiers.** Rewriting what was decided corrupts the record; disambiguating *which document a pointer names* repairs it. Maintainer ruling, 2026-07-25: *"the never edit rule is meant to prevent this situation, not prevent this situation from being fixed."* So a correction that is provably identifier-only — a `supersedes:` value changed from a number to the stem it already meant — is permissible, and nothing else about the file is. Any such correction MUST be a single-line diff that alters not one word of any decision, MUST be visible in its own commit, and still requires the maintainer-armed `adr-authoring-active` marker. MUST NOT touch Context, Decision, Alternatives, Consequences, Risks, `status:`, `date:`, `decided-by:`, or `title:` under this allowance.
+- MUST NOT number an ADR with a gap, and MUST NOT reuse a number an existing stem already holds — a shared number makes every bare reference to it ambiguous.
 - MUST NOT modify any file under `/adr-status` — it is read-only.
 - MUST NOT force the `decision-challenger` agent — its dispatch is MAY only.

--- a/plugins/ca/skills/decision-lifecycle/references/adr-template.md
+++ b/plugins/ca/skills/decision-lifecycle/references/adr-template.md
@@ -10,6 +10,11 @@ The single source of truth for the shape of an Architecture Decision Record unde
 `NNNN-<slug>.md` — a zero-padded 4-digit sequential number with no gaps (`0001-…`, `0002-…`),
 numbered across the existing `decisions/` directory.
 
+**The filename stem is the ADR's identifier** — `0014-githook-shim-dropin-fail-closed`, not
+`0014`. The number alone is a sort key, not a name: this repository already holds two ADRs
+numbered 0014, so `supersedes: 0014` named two documents at once until it was disambiguated.
+Reference an ADR by its full stem everywhere a machine reads it.
+
 ## File format
 
 ```markdown
@@ -18,7 +23,7 @@ status: proposed
 date: YYYY-MM-DD
 title: <title>
 decided-by: <user identifier>
-supersedes: NNNN | none
+supersedes: NNNN-<slug> | none
 governs: <optional, comma-separated path globs this decision constrains — e.g. src/auth/*, config/tls/*>
 ---
 
@@ -53,8 +58,16 @@ governs: <optional, comma-separated path globs this decision constrains — e.g.
   Phase 5 (a frontmatter `status:` edit only — never a body rewrite). Status transitions otherwise
   require explicit user instruction; never advance status on the skill's own judgment.
 - **`decided-by:`** names the user who made the decision — real attribution, never inferred.
-- **`supersedes:`** names the prior ADR's number (or `none`). Supersession is a forward-only chain:
-  set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:`** names the prior ADR's full filename stem — `supersedes:
+  0014-githook-shim-dropin-fail-closed`, not `supersedes: 0014` — or `none`. A bare number is
+  still accepted for the legacy records that carry one, but ONLY while it names exactly one
+  ADR; once a number is shared it is an error, not a guess, and
+  `.github/scripts/check_adr_identity.py` fails the build. Supersession is a forward-only
+  chain: set it on the new ADR; never edit the prior ADR to add a back-reference.
+- **`supersedes:` cannot say WHICH CLAUSE it supersedes.** A partial supersession — the new ADR
+  replaces some clauses of the prior one and leaves the rest in force — must say so in prose, and
+  a chain may legitimately fork when two ADRs supersede different clauses of one predecessor.
+  The frontmatter records only *which document*; the body records *how much of it*.
 - **`governs:`** (optional) lists fnmatch-style, repo-relative forward-slash path globs. When present,
   the post-write hook surfaces a "governed by ADR-NNNN" notice on any Write/Edit touching a matching
   file. Omit it for decisions without a file footprint.


### PR DESCRIPTION
Closes #416

## The defect

Two ADRs in this repository carry the number 0014, and two later ADRs supersede **different** ones of them:

| ADR | `supersedes: 0014` actually means |
| --- | --- |
| `0015-all-live-git-enforcers-and-persistent-trusted-identity` | `0014-githook-shim-dropin-fail-closed` |
| `0016-bounded-pi-child-credential-projection` | `0014-pi-host-authentication-and-fail-closed-tool-boundary` |

The same four characters name two different documents in two places, and only prose disambiguates them.

The blast radius was live, not theoretical. `_readinjectlib.py:391` and `post-write-edit.py:86` both derived the id as `fn.split("-")[0]`, so both 0014s collapsed onto one identifier. **While writing this PR my own read-inject hook emitted it:**

> `ADR-0014 (Treat Pi host authentication as opaque runtime state and fail closed on unknown tools) governs this file`

Byte-identical to what the *other* 0014 produces, apart from the title.

## The fix

**The filename stem is the identifier.** `0014-githook-shim-dropin-fail-closed`, not `0014`. It is unique by construction — the filesystem enforces it — so the collision becomes unrepresentable rather than merely unlikely.

A bare number is still accepted **only while it is unambiguous**. `0009`, `0017`, `0018`, `0019` all name one ADR and keep resolving. `0014` names two, so it raises. An ambiguous reference has no correct answer; returning one — even "the first match" — would silently invent a decision chain.

The historical collision is grandfathered by the **exact pair of stems, not by the number**. That is what makes it non-recurring: a *third* file numbered 0014 is not in the waiver and fails like any other new duplicate. The waiver covers the two files that exist, forever, and nothing else.

## TDD — verbatim red

**Red 1 — the id derivation.** Two same-numbered ADRs, indexed:

```
AssertionError: Lists differ: ['0014', '0014'] != ['0014-githook-shim-dropin-fail-closed', '0014-[49 chars]ary']

First differing element 0:
'0014'
'0014-githook-shim-dropin-fail-closed'

- ['0014', '0014']
+ ['0014-githook-shim-dropin-fail-closed',
+  '0014-pi-host-authentication-and-fail-closed-tool-boundary']
```

and the pointer text a reader would actually see:

```
AssertionError: False is not true : ['ADR-0014 (Git-hook shim) governs this file - do not contradict it; route changes via /ca:reconcile or /ca:adr.', 'ADR-0014 (Pi host auth) governs this file - do not contradict it; route changes via /ca:reconcile or /ca:adr.']
```

**Red 2 — the contract module** (16 failures, all `check_adr_identity is not importable - the ADR identity contract has no implementation yet`).

**Red 3 — the live decision record.** This one is still red on this branch; see "Blocked" below.

```
::error::ADR identity/supersession is ambiguous:
  - 0015-all-live-git-enforcers-and-persistent-trusted-identity: bare ADR number '0014' names 2 documents (0014-githook-shim-dropin-fail-closed, 0014-pi-host-authentication-and-fail-closed-tool-boundary) -- name the full filename stem instead
  - 0016-bounded-pi-child-credential-projection: bare ADR number '0014' names 2 documents (0014-githook-shim-dropin-fail-closed, 0014-pi-host-authentication-and-fail-closed-tool-boundary) -- name the full filename stem instead
```

## Proving the fix bites

- **A third file on an existing number fails.** `test_a_third_file_taking_the_grandfathered_number_is_rejected` adds `0014-a-third-decision-sneaking-in` and the contract rejects it; `test_a_new_duplicate_of_an_unrelated_number_is_rejected` does the same for `0009`.
- **An ambiguous bare number errors rather than resolving.** `test_an_ambiguous_bare_number_raises_instead_of_guessing`, plus `test_an_ambiguous_bare_number_never_returns_a_stem`, which fails loudly if a future "helpful" fallback ever picks the first match.
- **The CI path filter no longer lets it through.** The `hooks` job gains `.codearbiter/decisions/**`. Without it a PR that ONLY adds a decision file — the exact shape of a duplicate-number collision — would skip the job and land the ambiguity unchecked, the same gap that bit #384 and #404.

## The chain forks, and that is correct

`0016 -> {0017 -> 0018}` and `0016 -> 0019` are partial supersessions of different clauses. Not touched. `supersedes:` names a *document*, never a clause, so the authoring contract now says so explicitly and tells future authors to carry the scope in prose.

## Blocked: the one-time disambiguation

The maintainer's ruling, 2026-07-25:

> "the never edit rule is meant to prevent this situation, not prevent this situation from being fixed."

The principle is now recorded in `decision-lifecycle/SKILL.md`: **the never-edit rule protects decision CONTENT, not identifiers.** Rewriting what was decided corrupts the record; disambiguating which document a pointer names repairs it.

I attempted the sanctioned edit and **H-11 blocked it**:

```
PreToolUse:Edit hook error: [python3 "${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit.py"]:
BLOCKED [H-11]: ADR files are edited only via /adr (ORCHESTRATOR §3) - user attribution required.
```

`.codearbiter/.markers/adr-authoring-active` is absent, and `pre-edit.py` requires it present and under 30 minutes old. I did not arm it — arming it myself would be working around the hook, not clearing it.

**To finish, arm the marker and apply exactly this:**

```
.codearbiter/decisions/0015-all-live-git-enforcers-and-persistent-trusted-identity.md  line 6
-supersedes: 0014
+supersedes: 0014-githook-shim-dropin-fail-closed

.codearbiter/decisions/0016-bounded-pi-child-credential-projection.md                  line 6
-supersedes: 0014
+supersedes: 0014-pi-host-authentication-and-fail-closed-tool-boundary
```

Simulated against a copy of `decisions/`: **exactly one line changes in each file** (line 6 both times, same line count in and out), `check_adr_identity.check()` returns `[]`, and every ADR in the chain resolves — including the 0016 fork, untouched. Not one word of any decision changes.

## Suites

| Suite | Before | After |
| --- | --- | --- |
| `plugins/ca/hooks/tests` | 1125 OK | **1125 OK** |
| `.github/scripts` | 1179 OK (5 skipped) | 1199 run, **1197 OK** (5 skipped), 2 failing |
| `tools/sync-core.py --check` | OK | **OK** |
| `tools/build-surface.py --check` | OK | **OK** |
| `tools/build-host-packages.py --check --release-guard-base` | n/a | **OK** (0.1.16 -> 0.1.17) |
| `git diff --check origin/main HEAD` | exit 0 | **exit 0** |

The 2 failures are `LiveRepositoryContractTest` — the blocked edit above, and nothing else. They go green the moment those two lines land.

## Also in this PR

- The `governs` cache gains a schema key. Its mtime stamp only invalidates on an ADR edit, so without it a payload upgrade would keep serving pre-fix numeric ids out of an already-written cache until someone happened to touch a decisions/ file.
- ca-pi 0.1.16 -> 0.1.17: the shared core moves the vendored ca-pi hooks, and a payload change on a published version never reaches installed users.
- `core/pysrc/` and `core/surface/` edited as canonical; `sync-core.py` and `build-surface.py` re-run. No vendored copy hand-edited.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
