### PR TITLE
feat(review): /ca:review can review an inbound pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ predate the plugin rewrite and are grouped by date.
 
 ### Added
 
+- `/ca:review` can review an inbound GitHub pull request, not only the diff you
+  just wrote: `/ca:review #123` fetches that PR's diff and runs the same fleet,
+  the same path matrix, and the same `finding-triage` -> `checkpoint-aggregator`
+  funnel. A gate that only reviews its own author's change is a linter, not a
+  team gate, and reviewing code you did NOT write is where it earns its keep
+  (issue #80).
+
+  Deliberately an ARGUMENT rather than a `/ca:review-pr` command. The scope
+  resolver already took one, the fleet is scope-agnostic, and every phase
+  downstream operates on a diff regardless of where it came from - so a second
+  command would be a whole public surface (the catalog, three host projections,
+  the README counts, the site sidebar) whose only distinguishing feature is
+  where the diff was fetched from. The command count is unchanged.
+
+  Three guards ride with it. A missing or unauthenticated `gh` STOPs rather than
+  falling back to the working diff, which would report a verdict on the wrong
+  change under the PR's name. The diff is resolved ONCE, because the fleet runs
+  in parallel and a PR updated mid-review would otherwise have reviewers reading
+  different code. And posting the verdict is a separate, confirmed step that
+  never uses `--approve` or `--request-changes`: a comment on someone else's PR
+  is public the moment it lands, and those two flags carry merge authority this
+  command does not have.
+
 - `/ca:release` releases any of the four plugins, as one command taking the
   target as its argument (default `ca`, so a bare `/ca:release` is unchanged).
   It could only ever target `ca` before, because `LAST_TAG` resolution matched

--- a/core/surface/commands/review.md
+++ b/core/surface/commands/review.md
@@ -1,15 +1,29 @@
 ---
-description: Review the current diff with the reviewer fleet, funneled to one triaged verdict.
-argument-hint: "[path]" (defaults to the current diff)
+description: Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR.
+argument-hint: "[path | #<pr> | <pr-url>]" (defaults to the current diff)
 ---
 
 # {{CMD:review}} — diff review
 
-Read-only review of the current change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+Read-only review of a change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+
+**The change under review does not have to be yours.** `{{CMD:review}} #123` reviews an inbound pull request through the same fleet, the same matrix, and the same triage. That is the point of issue #80: a tool that only reviews the diff you just wrote is a linter for authors, not a gate for a team, and reviewing code you did NOT write is where a governance gate earns its keep.
+
+It is an ARGUMENT, not a second command. The scope resolver already took one, the fleet is scope-agnostic, and every phase downstream operates on a diff regardless of where it came from — so a `{{CMD:review}}-pr` would be a whole public surface (catalog, three host projections, README counts, sidebar) whose only distinguishing feature is where the diff was fetched from.
 
 ## Flow
 
-1. Resolve scope — `$ARGUMENTS` if a path is given, else the current diff.
+1. Resolve scope from `$ARGUMENTS`:
+   - **empty** → the current working diff (unchanged default).
+   - **a path** → that path (unchanged).
+   - **`#<number>`, a bare number, or a GitHub PR URL** → an INBOUND PR. Fetch its diff with
+     `gh pr diff <number>` and review that. If `gh` is missing or unauthenticated, STOP and say so —
+     do NOT silently fall back to the working diff, which would report a verdict on the wrong change
+     under the PR's name.
+
+   For a PR target, resolve the diff ONCE and review that text. Do not re-fetch per reviewer: the
+   fleet runs in parallel, and a PR updated mid-review would otherwise have different reviewers
+   reading different code and a triage that reconciles findings from two versions.
 2. Build the unit list by path matrix; each matched reviewer is one read-only unit:
 
    | Reviewer | Dispatched when scope touches |
@@ -26,6 +40,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
    `[NEEDS-TRIAGE]` on out-of-scope items) → `checkpoint-aggregator` (single verdict).
 4. Surface the aggregated verdict: findings by severity, file:line, remediation, and the applicable
    control from `{{PROJECT_DIR}}/.codearbiter/security-controls.md` for security findings.
+5. **For a PR target, posting the verdict is a separate, confirmed step.** Report locally first; post only on explicit instruction, with `gh pr review <number> --comment --body-file <file>`. A review comment on someone else's PR is outward-facing and effectively public the moment it lands — it notifies subscribers and cannot be un-sent. Never `--request-changes` or `--approve` from here: those carry merge authority, and this command produces a finding list, not a maintainer's decision.
 
 ## Severity
 
@@ -36,8 +51,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
 
 ## Hard gate
 
-Read-only — MUST NOT modify a file. BLOCK on any CRITICAL or HIGH finding: it must be resolved before
-`{{CMD:pr}}`. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
+Read-only — MUST NOT modify a file, and MUST NOT check out, merge, or otherwise move the repository to the PR's branch: reviewing an inbound PR means reading its DIFF, not adopting its code, and a checkout would run its content through hooks that trust the working tree. BLOCK on any CRITICAL or HIGH finding on your OWN change: it must be resolved before `{{CMD:pr}}`. On an inbound PR there is nothing local to block — the verdict is the deliverable. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
 verdict. MUST NOT resolve a `[CONFIRM-NN]` surfaced during review by guessing.
 
 ## When NOT to use

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 ## [0.3.0] — 2026-07-12 — Shared-state concurrency hardening
 
 ### Added
+- The projected review routine accepts an inbound pull request as its argument,
+  reviewing code the operator did not write through the existing fleet (#80).
+
 - `$ca-cleanup` (`post-merge-cleanup`): the already-merged branch transition —
   prove ancestry of the fetched default branch, classify leftover artifacts as
   unique / redundant / superseded, resolve each under its own confirmation,

--- a/plugins/ca-codex/skills/INDEX.md
+++ b/plugins/ca-codex/skills/INDEX.md
@@ -35,7 +35,7 @@ skill is invoked — never bulk-read this directory.
 | `$ca-reconcile` | SMARTS arbitration — reconcile architectural artifacts against the scaffold and prior decisions; every variance resolved by an explicit, user-attributed choice. |
 | `$ca-refactor` | Restructure code with behavioral parity proven through unmodified pre-existing tests, then refactor. No behavior change. |
 | `$ca-release` | Cut a release the only sanctioned way — SemVer bump from the commit log, a CHANGELOG section, an annotated tag. The only path to a version tag. |
-| `$ca-review` | Review the current diff with the reviewer fleet, funneled to one triaged verdict. |
+| `$ca-review` | Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR. |
 | `$ca-spike` | Exploratory spike on a throwaway branch — answer a named question with disposable code. Never merges; exits to a findings note or $ca-feature. |
 | `$ca-sprint` | Autonomous sprint — one interactive spec gate, then plan-to-PR execution with every auto-decision SMARTS-scored and logged. Hard gates remain true stops. |
 | `$ca-standup` | Daily repo hygiene — review the day's repo state, then perform the cleanups under per-action confirmation. Fast-forward only, never destructive without a yes. |

--- a/plugins/ca-codex/skills/ca-review/SKILL.md
+++ b/plugins/ca-codex/skills/ca-review/SKILL.md
@@ -1,16 +1,30 @@
 ---
 name: ca-review
-description: Review the current diff with the reviewer fleet, funneled to one triaged verdict.
-argument-hint: "\"[path]\" (defaults to the current diff)"
+description: Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR.
+argument-hint: "\"[path | #<pr> | <pr-url>]\" (defaults to the current diff)"
 ---
 
 # $ca-review — diff review
 
-Read-only review of the current change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+Read-only review of a change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+
+**The change under review does not have to be yours.** `$ca-review #123` reviews an inbound pull request through the same fleet, the same matrix, and the same triage. That is the point of issue #80: a tool that only reviews the diff you just wrote is a linter for authors, not a gate for a team, and reviewing code you did NOT write is where a governance gate earns its keep.
+
+It is an ARGUMENT, not a second command. The scope resolver already took one, the fleet is scope-agnostic, and every phase downstream operates on a diff regardless of where it came from — so a `$ca-review-pr` would be a whole public surface (catalog, three host projections, README counts, sidebar) whose only distinguishing feature is where the diff was fetched from.
 
 ## Flow
 
-1. Resolve scope — `$ARGUMENTS` if a path is given, else the current diff.
+1. Resolve scope from `$ARGUMENTS`:
+   - **empty** → the current working diff (unchanged default).
+   - **a path** → that path (unchanged).
+   - **`#<number>`, a bare number, or a GitHub PR URL** → an INBOUND PR. Fetch its diff with
+     `gh pr diff <number>` and review that. If `gh` is missing or unauthenticated, STOP and say so —
+     do NOT silently fall back to the working diff, which would report a verdict on the wrong change
+     under the PR's name.
+
+   For a PR target, resolve the diff ONCE and review that text. Do not re-fetch per reviewer: the
+   fleet runs in parallel, and a PR updated mid-review would otherwise have different reviewers
+   reading different code and a triage that reconciles findings from two versions.
 2. Build the unit list by path matrix; each matched reviewer is one read-only unit:
 
    | Reviewer | Dispatched when scope touches |
@@ -27,6 +41,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
    `[NEEDS-TRIAGE]` on out-of-scope items) → `checkpoint-aggregator` (single verdict).
 4. Surface the aggregated verdict: findings by severity, file:line, remediation, and the applicable
    control from `<project-root>/.codearbiter/security-controls.md` for security findings.
+5. **For a PR target, posting the verdict is a separate, confirmed step.** Report locally first; post only on explicit instruction, with `gh pr review <number> --comment --body-file <file>`. A review comment on someone else's PR is outward-facing and effectively public the moment it lands — it notifies subscribers and cannot be un-sent. Never `--request-changes` or `--approve` from here: those carry merge authority, and this command produces a finding list, not a maintainer's decision.
 
 ## Severity
 
@@ -37,8 +52,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
 
 ## Hard gate
 
-Read-only — MUST NOT modify a file. BLOCK on any CRITICAL or HIGH finding: it must be resolved before
-`$ca-pr`. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
+Read-only — MUST NOT modify a file, and MUST NOT check out, merge, or otherwise move the repository to the PR's branch: reviewing an inbound PR means reading its DIFF, not adopting its code, and a checkout would run its content through hooks that trust the working tree. BLOCK on any CRITICAL or HIGH finding on your OWN change: it must be resolved before `$ca-pr`. On an inbound PR there is nothing local to block — the verdict is the deliverable. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
 verdict. MUST NOT resolve a `[CONFIRM-NN]` surfaced during review by guessing.
 
 ## When NOT to use

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `ca-pi` are documented in this file.
 
+## [0.1.32] - 2026-07-26
+
+### Added
+
+- The projected review routine accepts an inbound pull request as its argument
+  (`#123`, a bare number, or a PR URL) and reviews it through the same fleet and
+  the same triage funnel as a local diff. Shipped as an ARGUMENT rather than a
+  second command, so the Pi command catalog and skill count are unchanged - a
+  `review-pr` skill would have been a new public surface whose only difference
+  is where the diff came from (#80).
+
 ## [0.1.31] - 2026-07-26
 
 ### Added

--- a/plugins/ca-pi/SKILLS.md
+++ b/plugins/ca-pi/SKILLS.md
@@ -36,7 +36,7 @@ skill is invoked — never bulk-read this directory.
 | `/ca-reconcile` | SMARTS arbitration — reconcile architectural artifacts against the scaffold and prior decisions; every variance resolved by an explicit, user-attributed choice. |
 | `/ca-refactor` | Restructure code with behavioral parity proven through unmodified pre-existing tests, then refactor. No behavior change. |
 | `/ca-release` | Cut a release the only sanctioned way — SemVer bump from the commit log, a CHANGELOG section, an annotated tag. The only path to a version tag. |
-| `/ca-review` | Review the current diff with the reviewer fleet, funneled to one triaged verdict. |
+| `/ca-review` | Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR. |
 | `/ca-spike` | Exploratory spike on a throwaway branch — answer a named question with disposable code. Never merges; exits to a findings note or /ca-feature. |
 | `/ca-sprint` | Autonomous sprint — one interactive spec gate, then plan-to-PR execution with every auto-decision SMARTS-scored and logged. Hard gates remain true stops. |
 | `/ca-standup` | Daily repo hygiene — review the day's repo state, then perform the cleanups under per-action confirmation. Fast-forward only, never destructive without a yes. |

--- a/plugins/ca-pi/generated/command-catalog.json
+++ b/plugins/ca-pi/generated/command-catalog.json
@@ -151,7 +151,7 @@
   },
   {
     "name": "review",
-    "description": "Review the current diff with the reviewer fleet, funneled to one triaged verdict.",
+    "description": "Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR.",
     "skillPath": "skills/ca-review/SKILL.md"
   },
   {

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/skills/ca-review/SKILL.md
+++ b/plugins/ca-pi/skills/ca-review/SKILL.md
@@ -1,16 +1,30 @@
 ---
 name: ca-review
-description: Review the current diff with the reviewer fleet, funneled to one triaged verdict.
-argument-hint: "\"[path]\" (defaults to the current diff)"
+description: Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR.
+argument-hint: "\"[path | #<pr> | <pr-url>]\" (defaults to the current diff)"
 ---
 
 # /ca-review — diff review
 
-Read-only review of the current change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+Read-only review of a change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+
+**The change under review does not have to be yours.** `/ca-review #123` reviews an inbound pull request through the same fleet, the same matrix, and the same triage. That is the point of issue #80: a tool that only reviews the diff you just wrote is a linter for authors, not a gate for a team, and reviewing code you did NOT write is where a governance gate earns its keep.
+
+It is an ARGUMENT, not a second command. The scope resolver already took one, the fleet is scope-agnostic, and every phase downstream operates on a diff regardless of where it came from — so a `/ca-review-pr` would be a whole public surface (catalog, three host projections, README counts, sidebar) whose only distinguishing feature is where the diff was fetched from.
 
 ## Flow
 
-1. Resolve scope — `$ARGUMENTS` if a path is given, else the current diff.
+1. Resolve scope from `$ARGUMENTS`:
+   - **empty** → the current working diff (unchanged default).
+   - **a path** → that path (unchanged).
+   - **`#<number>`, a bare number, or a GitHub PR URL** → an INBOUND PR. Fetch its diff with
+     `gh pr diff <number>` and review that. If `gh` is missing or unauthenticated, STOP and say so —
+     do NOT silently fall back to the working diff, which would report a verdict on the wrong change
+     under the PR's name.
+
+   For a PR target, resolve the diff ONCE and review that text. Do not re-fetch per reviewer: the
+   fleet runs in parallel, and a PR updated mid-review would otherwise have different reviewers
+   reading different code and a triage that reconciles findings from two versions.
 2. Build the unit list by path matrix; each matched reviewer is one read-only unit:
 
    | Reviewer | Dispatched when scope touches |
@@ -27,6 +41,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
    `[NEEDS-TRIAGE]` on out-of-scope items) → `checkpoint-aggregator` (single verdict).
 4. Surface the aggregated verdict: findings by severity, file:line, remediation, and the applicable
    control from `<project-root>/.codearbiter/security-controls.md` for security findings.
+5. **For a PR target, posting the verdict is a separate, confirmed step.** Report locally first; post only on explicit instruction, with `gh pr review <number> --comment --body-file <file>`. A review comment on someone else's PR is outward-facing and effectively public the moment it lands — it notifies subscribers and cannot be un-sent. Never `--request-changes` or `--approve` from here: those carry merge authority, and this command produces a finding list, not a maintainer's decision.
 
 ## Severity
 
@@ -37,8 +52,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
 
 ## Hard gate
 
-Read-only — MUST NOT modify a file. BLOCK on any CRITICAL or HIGH finding: it must be resolved before
-`/ca-pr`. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
+Read-only — MUST NOT modify a file, and MUST NOT check out, merge, or otherwise move the repository to the PR's branch: reviewing an inbound PR means reading its DIFF, not adopting its code, and a checkout would run its content through hooks that trust the working tree. BLOCK on any CRITICAL or HIGH finding on your OWN change: it must be resolved before `/ca-pr`. On an inbound PR there is nothing local to block — the verdict is the deliverable. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
 verdict. MUST NOT resolve a `[CONFIRM-NN]` surfaced during review by guessing.
 
 ## When NOT to use

--- a/plugins/ca/commands/review.md
+++ b/plugins/ca/commands/review.md
@@ -1,15 +1,29 @@
 ---
-description: Review the current diff with the reviewer fleet, funneled to one triaged verdict.
-argument-hint: "[path]" (defaults to the current diff)
+description: Review a diff with the reviewer fleet, funneled to one triaged verdict. Targets the current working diff, a path, or an inbound GitHub PR.
+argument-hint: "[path | #<pr> | <pr-url>]" (defaults to the current diff)
 ---
 
 # /ca:review — diff review
 
-Read-only review of the current change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+Read-only review of a change. Routes to `dispatching-parallel-agents`: dispatches the reviewer fleet by path matrix, dedupes, then funnels through `finding-triage` → `checkpoint-aggregator` to a single verdict. No code is modified.
+
+**The change under review does not have to be yours.** `/ca:review #123` reviews an inbound pull request through the same fleet, the same matrix, and the same triage. That is the point of issue #80: a tool that only reviews the diff you just wrote is a linter for authors, not a gate for a team, and reviewing code you did NOT write is where a governance gate earns its keep.
+
+It is an ARGUMENT, not a second command. The scope resolver already took one, the fleet is scope-agnostic, and every phase downstream operates on a diff regardless of where it came from — so a `/ca:review-pr` would be a whole public surface (catalog, three host projections, README counts, sidebar) whose only distinguishing feature is where the diff was fetched from.
 
 ## Flow
 
-1. Resolve scope — `$ARGUMENTS` if a path is given, else the current diff.
+1. Resolve scope from `$ARGUMENTS`:
+   - **empty** → the current working diff (unchanged default).
+   - **a path** → that path (unchanged).
+   - **`#<number>`, a bare number, or a GitHub PR URL** → an INBOUND PR. Fetch its diff with
+     `gh pr diff <number>` and review that. If `gh` is missing or unauthenticated, STOP and say so —
+     do NOT silently fall back to the working diff, which would report a verdict on the wrong change
+     under the PR's name.
+
+   For a PR target, resolve the diff ONCE and review that text. Do not re-fetch per reviewer: the
+   fleet runs in parallel, and a PR updated mid-review would otherwise have different reviewers
+   reading different code and a triage that reconciles findings from two versions.
 2. Build the unit list by path matrix; each matched reviewer is one read-only unit:
 
    | Reviewer | Dispatched when scope touches |
@@ -26,6 +40,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
    `[NEEDS-TRIAGE]` on out-of-scope items) → `checkpoint-aggregator` (single verdict).
 4. Surface the aggregated verdict: findings by severity, file:line, remediation, and the applicable
    control from `${CLAUDE_PROJECT_DIR}/.codearbiter/security-controls.md` for security findings.
+5. **For a PR target, posting the verdict is a separate, confirmed step.** Report locally first; post only on explicit instruction, with `gh pr review <number> --comment --body-file <file>`. A review comment on someone else's PR is outward-facing and effectively public the moment it lands — it notifies subscribers and cannot be un-sent. Never `--request-changes` or `--approve` from here: those carry merge authority, and this command produces a finding list, not a maintainer's decision.
 
 ## Severity
 
@@ -36,8 +51,7 @@ Read-only review of the current change. Routes to `dispatching-parallel-agents`:
 
 ## Hard gate
 
-Read-only — MUST NOT modify a file. BLOCK on any CRITICAL or HIGH finding: it must be resolved before
-`/ca:pr`. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
+Read-only — MUST NOT modify a file, and MUST NOT check out, merge, or otherwise move the repository to the PR's branch: reviewing an inbound PR means reading its DIFF, not adopting its code, and a checkout would run its content through hooks that trust the working tree. BLOCK on any CRITICAL or HIGH finding on your OWN change: it must be resolved before `/ca:pr`. On an inbound PR there is nothing local to block — the verdict is the deliverable. MUST NOT consume raw reviewer output — only the `finding-triage` → `checkpoint-aggregator`
 verdict. MUST NOT resolve a `[CONFIRM-NN]` surfaced during review by guessing.
 
 ## When NOT to use


### PR DESCRIPTION
## What

`/ca:review #123` reviews an inbound GitHub pull request through the existing fleet. Closes #80.

## Why

The reviewer fleet only ever ran on the diff *you just wrote*. `/ca:watch` watches a PR's CI but never runs the fleet against its diff. For a tool that markets itself as a **team gate**, the half of the value that comes from reviewing code you did *not* write was missing.

Same fleet, same path matrix, same `finding-triage` → `checkpoint-aggregator` funnel. As the issue puts it: *"plumbing a new input into an existing pipeline, not net-new logic."*

## An argument, not a new command

This follows the principle you set when ruling on #382: **the target becomes a parameter, not a new surface.**

The scope resolver already took an argument, the fleet is scope-agnostic, and every phase downstream operates on a diff regardless of where it came from. A `/ca:review-pr` would be a whole public surface — the catalog, three host projections, the README counts, the site sidebar — whose only distinguishing feature is *where the diff was fetched from*.

**Command count unchanged at 40**, confirmed by `check_badge_consistency.py`.

## Three guards

Each closes a way this could go wrong quietly:

1. **A missing or unauthenticated `gh` STOPs** rather than falling back to the working diff — which would report a verdict on the wrong change *under the PR's name*.
2. **The diff is resolved once.** The fleet runs in parallel; a PR updated mid-review would otherwise have different reviewers reading different code, and a triage reconciling findings across two versions.
3. **Posting is a separate, confirmed step**, and never uses `--approve` or `--request-changes`. A review comment on someone else's PR notifies subscribers and cannot be un-sent; those two flags carry merge authority this command does not have. It produces a finding list, not a maintainer's decision.

The hard gate also refuses to **check out** the PR branch — reviewing an inbound change means reading its diff, not adopting its code into a working tree the hooks trust.

## Verification

`test_ci_impact`, `test_badge_consistency`, `test_public_pi_docs`, `test_public_codex_docs`, `test_pi_parity`, `test_codex_parity_fixture`, `test_build_surface`, `test_routing_and_cleanup_surface` — all OK. Site-voice gate clean. Surface rebuilt to all three hosts.

## Versions

ca-pi **0.1.31 → 0.1.32**; ca (2.9.1) and ca-codex (0.3.0) carry no tag yet, so their entries join the open sections. Pi release guard confirms manifest, changelog, and generated root metadata advanced together.

Closes #80

https://claude.ai/code/session_01Y8UPz5RZwgnda3NbAVfd6L
