### PR TITLE
fix(hooks): normalize a non-object hook payload at read_input (ADR-0020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ predate the plugin rewrite and are grouped by date.
 
 ### Fixed
 
+- A hook payload that is valid JSON but not an object (`[]`, `3`, `"str"`,
+  `true`, `null`) is normalized to an empty payload at `read_input()` rather
+  than handed to the guards as a non-dict. Downstream, `tool_input()` evaluates
+  `(data or {}).get(...)`, so the falsy shapes were only accidentally safe and
+  the truthy ones raised `AttributeError` out of the guard. The hook envelope is
+  host-produced, not model-produced, so an unreadable shape is the same
+  compatibility event as unreadable syntax and now takes the same documented
+  warn-and-proceed path (ADR-0020). The ca-codex adapter still fails closed on
+  the same payload: it is a router, not a guard, and that asymmetry is now
+  recorded in both the ADR and the adapter.
 - Prune dry-run records, audit logs, CLI, footer, and cold-cache metrics now separate
   model-visible context savings from file-only sidecar cleanup; sidecar bytes
   no longer inflate the context-benefit decision or arm the cold-cache nudge.

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -613,17 +613,37 @@ def arbiter_active(root):
 def read_input():
     """Parse the hook JSON from stdin.
 
-    Deliberately fail-open on parse error: a malformed stdin input must NOT
-    brick the session by blocking every subsequent tool call. This is an
+    Deliberately fail-open on unreadable input: a malformed stdin payload must
+    NOT brick the session by blocking every subsequent tool call. This is an
     explicit, documented exception to the fail-loud principle — the correct
     behaviour here is warn + allow, not warn + block.
+
+    "Unreadable" covers a malformed SHAPE as well as malformed syntax
+    (ADR-0020). A payload that is valid JSON but not an object — `[]`, `3`,
+    `"str"`, `true`, `null` — parses cleanly and never reaches the except
+    branch, so it used to be handed downstream as a non-dict: `tool_input()`
+    evaluates `(data or {}).get(...)`, which makes the falsy ones accidentally
+    safe and raises AttributeError out of the guard on the truthy ones. Both
+    are normalized to `{}` here instead, at the one chokepoint that decides it.
+
+    The distinction between the two failures carries no security content: the
+    hook envelope is host-produced (Claude Code, Codex, Pi), not
+    model-produced. A model can place hostile content INSIDE `tool_input`, but
+    cannot make the top-level object a list — so a non-dict envelope means host
+    misbehaviour or version drift, the same compatibility event the parse-error
+    branch already rules on.
     """
     try:
         raw = sys.stdin.read()
-        return json.loads(raw) if raw.strip() else {}
+        data = json.loads(raw) if raw.strip() else {}
     except Exception as e:  # noqa: BLE001 — any malformed input
         warn(f"hook input unparseable ({e}); proceeding without enforcement")
         return {}
+    if not isinstance(data, dict):
+        warn(f"hook input is a JSON {type(data).__name__}, not an object; "
+             "proceeding without enforcement")
+        return {}
+    return data
 
 
 def tool_input(data):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 ## [0.3.0] — 2026-07-12 — Shared-state concurrency hardening
 
 ### Fixed
+- The guard layer now normalizes a non-object hook payload to an empty payload
+  at `read_input()`, so the adapter's shape check below is no longer the only
+  thing standing between a valid-JSON non-object and an `AttributeError` out of
+  a guard. The adapter's own refusal is unchanged and deliberate: it is a
+  router, so a payload it cannot route is one it cannot prove safe, while a
+  guard that cannot parse its own input takes the documented warn-and-proceed
+  path. ADR-0020 records the asymmetry.
 - The PreToolUse adapter validates the hook payload's shape before routing it.
   A valid-JSON but non-object payload (`null`, an array, a string, a number, a
   bool) used to raise `AttributeError` out of the adapter — exit 1, a traceback,

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -613,17 +613,37 @@ def arbiter_active(root):
 def read_input():
     """Parse the hook JSON from stdin.
 
-    Deliberately fail-open on parse error: a malformed stdin input must NOT
-    brick the session by blocking every subsequent tool call. This is an
+    Deliberately fail-open on unreadable input: a malformed stdin payload must
+    NOT brick the session by blocking every subsequent tool call. This is an
     explicit, documented exception to the fail-loud principle — the correct
     behaviour here is warn + allow, not warn + block.
+
+    "Unreadable" covers a malformed SHAPE as well as malformed syntax
+    (ADR-0020). A payload that is valid JSON but not an object — `[]`, `3`,
+    `"str"`, `true`, `null` — parses cleanly and never reaches the except
+    branch, so it used to be handed downstream as a non-dict: `tool_input()`
+    evaluates `(data or {}).get(...)`, which makes the falsy ones accidentally
+    safe and raises AttributeError out of the guard on the truthy ones. Both
+    are normalized to `{}` here instead, at the one chokepoint that decides it.
+
+    The distinction between the two failures carries no security content: the
+    hook envelope is host-produced (Claude Code, Codex, Pi), not
+    model-produced. A model can place hostile content INSIDE `tool_input`, but
+    cannot make the top-level object a list — so a non-dict envelope means host
+    misbehaviour or version drift, the same compatibility event the parse-error
+    branch already rules on.
     """
     try:
         raw = sys.stdin.read()
-        return json.loads(raw) if raw.strip() else {}
+        data = json.loads(raw) if raw.strip() else {}
     except Exception as e:  # noqa: BLE001 — any malformed input
         warn(f"hook input unparseable ({e}); proceeding without enforcement")
         return {}
+    if not isinstance(data, dict):
+        warn(f"hook input is a JSON {type(data).__name__}, not an object; "
+             "proceeding without enforcement")
+        return {}
+    return data
 
 
 def tool_input(data):

--- a/plugins/ca-codex/hooks/pre-tool-adapter.py
+++ b/plugins/ca-codex/hooks/pre-tool-adapter.py
@@ -30,12 +30,21 @@ file:
     unreadable payload — so an unreadable `apply_patch` skipped the write
     gate entirely.
   * Dispatching anyway launders the failure into a silent allow.
-    `_hooklib.read_input()` fails OPEN on an unparseable payload by explicit,
-    documented design (warn + proceed without enforcement). That exception is
-    correct at the GUARD layer, which has already been handed a payload the
-    host produced. Feeding it input the adapter itself could not validate
-    would convert "codeArbiter could not read this" into "codeArbiter allowed
-    this", which is exactly the outcome the guards exist to prevent.
+    `_hooklib.read_input()` fails OPEN on an unreadable payload by explicit,
+    documented design (warn + proceed without enforcement), for a malformed
+    SHAPE as well as malformed syntax. That exception is correct at the GUARD
+    layer, which has already been handed a payload the host produced. Feeding
+    it input the adapter itself could not validate would convert "codeArbiter
+    could not read this" into "codeArbiter allowed this", which is exactly the
+    outcome the guards exist to prevent.
+
+    The two directions are a deliberate asymmetry, not drift, and ADR-0020
+    ("Hook input fails open on malformed shape as well as malformed syntax")
+    is where it is written down: this file is a ROUTER, so a payload it cannot
+    route is one it cannot prove safe; a guard that cannot parse its own input
+    is a different case. The refusal here is additionally dormancy-aware — in a
+    repository that never opted into codeArbiter it passes through untouched —
+    so failing closed cannot break unrelated projects.
 
 The emitted reason is a short deterministic diagnostic. It never carries the
 payload text or an exception rendering: it is user-facing in Codex's UI, and

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.20] - 2026-07-25
+
+### Fixed
+
+- A hook payload that is valid JSON but not an object (`[]`, `3`, `"str"`,
+  `true`, `null`) is normalized to an empty payload at `read_input()` instead of
+  being handed to the guards as a non-dict, where the truthy ones raised
+  `AttributeError` out of the guard and the falsy ones were only accidentally
+  safe. The envelope is host-produced, not model-produced, so an unreadable
+  shape is the same compatibility event as unreadable syntax and takes the same
+  documented warn-and-proceed path (ADR-0020).
+
 ## [0.1.18] - 2026-07-25
 
 ### Added

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -613,17 +613,37 @@ def arbiter_active(root):
 def read_input():
     """Parse the hook JSON from stdin.
 
-    Deliberately fail-open on parse error: a malformed stdin input must NOT
-    brick the session by blocking every subsequent tool call. This is an
+    Deliberately fail-open on unreadable input: a malformed stdin payload must
+    NOT brick the session by blocking every subsequent tool call. This is an
     explicit, documented exception to the fail-loud principle — the correct
     behaviour here is warn + allow, not warn + block.
+
+    "Unreadable" covers a malformed SHAPE as well as malformed syntax
+    (ADR-0020). A payload that is valid JSON but not an object — `[]`, `3`,
+    `"str"`, `true`, `null` — parses cleanly and never reaches the except
+    branch, so it used to be handed downstream as a non-dict: `tool_input()`
+    evaluates `(data or {}).get(...)`, which makes the falsy ones accidentally
+    safe and raises AttributeError out of the guard on the truthy ones. Both
+    are normalized to `{}` here instead, at the one chokepoint that decides it.
+
+    The distinction between the two failures carries no security content: the
+    hook envelope is host-produced (Claude Code, Codex, Pi), not
+    model-produced. A model can place hostile content INSIDE `tool_input`, but
+    cannot make the top-level object a list — so a non-dict envelope means host
+    misbehaviour or version drift, the same compatibility event the parse-error
+    branch already rules on.
     """
     try:
         raw = sys.stdin.read()
-        return json.loads(raw) if raw.strip() else {}
+        data = json.loads(raw) if raw.strip() else {}
     except Exception as e:  # noqa: BLE001 — any malformed input
         warn(f"hook input unparseable ({e}); proceeding without enforcement")
         return {}
+    if not isinstance(data, dict):
+        warn(f"hook input is a JSON {type(data).__name__}, not an object; "
+             "proceeding without enforcement")
+        return {}
+    return data
 
 
 def tool_input(data):

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -613,17 +613,37 @@ def arbiter_active(root):
 def read_input():
     """Parse the hook JSON from stdin.
 
-    Deliberately fail-open on parse error: a malformed stdin input must NOT
-    brick the session by blocking every subsequent tool call. This is an
+    Deliberately fail-open on unreadable input: a malformed stdin payload must
+    NOT brick the session by blocking every subsequent tool call. This is an
     explicit, documented exception to the fail-loud principle — the correct
     behaviour here is warn + allow, not warn + block.
+
+    "Unreadable" covers a malformed SHAPE as well as malformed syntax
+    (ADR-0020). A payload that is valid JSON but not an object — `[]`, `3`,
+    `"str"`, `true`, `null` — parses cleanly and never reaches the except
+    branch, so it used to be handed downstream as a non-dict: `tool_input()`
+    evaluates `(data or {}).get(...)`, which makes the falsy ones accidentally
+    safe and raises AttributeError out of the guard on the truthy ones. Both
+    are normalized to `{}` here instead, at the one chokepoint that decides it.
+
+    The distinction between the two failures carries no security content: the
+    hook envelope is host-produced (Claude Code, Codex, Pi), not
+    model-produced. A model can place hostile content INSIDE `tool_input`, but
+    cannot make the top-level object a list — so a non-dict envelope means host
+    misbehaviour or version drift, the same compatibility event the parse-error
+    branch already rules on.
     """
     try:
         raw = sys.stdin.read()
-        return json.loads(raw) if raw.strip() else {}
+        data = json.loads(raw) if raw.strip() else {}
     except Exception as e:  # noqa: BLE001 — any malformed input
         warn(f"hook input unparseable ({e}); proceeding without enforcement")
         return {}
+    if not isinstance(data, dict):
+        warn(f"hook input is a JSON {type(data).__name__}, not an object; "
+             "proceeding without enforcement")
+        return {}
+    return data
 
 
 def tool_input(data):

--- a/plugins/ca/hooks/tests/test_hooklib.py
+++ b/plugins/ca/hooks/tests/test_hooklib.py
@@ -1,3 +1,5 @@
+import io
+import json
 import os
 import sys
 import tempfile
@@ -193,6 +195,63 @@ class TestProjectRootMemoization(unittest.TestCase):
                 _hooklib._reset_root_cache()
                 project_root()
             self.assertEqual(len(calls), 2)
+
+
+class TestReadInputShape(unittest.TestCase):
+    """ADR-0020: unreadable input yields `{}` whether the failure is syntactic
+    or structural.
+
+    `read_input()` already carries a documented fail-open exception for a
+    malformed payload — a hook that blocks every subsequent tool call bricks
+    the session. That exception used to cover malformed SYNTAX only. A payload
+    that is valid JSON but not an object parses cleanly, never reaches the
+    except branch, and is handed downstream as a non-dict. The envelope is
+    host-produced rather than model-produced, so that is host drift, not an
+    attack — the same compatibility event the existing exception already rules
+    on."""
+
+    def _read(self, raw):
+        with mock.patch.object(sys, "stdin", io.StringIO(raw)), \
+                mock.patch.object(_hooklib, "warn") as warned:
+            return _hooklib.read_input(), warned
+
+    def test_object_payload_passes_through_unwarned(self):
+        payload = {"tool_name": "Write", "tool_input": {"file_path": "a.py"}}
+        data, warned = self._read(json.dumps(payload))
+        self.assertEqual(data, payload)
+        warned.assert_not_called()
+
+    def test_empty_stdin_is_an_empty_payload_unwarned(self):
+        # Not a malformation — nothing was sent. It must not warn.
+        data, warned = self._read("   \n")
+        self.assertEqual(data, {})
+        warned.assert_not_called()
+
+    def test_truthy_non_object_payload_normalizes_instead_of_raising(self):
+        # The decisive case. These parse cleanly, so the except branch never
+        # sees them; downstream `tool_input()` evaluates `(data or {}).get(...)`
+        # on a TRUTHY non-dict and raises AttributeError out of the guard.
+        for raw in ("3", '"str"', "true", '[{"tool_input": {}}]'):
+            with self.subTest(raw=raw):
+                data, warned = self._read(raw)
+                self.assertEqual(data, {})
+                self.assertEqual(_hooklib.tool_input(data), {})
+                self.assertEqual(warned.call_count, 1)
+
+    def test_falsy_non_object_payload_normalizes_at_the_chokepoint(self):
+        # `or {}` made these accidentally safe downstream. Normalizing here is
+        # what makes them deliberately safe, at the one place that decides it.
+        for raw in ("[]", "null", "0", '""'):
+            with self.subTest(raw=raw):
+                data, warned = self._read(raw)
+                self.assertEqual(data, {})
+                self.assertEqual(warned.call_count, 1)
+
+    def test_malformed_syntax_still_fails_open(self):
+        # The pre-existing exception is unchanged, not replaced.
+        data, warned = self._read("{not json")
+        self.assertEqual(data, {})
+        self.assertEqual(warned.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements [ADR-0020 — Hook input fails open on malformed shape as well as malformed syntax](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0020-hook-input-fails-open-on-shape-as-well-as-syntax.md), ratified in #469.

## The defect

`read_input()` carries a documented, deliberate exception to the fail-loud principle: a malformed stdin payload must not brick the session by blocking every subsequent tool call, so a parse error warns and returns `{}`.

That exception covered malformed **syntax** only. A payload that is valid JSON but not an object — `[]`, `3`, `"str"`, `true`, `null` — parses cleanly, never reaches the `except` branch, and was returned as a non-dict. Downstream:

```python
def tool_input(data):
    return (data or {}).get("tool_input", {}) or {}
```

- **Falsy** non-dicts (`[]`, `null`, `0`, `""`) were *accidentally* safe, via the `or {}`.
- **Truthy** non-dicts (`3`, `"str"`, `true`, a non-empty array) raised `AttributeError` out of the guard.

## Why fail open rather than closed

The hook envelope is **host-produced, not model-produced**. It arrives on stdin from Claude Code, Codex, or Pi. A model can place hostile content *inside* `tool_input`, but cannot make the top-level object a list. A non-dict envelope therefore means host misbehaviour or version drift — a compatibility event, not an attack, and the same event the existing exception already ruled on.

Failing closed would buy no protection against a threat that cannot reach this surface, while creating exactly the failure the exception exists to prevent: a host payload change would brick every tool call until codeArbiter shipped a fix.

## The preserved asymmetry

`plugins/ca-codex/hooks/pre-tool-adapter.py` still fails **closed** on the same payload, and that stays. The adapter is a **router**: it decides which guard to dispatch to, so a payload it cannot route is one it cannot prove safe. A guard that cannot parse its own input is a different case.

That difference is intentional, not drift. Previously it lived only in the ADR; this PR also writes it into the adapter's module docstring, where the next person to read either side will find it. The adapter's refusal is additionally dormancy-aware — in a repository that never opted into codeArbiter it passes through untouched — so failing closed there cannot break unrelated projects.

## Tests

`TestReadInputShape` in `plugins/ca/hooks/tests/test_hooklib.py`:

| Case | Assertion |
| --- | --- |
| object payload | passes through, **no** warning |
| empty stdin | `{}`, **no** warning (nothing was sent — not a malformation) |
| truthy non-object (`3`, `"str"`, `true`, `[{...}]`) | `{}` + one warning; `tool_input()` no longer raises |
| falsy non-object (`[]`, `null`, `0`, `""`) | `{}` + one warning — deliberately safe, not accidentally |
| malformed syntax | unchanged: `{}` + one warning |

Verified red against the old implementation first (8 failures, all in the two non-object cases), then green. The full ca hook suite runs **1153 tests OK**; `test_codex_adapter.py` runs 82 tests OK, confirming the router's fail-closed contract is untouched.

## Release metadata

`_hooklib.py` is shared core, so the change vendors to all three hosts via `sync-core`. `ca` (2.9.1) and `ca-codex` (0.3.0) are both on unpublished versions, so their payload gates pass without a bump. `ca-pi` is published at 0.1.18 and advances to **0.1.20** — 0.1.19 is claimed by #468, which is in flight.

Closes nothing on its own; this is the build half of ADR-0020.
