### PR TITLE
fix(farm): refuse a Windows reserved device name as FARM_RUN_ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ predate the plugin rewrite and are grouped by date.
 
 ### Fixed
 
+- `FARM_RUN_ID` no longer accepts a Windows reserved device name. `NUL`, `CON`,
+  `AUX`, `PRN`, `COM1`-`COM9` and `LPT1`-`LPT9` match the run id's character
+  class perfectly, and Windows resolves them ahead of any extension, so `NUL`,
+  `nul` and `com1.log.1` all name a device rather than a directory. Since the
+  run id became a directory name under `.farm/runs/`, that made `mkdir` throw
+  outside the run's cleanup scope and took the run's receipts - its recovery
+  record - with it. Refused at startup on every platform, because an
+  orchestrator's `FARM_RUN_ID` travels between machines. Matched on the stem
+  only, so `console`, `nulls`, `COM0` and `COM10` remain valid (issue #440).
 - A hook payload that is valid JSON but not an object (`[]`, `3`, `"str"`,
   `true`, `null`) is normalized to an empty payload at `read_input()` rather
   than handed to the guards as a non-dict. Downstream, `tool_input()` evaluates

--- a/plugins/ca/tools/farm.js
+++ b/plugins/ca/tools/farm.js
@@ -1042,10 +1042,15 @@ function mintRunId() {
 }
 var msgOf = (e) => e instanceof Error ? e.message : String(e);
 var SAFE_RUN_ID = /^[A-Za-z0-9._-]{1,64}$/;
+var RESERVED_RUN_ID_STEM = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
 function assertSafeRunId(id) {
   if (!SAFE_RUN_ID.test(id) || id === "." || id === "..")
     throw new Error(
       `FARM_RUN_ID must be 1-64 characters of [A-Za-z0-9._-] and not "." or ".." (got ${JSON.stringify(id)})`
+    );
+  if (RESERVED_RUN_ID_STEM.test(id.split(".")[0]))
+    throw new Error(
+      `FARM_RUN_ID must not be a Windows reserved device name (CON, PRN, AUX, NUL, COM1-9, LPT1-9), with or without an extension \u2014 the run directory could not be created (got ${JSON.stringify(id)})`
     );
   return id;
 }

--- a/plugins/ca/tools/farm.ts
+++ b/plugins/ca/tools/farm.ts
@@ -1099,10 +1099,33 @@ const msgOf = (e: unknown) => (e instanceof Error ? e.message : String(e));
 // misconfigured orchestrator) or letting `../` place artifacts outside the
 // report dir.
 export const SAFE_RUN_ID = /^[A-Za-z0-9._-]{1,64}$/;
+
+// #440: the character class above is necessary but NOT sufficient. Windows
+// reserves a set of DEVICE names that match `[A-Za-z0-9._-]` perfectly, and
+// resolves them before any extension — so `NUL`, `nul`, `NUL.txt` and
+// `com1.log.1` all name the device, not a file. `mkdir` against one behaves
+// unpredictably, and `mkdir(runDir)` sits OUTSIDE the run's try/finally, so the
+// failure is an unhandled throw BEFORE the cleanup scope exists — and the run's
+// receipts, which are its recovery record, are lost with it.
+//
+// Refused on EVERY platform, not only Windows. `FARM_RUN_ID` is set by an
+// orchestrator whose configuration travels between machines, and an id that
+// works on one developer's Linux box while detonating on a colleague's Windows
+// one is exactly the class of failure a startup gate exists to prevent.
+//
+// Matched on the STEM ONLY — the text before the first `.`, which is what
+// Windows itself resolves — and anchored, so ordinary ids that merely resemble
+// a device name (`console`, `nulls`, `COM0`, `COM10`, `my-nul`) stay valid.
+const RESERVED_RUN_ID_STEM = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
 export function assertSafeRunId(id: string): string {
   if (!SAFE_RUN_ID.test(id) || id === "." || id === "..")
     throw new Error(
       `FARM_RUN_ID must be 1-64 characters of [A-Za-z0-9._-] and not "." or ".." (got ${JSON.stringify(id)})`,
+    );
+  if (RESERVED_RUN_ID_STEM.test(id.split(".")[0]))
+    throw new Error(
+      `FARM_RUN_ID must not be a Windows reserved device name (CON, PRN, AUX, NUL, COM1-9, LPT1-9), ` +
+        `with or without an extension — the run directory could not be created (got ${JSON.stringify(id)})`,
     );
   return id;
 }

--- a/plugins/ca/tools/farm.unit.test.ts
+++ b/plugins/ca/tools/farm.unit.test.ts
@@ -2269,6 +2269,55 @@ describe("assertSafeRunId — run id is a path segment (#397)", () => {
     for (const bad of ["..", ".", "../escape", "a/b", "a\\b", "", "x".repeat(65), "a b"])
       expect(() => assertSafeRunId(bad)).toThrow(/FARM_RUN_ID/);
   });
+
+  // #440. The character class above is necessary but not sufficient on Windows:
+  // NUL, CON, AUX, PRN, COM1-9 and LPT1-9 are DEVICE names, not filenames, and
+  // they match [A-Za-z0-9._-] perfectly. Since #397 the run id is both an
+  // ownership boundary and a directory name under `.farm/runs/<runId>/`, and
+  // `mkdir(runDir)` sits OUTSIDE the try/finally -- so a reserved name throws
+  // before the cleanup scope is even established, and the run's receipts, which
+  // are its recovery record, are lost.
+  //
+  // Refused on every platform, not only Windows: `FARM_RUN_ID` is set by an
+  // orchestrator whose config is routinely shared across machines, and a
+  // "works on my Linux box" id that detonates on a colleague's Windows one is
+  // the failure this prevents.
+  it("rejects Windows reserved device names (#440)", () => {
+    for (const bad of ["NUL", "CON", "AUX", "PRN", "COM1", "COM9", "LPT1", "LPT9"])
+      expect(() => assertSafeRunId(bad)).toThrow(/FARM_RUN_ID/);
+  });
+
+  it("rejects reserved names case-insensitively and with an extension (#440)", () => {
+    // Windows resolves the device before the extension, so `NUL.txt`,
+    // `nul.log.1` and `Com1.json` are all still the device.
+    for (const bad of ["nul", "Con", "cOm1", "NUL.txt", "nul.log.1", "Com1.json", "LPT9.tar.gz"])
+      expect(() => assertSafeRunId(bad)).toThrow(/FARM_RUN_ID/);
+  });
+
+  it("still accepts ordinary ids that merely resemble a reserved name (#440)", () => {
+    // The rule is exact-stem-only. Over-broad matching here would reject
+    // perfectly good ids -- and `.` is a legal id character, so the stem is the
+    // text before the FIRST dot, which is what Windows itself resolves.
+    for (const ok of [
+      "console",      // starts with CON
+      "nulls",        // starts with NUL
+      "COM0",         // COM0 is not reserved; only COM1-COM9 are
+      "COM10",        // two digits, not reserved
+      "LPT0",
+      "my-nul",
+      "nul-run",
+      "prn2",         // PRN takes no digit
+      "aux1",         // AUX takes no digit
+    ])
+      expect(assertSafeRunId(ok)).toBe(ok);
+  });
+
+  it("keeps minted ids acceptable under the reserved-name rule (#440)", () => {
+    // A minted id is 16 hex chars, so it can never collide with a reserved
+    // stem -- but pin it, because the day mintRunId's shape changes this is
+    // the assertion that notices.
+    for (let i = 0; i < 64; i++) expect(() => assertSafeRunId(mintRunId())).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`assertSafeRunId` validated the run id as a safe single path segment — no traversal, no separators, no `.`/`..`, bounded length. But Windows reserved **device** names match `[A-Za-z0-9._-]` perfectly: `NUL`, `CON`, `AUX`, `PRN`, `COM1`–`COM9`, `LPT1`–`LPT9`.

Since #397 the run id is both an ownership boundary and a directory name under `.farm/runs/<runId>/`, and `mkdir(runDir)` sits **outside** the run's `try/finally`. So a reserved name is not a tidy validation failure — it throws before the cleanup scope is even established, and the run's receipts (the stream, the per-task diffs, the JSON and Markdown report) go with it. Those receipts *are* the recovery record.

Reachable through the `FARM_RUN_ID` env var that #397 introduced so an orchestrator can pin the id.

## The fix

Refused at startup with the same bounded diagnostic as the other rejections, on **every platform** — not only Windows. An orchestrator's configuration travels between machines, and an id that works on one developer's Linux box while detonating on a colleague's Windows one is exactly the class of failure a startup gate exists to prevent.

Matched on the **stem only** — the text before the first `.`, which is what Windows itself resolves — anchored and case-insensitive:

```ts
const RESERVED_RUN_ID_STEM = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
```

So `NUL.txt`, `nul.log.1` and `Com1.json` are caught, while ordinary ids that merely *resemble* a device name stay valid.

| refused | accepted |
| --- | --- |
| `NUL`, `nul`, `Con`, `cOm1` | `console`, `nulls`, `my-nul`, `nul-run` |
| `NUL.txt`, `nul.log.1`, `LPT9.tar.gz` | `COM0`, `COM10`, `LPT0` (not reserved) |
| `COM1`–`COM9`, `LPT1`–`LPT9` | `prn2`, `aux1` (PRN and AUX take no digit) |

## Tests

**AC-1** — `FARM_RUN_ID=NUL` and a representative `COM1` are refused with the same bounded diagnostic as the existing rejections.
**AC-2** — case-insensitive, and the extension forms Windows also treats as the device.
**AC-3** — both pinned, plus a **positive control**: near-miss ids are still accepted, and 64 minted ids confirm `mintRunId`'s output can never collide with a reserved stem (the assertion that will notice the day its shape changes).

Verified red first: 2 of the 4 new cases failed against the old implementation.

Typecheck clean; full farm suite **302 passed / 1 skipped**; `farm.js` rebuilt from the changed source (the committed-artifact staleness gate).

Closes #440.
