### PR TITLE
feat(ci): gate ca-codex on a real Codex host install (#408)

### DIFF
--- a/.github/scripts/check_codex_host.py
+++ b/.github/scripts/check_codex_host.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Issue #408 — prove ca-codex installs into a REAL Codex host.
+
+The live-parity runbook already says what the static adapter test cannot do: it
+cannot prove that Codex delivers payloads, discovers hooks, or honours a block.
+Every required parity check invokes Python directly, and no workflow has ever
+installed or launched a real Codex runtime — so a protocol, trust, or
+hook-discovery regression can merge with every gate green.
+
+WHAT THIS COVERS, AND WHAT IT DELIBERATELY DOES NOT
+---------------------------------------------------
+A 2026-07-26 spike measured the boundary. Installing the checked-out plugin
+through a real host needs NO credential and NO network:
+
+    codex plugin marketplace add <checkout>     # local path is a valid SOURCE
+    codex plugin add ca-codex@<marketplace>
+    codex plugin list                           # -> installed, enabled, <version>
+
+Proving a hook FIRES does not. A hook runs inside a turn and a turn needs a
+model: `codex exec` against an unreachable provider initialises a complete
+session and then dies at the network boundary, having injected nothing. So the
+live enforcement proof needs a provider credential, which cannot be a required
+check on fork PRs, and is tracked separately.
+
+This script is therefore the credential-free half, and it says so rather than
+implying the rest is covered.
+
+THE GATE, mirroring `plugins/ca-sandbox/tools/docker-gate.ts` (#406)
+--------------------------------------------------------------------
+A missing runtime must not look like a pass:
+
+    CA_REQUIRE_CODEX=1   a real host is a PREREQUISITE. An absent or unusable
+                         `codex` exits non-zero instead of skipping. CI sets
+                         this; developer machines do not.
+
+Without it, an absent runtime SKIPS with an explicit notice and exit 0, which is
+right on a laptop and wrong on a merge gate.
+
+Usage:
+    python .github/scripts/check_codex_host.py          # audit, JSON to stdout
+    python .github/scripts/check_codex_host.py --json   # same, machine-readable only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST = REPO / "plugins" / "ca-codex" / ".codex-plugin" / "plugin.json"
+HOOKS_JSON = REPO / "plugins" / "ca-codex" / "hooks" / "hooks.json"
+
+# A workspace-relative home, NOT the system temp directory. Measured: Codex
+# refuses to create its helper binaries under a temp dir and warns on every
+# invocation ("Refusing to create helper binaries under temporary dir"), which
+# buries the lane's real output in noise.
+CODEX_HOME = REPO / ".codex-host-check"
+
+SCHEMA = "codearbiter-codex-host-v1"
+
+
+def _run(args: list[str], home: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["CODEX_HOME"] = str(home)
+    return subprocess.run(args, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", env=env, cwd=str(REPO))
+
+
+def codex_version() -> str | None:
+    """The runtime's version, or None when no usable `codex` is on PATH."""
+    if shutil.which("codex") is None:
+        return None
+    try:
+        proc = subprocess.run(["codex", "--version"], capture_output=True, text=True,
+                              encoding="utf-8", errors="replace", timeout=120)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def expected_version() -> str:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))["version"]
+
+
+def check_install(home: Path) -> list[dict]:
+    """Install the CHECKED-OUT plugin through the real host and read it back."""
+    results: list[dict] = []
+
+    def record(code: str, ok: bool, detail: str = "") -> None:
+        results.append({"code": code, "status": "pass" if ok else "fail",
+                        **({"detail": detail} if detail and not ok else {})})
+
+    added = _run(["codex", "plugin", "marketplace", "add", str(REPO)], home)
+    record("CODEX-HOST-MARKETPLACE", added.returncode == 0,
+           (added.stderr or added.stdout).strip()[-400:])
+    if added.returncode != 0:
+        return results
+
+    installed = _run(["codex", "plugin", "add", "ca-codex@codearbiter"], home)
+    record("CODEX-HOST-INSTALL", installed.returncode == 0,
+           (installed.stderr or installed.stdout).strip()[-400:])
+    if installed.returncode != 0:
+        return results
+
+    listed = _run(["codex", "plugin", "list"], home)
+    out = listed.stdout
+    record("CODEX-HOST-LIST", listed.returncode == 0,
+           (listed.stderr or out).strip()[-400:])
+
+    # The read-back is the point: an install that reports success but leaves the
+    # plugin DISABLED is exactly the drift a static adapter test cannot see.
+    row = next((line for line in out.splitlines() if line.startswith("ca-codex@")), "")
+    record("CODEX-HOST-ENABLED", "installed" in row and "enabled" in row, row.strip())
+
+    # What this version check can and cannot do, stated because a mutation test
+    # showed the obvious reading is wrong: bumping the manifest to 9.9.9 does NOT
+    # fail it, because the host installs FROM that same manifest and both sides
+    # move together. There is one source of truth, so this cannot detect drift
+    # between the checkout and the install.
+    #
+    # It does catch the failure that is actually possible here: a host that
+    # reports no version at all, or resolves a DIFFERENT one - which a stale
+    # marketplace snapshot can genuinely cause, since `plugin marketplace
+    # upgrade` exists precisely because a snapshot can lag its source.
+    want = expected_version()
+    record("CODEX-HOST-VERSION", bool(want) and want in row,
+           f"expected {want!r} in {row.strip()!r}")
+
+    # The installed CACHE path carries the resolved version independently of the
+    # listing text, so a host that reported one version and installed another
+    # shows up as a mismatch between these two.
+    resolved = sorted(d.name for d in home.glob("plugins/cache/*/ca-codex/*") if d.is_dir())
+    record("CODEX-HOST-RESOLVED-VERSION", resolved == [want],
+           f"cache holds {resolved}, listing claims {want!r}")
+
+    # The hooks the plugin claims must be present in the INSTALLED copy, not
+    # merely in the source tree - the install is a copy, and a copy can drop a
+    # dotfile or a subdirectory.
+    cached = list(home.glob("plugins/cache/*/ca-codex/*/hooks/hooks.json"))
+    record("CODEX-HOST-HOOKS-INSTALLED", len(cached) == 1,
+           f"found {len(cached)} installed hooks.json")
+    if cached:
+        try:
+            declared = json.loads(cached[0].read_text(encoding="utf-8"))["hooks"]
+            source = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))["hooks"]
+            record("CODEX-HOST-HOOKS-MATCH", set(declared) == set(source),
+                   f"installed {sorted(declared)} vs source {sorted(source)}")
+        except (ValueError, KeyError) as error:
+            record("CODEX-HOST-HOOKS-MATCH", False, str(error))
+
+    return results
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="ca-codex real-host install gate (#408)")
+    parser.add_argument("--json", action="store_true",
+                        help="print only the JSON report")
+    arguments = parser.parse_args(argv)
+
+    required = os.environ.get("CA_REQUIRE_CODEX") == "1"
+    version = codex_version()
+
+    if version is None:
+        report = {"schema": SCHEMA, "status": "fail" if required else "skip",
+                  "runtime": None, "results": []}
+        print(json.dumps(report))
+        if required:
+            print("::error::CA_REQUIRE_CODEX=1 but no usable `codex` runtime is on PATH; "
+                  "a missing host must not read as a passing gate (#408)", file=sys.stderr)
+            return 1
+        if not arguments.json:
+            print("codex host: no runtime on PATH - SKIPPED "
+                  "(set CA_REQUIRE_CODEX=1 to make this a failure)", file=sys.stderr)
+        return 0
+
+    # A disposable home, rebuilt every run: a leftover marketplace or a cached
+    # plugin from a previous run would let a BROKEN checkout pass on stale state.
+    if CODEX_HOME.exists():
+        shutil.rmtree(CODEX_HOME, ignore_errors=True)
+    CODEX_HOME.mkdir(parents=True, exist_ok=True)
+    try:
+        results = check_install(CODEX_HOME)
+    finally:
+        shutil.rmtree(CODEX_HOME, ignore_errors=True)
+
+    failed = [r for r in results if r["status"] != "pass"]
+    report = {"schema": SCHEMA, "status": "fail" if failed else "pass",
+              "runtime": version, "results": results}
+    print(json.dumps(report))
+
+    if failed:
+        for r in failed:
+            print(f"::error::{r['code']}: {r.get('detail', 'failed')}", file=sys.stderr)
+        return 1
+    if not arguments.json:
+        print(f"codex host: {version} installed the checked-out ca-codex "
+              f"{expected_version()} and read it back enabled", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
               # PR that ONLY widened the exclusion - the exact shape of a gate
               # quietly stopping - would otherwise skip the job that checks it.
               - '.github/scripts/payload_scope.py'
+              - '.github/scripts/check_codex_host.py'
               - '.github/scripts/test_payload_scope.py'
               - 'core/hosts.json'
               - 'tools/ci-impact.py'
@@ -1285,6 +1286,49 @@ jobs:
       - name: Check rendered surfaces match core/surface/ templates (both hosts)
         run: python3 tools/build-surface.py --check
 
+  codex-host:
+    name: "[CHECK] | [CDX ] | Real-host install"
+    # Issue #408. Every other ca-codex gate invokes Python directly and proves
+    # what the GUARD answers; none of them proves the HOST calls it, or even
+    # that the host can load the plugin at all. The live-parity runbook says so
+    # explicitly, and the shipped manifest still advertises Codex >= 0.143.0 on
+    # the strength of one manual check.
+    #
+    # This lane installs the CHECKED-OUT plugin through a real Codex runtime and
+    # reads it back. Deliberately credential-free, which a 2026-07-26 spike
+    # measured: `plugin marketplace add <local path>` + `plugin add` + `plugin
+    # list` need no provider key and no network, so this can be REQUIRED and
+    # still run on fork PRs.
+    #
+    # What it does NOT cover is stated rather than implied: proving a hook FIRES
+    # needs a turn, a turn needs a model, and a provider credential cannot be a
+    # required check on forks. That half is tracked separately.
+    needs: changes
+    if: needs.changes.outputs.ca-codex == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - name: Install the pinned Codex runtime
+        # Pinned, not @latest: an unpinned host makes this gate report upstream
+        # drift as a ca-codex regression, and the version claim in the manifest
+        # has to mean something continuously tested.
+        run: npm install -g @openai/codex@0.145.0
+      - name: Install ca-codex through the real host and read it back
+        env:
+          # A missing runtime must FAIL here rather than skip. On a developer
+          # machine the same script skips with a notice; on the merge gate,
+          # "the host check did not run" must never look like "it passed"
+          # (the docker-gate discipline from #406).
+          CA_REQUIRE_CODEX: "1"
+        run: python3 .github/scripts/check_codex_host.py
+
   prose-codex:
     name: "[CHECK] | [CDX ] | Reference graph"
     needs: changes
@@ -1555,6 +1599,7 @@ jobs:
       - version-bump
       - version-bump-sandbox
       - version-bump-codex
+      - codex-host
       - version-bump-pi
       - prose
       - badge-consistency
@@ -1568,7 +1613,7 @@ jobs:
     steps:
       - name: Require every required job to have succeeded or been skipped
         run: |
-          required_results="${{ needs['documentation-contract'].result }} ${{ needs['branch-protection'].result }} ${{ needs['tag-immutability'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }} ${{ needs['secret-scan'].result }}"
+          required_results="${{ needs['documentation-contract'].result }} ${{ needs['branch-protection'].result }} ${{ needs['tag-immutability'].result }} ${{ needs.changes.result }} ${{ needs['host-descriptors'].result }} ${{ needs['ci-impact'].result }} ${{ needs.tools.result }} ${{ needs['ca-sandbox-tools'].result }} ${{ needs['ca-pi-checks'].result }} ${{ needs['ca-pi-tools'].result }} ${{ needs['ca-pi-codeql'].result }} ${{ needs.hooks.result }} ${{ needs['version-bump'].result }} ${{ needs['version-bump-sandbox'].result }} ${{ needs['version-bump-codex'].result }} ${{ needs['codex-host'].result }} ${{ needs['version-bump-pi'].result }} ${{ needs.prose.result }} ${{ needs['badge-consistency'].result }} ${{ needs['prose-sandbox'].result }} ${{ needs.manifests.result }} ${{ needs['license-consistency'].result }} ${{ needs.surface.result }} ${{ needs['prose-codex'].result }} ${{ needs['secret-scan'].result }}"
           canary_result="${{ needs.ca-pi-latest.result }}"
           echo "upstream required results: $required_results"
           echo "advisory Pi canary result: $canary_result"


### PR DESCRIPTION
## What

A required CI lane that installs the **checked-out** ca-codex through a **real Codex runtime** and reads it back. This is #408's credential-free half.

## Why this half can be required

A spike on 2026-07-26 measured where the credential boundary actually falls, against real `codex-cli` 0.145.0.

**Credential-free, verified end to end:** `plugin marketplace add` accepts a **local path** as its `<SOURCE>`, so the checkout itself is the marketplace. No network, no provider key:

```
codex plugin marketplace add <checkout>   -> Added marketplace `codearbiter`
codex plugin add ca-codex@codearbiter     -> Added plugin `ca-codex`
codex plugin list                          -> ca-codex@codearbiter  installed, enabled  0.3.0
```

**Not credential-free:** proving a hook *fires* needs a turn, and a turn needs a model. `codex exec` against an unreachable provider initialises a complete session — workdir, provider, sandbox, session id — then dies at the network boundary having injected nothing. So the live enforcement proof needs a provider credential, cannot be a required check on fork PRs, and is **tracked separately rather than implied to be covered here**.

## The gate

Eight checks: the marketplace registers, the plugin installs, the listing reports it **installed and enabled**, the resolved version matches, the installed copy carries `hooks.json`, and its registered events match the source. That last pair matters because the install is a *copy*, and a copy can drop a dotdir.

Mirrors `docker-gate.ts`'s discipline (#406): **`CA_REQUIRE_CODEX=1` makes an absent runtime a failure**, so "the host check did not run" can never look like "it passed". Both modes verified — required-with-no-runtime exits 1 with a named error; unset skips with a notice and exits 0.

## Two things a mutation test corrected

**The version check cannot detect checkout-vs-install drift.** I assumed it could. Bumping the manifest to `9.9.9` does *not* fail it, because the host installs from that same manifest and both sides move together. It catches a host that reports no version or resolves a *different* one — which a stale marketplace snapshot genuinely causes, since `marketplace upgrade` exists precisely because a snapshot can lag. The cache-path check makes that observable independently of the listing text. Both facts are now in the code.

**I nearly shipped two fabricated values.** The `setup-node` SHA I first wrote was invented — the repo pins a different one, now corrected to its actual `v7.0.0` SHA. And I guessed the npm package name; `npm view @openai/codex version` confirms it exists and is `0.145.0`, matching the runtime the spike ran against. Neither should have gone in unverified.

## Also measured

`CODEX_HOME` is workspace-relative, **not** the system temp dir — Codex refuses to create helper binaries under temp and warns on every invocation, which would bury the lane's real output.

`codex doctor` is **not** usable as a gate: it reports no plugin or hook information and exits 1 purely on missing credentials.

## Verification

Ran against real `codex-cli` 0.145.0: 8/8 checks pass. `test_ci_impact` 42 tests OK, plus `test_codex_adapter`, `test_branch_protection`, `test_release_workflow`, and the `PI-SEC-ACTIONS-PIN` action-pinning gate.

## Versions

**No bump** — CI wiring and a new `.github/scripts` file; no plugin payload changes.

Refs #408

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
