### PR TITLE
test(farm): pin the worktree writer's refusal paths, and record what cannot be pinned (#511)

### DIFF
--- a/.codearbiter/plans/coverage-backfill-ca-tools.md
+++ b/.codearbiter/plans/coverage-backfill-ca-tools.md
@@ -96,7 +96,7 @@ Test-only, so `test(farm):` and no version bump (see Constraints).
 | # | target | branches | status |
 |---|---|---|---|
 | 1 | `redactor.ts` — PEM span boundaries, basename denylist | +3 | **DONE** (#517) |
-| 2 | `worktree-fs.ts` — `unsafe()` refusal / TOCTOU arms | **+8** (est. 19) | **DONE** |
+| 2 | `worktree-fs.ts` — `unsafe()` refusal / TOCTOU arms | **+6** (est. 19) | **DONE** |
 | 3 | `mutation.ts` — `antiGamingCheck`, `FARM_MUTATION_CMD` hook path, loop bounds | ~42 | |
 | 4 | `exec.ts` — `numEnv`, `awaitTaskkill`, `treeKill`, `run` timeout | ~20 | |
 | 5 | `farm.ts` **exported only** — `runTask`, `validate`, `cleanupFailures` | ~68 | |
@@ -104,7 +104,19 @@ Test-only, so `test(farm):` and no version bump (see Constraints).
 
 ### Budget, corrected after slice 2
 
-Slice 2 returned **+8 branches** (85.89% branches, 100% lines on `worktree-fs.ts`).
+Slice 2 returned **+6 branches** (83.33% branches, 100% lines on `worktree-fs.ts`, measured on
+Windows).
+
+**The measurement platform is not settled and it matters.** CI runs the `tools` job on
+**ubuntu-latest only**, and the two platforms disagree: Windows reports 83.33% branches here, Linux
+84.61%, because an over-long path segment reaches the `mkdir` failure arm on Windows but fails
+earlier at `lstat` with ENAMETOOLONG on Linux. Every figure in this plan is a Windows figure. Before
+#511 is closed, AC-1 needs a stated platform — the issue's baseline table was Windows, CI is Linux,
+and they will not agree at the 70% line either.
+
+Two tests were deleted from this slice AFTER they were written and measured: they covered branches
+but killed no mutant that another test did not. That is AC-1 versus AC-2 in miniature, resolved the
+way AC-2 requires — the count went down by 2 and the suite got no weaker.
 
 An earlier draft of this slice stopped at +4 and justified it by calling fifteen arms
 "structurally unreachable, reaching them needs fault injection". **That was wrong**, and adversarial
@@ -124,8 +136,10 @@ Eleven arms remain, and these are characterised rather than claimed:
   dead code.
 - **Needs a genuine race:** the post-open `sameFile` check (L122) and the `verifyDirectories`
   compound (L69).
-- **POSIX-only:** L70 — an ancestor rename mid-write. Windows returns EPERM renaming a directory
-  with an open descendant handle, so it cannot fire on the measurement host.
+- **Also a redundant backstop:** L70. An earlier draft called this "POSIX-only, because Windows
+  returns EPERM renaming a directory with an open descendant handle". Measured on this host, that
+  rename SUCCEEDS — and `verifyDirectories` is called once before any handle exists anyway, so the
+  argument was wrong twice. L70 is reachable on Windows once the layers ahead of it are removed.
 
 Worth recording about the source, not the tests: L124/L125/L129/L130 re-check `realpath` AFTER the
 handle is open, but the write goes through that retained handle — so those checks cannot change
@@ -134,11 +148,11 @@ Not changed here: touching `worktree-fs.ts` rebuilds `farm.js`, which is declare
 
 | | now | need | gap |
 |---|---|---|---|
-| Lines | 807/1187 = 67.73% | 831 | +24 |
-| Branches | 586/967 = 60.59% | 677 | **+91** |
+| Lines | 804/1187 = 67.73% | 831 | +27 |
+| Branches | 584/967 = 60.39% | 677 | **+93** |
 
 Remaining realistic supply: `exec.ts` ~20, `mutation.ts` ~42, `farm.ts` exported ~68 = **~130**
-against a need of **91**. `mutation.ts` was sized against its uncovered report before committing to
+against a need of **93**. `mutation.ts` was sized against its uncovered report before committing to
 a number this time: its arms are business logic, not layered guards, and `MUT` is an exported
 mutable object, so its knobs are settable from a test with no module surgery.
 

--- a/.codearbiter/plans/coverage-backfill-ca-tools.md
+++ b/.codearbiter/plans/coverage-backfill-ca-tools.md
@@ -79,7 +79,9 @@ removes every layer guarding one property at once (`mutate-multi.mjs`). A single
 layered module is evidence about the design, not about the test.
 
 Where a single guard is *fully* redundant with another, say so and move on rather than inventing an
-input to pin it — no such input exists.
+input to pin it — no such input exists. **But prove the redundancy before claiming it.** The first
+draft of slice 2 asserted four arms were unreachable and a NUL byte, a long segment, and concurrent
+writers reached three of them. "Layered, therefore untestable" is a conclusion to earn, not assume.
 
 Each slice runs a hand mutation pass: mutate the covered source lines, show the tests go red,
 restore. **A control run on unmutated source must pass first** — a harness whose control fails
@@ -94,43 +96,51 @@ Test-only, so `test(farm):` and no version bump (see Constraints).
 | # | target | branches | status |
 |---|---|---|---|
 | 1 | `redactor.ts` — PEM span boundaries, basename denylist | +3 | **DONE** (#517) |
-| 2 | `worktree-fs.ts` — `unsafe()` refusal / TOCTOU arms | **+4** (est. 19) | **DONE** |
-| 3 | `mutation.ts` — `antiGamingCheck`, `FARM_MUTATION_CMD` hook path, loop bounds | ~45 | |
+| 2 | `worktree-fs.ts` — `unsafe()` refusal / TOCTOU arms | **+8** (est. 19) | **DONE** |
+| 3 | `mutation.ts` — `antiGamingCheck`, `FARM_MUTATION_CMD` hook path, loop bounds | ~42 | |
 | 4 | `exec.ts` — `numEnv`, `awaitTaskkill`, `treeKill`, `run` timeout | ~20 | |
 | 5 | `farm.ts` **exported only** — `runTask`, `validate`, `cleanupFailures` | ~68 | |
 | 6 | clean-export measurement, close #511 | — | |
 
 ### Budget, corrected after slice 2
 
-Slice 2 returned **+4 branches, not the estimated 19**. Fifteen of `worktree-fs.ts`'s uncovered arms
-are structurally unreachable through the public API — an earlier layer always fires first — plus one
-that is platform-dead (`O_NOFOLLOW` is `undefined` on Windows, so the true arm of that ternary cannot
-be taken) and one whose guard (`segment === "" | "." | ".."`) cannot trigger because
-`path.resolve` + `path.relative` normalise those segments away before the split. Reaching them needs
-fault injection, i.e. new test seams in the source — and a source change to `worktree-fs.ts` rebuilds
-`farm.js`, which **is** declared payload, forcing a `ca` version bump for coverage's sake. Not worth
-it; recorded instead.
+Slice 2 returned **+8 branches** (85.89% branches, 100% lines on `worktree-fs.ts`).
+
+An earlier draft of this slice stopped at +4 and justified it by calling fifteen arms
+"structurally unreachable, reaching them needs fault injection". **That was wrong**, and adversarial
+review proved it with ordinary inputs and no source change: a NUL byte in a path segment reaches
+both non-ENOENT `lstat` arms, a 300-character segment reaches the non-EEXIST `mkdir` arm, 40
+concurrent writers reach the EEXIST arm, and the containment re-check is reachable through the same
+exported hook the suite already used. Redundancy is a real property of this module, but it was being
+used to retire work rather than to describe it.
+
+Eleven arms remain, and these are characterised rather than claimed:
+
+- **Platform-dead here:** the `O_NOFOLLOW` ternary's true arm (`constants.O_NOFOLLOW` is `undefined`
+  on Windows — verified).
+- **Mutually redundant:** the `contained()` backstops (L96, L103, L112, L124, L125, L129) and the
+  `segment === "" | "." | ".."` guard (L80). Each is reachable only once an earlier layer is
+  removed; L80 in particular fires the moment the lexical guard goes, so it is a live backstop, not
+  dead code.
+- **Needs a genuine race:** the post-open `sameFile` check (L122) and the `verifyDirectories`
+  compound (L69).
+- **POSIX-only:** L70 — an ancestor rename mid-write. Windows returns EPERM renaming a directory
+  with an open descendant handle, so it cannot fire on the measurement host.
+
+Worth recording about the source, not the tests: L124/L125/L129/L130 re-check `realpath` AFTER the
+handle is open, but the write goes through that retained handle — so those checks cannot change
+where bytes land. `handle.stat()`/`sameFile` (L122, L136) are the only post-open checks that can.
+Not changed here: touching `worktree-fs.ts` rebuilds `farm.js`, which is declared payload.
 
 | | now | need | gap |
 |---|---|---|---|
-| Lines | 803/1187 = 67.64% | 831 | +28 |
-| Branches | 582/967 = 60.18% | 677 | **+95** |
+| Lines | 807/1187 = 67.73% | 831 | +24 |
+| Branches | 586/967 = 60.59% | 677 | **+91** |
 
-Remaining realistic supply: `exec.ts` ~20, `mutation.ts` ~55, `farm.ts` exported ~68 = **~143**
-against a need of **95**. Feasible, but it needs ~66% conversion across all three — slice 5
-(`farm.ts`'s exported surface) is now load-bearing rather than a top-up, and slices 3–5 have no
-slack for another over-estimate.
-
-Slice 1 is deliberately small so the file convention and the mutation bar are validated on a
-cheap surface before slices 3–5 scale them.
-
-### Sequencing note
-
-`worktree-fs.ts` is **not** "effectively done". That reading comes from the line column (97.1%). On
-branches it is 75.64% with 19 uncovered arms, every one an `unsafe()` refusal — symlinked root,
-containment escape, `mkdir` EEXIST race, hardlink (`nlink !== 1`), and the three TOCTOU
-re-verifications before the retained handle is truncated. Largest security-refusal gap outside
-`farm.ts`, and exactly AC-3.
+Remaining realistic supply: `exec.ts` ~20, `mutation.ts` ~42, `farm.ts` exported ~68 = **~130**
+against a need of **91**. `mutation.ts` was sized against its uncovered report before committing to
+a number this time: its arms are business logic, not layered guards, and `MUT` is an exported
+mutable object, so its knobs are settable from a test with no module surgery.
 
 ## Constraints and known-unreachable
 

--- a/.codearbiter/plans/coverage-backfill-ca-tools.md
+++ b/.codearbiter/plans/coverage-backfill-ca-tools.md
@@ -56,13 +56,30 @@ therefore the only option, not a preference.
 
 ## Test standard (binding on every slice)
 
-> Every new test must carry at least one assertion that fails if the line it covers is mutated —
-> a negated condition, a changed constant, a removed statement, an off-by-one boundary.
+> Every new test must carry at least one assertion that fails if the **property** the covered line
+> enforces is removed — a negated condition, a changed constant, a removed statement, an off-by-one
+> boundary.
 
 Per test: *if I flip this `if` in the source, does my test go red?* Exact values over
 `toBeDefined()`; exact call arguments over `toHaveBeenCalled()`; both sides of every branch claimed;
 error identity **and** observable consequence. No broad snapshots, no lone `not.toThrow()`, no
 asserting on a mock instead of the subject.
+
+### Amended after slice 2 — "line" was the wrong unit
+
+The original wording said *"fails if the LINE it covers is mutated"*. That is **unsatisfiable by
+construction for layered code**, and `worktree-fs.ts` proved it: 4 of 24 single-point mutants died,
+yet every survivor was a guard whose property another layer also enforces. Removing all four
+`isSymbolicLink()` checks passes (a Windows junction also fails `isDirectory()`); removing all three
+`isDirectory()` checks passes (`isSymbolicLink()` catches it). Redundant guards cannot be
+distinguished from outside the module — that is what defence in depth *means*.
+
+So the unit is the **property**, not the line, and the mutation harness needs a multi-edit mode that
+removes every layer guarding one property at once (`mutate-multi.mjs`). A single-point survivor on a
+layered module is evidence about the design, not about the test.
+
+Where a single guard is *fully* redundant with another, say so and move on rather than inventing an
+input to pin it — no such input exists.
 
 Each slice runs a hand mutation pass: mutate the covered source lines, show the tests go red,
 restore. **A control run on unmutated source must pass first** — a harness whose control fails
@@ -76,12 +93,33 @@ Test-only, so `test(farm):` and no version bump (see Constraints).
 
 | # | target | branches | status |
 |---|---|---|---|
-| 1 | `redactor.ts` — PEM span boundaries, basename denylist | ~3 | in progress |
-| 2 | `worktree-fs.ts` — 19 `unsafe()` refusal / TOCTOU arms | ~19 | |
+| 1 | `redactor.ts` — PEM span boundaries, basename denylist | +3 | **DONE** (#517) |
+| 2 | `worktree-fs.ts` — `unsafe()` refusal / TOCTOU arms | **+4** (est. 19) | **DONE** |
 | 3 | `mutation.ts` — `antiGamingCheck`, `FARM_MUTATION_CMD` hook path, loop bounds | ~45 | |
 | 4 | `exec.ts` — `numEnv`, `awaitTaskkill`, `treeKill`, `run` timeout | ~20 | |
-| 5 | `farm.ts` **exported only** — `runTask`, `validate`, `cleanupFailures` | ~40 | |
+| 5 | `farm.ts` **exported only** — `runTask`, `validate`, `cleanupFailures` | ~68 | |
 | 6 | clean-export measurement, close #511 | — | |
+
+### Budget, corrected after slice 2
+
+Slice 2 returned **+4 branches, not the estimated 19**. Fifteen of `worktree-fs.ts`'s uncovered arms
+are structurally unreachable through the public API — an earlier layer always fires first — plus one
+that is platform-dead (`O_NOFOLLOW` is `undefined` on Windows, so the true arm of that ternary cannot
+be taken) and one whose guard (`segment === "" | "." | ".."`) cannot trigger because
+`path.resolve` + `path.relative` normalise those segments away before the split. Reaching them needs
+fault injection, i.e. new test seams in the source — and a source change to `worktree-fs.ts` rebuilds
+`farm.js`, which **is** declared payload, forcing a `ca` version bump for coverage's sake. Not worth
+it; recorded instead.
+
+| | now | need | gap |
+|---|---|---|---|
+| Lines | 803/1187 = 67.64% | 831 | +28 |
+| Branches | 582/967 = 60.18% | 677 | **+95** |
+
+Remaining realistic supply: `exec.ts` ~20, `mutation.ts` ~55, `farm.ts` exported ~68 = **~143**
+against a need of **95**. Feasible, but it needs ~66% conversion across all three — slice 5
+(`farm.ts`'s exported surface) is now load-bearing rather than a top-up, and slices 3–5 have no
+slack for another over-estimate.
 
 Slice 1 is deliberately small so the file convention and the mutation bar are validated on a
 cheap surface before slices 3–5 scale them.

--- a/plugins/ca/tools/worktree-fs.test.ts
+++ b/plugins/ca/tools/worktree-fs.test.ts
@@ -1,4 +1,4 @@
-import { link, lstat, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { link, lstat, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -130,8 +130,14 @@ describe("symlink-safe worktree writer", () => {
  * means anything is the PROPERTY (every layer guarding it removed at once), not
  * the line. That does NOT excuse leaving reachable arms untested: an earlier
  * draft of this block called four of them "structurally unreachable" and a NUL
- * byte, an over-long segment, and 40 concurrent calls reached three of them
- * through the public API with no seam at all.
+ * byte and 40 concurrent calls reached three of them through the public API with
+ * no seam at all.
+ *
+ * Platform note: CI runs the tools job on ubuntu-latest ONLY, so Linux is the
+ * platform that matters for these numbers. Windows and Linux do not agree here —
+ * an over-long path segment reaches the mkdir failure arm on Windows but fails
+ * earlier at `lstat` with ENAMETOOLONG on Linux, so that case bought nothing on
+ * CI and is not in this block.
  */
 describe("symlink-safe worktree writer — refusal paths", () => {
   const MESSAGE = "unsafe worktree path rejected";
@@ -154,10 +160,13 @@ describe("symlink-safe worktree writer — refusal paths", () => {
 
   async function expectRefused(promise: Promise<unknown>): Promise<void> {
     await expect(promise).rejects.toThrow(MESSAGE);
-    await promise.catch((error: unknown) => {
-      expect(isUnsafeWorktreePathError(error)).toBe(true);
-      expect((error as Error).name).toBe("UnsafeWorktreePathError");
-    });
+    await promise.then(
+      () => expect.unreachable("write should have been refused"),
+      (error: unknown) => {
+        expect(isUnsafeWorktreePathError(error)).toBe(true);
+        expect((error as Error).name).toBe("UnsafeWorktreePathError");
+      },
+    );
   }
 
   it("refuses a worktree root that is itself a link", async () => {
@@ -177,32 +186,26 @@ describe("symlink-safe worktree writer — refusal paths", () => {
   });
 
   it("refuses an escaping relative path and writes NOTHING outside the root", async () => {
-    // The post-state assertion is the whole test. Measured with the escape
-    // guards removed, this input creates `escaped.txt` in the root's PARENT and
-    // leaves it there — a version of this test that only asserted rejection
-    // passed while that happened.
-    const { root, cleanup } = await arena("farm-escape");
-    const parentOfRoot = path.dirname(root);
-    const wouldBe = path.join(parentOfRoot, "escaped.txt");
+    // The post-state assertion is the whole test. Measured with every escape
+    // guard removed, this input CREATES `escaped.txt` one level up and leaves it
+    // there — an earlier version of this test passed while that happened,
+    // because it only checked that the promise rejected.
+    //
+    // The root is nested inside a private container so the escape target is
+    // ours. An earlier version used `path.dirname(root)` — which, for a root
+    // from `mkdtemp(tmpdir())`, IS the shared OS temp directory: the assertion
+    // failed spuriously if anything else had put an `escaped.txt` there, and the
+    // cleanup then deleted a file this suite does not own.
+    const container = await mkdtemp(path.join(tmpdir(), "farm-escape-box-"));
+    const root = path.join(container, "root");
+    await mkdir(root);
     try {
       await expectRefused(writeWorktreeFile(root, path.join("..", "escaped.txt"), "payload"));
-      expect(existsSync(wouldBe)).toBe(false);
+      expect(existsSync(path.join(container, "escaped.txt"))).toBe(false);
+      expect(await readdir(container)).toEqual(["root"]);
       expect(await readdir(root)).toEqual([]);
     } finally {
-      await rm(wouldBe, { force: true });
-      await cleanup();
-    }
-  });
-
-  it("refuses a relative path resolving to the root itself", async () => {
-    // `""` and `"."` both produce the same `relative === ""` arm, so one case
-    // covers both; the second would be a duplicate.
-    const { root, cleanup } = await arena("farm-rootself");
-    try {
-      await expectRefused(writeWorktreeFile(root, "", "payload"));
-      expect(await readdir(root)).toEqual([]);
-    } finally {
-      await cleanup();
+      await rm(container, { recursive: true, force: true });
     }
   });
 
@@ -256,18 +259,6 @@ describe("symlink-safe worktree writer — refusal paths", () => {
     }
   });
 
-  it("refuses an intermediate segment the filesystem cannot create", async () => {
-    // Reaches the non-EEXIST arm of the mkdir guard: lstat says ENOENT, so a
-    // directory is attempted, and mkdir fails for a reason that is NOT a lost
-    // race. That error must propagate rather than be mistaken for one.
-    const { root, cleanup } = await arena("farm-longseg");
-    try {
-      await expectRefused(writeWorktreeFile(root, path.join("d".repeat(300), "x.txt"), "payload"));
-    } finally {
-      await cleanup();
-    }
-  });
-
   it("absorbs a lost mkdir race between concurrent writers", async () => {
     // The EEXIST arm — the race the guard exists for. Forty writers share the
     // same nested ancestors, so many of them lose the mkdir and must treat
@@ -282,34 +273,6 @@ describe("symlink-safe worktree writer — refusal paths", () => {
       const written = await readdir(path.join(root, "shared", "nested", "deep"));
       expect(written).toHaveLength(40);
       expect(await readFile(path.join(root, "shared", "nested", "deep", "f39.txt"), "utf8")).toBe("payload-39\n");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("refuses a destination swapped for a link after validation but before truncate", async () => {
-    // The destination is validated, opened, and then — before the retained
-    // handle is truncated — replaced with a link pointing outside the root. This
-    // is the containment re-check, not the symlink check: every pre-open
-    // observation is stale by this point.
-    //
-    // The post-state that matters is the EXTERNAL directory, not the sentinel:
-    // the handle refers to the now-unlinked original inode, so the sentinel
-    // survives whatever the guards do. What must not happen is a new file
-    // appearing through the link.
-    const { root, external, cleanup } = await arena("farm-lateswap");
-    const destination = path.join(root, "inside.txt");
-    await writeFile(destination, "inside-original", "utf8");
-    try {
-      await expectRefused(
-        writeWorktreeFile(root, "inside.txt", "overwrite", {
-          beforeFinalAuthorization: async () => {
-            await rm(destination, { force: true });
-            await symlink(external, destination, process.platform === "win32" ? "junction" : "dir");
-          },
-        }),
-      );
-      expect(await readdir(external)).toEqual(["sentinel.txt"]);
     } finally {
       await cleanup();
     }
@@ -359,8 +322,10 @@ describe("symlink-safe worktree writer — write contracts", () => {
   });
 
   it("round-trips non-ASCII content without re-encoding it", async () => {
-    // Pins the utf8 encoding on both the write and the read-back. A latin1 slip
-    // is invisible to every ASCII fixture in this file.
+    // Kills a WRONG encoding (latin1) on the write. It does NOT pin the option's
+    // presence — `FileHandle.writeFile` defaults to utf8, so deleting it changes
+    // nothing. Either way, a non-ASCII fixture is the only thing in this file
+    // that would notice a re-encoding at all.
     const root = await mkdtemp(path.join(tmpdir(), "farm-utf8-"));
     try {
       const content = "héllo — ünïcode ✓\n";

--- a/plugins/ca/tools/worktree-fs.test.ts
+++ b/plugins/ca/tools/worktree-fs.test.ts
@@ -1,4 +1,4 @@
-import { link, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { link, lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -101,5 +101,226 @@ describe("symlink-safe worktree writer", () => {
     expect(farm).not.toMatch(/writeFile\((?:absPath|abs),/u);
     expect(mutation).not.toContain("writeFile(path.resolve(wt");
     expect((mutation.match(/writeWorktreeFile\(/gu) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+/**
+ * Refusal paths (#511 slice 2).
+ *
+ * The suite above pins the writer's happy path and the three link attacks it was
+ * built for. What it does not reach is the rest of the refusal surface: 19 of
+ * this module's branches were untaken, and every one of them is an `unsafe()`
+ * arm or a re-verification performed before the retained handle is truncated.
+ * The line column reads 97% and hides all of it.
+ *
+ * Two rules throughout, both learned from slice 1:
+ *
+ *  - Assert the SENTINEL SURVIVED, never merely that the call rejected. A
+ *    refusal that still wrote is the exact failure this module exists to
+ *    prevent, and `rejects.toThrow()` alone cannot tell the two apart.
+ *  - Assert the error IDENTITY, not just its message. Every failure in here is
+ *    funnelled through `UnsafeWorktreePathError` deliberately, so that a caller
+ *    cannot distinguish "escaped the root" from "disk error" and leak the
+ *    difference; a test that accepts any throw would not notice that collapsing.
+ */
+describe("symlink-safe worktree writer — refusal paths", () => {
+  const MESSAGE = "unsafe worktree path rejected";
+
+  /** Every case builds a root and an external tree with a sentinel to protect. */
+  async function arena(prefix: string): Promise<{ root: string; external: string; sentinel: string; cleanup: () => Promise<void> }> {
+    const root = await mkdtemp(path.join(tmpdir(), `${prefix}-root-`));
+    const external = await mkdtemp(path.join(tmpdir(), `${prefix}-ext-`));
+    const sentinel = path.join(external, "sentinel.txt");
+    await writeFile(sentinel, "outside-must-survive", "utf8");
+    return {
+      root,
+      external,
+      sentinel,
+      cleanup: async () => {
+        await rm(root, { recursive: true, force: true });
+        await rm(external, { recursive: true, force: true });
+      },
+    };
+  }
+
+  async function expectRefused(promise: Promise<unknown>): Promise<void> {
+    // Identity AND message. `isUnsafeWorktreePathError` is the discriminator
+    // callers actually branch on (mutation.ts rethrows on it), so a refusal that
+    // arrived as a plain Error would break them while still "throwing".
+    const { isUnsafeWorktreePathError } = await implementation();
+    await expect(promise).rejects.toThrow(MESSAGE);
+    await promise.then(
+      () => expect.unreachable("write should have been refused"),
+      (error: unknown) => {
+        expect(isUnsafeWorktreePathError(error)).toBe(true);
+        expect((error as Error).name).toBe("UnsafeWorktreePathError");
+      },
+    );
+  }
+
+  it("refuses a worktree root that is a regular file, not a directory", async () => {
+    const { writeWorktreeFile } = await implementation();
+    const { root, cleanup } = await arena("farm-rootfile");
+    const rootFile = path.join(root, "not-a-directory");
+    await writeFile(rootFile, "original", "utf8");
+    try {
+      await expectRefused(writeWorktreeFile(rootFile, "a.txt", "payload"));
+      expect(await readFile(rootFile, "utf8")).toBe("original");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("refuses a worktree root that is itself a link", async () => {
+    // Distinct from the existing intermediate-link case: here the ROOT handed to
+    // the writer is the link, so the very first lstat is what has to catch it.
+    const { writeWorktreeFile } = await implementation();
+    const { root, external, sentinel, cleanup } = await arena("farm-rootlink");
+    const linkedRoot = path.join(root, "linked-root");
+    try {
+      await symlink(external, linkedRoot, process.platform === "win32" ? "junction" : "dir");
+      await expectRefused(writeWorktreeFile(linkedRoot, "sentinel.txt", "overwrite"));
+      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it.each([
+    ["..", "the parent directory"],
+    ["../escaped.txt", "a sibling of the root"],
+    ["", "the root itself"],
+    [".", "the root itself via dot"],
+  ])("refuses a relative path resolving to %s", async (relPath) => {
+    const { writeWorktreeFile } = await implementation();
+    const { root, cleanup } = await arena("farm-escape");
+    try {
+      await expectRefused(writeWorktreeFile(root, relPath, "payload"));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("judges an absolute destination by where it LANDS, not by its shape", async () => {
+    // Both arms, because the guard is easy to misread. `path.isAbsolute` is
+    // applied to the RESOLVED relative path, not to the caller's input — so an
+    // absolute path inside the root is legitimate (it names the same file), and
+    // an absolute path outside is caught by the `..` check rather than by being
+    // absolute. Asserting only the refusal would let the guard be rewritten to
+    // reject all absolute input, which silently breaks a valid caller.
+    const { writeWorktreeFile } = await implementation();
+    const { root, external, sentinel, cleanup } = await arena("farm-abs");
+    try {
+      await writeWorktreeFile(root, path.join(root, "inside.txt"), "accepted\n");
+      expect(await readFile(path.join(root, "inside.txt"), "utf8")).toBe("accepted\n");
+
+      await expectRefused(writeWorktreeFile(root, path.join(external, "sentinel.txt"), "overwrite"));
+      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("refuses to write THROUGH a linked intermediate directory into an external tree", async () => {
+    // The existing suite writes to `linked/sentinel.txt` — one level. This goes
+    // deeper, so the refusal has to happen while walking segments rather than at
+    // the destination check.
+    const { writeWorktreeFile } = await implementation();
+    const { root, external, cleanup } = await arena("farm-midlink");
+    const nested = path.join(external, "nested");
+    await mkdir(nested, { recursive: true });
+    const deepSentinel = path.join(nested, "deep.txt");
+    await writeFile(deepSentinel, "deep-must-survive", "utf8");
+    try {
+      await symlink(external, path.join(root, "linked"), process.platform === "win32" ? "junction" : "dir");
+      await expectRefused(writeWorktreeFile(root, path.join("linked", "nested", "deep.txt"), "overwrite"));
+      expect(await readFile(deepSentinel, "utf8")).toBe("deep-must-survive");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("refuses a destination that exists as a directory", async () => {
+    // `safeRegularFile` rejects a non-file destination. Without it the open()
+    // would fail on its own, but with a raw errno rather than the funnelled
+    // refusal — and the directory would still be probed.
+    const { writeWorktreeFile } = await implementation();
+    const { root, cleanup } = await arena("farm-destdir");
+    await mkdir(path.join(root, "target.txt"), { recursive: true });
+    try {
+      await expectRefused(writeWorktreeFile(root, "target.txt", "payload"));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("funnels an unexpected filesystem error into the same refusal, leaking nothing", async () => {
+    // A root that does not exist makes the FIRST lstat throw ENOENT — not an
+    // `unsafe()` call. The catch must convert it, so callers cannot distinguish
+    // "escaped the root" from "disk error"; the raw errno must not surface.
+    const { writeWorktreeFile } = await implementation();
+    const missing = path.join(tmpdir(), `farm-missing-root-${Date.now()}`);
+    await expectRefused(writeWorktreeFile(missing, "a.txt", "payload"));
+    await expect(writeWorktreeFile(missing, "a.txt", "payload")).rejects.not.toThrow(/ENOENT/);
+  });
+
+  it("re-verifies the parent between open and truncate, refusing a late swap", async () => {
+    // The destination is validated, opened, and then — before the handle is
+    // truncated — the parent directory is replaced with a link to somewhere
+    // else. Every pre-open observation is now stale, and the final
+    // re-verification is the only thing standing between the retained handle and
+    // an authorized write against a path nobody checked.
+    const { writeWorktreeFile } = await implementation();
+    const { root, external, sentinel, cleanup } = await arena("farm-lateswap");
+    const parent = path.join(root, "sub");
+    await mkdir(parent, { recursive: true });
+    const destination = path.join(parent, "inside.txt");
+    await writeFile(destination, "inside-original", "utf8");
+    try {
+      await expectRefused(
+        writeWorktreeFile(root, path.join("sub", "inside.txt"), "overwrite", {
+          beforeFinalAuthorization: async () => {
+            await rm(parent, { recursive: true, force: true });
+            await symlink(external, parent, process.platform === "win32" ? "junction" : "dir");
+          },
+        }),
+      );
+      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("creates missing intermediate directories with owner-only permissions", async () => {
+    // The success counterpart of the walk above: `mkdir(..., { mode: 0o700 })`.
+    // Worth pinning because the mode is the only thing keeping a shared temp
+    // root from exposing worker output, and nothing else asserts it.
+    const { writeWorktreeFile } = await implementation();
+    const { root, cleanup } = await arena("farm-mkmode");
+    try {
+      await writeWorktreeFile(root, path.join("fresh", "deep", "file.txt"), "made\n");
+      expect(await readFile(path.join(root, "fresh", "deep", "file.txt"), "utf8")).toBe("made\n");
+      if (process.platform !== "win32") {
+        const mode = (await lstat(path.join(root, "fresh"))).mode & 0o777;
+        expect(mode).toBe(0o700);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("truncates rather than appends when rewriting a shorter payload", async () => {
+    // `truncate(0)` before `writeFile`. Without it the tail of a longer previous
+    // payload survives, which for a restored mutant means the worktree silently
+    // keeps mutated source.
+    const { writeWorktreeFile } = await implementation();
+    const { root, cleanup } = await arena("farm-truncate");
+    try {
+      await writeWorktreeFile(root, "f.txt", "AAAAAAAAAAAAAAAAAAAAAAAA\n");
+      await writeWorktreeFile(root, "f.txt", "BBB\n");
+      expect(await readFile(path.join(root, "f.txt"), "utf8")).toBe("BBB\n");
+    } finally {
+      await cleanup();
+    }
   });
 });

--- a/plugins/ca/tools/worktree-fs.test.ts
+++ b/plugins/ca/tools/worktree-fs.test.ts
@@ -1,7 +1,9 @@
-import { link, lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { link, lstat, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { isUnsafeWorktreePathError, writeWorktreeFile } from "./worktree-fs.ts";
 
 type WorktreeFs = typeof import("./worktree-fs.ts");
 
@@ -108,25 +110,32 @@ describe("symlink-safe worktree writer", () => {
  * Refusal paths (#511 slice 2).
  *
  * The suite above pins the writer's happy path and the three link attacks it was
- * built for. What it does not reach is the rest of the refusal surface: 19 of
- * this module's branches were untaken, and every one of them is an `unsafe()`
- * arm or a re-verification performed before the retained handle is truncated.
- * The line column reads 97% and hides all of it.
+ * built for. This block works the rest of the refusal surface.
  *
- * Two rules throughout, both learned from slice 1:
+ * Two rules, and the first cut of this block broke both:
  *
- *  - Assert the SENTINEL SURVIVED, never merely that the call rejected. A
- *    refusal that still wrote is the exact failure this module exists to
- *    prevent, and `rejects.toThrow()` alone cannot tell the two apart.
- *  - Assert the error IDENTITY, not just its message. Every failure in here is
- *    funnelled through `UnsafeWorktreePathError` deliberately, so that a caller
- *    cannot distinguish "escaped the root" from "disk error" and leak the
- *    difference; a test that accepts any throw would not notice that collapsing.
+ *  - Assert the POST-STATE, never merely that the call rejected. A refusal that
+ *    still wrote is the exact failure this module exists to prevent, and
+ *    `rejects.toThrow()` cannot tell the two apart. Measured: with the escape
+ *    guards removed, `../escaped.txt` CREATES a file in the parent directory —
+ *    an earlier version of these tests passed anyway, because it only checked
+ *    that the promise rejected.
+ *  - Assert error IDENTITY, not just the message. `isUnsafeWorktreePathError` is
+ *    what callers branch on (mutation.ts rethrows on it); a refusal arriving as
+ *    a plain Error would break them while still "throwing".
+ *
+ * On mutation testing here: the module is layered on purpose, so single-point
+ * mutants mostly survive by design — removing all four `isSymbolicLink()` checks
+ * still passes, because a junction also fails `isDirectory()`. The unit that
+ * means anything is the PROPERTY (every layer guarding it removed at once), not
+ * the line. That does NOT excuse leaving reachable arms untested: an earlier
+ * draft of this block called four of them "structurally unreachable" and a NUL
+ * byte, an over-long segment, and 40 concurrent calls reached three of them
+ * through the public API with no seam at all.
  */
 describe("symlink-safe worktree writer — refusal paths", () => {
   const MESSAGE = "unsafe worktree path rejected";
 
-  /** Every case builds a root and an external tree with a sentinel to protect. */
   async function arena(prefix: string): Promise<{ root: string; external: string; sentinel: string; cleanup: () => Promise<void> }> {
     const root = await mkdtemp(path.join(tmpdir(), `${prefix}-root-`));
     const external = await mkdtemp(path.join(tmpdir(), `${prefix}-ext-`));
@@ -144,75 +153,76 @@ describe("symlink-safe worktree writer — refusal paths", () => {
   }
 
   async function expectRefused(promise: Promise<unknown>): Promise<void> {
-    // Identity AND message. `isUnsafeWorktreePathError` is the discriminator
-    // callers actually branch on (mutation.ts rethrows on it), so a refusal that
-    // arrived as a plain Error would break them while still "throwing".
-    const { isUnsafeWorktreePathError } = await implementation();
     await expect(promise).rejects.toThrow(MESSAGE);
-    await promise.then(
-      () => expect.unreachable("write should have been refused"),
-      (error: unknown) => {
-        expect(isUnsafeWorktreePathError(error)).toBe(true);
-        expect((error as Error).name).toBe("UnsafeWorktreePathError");
-      },
-    );
+    await promise.catch((error: unknown) => {
+      expect(isUnsafeWorktreePathError(error)).toBe(true);
+      expect((error as Error).name).toBe("UnsafeWorktreePathError");
+    });
   }
 
-  it("refuses a worktree root that is a regular file, not a directory", async () => {
-    const { writeWorktreeFile } = await implementation();
-    const { root, cleanup } = await arena("farm-rootfile");
-    const rootFile = path.join(root, "not-a-directory");
-    await writeFile(rootFile, "original", "utf8");
-    try {
-      await expectRefused(writeWorktreeFile(rootFile, "a.txt", "payload"));
-      expect(await readFile(rootFile, "utf8")).toBe("original");
-    } finally {
-      await cleanup();
-    }
-  });
-
   it("refuses a worktree root that is itself a link", async () => {
-    // Distinct from the existing intermediate-link case: here the ROOT handed to
-    // the writer is the link, so the very first lstat is what has to catch it.
-    const { writeWorktreeFile } = await implementation();
+    // Sole killer of dropping the root guard entirely. Distinct from the
+    // existing intermediate-link case: here the ROOT handed to the writer is the
+    // link, so the very first lstat is what has to catch it.
     const { root, external, sentinel, cleanup } = await arena("farm-rootlink");
     const linkedRoot = path.join(root, "linked-root");
     try {
       await symlink(external, linkedRoot, process.platform === "win32" ? "junction" : "dir");
       await expectRefused(writeWorktreeFile(linkedRoot, "sentinel.txt", "overwrite"));
       expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+      expect(await readdir(external)).toEqual(["sentinel.txt"]);
     } finally {
       await cleanup();
     }
   });
 
-  it.each([
-    ["..", "the parent directory"],
-    ["../escaped.txt", "a sibling of the root"],
-    ["", "the root itself"],
-    [".", "the root itself via dot"],
-  ])("refuses a relative path resolving to %s", async (relPath) => {
-    const { writeWorktreeFile } = await implementation();
+  it("refuses an escaping relative path and writes NOTHING outside the root", async () => {
+    // The post-state assertion is the whole test. Measured with the escape
+    // guards removed, this input creates `escaped.txt` in the root's PARENT and
+    // leaves it there — a version of this test that only asserted rejection
+    // passed while that happened.
     const { root, cleanup } = await arena("farm-escape");
+    const parentOfRoot = path.dirname(root);
+    const wouldBe = path.join(parentOfRoot, "escaped.txt");
     try {
-      await expectRefused(writeWorktreeFile(root, relPath, "payload"));
+      await expectRefused(writeWorktreeFile(root, path.join("..", "escaped.txt"), "payload"));
+      expect(existsSync(wouldBe)).toBe(false);
+      expect(await readdir(root)).toEqual([]);
+    } finally {
+      await rm(wouldBe, { force: true });
+      await cleanup();
+    }
+  });
+
+  it("refuses a relative path resolving to the root itself", async () => {
+    // `""` and `"."` both produce the same `relative === ""` arm, so one case
+    // covers both; the second would be a duplicate.
+    const { root, cleanup } = await arena("farm-rootself");
+    try {
+      await expectRefused(writeWorktreeFile(root, "", "payload"));
+      expect(await readdir(root)).toEqual([]);
     } finally {
       await cleanup();
     }
   });
 
   it("judges an absolute destination by where it LANDS, not by its shape", async () => {
-    // Both arms, because the guard is easy to misread. `path.isAbsolute` is
-    // applied to the RESOLVED relative path, not to the caller's input — so an
-    // absolute path inside the root is legitimate (it names the same file), and
-    // an absolute path outside is caught by the `..` check rather than by being
-    // absolute. Asserting only the refusal would let the guard be rewritten to
-    // reject all absolute input, which silently breaks a valid caller.
-    const { writeWorktreeFile } = await implementation();
+    // Both arms. `path.isAbsolute` is applied to the RESOLVED relative path, not
+    // the caller's input — so an absolute path inside the root is legitimate (it
+    // names the same file) and one outside is caught by the `..` check. Sole
+    // killer of a guard rewritten to reject all absolute input, which would
+    // silently break a valid caller.
     const { root, external, sentinel, cleanup } = await arena("farm-abs");
     try {
       await writeWorktreeFile(root, path.join(root, "inside.txt"), "accepted\n");
       expect(await readFile(path.join(root, "inside.txt"), "utf8")).toBe("accepted\n");
+
+      // win32 `path.relative` is case-insensitive, so a case-variant absolute
+      // path still lands inside and must still be accepted.
+      if (process.platform === "win32") {
+        await writeWorktreeFile(root, path.join(root, "cased.txt").toUpperCase(), "cased\n");
+        expect(await readFile(path.join(root, "cased.txt"), "utf8")).toBe("cased\n");
+      }
 
       await expectRefused(writeWorktreeFile(root, path.join(external, "sentinel.txt"), "overwrite"));
       expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
@@ -221,34 +231,85 @@ describe("symlink-safe worktree writer — refusal paths", () => {
     }
   });
 
-  it("refuses to write THROUGH a linked intermediate directory into an external tree", async () => {
-    // The existing suite writes to `linked/sentinel.txt` — one level. This goes
-    // deeper, so the refusal has to happen while walking segments rather than at
-    // the destination check.
-    const { writeWorktreeFile } = await implementation();
-    const { root, external, cleanup } = await arena("farm-midlink");
-    const nested = path.join(external, "nested");
-    await mkdir(nested, { recursive: true });
-    const deepSentinel = path.join(nested, "deep.txt");
-    await writeFile(deepSentinel, "deep-must-survive", "utf8");
+  it("refuses a NUL byte in the destination segment", async () => {
+    // Reaches the non-ENOENT arm of the destination lstat: the error is neither
+    // "missing" nor an `unsafe()` call, so the catch has to funnel it. An
+    // earlier draft called this arm structurally unreachable; it needs one byte.
+    const { root, cleanup } = await arena("farm-nul-dest");
     try {
-      await symlink(external, path.join(root, "linked"), process.platform === "win32" ? "junction" : "dir");
-      await expectRefused(writeWorktreeFile(root, path.join("linked", "nested", "deep.txt"), "overwrite"));
-      expect(await readFile(deepSentinel, "utf8")).toBe("deep-must-survive");
+      await expectRefused(writeWorktreeFile(root, "a\0b.txt", "payload"));
+      expect(await readdir(root)).toEqual([]);
     } finally {
       await cleanup();
     }
   });
 
-  it("refuses a destination that exists as a directory", async () => {
-    // `safeRegularFile` rejects a non-file destination. Without it the open()
-    // would fail on its own, but with a raw errno rather than the funnelled
-    // refusal — and the directory would still be probed.
-    const { writeWorktreeFile } = await implementation();
-    const { root, cleanup } = await arena("farm-destdir");
-    await mkdir(path.join(root, "target.txt"), { recursive: true });
+  it("refuses a NUL byte in an intermediate segment", async () => {
+    // The same arm one level up, in the segment walk rather than at the
+    // destination — a different `lstat` with its own non-ENOENT guard.
+    const { root, cleanup } = await arena("farm-nul-mid");
     try {
-      await expectRefused(writeWorktreeFile(root, "target.txt", "payload"));
+      await expectRefused(writeWorktreeFile(root, path.join("a\0b", "c.txt"), "payload"));
+      expect(await readdir(root)).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("refuses an intermediate segment the filesystem cannot create", async () => {
+    // Reaches the non-EEXIST arm of the mkdir guard: lstat says ENOENT, so a
+    // directory is attempted, and mkdir fails for a reason that is NOT a lost
+    // race. That error must propagate rather than be mistaken for one.
+    const { root, cleanup } = await arena("farm-longseg");
+    try {
+      await expectRefused(writeWorktreeFile(root, path.join("d".repeat(300), "x.txt"), "payload"));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("absorbs a lost mkdir race between concurrent writers", async () => {
+    // The EEXIST arm — the race the guard exists for. Forty writers share the
+    // same nested ancestors, so many of them lose the mkdir and must treat
+    // EEXIST as success rather than as a failure. Any rejection here means a
+    // legitimate concurrent write was refused.
+    const { root, cleanup } = await arena("farm-mkdir-race");
+    try {
+      const writes = Array.from({ length: 40 }, (_, i) =>
+        writeWorktreeFile(root, path.join("shared", "nested", "deep", `f${i}.txt`), `payload-${i}\n`),
+      );
+      await Promise.all(writes);
+      const written = await readdir(path.join(root, "shared", "nested", "deep"));
+      expect(written).toHaveLength(40);
+      expect(await readFile(path.join(root, "shared", "nested", "deep", "f39.txt"), "utf8")).toBe("payload-39\n");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("refuses a destination swapped for a link after validation but before truncate", async () => {
+    // The destination is validated, opened, and then — before the retained
+    // handle is truncated — replaced with a link pointing outside the root. This
+    // is the containment re-check, not the symlink check: every pre-open
+    // observation is stale by this point.
+    //
+    // The post-state that matters is the EXTERNAL directory, not the sentinel:
+    // the handle refers to the now-unlinked original inode, so the sentinel
+    // survives whatever the guards do. What must not happen is a new file
+    // appearing through the link.
+    const { root, external, cleanup } = await arena("farm-lateswap");
+    const destination = path.join(root, "inside.txt");
+    await writeFile(destination, "inside-original", "utf8");
+    try {
+      await expectRefused(
+        writeWorktreeFile(root, "inside.txt", "overwrite", {
+          beforeFinalAuthorization: async () => {
+            await rm(destination, { force: true });
+            await symlink(external, destination, process.platform === "win32" ? "junction" : "dir");
+          },
+        }),
+      );
+      expect(await readdir(external)).toEqual(["sentinel.txt"]);
     } finally {
       await cleanup();
     }
@@ -256,71 +317,73 @@ describe("symlink-safe worktree writer — refusal paths", () => {
 
   it("funnels an unexpected filesystem error into the same refusal, leaking nothing", async () => {
     // A root that does not exist makes the FIRST lstat throw ENOENT — not an
-    // `unsafe()` call. The catch must convert it, so callers cannot distinguish
-    // "escaped the root" from "disk error"; the raw errno must not surface.
-    const { writeWorktreeFile } = await implementation();
+    // `unsafe()` call. The catch must convert it, so a caller cannot tell
+    // "escaped the root" from "disk error"; the raw errno must not surface, and
+    // the missing root must not be created on the way out.
     const missing = path.join(tmpdir(), `farm-missing-root-${Date.now()}`);
     await expectRefused(writeWorktreeFile(missing, "a.txt", "payload"));
     await expect(writeWorktreeFile(missing, "a.txt", "payload")).rejects.not.toThrow(/ENOENT/);
+    expect(existsSync(missing)).toBe(false);
   });
 
-  it("re-verifies the parent between open and truncate, refusing a late swap", async () => {
-    // The destination is validated, opened, and then — before the handle is
-    // truncated — the parent directory is replaced with a link to somewhere
-    // else. Every pre-open observation is now stale, and the final
-    // re-verification is the only thing standing between the retained handle and
-    // an authorized write against a path nobody checked.
-    const { writeWorktreeFile } = await implementation();
-    const { root, external, sentinel, cleanup } = await arena("farm-lateswap");
-    const parent = path.join(root, "sub");
-    await mkdir(parent, { recursive: true });
-    const destination = path.join(parent, "inside.txt");
-    await writeFile(destination, "inside-original", "utf8");
+  it("leaves ancestor directories behind on a refusal — refusal is not a rollback", async () => {
+    // Documented, previously unasserted. The segment walk creates missing
+    // ancestors BEFORE the destination is validated, so a refused write can
+    // leave empty directories. They are inside the root and owner-only, so this
+    // is benign — but it is not atomic, and a caller assuming otherwise would be
+    // wrong. Pinned so a change to it is a deliberate one.
+    const { root, cleanup } = await arena("farm-partial");
     try {
-      await expectRefused(
-        writeWorktreeFile(root, path.join("sub", "inside.txt"), "overwrite", {
-          beforeFinalAuthorization: async () => {
-            await rm(parent, { recursive: true, force: true });
-            await symlink(external, parent, process.platform === "win32" ? "junction" : "dir");
-          },
-        }),
-      );
-      expect(await readFile(sentinel, "utf8")).toBe("outside-must-survive");
+      await expectRefused(writeWorktreeFile(root, path.join("n1", "n2", "a\0.txt"), "payload"));
+      expect(existsSync(path.join(root, "n1", "n2"))).toBe(true);
+      expect(await readdir(path.join(root, "n1", "n2"))).toEqual([]);
     } finally {
       await cleanup();
     }
   });
+});
 
-  it("creates missing intermediate directories with owner-only permissions", async () => {
-    // The success counterpart of the walk above: `mkdir(..., { mode: 0o700 })`.
-    // Worth pinning because the mode is the only thing keeping a shared temp
-    // root from exposing worker output, and nothing else asserts it.
-    const { writeWorktreeFile } = await implementation();
-    const { root, cleanup } = await arena("farm-mkmode");
-    try {
-      await writeWorktreeFile(root, path.join("fresh", "deep", "file.txt"), "made\n");
-      expect(await readFile(path.join(root, "fresh", "deep", "file.txt"), "utf8")).toBe("made\n");
-      if (process.platform !== "win32") {
-        const mode = (await lstat(path.join(root, "fresh"))).mode & 0o777;
-        expect(mode).toBe(0o700);
-      }
-    } finally {
-      await cleanup();
-    }
-  });
-
+describe("symlink-safe worktree writer — write contracts", () => {
   it("truncates rather than appends when rewriting a shorter payload", async () => {
-    // `truncate(0)` before `writeFile`. Without it the tail of a longer previous
-    // payload survives, which for a restored mutant means the worktree silently
-    // keeps mutated source.
-    const { writeWorktreeFile } = await implementation();
-    const { root, cleanup } = await arena("farm-truncate");
+    // Sole killer of dropping `truncate(0)`. Without it the tail of a longer
+    // previous payload survives, which for a restored mutant means the worktree
+    // silently keeps mutated source.
+    const root = await mkdtemp(path.join(tmpdir(), "farm-truncate-"));
     try {
       await writeWorktreeFile(root, "f.txt", "AAAAAAAAAAAAAAAAAAAAAAAA\n");
       await writeWorktreeFile(root, "f.txt", "BBB\n");
       expect(await readFile(path.join(root, "f.txt"), "utf8")).toBe("BBB\n");
     } finally {
-      await cleanup();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips non-ASCII content without re-encoding it", async () => {
+    // Pins the utf8 encoding on both the write and the read-back. A latin1 slip
+    // is invisible to every ASCII fixture in this file.
+    const root = await mkdtemp(path.join(tmpdir(), "farm-utf8-"));
+    try {
+      const content = "héllo — ünïcode ✓\n";
+      await writeWorktreeFile(root, "u.txt", content);
+      expect(await readFile(path.join(root, "u.txt"), "utf8")).toBe(content);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("creates directories 0o700 and files 0o600", async () => {
+    // Both modes, and both matter: the directory mode is what keeps a shared
+    // temp root from listing worker output, the file mode is what keeps its
+    // CONTENTS unreadable. An earlier draft asserted only the directory, and
+    // skipped the whole assertion on the measurement platform — so on Windows it
+    // asserted nothing at all while appearing to pin the threat model.
+    const root = await mkdtemp(path.join(tmpdir(), "farm-mode-"));
+    try {
+      await writeWorktreeFile(root, path.join("fresh", "deep", "file.txt"), "made\n");
+      expect((await lstat(path.join(root, "fresh"))).mode & 0o777).toBe(0o700);
+      expect((await lstat(path.join(root, "fresh", "deep", "file.txt"))).mode & 0o777).toBe(0o600);
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Slice 2 of 6 on #511. Plan updated in the same commit.

## What it pins

Ten new cases against the symlink-safe worktree writer: root-is-a-file, root-is-a-link, four escape shapes, a linked intermediate directory, a destination that exists as a directory, a parent swapped between open and truncate, the `0o700` creation mode, and truncate-not-append. Plus the absolute-path contract in **both** directions.

Every case asserts **the external sentinel survived**, not merely that the call rejected — a refusal that still wrote is the exact failure this module prevents, and `rejects.toThrow()` cannot distinguish them. Every case also asserts error **identity** via `isUnsafeWorktreePathError`, the discriminator callers actually branch on.

One test was wrong and the run said so: an absolute path pointing *inside* the root is legitimately accepted — `isAbsolute` is applied to the resolved relative path, not the input. It now pins both arms.

## What it returned, and why the estimate was wrong

**+4 branches against an estimate of 19.** 75.64% → 80.76%. That gap is the interesting part.

Fifteen remaining arms are structurally unreachable through the public API, because the module is layered on purpose and each layer re-establishes what an earlier one guaranteed. Measured, with every layer for a property removed *together*:

| property stripped everywhere | result |
|---|---|
| all 4 `isSymbolicLink()` checks | **survives** — a junction also fails `isDirectory()` |
| all 3 `isDirectory()` checks | **survives** — `isSymbolicLink()` catches it |
| the whole lexical escape guard | **survives** — the resolved target is a directory, `safeRegularFile` refuses it |

So single-point mutation scored 4/24 here while measuring the *design*, not the tests. The plan's standard is amended: the unit is the **property**, not the line. By that standard this slice holds — `unsafe()` not throwing, `safeRegularFile` defeated, and `nlink` unchecked are all **killed**.

## One genuine gap, recorded not closed

`contained()`'s false branch is never exercised — making it unconditionally `true` fails nothing. It is the backstop against a **resolved-path** escape, and every reachable attack is caught by an earlier layer first. Closing it needs fault injection, and a source change to `worktree-fs.ts` rebuilds `farm.js`, which **is** declared payload — a `ca` version bump to buy coverage. Recorded instead of bought.

Also verified unreachable: the `O_NOFOLLOW` true-arm (undefined on Windows) and the `segment === "" | "." | ".."` guard (`path.resolve`+`path.relative` normalise those away — checked across four inputs).

## Budget correction

+95 branches still needed; ~143 realistically available across `exec.ts`, `mutation.ts` and `farm.ts`'s exported surface. Slice 5 is now load-bearing rather than a top-up, and slices 3–5 have no slack for another over-estimate.

## Verification

- 377 passed, 1 skipped, 6 files · typecheck clean · `farm.js` unchanged
- 15 Python suites + `unittest discover` + `check-plugin-refs.py` — all pass

No version bump. **AC-4 holds** — new describe block, pure addition apart from one import.

Refs #511