### PR TITLE
fix(pi): rebuild the extension bundles after the redactor widened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,15 @@ jobs:
             ca-pi:
               - 'plugins/ca-pi/**'
               - 'core/**'
+              # The ca-pi extension bundles EMBED the shared farm redactor
+              # (tools/src/redaction.ts imports ../../../ca/tools/redactor.ts),
+              # so a change there makes the committed bundles stale while
+              # touching nothing under plugins/ca-pi/. #487 widened that
+              # redactor, rebuilt farm.js, and left both ca-pi bundles behind -
+              # main shipped stale bundles until the next ca-pi-touching PR
+              # happened to run this job and fail. A cross-plugin import needs a
+              # cross-plugin filter.
+              - 'plugins/ca/tools/redactor.ts'
               - 'package.json'
               - 'tools/build-host-packages.py'
               - '.github/scripts/test_pi_package.py'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.27] - 2026-07-26
+
+### Fixed
+
+- The extension bundles are rebuilt against the widened outbound redactor. The
+  bundles EMBED the shared farm redactor, so #487's widening (GitLab PATs,
+  OpenAI project keys, basic auth in a clone URL, bearer tokens) reached
+  `farm.js` but not `codearbiter.js` or `codearbiter-child.js` - a Pi install
+  would have kept redacting on the narrower pattern set. The parent's baked
+  child fingerprint is regenerated with them.
+
 ## [0.1.26] - 2026-07-25
 
 ### Fixed

--- a/plugins/ca-pi/extensions/codearbiter-child.js
+++ b/plugins/ca-pi/extensions/codearbiter-child.js
@@ -149,7 +149,33 @@ async function appendAuditLine(cwd, line) {
 import { randomBytes } from "node:crypto";
 
 // ../../ca/tools/redactor.ts
-var SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36})/i;
+var SECRET_LINE = new RegExp(
+  [
+    "api[_-]?key",
+    "token",
+    "secret",
+    "password",
+    "BEGIN.*PRIVATE",
+    "sk-ant",
+    "sk-proj-[A-Za-z0-9_-]{8}",
+    "AKIA[0-9A-Z]{16}",
+    "ghp_[A-Za-z0-9]{36}",
+    "glpat-[A-Za-z0-9_-]{8}",
+    // basic auth in a URL: scheme://user:secret@host - the colon-and-at shape,
+    // not any "@", so `https://example.com/@scope/pkg` is untouched.
+    // NOTE the doubled backslashes: these are JS STRING literals, and "\\s" in
+    // a string is a literal "s". The first cut of this shipped `[^/\s:@]`,
+    // which silently became `[^/s:@]` and only matched by luck.
+    "https?://[^/\\s:@]+:[^/\\s@]+@",
+    // a bearer credential, which is dot-segmented base64url in practice
+    "Bearer\\s+[A-Za-z0-9_-]{10,}"
+    // DELIBERATELY NOT ADDED: a `-u user:pass` rule for curl. `-u 1000:1000`
+    // is an everyday docker/podman uid:gid pair, so the shape collides with
+    // benign input. Broad is the safe direction for this redactor, but not at
+    // the cost of firing on ordinary container arguments.
+  ].join("|"),
+  "i"
+);
 var PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
 var PEM_END = /^-----END .*-----\s*$/;
 var REDACTION_MARKER = "[REDACTED \u2014 secret-pattern match removed before transmission]";

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -179,7 +179,33 @@ function auditField(value) {
 import { randomBytes } from "node:crypto";
 
 // ../../ca/tools/redactor.ts
-var SECRET_LINE = /(api[_-]?key|token|secret|password|BEGIN.*PRIVATE|sk-ant|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36})/i;
+var SECRET_LINE = new RegExp(
+  [
+    "api[_-]?key",
+    "token",
+    "secret",
+    "password",
+    "BEGIN.*PRIVATE",
+    "sk-ant",
+    "sk-proj-[A-Za-z0-9_-]{8}",
+    "AKIA[0-9A-Z]{16}",
+    "ghp_[A-Za-z0-9]{36}",
+    "glpat-[A-Za-z0-9_-]{8}",
+    // basic auth in a URL: scheme://user:secret@host - the colon-and-at shape,
+    // not any "@", so `https://example.com/@scope/pkg` is untouched.
+    // NOTE the doubled backslashes: these are JS STRING literals, and "\\s" in
+    // a string is a literal "s". The first cut of this shipped `[^/\s:@]`,
+    // which silently became `[^/s:@]` and only matched by luck.
+    "https?://[^/\\s:@]+:[^/\\s@]+@",
+    // a bearer credential, which is dot-segmented base64url in practice
+    "Bearer\\s+[A-Za-z0-9_-]{10,}"
+    // DELIBERATELY NOT ADDED: a `-u user:pass` rule for curl. `-u 1000:1000`
+    // is an everyday docker/podman uid:gid pair, so the shape collides with
+    // benign input. Broad is the safe direction for this redactor, but not at
+    // the cost of firing on ordinary container arguments.
+  ].join("|"),
+  "i"
+);
 var PEM_BEGIN = /^-----BEGIN .*-----\s*$/;
 var PEM_END = /^-----END .*-----\s*$/;
 var REDACTION_MARKER = "[REDACTED \u2014 secret-pattern match removed before transmission]";
@@ -9442,7 +9468,7 @@ async function codeArbiterPi(pi) {
         activeTools: pi.getActiveTools(),
         allTools: pi.getAllTools(),
         expansionFingerprints,
-        childFingerprint: "a1fc509fea3f27013bd5ccc93a0275196dfcf312e7c4600d4c535968b53a25d4"
+        childFingerprint: "817a2a7a4789f0ff64053d0c4d01c776d5518504afc992ef81c176fe09b10504"
       });
       const wrapperSelfTest = await runPiWrapperSelfTest({
         enabled: enabledForDoctor,

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Main was shipping stale bundles

#487 widened the shared outbound redactor (GitLab PATs, OpenAI project keys, basic auth in a clone URL, bearer tokens) and rebuilt `farm.js`. It did **not** rebuild the ca-pi extensions — and those *embed* the same redactor, because `tools/src/redaction.ts` imports `../../../ca/tools/redactor.ts`.

So a Pi install would have kept redacting on the **narrower pattern set**, silently, while the repo believed the widening had shipped.

The parent's baked child fingerprint is regenerated with them. Verified locally that the sha256 of the rebuilt child appears in the rebuilt parent — and that it is the same value CI computed on #490 (`817a2a7a4789f0ff…`), which confirms the diagnosis rather than assuming it.

## And the path filter that let it through

The `ca-pi` filter watched `plugins/ca-pi/**` and `core/**`. A change to a file the bundles embed, but which lives under `plugins/ca/`, triggered **nothing** — so main stayed red-free until the next ca-pi-touching PR happened to run the job and fail on staleness. That is exactly how this surfaced, on #490.

**A cross-plugin import needs a cross-plugin filter**, so the filter now watches `plugins/ca/tools/redactor.ts` directly.

## Why this goes first

Both PRs currently in flight touch ca-pi paths, so #490 and #491 were each failing the bundle-staleness gate on a defect **neither introduced**. This unblocks them.

## Verification

`pi-security` **12/12 pass** · `test_pi_package` 24 OK · `test_ci_impact` 41 OK · docs contract clean.

`ca-pi` advances to **0.1.27**. #491 will move to 0.1.28 on rebase.