### PR TITLE
feat(site): enforce VOICE.md's punctuation rule, and make it true

### DIFF
--- a/.github/scripts/check_site_voice.py
+++ b/.github/scripts/check_site_voice.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Issue #338 - site/VOICE.md's punctuation rule, finally enforced.
+
+`site/VOICE.md` has said this since 2026-07-02:
+
+    Em-dashes are not used as sentence separators in site prose. Restructure
+    with a period, a comma, a colon, or parentheses instead.
+
+Nothing enforced it. `_sloplib.in_antislop_doc_scope` governed repo-root docs
+and `docs/**` and had never covered `site/`, so the rule was prose asking
+politely - and 16 of the 36 authored pages violated it, for 24 days, while
+reviewers cited it at contributors.
+
+A rule with no gate is worse than no rule. It is not merely unenforced: people
+learn that the style docs are advisory, which is the same failure mode as a
+teardown report that over-counts its failures. So this is the gate.
+
+SCOPE IS AUTHORED PROSE, and the exclusions are load-bearing rather than
+convenient:
+
+  * `site/src/content/docs/reference/**` - 91 of the 128 pages there are
+    generated on every build. Flagging them would report findings nobody wrote
+    and nobody can fix in place.
+  * `site/src/content/docs/changelog.md` - a verbatim pass-through of the repo
+    CHANGELOG, which is payload prose under a different register.
+  * `site/src/curated/**` - mirrors of `plugins/ca` bodies. Framework prose,
+    already excluded via `plugins/`; mirroring it into the site must not smuggle
+    it back into scope.
+
+The file set comes from `git ls-files`, so a generated page cannot drift into
+scope by being written into a tracked directory: if it is not committed, it is
+not audited.
+
+KNOWN GAP, stated rather than discovered later. The detector is line-based: it
+requires word characters on both sides of the dash ON THE SAME LINE. A separator
+dash that lands at a line-wrap boundary -
+    ...it holds in one of three states —
+    listed below.
+- is therefore invisible to it, and three such dashes were found by hand in
+`codearbiter-directory.md` while fixing the flagged ones. They were fixed too,
+but the gate did not catch them and would not catch a new one. Closing that
+needs paragraph-level analysis rather than a per-line scan, which is a larger
+change than this gate; it is filed separately rather than implied to be handled.
+
+Usage:
+    python .github/scripts/check_site_voice.py           # audit, exit 1 on findings
+    python .github/scripts/check_site_voice.py --list    # paths only, exit 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "plugins" / "ca" / "hooks"))
+
+from _sloplib import find_prose_separator_dashes, in_antislop_doc_scope  # noqa: E402
+
+SITE_PROSE = "site/src/content/docs"
+
+
+def audited_paths() -> list[str]:
+    """Every git-TRACKED page under the authored site-prose root that the shared
+    scope predicate governs. One source of truth for scope: this script does not
+    re-implement the exclusions, it asks `in_antislop_doc_scope`."""
+    tracked = subprocess.run(
+        ["git", "ls-files", SITE_PROSE],
+        cwd=REPO, capture_output=True, text=True, encoding="utf-8", check=True,
+    ).stdout.split()
+    return sorted(p for p in tracked if in_antislop_doc_scope(p))
+
+
+def audit() -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for rel in audited_paths():
+        text = (REPO / rel).read_text(encoding="utf-8", errors="replace")
+        hits = find_prose_separator_dashes(text)
+        if hits:
+            out[rel] = hits
+    return out
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="print the audited paths and exit 0")
+    arguments = parser.parse_args(argv)
+
+    paths = audited_paths()
+    if arguments.list:
+        for rel in paths:
+            print(rel)
+        return 0
+
+    if not paths:
+        print("::error::no authored site prose found to audit - the scope predicate has drifted",
+              file=sys.stderr)
+        return 1
+
+    findings = audit()
+    total = sum(len(v) for v in findings.values())
+    if not findings:
+        print(f"site voice: {len(paths)} authored page(s) clean of prose separator dashes")
+        return 0
+
+    print(f"::error::site/VOICE.md forbids the em-dash as a sentence separator in site prose; "
+          f"{total} line(s) across {len(findings)} file(s) still use one. Restructure with a "
+          f"period, a comma, a colon, or parentheses.", file=sys.stderr)
+    for rel, hits in findings.items():
+        for hit in hits:
+            print(f"  {rel}:{hit['line']}: {hit['context'][:160]}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,11 @@ on:
       - "site/**"
       - "plugins/ca/**" # the reference is generated from the plugin, so rebuild when it changes
       - ".github/workflows/docs.yml" # this workflow gates the site graph; it must see its own edits
+      # Issue #338: the site-voice gate and the detector it calls. Without these
+      # a PR that only loosened the rule would skip the job that enforces it -
+      # the same defect class the impact filter already guards for ci.yml.
+      - ".github/scripts/check_site_voice.py"
+      - "core/pysrc/_sloplib.py"
   pull_request:
     branches: [main]
     paths:
@@ -74,6 +79,23 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
       - name: Typecheck
         run: npm run typecheck
+      - name: Enforce site/VOICE.md punctuation (issue #338)
+        # site/VOICE.md has banned the em-dash as a sentence separator in site
+        # prose since 2026-07-02, and NOTHING enforced it: _sloplib's scope
+        # covered repo-root docs and docs/**, never site/. 16 of the 36 authored
+        # pages violated the rule for 24 days while reviewers cited it at
+        # contributors. A rule with no gate is worse than no rule - people learn
+        # that the style docs are advisory.
+        #
+        # `deploy` needs this job, so a violation blocks the publish. Scope is
+        # AUTHORED prose only, drawn from `git ls-files` via the shared
+        # in_antislop_doc_scope: generated reference pages, the changelog
+        # pass-through, and the curated plugin mirrors are all excluded, because
+        # a finding nobody wrote and nobody can fix in place is noise.
+        #
+        # Runs from the repo root, not site/, since it audits tracked paths.
+        working-directory: .
+        run: python .github/scripts/check_site_voice.py
       - name: Test
         run: npm test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,25 @@ predate the plugin rewrite and are grouped by date.
 
 ### Fixed
 
+- site/VOICE.md's punctuation rule is finally enforced. It has banned the
+  em-dash as a sentence separator in site prose since 2026-07-02, and nothing
+  checked it: the anti-slop detector's scope covered repo-root docs and
+  `docs/**` and had never included `site/`. Sixteen of the thirty-six authored
+  pages violated the rule for twenty-four days while reviewers cited it at
+  contributors. A rule with no gate is worse than no rule, because people learn
+  that the style docs are advisory. 118 offending lines across 15 pages are
+  restructured with a period, a comma, a colon, or parentheses, and
+  `check_site_voice.py` now blocks the site publish on a new one (issue #338).
+- The detector no longer flags a definition-list dash (`- **term** - meaning`).
+  The rule is about *sentence* separators, and VOICE.md's own Terminology
+  anchors are written in that exact form, so enforcing it as written would have
+  made the gate contradict the guide. A real separator later on the same line is
+  still caught: only the definition dash is dropped, never the term before it.
+  The first cut of that exemption blanked the whole lead-in and silently
+  suppressed a genuine finding whenever inline code followed it, which an
+  adversarial reader caught before it shipped.
+- The detector's scope predicate recognises `.mdx` as prose. It keyed on `.md`
+  alone, so two authored site pages were invisible to a rule about writing.
 - The shipped `farm.js` bundle is now executed by the test suite, not merely
   regenerated and byte-compared. `includes/farm.md` tells operators to run
   `node <plugin>/tools/farm.js`, but the integration launcher ran `farm.ts`

--- a/core/pysrc/_sloplib.py
+++ b/core/pysrc/_sloplib.py
@@ -34,10 +34,28 @@ _RANGE_RE = re.compile(r"\d\s*[–—]\s*\d")
 # A letter or digit (Unicode), used to confirm a dash actually joins two text
 # spans rather than standing alone (e.g. a lone "—" N/A marker in a table cell).
 _WORD_RE = re.compile(r"[^\W_]", re.UNICODE)
+# A DEFINITION-LIST dash: `- **term** — meaning`. Structural, not a sentence
+# separator, and the rule this detector enforces says "sentence separators" -
+# site/VOICE.md's own Terminology anchors section is written in exactly this
+# form, so flagging it would make the gate contradict the style guide it exists
+# to enforce (#338). Anchored to the start of the line and to a bolded lead-in,
+# so an ordinary sentence that happens to contain bold text is untouched.
+#
+# The TERM is captured and kept; only the dash is dropped. Blanking the whole
+# lead-in was the first cut and it was a false-negative generator: on
+#     - **The gate-enforcement hooks** — `a.py`, `b.py` — make zero calls.
+# it removed the left-hand words, then _INLINE_CODE_RE blanked the backticks,
+# and the SECOND dash - a real separator - was left with no word character on
+# its left and escaped. That loosened the shared detector for docs/** and
+# repo-root too, not only for site prose.
+_DEFINITION_RE = re.compile(r"^(\s*(?:[-*+]\s+)?\*\*[^*]+\*\*\s*)[–—]")
 
 
 def _prose_only(line):
     """Drop the spans §3.A exempts so only candidate prose remains."""
+    # Only the definition DASH is dropped; the term is kept (group 1), so a
+    # later separator on the same line still has its left-hand context.
+    line = _DEFINITION_RE.sub(r"\1 ", line)
     line = _INLINE_CODE_RE.sub(" ", line)
     line = _URL_RE.sub(" ", line)
     line = _RANGE_RE.sub(" ", line)
@@ -78,18 +96,43 @@ def find_prose_separator_dashes(text):
     return findings
 
 
+# Authored site prose (#338). site/VOICE.md has banned em-dashes as sentence
+# separators since 2026-07-02, and nothing enforced it: this predicate covered
+# repo-root docs and docs/**, never site/. A rule with no gate, violated in 16
+# of its own 36 authored files, is worse than no rule - reviewers cite it and it
+# is wrong.
+#
+# Scope is AUTHORED prose only. Everything under content/docs/reference/ is
+# generated on every build (91 of the 128 files there), changelog.md is a
+# verbatim pass-through of the repo CHANGELOG, and site/src/curated/** mirrors
+# plugins/ca bodies - which are framework prose under a different register, and
+# already excluded via plugins/. Flagging any of those would report a finding
+# nobody wrote and nobody can fix in place.
+_SITE_PROSE_ROOT = "site/src/content/docs/"
+_SITE_PROSE_EXCLUDED = ("reference/", "changelog.md")
+
+
 def in_antislop_doc_scope(rel_path):
     """True for user-facing Markdown the anti-slop bundle governs: repo-root
-    community docs and docs/**. Excludes codeArbiter's own framework bodies
-    (everything under plugins/) and machine-managed .codearbiter/ state."""
+    community docs, docs/**, and AUTHORED site prose under
+    site/src/content/docs/ (#338). Excludes codeArbiter's own framework bodies
+    (everything under plugins/), machine-managed .codearbiter/ state, and every
+    generated site page."""
     if not rel_path:
         return False
     p = rel_path.replace("\\", "/")
     if p.startswith("./"):
         p = p[2:]
-    if not p.lower().endswith(".md"):
+    # `.mdx` counts: the rule is about prose, not about a file extension, and
+    # two authored site pages are .mdx.
+    if not p.lower().endswith((".md", ".mdx")):
         return False
     if p.startswith("plugins/") or p.startswith(".codearbiter/"):
+        return False
+    if p.startswith(_SITE_PROSE_ROOT):
+        rest = p[len(_SITE_PROSE_ROOT):]
+        return not rest.startswith(_SITE_PROSE_EXCLUDED)
+    if p.startswith("site/"):
         return False
     if p.startswith("docs/"):
         return True

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/hooks/_sloplib.py
+++ b/plugins/ca-codex/hooks/_sloplib.py
@@ -34,10 +34,28 @@ _RANGE_RE = re.compile(r"\d\s*[–—]\s*\d")
 # A letter or digit (Unicode), used to confirm a dash actually joins two text
 # spans rather than standing alone (e.g. a lone "—" N/A marker in a table cell).
 _WORD_RE = re.compile(r"[^\W_]", re.UNICODE)
+# A DEFINITION-LIST dash: `- **term** — meaning`. Structural, not a sentence
+# separator, and the rule this detector enforces says "sentence separators" -
+# site/VOICE.md's own Terminology anchors section is written in exactly this
+# form, so flagging it would make the gate contradict the style guide it exists
+# to enforce (#338). Anchored to the start of the line and to a bolded lead-in,
+# so an ordinary sentence that happens to contain bold text is untouched.
+#
+# The TERM is captured and kept; only the dash is dropped. Blanking the whole
+# lead-in was the first cut and it was a false-negative generator: on
+#     - **The gate-enforcement hooks** — `a.py`, `b.py` — make zero calls.
+# it removed the left-hand words, then _INLINE_CODE_RE blanked the backticks,
+# and the SECOND dash - a real separator - was left with no word character on
+# its left and escaped. That loosened the shared detector for docs/** and
+# repo-root too, not only for site prose.
+_DEFINITION_RE = re.compile(r"^(\s*(?:[-*+]\s+)?\*\*[^*]+\*\*\s*)[–—]")
 
 
 def _prose_only(line):
     """Drop the spans §3.A exempts so only candidate prose remains."""
+    # Only the definition DASH is dropped; the term is kept (group 1), so a
+    # later separator on the same line still has its left-hand context.
+    line = _DEFINITION_RE.sub(r"\1 ", line)
     line = _INLINE_CODE_RE.sub(" ", line)
     line = _URL_RE.sub(" ", line)
     line = _RANGE_RE.sub(" ", line)
@@ -78,18 +96,43 @@ def find_prose_separator_dashes(text):
     return findings
 
 
+# Authored site prose (#338). site/VOICE.md has banned em-dashes as sentence
+# separators since 2026-07-02, and nothing enforced it: this predicate covered
+# repo-root docs and docs/**, never site/. A rule with no gate, violated in 16
+# of its own 36 authored files, is worse than no rule - reviewers cite it and it
+# is wrong.
+#
+# Scope is AUTHORED prose only. Everything under content/docs/reference/ is
+# generated on every build (91 of the 128 files there), changelog.md is a
+# verbatim pass-through of the repo CHANGELOG, and site/src/curated/** mirrors
+# plugins/ca bodies - which are framework prose under a different register, and
+# already excluded via plugins/. Flagging any of those would report a finding
+# nobody wrote and nobody can fix in place.
+_SITE_PROSE_ROOT = "site/src/content/docs/"
+_SITE_PROSE_EXCLUDED = ("reference/", "changelog.md")
+
+
 def in_antislop_doc_scope(rel_path):
     """True for user-facing Markdown the anti-slop bundle governs: repo-root
-    community docs and docs/**. Excludes codeArbiter's own framework bodies
-    (everything under plugins/) and machine-managed .codearbiter/ state."""
+    community docs, docs/**, and AUTHORED site prose under
+    site/src/content/docs/ (#338). Excludes codeArbiter's own framework bodies
+    (everything under plugins/), machine-managed .codearbiter/ state, and every
+    generated site page."""
     if not rel_path:
         return False
     p = rel_path.replace("\\", "/")
     if p.startswith("./"):
         p = p[2:]
-    if not p.lower().endswith(".md"):
+    # `.mdx` counts: the rule is about prose, not about a file extension, and
+    # two authored site pages are .mdx.
+    if not p.lower().endswith((".md", ".mdx")):
         return False
     if p.startswith("plugins/") or p.startswith(".codearbiter/"):
+        return False
+    if p.startswith(_SITE_PROSE_ROOT):
+        rest = p[len(_SITE_PROSE_ROOT):]
+        return not rest.startswith(_SITE_PROSE_EXCLUDED)
+    if p.startswith("site/"):
         return False
     if p.startswith("docs/"):
         return True

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.26] - 2026-07-25
+
+### Fixed
+
+- The anti-slop dash detector no longer flags a definition-list dash
+  (`- **term** - meaning`). The rule it enforces is about SENTENCE separators,
+  and the style guides are themselves written in that form, so the detector was
+  contradicting the guides it exists to serve. A real separator later on the
+  same line is still reported: only the definition dash is dropped, never the
+  term before it (issue #338).
+
+### Changed
+
+- The detector's document scope now covers authored site prose, and recognises
+  `.mdx` as prose rather than keying on `.md` alone.
+
 ## [0.1.25] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_sloplib.py
+++ b/plugins/ca-pi/hooks/_sloplib.py
@@ -34,10 +34,28 @@ _RANGE_RE = re.compile(r"\d\s*[–—]\s*\d")
 # A letter or digit (Unicode), used to confirm a dash actually joins two text
 # spans rather than standing alone (e.g. a lone "—" N/A marker in a table cell).
 _WORD_RE = re.compile(r"[^\W_]", re.UNICODE)
+# A DEFINITION-LIST dash: `- **term** — meaning`. Structural, not a sentence
+# separator, and the rule this detector enforces says "sentence separators" -
+# site/VOICE.md's own Terminology anchors section is written in exactly this
+# form, so flagging it would make the gate contradict the style guide it exists
+# to enforce (#338). Anchored to the start of the line and to a bolded lead-in,
+# so an ordinary sentence that happens to contain bold text is untouched.
+#
+# The TERM is captured and kept; only the dash is dropped. Blanking the whole
+# lead-in was the first cut and it was a false-negative generator: on
+#     - **The gate-enforcement hooks** — `a.py`, `b.py` — make zero calls.
+# it removed the left-hand words, then _INLINE_CODE_RE blanked the backticks,
+# and the SECOND dash - a real separator - was left with no word character on
+# its left and escaped. That loosened the shared detector for docs/** and
+# repo-root too, not only for site prose.
+_DEFINITION_RE = re.compile(r"^(\s*(?:[-*+]\s+)?\*\*[^*]+\*\*\s*)[–—]")
 
 
 def _prose_only(line):
     """Drop the spans §3.A exempts so only candidate prose remains."""
+    # Only the definition DASH is dropped; the term is kept (group 1), so a
+    # later separator on the same line still has its left-hand context.
+    line = _DEFINITION_RE.sub(r"\1 ", line)
     line = _INLINE_CODE_RE.sub(" ", line)
     line = _URL_RE.sub(" ", line)
     line = _RANGE_RE.sub(" ", line)
@@ -78,18 +96,43 @@ def find_prose_separator_dashes(text):
     return findings
 
 
+# Authored site prose (#338). site/VOICE.md has banned em-dashes as sentence
+# separators since 2026-07-02, and nothing enforced it: this predicate covered
+# repo-root docs and docs/**, never site/. A rule with no gate, violated in 16
+# of its own 36 authored files, is worse than no rule - reviewers cite it and it
+# is wrong.
+#
+# Scope is AUTHORED prose only. Everything under content/docs/reference/ is
+# generated on every build (91 of the 128 files there), changelog.md is a
+# verbatim pass-through of the repo CHANGELOG, and site/src/curated/** mirrors
+# plugins/ca bodies - which are framework prose under a different register, and
+# already excluded via plugins/. Flagging any of those would report a finding
+# nobody wrote and nobody can fix in place.
+_SITE_PROSE_ROOT = "site/src/content/docs/"
+_SITE_PROSE_EXCLUDED = ("reference/", "changelog.md")
+
+
 def in_antislop_doc_scope(rel_path):
     """True for user-facing Markdown the anti-slop bundle governs: repo-root
-    community docs and docs/**. Excludes codeArbiter's own framework bodies
-    (everything under plugins/) and machine-managed .codearbiter/ state."""
+    community docs, docs/**, and AUTHORED site prose under
+    site/src/content/docs/ (#338). Excludes codeArbiter's own framework bodies
+    (everything under plugins/), machine-managed .codearbiter/ state, and every
+    generated site page."""
     if not rel_path:
         return False
     p = rel_path.replace("\\", "/")
     if p.startswith("./"):
         p = p[2:]
-    if not p.lower().endswith(".md"):
+    # `.mdx` counts: the rule is about prose, not about a file extension, and
+    # two authored site pages are .mdx.
+    if not p.lower().endswith((".md", ".mdx")):
         return False
     if p.startswith("plugins/") or p.startswith(".codearbiter/"):
+        return False
+    if p.startswith(_SITE_PROSE_ROOT):
+        rest = p[len(_SITE_PROSE_ROOT):]
+        return not rest.startswith(_SITE_PROSE_EXCLUDED)
+    if p.startswith("site/"):
         return False
     if p.startswith("docs/"):
         return True

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/hooks/_sloplib.py
+++ b/plugins/ca/hooks/_sloplib.py
@@ -34,10 +34,28 @@ _RANGE_RE = re.compile(r"\d\s*[–—]\s*\d")
 # A letter or digit (Unicode), used to confirm a dash actually joins two text
 # spans rather than standing alone (e.g. a lone "—" N/A marker in a table cell).
 _WORD_RE = re.compile(r"[^\W_]", re.UNICODE)
+# A DEFINITION-LIST dash: `- **term** — meaning`. Structural, not a sentence
+# separator, and the rule this detector enforces says "sentence separators" -
+# site/VOICE.md's own Terminology anchors section is written in exactly this
+# form, so flagging it would make the gate contradict the style guide it exists
+# to enforce (#338). Anchored to the start of the line and to a bolded lead-in,
+# so an ordinary sentence that happens to contain bold text is untouched.
+#
+# The TERM is captured and kept; only the dash is dropped. Blanking the whole
+# lead-in was the first cut and it was a false-negative generator: on
+#     - **The gate-enforcement hooks** — `a.py`, `b.py` — make zero calls.
+# it removed the left-hand words, then _INLINE_CODE_RE blanked the backticks,
+# and the SECOND dash - a real separator - was left with no word character on
+# its left and escaped. That loosened the shared detector for docs/** and
+# repo-root too, not only for site prose.
+_DEFINITION_RE = re.compile(r"^(\s*(?:[-*+]\s+)?\*\*[^*]+\*\*\s*)[–—]")
 
 
 def _prose_only(line):
     """Drop the spans §3.A exempts so only candidate prose remains."""
+    # Only the definition DASH is dropped; the term is kept (group 1), so a
+    # later separator on the same line still has its left-hand context.
+    line = _DEFINITION_RE.sub(r"\1 ", line)
     line = _INLINE_CODE_RE.sub(" ", line)
     line = _URL_RE.sub(" ", line)
     line = _RANGE_RE.sub(" ", line)
@@ -78,18 +96,43 @@ def find_prose_separator_dashes(text):
     return findings
 
 
+# Authored site prose (#338). site/VOICE.md has banned em-dashes as sentence
+# separators since 2026-07-02, and nothing enforced it: this predicate covered
+# repo-root docs and docs/**, never site/. A rule with no gate, violated in 16
+# of its own 36 authored files, is worse than no rule - reviewers cite it and it
+# is wrong.
+#
+# Scope is AUTHORED prose only. Everything under content/docs/reference/ is
+# generated on every build (91 of the 128 files there), changelog.md is a
+# verbatim pass-through of the repo CHANGELOG, and site/src/curated/** mirrors
+# plugins/ca bodies - which are framework prose under a different register, and
+# already excluded via plugins/. Flagging any of those would report a finding
+# nobody wrote and nobody can fix in place.
+_SITE_PROSE_ROOT = "site/src/content/docs/"
+_SITE_PROSE_EXCLUDED = ("reference/", "changelog.md")
+
+
 def in_antislop_doc_scope(rel_path):
     """True for user-facing Markdown the anti-slop bundle governs: repo-root
-    community docs and docs/**. Excludes codeArbiter's own framework bodies
-    (everything under plugins/) and machine-managed .codearbiter/ state."""
+    community docs, docs/**, and AUTHORED site prose under
+    site/src/content/docs/ (#338). Excludes codeArbiter's own framework bodies
+    (everything under plugins/), machine-managed .codearbiter/ state, and every
+    generated site page."""
     if not rel_path:
         return False
     p = rel_path.replace("\\", "/")
     if p.startswith("./"):
         p = p[2:]
-    if not p.lower().endswith(".md"):
+    # `.mdx` counts: the rule is about prose, not about a file extension, and
+    # two authored site pages are .mdx.
+    if not p.lower().endswith((".md", ".mdx")):
         return False
     if p.startswith("plugins/") or p.startswith(".codearbiter/"):
+        return False
+    if p.startswith(_SITE_PROSE_ROOT):
+        rest = p[len(_SITE_PROSE_ROOT):]
+        return not rest.startswith(_SITE_PROSE_EXCLUDED)
+    if p.startswith("site/"):
         return False
     if p.startswith("docs/"):
         return True

--- a/plugins/ca/hooks/tests/test_sloplib.py
+++ b/plugins/ca/hooks/tests/test_sloplib.py
@@ -119,5 +119,108 @@ class TestAntiSlopDocScope(unittest.TestCase):
         self.assertFalse(S.in_antislop_doc_scope(None))
 
 
+
+
+class TestSitePoseScope(unittest.TestCase):
+    """#338 - site/VOICE.md has banned em-dashes as sentence separators since
+    2026-07-02, and nothing enforced it: `in_antislop_doc_scope` covered
+    repo-root docs and docs/**, never site/. A rule with no gate, violated in 16
+    of its own 36 authored files, is worse than no rule - reviewers cite it and
+    it is wrong.
+
+    The scope is AUTHORED site prose only. Everything generated is excluded, by
+    path, because the generator would otherwise be flagged for output nobody
+    writes by hand and nobody can fix in place."""
+
+    def test_authored_site_docs_in_scope(self):
+        for p in (
+            "site/src/content/docs/overview.md",
+            "site/src/content/docs/guides/uninstalling.md",
+            "site/src/content/docs/concepts/hardening-history.md",
+            "site/src/content/docs/getting-started/install.md",
+            "site/src/content/docs/feature-forge/index.md",
+        ):
+            self.assertTrue(S.in_antislop_doc_scope(p), p)
+
+    def test_generated_reference_pages_out_of_scope(self):
+        # 91 of the 128 files under content/docs are generated into reference/
+        # on every build. They are not authored, not committed, and not fixable
+        # in place.
+        for p in (
+            "site/src/content/docs/reference/commands.md",
+            "site/src/content/docs/reference/agents/backend-author.md",
+        ):
+            self.assertFalse(S.in_antislop_doc_scope(p), p)
+
+    def test_generated_changelog_page_out_of_scope(self):
+        # Verbatim pass-through of the repo CHANGELOG, which is payload prose
+        # under a different voice.
+        self.assertFalse(S.in_antislop_doc_scope("site/src/content/docs/changelog.md"))
+
+    def test_curated_plugin_mirrors_out_of_scope(self):
+        # site/src/curated/** mirrors plugins/ca bodies. Those are framework
+        # prose governed by the plugin's own register, already excluded via
+        # plugins/ - mirroring them into site must not smuggle them back in.
+        for p in (
+            "site/src/curated/agents/backend-author.md",
+            "site/src/curated/commands/fix.md",
+        ):
+            self.assertFalse(S.in_antislop_doc_scope(p), p)
+
+    def test_site_source_that_is_not_docs_prose_out_of_scope(self):
+        for p in ("site/README.md", "site/VOICE.md", "site/src/components/Thing.md"):
+            self.assertFalse(S.in_antislop_doc_scope(p), p)
+
+    def test_mdx_authored_pages_are_in_scope_too(self):
+        # Two authored pages are .mdx. The predicate keyed on ".md" only, so
+        # they were invisible to a rule that is about prose, not file format.
+        self.assertTrue(S.in_antislop_doc_scope("site/src/content/docs/index.mdx"))
+
+
+
+
+class TestDefinitionListDashExempt(unittest.TestCase):
+    """#338 - the rule is about SENTENCE separators. A definition-list dash is
+    structural, and site/VOICE.md's own Terminology anchors are written in that
+    exact form, so flagging it would make the gate contradict the guide."""
+
+    def test_definition_list_dash_is_not_a_finding(self):
+        for line in (
+            "- **gate** — a phase exit condition (STOP/BLOCK).",
+            "* **lane** — a sanctioned path through the system.",
+            "**skill** — an orchestrator routine with phases.",
+        ):
+            self.assertEqual(S.find_prose_separator_dashes(line), [], line)
+
+    def test_a_real_separator_after_a_definition_is_still_caught(self):
+        # Only the definition DASH is dropped, never the term before it. A
+        # second dash on the same line is still a separator and must not ride in
+        # behind the exemption.
+        line = "- **gate** — a phase exit condition — and it blocks the call."
+        self.assertEqual(len(S.find_prose_separator_dashes(line)), 1)
+
+    def test_definition_exemption_survives_inline_code_after_it(self):
+        # The regression this exemption first shipped with, and the reason the
+        # test above was not enough: dropping the whole `- **term**` lead-in left
+        # the NEXT dash with no word character on its left once
+        # _INLINE_CODE_RE blanked the backticks, so a real separator vanished.
+        # Verbatim from site/src/content/docs/getting-started/compatibility.md,
+        # which the detector scored 1 before the exemption and 0 after.
+        line = "- **The gate-enforcement hooks** — `pre-bash.py`, `pre-write.py` — make **zero** network calls."
+        self.assertEqual(len(S.find_prose_separator_dashes(line)), 1)
+
+    def test_definition_term_is_preserved_for_downstream_checks(self):
+        # Stated as a property, not an implementation detail: whatever the
+        # exemption does, the term's own words must survive into the analysed
+        # text, or any later dash on the line loses its left-hand context.
+        self.assertIn("gate", S._prose_only("- **gate** — a phase exit condition"))
+
+    def test_bold_mid_sentence_is_not_treated_as_a_definition(self):
+        # The exemption is anchored to the start of the line, so an ordinary
+        # sentence containing bold text keeps its finding.
+        line = "The **commit gate** runs nine checks — every one must be green."
+        self.assertEqual(len(S.find_prose_separator_dashes(line)), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/site/src/content/docs/codearbiter-directory.md
+++ b/site/src/content/docs/codearbiter-directory.md
@@ -4,8 +4,8 @@ description: "Every file and directory under .codearbiter/, what writes it, what
 ---
 
 `.codearbiter/` is codeArbiter's project-state store: a root-level directory, outside `.claude/`,
-so it survives even if the plugin itself is uninstalled. It holds the project's own record — its
-spec, task board, decisions, and audit trail — separate from the plugin code that reads and
+so it survives even if the plugin itself is uninstalled. It holds the project's own record (its
+spec, task board, decisions, and audit trail), separate from the plugin code that reads and
 writes it. `/ca:init` scaffolds it; `/ca:create-context` (existing codebase) or `/ca:decompose`
 (greenfield) populates it. Its presence and content is the plugin's actual contract with your
 repo: if you want to know what codeArbiter knows about your project, or what it will do next,
@@ -22,23 +22,23 @@ those are noted below.
 
 | Path | Written by | Read by | Editable by hand? |
 |---|---|---|---|
-| `CONTEXT.md` | `/ca:init`, `/ca:decompose`, `/ca:create-context` | every enforcement hook (`arbiter_active()`), the orchestrator | Yes, but the frontmatter is guarded — see below |
-| `open-tasks.md` | `/ca:task` only | `/ca:status`, the statusline, `SessionStart` | No — guarded to `/ca:task` |
+| `CONTEXT.md` | `/ca:init`, `/ca:decompose`, `/ca:create-context` | every enforcement hook (`arbiter_active()`), the orchestrator | Yes, but the frontmatter is guarded (see below) |
+| `open-tasks.md` | `/ca:task` only | `/ca:status`, the statusline, `SessionStart` | No: guarded to `/ca:task` |
 | `open-questions.md` | the orchestrator, when a `[CONFIRM-NN]` is raised | `/ca:status`, `SessionStart`, the statusline | Yes |
-| `decisions/*.md`, `decision-log.md` | `/ca:adr` only | `/ca:adr-status`, `/ca:reconcile`, `post-write-edit.py` (H-12) | No — guarded to `/ca:adr` |
+| `decisions/*.md`, `decision-log.md` | `/ca:adr` only | `/ca:adr-status`, `/ca:reconcile`, `post-write-edit.py` (H-12) | No: guarded to `/ca:adr` |
 | `specs/*.md` | `brainstorming` skill (via `/ca:feature`, `/ca:sprint`) | `writing-plans`, `/ca:status` | Yes |
 | `plans/*.md` | `writing-plans` skill | `executing-plans`, `subagent-driven-development`, `/ca:status` | Yes |
 | `checkpoints/*.md` | `checkpoint-aggregator` agent (`/ca:checkpoint`) | `/ca:audit`, `/ca:status`-adjacent reads | Yes |
 | `audits/*.md` | `/ca:audit` | humans (report only) | Yes |
 | `reports/<run-id>/` | `/ca:tribunal` | `/ca:tribunal` on resume, the filing gate | Yes, but not while a run is in flight |
-| `sprint-log.md` | `/ca:sprint` | `/ca:status`, `/ca:audit` | No — append-only, guarded (H-05) |
-| `overrides.log` | `/ca:override`, `/ca:dev` entry/exit | statusline, `/ca:status`, `/ca:audit`, staleness-warn | No — append-only, guarded (H-05) |
-| `triage.log` | `/ca:feature` small-lane triage | `/ca:metrics`, `/ca:audit` | No — append-only, guarded (H-05) |
-| `gate-events.log` | every `block()`/`remind()`/`warn()` call in the hooks | (durable sink; no reader ships yet) | No — append-only, guarded (H-05) |
-| `.markers/` | `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr` | the commit-gate hooks (`pre-bash.py`, `pre-write.py`, `pre-edit.py`) | No — guarded, and hand-writing one is friction and an audit trail, not a proof (see below) |
-| `.provenance/*.json` | `context-creation`, `decompose`, `context-check` (re-scout/re-baseline) | `SessionStart` (drift line), `commit-gate` (auto-heal) | Not by hand — regenerate via `/ca:context-check` |
+| `sprint-log.md` | `/ca:sprint` | `/ca:status`, `/ca:audit` | No: append-only, guarded (H-05) |
+| `overrides.log` | `/ca:override`, `/ca:dev` entry/exit | statusline, `/ca:status`, `/ca:audit`, staleness-warn | No: append-only, guarded (H-05) |
+| `triage.log` | `/ca:feature` small-lane triage | `/ca:metrics`, `/ca:audit` | No: append-only, guarded (H-05) |
+| `gate-events.log` | every `block()`/`remind()`/`warn()` call in the hooks | (durable sink; no reader ships yet) | No: append-only, guarded (H-05) |
+| `.markers/` | `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr` | the commit-gate hooks (`pre-bash.py`, `pre-write.py`, `pre-edit.py`) | No: guarded, and hand-writing one is friction and an audit trail, not a proof (see below) |
+| `.provenance/*.json` | `context-creation`, `decompose`, `context-check` (re-scout/re-baseline) | `SessionStart` (drift line), `commit-gate` (auto-heal) | Not by hand: regenerate via `/ca:context-check` |
 | `security-controls.md`, `tech-stack.md`, `coding-standards.md` | `/ca:init` / `/ca:create-context` / `/ca:decompose`, kept current by hand or `/ca:context-check` | every reviewer agent, the crypto/secret gates | Yes |
-| `last-checkpoint` | `checkpoint-aggregator` agent | `/ca:status`, the statusline (overrides-since-checkpoint) | Not normally — it's a counter, not a note |
+| `last-checkpoint` | `checkpoint-aggregator` agent | `/ca:status`, the statusline (overrides-since-checkpoint) | Not normally: it's a counter, not a note |
 | `spikes/*.md` | `/ca:spike` | humans, `/ca:feature` (seeds `brainstorming`) | Yes |
 
 ## CONTEXT.md
@@ -46,7 +46,7 @@ those are noted below.
 The activation contract. Its leading YAML frontmatter carries two load-bearing keys:
 
 - **`arbiter: enabled`** — the single flag every enforcement hook checks via `arbiter_active()`
-  (`plugins/ca/hooks/_hooklib.py`). It must appear inside a *properly closed* frontmatter block —
+  (`plugins/ca/hooks/_hooklib.py`). It must appear inside a *properly closed* frontmatter block:
   `---` opens on line 1, `arbiter: enabled` somewhere inside, `---` closes it. A block that opens
   but never closes is treated as **malformed**, not disabled, and is surfaced as an error rather
   than silently ignored. A file with no frontmatter at all is simply dormant. No frontmatter,
@@ -75,35 +75,35 @@ frontmatter are both in place, the orchestrator persona loads on every session i
 **Readers:** every enforcement hook, the `SessionStart` injector, the statusline.
 **Editable by hand?** The prose body, yes. The frontmatter is guarded: a Write/Edit that would
 flip `arbiter: enabled` off, or corrupt the block, is blocked (`pre-write.py`/`pre-edit.py`,
-issue #159) — the file that turns every gate off can't itself be edited past the gate.
-**Delete it:** codeArbiter goes fully dormant in this repo on the next session — no persona, no
-enforcement, nothing loads. The rest of `.codearbiter/` is untouched on disk; recreating
+issue #159). The file that turns every gate off can't itself be edited past the gate.
+**Delete it:** codeArbiter goes fully dormant in this repo on the next session (no persona, no
+enforcement, nothing loads). The rest of `.codearbiter/` is untouched on disk; recreating
 `CONTEXT.md` (or running `/ca:init` again) reactivates it against whatever state remains.
 
 ## open-tasks.md
 
-The [board](/glossary/#board): one top-level `- ` bullet per task, in one of three states —
+The [board](/glossary/#board): one top-level `- ` bullet per task, in one of three states:
 queued (`- [ ]`), in-progress (`- [~]`, always carrying a started date), or done (`- [x]`). The
 only sanctioned writer is `/ca:task` (`add` / `start` / `done`), which calls the pure
 `_taskboardlib` transforms via `taskwrite.py` so every entry stays schema-conformant and every
-transition dated — hand-editing risked malforming the schema, which is why the command exists.
+transition dated. Hand-editing risked malforming the schema, which is why the command exists.
 A task's `[x]` done-flip, `[~]` start-flip, or new `[ ]` entry rides the work commit itself
 through commit-gate (ADR-0008); there's no separate lagging board-only PR.
 
 **Writers:** `/ca:task` only. **Readers:** `/ca:status`, the statusline, `SessionStart` (in-flight
-count and staleness). **Editable by hand?** No — guarded to the one writer.
+count and staleness). **Editable by hand?** No: guarded to the one writer.
 **Delete it:** the board is empty going forward; nothing else breaks, but every count that reads
 it (statusline, `/ca:status`) reports zero until tasks are re-added.
 
 ## open-questions.md
 
-The record of unresolved `[CONFIRM-NN]` items — numbered placeholders for a question only the
+The record of unresolved `[CONFIRM-NN]` items: numbered placeholders for a question only the
 user can answer, per the terminology lock in `ORCHESTRATOR.md` §0.1. An open `CONFIRM-NN` blocks
 stage promotion until it's resolved; it is never guessed at or resolved inside an ADR. The
 `SessionStart` hook and the statusline both count occurrences here.
 
 **Writers:** the orchestrator, when a skill surfaces a genuine unknown. **Readers:** `/ca:status`,
-`SessionStart`, the statusline. **Editable by hand?** Yes — resolving a `CONFIRM-NN` is a prose
+`SessionStart`, the statusline. **Editable by hand?** Yes: resolving a `CONFIRM-NN` is a prose
 edit recording the decision and its date. **Delete it:** any `[CONFIRM-NN]` count in the
 statusline or `/ca:status` reads zero; a future skill that needs to raise one recreates the file.
 
@@ -115,12 +115,12 @@ entry. `/ca:adr` is the only sanctioned author; both the shell flank (redirects,
 targeting `decisions/`) and the Write/Edit flank are guarded (H-11) so an ADR can't be
 fabricated, edited after the fact, or slipped in outside the command. Status moves through
 `proposed -> accepted -> superseded | rejected`; a superseding decision never rewrites the prior
-file — it appends a new numbered ADR whose own text names what it supersedes, and a new
+file. It appends a new numbered ADR whose own text names what it supersedes, and a new
 `decision-log.md` entry does the same.
 
 **Writers:** `/ca:adr` (via the `decision-lifecycle` skill) only. **Readers:** `/ca:adr-status`,
 `/ca:reconcile`, and `post-write-edit.py`'s H-12 advisory (a file matching an ADR's `governs:`
-glob gets a reminder on every future touch). **Editable by hand?** No — guarded.
+glob gets a reminder on every future touch). **Editable by hand?** No: guarded.
 **Delete it:** the project's decision history is gone; `governs:` reminders for any ADR that used
 to cover a file stop firing, and `/ca:adr-status` has nothing to report.
 
@@ -131,7 +131,7 @@ approved (`/ca:feature`, `/ca:sprint`). `writing-plans` reads an approved spec t
 plan, and `/ca:status` lists every slug here alongside its plan to show how far each pipeline got.
 
 **Writers:** `brainstorming`. **Readers:** `writing-plans`, `/ca:status`.
-**Editable by hand?** Yes — specs are prose documents; edit for clarity, but avoid rewriting
+**Editable by hand?** Yes. Specs are prose documents; edit for clarity, but avoid rewriting
 acceptance criteria the plan and its tests already trace against.
 **Delete it:** `/ca:status` no longer lists that pipeline; a plan that referenced the missing spec
 still runs (the plan is self-contained), but nothing can re-derive it from the (now-gone) spec.
@@ -153,8 +153,8 @@ resumption point; `/ca:status` can no longer report that pipeline's progress.
 One dated report per `/ca:checkpoint` sweep (`YYYY-MM-DD.md`), written by the
 `checkpoint-aggregator` agent from the finding-triage and decision-challenger output. Findings are
 classified by severity; the ones blocking the current change are called out, the rest recorded
-for later. `/ca:tribunal`'s deep-audit output is a distinct artifact (`reports/<run-id>/`, below)
-— checkpoints are the lean, routine sweep.
+for later. `/ca:tribunal`'s deep-audit output is a distinct artifact (`reports/<run-id>/`, below).
+Checkpoints are the lean, routine sweep.
 
 **Writers:** `checkpoint-aggregator`. **Readers:** humans (the report is the deliverable);
 `/ca:audit` pulls still-open findings from the most recent one. **Editable by hand?** Yes, though
@@ -165,7 +165,7 @@ recreates the directory and writes fresh.
 
 One dated governance packet per `/ca:audit` run (`YYYY-MM-DD.md`), assembling commits, overrides,
 ADRs, sprint auto-decisions, open questions, and open checkpoint findings for a given range into
-one document. `/ca:audit` is read-only against everything it summarizes — it never mutates
+one document. `/ca:audit` is read-only against everything it summarizes: it never mutates
 `overrides.log`, `decisions/`, or any of its other sources.
 
 **Writers:** `/ca:audit`. **Readers:** humans. **Editable by hand?** Yes.
@@ -179,25 +179,25 @@ presence, since `/ca:audit` re-derives everything from the underlying logs and f
 reuses the same `run-id` (the date is the run's creation date and never changes on resume). Every
 lens's findings are written one file per finding, plus append-only triage/run logs, so an
 interrupted deep audit picks back up from disk instead of restarting. Tribunal writes are confined
-to this directory until the filing gate — it never edits, refactors, or commits project code.
+to this directory until the filing gate. It never edits, refactors, or commits project code.
 
 **Writers:** `/ca:tribunal` only. **Readers:** `/ca:tribunal` itself, on resume, and the filing
 gate that turns approved findings into GitHub issues. **Editable by hand?** Not while a run is
-in flight — you'd desync the resumable state. **Delete it:** an in-flight tribunal run can no
+in flight: you'd desync the resumable state. **Delete it:** an in-flight tribunal run can no
 longer resume and restarts from scratch on next invocation; completed runs' local record is gone
-(filed GitHub issues, if any, are unaffected — they live on GitHub, not here).
+(filed GitHub issues, if any, are unaffected: they live on GitHub, not here).
 
 ## sprint-log.md
 
 The append-only ledger of every SMARTS-scored auto-decision an autonomous `/ca:sprint` makes on a
 non-hard-gate point, each entry carrying a confidence flag (`low` entries are the ones worth
-reviewing after the fact). Hard gates — security controls, auth/crypto/secrets, irreversible
-operations, an unresolved `[CONFIRM-NN]`, a merge to default — are never auto-decided and never
+reviewing after the fact). Hard gates (security controls, auth/crypto/secrets, irreversible
+operations, an unresolved `[CONFIRM-NN]`, a merge to default) are never auto-decided and never
 appear here as a resolved decision; they stop and surface to the user instead.
 
 **Writers:** `/ca:sprint`. **Readers:** `/ca:status`, `/ca:audit`, the staleness-warn check (a
 sprint marked active for over 30 minutes with no matching log activity gets a WARN).
-**Editable by hand?** No — one of the four append-only audit logs (H-05): a shell truncation/
+**Editable by hand?** No. One of the four append-only audit logs (H-05): a shell truncation/
 rewrite aimed at it is blocked, and a Write/Edit must be a verifiable tail-anchored append, never
 an overwrite or an empty-`old_string` edit passed off as one.
 **Delete it:** the sprint decision trail for past runs is gone; a `/ca:sprint` in progress that
@@ -213,10 +213,10 @@ rather than recording an empty `BY:` field. The statusline counts entries newer 
 `last-checkpoint` marker as "overrides since last checkpoint."
 
 **Writers:** `/ca:override`, `/ca:dev` (entry/exit lines). **Readers:** statusline, `/ca:status`,
-`/ca:audit`, the CONFIRM-09 staleness-warn check. **Editable by hand?** No — H-05 guarded, same as
+`/ca:audit`, the CONFIRM-09 staleness-warn check. **Editable by hand?** No. H-05 guarded, same as
 `sprint-log.md`: append-only, tail-anchored edits only, no truncation or rewrite.
-**Delete it:** the entire override history is gone — a genuine loss, since this is the one
-mechanical record that a bypass happened at all. codeArbiter keeps functioning; the audit trail
+**Delete it:** the entire override history is gone (a genuine loss, since this is the one
+mechanical record that a bypass happened at all). codeArbiter keeps functioning; the audit trail
 does not recover.
 
 ## triage.log
@@ -226,36 +226,36 @@ reasoning behind routing a change to the lighter lane instead of the full spec-t
 `/ca:metrics` reads it to compute the small-lane rate trend.
 
 **Writers:** `/ca:feature` (small-lane triage step). **Readers:** `/ca:metrics`, `/ca:audit`.
-**Editable by hand?** No — H-05 guarded, same append-only contract as the other three logs.
+**Editable by hand?** No: H-05 guarded, same append-only contract as the other three logs.
 **Delete it:** the small-lane classification history is gone; `/ca:metrics`' small-lane-rate trend
 has nothing to compare against until new entries accumulate.
 
 ## gate-events.log
 
-The durable, mechanical sink every `block()`, `remind()`, and `warn()` call in the hooks appends
-one line to — `[ISO-8601Z] KIND [tag] host=<host> hook=<script> | msg`. Before this log existed, a gate
-decision was visible only in the ephemeral per-turn stderr transcript; this makes every BLOCK,
-REMIND, and WARN durable and queryable after the fact. The write is fail-open by contract: a
+Every `block()`, `remind()`, and `warn()` call in the hooks appends one line to this durable,
+mechanical sink. Format: `[ISO-8601Z] KIND [tag] host=<host> hook=<script> | msg`. Before this log
+existed, a gate decision was visible only in the ephemeral per-turn stderr transcript; this makes
+every BLOCK, REMIND, and WARN durable and queryable after the fact. The write is fail-open by contract: a
 missing `.codearbiter/` directory or an unwritable log file is swallowed silently rather than
-changing the calling hook's exit code — this sink must never itself cause a gate to misbehave.
+changing the calling hook's exit code. This sink must never itself cause a gate to misbehave.
 
 **Writers:** every hook, via the shared `_log_gate_event()` helper in `_hooklib.py`.
-**Readers:** none ship yet as of this writing — it's a durable record for manual inspection or a
-future consumer. **Editable by hand?** No — H-05 guarded, same append-only contract.
+**Readers:** none ship yet as of this writing. It's a durable record for manual inspection or a
+future consumer. **Editable by hand?** No: H-05 guarded, same append-only contract.
 **Delete it:** past gate decisions are gone from the durable record; hooks keep blocking/reminding
 exactly as before (the log is a side effect of a gate decision, never a precondition for one), and
 a fresh file is created on the next event.
 
 ## .markers/
 
-Gate-pass tokens and short-lived UI flags, created on demand — this directory doesn't exist until
+Gate-pass tokens and short-lived UI flags, created on demand. This directory doesn't exist until
 the first marker-writing action runs. The load-bearing ones:
 
 - **`security-gate-passed`** — written by `security-pass.py` on a genuine crypto-compliance or
   secret-handling PASS. It contains a SHA-256 digest of every sensitive added line it approved,
   not just an empty touch. The commit-time gates (**H-09b** for crypto/TLS, **H-10b** for secrets)
   block a commit unless this marker is **fresh** (written within the last 30 minutes) **and**
-  covers every sensitive line in the current staged diff — a pass recorded for one diff can't
+  covers every sensitive line in the current staged diff. A pass recorded for one diff can't
   launder a later, different change through the freshness window.
 - **`migration-gate-passed`** — the same digest-binding contract, for the H-14 migration-review
   gate, written by `migration-pass.py` against a migration file's current content.
@@ -267,22 +267,22 @@ the first marker-writing action runs. The load-bearing ones:
 **Writers:** `security-pass.py`, `migration-pass.py`, `/ca:dev`, `/ca:adr`.
 **Readers:** the commit-gate hooks (`pre-bash.py`) that check `security-gate-passed` and
 `migration-gate-passed` before allowing a `git commit`.
-**Editable by hand?** No — `pre-write.py`/`pre-edit.py` block Write/Edit targeting this directory
+**Editable by hand?** No: `pre-write.py`/`pre-edit.py` block Write/Edit targeting this directory
 (issue #160), and `pre-bash.py`'s H-19 flank blocks the shell forge spellings too (`cp`/`mv`/`tee`/
 `sed`/a redirect, and an interpreter one-liner such as `python -c "open(...).write(...)"`). These
-flanks add real friction and leave an audit trail on the cooperative-agent path (ADR-0010) — they
+flanks add real friction and leave an audit trail on the cooperative-agent path (ADR-0010). They
 are not a proof. The marker is a *cooperative attestation*: `security-pass.py`/`migration-pass.py`
 re-derive digests from a public, pure function of the file content the forger already holds, so no
 digest scheme can make the marker unforgeable to a determined same-user process willing to
 reproduce that computation outside the sanctioned producer. Its value is the friction and the
 record it leaves, not unforgeability.
-**Delete it:** every commit-time crypto/secret/migration gate reverts to its unpassed state — the
+**Delete it:** every commit-time crypto/secret/migration gate reverts to its unpassed state. The
 next sensitive commit blocks until the corresponding gate runs again and re-records a pass. No
 enforcement is weakened; you just lose the standing "already checked" credit.
 
 ## .provenance/
 
-Per-doc JSON evidence files (`<doc>.json` — `tech-stack`, `coding-standards`,
+Per-doc JSON evidence files (`<doc>.json` for `tech-stack`, `coding-standards`,
 `security-controls`, `CONTEXT`, and similar derived docs), created the first time
 `context-creation` or `decompose` populates `.codearbiter/`. Each record lists the source paths
 that backed the doc's claims, a content hash per path (via `git hash-object`, so a line-ending
@@ -293,19 +293,19 @@ the affected doc from there.
 
 **Writers:** `context-creation`, `decompose`, and `context-check`'s re-scout/re-baseline actions.
 **Readers:** `SessionStart` (the drift line), commit-gate (auto-heal worklist).
-**Editable by hand?** Not usefully — a hand-edited hash wouldn't match anything real. Regenerate
+**Editable by hand?** Not usefully: a hand-edited hash wouldn't match anything real. Regenerate
 it through `/ca:context-check` instead. **Delete it:** drift detection goes silent for every doc
-that lost its record — no false positives, but no warning either, until the doc is re-scouted or
+that lost its record (no false positives, but no warning either), until the doc is re-scouted or
 re-baselined and a fresh provenance file is written.
 
 ## Other scaffold docs
 
 `security-controls.md`, `tech-stack.md`, and `coding-standards.md` round out the scaffold `/ca:init`
-produces. They're living reference documents, not audit logs — hand-editable, read by every
+produces. They're living reference documents, not audit logs: hand-editable, read by every
 reviewer agent (`security-controls.md` especially: the crypto-compliance and secret-handling gates
 read it before every review, and it's level 1 in the conflict hierarchy). `last-checkpoint` is a
 one-line counter (the override count at the time of the last `/ca:checkpoint`) that the statusline
-and `/ca:status` use to compute "overrides since last checkpoint" — it's a counter, not a note, so
-there's rarely reason to hand-edit it. `spikes/` holds one findings file per `/ca:spike` — the
-question asked, what was tried, the answer, and what it implies — written on exit, since spike code
+and `/ca:status` use to compute "overrides since last checkpoint." It's a counter, not a note, so
+there's rarely reason to hand-edit it. `spikes/` holds one findings file per `/ca:spike` (the
+question asked, what was tried, the answer, and what it implies), written on exit, since spike code
 itself is disposable and never merges.

--- a/site/src/content/docs/concepts/hardening-history.md
+++ b/site/src/content/docs/concepts/hardening-history.md
@@ -16,7 +16,7 @@ Coverage is what closes the time-of-check / time-of-use window: a pass minted fo
 
 The gate fails closed when the diff cannot be read. If git is unavailable or times out, `added_lines()` returns `None` (distinct from an empty diff), and codeArbiter treats that as a reason to block the commit rather than wave it through. H-14's file-list read follows the same fail-closed rule.
 
-The detection corpus is shared: `CRYPTO_RE` and `SECRET_RE` live once in `_hooklib.py`, so the redactor and the gate stay aligned on what counts as crypto or a secret — there is exactly one place either pattern set can be edited, and both consumers pick up the change together.
+The detection corpus is shared: `CRYPTO_RE` and `SECRET_RE` live once in `_hooklib.py`, so the redactor and the gate stay aligned on what counts as crypto or a secret. There is exactly one place either pattern set can be edited, and both consumers pick up the change together.
 
 ## Why the Board Has One Writer (ADR-0008)
 
@@ -24,7 +24,7 @@ The detection corpus is shared: `CRYPTO_RE` and `SECRET_RE` live once in `_hookl
 
 The commit gate is the single board-sync chokepoint. Phase 6 of the commit-gate skill identifies a schema-valid board transition and exempts it from the scope-creep check; Phase 7 stages it alongside the work. The board flip lands atomically with the code it describes: an abandoned PR abandons the flip with it, and there is no window where the board reads done while the corresponding work is not yet merged.
 
-This design replaced an earlier pattern of a separate, lagging `chore(board)` PR that could drift from the code it described. Cross-session board drift — a task left open after its work lands — is now eliminated by construction rather than by process discipline. See ADR-0008 for the full design rationale.
+This design replaced an earlier pattern of a separate, lagging `chore(board)` PR that could drift from the code it described. Cross-session board drift (a task left open after its work lands) is now eliminated by construction rather than by process discipline. See ADR-0008 for the full design rationale.
 
 `/ca:standup` and `/ca:doctor` each run a read-only reconciliation sweep and surface any merged-but-not-flipped task; they report findings without writing to the board themselves.
 
@@ -40,6 +40,6 @@ Dated record of enforcement hardening as it shipped, newest first. Versions corr
 
 ## Related
 
-- [Enforcement & Security](/enforcement/) — the user-facing statement of what is enforced.
+- [Enforcement & Security](/enforcement/): the user-facing statement of what is enforced.
 - [ADRs and the Decision Log](/concepts/adrs/)
 - [Hooks reference](/hooks/)

--- a/site/src/content/docs/enforcement.md
+++ b/site/src/content/docs/enforcement.md
@@ -86,7 +86,7 @@ addition: an enabled repository still requires Pi's own affirmative project-trus
 repository-aware startup. The parent registers repository-aware dispatch, farm preview, and native
 compaction only after the current session reports that trust, the repository is enabled, and the
 enforcement lifecycle is ready. A session opened before trust is granted, or before the repo opted
-in, stays inert — nothing repository-aware runs.
+in, stays inert: nothing repository-aware runs.
 
 `codearbiter_dispatch` and `codearbiter_farm_preview` are **parent-only** EXEC tools. A child
 process spawned to do author or reviewer work cannot escalate itself into repository-aware dispatch
@@ -96,7 +96,7 @@ governance secrets; that key is scoped to the trusted parent only.
 Run `/ca-doctor` to verify this is actually live: it inspects the active package path, command
 ownership, Python/core/bridge health, child fingerprint, and the H-03 wrapper self-test. Its
 module-identity check proves self-consistency between the operator-launched Pi CLI, imported module,
-package root, and reported version — it does **not** prove publisher authenticity. Verify the
+package root, and reported version. It does **not** prove publisher authenticity. Verify the
 installed source separately with `pi list` and `pi config`.
 
 ## Fail-Loud, Never Silently Dormant

--- a/site/src/content/docs/getting-started/claude-code-and-codex.md
+++ b/site/src/content/docs/getting-started/claude-code-and-codex.md
@@ -79,11 +79,11 @@ the supported bar for it is [ADR-0012](https://github.com/arbiterForge/codeArbit
 dual-host concurrency is accepted **at parity with same-host concurrency**, not stronger than it.
 Concretely:
 
-- **Safe:** the append-only audit writes (`overrides.log`, `gate-events.log`) — each line now
+- **Safe:** the append-only audit writes (`overrides.log`, `gate-events.log`). Each line now
   carries host attribution, and concurrent writers do not lose records.
 - **Not hardened, and not new to dual-host:** the task board (`open-tasks.md`) and the dev-marker
-  file are mutated with a lock-free read-modify-write. Two sessions racing the same mutation — for
-  example, both flipping the same task, or both entering/exiting `/ca:dev` — can drop an update or
+  file are mutated with a lock-free read-modify-write. Two sessions racing the same mutation (for
+  example, both flipping the same task, or both entering/exiting `/ca:dev`) can drop an update or
   clobber the marker, exactly as two concurrent Claude Code sessions on one checkout already can.
   This is pre-existing, host-agnostic concurrency debt, not a Codex-specific gap.
 

--- a/site/src/content/docs/getting-started/compatibility.md
+++ b/site/src/content/docs/getting-started/compatibility.md
@@ -15,11 +15,11 @@ and the [Pi install page](/getting-started/pi/) for the `ca-pi` install flow.
 | **Claude Code** | Any version with plugin support | `plugin.json` states no explicit minimum version; the plugin uses standard hook events (`SessionStart`, `PreToolUse`, `PostToolUse`) and the plugin/marketplace install commands documented in [Install](/getting-started/install/). |
 | **Codex** | Minimum 0.143.0; live-verified on 0.144.1 | `ca-codex` uses one OS-specific handler per event and a Codex adapter that converts the shared guard verdict to structured deny output. Trust the hook set through `/hooks`. |
 | **Pi** | 0.80.5 or 0.80.10 (this release line) | `ca-pi` is a Feature Forge `preview`, available and welcomed for real use while broader testing continues before stable status or a claim of 100% validation. Install it Git-only: `pi install git:github.com/arbiterForge/codeArbiter@ca-pi-v<version>`. Also requires Node.js 22.19+. Requires an affirmative project-trust decision before repository-aware startup. Its human-readable generated catalog is `plugins/ca-pi/SKILLS.md`. See [Install for Pi](/getting-started/pi/). |
-| **Python** | Python 3, stdlib only, resolvable as `python3` **or** `python` on `PATH` | Every hook is registered twice in `hooks.json` — once under `python3`, once under a `python3 -c "" \|\| python` fallback — so it runs on a machine where only `python` resolves. No third-party Python packages are ever installed or imported (ADR-0004: database-free, stdlib-only architecture). On Pi, a missing interpreter blocks mutating calls and surfaces an interpreter breadcrumb rather than failing silently. |
+| **Python** | Python 3, stdlib only, resolvable as `python3` **or** `python` on `PATH` | Every hook is registered twice in `hooks.json` (once under `python3`, once under a `python3 -c "" \|\| python` fallback), so it runs on a machine where only `python` resolves. No third-party Python packages are ever installed or imported (ADR-0004: database-free, stdlib-only architecture). On Pi, a missing interpreter blocks mutating calls and surfaces an interpreter breadcrumb rather than failing silently. |
 | **Operating system** | Windows, macOS, or Linux | Hooks are pure Python stdlib and carry no OS-specific code path beyond the interpreter-name fallback above. The `.git/hooks` backstop shim is a POSIX `sh` script; on Windows this runs under Git for Windows' bundled `sh.exe`, which ships with every standard Git install. Windows is also a promoted, tested platform for `ca-pi`; see [Windows notes](/getting-started/pi/#windows). |
-| **git** | Any reasonably current git | Required regardless of codeArbiter — the plugin reads repo state (`git config user.email`, branch, diff) via subprocess calls to your existing `git` binary, and installs the `.git/hooks` backstop through it. |
+| **git** | Any reasonably current git | Required regardless of codeArbiter: the plugin reads repo state (`git config user.email`, branch, diff) via subprocess calls to your existing `git` binary, and installs the `.git/hooks` backstop through it. |
 | **Node.js** | Not required for Claude Code or Codex | Node is required for `ca-pi` (22.19+) and is only otherwise needed to build or develop **this documentation site** (`site/`) and the optional pluggable-execution-farm TypeScript dispatcher (`plugins/ca/tools/`) if you use `/ca:sprint --farm`. Node is not a runtime dependency of the Claude Code/Codex enforcement hooks themselves. |
-| **Network access** | Not required for enforcement | See [Network Calls](#network-calls) below — the gate-enforcement hook chain makes zero network calls; two clearly-scoped, opt-in-by-default exceptions exist outside that chain. |
+| **Network access** | Not required for enforcement | See [Network Calls](#network-calls) below. The gate-enforcement hook chain makes zero network calls; two clearly-scoped, opt-in-by-default exceptions exist outside that chain. |
 
 ## Host Differences
 
@@ -53,7 +53,7 @@ parent-interactive only and absent from JSON, RPC, print, and hardened children.
 Confirm both before installing, per [Install](/getting-started/install/):
 
 - **Python 3 on `PATH`.** Without it, the gates and the session-startup injection silently do not
-  run — <kbd>/ca:doctor</kbd> catches this as an interpreter-resolution failure.
+  run. <kbd>/ca:doctor</kbd> catches this as an interpreter-resolution failure.
 - **`git config user.email` set.** Overrides and ADRs are attributed to this identity; an unset email
   is asked for once, interactively, rather than silently defaulting.
 
@@ -62,17 +62,17 @@ Confirm both before installing, per [Install](/getting-started/install/):
 Grepping every file under `plugins/ca/hooks/` for network-capable stdlib usage (`urllib`, `http.client`,
 `socket`) turns up exactly one file that actually opens a connection: `_updatelib.py`. (`_ledgerlib.py`
 matches a naive text search only because it uses the English word "requests" to mean tool-call
-records — it imports nothing network-capable.)
+records. It imports nothing network-capable.)
 
-- **The gate-enforcement hooks** — `pre-bash.py`, `pre-write.py`, `pre-edit.py`, `pre-read.py`,
-  `post-write-edit.py`, and `session-start.py`'s activation/briefing logic — make **zero** network
+- **The gate-enforcement hooks** (`pre-bash.py`, `pre-write.py`, `pre-edit.py`, `pre-read.py`,
+  `post-write-edit.py`, and `session-start.py`'s activation/briefing logic) make **zero** network
   calls. Every check is a local file read, a local `git` subprocess call against your own repo, or an
   in-process regex/parse. This is the enforcement chain compatibility and security actually depend on.
 - **The update-available notifier** (`_updatelib.py`) is a separate, non-blocking mechanism: a
   best-effort, once-a-day, fail-silent, unauthenticated HTTPS `GET` against GitHub's public Releases
   API (`api.github.com`), run as a **detached background process** off the `SessionStart` hot path so
   a slow or unreachable network never delays a session. It only ever displays a one-line notice; it
-  never applies an update. This ships on by default but is easy to make fully offline — see
+  never applies an update. This ships on by default but is easy to make fully offline: see
   [Staying up to date](https://github.com/arbiterForge/codeArbiter#staying-up-to-date) in the project
   README for the opt-out.
 - **The pluggable execution farm** (`/ca:sprint --farm`, opt-in, requires `FARM_API_KEY`) sends
@@ -86,11 +86,11 @@ background against your own configured remote (the repo-hygiene briefing).
 
 ## Third-Party Dependencies
 
-Zero, for the plugin itself. `plugins/ca/hooks/*.py` import only the Python standard library — no
+Zero, for the plugin itself. `plugins/ca/hooks/*.py` import only the Python standard library: no
 `pip install`, no `requirements.txt`, no compiled binaries (ADR-0004). The one TypeScript toolchain in
 the repo, `plugins/ca/tools/` (the farm dispatcher), carries its own `devDependencies` for its own
-build and test — those are irrelevant to whether the enforcement hooks run, since the hooks never
+build and test. Those are irrelevant to whether the enforcement hooks run, since the hooks never
 import from that package.
 
-The docs site (`site/`) has its own, larger `package.json` (Astro, Starlight, vitest) — that's a
+The docs site (`site/`) has its own, larger `package.json` (Astro, Starlight, vitest). That's a
 dependency surface for **building this website**, never for using the plugin.

--- a/site/src/content/docs/getting-started/install.md
+++ b/site/src/content/docs/getting-started/install.md
@@ -3,11 +3,11 @@ title: Install
 description: "Install codeArbiter for Claude Code, Codex, or Pi, opt into the shared .codearbiter/ store, and verify enforcement."
 ---
 
-codeArbiter ships four sibling plugins from one marketplace: three governance hosts — `ca` (Claude
-Code), `ca-codex` (Codex), and `ca-pi` (Pi) — plus `ca-sandbox`, an infrastructure plugin unrelated to
-gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)). This page covers Claude Code and Codex
-install; Pi has its own dedicated walkthrough at [Install for Pi](/getting-started/pi/) (a different
-distribution model — Git-only, no npm release). All three governance hosts enforce the same
+codeArbiter ships four sibling plugins from one marketplace. Three are governance hosts: `ca` (Claude
+Code), `ca-codex` (Codex), and `ca-pi` (Pi). The fourth, `ca-sandbox`, is an infrastructure plugin
+unrelated to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)). This page covers Claude Code
+and Codex install; Pi has its own dedicated walkthrough at [Install for Pi](/getting-started/pi/) (a
+different distribution model: Git-only, no npm release). All three governance hosts enforce the same
 `.codearbiter/` project store. The
 [Claude Code + Codex evidence](/getting-started/claude-code-and-codex/) defines the verified boundary,
 and [Compatibility](/getting-started/compatibility/) has the full host-differences matrix.
@@ -23,7 +23,7 @@ Confirm both before installing:
   python3 --version || python --version
   ```
 
-  Either succeeding is enough — hooks are registered under both names, falling back to whichever
+  Either succeeding is enough: hooks are registered under both names, falling back to whichever
   resolves.
 
 - **`git config user.email` set**: overrides and ADRs are attributed to this identity. Verify with:
@@ -46,9 +46,9 @@ codeArbiter self-hosts a multi-plugin marketplace from its GitHub repo. In any C
 /plugin install ca@codearbiter
 ```
 
-Claude Code's own plugin trust flow governs whether the hooks fire at all — the standard prompt you
-see when installing any plugin that registers hooks. Approve it once at install time (no separate
-per-hook approval step, unlike Codex's `/hooks` review) and hooks, commands, and agents load
+Whether the hooks fire at all is governed by Claude Code's own plugin trust flow: the standard
+prompt you see when installing any plugin that registers hooks. Approve it once at install time
+(no separate per-hook approval step, unlike Codex's `/hooks` review) and hooks, commands, and agents load
 automatically from then on. All commands resolve under the `/ca:` namespace.
 
 **Verify the install succeeded** before moving on. Run `/plugin list` (or `/plugin`) and confirm `ca`
@@ -110,7 +110,7 @@ claude plugin uninstall ca
 ```
 
 (Substitute `codex plugin remove ca-codex@codearbiter` / `codex plugin add ca-codex@codearbiter` for
-Codex.) `.codearbiter/` in every repository is untouched by either uninstall or reinstall — only the
+Codex.) `.codearbiter/` in every repository is untouched by either uninstall or reinstall: only the
 plugin payload moves. `/ca:doctor` reports the currently cached version so you can confirm the update
 actually landed; see its [remediation ladder](/reference/commands/doctor/) if it still looks stale.
-Pi updates differently — see [Uninstall, Upgrade, and Version Pinning](/getting-started/pi/#uninstall-upgrade-and-version-pinning).
+Pi updates differently. See [Uninstall, Upgrade, and Version Pinning](/getting-started/pi/#uninstall-upgrade-and-version-pinning).

--- a/site/src/content/docs/getting-started/pi.md
+++ b/site/src/content/docs/getting-started/pi.md
@@ -32,7 +32,7 @@ pi list
 pi config
 ```
 
-`pi list` and `pi config` let you verify the installed source before trusting it — see
+`pi list` and `pi config` let you verify the installed source before trusting it. See
 [Trust and Security](#trust-and-security) below.
 
 ## 2. Grant Project Trust
@@ -41,7 +41,7 @@ Installing the plugin does not enforce anything. After inspecting the project, g
 trust, then start a fresh session. The parent only registers repository-aware dispatch, farm
 preview, and native compaction once the current session reports affirmative project trust, the
 repository is enabled, and the enforcement lifecycle is ready. Nothing repository-aware runs before
-that — a session started before trust was granted, or before it opted the repo in, stays inert.
+that: a session started before trust was granted, or before it opted the repo in, stays inert.
 
 ## 3. Scaffold and Activate the Repo
 
@@ -70,7 +70,7 @@ Run `/ca-doctor`:
 Doctor inspects the active package path, the canonical Pi CLI and package origin, command ownership,
 supported-version expansion fingerprints, Python/core/bridge health, child fingerprint, final mutator
 wrappers, and the H-03 wrapper self-test. The module-identity row proves self-consistency between the
-operator-launched Pi CLI, imported module, package root, and reported version — it does **not** prove
+operator-launched Pi CLI, imported module, package root, and reported version. It does **not** prove
 publisher authenticity. Verify the source separately with `pi list` and `pi config`.
 
 ## Trust and Security
@@ -88,8 +88,8 @@ removing `ca-pi`.
 
 Windows is a promoted, tested platform for `ca-pi`. Child Pi processes (author and reviewer work,
 dispatched through `codearbiter_dispatch`) are supervised through a Windows-specific helper so
-cancellation and timeout cleanup terminate the whole process tree — no zombie processes left behind
-on `Ctrl+C` or a dispatch timeout.
+cancellation and timeout cleanup terminate the whole process tree: no zombie processes are left
+behind on `Ctrl+C` or a dispatch timeout.
 
 ## Next steps
 

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -41,10 +41,10 @@ As the author writes `payment.ts`, the [advisory](/glossary/#advisory) hook fire
 REMINDER [H-09]: Crypto/TLS pattern detected. Run the crypto-compliance check + dispatch auth-crypto-reviewer (no MD5/SHA1/DES/3DES/RC2/RC4/Blowfish; do not disable TLS verification). The commit will block until the gate records a pass.
 ```
 
-`[H-09]` is a gate ID — look up any gate ID you see bracketed like this in the
+`[H-09]` is a gate ID. Look up any gate ID you see bracketed like this in the
 [hook gates reference](/reference/hooks-gates/).
 
-The author wrote `createHash("md5")` to derive an idempotency key from the payment payload. MD5 is in codeArbiter's banned-primitive list. The advisory does not stop the write — it tells you the commit will. (The scan behind this gate is language-agnostic: a Python `hashlib.md5` call trips the identical H-09/H-09b pair.)
+The author wrote `createHash("md5")` to derive an idempotency key from the payment payload. MD5 is in codeArbiter's banned-primitive list. The advisory does not stop the write. It tells you the commit will. (The scan behind this gate is language-agnostic: a Python `hashlib.md5` call trips the identical H-09/H-09b pair.)
 
 ## 3. Observe the Gate Catch
 
@@ -60,14 +60,14 @@ The commit gate runs `pre-bash.py` before the `git commit` shell call fires. It 
 BLOCKED [H-09b]: This commit introduces crypto/TLS changes, but no security-gate pass is recorded (.codearbiter/.markers/security-gate-passed). Run the crypto-compliance gate (it records the pass), then commit.
 ```
 
-`.codearbiter/.markers/security-gate-passed` is a [marker](/glossary/#marker) — a small file that
+`.codearbiter/.markers/security-gate-passed` is a [marker](/glossary/#marker), a small file that
 records a gate's pass state so a later gate can check it without re-running the review. `[H-09b]` is
 the blocking counterpart to the `[H-09]` advisory above; see the
 [hook gates reference](/reference/hooks-gates/) for both.
 
 The `git commit` did not run. The mistake did not reach version control.
 
-To clear the gate, the crypto-compliance skill reviews the flagged line. MD5 as a hashing primitive is a banned pattern; the skill proposes replacing it with `createHash("sha256")`, which is on the approved list. Once the fix lands and the tests still pass, run `/ca:commit` again — you should see it succeed, with a line confirming the security-gate pass was recorded and bound to the changed line.
+To clear the gate, the crypto-compliance skill reviews the flagged line. MD5 as a hashing primitive is a banned pattern; the skill proposes replacing it with `createHash("sha256")`, which is on the approved list. Once the fix lands and the tests still pass, run `/ca:commit` again. You should see it succeed, with a line confirming the security-gate pass was recorded and bound to the changed line.
 
 That is the commit gate working as designed: the advisory surfaces the problem at write time, and the hard gate closes before the mistake ships.
 

--- a/site/src/content/docs/guides/adding-a-dependency.md
+++ b/site/src/content/docs/guides/adding-a-dependency.md
@@ -96,4 +96,4 @@ This is advisory only. It does not block the write. The install gate depends on 
 
 - [add-dep command reference](/reference/commands/add-dep/)
 - [dependency-reviewer agent](/reference/agents/dependency-reviewer/)
-- [Enforcement & Security](/enforcement/) — H-07 advisory and the full gate catalog
+- [Enforcement & Security](/enforcement/): H-07 advisory and the full gate catalog

--- a/site/src/content/docs/guides/ca-sandbox.md
+++ b/site/src/content/docs/guides/ca-sandbox.md
@@ -1,9 +1,9 @@
 ---
 title: "ca-sandbox: Explore Untrusted Code"
-description: "What ca-sandbox is, how its isolation model holds, and how to install and use it — a locally-hosted GitHub-Codespace equivalent, not part of the governance kernel."
+description: "What ca-sandbox is, how its isolation model holds, and how to install and use it: a locally-hosted GitHub-Codespace equivalent, not part of the governance kernel."
 ---
 
-`ca-sandbox` is one of codeArbiter's four sibling plugins (ADR-0007) — but unlike `ca`, `ca-codex`,
+`ca-sandbox` is one of codeArbiter's four sibling plugins (ADR-0007). But unlike `ca`, `ca-codex`,
 and `ca-pi`, it is not a governance host. It carries no gates, no `.codearbiter/` orchestration, and
 no relationship to the test-first/review/commit-gate pipeline the rest of this site documents. It is
 an **infrastructure** plugin with one job: run code you do not trust without exposing your machine.
@@ -16,7 +16,7 @@ container you can explore, run, and tear down.
 
 `ca-sandbox` is a [Feature Forge](/feature-forge/overview/) preview plugin. Its automated suite is
 green, but the `--with-claude` path (running Claude Code inside the box) is verified only against a
-dummy token, not yet a real interactive session — see
+dummy token, not yet a real interactive session. See
 [What's in the Forge](/feature-forge/whats-in-the-forge/#ca-sandbox-local-codespace) for the fuller
 writeup and how to help promote it.
 
@@ -24,12 +24,12 @@ writeup and how to help promote it.
 
 The isolation holds by construction, not by trust:
 
-- No bind mounts — the repo lives on a named Docker volume at `/work/repo`, dependencies out-of-tree
+- No bind mounts: the repo lives on a named Docker volume at `/work/repo`, dependencies out-of-tree
   at `/deps`.
 - No `/var/run/docker.sock` mount; never `--privileged`.
 - `--cap-drop ALL`, `--security-opt no-new-privileges`, read-only root filesystem, non-root user,
   resource caps.
-- Getting work back out is host-initiated only (`sandbox cp`, a `docker cp` pull) — the container is
+- Getting work back out is host-initiated only (`sandbox cp`, a `docker cp` pull): the container is
   never given a path back into the host.
 - Network defaults to **offline** (`--network none`); `clone-then-cut` allows egress for the
   clone/build only, then severs it; an experimental `allowlist` mode exists but is not the recommended
@@ -37,9 +37,9 @@ The isolation holds by construction, not by trust:
 
 ## Requirements
 
-- A working Docker engine (Linux containers) — Docker Desktop (Windows/macOS, WSL2 backend) or native
+- A working Docker engine (Linux containers): Docker Desktop (Windows/macOS, WSL2 backend) or native
   Linux.
-- `nixpacks` on `PATH` (or, on Windows, inside a WSL distro — see the
+- `nixpacks` on `PATH`, or on Windows inside a WSL distro (see the
   [`ca-sandbox` README](https://github.com/arbiterForge/codeArbiter/blob/main/plugins/ca-sandbox/README.md#windows--the-wsl-bridge)
   for the WSL-bridge build path). Without it, `ca-sandbox` falls back to a generated Dockerfile with
   narrower stack coverage.

--- a/site/src/content/docs/guides/overriding-a-gate.md
+++ b/site/src/content/docs/guides/overriding-a-gate.md
@@ -3,7 +3,7 @@ title: "Override a Gate Safely"
 description: "Bypass a blocked gate with /ca:override, the only sanctioned path: one audit line is appended to overrides.log, your identity comes from git config user.email, and the bypass is permanent in the trail."
 ---
 
-A gate blocked your command and the action is genuinely justified. Use `/ca:override "reason"` to bypass it — the only sanctioned path, since any other bypass leaves no record in the audit trail.
+A gate blocked your command and the action is genuinely justified. Use `/ca:override "reason"` to bypass it. That is the only sanctioned path, since any other bypass leaves no record in the audit trail.
 
 Before running it, identify which kind of gate you are facing. The two paths are different.
 

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -91,7 +91,7 @@ Doctor checks that the `statusLine.command` entry in `~/.claude/settings.json` p
 `ca-pi` currently ships as a Feature Forge `preview`. Real use and feedback are
 welcome; reports from live repositories help it graduate.
 
-On Pi, run `/ca-doctor` first — it is the diagnostic entry point, checking the active package path,
+On Pi, run `/ca-doctor` first. It is the diagnostic entry point, checking the active package path,
 canonical Pi CLI and package origin, command ownership, supported-version fingerprints,
 Python/core/bridge health, child fingerprint, final mutator wrappers, and the H-03 wrapper
 self-test.
@@ -102,9 +102,9 @@ Pi has several distinct silent-inactivity states that look alike but have differ
 |---------|--------------|-----|
 | Nothing enforces, no orchestrator persona | `.codearbiter/CONTEXT.md` missing or `arbiter: enabled` not set | Run `/ca-init`, per [Repo Activation](#repo-activation) above |
 | Repo is enabled but still dormant | Pi project trust not granted | Grant Pi project trust for the repo, then start a fresh session |
-| Trust was just granted but still dormant | Trust was granted in the current session, not a fresh one | Start a new session after granting trust — the parent registers repository-aware dispatch only on a fresh session that reports the trust decision |
+| Trust was just granted but still dormant | Trust was granted in the current session, not a fresh one | Start a new session after granting trust: the parent registers repository-aware dispatch only on a fresh session that reports the trust decision |
 | Mutating calls fail, or an interpreter breadcrumb appears | Python 3 not on `PATH` | Add Python 3 to `PATH`; `ca-pi` blocks mutating calls rather than failing silently when the interpreter is missing |
-| `/ca-<name>` doesn't do anything | Wrong invocation syntax | Pi uses `/ca-<name>` generated aliases with `/skill:ca-<name>` as the host-native fallback — this differs from Codex's `$ca-<name>` convention |
+| `/ca-<name>` doesn't do anything | Wrong invocation syntax | Pi uses `/ca-<name>` generated aliases with `/skill:ca-<name>` as the host-native fallback. This differs from Codex's `$ca-<name>` convention |
 | Doctor reports an unsupported version | Pi CLI is not 0.80.5 or 0.80.10 | Upgrade to Pi 0.80.5 or Pi 0.80.10, the only supported versions in this release line; see [Compatibility](/getting-started/compatibility/) |
 
 ## Symptom Reference

--- a/site/src/content/docs/guides/uninstalling.md
+++ b/site/src/content/docs/guides/uninstalling.md
@@ -13,17 +13,17 @@ audit history available to the other host.
 Enforcement in a repository is controlled by a single flag: `arbiter: enabled` in `.codearbiter/CONTEXT.md`
 frontmatter. Every enforcement hook checks that flag through `arbiter_active()` and exits immediately,
 without running any gate logic, when it is absent or set to anything other than `enabled`. Turning it
-off makes the plugin genuinely dormant in that repository — the orchestrator persona never loads, and
+off makes the plugin genuinely dormant in that repository: the orchestrator persona never loads, and
 every `PreToolUse`/`PreToolUse`-guarded hook returns before doing anything.
 
 The flag is deliberately hard to flip from inside a session, by design. **H-18** blocks a shell
 redirect, `Write`, or `Edit` that would change `arbiter: enabled` to `arbiter: disabled` (or otherwise
-corrupt the frontmatter) through `.codearbiter/CONTEXT.md` — the gates cannot silence themselves from
+corrupt the frontmatter) through `.codearbiter/CONTEXT.md`. The gates cannot silence themselves from
 inside the repo they govern. Reads (`cat`, `grep`) still pass through untouched.
 
 Unlike the crypto/secret and migration gates (H-09b/H-10b, H-14), H-18 has no marker-based bypass that
 `/ca:override` can unlock. Its block calls in `pre-bash.py`, `pre-write.py`, and `pre-edit.py` are
-unconditional — there is no override flag the hook code checks. Running `/ca:override` first does not
+unconditional: there is no override flag the hook code checks. Running `/ca:override` first does not
 make the block go away; the hook still fires on the next Bash/Write/Edit call that touches
 `CONTEXT.md`. That's deliberate: the block exists precisely so a session cannot talk itself past it.
 
@@ -31,7 +31,7 @@ The honest, sanctioned path is to make the edit through a channel H-18 doesn't i
 only subscribes to Claude Code's own `PreToolUse` hook on the Bash, Write, and Edit tools:
 
 1. Close or step outside the active Claude Code session for that repo (or use a different terminal /
-   editor entirely — a plain text editor, `vim`, VS Code, a shell outside Claude Code's Bash tool).
+   editor entirely: a plain text editor, `vim`, VS Code, a shell outside Claude Code's Bash tool).
 2. Edit `.codearbiter/CONTEXT.md` directly and change the frontmatter line to:
 
    ```yaml
@@ -42,27 +42,27 @@ only subscribes to Claude Code's own `PreToolUse` hook on the Bash, Write, and E
 
 3. Log the change for the audit trail, the same way any other gate exception is recorded, by running
    `/ca:override "disabling codeArbiter for this repository"` in a session **after** the edit (or
-   before — the log entry and the edit are independent; only the edit itself needs to happen outside
-   the tool-mediated path). This keeps `.codearbiter/overrides.log` an honest record of the change even
-   though the hook itself never granted permission.
+   before, because the log entry and the edit are independent; only the edit itself needs to happen
+   outside the tool-mediated path). This keeps `.codearbiter/overrides.log` an honest record of the
+   change even though the hook itself never granted permission.
 4. Verify: open a new Claude Code session in the repo. No orchestrator persona loads, the statusline's
    arbiter row (stage · tasks · questions · overrides) does not render, and any tool call proceeds
    without a gate check.
 
-There is no hidden bypass inside a session, and this page will not pretend there is one — H-18 guards
+There is no hidden bypass inside a session, and this page will not pretend there is one. H-18 guards
 exactly the tool flanks Claude Code mediates, and an edit outside those tools was never something it
 could stop.
 
 Re-enabling is the same edit in reverse (`arbiter: disabled` → `arbiter: enabled`), no override
-required — H-18 only blocks disabling the switch, not re-enabling it.
+required. H-18 only blocks disabling the switch, not re-enabling it.
 
 ## Pi
 
 `ca-pi` currently ships as a Feature Forge `preview`. Real use and feedback are
 welcome while broader testing continues before stable status.
 
-`ca-pi` is distributed Git-only, versioned independently as `ca-pi-v<version>` tags — not tied to
-the `ca`/`ca-codex` release cadence. There is no npm release and no auto-update.
+`ca-pi` is distributed Git-only, versioned independently as `ca-pi-v<version>` tags (not tied to
+the `ca`/`ca-codex` release cadence). There is no npm release and no auto-update.
 
 **Upgrade or pin a version:** re-run `pi install` with the new pinned tag:
 
@@ -78,7 +78,7 @@ pi remove git:github.com/arbiterForge/codeArbiter@ca-pi-v<version>
 
 (`pi uninstall` is the equivalent alias.) Confirm removal with `pi list`.
 
-Uninstalling `ca-pi` does not touch `.codearbiter/` in any repository — that state survives, the
+Uninstalling `ca-pi` does not touch `.codearbiter/` in any repository: that state survives, the
 same as for Claude Code and Codex, and another governance host can pick it up.
 
 ## Full Uninstall
@@ -107,18 +107,18 @@ pi remove git:github.com/arbiterForge/codeArbiter@ca-pi-v<version>
 
 This removes the plugin payload (hooks, commands, agents, skills) from Claude Code's plugin cache.
 Hooks, commands, and the statusline wiring stop loading from the next session onward. `claude plugin
-update` is **not** sufficient for a full removal — it can leave a stale cached payload behind when the
+update` is **not** sufficient for a full removal. It can leave a stale cached payload behind when the
 marketplace version string hasn't changed; `uninstall` is the clean path.
 
-You can also manage the marketplace entry (`codearbiter`) itself — added at install time with
-`/plugin marketplace add arbiterForge/codeArbiter` — through the `/plugin` command's interactive
-marketplace management screen in any Claude Code session, if you want it gone too.
+The marketplace entry (`codearbiter`) itself was added at install time with
+`/plugin marketplace add arbiterForge/codeArbiter`. If you want that gone too, you can manage it
+through the `/plugin` command's interactive marketplace management screen in any Claude Code session.
 
 ### 2. Decide What Happens to `.codearbiter/`
 
 Uninstalling the plugin does **not** touch `.codearbiter/` in any repository. That directory is your
-repo's state — specs, plans, ADRs, the decision log, tribunal reports, and the append-only overrides
-audit trail — and it survives the plugin by design, the same way it's meant to survive a plugin update.
+repo's state (specs, plans, ADRs, the decision log, tribunal reports, and the append-only overrides
+audit trail), and it survives the plugin by design, the same way it's meant to survive a plugin update.
 Deleting it is a separate, deliberate act:
 
 ```text
@@ -126,7 +126,7 @@ rm -rf .codearbiter/
 ```
 
 Consider whether the audit trail in `.codearbiter/overrides.log` and `.codearbiter/decisions/` has
-value to keep even after you stop using the plugin day to day — it's a plain-file record, readable
+value to keep even after you stop using the plugin day to day: it's a plain-file record, readable
 without codeArbiter installed.
 
 ### 3. Remove the Statusline
@@ -139,11 +139,11 @@ plugin (the command needs the plugin's `wire-statusline.py` to run):
 ```
 
 This restores whatever `statusLine.command` was in `~/.claude/settings.json` before you wired
-codeArbiter in — or removes the key entirely if there was none — and restores any prior `spinnerVerbs`
+codeArbiter in (or removes the key entirely if there was none), and restores any prior `spinnerVerbs`
 the same way. See [Set Up the Statusline](/guides/the-statusline/#remove-the-statusline) for the full
 behavior.
 
-If you already uninstalled the plugin first, `/ca:statusline uninstall` is no longer available — edit
+If you already uninstalled the plugin first, `/ca:statusline uninstall` is no longer available. Edit
 `~/.claude/settings.json` by hand and remove the `statusLine` entry that points at
 `hooks/statusline.py` under the plugin's cache path.
 
@@ -156,19 +156,19 @@ Bash hook's literal-string match (`g=git; c=commit; $g $c`) would otherwise slip
 entirely.
 
 These shims are managed only in repositories you opened with the plugin active, and only removed
-automatically the next time codeArbiter runs there — which won't happen once the plugin is
+automatically the next time codeArbiter runs there, which won't happen once the plugin is
 uninstalled. Remove them by hand, per repository:
 
 ```sh
 python plugins/ca/hooks/_githooks.py uninstall .
 ```
 
-(Run this from a checkout that still has the plugin's hook files present — for example, before you
+(Run this from a checkout that still has the plugin's hook files present: for example, before you
 uninstall the plugin, or from a fresh clone of the codeArbiter repo pointed at your target repo's path
 as the second argument.) `_githooks.py uninstall` removes only shims that carry codeArbiter's sentinel
 comment; a pre-existing hook from another tool (husky, pre-commit-framework) is left untouched.
 
-If that script isn't available, remove the files directly — they only exist if codeArbiter installed
+If that script isn't available, remove the files directly. They only exist if codeArbiter installed
 them (check for the sentinel comment `# codeArbiter-managed git hook (#161)` at the top):
 
 ```sh
@@ -199,8 +199,8 @@ what to check first.
 **Before you uninstall mid-feature, check:**
 
 1. Run <kbd>/ca:status</kbd> to see the current stage, open tasks, and any unresolved `CONFIRM-NN`
-   questions — resolve or note anything open before losing the orchestrator's view of it.
+   questions. Resolve or note anything open before losing the orchestrator's view of it.
 2. Confirm the branch is pushed or otherwise backed up if you're also about to remove local state.
 3. If a commit is staged but hasn't cleared `commit-gate`, either finish the commit through the plugin
    first or be aware you're now committing without the gate's verification, secret-scan, and
-   behavioral-proof checks — nothing enforces those once the plugin is gone.
+   behavioral-proof checks. Nothing enforces those once the plugin is gone.

--- a/site/src/content/docs/hooks.md
+++ b/site/src/content/docs/hooks.md
@@ -27,7 +27,7 @@ codeArbiter enforces its gates as Claude Code hooks under `plugins/ca/hooks/`. E
 
 Every hook is registered **twice** in `hooks.json`: once under `python3`, and once under a `python3 -c "" || python` fallback. On a stock Windows box that has only the `python` interpreter, the gates still fire. The two entries each receive their own stdin, so a real block is never swallowed by the fallback.
 
-For the exact, word-for-word message text a hook prints for every gate ID — generated directly from each `block()`/`remind()` call site, so it can never drift from the narrative summaries below — see the [Hook Gates reference](/reference/hooks-gates/).
+For the exact, word-for-word message text a hook prints for every gate ID (generated directly from each `block()`/`remind()` call site, so it can never drift from the narrative summaries below), see the [Hook Gates reference](/reference/hooks-gates/).
 
 ## Registered Hooks
 
@@ -66,7 +66,7 @@ For the exact, word-for-word message text a hook prints for every gate ID — ge
 - **Event:** `PreToolUse`, matcher `Bash|PowerShell`.
 - **Script:** `pre-bash.py`.
 - **What it enforces:**
-  - **H-00:** fail-closed backstop. If the guard itself crashes on an unexpected input, or git cannot be read to resolve the branch/diff state, the operation is **blocked** rather than allowed through — a guard that cannot determine whether an operation is safe treats it as unsafe.
+  - **H-00:** fail-closed backstop. If the guard itself crashes on an unexpected input, or git cannot be read to resolve the branch/diff state, the operation is **blocked** rather than allowed through. A guard that cannot determine whether an operation is safe treats it as unsafe.
   - **H-01:** no direct commit/push to the default branch (`main`/`master` case-insensitive), including a detached HEAD on a protected tip and protected refspecs (`HEAD:main`, `:main`, `refs/heads/main`, `--all`/`--mirror`). The branch is resolved against the repository the git command actually targets (a `git -C <dir>` composes repeated `-C` the way git does), not the session's project dir.
   - **H-02:** no force-push (`--force`, `--force-with-lease`, `--force-if-includes`, `-f`, `+refspec`).
   - **H-03:** no wildcard staging (flag forms `-A`/`--all`/`-u`/`.`; argument forms globs, directories, pathspec magic).
@@ -100,7 +100,7 @@ For the exact, word-for-word message text a hook prints for every gate ID — ge
 - **Event:** `PreToolUse`, matcher `Edit|MultiEdit`.
 - **Script:** `pre-edit.py`.
 - **What it enforces:**
-  - **H-05:** on an audit log, MultiEdit is blocked outright (cannot express a verifiable append), an Edit with an empty `old_string` is blocked (it can never be a pure append), a `replace_all` Edit is rejected outright, and an Edit is admitted only as a strict **tail append** — `new_string` must equal the current content plus an appended tail, with `old_string` occurring exactly once. This closes the earlier hole where a mid-file insertion or a multi-site suffix rewrite passed as an "append".
+  - **H-05:** on an audit log, MultiEdit is blocked outright (cannot express a verifiable append), an Edit with an empty `old_string` is blocked (it can never be a pure append), a `replace_all` Edit is rejected outright, and an Edit is admitted only as a strict **tail append**: `new_string` must equal the current content plus an appended tail, with `old_string` occurring exactly once. This closes the earlier hole where a mid-file insertion or a multi-site suffix rewrite passed as an "append".
   - **H-11:** the same fresh `adr-authoring-active` marker requirement for `decisions/` `.md` files.
   - **H-18 / H-19:** the same activation-switch and gate-marker protections as the Write flank.
 - **Why:** Closes the Edit/MultiEdit flank; an append-only log accepts only verifiable tail appends.
@@ -158,7 +158,7 @@ The settings-wired statusline renderer (installed by `wire-statusline.py`; the r
 
 ### git-enforce.py
 
-The `pre-commit` / `pre-push` shim installed into the repo's own `.git/hooks/` (idempotently, at `/ca:init` and on session start; never overwriting a pre-existing foreign hook). It enforces the protected-branch, force-push, and crypto/secret/migration gates **at the git operation itself**, below the command spelling — so shell indirection (`g=git; $g commit`) that never reaches the `pre-bash.py` matcher is still gated. It resolves the repository it runs in via `git rev-parse --show-toplevel` from its own working directory, reuses the same detection primitives as `pre-bash.py` so the two cannot drift, and is written atomically so a torn install can never leave a sentinel-less partial shim. This backstop is what `pre-bash.py`'s H-20 protects (a `--no-verify` would skip it).
+The `pre-commit` / `pre-push` shim installed into the repo's own `.git/hooks/` (idempotently, at `/ca:init` and on session start; never overwriting a pre-existing foreign hook). It enforces the protected-branch, force-push, and crypto/secret/migration gates **at the git operation itself**, below the command spelling: shell indirection (`g=git; $g commit`) that never reaches the `pre-bash.py` matcher is still gated. It resolves the repository it runs in via `git rev-parse --show-toplevel` from its own working directory, reuses the same detection primitives as `pre-bash.py` so the two cannot drift, and is written atomically so a torn install can never leave a sentinel-less partial shim. This backstop is what `pre-bash.py`'s H-20 protects (a `--no-verify` would skip it).
 
 ### security-pass.py / migration-pass.py
 

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -3,11 +3,11 @@ title: What Is codeArbiter
 description: How codeArbiter orchestrates shared gated workflows in Claude Code, Codex, and Pi.
 ---
 
-codeArbiter ships four sibling plugins from one marketplace: three governance hosts — `ca` for Claude
-Code, `ca-codex` for Codex, and `ca-pi` for Pi — plus `ca-sandbox`, an infrastructure plugin unrelated
-to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)). All three governance hosts inject the
-same orchestrator responsibilities, enforce the same policy core, and use one checked-in
-`.codearbiter/` directory for project context and audit state. See the
+codeArbiter ships four sibling plugins from one marketplace. Three are governance hosts: `ca` for
+Claude Code, `ca-codex` for Codex, and `ca-pi` for Pi. The fourth is `ca-sandbox`, an infrastructure
+plugin unrelated to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)). All three governance
+hosts inject the same orchestrator responsibilities, enforce the same policy core, and use one
+checked-in `.codearbiter/` directory for project context and audit state. See the
 [Claude Code + Codex evidence](/getting-started/claude-code-and-codex/) for the verified boundary
 between those two, and [Pi](/getting-started/pi/) for the third host's install and trust model.
 The complete `ca-pi` adapter is currently a Feature Forge `preview`: real use


### PR DESCRIPTION
`site/VOICE.md` has said this since 2026-07-02:

> Em-dashes are not used as sentence separators in site prose. Restructure with a period, a comma, a colon, or parentheses instead.

**Nothing enforced it.** `_sloplib.in_antislop_doc_scope` governed repo-root docs and `docs/**` and had never covered `site/` — so the rule was prose asking politely, and **16 of the 36 authored pages violated it for 24 days** while reviewers cited it at contributors.

A rule with no gate is worse than no rule: people learn the style docs are advisory. That is the same corrosion as a teardown report that over-counts its failures (#433) or a suite that is red once in four (#462). So this ships **the gate first and the prose second**.

## The gate

`.github/scripts/check_site_voice.py`, wired into `docs.yml`'s `site-check` — which `deploy` needs, so a violation blocks the publish.

Its file set comes from `git ls-files`, so a generated page cannot drift into scope by landing in a tracked directory: **if it isn't committed, it isn't audited.** It doesn't re-implement the exclusions either; it asks the shared scope predicate, so there is one definition of scope rather than two that can disagree.

**Scope is authored prose**, and each exclusion is load-bearing rather than convenient:

| excluded | why |
| --- | --- |
| `content/docs/reference/**` | generated every build — 91 of the 128 pages there |
| `content/docs/changelog.md` | verbatim pass-through of the repo CHANGELOG, a different register |
| `site/src/curated/**` | mirrors of `plugins/ca` bodies, already excluded via `plugins/` |

A finding nobody wrote and nobody can fix in place is noise, and noise is how a gate gets ignored.

## Two detector corrections, both found by building the gate

**The detector flagged definition-list dashes** (`- **term** — meaning`). The rule is about *sentence* separators, and VOICE.md's own Terminology anchors are written in exactly that form — enforcing it as written would have made the gate contradict the guide it enforces. Now exempt, anchored to line-start and a bolded lead-in.

**That exemption's first cut was a false-negative generator**, caught by an adversarial reader *before* it shipped. Blanking the whole `- **term**` lead-in left the next dash with no word character on its left once inline code was stripped, so on:

```
- **The gate-enforcement hooks** — `a.py`, `b.py` — make zero calls.
```

a real separator scored **1 before and 0 after** — and that loosened the shared detector for `docs/**` and repo-root too, not only site prose. Only the definition *dash* is dropped now; the term is kept. The test meant to cover this passed only because its fixture had no inline code, so the real line is now a fixture.

Also: the scope predicate keyed on `.md` alone, so the two authored `.mdx` pages were invisible to a rule about writing.

## The prose

**118 offending lines across 15 pages**, restructured by what each dash was *doing* — parentheses or a comma pair for an aside, a colon for a consequence or list lead-in, a period where two independent statements had been welded. Table cells are in scope (`| No — guarded |` → `| No: guarded |`): a reader doesn't care that the dash sits in a cell.

Verified: every code span, link target, version, flag, path, gate ID and ADR reference is **byte-identical** across all 15 files; no generated page, no curated mirror, and nothing outside `site/src/content/docs` was touched; zero CRLF drift.

Two rewrites were **revised after review rather than defended**: an appositive that wedged 16 words between subject and verb in `install.md`, and a fifth comma added to a four-item list in `enforcement.md` — where `pi.md` already renders the identical sentence with a period, so it now matches.

## Known gap, recorded rather than implied

The detector is line-based, so **a separator dash at a line-wrap boundary is invisible to it**. Three such dashes were found *by hand* while fixing the flagged ones. They're fixed, but the gate didn't catch them and wouldn't catch a new one. Closing it needs paragraph-level analysis — a different change from this gate. Documented in the script's docstring and filed as **#484**.

## Verification

Gate exit 0 over 36 authored pages · site suite **438/438** · sloplib **33 tests** · full ca hook suite **1169** · `test_ci_impact` 41 · docs contract clean · `sync-core --check` byte-identical across three plugins.

`ca-pi` advances to **0.1.26** for the shared hook change.

Closes #338.
