### PR TITLE
docs(adr): ADR-0020, ADR-0021, ADR-0022 from the 2026-07-25 sprint rulings

### DIFF
--- a/.codearbiter/decisions/0020-hook-input-fails-open-on-shape-as-well-as-syntax.md
+++ b/.codearbiter/decisions/0020-hook-input-fails-open-on-shape-as-well-as-syntax.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+date: 2026-07-25
+title: Hook input fails open on malformed shape as well as malformed syntax
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: core/pysrc/_hooklib.py, core/pysrc/pre-bash.py, core/pysrc/pre-write.py, core/pysrc/pre-edit.py, core/pysrc/pre-read.py, core/pysrc/post-write-edit.py
+---
+
+# ADR-0020 — Hook input fails open on malformed shape as well as malformed syntax
+
+## Status
+Accepted — explicitly decided by SUaDtL@users.noreply.github.com on 2026-07-25.
+
+## Context
+`_hooklib.read_input()` already carries a documented, deliberate exception to the fail-loud
+principle: a malformed stdin payload must NOT brick the session by blocking every subsequent tool
+call, so a parse error warns and returns `{}`.
+
+That exception covers malformed **syntax** only. A payload that is valid JSON but not an object —
+`[]`, `3`, `"str"`, `true`, `null` — parses cleanly and is returned as a non-dict. Downstream,
+`tool_input(data)` evaluates `(data or {}).get(...)`, so *falsy* non-dicts (`[]`, `null`) are
+accidentally safe via the `or {}`, while *truthy* ones (`3`, `"str"`, `true`) raise AttributeError
+out of the guard.
+
+The decisive fact is that **the hook envelope is host-produced, not model-produced.** It arrives on
+stdin from Claude Code, Codex, or Pi. A model can place hostile content *inside* `tool_input`
+fields, but cannot make the top-level object a list. A non-dict envelope therefore means host
+misbehaviour or version drift — a compatibility event, not an attack.
+
+## Decision
+Treat a malformed **shape** exactly as the existing exception treats malformed **syntax**: normalize
+any non-dict payload to `{}` at the single `read_input()` chokepoint, and widen the docstring to say
+so. Unreadable input is unreadable, whether the failure is syntactic or structural.
+
+The distinction between the two carries no security content here. Both mean *the guard cannot read
+this call*, which is the exact situation the documented exception already ruled on.
+
+## Alternatives considered
+- **Fail closed on a non-dict envelope** — rejected. It buys no protection against a threat that
+  cannot reach this surface (the envelope is not model-controlled), while creating precisely the
+  failure the existing exception exists to prevent: a host payload change would brick every tool
+  call until codeArbiter shipped a fix.
+- **Split the rule by position — router fails closed, guard fails open** — considered and not taken
+  as doctrine. It is more precise, but it makes every future hook author decide which side their
+  code is on, and the asymmetry is better recorded as a note than as a rule (see below).
+
+## Consequences
+One rule, stated once, at one chokepoint: unreadable input yields `{}` and a warning. Every host —
+including future ones — inherits it without a per-host decision.
+
+**A deliberate asymmetry is recorded rather than removed.** The ca-codex *adapter*
+(`plugins/ca-codex/hooks/pre-tool-adapter.py`) fails CLOSED on a non-object payload, and that stays.
+The adapter is a **router**: it decides which guard to dispatch to, so a payload it cannot route is
+one it cannot prove safe. A guard that cannot parse its own input is a different case. That
+difference is intentional, not drift, and this ADR is the place it is written down. The adapter's
+refusal is additionally dormancy-aware — in a repository that never opted into codeArbiter it passes
+through untouched — so failing closed there cannot break unrelated projects.
+
+## Risks
+Normalizing a non-dict envelope to `{}` means a guard proceeds with no `tool_input` rather than
+refusing, so a host that silently changed its envelope shape would degrade to unenforced calls with
+only a warning to show for it. That is the accepted cost of the existing exception, now applied
+consistently.
+
+This decision is proven wrong if a host is found where the envelope shape is model-influenceable, or
+if the warning proves too quiet to surface a real host drift — in which case the remedy is to make
+the degradation louder, not to fail closed and brick the session.

--- a/.codearbiter/decisions/0021-per-call-python-bridge-spawn-is-the-cross-host-cost-model.md
+++ b/.codearbiter/decisions/0021-per-call-python-bridge-spawn-is-the-cross-host-cost-model.md
@@ -1,0 +1,57 @@
+---
+status: accepted
+date: 2026-07-25
+title: Per-call Python bridge spawn is the cross-host cost model
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: plugins/ca-pi/tools/src/bridge.ts, plugins/ca-pi/hooks/pi-bridge.py
+---
+
+# ADR-0021 — Per-call Python bridge spawn is the cross-host cost model
+
+## Status
+Accepted — explicitly decided by SUaDtL@users.noreply.github.com on 2026-07-25.
+
+## Context
+Every gated Pi tool call spawns a fresh Python bridge process. Tribunal finding performance-001
+raised whether that should become a persistent bridge worker, and downgraded itself from high on a
+decisive observation: **Claude Code pays the same per-call hook-spawn cost.** The question is
+therefore not whether spawning is free — it is whether Pi should diverge from the cost model every
+other host already accepts.
+
+`.github/scripts/pi_benchmark.py` measures the cost (`medianMs`, `p95Ms`) and is wired into CI path
+filters, so the number is observable rather than anecdotal.
+
+## Decision
+Accept the per-call spawn as the cross-host standard cost model. Do not build a persistent bridge
+worker.
+
+The per-call process is **stateless by construction**: it holds no lifetime, carries nothing between
+gate decisions, and dies with the decision it made. That property is the point, not a side effect.
+
+## Alternatives considered
+- **Persistent bridge worker (daemon)** — rejected. It places a long-lived process holding
+  enforcement authority in front of every gated tool call, requiring its own authentication, health
+  checking, restart, and staleness handling. A wedged worker degrades every subsequent gated call
+  rather than one.
+- **Reduce spawn cost instead** — not needed now, and explicitly the preferred remedy if latency
+  ever becomes a real problem (see reopen condition).
+
+## Consequences
+One code path, no daemon lifecycle, and no state that can be poisoned between calls. Pi's cost
+profile matches Claude Code's, so "is this slow?" is answered the same way on every host.
+
+The cost is linear in gated tool calls and is paid on every one. That is accepted.
+
+## Risks
+The rejection rests on a judgement about where this codebase actually breaks. The 2026-07-25 sweep
+produced three independent defects from long-lived or ambient state — a statusline pinned into a
+worktree that was then pruned, a broker listener that could outlive its child, and a token bound to a
+broker rather than to a process. A daemon in the enforcement path would add exactly that class of
+surface.
+
+This decision is proven wrong if the measured `p95Ms` becomes a real impediment to normal work. The
+remedy in that case is to make the bridge **cheaper to start** — trimming imports, deferring work
+off the hot path — not to keep one alive. Adopting a persistent worker would require superseding this
+ADR and confronting the daemon-lifetime surface deliberately, rather than arriving at it by
+increments.

--- a/.codearbiter/decisions/0022-auto-route-unambiguous-safe-intent-into-its-command.md
+++ b/.codearbiter/decisions/0022-auto-route-unambiguous-safe-intent-into-its-command.md
@@ -1,0 +1,83 @@
+---
+status: accepted
+date: 2026-07-25
+title: Auto-route unambiguous, non-destructive intent into its command
+decided-by: SUaDtL@users.noreply.github.com
+supersedes: none
+governs: core/surface/includes/redirect.md, core/surface/includes/routing-table.md, plugins/ca/ORCHESTRATOR.md, plugins/ca-codex/ORCHESTRATOR.md, plugins/ca-pi/ORCHESTRATOR.md
+---
+
+# ADR-0022 — Auto-route unambiguous, non-destructive intent into its command
+
+## Status
+Accepted — explicitly decided by SUaDtL@users.noreply.github.com on 2026-07-25. Amends ORCHESTRATOR
+§6; the §6 invariant itself is preserved, not relaxed (see Decision).
+
+## Context
+§6 read: *"All intent flows through a slash command … The user picks; nothing routes without their
+command."* In practice the orchestrator would infer the intent, name the exact command, and then ask
+the user to type it back — a redirect of the form *"for that action, run `/ca:fix <exactly what you
+just asked for>`"*.
+
+That is ceremony, not governance. Naming the command demonstrates the routing was already
+understood; requiring it to be retyped adds friction without adding a decision.
+
+The friction also produced harm rather than safety. Issue #308 records a post-merge cleanup where no
+command owned the operation and the redirect loop produced **two incorrect routes — first to
+`/ca:chore`, then to `/ca:override`.** An override for routine repository hygiene is exactly what
+overrides exist to be rare for: a rule intended to ensure deliberate routing instead manufactured an
+unjustified bypass.
+
+## Decision
+Route on understood intent, in three tiers:
+
+1. **Unambiguous and non-destructive** — route directly into the command. Every gate runs exactly as
+   if the user had typed it.
+2. **Probable** — ask once, naming the command (*"did you mean `/ca:fix`?"*). One approval, then
+   route. The user approves rather than retypes.
+3. **Genuinely unclear** — present the candidate commands and let the user pick.
+
+**The invariant §6 actually protects is preserved by construction.** §6 exists so that nothing
+happens outside a gated command path — not so that the user does typing. Auto-routing *into* the
+command satisfies it completely. What remains prohibited, and is the line this ADR draws, is the
+orchestrator performing the work itself instead of routing: it routes the command, it does not
+improvise the operation.
+
+**Clarity and risk are separate axes.** Tier 1 requires BOTH unambiguous intent AND a
+non-destructive command. Anything irreversible or gate-bypassing — `/ca:override`, merge to the
+default branch, branch or worktree deletion, release and tag publication, `/ca:dev` entry — drops to
+tier 2 and asks, even when the intent is obvious. There the confirmation is the gate, not friction.
+
+## Alternatives considered
+- **Keep §6 as written** — rejected. The dead end it produced was caused by no command owning the
+  operation, and the redirect loop converted that gap into a wrong override rather than preventing
+  one.
+- **Auto-route anything unambiguous, destructive included** — rejected. The commands' own gates do
+  stop and ask in most cases, but "clear intent" and "safe to perform without confirmation" are
+  different properties, and conflating them puts the irreversible cases on the wrong side.
+- **Declare the destructive set per-command in the routing table** — considered and deferred. It is
+  more auditable and prevents a new command being auto-routed by omission; recorded here as the
+  preferred refinement if the hardcoded set proves hard to keep current.
+
+## Consequences
+The redirect stops asking for a command it has already named. A user saying "go fix that" or "let's
+run a checkpoint" reaches the routed skill with its gates intact.
+
+Issue #308's other half ships alongside: a sanctioned owner for the merged-branch transition, which
+proves the branch is an ancestor of the *fetched* default, classifies dirty artifacts as unique,
+redundant, or superseded, and never discards unique or ambiguous data without per-item confirmation.
+Closing that gap removes the cause the redirect loop was reacting to.
+
+## Risks
+"Unambiguous" is a judgement the orchestrator makes about its own routing, so a mis-classification
+routes a command the user did not intend. Two things bound it: tier 1 excludes everything
+irreversible, and the routed command's own gates still run — a wrongly routed `/ca:fix` stops at
+`tdd` Phase 1 exactly as a typed one would.
+
+The destructive set is enumerated in the orchestrator rather than declared per command, so a newly
+added destructive command could be auto-routed by omission. That is the known weakness, and the
+routing-table variant above is the fix if it bites.
+
+This decision is proven wrong if auto-routing produces a command the user did not want with
+consequences a gate did not catch, or if the destructive enumeration is found stale after a new
+command ships.

--- a/.codearbiter/decisions/decision-log.md
+++ b/.codearbiter/decisions/decision-log.md
@@ -784,3 +784,119 @@ Accepted `0016-bounded-pi-child-credential-projection.md` and the adversarial fi
 child can read its own projected credential and defeat exact-value result matching by encoding it.
 
 ---
+
+## DECISION-0025 — ADR-0020 — Hook input fails open on malformed shape as well as malformed syntax
+
+**Date:** 2026-07-25
+**Status:** accepted
+**Supersedes:** none
+**Decided by:** SUaDtL@users.noreply.github.com ("A — extend fail-open")
+**Decision category:** hook contract / fail direction
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** `_hooklib.read_input()` documents a deliberate fail-OPEN exception for malformed stdin, on the grounds that a bad payload must not brick the session.
+- **Scaffold position:** That exception covers malformed syntax only. Valid-but-non-object JSON parses cleanly and returns a non-dict, and truthy non-dicts then raise AttributeError out of every guard, while falsy ones survive only by accident of `(data or {})`.
+- **Status type:** open-decision-closure
+
+### Decision
+Treat malformed shape exactly as malformed syntax: normalize any non-dict payload to `{}` at the
+single `read_input()` chokepoint. Unreadable input is unreadable regardless of whether the failure is
+syntactic or structural.
+
+### SMARTS rationale
+Securable is the lens that decides it, and it decides for fail-open: the hook envelope is
+HOST-produced, not model-produced. A model can place hostile content inside `tool_input` fields but
+cannot make the top-level object a list, so failing closed protects against a threat that cannot
+reach this surface. Reliable and Available are Strong for fail-open and Weak for fail-closed — a host
+payload change would otherwise brick every tool call until codeArbiter shipped a fix, which is the
+exact failure the documented exception exists to prevent. Maintainable favours one rule at one
+chokepoint over a per-position rule. Conflict hierarchy resolves at Level 2 (correctness), because
+Level 1 has no genuine stake.
+
+### Implementation implication
+Normalize in `core/pysrc/_hooklib.py` and widen its docstring; re-vendor via `tools/sync-core.py`.
+Record that the ca-codex ADAPTER's fail-CLOSED behaviour on non-object payloads is a deliberate
+asymmetry and stays: a router that cannot route cannot prove the call safe, unlike a guard that
+cannot parse. That refusal is dormancy-aware, so it cannot affect repositories that never opted in.
+
+---
+
+## DECISION-0026 — ADR-0021 — Per-call Python bridge spawn is the cross-host cost model
+
+**Date:** 2026-07-25
+**Status:** accepted
+**Supersedes:** none
+**Decided by:** SUaDtL@users.noreply.github.com ("A — accept per-call spawn as the cost model")
+**Decision category:** performance / enforcement architecture
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** Tribunal finding performance-001 proposes a persistent bridge worker to remove the per-gated-call Python spawn.
+- **Scaffold position:** Claude Code pays the same per-call hook-spawn cost, so Pi is not anomalous; the finding downgraded itself on that basis.
+- **Status type:** open-decision-closure
+
+### Decision
+Accept the per-call spawn as the cross-host standard. Do not build a persistent worker. The per-call
+process is stateless by construction — no lifetime, nothing carried between gate decisions.
+
+### SMARTS rationale
+Securable and Reliable both favour accepting. A persistent worker is a long-lived process holding
+enforcement authority in front of every gated call, requiring its own auth, health check, restart and
+staleness handling; a wedged worker degrades every subsequent call rather than one. The 2026-07-25
+sweep produced three independent defects from long-lived or ambient state (a statusline pinned into a
+pruned worktree, a broker listener that could outlive its child, a token bound to a broker rather
+than a process), which is direct evidence about where this codebase actually breaks. Available is
+the only lens favouring the daemon, and the cost it removes is one every other host already pays.
+
+### Implementation implication
+Record the acceptance; no code change. Keep `.github/scripts/pi_benchmark.py` as the observable
+guard. If measured p95 later becomes a real impediment, the remedy is to make the bridge cheaper to
+start, not to keep one alive — adopting a daemon would require superseding ADR-0021 deliberately.
+
+---
+
+## DECISION-0027 — ADR-0022 — Auto-route unambiguous, non-destructive intent into its command
+
+**Date:** 2026-07-25
+**Status:** accepted
+**Supersedes:** none
+**Decided by:** SUaDtL@users.noreply.github.com ("auto route obvious … it SHOULD actually route the command though. not free ball it"; destructive commands always confirm)
+**Decision category:** orchestration / user interaction contract
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** ORCHESTRATOR §6 states that all intent flows through a slash command and "nothing routes without their command", so the orchestrator names the command and asks the user to type it.
+- **Scaffold position:** Naming the command proves the routing was already understood, so requiring it to be retyped adds friction without adding a decision — and in issue #308's observed flow that friction produced two incorrect routes, to `/ca:chore` and then to `/ca:override`, for routine post-merge hygiene.
+- **Status type:** same-level-conflict-resolution
+
+### Decision
+Route on understood intent in three tiers: auto-route when intent is unambiguous AND the command is
+non-destructive; ask once naming the command when intent is probable; present candidates when it is
+genuinely unclear. The orchestrator routes the command and never performs the operation itself.
+Irreversible or gate-bypassing commands always confirm, however clear the intent.
+
+### SMARTS rationale
+The maintainer's framing corrected the analysis: §6's invariant is that nothing happens outside a
+gated command path, NOT that the user does typing — so auto-routing INTO the command preserves
+Securable entirely, and what §6 actually prohibits is the orchestrator improvising the work. Given
+that, Available and Reliable both favour routing, and the evidence is that the friction produced an
+unjustified override rather than preventing one. Maintainable is the cost: "unambiguous" is a
+judgement, and the destructive set is enumerated rather than declared per command. Conflict hierarchy
+Level 3 (maintainability/reviewability) governs, since Level 1 is untouched.
+
+### Implementation implication
+Amend §6 in `plugins/ca/ORCHESTRATOR.md` and its sibling host copies via `core/surface`, and rework
+`includes/redirect.md` into the three tiers. Enumerate the always-confirm set (`/ca:override`, merge
+to default, branch and worktree deletion, release and tag publication, `/ca:dev` entry). Ship #308's
+other half — a sanctioned owner for the merged-branch transition with ancestry proof against the
+fetched default, artifact classification, and per-item confirmation before discarding anything unique
+or ambiguous. Prefer moving the destructive declaration into the routing table if the enumerated set
+proves hard to keep current.
+
+### Resolves same-level conflict between (when applicable)
+ORCHESTRATOR §6's command-enforcement directive and issue #308's observed post-merge cleanup dead
+end, in which no command owned the operation and the redirect loop produced an unjustified
+`/ca:override`.
+
+---


### PR DESCRIPTION
Three maintainer decisions from today's sprint, recorded together so the governance record catches up with the rulings in one place. Each carries its `DECISION-00NN` log entry. Numbered 0020–0022 under the stem-identity rule that landed in #466.

## ADR-0020 — hook input fails open on shape as well as syntax

`_hooklib.read_input()` already documented a deliberate fail-**open** exception: a malformed payload must not brick the session. That covered malformed *syntax* only. Valid-but-non-object JSON (`[]`, `3`, `"str"`, `true`) parses cleanly and returns a non-dict — and truthy non-dicts then raise `AttributeError` out of every guard, while falsy ones survive only by accident of `(data or {})`.

The decisive fact: **the hook envelope is host-produced, not model-produced.** A model can place hostile content *inside* `tool_input`, but cannot make the top-level object a list. So failing closed would guard a surface no model can reach, while creating exactly the session-bricking the exception exists to prevent.

Records the deliberate asymmetry rather than removing it: the ca-codex **adapter** fails **closed** on a non-object payload and stays that way. A *router* that cannot route cannot prove the call safe — unlike a *guard* that cannot parse. That refusal is dormancy-aware, so it cannot affect repositories that never opted in.

## ADR-0021 — per-call Python bridge spawn is the cross-host cost model

Tribunal `performance-001` proposed a persistent bridge worker and downgraded itself on the observation that **Claude Code pays the same per-call hook-spawn cost.**

Accepted as-is. The per-call process is **stateless by construction** — no lifetime, nothing carried between gate decisions. The rejection is grounded in this sprint's own evidence: three independent defects came from long-lived or ambient state (a statusline pinned into a pruned worktree, a broker listener that could outlive its child, a token bound to a broker rather than a process). A daemon in the enforcement path adds precisely that class.

Reopen condition is concrete: if measured `p95Ms` becomes a real impediment, make the bridge **cheaper to start** — not keep one alive.

## ADR-0022 — auto-route unambiguous, non-destructive intent (amends §6)

§6 read *"nothing routes without their command"*, so the orchestrator would name the exact command and then ask the user to type it back.

**The maintainer's framing corrected the analysis, and the ADR records it:** §6's invariant is that nothing happens outside a *gated command path* — not that the user does typing. Auto-routing **into** the command preserves it entirely; what §6 actually prohibits is the orchestrator improvising the operation instead of routing it.

Three tiers: unambiguous + non-destructive routes directly; probable asks once naming the command; genuinely unclear presents candidates. **Clarity and risk are separate axes** — `/ca:override`, merge to default, branch/worktree deletion, release and tag publication, and `/ca:dev` entry always confirm, however obvious the intent. There the confirmation *is* the gate.

Motivating evidence from #308: the redirect loop produced **two incorrect routes — `/ca:chore`, then `/ca:override`** — for routine post-merge hygiene. A rule meant to ensure deliberate routing manufactured an unjustified bypass.

## Verification

| Check | Result |
|---|---|
| `.github/scripts` full suite | **1221 tests, OK** (skipped=5) |
| `check_adr_identity.py` | stems unique; every `supersedes:` names exactly one decision |
| `test_adr_identity` | 20 tests, OK |
| `git diff --check origin/main HEAD` | exit 0 |

## Follow-on work these authorize

ADR-0020 and ADR-0022 are records, not implementations. The code for both is queued: the `read_input` normalization, and §6's rework plus #308's sanctioned post-merge cleanup owner (ancestry proof against the *fetched* default, artifact classification, per-item confirmation before discarding anything unique). ADR-0021 needs no code.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
