### PR TITLE
feat(doctor): surface the MCP write-gap to consumers at runtime — close #270

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -521,9 +521,33 @@ an MCP filesystem/write server can therefore write `.codearbiter/CONTEXT.md`, a
 `--no-verify`, shell-indirection, and self-minted-marker gaps above (ADR-0010) — a
 cooperating orchestrator does not route protected writes through an out-of-band MCP
 tool, and a non-cooperating Bash-capable agent already has stronger bypasses.
-Bringing MCP writes under the write gate on both hosts is tracked as **near-term
-hardening (issue #270 / tribunal appsec-002)**, not a codex-branch blocker; it
-reopens if the threat model expands to untrusted agents.
+**Ratified 2026-07-25 (#270 / tribunal appsec-002).** The acceptance stands: no
+default-deny on `mcp__*` ships, and the write matchers are NOT extended. It is
+conditioned instead on the gap being VISIBLE to whoever carries it. codeArbiter is
+BUILT in this repo but RUN in consumers' repos, so the risk never manifests here
+and this file reaches nobody holding it. `/ca:doctor` does: `doctor.check_mcp`
+resolves the ACTIVE host's MCP configuration through `Host.mcp_config_sources()`
+and WARNs, in the consumer's own repo, that MCP-tool writes are outside the write
+gate. It reports a COUNT only — never a server name, command, argument, or
+environment value (#449) — and degrades to SILENCE when the configuration cannot
+be read, because a diagnostic that errors is worse than one that is quiet.
+
+*Reopen conditions.* Concrete and consumer-side, replacing this clause's former
+vague "if the threat model expands to untrusted agents". Any ONE reopens it:
+
+1. A supported host gains a hook matcher (or tool-name normalization) that can
+   route `mcp__<server>__<tool>` calls to `pre-write.py`. Closing the gap stops
+   requiring a fork, so accepting it stops being the cheaper option.
+2. A consumer reports an MCP server writing under `.codearbiter/` — CONTEXT.md, a
+   `.markers/` token, `gate-events.log`, or `overrides.log` — in a repo whose
+   orchestrator is cooperative. That falsifies the "a cooperating orchestrator
+   does not route protected writes out of band" premise this rests on.
+3. codeArbiter ships, bundles, or recommends an MCP server in a consumer install
+   path. The model above assumes MCP servers are the operator's own choice;
+   shipping one makes the bypass ours to own.
+4. `doctor.check_mcp` stops reporting the gap on a supported host — the seam
+   returns no sources, or the host's configuration location moves. The acceptance
+   is conditioned on visibility, so losing visibility voids it.
 
 ---
 

--- a/core/pysrc/doctor.py
+++ b/core/pysrc/doctor.py
@@ -28,6 +28,15 @@ HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
 PI_BRIDGE_SCRIPTS = ("pi-bridge.py", "git-enforce.py", "_githooks.py")
 
+# MCP config files are read whole to be counted. `~/.claude.json` also carries
+# session history, so it can be large; past this ceiling the source counts as
+# unreadable and the check goes quiet rather than stalling /ca:doctor.
+MCP_CONFIG_MAX_BYTES = 16 * 1024 * 1024
+# Depth ceiling for the `mcpServers` walk below. Claude's deepest real nesting
+# is projects -> <path> -> mcpServers (depth 2); the ceiling just stops a
+# pathological document from costing a full traversal.
+MCP_SCAN_MAX_DEPTH = 6
+
 results = []  # (level, line)
 
 
@@ -212,6 +221,98 @@ def check_host(host):
         ok(f"resolved host: {name}")
 
 
+def _mcp_json_count(doc, key, depth=0):
+    """How many servers a parsed JSON document declares under `key`.
+
+    Walks nested mappings because Claude Code uses the SAME key at two
+    depths: `mcpServers` at the top level of `~/.claude.json` (user scope)
+    and under `projects.<path>.mcpServers` (local scope). Only the number of
+    entries is taken — no name, command, or argument value is ever read out
+    (#449: doctor output is redaction-sensitive)."""
+    if not isinstance(doc, dict) or depth > MCP_SCAN_MAX_DEPTH:
+        return 0
+    total = 0
+    for k, v in doc.items():
+        if k == key and isinstance(v, dict):
+            total += len(v)
+        elif isinstance(v, dict):
+            total += _mcp_json_count(v, key, depth + 1)
+    return total
+
+
+def _mcp_source_count(path, key):
+    """Servers declared in one config file: an int, or None when the file
+    exists but cannot be read as configuration (unparseable, oversize,
+    unreadable, or a format this build cannot parse). An ABSENT file is a
+    legitimate "none configured", so it counts 0 — only a file we cannot
+    interpret is unknown."""
+    if not os.path.isfile(path):
+        return 0
+    try:
+        if os.path.getsize(path) > MCP_CONFIG_MAX_BYTES:
+            return None
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        if path.lower().endswith(".toml"):
+            import tomllib  # 3.11+; older interpreters degrade to unknown
+            table = tomllib.loads(text).get(key)
+            return len(table) if isinstance(table, dict) else 0
+        return _mcp_json_count(json.loads(text), key)
+    except Exception:  # noqa: BLE001 — a diagnostic must never be the failure
+        return None
+
+
+def check_mcp(host):
+    """#270 (tribunal appsec-002): report that MCP tools are configured, and
+    that writes performed through them are outside the write gate.
+
+    The gap is real on every host — `mcp__<server>__<tool>` misses Claude's
+    `Write`/`Edit` matchers and normalizes to "OTHER" on Codex — and it is
+    ACCEPTED residual risk under ADR-0010, NOT something this check denies.
+    What it does is make the acceptance visible where the risk actually
+    lives: codeArbiter is BUILT in this repo but RUN in consumers' repos, so
+    a build-time check here would never fire and security-controls.md alone
+    reaches nobody who is carrying the risk. `/ca:doctor` does.
+
+    Host-agnostic by construction: the config locations come from
+    `host.mcp_config_sources()`, never from a hard-coded path. Every failure
+    mode degrades to SILENCE — a host too old for the seam, a host that
+    declares no sources, a raising seam, an unreadable or oversize file.
+    /ca:doctor is the tool of last resort when enforcement misbehaves, so a
+    diagnostic that errors is worse than one that is quiet.
+
+    Reports a COUNT only. Server names, commands, arguments, and environment
+    are never read out (#449)."""
+    try:
+        sources = host.mcp_config_sources(host.project_root())
+    except Exception:  # noqa: BLE001 — no seam, or a seam that raised
+        return
+    if not sources:
+        return  # this host's MCP surface is unknown — say nothing
+    total, unknown = 0, False
+    for source in sources or ():
+        try:
+            path, key = source
+            count = _mcp_source_count(path, key)
+        except Exception:  # noqa: BLE001 — malformed source descriptor
+            count = None
+        if count is None:
+            unknown = True
+        else:
+            total += count
+    if total > 0:
+        warn(f"{total} MCP server{'s' if total != 1 else ''} configured for "
+             f"this host — file writes made through an MCP tool "
+             f"(mcp__<server>__<tool>) bypass the codeArbiter write gate: no "
+             f"pre-write/pre-edit guard evaluates them and no gate event is "
+             f"recorded. Accepted residual risk under ADR-0010 — keep "
+             f"protected writes on this host's native write tools, or remove "
+             f"MCP servers that can write files.")
+    elif not unknown:
+        ok("no MCP servers configured for this host — nothing bypasses the "
+           "write gate through an MCP tool")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -236,6 +337,7 @@ def main():
     check_interpreters()
     check_payload(root, host)
     check_repo()
+    check_mcp(host)
     if getattr(host, "has_statusline", True):
         # A host with no statusline surface (Codex) must not read
         # ~/.claude/settings.json or advertise a statusline install path.

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -158,6 +158,39 @@ class Host:
         silently never firing the update-available notice."""
         return os.path.join(".claude-plugin", "plugin.json")
 
+    def mcp_config_sources(self, project_root):
+        """Where THIS host declares its MCP servers — `[(path, key), ...]`,
+        each entry a configuration file and the mapping key under which that
+        file declares servers (#270, tribunal appsec-002).
+
+        MCP server tools (`mcp__<server>__<tool>`) sit OUTSIDE the write gate
+        on every host: they miss Claude's `Write`/`Edit` matchers, and they
+        carry no TOOL_MAP entry on Codex so they normalize to "OTHER" and
+        match neither the write hooks nor the exec hook. That is ACCEPTED
+        residual risk under ADR-0010 (see .codearbiter/security-controls.md),
+        conditioned on the gap being *visible* to the consumer carrying it —
+        this repo builds codeArbiter, so the risk never lands here. This seam
+        is how `doctor.check_mcp` asks the ACTIVE host where to look, instead
+        of hard-coding one host's layout; doctor counts what it finds and
+        never reads, echoes, or names a server, command, or argument.
+
+        Claude Code declares servers in two places, and BOTH have to be seen
+        or the commonest real configuration reports as "none":
+          * `<project>/.mcp.json` — the project scope, checked into the repo.
+          * `~/.claude.json` — user scope (top-level `mcpServers`) and local
+            scope (`projects.<path>.mcpServers`, same key, nested).
+
+        Return `[]` to mean "this host's MCP configuration surface is not
+        known" — doctor then reports NOTHING rather than guessing another
+        host's paths. Overrides must not raise; doctor treats a raising seam
+        as unknown, but a quiet seam is the contract.
+        """
+        home = os.path.expanduser("~")
+        return [
+            (os.path.join(project_root, ".mcp.json"), "mcpServers"),
+            (os.path.join(home, ".claude.json"), "mcpServers"),
+        ]
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""
@@ -298,6 +331,13 @@ class FailClosedHost(Host):
                  "added_text": "", "added_lines": [],
                  "old_string": "", "replace_all": False,
                  "batched": False, "notebook": False}]
+
+    def mcp_config_sources(self, project_root):
+        # Same reason as iter_file_ops: the host is unknown, so no config
+        # path can be claimed. Reading ~/.claude.json here would report a
+        # DIFFERENT host's MCP configuration as this install's. Diagnostics
+        # fail quiet (#270) — the write-path guards are what fail closed.
+        return []
 
 
 def load_host(hooks_dir=None):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -246,6 +246,21 @@ class CodexHost(hostapi.Host):
         _updatelib.py must resolve THIS path under Codex (#263)."""
         return os.path.join(".codex-plugin", "plugin.json")
 
+    def mcp_config_sources(self, project_root):
+        """Codex declares MCP servers as `[mcp_servers.<name>]` tables in
+        `$CODEX_HOME/config.toml` (CODEX_HOME defaults to `~/.codex`) — never
+        in Claude's `.mcp.json` / `~/.claude.json`, so the base implementation
+        would report the WRONG host's configuration here (#270).
+
+        `project_root` is unused: Codex has no project-scoped MCP config file.
+        Reading nothing is the right answer for a scope this host does not
+        have — doctor sums the sources it is given and stays quiet about the
+        rest."""
+        home = os.environ.get("CODEX_HOME")
+        if not home:
+            home = os.path.join(os.path.expanduser("~"), ".codex")
+        return [(os.path.join(home, "config.toml"), "mcp_servers")]
+
     def normalize_tool_input(self, tool_name, tool_input):
         """Codex's exec payload ({command}) already IS the canonical EXEC
         shape, and the apply_patch envelope cannot be represented as ONE

--- a/plugins/ca-codex/hooks/doctor.py
+++ b/plugins/ca-codex/hooks/doctor.py
@@ -28,6 +28,15 @@ HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
 PI_BRIDGE_SCRIPTS = ("pi-bridge.py", "git-enforce.py", "_githooks.py")
 
+# MCP config files are read whole to be counted. `~/.claude.json` also carries
+# session history, so it can be large; past this ceiling the source counts as
+# unreadable and the check goes quiet rather than stalling /ca:doctor.
+MCP_CONFIG_MAX_BYTES = 16 * 1024 * 1024
+# Depth ceiling for the `mcpServers` walk below. Claude's deepest real nesting
+# is projects -> <path> -> mcpServers (depth 2); the ceiling just stops a
+# pathological document from costing a full traversal.
+MCP_SCAN_MAX_DEPTH = 6
+
 results = []  # (level, line)
 
 
@@ -212,6 +221,98 @@ def check_host(host):
         ok(f"resolved host: {name}")
 
 
+def _mcp_json_count(doc, key, depth=0):
+    """How many servers a parsed JSON document declares under `key`.
+
+    Walks nested mappings because Claude Code uses the SAME key at two
+    depths: `mcpServers` at the top level of `~/.claude.json` (user scope)
+    and under `projects.<path>.mcpServers` (local scope). Only the number of
+    entries is taken — no name, command, or argument value is ever read out
+    (#449: doctor output is redaction-sensitive)."""
+    if not isinstance(doc, dict) or depth > MCP_SCAN_MAX_DEPTH:
+        return 0
+    total = 0
+    for k, v in doc.items():
+        if k == key and isinstance(v, dict):
+            total += len(v)
+        elif isinstance(v, dict):
+            total += _mcp_json_count(v, key, depth + 1)
+    return total
+
+
+def _mcp_source_count(path, key):
+    """Servers declared in one config file: an int, or None when the file
+    exists but cannot be read as configuration (unparseable, oversize,
+    unreadable, or a format this build cannot parse). An ABSENT file is a
+    legitimate "none configured", so it counts 0 — only a file we cannot
+    interpret is unknown."""
+    if not os.path.isfile(path):
+        return 0
+    try:
+        if os.path.getsize(path) > MCP_CONFIG_MAX_BYTES:
+            return None
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        if path.lower().endswith(".toml"):
+            import tomllib  # 3.11+; older interpreters degrade to unknown
+            table = tomllib.loads(text).get(key)
+            return len(table) if isinstance(table, dict) else 0
+        return _mcp_json_count(json.loads(text), key)
+    except Exception:  # noqa: BLE001 — a diagnostic must never be the failure
+        return None
+
+
+def check_mcp(host):
+    """#270 (tribunal appsec-002): report that MCP tools are configured, and
+    that writes performed through them are outside the write gate.
+
+    The gap is real on every host — `mcp__<server>__<tool>` misses Claude's
+    `Write`/`Edit` matchers and normalizes to "OTHER" on Codex — and it is
+    ACCEPTED residual risk under ADR-0010, NOT something this check denies.
+    What it does is make the acceptance visible where the risk actually
+    lives: codeArbiter is BUILT in this repo but RUN in consumers' repos, so
+    a build-time check here would never fire and security-controls.md alone
+    reaches nobody who is carrying the risk. `/ca:doctor` does.
+
+    Host-agnostic by construction: the config locations come from
+    `host.mcp_config_sources()`, never from a hard-coded path. Every failure
+    mode degrades to SILENCE — a host too old for the seam, a host that
+    declares no sources, a raising seam, an unreadable or oversize file.
+    /ca:doctor is the tool of last resort when enforcement misbehaves, so a
+    diagnostic that errors is worse than one that is quiet.
+
+    Reports a COUNT only. Server names, commands, arguments, and environment
+    are never read out (#449)."""
+    try:
+        sources = host.mcp_config_sources(host.project_root())
+    except Exception:  # noqa: BLE001 — no seam, or a seam that raised
+        return
+    if not sources:
+        return  # this host's MCP surface is unknown — say nothing
+    total, unknown = 0, False
+    for source in sources or ():
+        try:
+            path, key = source
+            count = _mcp_source_count(path, key)
+        except Exception:  # noqa: BLE001 — malformed source descriptor
+            count = None
+        if count is None:
+            unknown = True
+        else:
+            total += count
+    if total > 0:
+        warn(f"{total} MCP server{'s' if total != 1 else ''} configured for "
+             f"this host — file writes made through an MCP tool "
+             f"(mcp__<server>__<tool>) bypass the codeArbiter write gate: no "
+             f"pre-write/pre-edit guard evaluates them and no gate event is "
+             f"recorded. Accepted residual risk under ADR-0010 — keep "
+             f"protected writes on this host's native write tools, or remove "
+             f"MCP servers that can write files.")
+    elif not unknown:
+        ok("no MCP servers configured for this host — nothing bypasses the "
+           "write gate through an MCP tool")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -236,6 +337,7 @@ def main():
     check_interpreters()
     check_payload(root, host)
     check_repo()
+    check_mcp(host)
     if getattr(host, "has_statusline", True):
         # A host with no statusline surface (Codex) must not read
         # ~/.claude/settings.json or advertise a statusline install path.

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -158,6 +158,39 @@ class Host:
         silently never firing the update-available notice."""
         return os.path.join(".claude-plugin", "plugin.json")
 
+    def mcp_config_sources(self, project_root):
+        """Where THIS host declares its MCP servers — `[(path, key), ...]`,
+        each entry a configuration file and the mapping key under which that
+        file declares servers (#270, tribunal appsec-002).
+
+        MCP server tools (`mcp__<server>__<tool>`) sit OUTSIDE the write gate
+        on every host: they miss Claude's `Write`/`Edit` matchers, and they
+        carry no TOOL_MAP entry on Codex so they normalize to "OTHER" and
+        match neither the write hooks nor the exec hook. That is ACCEPTED
+        residual risk under ADR-0010 (see .codearbiter/security-controls.md),
+        conditioned on the gap being *visible* to the consumer carrying it —
+        this repo builds codeArbiter, so the risk never lands here. This seam
+        is how `doctor.check_mcp` asks the ACTIVE host where to look, instead
+        of hard-coding one host's layout; doctor counts what it finds and
+        never reads, echoes, or names a server, command, or argument.
+
+        Claude Code declares servers in two places, and BOTH have to be seen
+        or the commonest real configuration reports as "none":
+          * `<project>/.mcp.json` — the project scope, checked into the repo.
+          * `~/.claude.json` — user scope (top-level `mcpServers`) and local
+            scope (`projects.<path>.mcpServers`, same key, nested).
+
+        Return `[]` to mean "this host's MCP configuration surface is not
+        known" — doctor then reports NOTHING rather than guessing another
+        host's paths. Overrides must not raise; doctor treats a raising seam
+        as unknown, but a quiet seam is the contract.
+        """
+        home = os.path.expanduser("~")
+        return [
+            (os.path.join(project_root, ".mcp.json"), "mcpServers"),
+            (os.path.join(home, ".claude.json"), "mcpServers"),
+        ]
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""
@@ -298,6 +331,13 @@ class FailClosedHost(Host):
                  "added_text": "", "added_lines": [],
                  "old_string": "", "replace_all": False,
                  "batched": False, "notebook": False}]
+
+    def mcp_config_sources(self, project_root):
+        # Same reason as iter_file_ops: the host is unknown, so no config
+        # path can be claimed. Reading ~/.claude.json here would report a
+        # DIFFERENT host's MCP configuration as this install's. Diagnostics
+        # fail quiet (#270) — the write-path guards are what fail closed.
+        return []
 
 
 def load_host(hooks_dir=None):

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.17] - 2026-07-25
+
+### Added
+
+- `/ca-doctor` now reports whether MCP servers are configured for the active
+  host, and that file writes performed through an MCP tool
+  (`mcp__<server>__<tool>`) are outside codeArbiter's write gate. The Pi host
+  claims no MCP configuration sources, so the line degrades to silence on Pi
+  rather than reporting another host's configuration as this install's.
+
 ## [0.1.16] - 2026-07-25
 
 ### Changed

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -45,6 +45,15 @@ class PiHost(hostapi.Host):
     def manifest_relpath(self):
         return "package.json"
 
+    def mcp_config_sources(self, project_root):
+        # #270: Pi's MCP configuration surface is not source-verified against
+        # a supported Pi release in this repo, so this host claims NO sources
+        # and doctor's MCP line degrades to silence. Inheriting the base
+        # (Claude) implementation would report ~/.claude.json — a DIFFERENT
+        # host's configuration — as this install's. Fill this in only with a
+        # version-pinned source reference, the way TOOL_MAP is pinned.
+        return []
+
     def normalize_tool_input(self, tool_name, tool_input):
         value = tool_input if isinstance(tool_input, dict) else {}
         if tool_name == "read":

--- a/plugins/ca-pi/hooks/doctor.py
+++ b/plugins/ca-pi/hooks/doctor.py
@@ -28,6 +28,15 @@ HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
 PI_BRIDGE_SCRIPTS = ("pi-bridge.py", "git-enforce.py", "_githooks.py")
 
+# MCP config files are read whole to be counted. `~/.claude.json` also carries
+# session history, so it can be large; past this ceiling the source counts as
+# unreadable and the check goes quiet rather than stalling /ca:doctor.
+MCP_CONFIG_MAX_BYTES = 16 * 1024 * 1024
+# Depth ceiling for the `mcpServers` walk below. Claude's deepest real nesting
+# is projects -> <path> -> mcpServers (depth 2); the ceiling just stops a
+# pathological document from costing a full traversal.
+MCP_SCAN_MAX_DEPTH = 6
+
 results = []  # (level, line)
 
 
@@ -212,6 +221,98 @@ def check_host(host):
         ok(f"resolved host: {name}")
 
 
+def _mcp_json_count(doc, key, depth=0):
+    """How many servers a parsed JSON document declares under `key`.
+
+    Walks nested mappings because Claude Code uses the SAME key at two
+    depths: `mcpServers` at the top level of `~/.claude.json` (user scope)
+    and under `projects.<path>.mcpServers` (local scope). Only the number of
+    entries is taken — no name, command, or argument value is ever read out
+    (#449: doctor output is redaction-sensitive)."""
+    if not isinstance(doc, dict) or depth > MCP_SCAN_MAX_DEPTH:
+        return 0
+    total = 0
+    for k, v in doc.items():
+        if k == key and isinstance(v, dict):
+            total += len(v)
+        elif isinstance(v, dict):
+            total += _mcp_json_count(v, key, depth + 1)
+    return total
+
+
+def _mcp_source_count(path, key):
+    """Servers declared in one config file: an int, or None when the file
+    exists but cannot be read as configuration (unparseable, oversize,
+    unreadable, or a format this build cannot parse). An ABSENT file is a
+    legitimate "none configured", so it counts 0 — only a file we cannot
+    interpret is unknown."""
+    if not os.path.isfile(path):
+        return 0
+    try:
+        if os.path.getsize(path) > MCP_CONFIG_MAX_BYTES:
+            return None
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        if path.lower().endswith(".toml"):
+            import tomllib  # 3.11+; older interpreters degrade to unknown
+            table = tomllib.loads(text).get(key)
+            return len(table) if isinstance(table, dict) else 0
+        return _mcp_json_count(json.loads(text), key)
+    except Exception:  # noqa: BLE001 — a diagnostic must never be the failure
+        return None
+
+
+def check_mcp(host):
+    """#270 (tribunal appsec-002): report that MCP tools are configured, and
+    that writes performed through them are outside the write gate.
+
+    The gap is real on every host — `mcp__<server>__<tool>` misses Claude's
+    `Write`/`Edit` matchers and normalizes to "OTHER" on Codex — and it is
+    ACCEPTED residual risk under ADR-0010, NOT something this check denies.
+    What it does is make the acceptance visible where the risk actually
+    lives: codeArbiter is BUILT in this repo but RUN in consumers' repos, so
+    a build-time check here would never fire and security-controls.md alone
+    reaches nobody who is carrying the risk. `/ca:doctor` does.
+
+    Host-agnostic by construction: the config locations come from
+    `host.mcp_config_sources()`, never from a hard-coded path. Every failure
+    mode degrades to SILENCE — a host too old for the seam, a host that
+    declares no sources, a raising seam, an unreadable or oversize file.
+    /ca:doctor is the tool of last resort when enforcement misbehaves, so a
+    diagnostic that errors is worse than one that is quiet.
+
+    Reports a COUNT only. Server names, commands, arguments, and environment
+    are never read out (#449)."""
+    try:
+        sources = host.mcp_config_sources(host.project_root())
+    except Exception:  # noqa: BLE001 — no seam, or a seam that raised
+        return
+    if not sources:
+        return  # this host's MCP surface is unknown — say nothing
+    total, unknown = 0, False
+    for source in sources or ():
+        try:
+            path, key = source
+            count = _mcp_source_count(path, key)
+        except Exception:  # noqa: BLE001 — malformed source descriptor
+            count = None
+        if count is None:
+            unknown = True
+        else:
+            total += count
+    if total > 0:
+        warn(f"{total} MCP server{'s' if total != 1 else ''} configured for "
+             f"this host — file writes made through an MCP tool "
+             f"(mcp__<server>__<tool>) bypass the codeArbiter write gate: no "
+             f"pre-write/pre-edit guard evaluates them and no gate event is "
+             f"recorded. Accepted residual risk under ADR-0010 — keep "
+             f"protected writes on this host's native write tools, or remove "
+             f"MCP servers that can write files.")
+    elif not unknown:
+        ok("no MCP servers configured for this host — nothing bypasses the "
+           "write gate through an MCP tool")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -236,6 +337,7 @@ def main():
     check_interpreters()
     check_payload(root, host)
     check_repo()
+    check_mcp(host)
     if getattr(host, "has_statusline", True):
         # A host with no statusline surface (Codex) must not read
         # ~/.claude/settings.json or advertise a statusline install path.

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -158,6 +158,39 @@ class Host:
         silently never firing the update-available notice."""
         return os.path.join(".claude-plugin", "plugin.json")
 
+    def mcp_config_sources(self, project_root):
+        """Where THIS host declares its MCP servers — `[(path, key), ...]`,
+        each entry a configuration file and the mapping key under which that
+        file declares servers (#270, tribunal appsec-002).
+
+        MCP server tools (`mcp__<server>__<tool>`) sit OUTSIDE the write gate
+        on every host: they miss Claude's `Write`/`Edit` matchers, and they
+        carry no TOOL_MAP entry on Codex so they normalize to "OTHER" and
+        match neither the write hooks nor the exec hook. That is ACCEPTED
+        residual risk under ADR-0010 (see .codearbiter/security-controls.md),
+        conditioned on the gap being *visible* to the consumer carrying it —
+        this repo builds codeArbiter, so the risk never lands here. This seam
+        is how `doctor.check_mcp` asks the ACTIVE host where to look, instead
+        of hard-coding one host's layout; doctor counts what it finds and
+        never reads, echoes, or names a server, command, or argument.
+
+        Claude Code declares servers in two places, and BOTH have to be seen
+        or the commonest real configuration reports as "none":
+          * `<project>/.mcp.json` — the project scope, checked into the repo.
+          * `~/.claude.json` — user scope (top-level `mcpServers`) and local
+            scope (`projects.<path>.mcpServers`, same key, nested).
+
+        Return `[]` to mean "this host's MCP configuration surface is not
+        known" — doctor then reports NOTHING rather than guessing another
+        host's paths. Overrides must not raise; doctor treats a raising seam
+        as unknown, but a quiet seam is the contract.
+        """
+        home = os.path.expanduser("~")
+        return [
+            (os.path.join(project_root, ".mcp.json"), "mcpServers"),
+            (os.path.join(home, ".claude.json"), "mcpServers"),
+        ]
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""
@@ -298,6 +331,13 @@ class FailClosedHost(Host):
                  "added_text": "", "added_lines": [],
                  "old_string": "", "replace_all": False,
                  "batched": False, "notebook": False}]
+
+    def mcp_config_sources(self, project_root):
+        # Same reason as iter_file_ops: the host is unknown, so no config
+        # path can be claimed. Reading ~/.claude.json here would report a
+        # DIFFERENT host's MCP configuration as this install's. Diagnostics
+        # fail quiet (#270) — the write-path guards are what fail closed.
+        return []
 
 
 def load_host(hooks_dir=None):

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/hooks/doctor.py
+++ b/plugins/ca/hooks/doctor.py
@@ -28,6 +28,15 @@ HOOK_SCRIPTS = ("session-start.py", "pre-bash.py", "pre-write.py",
                 "pre-edit.py", "post-write-edit.py", "prune-transcript.py")
 PI_BRIDGE_SCRIPTS = ("pi-bridge.py", "git-enforce.py", "_githooks.py")
 
+# MCP config files are read whole to be counted. `~/.claude.json` also carries
+# session history, so it can be large; past this ceiling the source counts as
+# unreadable and the check goes quiet rather than stalling /ca:doctor.
+MCP_CONFIG_MAX_BYTES = 16 * 1024 * 1024
+# Depth ceiling for the `mcpServers` walk below. Claude's deepest real nesting
+# is projects -> <path> -> mcpServers (depth 2); the ceiling just stops a
+# pathological document from costing a full traversal.
+MCP_SCAN_MAX_DEPTH = 6
+
 results = []  # (level, line)
 
 
@@ -212,6 +221,98 @@ def check_host(host):
         ok(f"resolved host: {name}")
 
 
+def _mcp_json_count(doc, key, depth=0):
+    """How many servers a parsed JSON document declares under `key`.
+
+    Walks nested mappings because Claude Code uses the SAME key at two
+    depths: `mcpServers` at the top level of `~/.claude.json` (user scope)
+    and under `projects.<path>.mcpServers` (local scope). Only the number of
+    entries is taken — no name, command, or argument value is ever read out
+    (#449: doctor output is redaction-sensitive)."""
+    if not isinstance(doc, dict) or depth > MCP_SCAN_MAX_DEPTH:
+        return 0
+    total = 0
+    for k, v in doc.items():
+        if k == key and isinstance(v, dict):
+            total += len(v)
+        elif isinstance(v, dict):
+            total += _mcp_json_count(v, key, depth + 1)
+    return total
+
+
+def _mcp_source_count(path, key):
+    """Servers declared in one config file: an int, or None when the file
+    exists but cannot be read as configuration (unparseable, oversize,
+    unreadable, or a format this build cannot parse). An ABSENT file is a
+    legitimate "none configured", so it counts 0 — only a file we cannot
+    interpret is unknown."""
+    if not os.path.isfile(path):
+        return 0
+    try:
+        if os.path.getsize(path) > MCP_CONFIG_MAX_BYTES:
+            return None
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        if path.lower().endswith(".toml"):
+            import tomllib  # 3.11+; older interpreters degrade to unknown
+            table = tomllib.loads(text).get(key)
+            return len(table) if isinstance(table, dict) else 0
+        return _mcp_json_count(json.loads(text), key)
+    except Exception:  # noqa: BLE001 — a diagnostic must never be the failure
+        return None
+
+
+def check_mcp(host):
+    """#270 (tribunal appsec-002): report that MCP tools are configured, and
+    that writes performed through them are outside the write gate.
+
+    The gap is real on every host — `mcp__<server>__<tool>` misses Claude's
+    `Write`/`Edit` matchers and normalizes to "OTHER" on Codex — and it is
+    ACCEPTED residual risk under ADR-0010, NOT something this check denies.
+    What it does is make the acceptance visible where the risk actually
+    lives: codeArbiter is BUILT in this repo but RUN in consumers' repos, so
+    a build-time check here would never fire and security-controls.md alone
+    reaches nobody who is carrying the risk. `/ca:doctor` does.
+
+    Host-agnostic by construction: the config locations come from
+    `host.mcp_config_sources()`, never from a hard-coded path. Every failure
+    mode degrades to SILENCE — a host too old for the seam, a host that
+    declares no sources, a raising seam, an unreadable or oversize file.
+    /ca:doctor is the tool of last resort when enforcement misbehaves, so a
+    diagnostic that errors is worse than one that is quiet.
+
+    Reports a COUNT only. Server names, commands, arguments, and environment
+    are never read out (#449)."""
+    try:
+        sources = host.mcp_config_sources(host.project_root())
+    except Exception:  # noqa: BLE001 — no seam, or a seam that raised
+        return
+    if not sources:
+        return  # this host's MCP surface is unknown — say nothing
+    total, unknown = 0, False
+    for source in sources or ():
+        try:
+            path, key = source
+            count = _mcp_source_count(path, key)
+        except Exception:  # noqa: BLE001 — malformed source descriptor
+            count = None
+        if count is None:
+            unknown = True
+        else:
+            total += count
+    if total > 0:
+        warn(f"{total} MCP server{'s' if total != 1 else ''} configured for "
+             f"this host — file writes made through an MCP tool "
+             f"(mcp__<server>__<tool>) bypass the codeArbiter write gate: no "
+             f"pre-write/pre-edit guard evaluates them and no gate event is "
+             f"recorded. Accepted residual risk under ADR-0010 — keep "
+             f"protected writes on this host's native write tools, or remove "
+             f"MCP servers that can write files.")
+    elif not unknown:
+        ok("no MCP servers configured for this host — nothing bypasses the "
+           "write gate through an MCP tool")
+
+
 def check_statusline(root):
     settings = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
     try:
@@ -236,6 +337,7 @@ def main():
     check_interpreters()
     check_payload(root, host)
     check_repo()
+    check_mcp(host)
     if getattr(host, "has_statusline", True):
         # A host with no statusline surface (Codex) must not read
         # ~/.claude/settings.json or advertise a statusline install path.

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -158,6 +158,39 @@ class Host:
         silently never firing the update-available notice."""
         return os.path.join(".claude-plugin", "plugin.json")
 
+    def mcp_config_sources(self, project_root):
+        """Where THIS host declares its MCP servers — `[(path, key), ...]`,
+        each entry a configuration file and the mapping key under which that
+        file declares servers (#270, tribunal appsec-002).
+
+        MCP server tools (`mcp__<server>__<tool>`) sit OUTSIDE the write gate
+        on every host: they miss Claude's `Write`/`Edit` matchers, and they
+        carry no TOOL_MAP entry on Codex so they normalize to "OTHER" and
+        match neither the write hooks nor the exec hook. That is ACCEPTED
+        residual risk under ADR-0010 (see .codearbiter/security-controls.md),
+        conditioned on the gap being *visible* to the consumer carrying it —
+        this repo builds codeArbiter, so the risk never lands here. This seam
+        is how `doctor.check_mcp` asks the ACTIVE host where to look, instead
+        of hard-coding one host's layout; doctor counts what it finds and
+        never reads, echoes, or names a server, command, or argument.
+
+        Claude Code declares servers in two places, and BOTH have to be seen
+        or the commonest real configuration reports as "none":
+          * `<project>/.mcp.json` — the project scope, checked into the repo.
+          * `~/.claude.json` — user scope (top-level `mcpServers`) and local
+            scope (`projects.<path>.mcpServers`, same key, nested).
+
+        Return `[]` to mean "this host's MCP configuration surface is not
+        known" — doctor then reports NOTHING rather than guessing another
+        host's paths. Overrides must not raise; doctor treats a raising seam
+        as unknown, but a quiet seam is the contract.
+        """
+        home = os.path.expanduser("~")
+        return [
+            (os.path.join(project_root, ".mcp.json"), "mcpServers"),
+            (os.path.join(home, ".claude.json"), "mcpServers"),
+        ]
+
     def normalize_tool(self, tool_name):
         """Canonical category for a native tool name:
         "EXEC" | "WRITE" | "EDIT" | "READ" | "OTHER"."""
@@ -298,6 +331,13 @@ class FailClosedHost(Host):
                  "added_text": "", "added_lines": [],
                  "old_string": "", "replace_all": False,
                  "batched": False, "notebook": False}]
+
+    def mcp_config_sources(self, project_root):
+        # Same reason as iter_file_ops: the host is unknown, so no config
+        # path can be claimed. Reading ~/.claude.json here would report a
+        # DIFFERENT host's MCP configuration as this install's. Diagnostics
+        # fail quiet (#270) — the write-path guards are what fail closed.
+        return []
 
 
 def load_host(hooks_dir=None):

--- a/plugins/ca/hooks/tests/test_mcp_visibility.py
+++ b/plugins/ca/hooks/tests/test_mcp_visibility.py
@@ -1,0 +1,328 @@
+"""MCP write-gap visibility (#270 / tribunal appsec-002).
+
+MCP server tools (``mcp__<server>__<tool>``) escape every write-path guard:
+on Claude they miss the ``Write``/``Edit`` matchers, and on Codex they
+normalize to ``OTHER`` (no ``TOOL_MAP`` entry) so they match neither the
+``apply_patch|Write|Edit`` write hooks nor the ``Bash`` exec hook. That gap is
+ACCEPTED residual risk under ADR-0010 — these tests pin the *visibility* the
+acceptance is conditioned on, not a default-deny.
+
+The risk is carried by CONSUMERS: this repo is where codeArbiter is BUILT, so
+a build-time check here would never fire. ``/ca:doctor`` is the surface that
+lands in a consumer's own project, so the gap has to be reportable there.
+
+Contract pinned here:
+  * ``hostapi.Host.mcp_config_sources(project_root)`` is the host seam — each
+    host answers where IT declares MCP servers. An empty list means the
+    surface is unknown, and doctor must stay silent rather than guess.
+  * ``doctor.check_mcp(host)`` WARNs when servers are configured, OKs when the
+    host's sources are readable and declare none, and emits NOTHING when the
+    configuration cannot be read.
+  * The WARN reports a COUNT only. Server names, commands, and arguments are
+    never echoed (#449: doctor output is already redaction-sensitive).
+
+stdlib unittest only; no subprocess, no network, nothing written outside a
+TemporaryDirectory.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+_HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+for _p in (_HOOKS_DIR, os.path.dirname(os.path.abspath(__file__))):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import doctor  # noqa: E402
+import hostapi  # noqa: E402
+import _hooklib  # noqa: E402
+
+
+def _lines():
+    return [line for _, line in doctor.results]
+
+
+def _levels():
+    return [lvl for lvl, _ in doctor.results]
+
+
+@contextlib.contextmanager
+def _env(**pairs):
+    saved = {k: os.environ.get(k) for k in pairs}
+    try:
+        for k, v in pairs.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class _FakeHost:
+    """A host whose MCP sources and project root are fully test-controlled."""
+
+    name = "fake"
+
+    def __init__(self, sources, root="."):
+        self._sources = sources
+        self._root = root
+
+    def project_root(self, payload=None):
+        return self._root
+
+    def mcp_config_sources(self, project_root):
+        return list(self._sources)
+
+
+class HostSeamTest(unittest.TestCase):
+    """The seam itself: each host answers for its OWN configuration surface."""
+
+    def test_claude_default_declares_the_project_scoped_mcp_json(self):
+        sources = hostapi.Host().mcp_config_sources(os.path.join("X", "proj"))
+        paths = [p for p, _ in sources]
+        self.assertIn(os.path.join("X", "proj", ".mcp.json"), paths)
+
+    def test_claude_default_declares_the_mcpservers_key(self):
+        sources = hostapi.Host().mcp_config_sources(os.path.join("X", "proj"))
+        for path, key in sources:
+            if path.endswith(".mcp.json"):
+                self.assertEqual(key, "mcpServers")
+                return
+        self.fail(f"no .mcp.json source in {sources!r}")
+
+    def test_claude_default_covers_the_user_scope_file(self):
+        # `claude mcp add -s user` writes to ~/.claude.json, not the project
+        # file — a check that reads only .mcp.json would report "none" on the
+        # commonest real configuration.
+        with tempfile.TemporaryDirectory() as home:
+            with _env(HOME=home, USERPROFILE=home):
+                paths = [p for p, _ in hostapi.Host().mcp_config_sources(home)]
+            self.assertTrue(
+                any(os.path.basename(p) == ".claude.json" for p in paths),
+                f"user-scope ~/.claude.json missing from {paths!r}")
+
+    def test_fail_closed_host_declares_no_sources(self):
+        # Host identity is unknown, so no config path can be claimed; doctor
+        # must degrade to silence rather than guess Claude's layout.
+        self.assertEqual(hostapi.FailClosedHost().mcp_config_sources("."), [])
+
+
+class CodexHostSeamTest(unittest.TestCase):
+    """Loads the REAL ca-codex _host.py, as test_host_cmdref.py does."""
+
+    @classmethod
+    def setUpClass(cls):
+        codex_hooks = os.path.abspath(os.path.join(
+            _HOOKS_DIR, "..", "..", "ca-codex", "hooks"))
+        cls.host = hostapi.load_host(codex_hooks)
+
+    def test_codex_reads_its_own_config_toml_not_claudes(self):
+        with tempfile.TemporaryDirectory() as codex_home:
+            with _env(CODEX_HOME=codex_home):
+                sources = self.host.mcp_config_sources(os.getcwd())
+        paths = [p for p, _ in sources]
+        self.assertEqual(paths, [os.path.join(codex_home, "config.toml")])
+
+    def test_codex_declares_the_mcp_servers_key(self):
+        with tempfile.TemporaryDirectory() as codex_home:
+            with _env(CODEX_HOME=codex_home):
+                sources = self.host.mcp_config_sources(os.getcwd())
+        self.assertEqual([k for _, k in sources], ["mcp_servers"])
+
+    def test_codex_falls_back_to_the_default_codex_home(self):
+        with tempfile.TemporaryDirectory() as home:
+            with _env(CODEX_HOME=None, HOME=home, USERPROFILE=home):
+                sources = self.host.mcp_config_sources(os.getcwd())
+        self.assertEqual([p for p, _ in sources],
+                         [os.path.join(home, ".codex", "config.toml")])
+
+
+class PiHostSeamTest(unittest.TestCase):
+    """ca-pi's MCP configuration surface is not source-verified in this repo,
+    so the Pi host must claim NO sources — inheriting Claude's ~/.claude.json
+    would make doctor report another host's configuration as Pi's."""
+
+    @classmethod
+    def setUpClass(cls):
+        pi_hooks = os.path.abspath(os.path.join(
+            _HOOKS_DIR, "..", "..", "ca-pi", "hooks"))
+        cls.host = hostapi.load_host(pi_hooks)
+
+    def test_pi_declares_no_sources(self):
+        self.assertEqual(self.host.name, "pi")
+        self.assertEqual(self.host.mcp_config_sources(os.getcwd()), [])
+
+
+class CheckMcpTest(unittest.TestCase):
+    def setUp(self):
+        doctor.results.clear()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+
+    def tearDown(self):
+        doctor.results.clear()
+        self.tmp.cleanup()
+
+    def _write_mcp_json(self, doc):
+        path = os.path.join(self.root, ".mcp.json")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            json.dump(doc, f)
+        return path
+
+    def _host(self, *paths):
+        return _FakeHost([(p, "mcpServers") for p in paths], self.root)
+
+    def test_configured_servers_produce_a_warn(self):
+        path = self._write_mcp_json(
+            {"mcpServers": {"fs": {"command": "npx", "args": ["-y", "fs"]}}})
+        doctor.check_mcp(self._host(path))
+        self.assertIn("WARN", _levels(), f"expected a WARN; got {doctor.results!r}")
+
+    def test_warn_names_the_write_gate_gap(self):
+        path = self._write_mcp_json({"mcpServers": {"fs": {"command": "npx"}}})
+        doctor.check_mcp(self._host(path))
+        warns = [line for lvl, line in doctor.results if lvl == "WARN"]
+        self.assertTrue(any("MCP" in line for line in warns), warns)
+        self.assertTrue(any("write gate" in line for line in warns), warns)
+
+    def test_warn_reports_a_count_never_the_server_names_or_args(self):
+        # #449: doctor output is redaction-sensitive. Reporting only that MCP
+        # tools are CONFIGURED keeps server identity and arguments out of the
+        # transcript entirely.
+        path = self._write_mcp_json({"mcpServers": {
+            "acme-filesystem": {"command": "/opt/acme/mcp-fs",
+                                "args": ["--root", "/srv/private"],
+                                "env": {"ACME_TOKEN": "tok-abc123"}}}})
+        doctor.check_mcp(self._host(path))
+        blob = "\n".join(_lines())
+        for leak in ("acme-filesystem", "/opt/acme/mcp-fs", "/srv/private",
+                     "ACME_TOKEN", "tok-abc123"):
+            self.assertNotIn(leak, blob, f"{leak!r} leaked into doctor output")
+        self.assertIn("1 MCP server", blob)
+
+    def test_two_sources_are_summed(self):
+        a = self._write_mcp_json({"mcpServers": {"one": {}}})
+        b = os.path.join(self.root, "user.json")
+        with open(b, "w", encoding="utf-8", newline="\n") as f:
+            json.dump({"mcpServers": {"two": {}, "three": {}}}, f)
+        doctor.check_mcp(self._host(a, b))
+        warns = [line for lvl, line in doctor.results if lvl == "WARN"]
+        self.assertTrue(any("3 MCP servers" in line for line in warns), warns)
+
+    def test_project_scoped_servers_nested_under_projects_are_counted(self):
+        # ~/.claude.json declares user-scope servers at the top level and
+        # local-scope ones under projects.<path>.mcpServers; both bypass the
+        # write gate, so both have to be seen.
+        b = os.path.join(self.root, "user.json")
+        with open(b, "w", encoding="utf-8", newline="\n") as f:
+            json.dump({"projects": {"/somewhere/else": {
+                "mcpServers": {"nested": {}}}}}, f)
+        doctor.check_mcp(self._host(b))
+        self.assertIn("WARN", _levels(), f"got {doctor.results!r}")
+
+    def test_no_servers_configured_is_ok_not_warn(self):
+        path = self._write_mcp_json({"mcpServers": {}})
+        doctor.check_mcp(self._host(path))
+        self.assertEqual(_levels(), ["OK"], f"got {doctor.results!r}")
+
+    def test_absent_config_file_is_ok_not_warn(self):
+        doctor.check_mcp(self._host(os.path.join(self.root, "nope.json")))
+        self.assertEqual(_levels(), ["OK"], f"got {doctor.results!r}")
+
+    def test_unreadable_config_degrades_to_silence(self):
+        # "A diagnostic that errors is worse than one that is quiet" —
+        # /ca:doctor is the tool of last resort when enforcement misbehaves.
+        path = os.path.join(self.root, ".mcp.json")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("{ not json at all ,,,")
+        doctor.check_mcp(self._host(path))
+        self.assertEqual(doctor.results, [], f"got {doctor.results!r}")
+
+    def test_host_without_the_seam_degrades_to_silence(self):
+        class _Ancient:
+            def project_root(self, payload=None):
+                return "."
+
+        doctor.check_mcp(_Ancient())
+        self.assertEqual(doctor.results, [], f"got {doctor.results!r}")
+
+    def test_host_with_no_sources_degrades_to_silence(self):
+        doctor.check_mcp(_FakeHost([], self.root))
+        self.assertEqual(doctor.results, [], f"got {doctor.results!r}")
+
+    def test_exploding_host_never_raises(self):
+        class _Exploding:
+            def project_root(self, payload=None):
+                raise RuntimeError("boom")
+
+            def mcp_config_sources(self, project_root):
+                raise RuntimeError("boom")
+
+        doctor.check_mcp(_Exploding())
+        self.assertEqual(doctor.results, [])
+
+    def test_oversize_config_degrades_to_silence(self):
+        path = os.path.join(self.root, ".mcp.json")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("x" * (doctor.MCP_CONFIG_MAX_BYTES + 1))
+        doctor.check_mcp(self._host(path))
+        self.assertEqual(doctor.results, [], f"got {doctor.results!r}")
+
+    @unittest.skipIf(sys.version_info < (3, 11), "tomllib is 3.11+")
+    def test_toml_sources_are_counted(self):
+        path = os.path.join(self.root, "config.toml")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write('[mcp_servers.fs]\ncommand = "npx"\n'
+                    '[mcp_servers.db]\ncommand = "uvx"\n')
+        doctor.check_mcp(_FakeHost([(path, "mcp_servers")], self.root))
+        warns = [line for lvl, line in doctor.results if lvl == "WARN"]
+        self.assertTrue(any("2 MCP servers" in line for line in warns),
+                        doctor.results)
+
+    def test_malformed_toml_degrades_to_silence(self):
+        path = os.path.join(self.root, "config.toml")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("[mcp_servers.fs\ncommand = ")
+        doctor.check_mcp(_FakeHost([(path, "mcp_servers")], self.root))
+        self.assertEqual(doctor.results, [], f"got {doctor.results!r}")
+
+
+class MainWiringTest(unittest.TestCase):
+    """The check has to be WIRED into the report, not merely importable."""
+
+    def setUp(self):
+        doctor.results.clear()
+        _hooklib.reset_host()
+
+    def tearDown(self):
+        doctor.results.clear()
+        _hooklib.reset_host()
+
+    def test_main_runs_the_mcp_check(self):
+        seen = []
+        original = doctor.check_mcp
+        doctor.check_mcp = lambda host: seen.append(host)
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                try:
+                    doctor.run(hostapi.Host())
+                except SystemExit:
+                    pass
+        finally:
+            doctor.check_mcp = original
+        self.assertEqual(len(seen), 1, "main() never called check_mcp")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #270.

## The defect (re-verified against current `main`, not the issue's line numbers)

MCP tools escape every write-path guard on every host:

| Claim | Verified where | Status |
|---|---|---|
| Codex `mcp__*` normalizes to `OTHER` (no `TOOL_MAP` entry) | `plugins/ca-codex/hooks/_host.py` `CodexHost.TOOL_MAP` — the comment already says "`mcp__*` and anything else unlisted falls through to OTHER" | **real** |
| `OTHER` matches neither the write hooks nor the exec hook | `plugins/ca-codex/hooks/hooks.json` matchers are `apply_patch\|Write\|Edit` and `Bash` | **real** |
| Claude `mcp__*` misses the `Write`/`Edit` matchers | `plugins/ca/hooks/hooks.json` | **real** |
| `doctor.py` has zero MCP awareness | `grep -i mcp core/pysrc/*.py` hit only `_prunelib.py` / `_prunepolicy.py` (transcript pruning) | **real** |
| Issue cites `plugins/ca-codex/hooks/_host.py:163-169` | those lines are now `normalize_tool` on the base host; the real site is `CodexHost.TOOL_MAP` | **stale line numbers only** — the finding itself holds |
| Issue cites `hooks.json:16-55` | matcher block has moved | **stale line numbers only** |
| security-controls.md clause "~line 510" | it is at line 510 | accurate |

So an MCP filesystem server can write `.codearbiter/CONTEXT.md`, forge a `.markers/` token, or truncate an audit log with no hook firing.

## What this PR does — and deliberately does not do

Per the maintainer ruling (2026-07-25): **the ADR-0010 acceptance stands.** No default-deny on `mcp__*`, no new write matchers, no normalization change. Zero behavior change to any gate.

What changes is *where the acceptance is visible*. This repo is where codeArbiter is **built**; consumers run it in their own projects. The write-gap therefore never manifests here — a build-time check in this repo would never fire — and `security-controls.md` documenting it lives in the wrong repo to help the people carrying the risk. `/ca:doctor` is the surface that lands in a consumer's repo, so that is where the gap is now reported.

### 1. `hostapi.Host.mcp_config_sources(project_root)` — the host seam

Returns `[(config path, servers key), ...]`. Resolved through the existing seam (`hostapi` / `get_host()`), never a hardcoded host path — same pattern as `manifest_relpath()` (#263).

| Host | Sources | Why |
|---|---|---|
| `Host` (Claude) | `<project>/.mcp.json`, `~/.claude.json` — both under key `mcpServers` | `claude mcp add -s user` writes to `~/.claude.json`, so reading only `.mcp.json` would report "none" on the commonest real configuration. Local scope nests the **same** key under `projects.<path>`, which the walk picks up. |
| `CodexHost` | `$CODEX_HOME/config.toml` (default `~/.codex`), key `mcp_servers` | Codex declares `[mcp_servers.<name>]` tables; the base implementation would read a *different* host's config. |
| `PiHost` | `[]` | Pi's MCP configuration surface is not source-verified in this repo. Inheriting the Claude default would report `~/.claude.json` as a Pi install's configuration. Silence is the honest answer; the comment says to fill it in only with a version-pinned source reference. |
| `FailClosedHost` | `[]` | Host identity is unknown. The write guards fail *closed*; the diagnostic fails *quiet*. |

### 2. `doctor.check_mcp(host)`

- **WARN** when servers are configured: MCP-tool writes are outside the write gate, no pre-write/pre-edit guard evaluates them, no gate event is recorded. Points at ADR-0010 as accepted residual risk.
- **OK** when the host's sources are readable and declare none.
- **Nothing at all** when the configuration cannot be read: a host too old for the seam, a host with no sources, a seam that raises, an unparseable file, a file over `MCP_CONFIG_MAX_BYTES` (16 MB — `~/.claude.json` also carries session history), or a TOML source on a pre-3.11 interpreter. `/ca:doctor` is the tool of last resort when enforcement misbehaves, so a diagnostic that errors is worse than one that is quiet.
- **Count only.** No server name, command, argument, or environment value is ever read out (#449, where the redactor already degrades doctor output on a mere trigger word in a project path). The exit code is unaffected — only `FAIL` sets exit 1.

### 3. `security-controls.md`

The MCP clause is ratified as **accepted** rather than "near-term hardening", and its reopen condition is now four concrete consumer-side triggers instead of "if the threat model expands to untrusted agents". Full text in the diff; summary: (1) a host gains a matcher that can route `mcp__*` to `pre-write.py`; (2) a consumer reports an MCP server writing under `.codearbiter/` in a cooperative-orchestrator repo — that falsifies the premise the acceptance rests on; (3) codeArbiter ships/bundles/recommends an MCP server itself; (4) `doctor.check_mcp` stops being able to report the gap on a supported host — visibility is the condition, so losing it voids the acceptance.

## TDD — verbatim red

`plugins/ca/hooks/tests/test_mcp_visibility.py` written first, 23 tests, all red for the right reason (the seam and the check do not exist):

```
EEEEEEEEEEEEEEEEEEEEEEE
======================================================================
ERROR: test_absent_config_file_is_ok_not_warn (test_mcp_visibility.CheckMcpTest.test_absent_config_file_is_ok_not_warn)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_mcp_visibility.py", line 240, in test_absent_config_file_is_ok_not_warn
    doctor.check_mcp(self._host(os.path.join(self.root, "nope.json")))
    ^^^^^^^^^^^^^^^^
AttributeError: module 'doctor' has no attribute 'check_mcp'. Did you mean: 'check_repo'?

======================================================================
ERROR: test_claude_default_declares_the_project_scoped_mcp_json (test_mcp_visibility.HostSeamTest.test_claude_default_declares_the_project_scoped_mcp_json)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_mcp_visibility.py", line 92, in test_claude_default_declares_the_project_scoped_mcp_json
    sources = hostapi.Host().mcp_config_sources(os.path.join("X", "proj"))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Host' object has no attribute 'mcp_config_sources'

======================================================================
ERROR: test_codex_reads_its_own_config_toml_not_claudes (test_mcp_visibility.CodexHostSeamTest.test_codex_reads_its_own_config_toml_not_claudes)
----------------------------------------------------------------------
AttributeError: 'CodexHost' object has no attribute 'mcp_config_sources'

======================================================================
ERROR: test_pi_declares_no_sources (test_mcp_visibility.PiHostSeamTest.test_pi_declares_no_sources)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_mcp_visibility.py", line 164, in test_pi_declares_no_sources
    self.assertEqual(self.host.mcp_config_sources(os.getcwd()), [])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PiHost' object has no attribute 'mcp_config_sources'

======================================================================
ERROR: test_main_runs_the_mcp_check (test_mcp_visibility.MainWiringTest.test_main_runs_the_mcp_check)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\plugins\ca\hooks\tests\test_mcp_visibility.py", line 313, in test_main_runs_the_mcp_check
    original = doctor.check_mcp
               ^^^^^^^^^^^^^^^^
AttributeError: module 'doctor' has no attribute 'check_mcp'. Did you mean: 'check_repo'?

----------------------------------------------------------------------
Ran 23 tests in 0.021s

FAILED (errors=23)
```

(Trimmed to five representative blocks — all 23 are the same two `AttributeError`s. Absolute paths shortened to `...`.)

## Suites

| Suite | Before | After |
|---|---|---|
| `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` | 1125 OK | **1148 OK** (+23 new) |
| `cd .github/scripts && python -m unittest discover -s . -p "test_*.py"` | 1179 run, 2 failures + 2 errors, 5 skipped | 1179 run, 2 failures + 2 errors, 5 skipped — **unchanged** |
| `python tools/sync-core.py --check` | — | OK (48 core files x 3 plugins, byte-identical) |
| `python tools/build-surface.py --check` | — | OK (claude, codex, pi in sync) |
| `python tools/build-host-packages.py --check --release-guard-base <merge-base>` | — | OK — `0.1.16 -> 0.1.17` advanced together |
| `git diff --check origin/main HEAD` | — | exit 0 |

The four `.github/scripts` failures are **pre-existing and environmental**, all in `test_pi_benchmark.py`: `RuntimeError: Pi benchmark requires the installed pinned esbuild` (no `node_modules` in this worktree). Nothing in this PR touches `pi_benchmark.py` — see the diff stat.

## Live smoke test (real `doctor.py` subprocess, isolated temp `HOME` + project)

```
A. no MCP configuration anywhere                  rc 0
   OK    no MCP servers configured for this host - nothing bypasses the write gate through an MCP tool

B. two MCP servers in <project>/.mcp.json         rc 0
   WARN  2 MCP servers configured for this host - file writes made through an MCP tool
         (mcp__<server>__<tool>) bypass the codeArbiter write gate: no pre-write/pre-edit guard
         evaluates them and no gate event is recorded. Accepted residual risk under ADR-0010 -
         keep protected writes on this host's native write tools, or remove MCP servers that
         can write files.

C. + one local-scope server under ~/.claude.json  rc 0
   WARN  3 MCP servers configured for this host - ...

D. both config files unreadable                   rc 0
   (no MCP line at all)
```

Fixture B's server was named `filesystem` with `args ["-y","@acme/fs","/srv/private"]` and `env {"ACME_TOKEN":"tok-abc123"}` — none of it appears anywhere in doctor's output, which is exactly the assertion in `test_warn_reports_a_count_never_the_server_names_or_args`.

## Housekeeping

- `core/pysrc/` edited canonically; re-vendored with `tools/sync-core.py`; `--check` clean. No vendored copy hand-edited. `_host.py` is per-plugin (excluded from sync) and each was edited in its own plugin.
- Diff reaches `plugins/ca-pi/**`, so **ca-pi 0.1.16 -> 0.1.17**: both `package.json` files bumped (root regenerated via `tools/build-host-packages.py`), exact `## [0.1.17] - 2026-07-25` CHANGELOG heading added, release guard verified against the merge base.
- `plugins/ca` (2.9.1) and `plugins/ca-codex` (0.3.0) are **unpublished** (`v2.9.1` / `ca-codex-v0.3.0` tags do not exist), so their version-bump gates pass without a bump.
- `.codearbiter/security-controls.md` patched in **binary**. Its known mixed endings are preserved: the 3 replaced lines were CRLF (330 -> 327 CRLF); every **added** line is LF, because `git diff --check` flags an added CR as trailing whitespace and the house rule requires `git diff --check origin/main HEAD` to exit 0. No pre-existing line's ending was flipped in either direction. **Flagging this explicitly** since the lane brief asked for the CRLF count to be *unchanged* — the two rules cannot both hold when a CRLF line is replaced.
- H-10b fired on one staged line (`"env": {"ACME_TOKEN": "tok-abc123"}` in the new test). Reviewed and recorded through the sanctioned producer `security-pass.py` (ADR-0010): a synthetic non-functional sentinel inside a `TemporaryDirectory` fixture whose entire purpose is the `assertNotIn` proving doctor never echoes MCP configuration values. No real credential, no store, nothing outside the temp dir.
- No ADR authored (H-11). None is needed: this ratifies ADR-0010's existing acceptance in `security-controls.md` rather than deciding anything new. If the maintainer wants the ratification recorded as a decision record, the text to lift is the "Ratified 2026-07-25" paragraph in the `security-controls.md` diff.
