### PR TITLE
fix(release): the notes guard rejected every namespaced tag, so no sibling could publish

### DIFF
--- a/.github/scripts/_releaselib.py
+++ b/.github/scripts/_releaselib.py
@@ -90,9 +90,27 @@ RELEASE_TAG_PREFIXES = {
 
 
 def _bare_version(tag):
-    """`v2.6.0` / `[2.6.0]` / `2.6.0` -> `2.6.0`. Lets the heading match compare
-    a `vX.Y.Z` tag against a bracket-style heading without caring about style."""
-    return tag.strip().lstrip("v").strip("[]") if isinstance(tag, str) else tag
+    """`v2.6.0` / `[2.6.0]` / `2.6.0` / `ca-pi-v0.1.31` -> the bare SemVer.
+
+    Lets the heading match compare a tag against a bracket-style changelog
+    heading without caring about either spelling.
+
+    This used to be `tag.lstrip("v")`, which strips only a LEADING "v" — right
+    for ca's bare `v2.9.1`, and wrong for every namespaced sibling, because
+    `"ca-pi-v0.1.31".lstrip("v")` is unchanged and never equals the `0.1.31`
+    parsed out of the heading. The hosted publish action treats a failed
+    `notes-match` as a STOP, so the ca-codex, ca-sandbox and ca-pi lanes could
+    not have completed a release at all: they would have aborted at that guard
+    on a perfectly correct changelog, every time. Nothing caught it because the
+    lanes had never been dispatched and every test used a bare `v` tag.
+
+    Anchored on the SemVer at the END rather than by stripping a known prefix,
+    so a fifth plugin's namespace works without being enumerated here."""
+    if not isinstance(tag, str):
+        return tag
+    text = tag.strip().strip("[]")
+    match = re.search(r"(\d+\.\d+\.\d+.*)$", text)
+    return match.group(1) if match else text.lstrip("v")
 
 
 def last_tag_select(tags, prefix="v"):

--- a/.github/scripts/test_release_lib.py
+++ b/.github/scripts/test_release_lib.py
@@ -667,5 +667,67 @@ class LastTagPerSeriesTest(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertIn("unknown release target", err.getvalue())
 
+
+class NotesHeadingNamespacedTagTest(unittest.TestCase):
+    """#493's sibling lanes abort at the notes guard, on every dispatch.
+
+    `_bare_version` stripped only a LEADING "v" (`tag.lstrip("v")`), which is
+    right for ca's bare `v2.9.1` and wrong for every namespaced sibling:
+    `"ca-pi-v0.1.31".lstrip("v")` is unchanged, so it never equals the `0.1.31`
+    parsed out of the changelog heading.
+
+    The hosted publish action runs
+
+        python3 .github/scripts/_releaselib.py notes-match "$TAG" notes.md
+
+    and a non-zero exit STOPS the publish. So the ca-codex, ca-sandbox and ca-pi
+    lanes added by #382 could never have completed a release - they would have
+    aborted at this guard every time, on a correct changelog. Undetected because
+    the lanes had never been dispatched and every existing test here used a bare
+    `v` tag."""
+
+    def _notes(self, version):
+        return f"## [{version}] - 2026-07-26\n\n### Added\n\n- a thing\n"
+
+    def test_every_release_series_matches_its_own_notes(self):
+        for target, prefix in _releaselib.RELEASE_TAG_PREFIXES.items():
+            version = "1.2.3"
+            with self.subTest(target=target):
+                self.assertTrue(
+                    _releaselib.notes_heading_matches(
+                        self._notes(version), f"{prefix}{version}"),
+                    f"{target}: a correct changelog must satisfy its own tag")
+
+    def test_a_namespaced_tag_still_rejects_the_wrong_section(self):
+        # The guard must keep its actual job: a stale notes file publishes the
+        # wrong changelog section under the right tag.
+        self.assertFalse(
+            _releaselib.notes_heading_matches(self._notes("0.1.30"), "ca-pi-v0.1.31"))
+        self.assertFalse(
+            _releaselib.notes_heading_matches(self._notes("1.0.0"), "ca-sandbox-v2.0.0"))
+
+    def test_one_series_does_not_satisfy_another(self):
+        # `ca-pi-v1.2.3` and `ca-sandbox-v1.2.3` share a version. The guard
+        # compares VERSIONS, so both match a 1.2.3 section - which is correct:
+        # the tag namespace is enforced by the lane that chose it, not here.
+        # Pinned so a future "strip the prefix" change cannot quietly start
+        # rejecting a legitimate release.
+        notes = self._notes("1.2.3")
+        self.assertTrue(_releaselib.notes_heading_matches(notes, "ca-pi-v1.2.3"))
+        self.assertTrue(_releaselib.notes_heading_matches(notes, "ca-sandbox-v1.2.3"))
+
+    def test_bare_version_extracts_the_semver_from_any_spelling(self):
+        cases = {
+            "v2.6.0": "2.6.0",
+            "2.6.0": "2.6.0",
+            "[2.6.0]": "2.6.0",
+            "ca-pi-v0.1.31": "0.1.31",
+            "ca-codex-v0.3.0": "0.3.0",
+            "ca-sandbox-v0.1.5": "0.1.5",
+        }
+        for spelling, want in cases.items():
+            with self.subTest(spelling=spelling):
+                self.assertEqual(_releaselib._bare_version(spelling), want)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`_bare_version` now extracts the SemVer from any tag spelling, including namespaced ones.

## Severity

**The three sibling release lanes added by #382 could not have completed a release.** They would have aborted at the notes guard — on a perfectly correct changelog — every single time.

`_bare_version` stripped only a **leading** `"v"`:

```python
tag.strip().lstrip("v").strip("[]")
```

Right for ca's bare `v2.9.1`. Wrong for every namespaced sibling, because `"ca-pi-v0.1.31".lstrip("v")` is **unchanged** — it starts with `c` — so it never equals the `0.1.31` parsed out of the heading.

The publish action runs:

```
python3 .github/scripts/_releaselib.py notes-match "$TAG" notes.md
```

and treats a non-zero exit as a **STOP**. So `ca-codex`, `ca-sandbox` and `ca-pi` all failed closed there.

```
v2.9.1              bare='2.9.1'              matches=True
ca-pi-v0.1.31       bare='ca-pi-v0.1.31'      matches=False
ca-codex-v0.3.0     bare='ca-codex-v0.3.0'    matches=False
ca-sandbox-v0.1.5   bare='ca-sandbox-v0.1.5'  matches=False
```

## How it was found, and why that's uncomfortable

By **dry-running the ca-pi lane against the real changelog** — not by a test.

#382 shipped with 58 workflow-contract tests and a PR of mine claiming to prove *"version/tag/changelog isolation across all four streams"*. Those tests assert each lane passes the right paths to the shared action, and that the action **calls** this guard. **None of them ran the guard against a namespaced tag.** Every existing `notes-match` test used a bare `v` tag, so the entire sibling half of the feature was untested exactly where it mattered.

The lanes looked complete, had contract coverage, and would have failed on first use. That is the failure mode the contract suite exists to prevent, and it did not.

## The fix

Anchor on the SemVer at the **end** rather than stripping a known prefix, so a fifth plugin's namespace works without being enumerated:

```python
match = re.search(r"(\d+\.\d+\.\d+.*)$", text)
```

## Verification

**Against the real changelogs, not fixtures** — the same extraction the shipped action performs:

```
ca-pi-v0.1.31      -> notes-match PASS (14 lines)
ca-sandbox-v0.1.5  -> notes-match PASS (51 lines)
ca-codex-v0.3.0    -> notes-match PASS (79 lines)
```

New tests pin every series against its own notes, and keep the guard's real job intact — a stale section still fails. RED first: all three siblings failed before the fix.

`test_release_lib.py` 83 tests OK (was 79), `test_release_workflow.py` 58 OK.

## Versions

**No bump** — `.github/scripts` only; no plugin payload changes.

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
