### PR TITLE
fix(ci): audit the build toolchain, not an empty graph

### DIFF
--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -153,18 +153,33 @@ node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" <file>.
 
 ## CVE gate (supply chain)
 
-The configured CVE gate is `npm audit --omit=dev --audit-level=high`, run after
-`npm ci` against every dependency graph the repo ships or publishes:
+**One threshold, `high`, everywhere.** A HIGH-or-worse advisory fails the build
+in every audit gate this repo runs. Two scopes share it, and which one applies
+depends on whether the graph's *output* is the product:
 
-| graph | workflow / job | production deps today |
-| --- | --- | --- |
-| `plugins/ca/tools` | `ci.yml` — `tools` | none |
-| `plugins/ca-sandbox/tools` | `ci.yml` — `ca-sandbox-tools` | none |
-| `plugins/ca-pi/tools` | `ci.yml` — `ca-pi-checks` | none |
-| `site` (docs site) | `docs.yml` — `site-check`, which `deploy` needs | astro, starlight, markdown-remark |
+| graph | workflow / job | production deps today | scope audited |
+| --- | --- | --- | --- |
+| `plugins/ca/tools` | `ci.yml` — `tools` | none | production **and dev** |
+| `plugins/ca-sandbox/tools` | `ci.yml` — `ca-sandbox-tools` | none | production **and dev** |
+| `plugins/ca-pi/tools` | `ci.yml` — `ca-pi-checks` | none | production **and dev** |
+| `site` (docs site) | `docs.yml` — `site-check`, which `deploy` needs | astro, starlight, markdown-remark | production |
 
-A HIGH-or-worse advisory fails the build; `--omit=dev` scopes the gate to
-shipped dependencies so routine dev-tool advisories don't block unrelated PRs.
+- `npm audit --omit=dev --audit-level=high` — the production gate, run on all
+  four graphs. On `site` it is the live gate: that is the only graph declaring
+  production dependencies. On the three tools graphs it audits an empty graph
+  and is purely a *durability* setting, deciding what happens the day one of
+  them takes on a runtime dependency.
+- `npm audit --audit-level=high` — the dev-inclusive gate (issue #434), run on
+  the three `plugins/*/tools` graphs. Every package in those trees is a dev
+  dependency, and they are the ones that build `farm.js`, `sandbox.js`, and the
+  ca-pi extension bundles — committed, shipped artifacts. A build-time
+  compromise there lands in a reviewed artifact, so "dev dependency"
+  understates the blast radius when the dev dependency's output is the product.
+
+`site`'s dev tree is deliberately not on the dev-inclusive gate: its build
+output is a static site republished from source on every deploy, not a committed
+binary artifact carried into consumers' repositories.
+
 This enforces the supply-chain posture described in `security-controls.md`.
 
 **What the threshold actually buys, honestly.** Three of the four graphs above
@@ -178,14 +193,19 @@ threshold was lowered from `critical` to `high` across all four so a single rule
 covers the repo — not because the farm or sandbox audits would have caught #400.
 They would not have seen it.
 
-The dev trees, where these packages' advisories actually are, are **not** covered
-by this gate. Measured in `plugins/ca/tools` at the time of writing, `npm audit
---json` reports `{prod: 1, dev: 104}` — the single prod entry being the root
-package itself — and one **HIGH** advisory (`postcss`) that the shipped
-`--omit=dev` gate never sees. All four graphs pass `npm audit --omit=dev
---audit-level=high` today. Issue #434 tracks extending the sweep to the dev
-trees, and notes the blast radius: those dev dependencies build `farm.js` and
-`sandbox.js`, which are committed, shipped artifacts.
+**What issue #434 found, and how the dev gate was proven.** Measured in
+`plugins/ca/tools`, `npm audit --json` reported `{prod: 1, dev: 104}` — the
+single prod entry being the root package itself — and one **HIGH** advisory,
+GHSA-r28c-9q8g-f849 (`postcss` ≤ 8.5.17, arbitrary `.map` file disclosure via
+source-map auto-loading). The `--omit=dev` gate reported **zero vulnerabilities
+against the vulnerable lockfile and against the fixed one alike**, at any
+threshold. The advisory surfaced only because dependabot happened to file the
+bump on a sibling graph — luck, not a control.
+
+The dev-inclusive gate was proven against that exact known-vulnerable state
+rather than only against a clean one: run on the pre-fix `plugins/ca/tools`
+lockfile (postcss 8.5.15) it exits 1 and names the advisory, where the
+production gate exits 0. All four graphs pass both applicable gates today.
 
 ## Secrets scan
 

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -25,6 +25,11 @@ DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
 GITLEAKS_CONFIG = REPO_ROOT / ".gitleaks.toml"
 # The one audit threshold every dependency graph in this repo is gated at.
 NPM_AUDIT_GATE = "npm audit --omit=dev --audit-level=high"
+# Issue #434: the tools graphs declare zero production dependencies, so the
+# `--omit=dev` gate above audits an empty graph there. This one covers the build
+# toolchain that actually exists - the dev dependencies that produce farm.js,
+# sandbox.js, and the ca-pi extension bundles. Same threshold, by contract.
+NPM_AUDIT_DEV_GATE = "npm audit --audit-level=high"
 PI_PROMOTION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pi-promotion.yml"
 PI_TEST_DIR = REPO_ROOT / "plugins" / "ca-pi" / "tools" / "test"
 PI_PLATFORM_CONTRACT = REPO_ROOT / ".github" / "scripts" / "test_pi_platform_contract.py"
@@ -1112,18 +1117,22 @@ class WorkflowContractTest(unittest.TestCase):
         # Issue #403: site/package-lock.json - the ONLY graph in this repo that
         # declares production dependencies (astro, starlight, markdown-remark) -
         # was audited by nothing, and #400's three HIGH advisories all lived
-        # there.  The farm/sandbox gates were separately pinned at `critical`,
-        # but tightening those two is a DURABILITY change, not a live one:
-        # measured, plugins/ca/tools, plugins/ca-sandbox/tools and
-        # plugins/ca-pi/tools each declare ZERO production dependencies, so
-        # `--omit=dev` audits an empty graph there at any threshold.  It decides
-        # what happens the day one of them takes on a runtime dependency.
-        # Issue #434 tracks extending the sweep to the dev trees, which is where
-        # those packages' advisories actually are.
+        # there.
         #
-        # One threshold, asserted per invocation, across every graph the repo
-        # ships or publishes.
-        expected = NPM_AUDIT_GATE
+        # Issue #434 closed the other half.  `--omit=dev` on the three tools
+        # graphs audits an EMPTY graph: each declares zero production
+        # dependencies, so that gate saw nothing at any threshold.  Every
+        # package in those trees is a dev dependency, and they are the ones that
+        # build farm.js, sandbox.js, and the ca-pi extension bundles - committed,
+        # shipped artifacts.  GHSA-r28c-9q8g-f849 (postcss, HIGH) sat in
+        # plugins/ca/tools reported as zero vulnerabilities by the omit-dev gate
+        # against both the vulnerable AND the fixed lockfile; it surfaced only
+        # because dependabot happened to file the bump.
+        #
+        # So each tools graph now carries TWO audits: the durability gate for
+        # the day it takes on a runtime dependency, and the dev-inclusive gate
+        # that covers the toolchain actually present.  ONE THRESHOLD across all
+        # of them - that is the invariant this asserts.
         invocations: list[tuple[str, str]] = []
         for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
             invocations += [
@@ -1131,13 +1140,58 @@ class WorkflowContractTest(unittest.TestCase):
                 for command in npm_audit_invocations(workflow.read_text(encoding="utf-8"))
             ]
         self.assertEqual(
-            len(invocations),
-            4,
-            "expected exactly the farm, sandbox, ca-pi, and site audit gates",
+            sorted(command for _, command in invocations),
+            sorted(
+                # farm, sandbox, ca-pi: production-durability gate ...
+                [f"run: {NPM_AUDIT_GATE}"] * 3
+                # ... plus the dev-inclusive gate that covers the real toolchain
+                + [f"run: {NPM_AUDIT_DEV_GATE}"] * 3
+                # site: the one graph with production dependencies (docs.yml)
+                + [f"run: {NPM_AUDIT_GATE}"]
+            ),
+            "expected a production and a dev-inclusive audit on each tools graph, "
+            "plus the site production audit",
         )
         for name, command in invocations:
             with self.subTest(workflow=name, command=command):
-                self.assertEqual(command, f"run: {expected}")
+                self.assertRegex(
+                    command,
+                    r"--audit-level=high$",
+                    "every audit gate in the repo must use the SAME threshold",
+                )
+
+    def test_each_plugin_tools_graph_is_audited_with_dev_dependencies_included(self):
+        """Issue #434 AC-1: a HIGH advisory in a `plugins/*/tools` DEV dependency
+        must fail CI.
+
+        Asserted per job rather than by counting lines, so a dev gate that is
+        deleted from one graph - or a fourth tools graph added without one -
+        fails here rather than passing on an unchanged total."""
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = workflow_jobs(ci)
+        installs = npm_install_jobs(ci)
+        tools_graphs = {
+            job_id: directory
+            for job_id, directory in installs.items()
+            if re.fullmatch(r"plugins/[^/]+/tools", directory)
+        }
+        self.assertTrue(tools_graphs, "no plugins/*/tools graph found in ci.yml")
+        # Every tools graph must be dev-audited by SOME job (ca-pi-tools installs
+        # the same directory ca-pi-checks audits, exactly as the omit-dev rule
+        # above already allows).
+        dev_audited = {
+            directory
+            for job_id, directory in installs.items()
+            if f"run: {NPM_AUDIT_DEV_GATE}" in jobs[job_id]
+        }
+        for job_id, directory in sorted(tools_graphs.items()):
+            with self.subTest(job=job_id, directory=directory):
+                self.assertIn(
+                    directory,
+                    dev_audited,
+                    f"{job_id} installs {directory}, whose dev dependencies build a "
+                    f"committed artifact, but nothing audits them",
+                )
         # EVERY GRAPH THIS REPO INSTALLS IS AUDITED SOMEWHERE.  This used to
         # iterate the hardcoded triple ("tools", "ca-sandbox-tools",
         # "ca-pi-checks") under a comment claiming "every job that installs a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,26 @@ jobs:
         # One threshold applies to every audited graph (farm, sandbox, ca-pi,
         # docs site); test_ci_impact.py asserts that.
         run: npm audit --omit=dev --audit-level=high
+      - name: Audit build toolchain (CVE gate - fail on HIGH, dev deps included)
+        # Issue #434. The step above is `--omit=dev`, and all three tools graphs
+        # declare no production dependencies - so on its own it audits an empty
+        # graph and sees nothing. Every dependency here is a dev dependency, and
+        # they are the ones that BUILD the committed, shipped artifacts
+        # (farm.js, sandbox.js, the ca-pi extension bundles). A build-time
+        # compromise lands in a reviewed-and-committed artifact, so "dev
+        # dependency" understates the blast radius when the dev dependency's
+        # output is the product.
+        #
+        # This is what actually caught GHSA-r28c-9q8g-f849 (postcss, HIGH) in
+        # plugins/ca/tools: `--omit=dev --audit-level=critical` reported zero
+        # against the vulnerable lockfile AND against the fixed one, and the
+        # advisory only ever surfaced because dependabot happened to file the
+        # bump. That is luck, not a control.
+        #
+        # Same HIGH threshold as every other audited graph, so one policy covers
+        # the repo; test_ci_impact.py asserts that no audit step in this
+        # workflow uses a different one.
+        run: npm audit --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Test
@@ -330,6 +350,26 @@ jobs:
         # dependencies either, so this audits an empty graph today and is a
         # durability setting rather than a live gate.
         run: npm audit --omit=dev --audit-level=high
+      - name: Audit build toolchain (CVE gate - fail on HIGH, dev deps included)
+        # Issue #434. The step above is `--omit=dev`, and all three tools graphs
+        # declare no production dependencies - so on its own it audits an empty
+        # graph and sees nothing. Every dependency here is a dev dependency, and
+        # they are the ones that BUILD the committed, shipped artifacts
+        # (farm.js, sandbox.js, the ca-pi extension bundles). A build-time
+        # compromise lands in a reviewed-and-committed artifact, so "dev
+        # dependency" understates the blast radius when the dev dependency's
+        # output is the product.
+        #
+        # This is what actually caught GHSA-r28c-9q8g-f849 (postcss, HIGH) in
+        # plugins/ca/tools: `--omit=dev --audit-level=critical` reported zero
+        # against the vulnerable lockfile AND against the fixed one, and the
+        # advisory only ever surfaced because dependabot happened to file the
+        # bump. That is luck, not a control.
+        #
+        # Same HIGH threshold as every other audited graph, so one policy covers
+        # the repo; test_ci_impact.py asserts that no audit step in this
+        # workflow uses a different one.
+        run: npm audit --audit-level=high
       - name: Typecheck
         run: npm run typecheck
       - name: Docker preflight (REQUIRED prerequisite - fail, never skip)
@@ -429,6 +469,26 @@ jobs:
         # rather than in the six-cell ca-pi-tools matrix - the verdict does not
         # depend on OS or Pi version.
         run: npm audit --omit=dev --audit-level=high
+      - name: Audit build toolchain (CVE gate - fail on HIGH, dev deps included)
+        # Issue #434. The step above is `--omit=dev`, and all three tools graphs
+        # declare no production dependencies - so on its own it audits an empty
+        # graph and sees nothing. Every dependency here is a dev dependency, and
+        # they are the ones that BUILD the committed, shipped artifacts
+        # (farm.js, sandbox.js, the ca-pi extension bundles). A build-time
+        # compromise lands in a reviewed-and-committed artifact, so "dev
+        # dependency" understates the blast radius when the dev dependency's
+        # output is the product.
+        #
+        # This is what actually caught GHSA-r28c-9q8g-f849 (postcss, HIGH) in
+        # plugins/ca/tools: `--omit=dev --audit-level=critical` reported zero
+        # against the vulnerable lockfile AND against the fixed one, and the
+        # advisory only ever surfaced because dependabot happened to file the
+        # bump. That is luck, not a control.
+        #
+        # Same HIGH threshold as every other audited graph, so one policy covers
+        # the repo; test_ci_impact.py asserts that no audit step in this
+        # workflow uses a different one.
+        run: npm audit --audit-level=high
       - name: Check generated root package metadata
         working-directory: .
         run: python tools/build-host-packages.py --check

--- a/plugins/ca/tools/package-lock.json
+++ b/plugins/ca/tools/package-lock.json
@@ -1215,9 +1215,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1271,9 +1271,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1291,7 +1291,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## The blind spot

The repo ran `npm audit --omit=dev --audit-level=high` on all three `plugins/*/tools` graphs. **Each declares zero production dependencies**, so that gate audited an empty graph and could not report anything at any threshold.

Every package in those trees is a dev dependency — and they are the ones that build `farm.js`, `sandbox.js`, and the ca-pi extension bundles. Those are **committed, shipped artifacts**. A build-time compromise there lands in a reviewed artifact carried into consumers' repositories, so "dev dependency" understates the blast radius when the dev dependency's output *is* the product.

**GHSA-r28c-9q8g-f849** (`postcss` ≤ 8.5.17, arbitrary `.map` file disclosure via source-map auto-loading, **HIGH**) sat in `plugins/ca/tools` the whole time. It surfaced only because dependabot happened to file the same bump on a sibling graph. That is luck, not a control.

## The change

Each tools job now carries **two audits at the same threshold**:

| gate | graphs | what it covers |
| --- | --- | --- |
| `npm audit --omit=dev --audit-level=high` | all four | production deps. Live on `site`; a *durability* setting on the three tools graphs, for the day one takes on a runtime dependency. |
| `npm audit --audit-level=high` | the three `plugins/*/tools` graphs | the build toolchain that actually exists. |

`site` keeps the production gate only: its build output is a static site republished from source on every deploy, not a committed binary artifact.

Also bumps the advisory the new gate finds: **postcss 8.5.15 → 8.5.23** (with nanoid 3.3.13 → 3.3.16 alongside) in `plugins/ca/tools`. Both are vitest/vite transitives, not part of the esbuild bundle — `npm run build` reproduces `farm.js` byte-identically, and the suite is **298 passed / 1 skipped**.

## Proof, per acceptance criterion

**AC-1 — a HIGH advisory in a `plugins/*/tools` dev dependency fails CI.**
`test_each_plugin_tools_graph_is_audited_with_dev_dependencies_included` asserts the dev gate **per tools graph**, derived from the jobs that run `npm ci`, rather than by counting lines — so a gate deleted from one graph, or a fourth graph added without one, fails here rather than passing on an unchanged total. Verified red against `origin/main` in a detached worktree: **5 subtest failures** there, green here.

**AC-2 — one threshold, and `tech-stack.md` matches what CI runs.**
The threshold assertion became a *property* (`--audit-level=high$` on every invocation) instead of an exact string, plus an exact multiset of the seven expected invocations. `tech-stack.md`'s CVE-gate section is rewritten to state both scopes, which graphs get which, and why `site` is deliberately excluded from the dev gate.

**AC-3 — proven against the known-vulnerable state, not only a clean one.**
Run against the pre-fix `plugins/ca/tools` lockfile (postcss 8.5.15):

```
$ npm audit --omit=dev --audit-level=high
found 0 vulnerabilities
exit=0

$ npm audit --audit-level=high
postcss  <=8.5.17
Severity: high
PostCSS: Path Traversal in Previous Source Map Auto-Loading ...
1 high severity vulnerability
exit=1
```

Against the fixed lockfile the new gate exits 0. That is the whole point: the old gate reported zero against the vulnerable lockfile **and** the fixed one, so it could never have distinguished them.

Closes #434. Resolves dependabot alert #29.
