### PR TITLE
fix(pi): run the test suite against a disposable operator home

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -153,6 +153,15 @@ broker, so neither a stranded root nor a surviving listener can outlive the
 child. Task/prompt content is
 stdin-only, never argv, environment, or a temporary file. Tests use disposable
 Pi homes and dummy credentials and never inspect or mutate the real auth store.
+That clause is enforced by construction rather than per test file: the ca-pi
+vitest suite loads `test/setup-disposable-home.ts` before any test, which
+repoints every home variable Node consults (`HOME`, `USERPROFILE`, and the
+Windows `HOMEDRIVE`/`HOMEPATH` pair) plus `PI_CODING_AGENT_DIR` at a `mkdtemp`
+root seeded with an obviously fake record. The request fixtures spread
+`process.env`, so before that redirection roughly 25 tests resolved the
+operator's real `~/.pi/agent/auth.json` (issue #464). `security.test.ts` asserts
+the effect - where `os.homedir()` actually resolves - not that a setup file is
+listed somewhere.
 
 All other codeArbiter-defined env vars (`FARM_MODEL`, `FARM_BASE_BRANCH`, etc.)
 are non-sensitive configuration and may freely use `process.env`. Provider

--- a/.github/scripts/test_host_descriptors.py
+++ b/.github/scripts/test_host_descriptors.py
@@ -173,6 +173,17 @@ _ISSUE_455_NON_POLICY_ARTIFACTS = frozenset({
 })
 
 
+# Issue #464: the vitest setup file that repoints every home variable and
+# PI_CODING_AGENT_DIR at a disposable root before any test runs, so
+# security-controls.md's "tests use disposable Pi homes and dummy credentials"
+# clause is true by construction rather than per test file. Build-time only --
+# it is loaded by vitest, never by the shipped extension. Path-exact like every
+# set above, so an unlisted file under tools/ still fails closed.
+_ISSUE_464_NON_POLICY_ARTIFACTS = frozenset({
+    "tools/test/setup-disposable-home.ts",
+})
+
+
 def _load_module(name, path):
     spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
@@ -403,6 +414,7 @@ def _pi_policy_surfaces_from_disk(pi_host):
         | set(_ISSUE_370_NON_POLICY_ARTIFACTS)
         | set(_ISSUE_374_NON_POLICY_ARTIFACTS)
         | set(_ISSUE_455_NON_POLICY_ARTIFACTS)
+        | set(_ISSUE_464_NON_POLICY_ARTIFACTS)
         | shared_hooks
         | ({pi_host.catalog} if pi_host.catalog else set())
     )

--- a/.github/scripts/test_pi_security.py
+++ b/.github/scripts/test_pi_security.py
@@ -206,11 +206,19 @@ def adversarial_results() -> list[dict[str, object]]:
     )
     rows: list[dict[str, object]] = []
     for code, tests in suites:
-        command = [npm, "--prefix", "plugins/ca-pi/tools", "exec", "vitest", "run", *tests]
+        # Issue #464: run FROM the package, not from the repo root with
+        # repo-relative paths. `npm --prefix` moves npm, not vitest: invoked from
+        # REPO, vitest took the repo root as its own root and never loaded
+        # plugins/ca-pi/tools/vitest.config.ts - so these suites ran without the
+        # package's `define` globals AND without its setup file, which is how a
+        # green PI-SEC row was reported for a suite running against the
+        # operator's real home. The paths in `suites` are already
+        # package-relative, so only the cwd needed to move.
+        command = [npm, "exec", "vitest", "run", *tests]
         try:
             completed = subprocess.run(
                 command,
-                cwd=REPO,
+                cwd=REPO / "plugins" / "ca-pi" / "tools",
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.23",
+  "version": "0.1.25",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.25] - 2026-07-25
+
+### Fixed
+
+- The ca-pi test suite no longer reads the operator's real
+  `~/.pi/agent/auth.json`. `security-controls.md` states that tests use
+  disposable Pi homes and dummy credentials and never inspect the real auth
+  store; the request fixtures spread `process.env`, so roughly 25 tests that did
+  not set their own overrides resolved the actual store. The suite now loads a
+  setup file that repoints every home variable Node consults - including the
+  Windows `HOMEDRIVE`/`HOMEPATH` pair - plus `PI_CODING_AGENT_DIR` at a
+  disposable root seeded with an obvious dummy, so the control is true by
+  construction rather than per test file (issue #464).
+- The Pi security contract now runs the ca-pi suites FROM the package rather
+  than from the repository root. `npm --prefix` moves npm, not vitest, so those
+  runs never loaded `plugins/ca-pi/tools/vitest.config.ts` - they executed
+  without the package's build-time globals and, latterly, without its setup
+  file, which is how a green security row could be reported for a suite running
+  against the real home.
+
 ## [0.1.23] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.23",
+  "version": "0.1.25",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/test/bridge.test.ts
+++ b/plugins/ca-pi/tools/test/bridge.test.ts
@@ -1,5 +1,5 @@
 import { access, chmod, copyFile, mkdtemp, mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
-import { realpathSync } from "node:fs";
+import { mkdtempSync, realpathSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { delimiter, isAbsolute, resolve } from "node:path";
@@ -188,8 +188,18 @@ async function clientFor(source: string, options: { timeoutMs?: number; maxStrea
   return (await clientFixture(source, options)).bridge;
 }
 
+// Issue #464: this used to pass `tmpdir()` ITSELF as the project cwd. That is
+// not a project root, it is the shared system temp directory - so once the
+// suite began running against a disposable operator home (also created under
+// tmpdir, as every fixture here is), `canonicalUserHome` correctly refused a
+// home nested inside the project root and every call came back "path validation
+// failed". The bridge was right; the fixture was borrowing a directory that
+// belongs to everybody. A dedicated per-file project root fixes it and is what
+// the other fixtures in this file already do.
+const projectCwd = mkdtempSync(resolve(tmpdir(), "ca-pi-bridge-cwd-"));
+
 function request(tool: string, input: Record<string, unknown>) {
-  return { version: 1 as const, event: "tool_call", cwd: tmpdir(), tool, input };
+  return { version: 1 as const, event: "tool_call", cwd: projectCwd, tool, input };
 }
 
 async function executeWrappedRead(bridge: BridgePort, cwd: string): Promise<Record<string, unknown>> {

--- a/plugins/ca-pi/tools/test/security.test.ts
+++ b/plugins/ca-pi/tools/test/security.test.ts
@@ -1,5 +1,6 @@
 import { link, lstat, mkdir, mkdtemp, open, readFile, realpath, rm, utimes, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFileSync, realpathSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { describe, expect, test } from "vitest";
@@ -462,5 +463,51 @@ describe("ADR-0014 adversarial promotion contract", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+// Issue #464 AC-2. `security-controls.md` states that tests use disposable Pi
+// homes and dummy credentials and NEVER inspect or mutate the real auth store.
+// That clause was false: `runner-isolation.test.ts` spreads `process.env` into
+// its request fixture, so every case that did not explicitly override HOME or
+// PI_CODING_AGENT_DIR resolved the operator's actual ~/.pi/agent/auth.json.
+//
+// A control document describing behaviour the suite does not follow is worse
+// than no document - reviewers cite it, and it is wrong. So this asserts the
+// clause rather than restating it, and it asserts the EFFECT (where the process
+// actually resolves ~) rather than that a setup file was listed somewhere.
+describe("#464 - the suite runs against a disposable operator home", () => {
+  const disposable = process.env.CODEARBITER_TEST_DISPOSABLE_HOME;
+
+  test("the setup file ran and repointed every home variable", () => {
+    expect(disposable, "test/setup-disposable-home.ts did not run").toBeTruthy();
+    expect(process.env.HOME).toBe(disposable);
+    expect(process.env.USERPROFILE).toBe(disposable);
+    // Windows resolves USERPROFILE first, then HOMEDRIVE + HOMEPATH, and
+    // ignores HOME entirely - so a half-redirected home still reaches the real
+    // profile there. This is the assertion that catches that.
+    expect(process.env.HOMEDRIVE).toBeUndefined();
+    expect(process.env.HOMEPATH).toBeUndefined();
+  });
+
+  test("os.homedir() resolves inside the disposable root, not the real profile", () => {
+    expect(realpathSync(homedir())).toBe(realpathSync(disposable!));
+  });
+
+  test("the seeded auth store is an obvious dummy, and is the one a child would read", () => {
+    const store = resolve(process.env.PI_CODING_AGENT_DIR!, "auth.json");
+    expect(realpathSync(store).startsWith(realpathSync(disposable!))).toBe(true);
+    const record = JSON.parse(readFileSync(store, "utf8")) as Record<string, { key?: string }>;
+    expect(record.openai?.key).toMatch(/dummy/i);
+    // The point of the whole exercise: no plausible credential shape survives
+    // in the store an ordinary test run reads.
+    expect(JSON.stringify(record)).not.toMatch(/sk-[A-Za-z0-9]{16}|ghp_|AKIA[0-9A-Z]{16}/u);
+  });
+
+  test("a spread of process.env therefore carries the disposable home", () => {
+    // The exact shape that leaked: `{ ...process.env }` into a request fixture.
+    const parentEnv = { ...process.env };
+    expect(parentEnv.HOME).toBe(disposable);
+    expect(parentEnv.PI_CODING_AGENT_DIR!.startsWith(disposable!)).toBe(true);
   });
 });

--- a/plugins/ca-pi/tools/test/setup-disposable-home.ts
+++ b/plugins/ca-pi/tools/test/setup-disposable-home.ts
@@ -1,0 +1,60 @@
+/**
+ * setup-disposable-home.ts — issue #464.
+ *
+ * `.codearbiter/security-controls.md` states verbatim that tests use disposable
+ * Pi homes and dummy credentials and NEVER inspect or mutate the real auth
+ * store. `runner-isolation.test.ts` contradicted that across roughly 25 tests:
+ * its request fixture spreads `process.env`, so every case that did not
+ * explicitly override `HOME` / `PI_CODING_AGENT_DIR` resolved the operator's
+ * actual `~/.pi/agent/auth.json`.
+ *
+ * A control document that describes behaviour the suite does not follow is
+ * worse than no document — reviewers cite it, and it is wrong. And reading a
+ * real credential store during an ordinary test run is the exact boundary
+ * ADR-0016 and ADR-0019 exist to police; it also makes the suite's result
+ * depend on developer machine state.
+ *
+ * This runs BEFORE any test file, per worker, and repoints the home the whole
+ * process resolves at a disposable root seeded with an obviously fake record.
+ * Fixing the class rather than the instances is deliberate: the fixture spread
+ * is what leaked, so every future test inherits the disposable home for free
+ * instead of each author remembering an override. Tests that set their own
+ * `HOME` / `PI_CODING_AGENT_DIR` are unaffected — they already point somewhere
+ * disposable, which is what they were demonstrating.
+ *
+ * Every variable `os.homedir()` consults is set, not just `HOME`: on Windows
+ * Node reads `USERPROFILE` first, then `HOMEDRIVE` + `HOMEPATH`, and ignores
+ * `HOME` entirely.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+/** Unmistakably fake, and shaped like a real record so a reader that parses it
+ * still gets a valid document rather than a confusing crash. */
+export const DUMMY_AUTH = {
+  openai: { type: "api_key", key: "dummy-disposable-home-not-a-credential" },
+} as const;
+
+const root = mkdtempSync(resolve(tmpdir(), "ca-pi-operator-home-"));
+const agent = resolve(root, ".pi", "agent");
+mkdirSync(agent, { recursive: true });
+writeFileSync(resolve(agent, "auth.json"), JSON.stringify(DUMMY_AUTH), "utf8");
+
+process.env.HOME = root;
+process.env.USERPROFILE = root;
+delete process.env.HOMEDRIVE;
+delete process.env.HOMEPATH;
+process.env.PI_CODING_AGENT_DIR = agent;
+// Read by the guard in security.test.ts, which asserts the redirection actually
+// took effect rather than trusting that this file ran.
+process.env.CODEARBITER_TEST_DISPOSABLE_HOME = root;
+
+// Best-effort: a leaked temp home must never be the thing that fails a suite.
+process.on("exit", () => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});

--- a/plugins/ca-pi/tools/vitest.config.ts
+++ b/plugins/ca-pi/tools/vitest.config.ts
@@ -21,5 +21,16 @@ export default defineConfig({
   test: {
     environment: "node",
     fileParallelism: false,
+    // Issue #464: security-controls.md states that tests use disposable Pi
+    // homes and dummy credentials and never inspect the real auth store. This
+    // makes that true by construction rather than per test file - the request
+    // fixture spreads process.env, so a home redirected here is inherited by
+    // every case that does not set its own.
+    // Absolute, derived from this config's own URL. A relative entry resolves
+    // against vitest's `root`, which is the REPO root when the security
+    // contract invokes `vitest run plugins/ca-pi/tools/test/...` from there -
+    // and a setup file that silently does not load is worse than none, since
+    // the suite then runs against the operator's real home while looking fine.
+    setupFiles: [fileURLToPath(new URL("./test/setup-disposable-home.ts", import.meta.url))],
   },
 });


### PR DESCRIPTION
## The defect

`.codearbiter/security-controls.md` states **verbatim** that tests use disposable Pi homes and dummy credentials and never inspect or mutate the real auth store. `runner-isolation.test.ts` contradicted that across roughly 25 tests: the request fixture spreads `process.env`, so every case that did not explicitly override `HOME` / `PI_CODING_AGENT_DIR` resolved the operator's actual `~/.pi/agent/auth.json`.

A control document describing behaviour the suite does not follow is **worse than no document** — reviewers cite it, and it is wrong. Reading a real credential store during an ordinary test run is also the exact boundary ADR-0016 and ADR-0019 exist to police, and it makes the suite's result depend on developer machine state.

## The fix

Fixed as a **class**, not as instances. `test/setup-disposable-home.ts` runs before any test file and repoints:

- `HOME`, `USERPROFILE`, and the Windows `HOMEDRIVE`/`HOMEPATH` pair — Node reads those two *first* on Windows and ignores `HOME` entirely, so a `HOME`-only redirect silently misses;
- `PI_CODING_AGENT_DIR`;

at a `mkdtemp` root seeded with an obviously fake record. The fixture *spread* is what leaked, so every future test inherits the disposable home rather than each author remembering an override. Tests that set their own home are unaffected — they already pointed somewhere disposable, which is what they were demonstrating.

## Two real defects the redirection exposed

Both pre-existing, both surfaced only because the suite stopped silently borrowing the real home.

**1. `bridge.test.ts` passed `tmpdir()` itself as the project cwd.** That is not a project root, it is the shared system temp directory — and every fixture here, including the new disposable home, is created under it. `canonicalUserHome` correctly refuses a home nested inside the project root, so six bridge tests began failing with `path validation failed`. **The bridge was right; the fixture was borrowing a directory that belongs to everybody.** It now takes a dedicated per-file project root, as the other fixtures in that file already do.

**2. The Pi security contract never loaded the ca-pi vitest config.** It invoked `npm --prefix plugins/ca-pi/tools exec vitest run <repo-relative paths>` from the repository root. `--prefix` moves *npm*, not vitest: vitest took the repo root as its own root, so those suites ran without the package's build-time `define` globals and — once this change landed — without its setup file. That is how a **green `PI-SEC-ADVERSARIAL` row could be reported for a suite running against the operator's real home.** It now runs *from* the package; the test paths were already package-relative, so only the cwd moved. The config's `setupFiles` entry is absolute, derived from the config's own URL, because a setup file that silently does not load is worse than none.

## Tests

| AC | how |
| --- | --- |
| **AC-1** | no test resolves a path under the real user home — asserted through the **effect** (where `os.homedir()` actually resolves), not by scanning sources for `homedir()` calls |
| **AC-2** | four guards in `security.test.ts`: the setup ran and every home variable moved (including the two Windows-only ones); `homedir()` resolves inside the disposable root; the seeded store is an obvious dummy carrying no credential-shaped value; and a `{ ...process.env }` spread — *the exact shape that leaked* — carries the disposable home |
| **AC-3** | `security-controls.md`'s clause is now true of the suite as written, and says how it is enforced |

**Verified red first**: removing the setup file from the config fails all four guards, and the assertion output literally reads `expected 'C:\Users\brenn' to be undefined`.

Also green: full ca-pi tools suite **735 passed / 1 skipped**, typecheck clean, Pi security contract **12/12 pass**, `test_pi_package` 24 OK, `check_docs_contract` OK. `security-controls.md` was patched byte-preserving — its 327 CRLF lines are unchanged, so the diff is 9 added lines rather than a whole-file rewrite.

## A note on the version bump

`ca-pi` advances to **0.1.25** for a change entirely under `tools/test/` plus a vitest config. That bump is required only because the payload gate still scopes `plugins/ca-pi` wholesale — which is exactly the tax #435 (PR #476) removes. Once that lands, this class of change stops demanding a version.

Closes #464.
