### PR TITLE
fix(tests): keep the suites inside their own temp dirs, and stop them leaking

### DIFF
--- a/.github/scripts/test_suite_hermeticity.py
+++ b/.github/scripts/test_suite_hermeticity.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Issue #442 AC-3 — the test suites must not write outside their own temp dirs.
+
+Running the sanctioned hook suite mutated the developer's REAL home directory:
+`~/.claude/settings.json` was rewritten (both `statusLine.command` and
+`_codearbiterStatuslineOwner` repointed at whatever plugin root the test process
+resolved), and `~/.codearbiter/` gained a ledger, its lock, five session shards,
+and an update-state cache. Four modules on main did it, none of them using the
+`redirect_home` helper that already sat beside them.
+
+That is worse than untidy. It broke the maintainer's statusline three times in
+one day; it makes the suite non-hermetic, so two developers running it get
+different global config afterwards; and it is why a subagent tripped an
+"irreversible local destruction" check trying to clean up the mess. CI never
+noticed, because a fresh runner has no pre-existing settings to clobber.
+
+HOW THIS GUARD WORKS, AND WHY NOT A REAL-HOME SNAPSHOT
+------------------------------------------------------
+The obvious guard — hash the developer's real `~` before and after — is
+destructive by observation: it can only detect damage that has already been
+done, on the machine you care about. Instead this runs each suite in a
+subprocess whose home is a PRISTINE temp directory, seeded with a plausible
+stale-but-real `~/.claude/settings.json`, and asserts that directory comes back
+BYTE-IDENTICAL: nothing created, nothing modified, nothing deleted.
+
+That is strictly stronger. It proves the suite touches no user-global path at
+all, rather than proving it happened not to touch one machine's. And it is safe
+to run anywhere, including on the machine that was being damaged.
+
+The seeded `settings.json` matters: `heal_statusline_wiring` returns early when
+no settings file exists, so an EMPTY fake home would hide exactly the write this
+issue is about.
+
+Every home variable `os.path.expanduser("~")` consults is redirected, not just
+`HOME`: on Windows `ntpath` reads `USERPROFILE` first, then `HOMEDRIVE` +
+`HOMEPATH`, and ignores `HOME` entirely — the precise reason the original
+offenders escaped notice on the maintainer's machine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Every key expanduser("~") consults, on any platform.
+HOME_KEYS = ("HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH")
+
+# A stale-but-real owner pin, so the statusline self-heal has something to
+# rewrite. Without this the write under test cannot happen at all.
+SEEDED_SETTINGS = """{
+  "statusLine": {
+    "type": "command",
+    "command": "\\"python\\" \\"/opt/acme/codearbiter/ca/1.0.0/hooks/statusline.py\\""
+  },
+  "_codearbiterStatuslineOwner": "codearbiter/ca/1.0.0/hooks/statusline.py"
+}
+"""
+
+SUITES = (
+    (
+        "ca hook suite",
+        [sys.executable, "-m", "unittest", "discover",
+         "-s", "plugins/ca/hooks/tests", "-p", "test_*.py", "-t", "."],
+    ),
+    # AC-4: the same audit, applied to the .github/scripts tests. Listed
+    # explicitly rather than discovered, so a new script test is a deliberate
+    # addition here rather than a silent omission.
+    (
+        "hook-guard matrix",
+        [sys.executable, ".github/scripts/test_hook_guards.py"],
+    ),
+    (
+        "codex adapter parity",
+        [sys.executable, ".github/scripts/test_codex_adapter.py"],
+    ),
+    (
+        "dual-host store",
+        [sys.executable, ".github/scripts/test_dual_host_store.py"],
+    ),
+)
+
+
+def snapshot(root: Path) -> dict[str, str]:
+    """Path -> content digest for every file under `root`, dirs included as
+    markers so an empty directory left behind is still a difference."""
+    out: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        rel = path.relative_to(root).as_posix()
+        if path.is_dir():
+            out[rel + "/"] = "<dir>"
+        elif path.is_file():
+            out[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return out
+
+
+def seeded_home(root: Path) -> None:
+    claude = root / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "settings.json").write_text(SEEDED_SETTINGS, encoding="utf-8", newline="\n")
+
+
+def run_suite(command: list[str], home: Path) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    for key in HOME_KEYS:
+        environment.pop(key, None)
+    environment["HOME"] = str(home)
+    environment["USERPROFILE"] = str(home)
+    # Deliberately NOT setting CODEARBITER_LEDGER / CODEARBITER_UPDATE_STATE.
+    # Those are the seams a well-behaved test uses to point its own state at its
+    # own temp dir; pinning them here would force correct code to look incorrect
+    # and, worse, would let an offender pass by writing to a path this guard
+    # itself supplied. Unset, the production fallback applies -- expanduser("~"),
+    # which is the fake home -- so any suite that neglects the seam is caught.
+    for seam in ("CODEARBITER_LEDGER", "CODEARBITER_UPDATE_STATE"):
+        environment.pop(seam, None)
+    return subprocess.run(
+        command, cwd=REPO, env=environment, capture_output=True,
+        text=True, encoding="utf-8", errors="replace", timeout=900,
+    )
+
+
+class TestSuitesStayInsideTheirTempDirs(unittest.TestCase):
+    maxDiff = None
+
+    def assert_home_untouched(self, name: str, command: list[str]) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            seeded_home(home)
+            before = snapshot(home)
+            result = run_suite(command, home)
+            after = snapshot(home)
+
+        self.assertEqual(
+            result.returncode, 0,
+            f"{name} did not pass under a redirected home:\n{result.stdout[-4000:]}\n{result.stderr[-4000:]}",
+        )
+        created = sorted(set(after) - set(before))
+        removed = sorted(set(before) - set(after))
+        modified = sorted(key for key in set(before) & set(after) if before[key] != after[key])
+        self.assertEqual(
+            (created, removed, modified), ([], [], []),
+            f"{name} wrote outside its temp dirs. On a developer machine these are "
+            f"paths under the REAL home.\n"
+            f"  created:  {created}\n  removed:  {removed}\n  modified: {modified}",
+        )
+
+    def test_ca_hook_suite_leaves_the_user_home_byte_identical(self):
+        name, command = SUITES[0]
+        self.assert_home_untouched(name, command)
+
+    def test_github_script_suites_leave_the_user_home_byte_identical(self):
+        for name, command in SUITES[1:]:
+            with self.subTest(suite=name):
+                self.assert_home_untouched(name, command)
+
+
+class TestTheSuiteLeaksNoHandlesOrProcesses(unittest.TestCase):
+    """Issue #462 — the intermittent-red half.
+
+    The same tree, unchanged, produced `FAILED (errors=2)` on one run and `OK`
+    on the next three. The signal was in the warnings: unclosed `settings.json`
+    and `CONTEXT.md` handles, five leaked subprocesses, and an implicitly
+    reclaimed `HTTPError`. On Windows an unclosed handle blocks
+    `TemporaryDirectory` cleanup and a live child holds a temp path, so teardown
+    RAISES instead of the assertion failing — intermittent ERRORS, not failures,
+    with no code change between runs.
+
+    That erodes the signal the suite exists to provide. This sweep already
+    showed the failure mode: a genuinely red Windows cell was hit five times and
+    each time the correct-but-corrosive response was "re-run it." A suite that
+    is red once in four trains everyone to re-run first and diagnose never,
+    which is precisely how a real regression gets waved through. It also makes
+    bisecting unreliable, since a clean step cannot be trusted on one run.
+
+    So the warnings are the assertion. `Enable tracemalloc` lines are dropped:
+    they are the interpreter's advice about a warning, not a warning."""
+
+    ADVICE = "Enable tracemalloc"
+
+    def test_the_ca_hook_suite_emits_no_resource_warnings(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            seeded_home(home)
+            result = run_suite(
+                [sys.executable, "-W", "always::ResourceWarning", "-m", "unittest",
+                 "discover", "-s", "plugins/ca/hooks/tests", "-p", "test_*.py", "-t", "."],
+                home,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr[-4000:])
+        warnings = [
+            line.strip()
+            for line in (result.stdout + result.stderr).splitlines()
+            if "ResourceWarning" in line and self.ADVICE not in line
+        ]
+        self.assertEqual(
+            warnings, [],
+            "the hook suite leaked a handle or a process. On Windows these turn a "
+            "later teardown into an intermittent ERROR:\n  " + "\n  ".join(warnings),
+        )
+
+
+class TestTheGuardItselfCanFail(unittest.TestCase):
+    """A hermeticity guard that cannot fail is decoration. This proves the
+    detector sees a write, so a green result above means something."""
+
+    def test_a_suite_that_writes_to_home_is_caught(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            seeded_home(home)
+            before = snapshot(home)
+            result = run_suite(
+                [sys.executable, "-c",
+                 "import os,pathlib;"
+                 "p=pathlib.Path(os.path.expanduser('~'))/'.codearbiter';"
+                 "p.mkdir(parents=True,exist_ok=True);"
+                 "(p/'ledger.json').write_text('{}')"],
+                home,
+            )
+            after = snapshot(home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotEqual(before, after, "the detector did not notice a write to ~")
+        self.assertIn(".codearbiter/ledger.json", set(after) - set(before))
+
+    def test_a_suite_that_modifies_the_seeded_settings_is_caught(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            seeded_home(home)
+            before = snapshot(home)
+            result = run_suite(
+                [sys.executable, "-c",
+                 "import os,pathlib;"
+                 "p=pathlib.Path(os.path.expanduser('~'))/'.claude'/'settings.json';"
+                 "p.write_text('{}')"],
+                home,
+            )
+            after = snapshot(home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotEqual(
+            before[".claude/settings.json"], after[".claude/settings.json"],
+            "the detector did not notice settings.json being rewritten",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -889,6 +889,20 @@ jobs:
         # locally per CONTRIBUTING; wired here so the guards are mechanically
         # enforced. Stdlib-only, cross-platform (discovered on every matrix OS).
         run: python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"
+      - name: Enforce suite hermeticity (issues #442, #462)
+        # The suite used to mutate the DEVELOPER'S REAL HOME - rewriting
+        # ~/.claude/settings.json and littering ~/.codearbiter/ - and to leak
+        # file handles and child processes, which on Windows turns a later
+        # teardown into an intermittent ERROR rather than a FAILURE. CI never
+        # noticed either: a fresh runner has no settings to clobber, and a
+        # ResourceWarning is not a test result.
+        #
+        # This runs each suite under a PRISTINE redirected home seeded with a
+        # stale-but-real settings.json, and asserts that home comes back
+        # byte-identical and the run emits no ResourceWarning. It re-runs the
+        # hook suite twice over, so it is deliberately placed after the suite
+        # itself rather than in place of it.
+        run: python .github/scripts/test_suite_hermeticity.py
       - name: Run ADR identity + supersession contract tests
         # #416: two ADRs share the number 0014, so a bare `supersedes: 0014`
         # named two documents at once. The identifier is the filename STEM;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,29 @@ predate the plugin rewrite and are grouped by date.
 
 ### Fixed
 
+- The test suites no longer write outside their own temp directories. Running
+  the hook suite rewrote the developer's real `~/.claude/settings.json` — both
+  the statusline command and its owner key repointed at whatever plugin root the
+  test process resolved — and littered `~/.codearbiter/` with a ledger, its
+  lock, five session shards and an update cache. Four modules did it, none using
+  the `redirect_home` helper that already sat beside them, and CI never noticed
+  because a fresh runner has no settings to clobber. All four now take a
+  module-level isolation fixture, which covers every test class added later
+  rather than relying on one more remembered `setUp` (issue #442).
+- The hook suite no longer leaks file handles or child processes. Unclosed
+  `settings.json` / `CONTEXT.md` reads, five never-reaped subprocesses, and an
+  implicitly reclaimed `HTTPError` produced `ResourceWarning`s — and on Windows
+  an open handle blocks `TemporaryDirectory` cleanup while a live child holds a
+  temp path, so teardown *raised* instead of the assertion failing. That is why
+  the same unchanged tree went `FAILED (errors=2)` on one run and `OK` on the
+  next three. Handles are closed, subprocesses are reaped through `addCleanup`
+  regardless of assertion outcome, and the two detached background spawns
+  `session-start.py` fires are stubbed in the harness rather than launched for
+  real (issue #462).
+- A new CI gate keeps both closed: each suite runs under a pristine redirected
+  home seeded with a stale-but-real `settings.json`, and must leave it
+  byte-identical while emitting no `ResourceWarning`. The guard proves its own
+  detector can fail, so a green result means something.
 - `FARM_RUN_ID` no longer accepts a Windows reserved device name. `NUL`, `CON`,
   `AUX`, `PRN`, `COM1`-`COM9` and `LPT1`-`LPT9` match the run id's character
   class perfectly, and Windows resolves them ahead of any extension, so `NUL`,

--- a/plugins/ca/hooks/tests/_helpers.py
+++ b/plugins/ca/hooks/tests/_helpers.py
@@ -2,6 +2,7 @@
 # here (into tempdirs by the callers) rather than checked in.
 import json
 import os
+import tempfile
 
 FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
 
@@ -29,6 +30,52 @@ def restore_home(saved):
             os.environ.pop(k, None)
         else:
             os.environ[k] = v
+
+
+# Every user-GLOBAL state path the payload writes, and the env seam each one
+# already honours. `redirect_home` alone is not enough: a test that redirects ~
+# still lands its ledger and update cache in the redirected home, which is the
+# right answer for a per-test temp home but the wrong one for a module that
+# never meant to write user-global state at all.
+_STATE_SEAMS = ("CODEARBITER_LEDGER", "CODEARBITER_UPDATE_STATE")
+
+
+def isolate_user_state():
+    """Point ~ AND every user-global state path at one fresh temp directory.
+
+    Issue #442: running the hook suite rewrote the developer's real
+    `~/.claude/settings.json` and littered `~/.codearbiter/` with a ledger, its
+    lock, five session shards, and an update cache. Four modules did it, none of
+    them using `redirect_home`, which already sat right here.
+
+    Call from `setUpModule`, not `setUp`. The leak is module-wide -- the
+    offending modules have 16 and 23 test classes between them -- so a
+    per-class fix is one forgotten `setUp` away from regressing, while a module
+    fixture covers every class added later for free.
+
+    Returns a token for `release_user_state()` in `tearDownModule`."""
+    directory = tempfile.TemporaryDirectory(prefix="ca-test-home-")
+    saved_home = redirect_home(directory.name)
+    saved_seams = {key: os.environ.get(key) for key in _STATE_SEAMS}
+    os.environ["CODEARBITER_LEDGER"] = os.path.join(directory.name, "ledger.json")
+    os.environ["CODEARBITER_UPDATE_STATE"] = os.path.join(directory.name, "update-state.json")
+    return directory, saved_home, saved_seams
+
+
+def release_user_state(token):
+    directory, saved_home, saved_seams = token
+    restore_home(saved_home)
+    for key, value in saved_seams.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    # Windows keeps a handle alive briefly after a subprocess exits; a leaked
+    # temp home must never be the thing that fails a suite.
+    try:
+        directory.cleanup()
+    except OSError:
+        pass
 
 
 def fixture(name):

--- a/plugins/ca/hooks/tests/test_colorlib.py
+++ b/plugins/ca/hooks/tests/test_colorlib.py
@@ -16,6 +16,31 @@ if _HOOKS_DIR not in sys.path:
 
 import _colorlib
 import _boxlib
+from _helpers import isolate_user_state, release_user_state
+
+
+# Issue #442: this module writes user-GLOBAL state - the statusline pin in
+# `~/.claude/settings.json`, and/or the `~/.codearbiter/` ledger and update
+# cache. Running the suite used to do that to the DEVELOPER'S REAL HOME: the
+# statusline pin was repointed at whatever plugin root the test process
+# resolved (it broke the maintainer's statusline three times in one day), and
+# `~/.codearbiter/` gained a ledger, its lock, five session shards and an
+# update cache. CI never noticed, because a fresh runner has no pre-existing
+# settings to clobber.
+#
+# The fixture is module-level rather than per-class ON PURPOSE. The leak is
+# module-wide, this file has many test classes, and a per-class `setUp` is one
+# forgotten override away from regressing - while `setUpModule` covers every
+# class added later for free. `.github/scripts/test_suite_hermeticity.py` is the
+# backstop that fails if any suite writes outside its temp dirs.
+def setUpModule():
+    global _USER_STATE
+    _USER_STATE = isolate_user_state()
+
+
+def tearDownModule():
+    release_user_state(_USER_STATE)
+
 
 
 class TestPaletteResolution(unittest.TestCase):

--- a/plugins/ca/hooks/tests/test_init_codearbiter.py
+++ b/plugins/ca/hooks/tests/test_init_codearbiter.py
@@ -5,6 +5,18 @@ import sys
 import tempfile
 import unittest
 
+
+# #462: an unclosed file handle is not cosmetic on Windows -- it blocks the
+# enclosing TemporaryDirectory's cleanup, so teardown RAISES instead of the
+# assertion failing. That is the shape the intermittent suite showed: errors,
+# not failures, with no code change between runs. A suite that is red once in
+# four trains everyone to re-run first and diagnose never, which is how a real
+# regression gets waved through.
+def _read_text(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
 # Load init-codearbiter.py as a module (filename has a hyphen).
 _HOOKS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _SCRIPT = os.path.join(_HOOKS_DIR, "init-codearbiter.py")
@@ -120,12 +132,12 @@ class TestIdempotencyGuard(unittest.TestCase):
 
     def test_existing_files_unchanged_after_failed_rerun(self):
         cad = os.path.join(self.root, ".codearbiter")
-        ctx_before = open(os.path.join(cad, "CONTEXT.md"), encoding="utf-8").read()
+        ctx_before = _read_text(os.path.join(cad, "CONTEXT.md"))
         try:
             ic.main(["--root", self.root])
         except SystemExit:
             pass
-        ctx_after = open(os.path.join(cad, "CONTEXT.md"), encoding="utf-8").read()
+        ctx_after = _read_text(os.path.join(cad, "CONTEXT.md"))
         self.assertEqual(ctx_before, ctx_after)
 
 

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -30,7 +30,31 @@ local_date_iso = _mod.local_date_iso
 write_standup_marker = _mod.write_standup_marker
 provenance_drift_line = _mod.provenance_drift_line
 
-from _helpers import durable_plugin_copy  # noqa: E402
+from _helpers import durable_plugin_copy, isolate_user_state, release_user_state  # noqa: E402
+
+
+# Issue #442: this module writes user-GLOBAL state - the statusline pin in
+# `~/.claude/settings.json`, and/or the `~/.codearbiter/` ledger and update
+# cache. Running the suite used to do that to the DEVELOPER'S REAL HOME: the
+# statusline pin was repointed at whatever plugin root the test process
+# resolved (it broke the maintainer's statusline three times in one day), and
+# `~/.codearbiter/` gained a ledger, its lock, five session shards and an
+# update cache. CI never noticed, because a fresh runner has no pre-existing
+# settings to clobber.
+#
+# The fixture is module-level rather than per-class ON PURPOSE. The leak is
+# module-wide, this file has many test classes, and a per-class `setUp` is one
+# forgotten override away from regressing - while `setUpModule` covers every
+# class added later for free. `.github/scripts/test_suite_hermeticity.py` is the
+# backstop that fails if any suite writes outside its temp dirs.
+def setUpModule():
+    global _USER_STATE
+    _USER_STATE = isolate_user_state()
+
+
+def tearDownModule():
+    release_user_state(_USER_STATE)
+
 
 # The real plugin payload root (parent of the hooks/ dir holding session-start.py).
 _REAL_PLUGIN = os.path.dirname(os.path.dirname(os.path.abspath(_mod.__file__)))
@@ -1201,7 +1225,14 @@ class TestSpawnBackgroundUpdateRefresh(unittest.TestCase):
             elapsed = _time.time() - t0
             self.assertLess(elapsed, 1.0, "spawn must return immediately, never await the child")
             if proc is not None:
-                proc.wait(timeout=5)
+                # #462: wait() alone leaves the handle's pipes open, and the
+                # ResourceWarning it raises at GC time is the quiet half of the
+                # intermittent-teardown problem. communicate() drains and closes.
+                try:
+                    proc.communicate(timeout=5)
+                except Exception:  # noqa: BLE001
+                    proc.kill()
+                    proc.communicate(timeout=5)
         finally:
             import shutil
             shutil.rmtree(plugin_dir, ignore_errors=True)

--- a/plugins/ca/hooks/tests/test_standup.py
+++ b/plugins/ca/hooks/tests/test_standup.py
@@ -8,12 +8,37 @@ import time
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _helpers import isolate_user_state, release_user_state  # noqa: E402
 
 import _standuplib as sl
 
 # Load the hyphenated session-start.py without executing main() — same idiom as
 # test_session_start.py.
 import importlib.util as _ilu
+
+
+# Issue #442: this module writes user-GLOBAL state - the statusline pin in
+# `~/.claude/settings.json`, and/or the `~/.codearbiter/` ledger and update
+# cache. Running the suite used to do that to the DEVELOPER'S REAL HOME: the
+# statusline pin was repointed at whatever plugin root the test process
+# resolved (it broke the maintainer's statusline three times in one day), and
+# `~/.codearbiter/` gained a ledger, its lock, five session shards and an
+# update cache. CI never noticed, because a fresh runner has no pre-existing
+# settings to clobber.
+#
+# The fixture is module-level rather than per-class ON PURPOSE. The leak is
+# module-wide, this file has many test classes, and a per-class `setUp` is one
+# forgotten override away from regressing - while `setUpModule` covers every
+# class added later for free. `.github/scripts/test_suite_hermeticity.py` is the
+# backstop that fails if any suite writes outside its temp dirs.
+def setUpModule():
+    global _USER_STATE
+    _USER_STATE = isolate_user_state()
+
+
+def tearDownModule():
+    release_user_state(_USER_STATE)
+
 
 _spec = _ilu.spec_from_file_location(
     "session_start",
@@ -871,8 +896,23 @@ class _MainHarness(unittest.TestCase):
             "project_root": _mod.project_root,
             "_default_git_runner": _mod._default_git_runner,
             "_detached_fetch_spawner": _mod._detached_fetch_spawner,
+            "_detached_update_refresh_spawner": _mod._detached_update_refresh_spawner,
         }
         _mod.project_root = lambda: self.root
+        # #462: main() ends by firing TWO fully detached, never-awaited children
+        # (a git fetch and update-refresh.py). That is correct in production and
+        # wrong in a test: the Popen handles are garbage-collected with live
+        # children behind them, which is the `subprocess N is still running`
+        # ResourceWarning the intermittent suite emitted - and on Windows a live
+        # child holding a fixture path turns the next teardown into an ERROR
+        # rather than a FAILURE. Both seams exist precisely so a caller can
+        # supply its own; the harness supplies recording no-ops, so the spawn is
+        # still observable but nothing is launched.
+        self.spawned = []
+        _mod._detached_fetch_spawner = lambda args, root: self.spawned.append(
+            ("fetch", tuple(args), root))
+        _mod._detached_update_refresh_spawner = lambda plugin: self.spawned.append(
+            ("refresh", plugin))
 
     def tearDown(self):
         for name, fn in self._saved.items():

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -23,7 +23,31 @@ import statusline as sl
 import _subagentslib as subs
 
 # Re-import helpers used by ledger tests.
-from _helpers import redirect_home, restore_home
+from _helpers import isolate_user_state, redirect_home, release_user_state, restore_home
+
+
+# Issue #442: this module writes user-GLOBAL state - the statusline pin in
+# `~/.claude/settings.json`, and/or the `~/.codearbiter/` ledger and update
+# cache. Running the suite used to do that to the DEVELOPER'S REAL HOME: the
+# statusline pin was repointed at whatever plugin root the test process
+# resolved (it broke the maintainer's statusline three times in one day), and
+# `~/.codearbiter/` gained a ledger, its lock, five session shards and an
+# update cache. CI never noticed, because a fresh runner has no pre-existing
+# settings to clobber.
+#
+# The fixture is module-level rather than per-class ON PURPOSE. The leak is
+# module-wide, this file has many test classes, and a per-class `setUp` is one
+# forgotten override away from regressing - while `setUpModule` covers every
+# class added later for free. `.github/scripts/test_suite_hermeticity.py` is the
+# backstop that fails if any suite writes outside its temp dirs.
+def setUpModule():
+    global _USER_STATE
+    _USER_STATE = isolate_user_state()
+
+
+def tearDownModule():
+    release_user_state(_USER_STATE)
+
 
 
 class TestSubagentModels(unittest.TestCase):

--- a/plugins/ca/hooks/tests/test_taskwrite.py
+++ b/plugins/ca/hooks/tests/test_taskwrite.py
@@ -109,6 +109,28 @@ if _CA_TEST_HOLD_MS > 0:
 '''
 
 
+def _reap(process):
+    """Terminate and fully drain a test subprocess. Idempotent and never raises:
+    a cleanup helper must not be the thing that fails a suite (#462)."""
+    try:
+        if process.poll() is None:
+            process.terminate()
+        process.communicate(timeout=10)
+    except Exception:  # noqa: BLE001
+        try:
+            process.kill()
+            process.communicate(timeout=10)
+        except Exception:  # noqa: BLE001
+            pass
+    finally:
+        for stream in (process.stdout, process.stderr, process.stdin):
+            try:
+                if stream is not None:
+                    stream.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
 def _wait_for_file(path, timeout=CONCURRENCY_TEST_WAIT):
     """Bounded poll for a marker file's existence. Returns True/False; never
     raises, never blocks past `timeout`."""
@@ -177,10 +199,17 @@ class TaskwriteContentionTest(unittest.TestCase):
             env["CA_TEST_ACQUIRED_MARKER"] = marker
         else:
             env.pop("CA_TEST_ACQUIRED_MARKER", None)
-        return subprocess.Popen(
+        process = subprocess.Popen(
             [sys.executable, self._taskwrite_script] + argv,
             cwd=self.root, env=env, text=True,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # #462: registered on the TestCase, not left to _finish(). An assertion
+        # that fires BEFORE _finish() would otherwise leave a live child holding
+        # the fixture's temp dir, and on Windows that turns the NEXT test's
+        # teardown into an ERROR rather than this test's FAILURE - exactly the
+        # intermittent shape the suite showed.
+        self.addCleanup(_reap, process)
+        return process
 
     def _finish(self, proc):
         out, err = proc.communicate(timeout=CONCURRENCY_TEST_WAIT)

--- a/plugins/ca/hooks/tests/test_updatelib.py
+++ b/plugins/ca/hooks/tests/test_updatelib.py
@@ -298,6 +298,13 @@ class TestFetchLatestTag(unittest.TestCase):
         import urllib.error
         refused = urllib.error.HTTPError(
             U.UPDATE_API_URL, 302, "Found", {"Location": "http://evil.example/steal"}, None)
+        # #462: HTTPError is itself a file-like response object. Constructed with
+        # fp=None it still allocates a spooled temp file, and letting the garbage
+        # collector reclaim it emits `ResourceWarning: Implicitly cleaning up
+        # <HTTPError 302>` at an unrelated point in the run. Closing it here is
+        # what keeps the suite's warning output empty, so a NEW leak is visible
+        # instead of lost in the noise.
+        self.addCleanup(refused.close)
         opener = _FakeOpener(exc=refused)
         self.assertIsNone(U.fetch_latest_tag(opener=opener))
         # Exactly one call was attempted (the initial request); no follow-up

--- a/plugins/ca/hooks/tests/test_wire_statusline.py
+++ b/plugins/ca/hooks/tests/test_wire_statusline.py
@@ -7,6 +7,18 @@ import sys
 import tempfile
 import unittest
 
+
+# #462: an unclosed file handle is not cosmetic on Windows -- it blocks the
+# enclosing TemporaryDirectory's cleanup, so teardown RAISES instead of the
+# assertion failing. That is the shape the intermittent suite showed: errors,
+# not failures, with no code change between runs. A suite that is red once in
+# four trains everyone to re-run first and diagnose never, which is how a real
+# regression gets waved through.
+def _read_text(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
 # Load wire-statusline.py as a module (filename has a hyphen).
 _HOOKS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _SCRIPT = os.path.join(_HOOKS_DIR, "wire-statusline.py")
@@ -354,7 +366,7 @@ class TestIdempotentRefresh(unittest.TestCase):
                  "--plugin-root", self.root, "--interp", "python"])
         data = _read(self.settings)
         # BACKUP_KEY should still only appear once (JSON keys are unique by spec)
-        raw = open(self.settings, encoding="utf-8").read()
+        raw = _read_text(self.settings)
         self.assertEqual(raw.count(ws.BACKUP_KEY), 1)
 
     def test_second_install_statusline_still_ours(self):
@@ -601,7 +613,7 @@ class TestSpinnerVerbsIdempotent(unittest.TestCase):
     def test_second_install_spinner_backup_key_appears_once(self):
         ws.main(["install", "--settings", self.settings,
                  "--plugin-root", self.root, "--interp", "python"])
-        raw = open(self.settings, encoding="utf-8").read()
+        raw = _read_text(self.settings)
         self.assertEqual(raw.count(ws.SPINNER_BACKUP_KEY), 1)
 
     def test_second_install_verbs_still_set(self):


### PR DESCRIPTION
Two defects, one class: the test suites reach outside their sandbox.

## #442 — the suite mutated the developer's real home

Running the sanctioned hook suite rewrote `~/.claude/settings.json` (both `statusLine.command` and `_codearbiterStatuslineOwner` repointed at whatever plugin root the test process resolved) and littered `~/.codearbiter/` with a ledger, its lock, five session shards, and an update cache.

Four modules did it — `test_session_start`, `test_standup`, `test_colorlib`, `test_statusline` — and **none used `redirect_home`, which already sat beside them in `_helpers.py`.**

It broke the maintainer's statusline three times in one day. It makes the suite non-hermetic, so two developers running it end up with different global config. It is why a subagent tripped an "irreversible local destruction" check trying to clean up the mess. And CI never noticed: a fresh runner has no pre-existing settings to clobber.

The fixture is **module-level, not per-class, on purpose.** The leak is module-wide, those two modules carry 16 and 23 test classes between them, and a per-class `setUp` is one forgotten override away from regressing — while `setUpModule` covers every class added later for free. It pins `~` *and* the two user-global state seams (`CODEARBITER_LEDGER`, `CODEARBITER_UPDATE_STATE`) at one temp dir.

## #462 — the suite leaked handles and processes

The same unchanged tree produced `FAILED (errors=2)` on one run and `OK` on the next three. On Windows an open handle blocks `TemporaryDirectory` cleanup and a live child holds a temp path, so teardown **raises** instead of the assertion failing — intermittent *errors*, not failures, with no code change between runs.

| leak | fix |
| --- | --- |
| unclosed reads at `test_wire_statusline.py:357/:604`, `test_init_codearbiter.py` | routed through a `with` block |
| 5 never-reaped subprocesses in `test_taskwrite` | reaped via `addCleanup`, so an assertion firing *before* `_finish()` can't leave a live child holding the fixture dir |
| `test_session_start` spawn handle | `communicate()` rather than `wait()` — drains *and* closes the pipes |
| implicitly reclaimed `HTTPError` | closed; constructed with `fp=None` it still allocates a spooled temp file |
| the two detached spawns `main()` fires | stubbed in `_MainHarness` |

That last one is the interesting one. `session-start.py main()` ends by firing a real `git fetch` and a real `update-refresh.py`, fully detached and never awaited — correct in production, wrong in a test. Those were the five leaked pids. Both seams exist for injection; the harness now records instead of launching, which also drops `test_standup` from ~90s to **0.4s**.

## The guard

`.github/scripts/test_suite_hermeticity.py`, wired into the hooks job.

The obvious guard — hash the developer's real `~` before and after — is **destructive by observation**: it can only detect damage already done, on the machine you care about. Instead each suite runs in a subprocess whose home is a *pristine* temp directory seeded with a plausible stale-but-real `settings.json`, and that directory must come back byte-identical: nothing created, modified, or removed. Strictly stronger, and safe to run on the machine that was being damaged.

The seeded `settings.json` is load-bearing: `heal_statusline_wiring` returns early when no settings file exists, so an *empty* fake home would hide exactly the write this issue is about.

It deliberately does **not** pin the ledger/update-state env seams. Those are what a well-behaved test uses to point its own state at its own temp dir; pinning them would force correct code to look incorrect and — worse — would let an offender pass by writing to a path the guard itself supplied.

| AC | covered by |
| --- | --- |
| **AC-1 / AC-2** | the seeded home is byte-identical after the run: no settings rewrite, no `~/.codearbiter/` entries |
| **AC-3** | the guard fails if any suite writes outside its temp dir — proven by two deliberate offenders, because a hermeticity guard that cannot fail is decoration |
| **AC-4** | the same audit applied to the `.github/scripts` suites (hook-guard matrix, codex adapter, dual-host store) |

Plus a class asserting the suite emits **no `ResourceWarning`**, which is what keeps #462 closed rather than merely fixed.

## Verification

**Red first**: the guard reported all 10 leaked paths against the unmodified suite, and 9 `ResourceWarning`s.

**Green after**: 5/5 guard tests pass, hook suite **1153 tests OK**, `test_ci_impact` 40 OK, `check_docs_contract` OK, `sync-core --check` OK.

Closes #442. Closes #462.
