### PR TITLE
fix(docs): refine navigation and diagram rendering

### DIFF
--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -16,6 +17,7 @@ REPO = Path(__file__).resolve().parents[2]
 MODULE_PATH = REPO / ".github" / "scripts" / "pi_promotion.py"
 DOCS_MODULE_PATH = REPO / ".github" / "scripts" / "check_docs_contract.py"
 WORKFLOW_PATH = REPO / ".github" / "workflows" / "pi-promotion.yml"
+CI_WORKFLOW_PATH = REPO / ".github" / "workflows" / "ci.yml"
 
 
 def validation_job(workflow: str) -> str:
@@ -271,6 +273,34 @@ class PromotionReceiptTests(unittest.TestCase):
             with self.subTest(contract=identifier):
                 self.assertIn(f"contract --id {identifier} ", validate)
                 self.assertIn(identifier, module.CONTRACT_IDS)
+
+    def test_receipt_state_is_bound_after_the_runner_environment_exists(self):
+        validate = validation_job(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        binding = (
+            'echo "CA_PI_RECEIPT_STATE=$RUNNER_TEMP/pi-promotion-failures.json" '
+            '>> "$GITHUB_ENV"'
+        )
+        self.assertNotIn("${{ runner.temp }}", validate)
+        self.assertEqual(validate.count(binding), 1)
+        self.assertLess(
+            validate.index("Bind receipt state inside the runner environment"),
+            validate.index("actions/checkout@"),
+        )
+        consumers = [match.start() for match in re.finditer(r"\$CA_PI_RECEIPT_STATE", validate)]
+        self.assertGreater(len(consumers), 0)
+        self.assertLess(validate.index(binding), min(consumers))
+
+    def test_workflow_only_changes_reach_the_promotion_contract_suite(self):
+        from test_ci_impact import paths_filter, push_trigger_paths, workflow_jobs
+
+        ci = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+        guarded = ".github/workflows/pi-promotion.yml"
+        self.assertIn(guarded, push_trigger_paths(ci))
+        self.assertIn(guarded, paths_filter(ci, "hooks"))
+        self.assertIn(
+            "python .github/scripts/test_pi_promotion.py",
+            workflow_jobs(ci)["hooks"],
+        )
 
     def test_failed_candidate_renders_one_receipt_to_the_summary_and_artifact(self):
         validate = validation_job(WORKFLOW_PATH.read_text(encoding="utf-8"))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ on:
       # workflow's dispatch-exclusivity, merge-readiness, and tag-integrity
       # gates. A push that weakens only release.yml must still start a run.
       - ".github/workflows/release.yml"
+      # test_pi_promotion.py guards the promotion workflow itself. A workflow-
+      # only edit must start the hooks job that executes that contract suite.
+      - ".github/workflows/pi-promotion.yml"
       # The publish mechanics moved out of release.yml into a shared
       # composite action (#382), so the same reasoning covers it.
       - ".github/actions/**"
@@ -185,6 +188,9 @@ jobs:
               # test_release_workflow.py runs in the hooks job and is the only
               # guard on the release workflow's publish gates (#378/#380/#385).
               - '.github/workflows/release.yml'
+              # test_pi_promotion.py guards this workflow's runner-bound state
+              # and receipt contract, so a workflow-only PR must reach hooks.
+              - '.github/workflows/pi-promotion.yml'
               # The publish mechanics moved out of release.yml into a
               # shared composite action (#382); without this, the one
               # file that can weaken the #380 tag guards is unwatched.

--- a/.github/workflows/pi-promotion.yml
+++ b/.github/workflows/pi-promotion.yml
@@ -86,9 +86,11 @@ jobs:
     # approved specification promises. The state file lives in RUNNER_TEMP so it
     # can never be picked up as a workspace artifact.
     env:
-      CA_PI_RECEIPT_STATE: ${{ runner.temp }}/pi-promotion-failures.json
       CA_PI_CANDIDATE: ${{ needs.resolve.outputs.candidate }}
     steps:
+      - name: Bind receipt state inside the runner environment
+        shell: bash
+        run: echo "CA_PI_RECEIPT_STATE=$RUNNER_TEMP/pi-promotion-failures.json" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/site/public/diagrams/activation-states.svg
+++ b/site/public/diagrams/activation-states.svg
@@ -16,23 +16,23 @@
   <rect width="976" height="410" rx="14" fill="url(#canvas)"/>
   <rect width="976" height="410" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="974" height="408" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">ACTIVATION CONTRACT</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Read .codearbiter/CONTEXT.md once; classify its leading frontmatter.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="910">ACTIVATION CONTRACT</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="910">Read .codearbiter/CONTEXT.md once; classify its leading frontmatter.</text>
 <rect x="42" y="126" width="248" height="96" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="166" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Read CONTEXT.md</text>
-<text x="166" y="204" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">leading YAML only</text>
+<text x="166" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="224">Read CONTEXT.md</text>
+<text x="166" y="204" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="224">leading YAML only</text>
 <rect x="372" y="112" width="240" height="94" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="492" y="143" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Dormant</text>
-<text x="492" y="188" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">missing file or no block</text>
+<text x="492" y="143" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="216">Dormant</text>
+<text x="492" y="188" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="216">missing file or no block</text>
 <rect x="372" y="236" width="240" height="94" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="492" y="267" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Malformed</text>
-<text x="492" y="312" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">error surfaced</text>
+<text x="492" y="267" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="216">Malformed</text>
+<text x="492" y="312" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="216">error surfaced</text>
 <rect x="694" y="174" width="240" height="94" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="814" y="205" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Enabled</text>
-<text x="814" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">arbiter: enabled</text>
+<text x="814" y="205" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="216">Enabled</text>
+<text x="814" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="216">arbiter: enabled</text>
 <path d="M296 174 L362 159" fill="none" stroke="#3a4c60" stroke-width="2.25" marker-end="url(#arrow)"/>
 <path d="M296 174 L362 283" fill="none" stroke="#ff7b72" stroke-width="2.25" marker-end="url(#arrow)"/>
 <path d="M618 252 L684 221" fill="none" stroke="#58d68d" stroke-width="2.25" marker-end="url(#arrow)"/>
-<text x="492" y="354" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#ff7b72" text-anchor="middle" data-label-kind="annotation">A malformed block never silently disables enforcement.</text>
-<text x="492" y="378" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">The next activation check sees any file change.</text>
+<text x="492" y="354" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#ff7b72" text-anchor="middle" data-label-kind="annotation" data-max-width="920">A malformed block never silently disables enforcement.</text>
+<text x="492" y="378" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="920">The next activation check sees any file change.</text>
 </svg>

--- a/site/public/diagrams/commit-gate-phases.svg
+++ b/site/public/diagrams/commit-gate-phases.svg
@@ -16,49 +16,49 @@
   <rect width="1230" height="540" rx="14" fill="url(#canvas)"/>
   <rect width="1230" height="540" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1228" height="538" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">COMMIT-GATE</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Nine phases. Every failure is a hard BLOCK.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1164">COMMIT-GATE</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1164">Nine phases. Every failure is a hard BLOCK.</text>
 <rect x="42" y="126" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="172" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Permission</text>
-<text x="172" y="200" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 1</text>
+<text x="172" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Permission</text>
+<text x="172" y="200" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 1</text>
 <path d="M308 172 L366 172" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="376" y="126" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="506" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Branch</text>
-<text x="506" y="200" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 2</text>
+<text x="506" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Branch</text>
+<text x="506" y="200" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 2</text>
 <path d="M642 172 L700 172" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="710" y="126" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="840" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Classify</text>
-<text x="840" y="200" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 3</text>
+<text x="840" y="157" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Classify</text>
+<text x="840" y="200" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 3</text>
 <polyline points="840,224 840,248" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="710" y="258" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="840" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Verify</text>
-<text x="840" y="332" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 4</text>
+<text x="840" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Verify</text>
+<text x="840" y="332" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 4</text>
 <path d="M704 304 L646 304" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="376" y="258" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="506" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Behavioral</text>
-<text x="506" y="308" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">proof</text>
-<text x="506" y="332" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 5</text>
+<text x="506" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Behavioral</text>
+<text x="506" y="308" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">proof</text>
+<text x="506" y="332" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 5</text>
 <path d="M370 304 L312 304" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="42" y="258" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="172" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Diff review</text>
-<text x="172" y="332" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 6</text>
+<text x="172" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Diff review</text>
+<text x="172" y="332" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 6</text>
 <polyline points="172,356 172,380" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="42" y="390" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="172" y="421" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Selective</text>
-<text x="172" y="440" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">stage</text>
-<text x="172" y="464" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 7</text>
+<text x="172" y="421" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Selective</text>
+<text x="172" y="440" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">stage</text>
+<text x="172" y="464" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 7</text>
 <path d="M308 436 L366 436" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="376" y="390" width="260" height="92" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="506" y="421" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Message</text>
-<text x="506" y="464" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 8</text>
+<text x="506" y="421" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Message</text>
+<text x="506" y="464" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 8</text>
 <path d="M642 436 L700 436" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="710" y="390" width="260" height="92" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="840" y="421" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Commit</text>
-<text x="840" y="464" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">phase 9</text>
+<text x="840" y="421" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">Commit</text>
+<text x="840" y="464" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">phase 9</text>
 <rect x="970" y="258" width="218" height="92" rx="10" fill="#17212d" stroke="#f0b92f" stroke-width="2" stroke-dasharray="7 6"/>
-<text x="1079" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#f6f7f9" text-anchor="middle">5.5 · Provenance</text>
-<text x="1079" y="308" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#f6f7f9" text-anchor="middle">auto-heal</text>
-<text x="1079" y="334" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">only on drift</text>
+<text x="1079" y="289" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="254">5.5 · Provenance</text>
+<text x="1079" y="308" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="254">auto-heal</text>
+<text x="1079" y="334" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="254">only on drift</text>
 <polyline points="636,304 956,304" fill="none" stroke="#f0b92f" stroke-width="2.25" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
-<text x="1188" y="508" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">A BLOCK clears only through the logged /ca:override path.</text>
+<text x="1188" y="508" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1164">A BLOCK clears only through the logged /ca:override path.</text>
 </svg>

--- a/site/public/diagrams/core-fanout.svg
+++ b/site/public/diagrams/core-fanout.svg
@@ -16,33 +16,34 @@
   <rect width="1166" height="476" rx="14" fill="url(#canvas)"/>
   <rect width="1166" height="476" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1164" height="474" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">BUILD-TIME GENERATION</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">One source fans out only after the byte-identity gate.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1100">BUILD-TIME GENERATION</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1100">One source fans out only after the byte-identity gate.</text>
 <rect x="42" y="190" width="220" height="110" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="152" y="221" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">core/pysrc</text>
-<text x="152" y="240" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">core/surface</text>
-<text x="152" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">shared hook core + surface</text>
+<text x="152" y="221" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="196">core/pysrc</text>
+<text x="152" y="240" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="196">core/surface</text>
+<text x="152" y="266" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="196">shared hook core</text>
+<text x="152" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="196">+ surface</text>
 <rect x="334" y="190" width="190" height="110" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="429" y="221" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">CI gate</text>
-<text x="429" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">byte-identity check</text>
+<text x="429" y="221" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="166">CI gate</text>
+<text x="429" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="166">byte-identity check</text>
 <path d="M268 245 L324 245" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="604" y="118" width="220" height="84" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="714" y="149" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">ca</text>
-<text x="714" y="184" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">Claude Code plugin</text>
+<text x="714" y="149" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="196">ca</text>
+<text x="714" y="184" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="196">Claude Code plugin</text>
 <rect x="604" y="222" width="220" height="84" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="714" y="253" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">ca-codex</text>
-<text x="714" y="288" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">Codex plugin</text>
+<text x="714" y="253" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="196">ca-codex</text>
+<text x="714" y="288" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="196">Codex plugin</text>
 <rect x="604" y="326" width="220" height="84" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="714" y="357" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">ca-pi</text>
-<text x="714" y="392" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">Pi plugin</text>
+<text x="714" y="357" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="196">ca-pi</text>
+<text x="714" y="392" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="196">Pi plugin</text>
 <polyline points="530,245 564,245 564,160 594,160" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <path d="M530 245 L594 264" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <polyline points="530,245 564,245 564,368 594,368" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="904" y="222" width="220" height="84" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="1014" y="253" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">one .codearbiter/</text>
-<text x="1014" y="288" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">shared checked-in state</text>
+<text x="1014" y="253" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="196">one .codearbiter/</text>
+<text x="1014" y="288" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="196">shared checked-in state</text>
 <polyline points="830,160 864,160 864,264 894,264" fill="none" stroke="#3a4c60" stroke-width="2.25" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
 <path d="M830 264 L894 264" fill="none" stroke="#3a4c60" stroke-width="2.25" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
 <polyline points="830,368 864,368 864,264 894,264" fill="none" stroke="#3a4c60" stroke-width="2.25" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
-<text x="42" y="444" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="start" data-label-kind="annotation">sync-core.py and build-surface.py generate host-native surfaces; CI gates every edge.</text>
+<text x="42" y="444" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="start" data-label-kind="annotation" data-max-width="1100">sync-core.py and build-surface.py generate host-native surfaces; CI gates every edge.</text>
 </svg>

--- a/site/public/diagrams/four-tier-map.svg
+++ b/site/public/diagrams/four-tier-map.svg
@@ -16,33 +16,39 @@
   <rect width="1128" height="430" rx="14" fill="url(#canvas)"/>
   <rect width="1128" height="430" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1126" height="428" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">JUST-IN-TIME CONTEXT</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Read(file) checks four tiers in strict priority order.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1062">JUST-IN-TIME CONTEXT</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1062">Read(file) checks four tiers in strict priority order.</text>
 <rect x="42" y="154" width="188" height="92" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="136" y="185" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Read(file)</text>
-<text x="136" y="228" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">PreToolUse hook</text>
-<rect x="300" y="132" width="170" height="136" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="385" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">1 · security-controls.md</text>
-<text x="385" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">security-entry files</text>
+<text x="136" y="185" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="164">Read(file)</text>
+<text x="136" y="228" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="164">PreToolUse hook</text>
+<rect x="300" y="132" width="184" height="136" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
+<text x="392" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">1</text>
+<text x="392" y="182" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">security-</text>
+<text x="392" y="201" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">controls.md</text>
+<text x="392" y="234" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">security-entry</text>
+<text x="392" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">files</text>
 <path d="M236 200 L290 200" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
-<path d="M476 200 L495 200" fill="none" stroke="#ff7b72" stroke-width="2.25" marker-end="url(#arrow)"/>
-<rect x="505" y="132" width="170" height="136" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="590" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">2 · decisions/</text>
-<text x="590" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">accepted ADR governs glob</text>
-<path d="M681 200 L700 200" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
-<rect x="710" y="132" width="170" height="136" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="795" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">3 · specs/</text>
-<text x="795" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">approved Governs header</text>
-<path d="M886 200 L905 200" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
-<rect x="915" y="132" width="170" height="136" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="1000" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">4 · provenance</text>
-<text x="1000" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">stored hash still matches</text>
+<rect x="500" y="132" width="184" height="136" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
+<text x="592" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">2</text>
+<text x="592" y="182" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">decisions/</text>
+<text x="592" y="234" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">accepted ADR</text>
+<text x="592" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">governs glob</text>
+<rect x="700" y="132" width="184" height="136" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
+<text x="792" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">3</text>
+<text x="792" y="182" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">specs/</text>
+<text x="792" y="234" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">approved Governs</text>
+<text x="792" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">header</text>
+<rect x="900" y="132" width="184" height="136" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
+<text x="992" y="163" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">4</text>
+<text x="992" y="182" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="160">provenance</text>
+<text x="992" y="234" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">stored hash</text>
+<text x="992" y="250" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="160">still matches</text>
 <rect x="300" y="310" width="375" height="82" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="487.5" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Inject highest-priority pointer</text>
-<text x="487.5" y="374" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">budget ≤ 150 tokens</text>
+<text x="487.5" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="351">Inject highest-priority pointer</text>
+<text x="487.5" y="374" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="351">budget ≤ 150 tokens</text>
 <rect x="710" y="310" width="375" height="82" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="897.5" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">No tier matches</text>
-<text x="897.5" y="374" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">no injection · zero git calls</text>
+<text x="897.5" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="351">No tier matches</text>
+<text x="897.5" y="374" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="351">no injection · zero git calls</text>
 <polyline points="642,268 642,290 487,290 487,300" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <polyline points="970,268 970,300" fill="none" stroke="#3a4c60" stroke-width="2.25" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
 </svg>

--- a/site/public/diagrams/gate-model.svg
+++ b/site/public/diagrams/gate-model.svg
@@ -16,31 +16,34 @@
   <rect width="1140" height="470" rx="14" fill="url(#canvas)"/>
   <rect width="1140" height="470" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1138" height="468" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="44" y="50" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">GATE BEHAVIOR</text>
-<text x="44" y="82" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="20" font-weight="750" fill="#f6f7f9" text-anchor="start">The same approach. Two different outcomes.</text>
+  <text x="44" y="50" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1072">GATE BEHAVIOR</text>
+<text x="44" y="82" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="20" font-weight="750" fill="#f6f7f9" text-anchor="start" data-max-width="1072">The same approach. Two different outcomes.</text>
 <rect x="44" y="116" width="512" height="284" rx="14" fill="#121a24" stroke="#9b6811" stroke-width="2"/>
 <rect x="584" y="116" width="512" height="284" rx="14" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="74" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation">SOFT GATE</text>
-<text x="614" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#ff7b72" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation">HARD GATE</text>
+<text x="74" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation" data-max-width="1042">SOFT GATE</text>
+<text x="614" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#ff7b72" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation" data-max-width="502">HARD GATE</text>
 <rect x="74" y="184" width="190" height="94" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="169" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Decision surfaced</text>
-<text x="169" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">waiting for user</text>
+<text x="169" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="166">Decision</text>
+<text x="169" y="234" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="166">surfaced</text>
+<text x="169" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="166">waiting for user</text>
 <rect x="344" y="184" width="182" height="94" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="435" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Work proceeds</text>
-<text x="435" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">after user acts</text>
+<text x="435" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="158">Work proceeds</text>
+<text x="435" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="158">after user acts</text>
 <path d="M270 231 L334 231" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
-<text x="300" y="216" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">human choice</text>
+<text x="300" y="216" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#f0b92f" text-anchor="middle" letter-spacing="0.8" data-label-kind="annotation" data-max-width="70">DECISION</text>
 <rect x="614" y="184" width="190" height="94" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="709" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Stopped</text>
-<text x="709" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">never auto-decided</text>
+<text x="709" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="166">Stopped</text>
+<text x="709" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="166">never auto-decided</text>
 <rect x="884" y="184" width="182" height="94" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="975" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">User action</text>
-<text x="975" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">required to continue</text>
+<text x="975" y="215" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="158">User action</text>
+<text x="975" y="244" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="158">required</text>
+<text x="975" y="260" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="158">to continue</text>
 <path d="M810 231 L874 231" fill="none" stroke="#ff7b72" stroke-width="2.25" marker-end="url(#arrow)"/>
-<text x="840" y="216" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#ff7b72" text-anchor="middle" data-label-kind="annotation">hard stop</text>
-<text x="74" y="322" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">Surfaces the exact choice.</text>
-<text x="74" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">Resumes when the user decides.</text>
-<text x="614" y="322" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">Security, auth/crypto, irreversible ops,</text>
-<text x="614" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">gate bypass, and merge-to-default remain stops.</text>
-<text x="44" y="436" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="start" data-label-kind="annotation">Frequent hard-gate trips indicate a thin specification, not a normal control loop.</text>
+<text x="840" y="216" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#ff7b72" text-anchor="middle" letter-spacing="0.8" data-label-kind="annotation" data-max-width="36">STOP</text>
+<text x="74" y="322" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="452">Surfaces the exact choice.</text>
+<text x="74" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="452">Resumes when the user decides.</text>
+<text x="614" y="322" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="452">Security, auth/crypto, and irreversible ops stop.</text>
+<text x="614" y="341" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="452">Gate bypass and merge-to-default stop.</text>
+<text x="614" y="360" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="452">Only the user can clear the gate.</text>
+<text x="44" y="436" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="start" data-label-kind="annotation" data-max-width="1072">Frequent hard-gate trips indicate a thin specification, not a normal control loop.</text>
 </svg>

--- a/site/public/diagrams/lane-add-dep.svg
+++ b/site/public/diagrams/lane-add-dep.svg
@@ -16,16 +16,16 @@
   <rect width="1120" height="360" rx="14" fill="url(#canvas)"/>
   <rect width="1120" height="360" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1118" height="358" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">DEPENDENCY LANE</text>
-<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Review the supply chain before installation.</text>
+  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1044">DEPENDENCY LANE</text>
+<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1044">Review the supply chain before installation.</text>
 <rect x="52" y="112" width="489" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">COMMAND</text>
+<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1026">COMMAND</text>
 <rect x="68" y="160" width="457" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="296.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:add-dep</text>
+<text x="296.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">/ca:add-dep</text>
 <path d="M547 202 L571 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="579" y="112" width="489" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="597" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#58d68d" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">AGENT</text>
+<text x="597" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#58d68d" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="499">AGENT</text>
 <rect x="595" y="160" width="457" height="30" rx="6" fill="#17212d" stroke="#58d68d" stroke-width="1.5"/>
-<text x="823.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">dependency-reviewer</text>
-<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">license · provenance · vulnerability review must clear before install</text>
+<text x="823.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">dependency-reviewer</text>
+<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1044">license · provenance · vulnerability review must clear before install</text>
 </svg>

--- a/site/public/diagrams/lane-adr.svg
+++ b/site/public/diagrams/lane-adr.svg
@@ -16,18 +16,18 @@
   <rect width="1120" height="360" rx="14" fill="url(#canvas)"/>
   <rect width="1120" height="360" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1118" height="358" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">DECISION LANE</text>
-<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Author a durable decision, then inspect its health.</text>
+  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1044">DECISION LANE</text>
+<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1044">Author a durable decision, then inspect its health.</text>
 <rect x="52" y="112" width="489" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">COMMANDS</text>
+<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1026">COMMANDS</text>
 <rect x="68" y="160" width="457" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="296.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:adr</text>
+<text x="296.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">/ca:adr</text>
 <rect x="68" y="198" width="457" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="296.5" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:adr-status</text>
+<text x="296.5" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">/ca:adr-status</text>
 <path d="M547 202 L571 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="579" y="112" width="489" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="597" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">SKILL</text>
+<text x="597" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="499">SKILL</text>
 <rect x="595" y="160" width="457" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="823.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">decision-lifecycle</text>
-<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">the ADR is numbered, dated, user-attributed, and governed</text>
+<text x="823.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">decision-lifecycle</text>
+<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1044">the ADR is numbered, dated, user-attributed, and governed</text>
 </svg>

--- a/site/public/diagrams/lane-feature.svg
+++ b/site/public/diagrams/lane-feature.svg
@@ -16,31 +16,31 @@
   <rect width="1120" height="360" rx="14" fill="url(#canvas)"/>
   <rect width="1120" height="360" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1118" height="358" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">FEATURE LANE</text>
-<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">From approved intent to reviewed pull request.</text>
+  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1044">FEATURE LANE</text>
+<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1044">From approved intent to reviewed pull request.</text>
 <rect x="52" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">COMMANDS</text>
+<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1026">COMMANDS</text>
 <rect x="68" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="208.66666666666666" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:feature</text>
+<text x="208.66666666666666" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:feature</text>
 <rect x="68" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="208.66666666666666" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:commit</text>
+<text x="208.66666666666666" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:commit</text>
 <rect x="68" y="236" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="208.66666666666666" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:pr</text>
+<text x="208.66666666666666" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:pr</text>
 <path d="M371.3333333333333 202 L395.3333333333333 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="403.3333333333333" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="421.3333333333333" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">SKILLS</text>
+<text x="421.3333333333333" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="674">SKILLS</text>
 <rect x="419.3333333333333" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="560" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">brainstorming</text>
+<text x="560" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">brainstorming</text>
 <rect x="419.3333333333333" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="560" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">writing-plans</text>
+<text x="560" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">writing-plans</text>
 <rect x="419.3333333333333" y="236" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="560" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">tdd</text>
+<text x="560" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">tdd</text>
 <path d="M722.6666666666666 202 L746.6666666666666 202" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="754.6666666666666" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="772.6666666666666" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#58d68d" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">AGENTS</text>
+<text x="772.6666666666666" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#58d68d" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="323">AGENTS</text>
 <rect x="770.6666666666666" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#58d68d" stroke-width="1.5"/>
-<text x="911.3333333333333" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">author agents</text>
+<text x="911.3333333333333" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">author agents</text>
 <rect x="770.6666666666666" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#58d68d" stroke-width="1.5"/>
-<text x="911.3333333333333" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">reviewer agents</text>
-<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">execution order is governed; the default branch is never a direct write</text>
+<text x="911.3333333333333" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">reviewer agents</text>
+<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1044">execution order is governed; the default branch is never a direct write</text>
 </svg>

--- a/site/public/diagrams/lane-flow.svg
+++ b/site/public/diagrams/lane-flow.svg
@@ -16,27 +16,27 @@
   <rect width="1200" height="310" rx="14" fill="url(#canvas)"/>
   <rect width="1200" height="310" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1198" height="308" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">GATED LANE FLOW</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Intent routes to its owner, clears the applicable gates, and ships through a pull request.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1134">GATED LANE FLOW</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1134">Intent routes to its owner, clears the applicable gates, and ships through a pull request.</text>
 <rect x="42" y="120" width="189.6" height="92" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="136.8" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">/ca:fix</text>
-<text x="136.8" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">COMMAND</text>
+<text x="136.8" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="165.6">/ca:fix</text>
+<text x="136.8" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="165.6">COMMAND</text>
 <path d="M237.6 166 L265.6 166" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="273.6" y="120" width="189.6" height="92" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="368.40000000000003" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">orchestrator</text>
-<text x="368.40000000000003" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">ROUTE</text>
+<text x="368.40000000000003" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="165.6">orchestrator</text>
+<text x="368.40000000000003" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="165.6">ROUTE</text>
 <path d="M469.20000000000005 166 L497.20000000000005 166" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="505.2" y="120" width="189.6" height="92" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="600" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">tests · review</text>
-<text x="600" y="170" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">security</text>
-<text x="600" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">GATE</text>
+<text x="600" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="165.6">tests · review</text>
+<text x="600" y="170" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="165.6">security</text>
+<text x="600" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="165.6">GATE</text>
 <path d="M700.8 166 L728.8 166" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="736.8" y="120" width="189.6" height="92" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="831.5999999999999" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">version control</text>
-<text x="831.5999999999999" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">SHIP</text>
+<text x="831.5999999999999" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="165.6">version control</text>
+<text x="831.5999999999999" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="165.6">SHIP</text>
 <path d="M932.4 166 L960.4 166" fill="none" stroke="#58d68d" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="968.4" y="120" width="189.6" height="92" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="1063.2" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">pull request</text>
-<text x="1063.2" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">MERGE PATH</text>
-<text x="1158" y="274" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">never a direct write to the default branch</text>
+<text x="1063.2" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="165.6">pull request</text>
+<text x="1063.2" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="165.6">MERGE PATH</text>
+<text x="1158" y="274" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1134">never a direct write to the default branch</text>
 </svg>

--- a/site/public/diagrams/lane-opt-in.svg
+++ b/site/public/diagrams/lane-opt-in.svg
@@ -16,25 +16,25 @@
   <rect width="1120" height="360" rx="14" fill="url(#canvas)"/>
   <rect width="1120" height="360" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1118" height="358" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">REPOSITORY OPT-IN</text>
-<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Choose exactly one initialization path.</text>
+  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1044">REPOSITORY OPT-IN</text>
+<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1044">Choose exactly one initialization path.</text>
 <rect x="52" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">NEW PROJECT</text>
+<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1026">NEW PROJECT</text>
 <rect x="68" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="208.66666666666666" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:init</text>
+<text x="208.66666666666666" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:init</text>
 <rect x="68" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="208.66666666666666" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:decompose</text>
+<text x="208.66666666666666" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:decompose</text>
 <path d="M371.3333333333333 202 L395.3333333333333 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="403.3333333333333" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="421.3333333333333" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">EXISTING CODE</text>
+<text x="421.3333333333333" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="674">EXISTING CODE</text>
 <rect x="419.3333333333333" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="560" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:create-context</text>
+<text x="560" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:create-context</text>
 <path d="M722.6666666666666 202 L746.6666666666666 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="754.6666666666666" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="772.6666666666666" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">SKILLS</text>
+<text x="772.6666666666666" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="323">SKILLS</text>
 <rect x="770.6666666666666" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="911.3333333333333" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">decompose</text>
+<text x="911.3333333333333" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">decompose</text>
 <rect x="770.6666666666666" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="911.3333333333333" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">context-creation</text>
-<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">one repository routes to one initialization path</text>
+<text x="911.3333333333333" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">context-creation</text>
+<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1044">one repository routes to one initialization path</text>
 </svg>

--- a/site/public/diagrams/lane-release.svg
+++ b/site/public/diagrams/lane-release.svg
@@ -16,18 +16,18 @@
   <rect width="1120" height="360" rx="14" fill="url(#canvas)"/>
   <rect width="1120" height="360" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1118" height="358" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">RELEASE LANE</text>
-<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Derive a version, update the record, and clear commit-gate.</text>
+  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1044">RELEASE LANE</text>
+<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1044">Derive a version, update the record, and clear commit-gate.</text>
 <rect x="52" y="112" width="489" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">COMMAND</text>
+<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1026">COMMAND</text>
 <rect x="68" y="160" width="457" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="296.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:release</text>
+<text x="296.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">/ca:release</text>
 <path d="M547 202 L571 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="579" y="112" width="489" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="597" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">SKILLS</text>
+<text x="597" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="499">SKILLS</text>
 <rect x="595" y="160" width="457" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="823.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">release</text>
+<text x="823.5" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">release</text>
 <rect x="595" y="198" width="457" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="823.5" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">commit-gate</text>
-<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">SemVer, changelog, commit, and annotated tag move together</text>
+<text x="823.5" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="447">commit-gate</text>
+<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1044">SemVer, changelog, commit, and annotated tag move together</text>
 </svg>

--- a/site/public/diagrams/lane-sprint.svg
+++ b/site/public/diagrams/lane-sprint.svg
@@ -16,29 +16,29 @@
   <rect width="1120" height="360" rx="14" fill="url(#canvas)"/>
   <rect width="1120" height="360" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1118" height="358" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">AUTONOMOUS SPRINT LANE</text>
-<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">One approved target, then governed plan-to-PR execution.</text>
+  <text x="52" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1044">AUTONOMOUS SPRINT LANE</text>
+<text x="52" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1044">One approved target, then governed plan-to-PR execution.</text>
 <rect x="52" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">COMMAND</text>
+<text x="70" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1026">COMMAND</text>
 <rect x="68" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#f0b92f" stroke-width="1.5"/>
-<text x="208.66666666666666" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">/ca:sprint</text>
+<text x="208.66666666666666" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">/ca:sprint</text>
 <path d="M371.3333333333333 202 L395.3333333333333 202" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="403.3333333333333" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="421.3333333333333" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">SKILLS</text>
+<text x="421.3333333333333" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="674">SKILLS</text>
 <rect x="419.3333333333333" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="560" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">writing-plans</text>
+<text x="560" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">writing-plans</text>
 <rect x="419.3333333333333" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="560" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-label-kind="annotation">subagent-driven-development</text>
+<text x="560" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-label-kind="annotation" data-max-width="271.3333333333333">subagent-driven-development</text>
 <rect x="419.3333333333333" y="236" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#7ab7ff" stroke-width="1.5"/>
-<text x="560" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">commit-gate</text>
+<text x="560" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">commit-gate</text>
 <path d="M722.6666666666666 202 L746.6666666666666 202" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="754.6666666666666" y="112" width="313.3333333333333" height="180" rx="12" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="772.6666666666666" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#58d68d" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">ROLES</text>
+<text x="772.6666666666666" y="140" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#58d68d" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="323">ROLES</text>
 <rect x="770.6666666666666" y="160" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#58d68d" stroke-width="1.5"/>
-<text x="911.3333333333333" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">author worker</text>
+<text x="911.3333333333333" y="180" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">author worker</text>
 <rect x="770.6666666666666" y="198" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#58d68d" stroke-width="1.5"/>
-<text x="911.3333333333333" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">reviewer fleet</text>
+<text x="911.3333333333333" y="218" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">reviewer fleet</text>
 <rect x="770.6666666666666" y="236" width="281.3333333333333" height="30" rx="6" fill="#17212d" stroke="#58d68d" stroke-width="1.5"/>
-<text x="911.3333333333333" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle">branch finisher</text>
-<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">SMARTS calls are logged; hard gates remain true stops</text>
+<text x="911.3333333333333" y="256" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="650" fill="#f6f7f9" text-anchor="middle" data-max-width="271.3333333333333">branch finisher</text>
+<text x="1068" y="329" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1044">SMARTS calls are logged; hard gates remain true stops</text>
 </svg>

--- a/site/public/diagrams/provenance-drift-flow.svg
+++ b/site/public/diagrams/provenance-drift-flow.svg
@@ -16,22 +16,22 @@
   <rect width="1200" height="310" rx="14" fill="url(#canvas)"/>
   <rect width="1200" height="310" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1198" height="308" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">CONTEXT-DRIFT PROVENANCE</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Detect, surface, and heal stale documentation claims.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1134">CONTEXT-DRIFT PROVENANCE</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1134">Detect, surface, and heal stale documentation claims.</text>
 <rect x="42" y="120" width="247.5" height="92" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="165.75" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Source changes</text>
-<text x="165.75" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">tracked file edited</text>
+<text x="165.75" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="223.5">Source changes</text>
+<text x="165.75" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="223.5">tracked file edited</text>
 <path d="M295.5 166 L323.5 166" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="331.5" y="120" width="247.5" height="92" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="455.25" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Drift detected</text>
-<text x="455.25" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">hash mismatch</text>
+<text x="455.25" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="223.5">Drift detected</text>
+<text x="455.25" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="223.5">hash mismatch</text>
 <path d="M585 166 L613 166" fill="none" stroke="#ff7b72" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="621" y="120" width="247.5" height="92" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="744.75" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">SessionStart</text>
-<text x="744.75" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">one passive line</text>
+<text x="744.75" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="223.5">SessionStart</text>
+<text x="744.75" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="223.5">one passive line</text>
 <path d="M874.5 166 L902.5 166" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="910.5" y="120" width="247.5" height="92" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="1034.25" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Commit-gate</text>
-<text x="1034.25" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">re-baseline or update</text>
-<text x="1158" y="274" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation">A drifted claim is suppressed; /ca:context-check performs the same detection manually.</text>
+<text x="1034.25" y="151" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="223.5">Commit-gate</text>
+<text x="1034.25" y="194" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="223.5">re-baseline or update</text>
+<text x="1158" y="274" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="end" data-label-kind="annotation" data-max-width="1134">A drifted claim is suppressed; /ca:context-check performs the same detection manually.</text>
 </svg>

--- a/site/public/diagrams/sandbox-boundary.svg
+++ b/site/public/diagrams/sandbox-boundary.svg
@@ -16,31 +16,31 @@
   <rect width="1104" height="510" rx="14" fill="url(#canvas)"/>
   <rect width="1104" height="510" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1102" height="508" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">CA-SANDBOX BOUNDARY</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">The repository enters a constrained container; the host does not.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1038">CA-SANDBOX BOUNDARY</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1038">The repository enters a constrained container; the host does not.</text>
 <rect x="42" y="116" width="1020" height="336" rx="16" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="68" y="148" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#91a0b2" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">HOST</text>
+<text x="68" y="148" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#91a0b2" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="1012">HOST</text>
 <rect x="68" y="176" width="230" height="96" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="183" y="207" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Host filesystem</text>
-<text x="183" y="254" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">projects · credentials</text>
+<text x="183" y="207" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="206">Host filesystem</text>
+<text x="183" y="254" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="206">projects · credentials</text>
 <rect x="68" y="312" width="230" height="96" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="183" y="343" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Docker daemon</text>
-<text x="183" y="390" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">socket never mounted</text>
+<text x="183" y="343" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="206">Docker daemon</text>
+<text x="183" y="390" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="206">socket never mounted</text>
 <rect x="372" y="146" width="650" height="272" rx="14" fill="#17212d" stroke="#f0b92f" stroke-width="2"/>
-<text x="398" y="178" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation">CONTAINER</text>
+<text x="398" y="178" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.6" data-label-kind="annotation" data-max-width="682">CONTAINER</text>
 <rect x="398" y="202" width="260" height="92" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="528" y="233" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">/work/repo</text>
-<text x="528" y="276" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">Docker named volume</text>
+<text x="528" y="233" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">/work/repo</text>
+<text x="528" y="276" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">Docker named volume</text>
 <rect x="714" y="202" width="276" height="92" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="852" y="233" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Runtime controls</text>
-<text x="852" y="276" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">read-only · user 1000:1000</text>
+<text x="852" y="233" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="252">Runtime controls</text>
+<text x="852" y="276" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="252">read-only · user 1000:1000</text>
 <rect x="398" y="322" width="260" height="68" rx="10" fill="#121a24" stroke="#ff7b72" stroke-width="2"/>
-<text x="528" y="353" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">No host mounts</text>
-<text x="528" y="372" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">no socket · no bind</text>
+<text x="528" y="353" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="236">No host mounts</text>
+<text x="528" y="372" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="236">no socket · no bind</text>
 <rect x="714" y="322" width="276" height="68" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="852" y="353" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">Policy controls</text>
-<text x="852" y="372" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">no network · resource caps</text>
+<text x="852" y="353" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="252">Policy controls</text>
+<text x="852" y="372" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="252">no network · resource caps</text>
 <path d="M304 224 L362 248" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
 <polyline points="658,248 688,248 688,356 704,356" fill="none" stroke="#3a4c60" stroke-width="2.25" marker-end="url(#arrow)"/>
-<text x="552" y="478" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">Reviewed output leaves only through host-initiated docker cp. Unknown network policy fails closed.</text>
+<text x="552" y="478" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="1056">Reviewed output leaves only through host-initiated docker cp. Unknown network policy fails closed.</text>
 </svg>

--- a/site/public/diagrams/two-axis-model.svg
+++ b/site/public/diagrams/two-axis-model.svg
@@ -16,35 +16,35 @@
   <rect width="1112" height="450" rx="14" fill="url(#canvas)"/>
   <rect width="1112" height="450" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="1110" height="448" rx="13" fill="none" stroke="#3a4c60" stroke-width="2"/>
-  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2">RELEASE MODEL</text>
-<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start">Payload versions and feature maturity answer different questions.</text>
+  <text x="42" y="48" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="14" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="2" data-max-width="1046">RELEASE MODEL</text>
+<text x="42" y="78" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#f6f7f9" text-anchor="start" data-max-width="1046">Payload versions and feature maturity answer different questions.</text>
 <rect x="42" y="116" width="500" height="300" rx="14" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
 <rect x="570" y="116" width="500" height="300" rx="14" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="72" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation">SEMVER AXIS</text>
-<text x="600" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation">FEATURE FORGE AXIS</text>
-<text x="72" y="188" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="20" font-weight="750" fill="#f6f7f9" text-anchor="start">Whole payload</text>
-<text x="600" y="188" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="20" font-weight="750" fill="#f6f7f9" text-anchor="start">Per-feature maturity</text>
+<text x="72" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#7ab7ff" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation" data-max-width="1016">SEMVER AXIS</text>
+<text x="600" y="154" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="750" fill="#f0b92f" text-anchor="start" letter-spacing="1.8" data-label-kind="annotation" data-max-width="488">FEATURE FORGE AXIS</text>
+<text x="72" y="188" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="20" font-weight="750" fill="#f6f7f9" text-anchor="start" data-max-width="1016">Whole payload</text>
+<text x="600" y="188" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="20" font-weight="750" fill="#f6f7f9" text-anchor="start" data-max-width="488">Per-feature maturity</text>
 <rect x="72" y="224" width="124" height="76" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="134" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">v2.5.1</text>
-<text x="134" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">released</text>
+<text x="134" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="100">v2.5.1</text>
+<text x="134" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="100">released</text>
 <rect x="230" y="224" width="124" height="76" rx="10" fill="#121a24" stroke="#7ab7ff" stroke-width="2"/>
-<text x="292" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">v2.5.2</text>
-<text x="292" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">current</text>
+<text x="292" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="100">v2.5.2</text>
+<text x="292" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="100">current</text>
 <rect x="388" y="224" width="124" height="76" rx="10" fill="#121a24" stroke="#3a4c60" stroke-width="2"/>
-<text x="450" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">v2.6.0</text>
-<text x="450" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">next</text>
+<text x="450" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="100">v2.6.0</text>
+<text x="450" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="100">next</text>
 <path d="M202 262 L220 262" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <path d="M360 262 L378 262" fill="none" stroke="#7ab7ff" stroke-width="2.25" marker-end="url(#arrow)"/>
 <rect x="600" y="224" width="154" height="76" rx="10" fill="#121a24" stroke="#f0b92f" stroke-width="2"/>
-<text x="677" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">preview</text>
-<text x="677" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">opt-in · dormant</text>
+<text x="677" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="130">preview</text>
+<text x="677" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="130">opt-in · dormant</text>
 <rect x="886" y="224" width="154" height="76" rx="10" fill="#121a24" stroke="#58d68d" stroke-width="2"/>
-<text x="963" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle">stable</text>
-<text x="963" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">on by default</text>
+<text x="963" y="255" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#f6f7f9" text-anchor="middle" data-max-width="130">stable</text>
+<text x="963" y="282" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="130">on by default</text>
 <path d="M760 262 L876 262" fill="none" stroke="#f0b92f" stroke-width="2.25" marker-end="url(#arrow)"/>
-<text x="818" y="246" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation">evidence</text>
-<text x="72" y="344" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">A version bump reaches every user.</text>
-<text x="72" y="363" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">Governed by MAJOR · MINOR · PATCH.</text>
-<text x="600" y="344" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">A preview can exist inside a stable release.</text>
-<text x="600" y="363" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start">Promotion requires real-world evidence.</text>
+<text x="818" y="246" font-family="JetBrains Mono Variable, Consolas, Cascadia Mono, monospace" font-size="12" font-weight="500" fill="#91a0b2" text-anchor="middle" data-label-kind="annotation" data-max-width="540">evidence</text>
+<text x="72" y="344" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="440">A version bump reaches every user.</text>
+<text x="72" y="363" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="440">Governed by MAJOR · MINOR · PATCH.</text>
+<text x="600" y="344" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="440">A preview can exist inside a stable release.</text>
+<text x="600" y="363" font-family="Manrope Variable, Segoe UI, Arial, sans-serif" font-size="14" font-weight="500" fill="#c7d0da" text-anchor="start" data-label-kind="copy" data-max-width="440">Promotion requires real-world evidence.</text>
 </svg>

--- a/site/scripts/diagram-audit.ts
+++ b/site/scripts/diagram-audit.ts
@@ -74,11 +74,16 @@ export function auditDiagram(svg: string, filename: string): string[] {
 
     const size = Number(sizeMatch[1]);
     const maximum = Number(maximumMatch[1]);
-    const copy = (match.groups?.copy ?? "")
-      .replaceAll("&amp;", "&")
-      .replaceAll("&lt;", "<")
-      .replaceAll("&gt;", ">")
-      .replaceAll("&quot;", '"');
+    const entities: Record<string, string> = {
+      "&amp;": "&",
+      "&lt;": "<",
+      "&gt;": ">",
+      "&quot;": '"',
+    };
+    const copy = (match.groups?.copy ?? "").replace(
+      /&(amp|lt|gt|quot);/g,
+      (entity) => entities[entity],
+    );
     const characters = [...copy];
     const mono = familyMatch[1].includes("monospace");
     const weight = Number(attributes.match(/\bfont-weight="([\d.]+)"/)?.[1] ?? 500);

--- a/site/scripts/diagram-audit.ts
+++ b/site/scripts/diagram-audit.ts
@@ -58,6 +58,55 @@ export function auditDiagram(svg: string, filename: string): string[] {
     }
   }
 
+  for (const match of svg.matchAll(/<text\b(?<attributes>[^>]*)>(?<copy>[^<]*)<\/text>/g)) {
+    const attributes = match.groups?.attributes ?? "";
+    const maximumMatch = attributes.match(/\bdata-max-width="([\d.]+)"/);
+    if (!maximumMatch) {
+      violations.push(`${filename}: text has no declared maximum width`);
+      continue;
+    }
+    const sizeMatch = attributes.match(/\bfont-size="([\d.]+)"/);
+    const familyMatch = attributes.match(/\bfont-family="([^"]+)"/);
+    if (!sizeMatch || !familyMatch) {
+      violations.push(`${filename}: bounded text is missing measurable font metrics`);
+      continue;
+    }
+
+    const size = Number(sizeMatch[1]);
+    const maximum = Number(maximumMatch[1]);
+    const copy = (match.groups?.copy ?? "")
+      .replaceAll("&amp;", "&")
+      .replaceAll("&lt;", "<")
+      .replaceAll("&gt;", ">")
+      .replaceAll("&quot;", '"');
+    const characters = [...copy];
+    const mono = familyMatch[1].includes("monospace");
+    const weight = Number(attributes.match(/\bfont-weight="([\d.]+)"/)?.[1] ?? 500);
+    const weightFactor = weight >= 700 ? 1.03 : weight >= 600 ? 1.015 : 1;
+    const letterSpacing = Number(
+      attributes.match(/\bletter-spacing="(-?[\d.]+)"/)?.[1] ?? 0,
+    );
+    const glyphWidth = characters.reduce((total, character) => {
+      if (mono) return total + size * 0.66;
+      if (character === " ") return total + size * 0.34;
+      if (/[ilI1.,:;|!'`]/.test(character)) return total + size * 0.38;
+      if (/[mw]/.test(character)) return total + size * 0.92;
+      if (/[MW@%&#]/.test(character)) return total + size;
+      if (/[A-Z0-9]/.test(character)) return total + size * 0.74;
+      if (/[-/()[\]]/.test(character)) return total + size * 0.46;
+      return total + size * 0.64;
+    }, 0);
+    const width =
+      glyphWidth * weightFactor + Math.max(0, characters.length - 1) * letterSpacing;
+
+    if (width > maximum) {
+      const kind = attributes.match(/\bdata-label-kind="([^"]+)"/)?.[1] ?? "text";
+      violations.push(
+        `${filename}: ${kind} width ${Math.round(width * 10) / 10} exceeds declared maximum ${maximum}`,
+      );
+    }
+  }
+
   const seenUnknownColors = new Set<string>();
   for (const match of svg.matchAll(/#[0-9a-fA-F]{6}\b/g)) {
     const color = match[0].toLowerCase();

--- a/site/scripts/generate-diagrams.ts
+++ b/site/scripts/generate-diagrams.ts
@@ -43,6 +43,8 @@ function label(
     family?: "sans" | "mono";
     letterSpacing?: number;
     annotation?: boolean;
+    kind?: "copy";
+    maxWidth?: number;
   } = {},
 ): string {
   const size = options.size ?? 14;
@@ -57,7 +59,9 @@ function label(
     `text-anchor="${options.anchor ?? "start"}"`,
   ];
   if (options.letterSpacing) attrs.push(`letter-spacing="${options.letterSpacing}"`);
-  if (options.annotation) attrs.push('data-label-kind="annotation"');
+  if (options.kind) attrs.push(`data-label-kind="${options.kind}"`);
+  else if (options.annotation) attrs.push('data-label-kind="annotation"');
+  if (options.maxWidth) attrs.push(`data-max-width="${options.maxWidth}"`);
   return `<text ${attrs.join(" ")}>${escapeXml(value)}</text>`;
 }
 
@@ -81,6 +85,7 @@ function card(
   accent: string = C.lineStrong,
 ): string {
   const titleLines = title.split("\n");
+  const subtitleLines = subtitle.split("\n");
   const titleY = subtitle ? y + 31 : y + height / 2 + 5 - ((titleLines.length - 1) * 9);
   return [
     `<rect x="${x}" y="${y}" width="${width}" height="${height}" rx="10" fill="${C.panel}" stroke="${accent}" stroke-width="2"/>`,
@@ -89,15 +94,17 @@ function card(
       color: C.white,
       weight: 700,
       anchor: "middle",
+      maxWidth: width - 24,
     }),
     subtitle
-      ? label(x + width / 2, y + height - 18, subtitle, {
+      ? multiline(x + width / 2, y + height - 18 - ((subtitleLines.length - 1) * 16), subtitleLines, {
           size: 12,
           color: C.muted,
           anchor: "middle",
           family: "mono",
           annotation: true,
-        })
+          maxWidth: width - 24,
+        }, 16)
       : "",
   ].join("\n");
 }
@@ -121,7 +128,25 @@ function elbow(
   return `<polyline points="${points.map(([x, y]) => `${x},${y}`).join(" ")}" fill="none" stroke="${color}" stroke-width="2.25"${dashed ? ' stroke-dasharray="7 6"' : ""} marker-end="url(#arrow)"/>`;
 }
 
+function declareCanvasTextBounds(body: string, width: number): string {
+  const inset = 24;
+  return body.replace(/<text\b(?<attributes>[^>]*)>/g, (tag, attributes: string) => {
+    if (/\bdata-max-width=/.test(attributes)) return tag;
+    const x = Number(attributes.match(/\bx="([\d.]+)"/)?.[1]);
+    if (!Number.isFinite(x)) return tag;
+    const anchor = attributes.match(/\btext-anchor="([^"]+)"/)?.[1] ?? "start";
+    const maximum =
+      anchor === "middle"
+        ? 2 * Math.min(x - inset, width - inset - x)
+        : anchor === "end"
+          ? x - inset
+          : width - inset - x;
+    return tag.replace(/>$/, ` data-max-width="${Math.max(1, Math.floor(maximum))}">`);
+  });
+}
+
 function shell(title: string, desc: string, width: number, height: number, body: string): string {
+  const boundedBody = declareCanvasTextBounds(body, width);
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" role="img" data-diagram-system="ca-v2">
   <title>${escapeXml(title)}</title>
   <desc>${escapeXml(desc)}</desc>
@@ -140,7 +165,7 @@ function shell(title: string, desc: string, width: number, height: number, body:
   <rect width="${width}" height="${height}" rx="14" fill="url(#canvas)"/>
   <rect width="${width}" height="${height}" rx="14" fill="url(#grid)"/>
   <rect x="1" y="1" width="${width - 2}" height="${height - 2}" rx="13" fill="none" stroke="${C.lineStrong}" stroke-width="2"/>
-  ${body}
+  ${boundedBody}
 </svg>
 `;
 }
@@ -187,6 +212,7 @@ function laneDiagram(title: string, desc: string, columns: LaneColumn[], note: s
         color: C.white,
         weight: 650,
         anchor: "middle",
+        maxWidth: columnWidth - 42,
       }));
     });
     if (index < columns.length - 1) {
@@ -246,16 +272,46 @@ function gateModel(): string {
     `<rect x="584" y="116" width="512" height="284" rx="14" fill="${C.panel}" stroke="${C.danger}" stroke-width="2"/>`,
     label(74, 154, "SOFT GATE", { size: 12, annotation: true, family: "mono", color: C.gold, weight: 750, letterSpacing: 1.8 }),
     label(614, 154, "HARD GATE", { size: 12, annotation: true, family: "mono", color: C.danger, weight: 750, letterSpacing: 1.8 }),
-    card(74, 184, 190, 94, "Decision surfaced", "waiting for user", C.gold),
+    card(74, 184, 190, 94, "Decision\nsurfaced", "waiting for user", C.gold),
     card(344, 184, 182, 94, "Work proceeds", "after user acts", C.positive),
     arrow(270, 231, 334, 231, C.gold),
-    label(300, 216, "human choice", { size: 12, annotation: true, family: "mono", color: C.muted, anchor: "middle" }),
+    label(300, 216, "DECISION", {
+      size: 12,
+      annotation: true,
+      family: "mono",
+      color: C.gold,
+      anchor: "middle",
+      letterSpacing: 0.8,
+      maxWidth: 70,
+    }),
     card(614, 184, 190, 94, "Stopped", "never auto-decided", C.danger),
-    card(884, 184, 182, 94, "User action", "required to continue", C.danger),
+    card(884, 184, 182, 94, "User action", "required\nto continue", C.danger),
     arrow(810, 231, 874, 231, C.danger),
-    label(840, 216, "hard stop", { size: 12, annotation: true, family: "mono", color: C.danger, anchor: "middle" }),
-    multiline(74, 322, ["Surfaces the exact choice.", "Resumes when the user decides."], { size: 14, color: C.text }),
-    multiline(614, 322, ["Security, auth/crypto, irreversible ops,", "gate bypass, and merge-to-default remain stops."], { size: 14, color: C.text }),
+    label(840, 216, "STOP", {
+      size: 12,
+      annotation: true,
+      family: "mono",
+      color: C.danger,
+      anchor: "middle",
+      letterSpacing: 0.8,
+      maxWidth: 36,
+    }),
+    multiline(74, 322, ["Surfaces the exact choice.", "Resumes when the user decides."], {
+      size: 14,
+      color: C.text,
+      kind: "copy",
+      maxWidth: 452,
+    }),
+    multiline(614, 322, [
+      "Security, auth/crypto, and irreversible ops stop.",
+      "Gate bypass and merge-to-default stop.",
+      "Only the user can clear the gate.",
+    ], {
+      size: 14,
+      color: C.text,
+      kind: "copy",
+      maxWidth: 452,
+    }),
     label(44, 436, "Frequent hard-gate trips indicate a thin specification, not a normal control loop.", {
       size: 12,
       annotation: true,
@@ -301,10 +357,10 @@ function fourTierMap(): string {
   const title = "File-to-knowledge priority map";
   const desc = "A file read is matched in priority order against security controls, accepted architecture decisions, approved specifications, and fresh provenance.";
   const tiers = [
-    ["1", "security-controls.md", "security-entry files", C.danger],
-    ["2", "decisions/", "accepted ADR governs glob", C.gold],
-    ["3", "specs/", "approved Governs header", C.info],
-    ["4", "provenance", "stored hash still matches", C.positive],
+    ["1", "security-\ncontrols.md", "security-entry\nfiles", C.danger],
+    ["2", "decisions/", "accepted ADR\ngoverns glob", C.gold],
+    ["3", "specs/", "approved Governs\nheader", C.info],
+    ["4", "provenance", "stored hash\nstill matches", C.positive],
   ] as const;
   const body = [
     label(42, 48, "JUST-IN-TIME CONTEXT", { size: 14, family: "mono", color: C.gold, weight: 750, letterSpacing: 2 }),
@@ -312,10 +368,9 @@ function fourTierMap(): string {
     card(42, 154, 188, 92, "Read(file)", "PreToolUse hook", C.info),
   ];
   tiers.forEach(([number, name, subtitle, tone], index) => {
-    const x = 300 + index * 205;
-    body.push(card(x, 132, 170, 136, `${number} · ${name}`, subtitle, tone));
+    const x = 300 + index * 200;
+    body.push(card(x, 132, 184, 136, `${number}\n${name}`, subtitle, tone));
     if (index === 0) body.push(arrow(236, 200, 290, 200, C.info));
-    if (index < tiers.length - 1) body.push(arrow(x + 176, 200, x + 195, 200, tone));
   });
   body.push(card(300, 310, 375, 82, "Inject highest-priority pointer", "budget ≤ 150 tokens", C.gold));
   body.push(card(710, 310, 375, 82, "No tier matches", "no injection · zero git calls", C.lineStrong));
@@ -330,7 +385,7 @@ function coreFanout(): string {
   const body = [
     label(42, 48, "BUILD-TIME GENERATION", { size: 14, family: "mono", color: C.gold, weight: 750, letterSpacing: 2 }),
     label(42, 78, "One source fans out only after the byte-identity gate.", { size: 18, color: C.white, weight: 700 }),
-    card(42, 190, 220, 110, "core/pysrc\ncore/surface", "shared hook core + surface", C.info),
+    card(42, 190, 220, 110, "core/pysrc\ncore/surface", "shared hook core\n+ surface", C.info),
     card(334, 190, 190, 110, "CI gate", "byte-identity check", C.gold),
     arrow(268, 245, 324, 245, C.info),
     card(604, 118, 220, 84, "ca", "Claude Code plugin", C.gold),
@@ -417,8 +472,18 @@ function twoAxisModel(): string {
     card(886, 224, 154, 76, "stable", "on by default", C.positive),
     arrow(760, 262, 876, 262, C.gold),
     label(818, 246, "evidence", { size: 12, annotation: true, family: "mono", color: C.muted, anchor: "middle" }),
-    multiline(72, 344, ["A version bump reaches every user.", "Governed by MAJOR · MINOR · PATCH."], { size: 14, color: C.text }),
-    multiline(600, 344, ["A preview can exist inside a stable release.", "Promotion requires real-world evidence."], { size: 14, color: C.text }),
+    multiline(72, 344, ["A version bump reaches every user.", "Governed by MAJOR · MINOR · PATCH."], {
+      size: 14,
+      color: C.text,
+      kind: "copy",
+      maxWidth: 440,
+    }),
+    multiline(600, 344, ["A preview can exist inside a stable release.", "Promotion requires real-world evidence."], {
+      size: 14,
+      color: C.text,
+      kind: "copy",
+      maxWidth: 440,
+    }),
   ];
   return shell(title, desc, 1112, 450, body.join("\n"));
 }

--- a/site/src/components/SplashDocsRail.astro
+++ b/site/src/components/SplashDocsRail.astro
@@ -16,7 +16,7 @@ const overviewHref = `${basePath}/overview/`;
   ></button>
 </div>
 
-<div class="ca-docs-tray" data-ca-docs-tray>
+<div class="ca-docs-tray not-content" data-ca-docs-tray>
   <aside
     class="ca-docs-drawer sidebar-pane not-content"
     id="ca-docs-drawer"

--- a/site/src/components/SplashDocsRail.astro
+++ b/site/src/components/SplashDocsRail.astro
@@ -7,21 +7,6 @@ const overviewHref = `${basePath}/overview/`;
 ---
 
 <ca-splash-docs>
-<div class="ca-docs-rail" data-ca-docs-rail>
-  <button
-    class="ca-docs-rail__opener"
-    type="button"
-    aria-controls="ca-docs-drawer"
-    aria-expanded="false"
-  >
-    <span class="ca-docs-rail__triangle" aria-hidden="true"></span>
-    <span class="ca-docs-rail__label">OPEN DOCS</span>
-  </button>
-  <noscript>
-    <a class="ca-docs-rail__fallback" href={overviewHref}>Open docs</a>
-  </noscript>
-</div>
-
 <div class="ca-docs-drawer-layer not-content" data-ca-docs-drawer-layer hidden>
   <button
     class="ca-docs-drawer__backdrop"
@@ -29,29 +14,17 @@ const overviewHref = `${basePath}/overview/`;
     aria-label="Close documentation navigation"
     data-ca-docs-drawer-close
   ></button>
+</div>
+
+<div class="ca-docs-tray" data-ca-docs-tray>
   <aside
     class="ca-docs-drawer"
     id="ca-docs-drawer"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="ca-docs-drawer-title"
+    aria-label="Documentation navigation"
     aria-hidden="true"
+    inert
     tabindex="-1"
   >
-    <div class="ca-docs-drawer__head">
-      <div>
-        <span>Documentation</span>
-        <strong id="ca-docs-drawer-title">Find your next move</strong>
-      </div>
-      <button
-        class="ca-docs-drawer__close"
-        type="button"
-        aria-label="Close documentation navigation"
-        data-ca-docs-drawer-close
-      >
-        <span aria-hidden="true">×</span>
-      </button>
-    </div>
     <nav class="ca-docs-drawer__nav" aria-label="Documentation sections">
       {
         sidebar.length > 0 ? (
@@ -62,6 +35,20 @@ const overviewHref = `${basePath}/overview/`;
       }
     </nav>
   </aside>
+  <button
+    class="ca-docs-rail__opener"
+    type="button"
+    aria-label="Open documentation navigation"
+    aria-controls="ca-docs-drawer"
+    aria-expanded="false"
+  >
+    <span class="ca-docs-rail__triangle" aria-hidden="true"></span>
+    <span class="ca-docs-rail__label ca-docs-rail__label--open">OPEN DOCS</span>
+    <span class="ca-docs-rail__label ca-docs-rail__label--close">CLOSE DOCS</span>
+  </button>
+  <noscript>
+    <a class="ca-docs-rail__fallback" href={overviewHref}>Open docs</a>
+  </noscript>
 </div>
 </ca-splash-docs>
 
@@ -72,13 +59,13 @@ const overviewHref = `${basePath}/overview/`;
     connectedCallback(): void {
       if (this.dataset.initialized === "true") return;
 
-      const rail = this.querySelector<HTMLElement>("[data-ca-docs-rail]");
-      const opener = rail?.querySelector<HTMLButtonElement>(".ca-docs-rail__opener");
+      const tray = this.querySelector<HTMLElement>("[data-ca-docs-tray]");
+      const opener = tray?.querySelector<HTMLButtonElement>(".ca-docs-rail__opener");
       const layer = this.querySelector<HTMLElement>("[data-ca-docs-drawer-layer]");
       const drawer = this.querySelector<HTMLElement>("#ca-docs-drawer");
       const closeControls =
         layer?.querySelectorAll<HTMLButtonElement>("[data-ca-docs-drawer-close]");
-      if (!rail || !opener || !layer || !drawer || !closeControls) return;
+      if (!tray || !opener || !layer || !drawer || !closeControls) return;
 
       this.dataset.initialized = "true";
       let previousBodyOverflow = "";
@@ -99,10 +86,11 @@ const overviewHref = `${basePath}/overview/`;
       ].join(",");
 
       const getFocusableElements = (): HTMLElement[] =>
-        [...drawer.querySelectorAll<HTMLElement>(focusableSelector)].filter(
+        [...tray.querySelectorAll<HTMLElement>(focusableSelector)].filter(
           (element) =>
             !element.hasAttribute("hidden") &&
             element.getAttribute("aria-hidden") !== "true" &&
+            !element.closest("[inert]") &&
             element.getClientRects().length > 0,
         );
 
@@ -141,8 +129,13 @@ const overviewHref = `${basePath}/overview/`;
         previousBodyOverflow = document.body.style.overflow;
         layer.hidden = false;
         drawer.setAttribute("aria-hidden", "false");
+        drawer.inert = false;
         opener.setAttribute("aria-expanded", "true");
-        rail.dataset.open = "true";
+        opener.setAttribute("aria-label", "Close documentation navigation");
+        tray.setAttribute("role", "dialog");
+        tray.setAttribute("aria-modal", "true");
+        tray.setAttribute("aria-label", "Documentation navigation");
+        tray.dataset.open = "true";
         document.body.style.overflow = "hidden";
         setBackgroundInert(true);
         const [first] = getFocusableElements();
@@ -154,8 +147,13 @@ const overviewHref = `${basePath}/overview/`;
       ): void => {
         layer.hidden = true;
         drawer.setAttribute("aria-hidden", "true");
+        drawer.inert = true;
         opener.setAttribute("aria-expanded", "false");
-        delete rail.dataset.open;
+        opener.setAttribute("aria-label", "Open documentation navigation");
+        tray.removeAttribute("role");
+        tray.removeAttribute("aria-modal");
+        tray.removeAttribute("aria-label");
+        delete tray.dataset.open;
         document.body.style.overflow = previousBodyOverflow;
         setBackgroundInert(false);
         if (options.restoreFocus !== false) opener.focus();
@@ -191,7 +189,7 @@ const overviewHref = `${basePath}/overview/`;
       closeControls.forEach((control) =>
         control.addEventListener("click", () => closeDrawer()),
       );
-      drawer.addEventListener("keydown", trapFocus);
+      tray.addEventListener("keydown", trapFocus);
       document.addEventListener("keydown", handleEscape);
 
       this.cleanup = () => {

--- a/site/src/components/SplashDocsRail.astro
+++ b/site/src/components/SplashDocsRail.astro
@@ -1,5 +1,5 @@
 ---
-import SidebarSublist from "./SidebarSublist.astro";
+import Sidebar from "./Sidebar.astro";
 
 const { sidebar } = Astro.locals.starlightRoute;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -18,22 +18,22 @@ const overviewHref = `${basePath}/overview/`;
 
 <div class="ca-docs-tray" data-ca-docs-tray>
   <aside
-    class="ca-docs-drawer"
+    class="ca-docs-drawer sidebar-pane not-content"
     id="ca-docs-drawer"
     aria-label="Documentation navigation"
     aria-hidden="true"
     inert
     tabindex="-1"
   >
-    <nav class="ca-docs-drawer__nav" aria-label="Documentation sections">
+    <div class="sidebar-content sl-flex">
       {
         sidebar.length > 0 ? (
-          <SidebarSublist sublist={sidebar} />
+          <Sidebar />
         ) : (
           <a class="ca-docs-drawer__direct" href={overviewHref}>What Is codeArbiter</a>
         )
       }
-    </nav>
+    </div>
   </aside>
   <button
     class="ca-docs-rail__opener"

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -59,11 +59,12 @@ ca-splash-docs {
 
 .ca-docs-tray {
   --ca-docs-handle-width: 38px;
-  --ca-docs-drawer-width: 292px;
+  --ca-docs-drawer-width: 300px;
   position: fixed;
   z-index: 65;
   inset-block: var(--sl-nav-height) 0;
   inset-inline-start: 0;
+  margin: 0;
   display: grid;
   grid-template-columns: var(--ca-docs-drawer-width) var(--ca-docs-handle-width);
   width: calc(var(--ca-docs-drawer-width) + var(--ca-docs-handle-width));
@@ -140,6 +141,7 @@ ca-splash-docs {
   position: fixed;
   z-index: 60;
   inset: var(--sl-nav-height) 0 0;
+  margin: 0;
 }
 
 .ca-docs-drawer-layer[hidden] {
@@ -161,96 +163,19 @@ ca-splash-docs {
   width: 100%;
   height: 100%;
   overflow-y: auto;
-  border-inline-end: 1px solid var(--ca-line-strong);
-  color: var(--ca-ink-soft);
-  background:
-    linear-gradient(180deg, rgb(240 185 47 / 5%), transparent 13rem),
-    var(--ca-bg-raised);
+  scrollbar-gutter: stable;
+  border-inline-end: 1px solid var(--sl-color-hairline-shade);
 }
 
 .ca-docs-tray[data-open="true"] .ca-docs-drawer {
   box-shadow: 24px 0 70px rgb(0 0 0 / 48%);
 }
 
-.ca-docs-drawer__nav {
-  padding: 1rem 0.75rem 2rem;
-}
-
-.ca-docs-drawer__nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.ca-docs-drawer__nav .top-level > li + li {
-  margin-block-start: 0.25rem;
-}
-
-.ca-docs-drawer__nav .top-level > li {
-  padding-block-end: 0.3rem;
-  border-block-end: 1px solid rgb(58 76 96 / 42%);
-}
-
-.ca-docs-drawer__nav summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.65rem;
-  padding: 0.65rem 0.7rem;
-  border-radius: var(--ca-radius-sm);
-  list-style: none;
-  cursor: pointer;
-}
-
-.ca-docs-drawer__nav summary:hover {
-  background: rgb(255 255 255 / 2.5%);
-}
-
-.ca-docs-drawer__nav summary::marker,
-.ca-docs-drawer__nav summary::-webkit-details-marker {
-  display: none;
-  content: "";
-}
-
-.ca-docs-drawer__nav summary::before {
-  content: none;
-  display: none;
-}
-
-.ca-docs-drawer__nav summary .caret {
-  flex: 0 0 auto;
-  margin-inline-start: auto;
-}
-
-.ca-docs-drawer__nav ul ul {
-  padding: 0.15rem 0 0.45rem 2.55rem;
-}
-
-.ca-docs-drawer__nav ul ul li {
-  margin-inline-start: 0;
-  padding-inline-start: 0;
-  border-inline-start: 0;
-}
-
-.ca-docs-drawer__nav ul ul a {
-  padding: 0.4rem 0.6rem;
-  color: var(--ca-ink-muted);
-  font-size: 0.81rem;
-  line-height: 1.35;
-}
-
-.ca-docs-drawer__nav ul ul a:hover,
-.ca-docs-drawer__nav ul ul a:focus-visible {
-  color: var(--ca-ink);
-}
-
-.ca-docs-drawer__nav .top-level > li > details > summary .large {
-  font-size: 0.91rem;
-}
-
-.ca-docs-drawer__nav .group-icon {
-  width: 1.8rem;
-  height: 1.8rem;
+.ca-docs-drawer .sidebar-content {
+  min-height: max-content;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1rem 0;
 }
 
 .ca-docs-drawer__direct {
@@ -899,7 +824,7 @@ ca-splash-docs {
 
   .ca-docs-tray {
     --ca-docs-handle-width: 31px;
-    --ca-docs-drawer-width: min(292px, calc(100vw - 31px));
+    --ca-docs-drawer-width: min(300px, calc(100vw - 31px));
   }
 
   .ca-docs-rail__label {

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -34,7 +34,7 @@
 .ca-landing::before {
   position: fixed;
   z-index: 0;
-  inset: 4rem 0 0;
+  inset: var(--sl-nav-height) 0 0;
   background-color: var(--ca-bg);
   background-image:
     linear-gradient(90deg, rgb(9 13 18 / 96%) 0%, rgb(9 13 18 / 66%) 45%, rgb(9 13 18 / 82%) 100%),
@@ -57,16 +57,22 @@ ca-splash-docs {
   display: contents;
 }
 
-.ca-docs-rail {
+.ca-docs-tray {
+  --ca-docs-handle-width: 38px;
+  --ca-docs-drawer-width: 292px;
   position: fixed;
   z-index: 65;
-  inset-block: 4rem 0;
+  inset-block: var(--sl-nav-height) 0;
   inset-inline-start: 0;
-  width: 38px;
-  border-inline-end: 1px solid rgb(58 76 96 / 72%);
-  background: rgb(10 15 21 / 92%);
-  box-shadow: 10px 0 30px rgb(0 0 0 / 18%);
-  backdrop-filter: blur(14px);
+  display: grid;
+  grid-template-columns: var(--ca-docs-drawer-width) var(--ca-docs-handle-width);
+  width: calc(var(--ca-docs-drawer-width) + var(--ca-docs-handle-width));
+  transform: translateX(calc(-1 * var(--ca-docs-drawer-width)));
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ca-docs-tray[data-open="true"] {
+  transform: translateX(0);
 }
 
 .ca-docs-rail__opener {
@@ -78,8 +84,11 @@ ca-splash-docs {
   gap: 0.85rem;
   padding: 1.1rem 0;
   border: 0;
+  border-inline: 1px solid rgb(58 76 96 / 72%);
   color: var(--ca-brand-bright);
-  background: transparent;
+  background: rgb(10 15 21 / 94%);
+  box-shadow: 10px 0 30px rgb(0 0 0 / 18%);
+  backdrop-filter: blur(14px);
   cursor: pointer;
 }
 
@@ -88,15 +97,15 @@ ca-splash-docs {
 }
 
 .ca-docs-rail__triangle {
-  width: 0;
-  height: 0;
-  border-block: 5px solid transparent;
-  border-inline-start: 7px solid currentColor;
-  transition: transform 160ms ease;
+  font: 800 0.8rem/1 var(--ca-font-mono);
 }
 
-.ca-docs-rail[data-open="true"] .ca-docs-rail__triangle {
-  transform: rotate(180deg);
+.ca-docs-rail__triangle::before {
+  content: ">";
+}
+
+.ca-docs-tray[data-open="true"] .ca-docs-rail__triangle::before {
+  content: "<";
 }
 
 .ca-docs-rail__label {
@@ -106,9 +115,23 @@ ca-splash-docs {
   writing-mode: vertical-rl;
 }
 
+.ca-docs-rail__label--close {
+  display: none;
+}
+
+.ca-docs-tray[data-open="true"] .ca-docs-rail__label--open {
+  display: none;
+}
+
+.ca-docs-tray[data-open="true"] .ca-docs-rail__label--close {
+  display: inline;
+}
+
 .ca-docs-rail__fallback {
   position: absolute;
-  inset: 0;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: var(--ca-docs-handle-width);
   overflow: hidden;
   text-indent: -999px;
 }
@@ -116,9 +139,7 @@ ca-splash-docs {
 .ca-docs-drawer-layer {
   position: fixed;
   z-index: 60;
-  inset-block: 4rem 0;
-  inset-inline-end: 0;
-  inset-inline-start: 38px;
+  inset: var(--sl-nav-height) 0 0;
 }
 
 .ca-docs-drawer-layer[hidden] {
@@ -136,67 +157,23 @@ ca-splash-docs {
 }
 
 .ca-docs-drawer {
-  position: absolute;
-  z-index: 1;
-  inset-block: 0;
-  inset-inline-start: 0;
-  width: 292px;
+  position: relative;
+  width: 100%;
+  height: 100%;
   overflow-y: auto;
   border-inline-end: 1px solid var(--ca-line-strong);
   color: var(--ca-ink-soft);
   background:
     linear-gradient(180deg, rgb(240 185 47 / 5%), transparent 13rem),
     var(--ca-bg-raised);
+}
+
+.ca-docs-tray[data-open="true"] .ca-docs-drawer {
   box-shadow: 24px 0 70px rgb(0 0 0 / 48%);
 }
 
-.ca-docs-drawer__head {
-  position: sticky;
-  z-index: 2;
-  top: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1rem 0.9rem 1.25rem;
-  border-block-end: 1px solid var(--ca-line);
-  background: rgb(14 20 28 / 94%);
-  backdrop-filter: blur(14px);
-}
-
-.ca-docs-drawer__head span {
-  display: block;
-  color: var(--ca-brand);
-  font: 750 0.65rem/1.2 var(--ca-font-mono);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.ca-docs-drawer__head strong {
-  display: block;
-  margin-block-start: 0.25rem;
-  color: var(--ca-ink);
-  font-size: 0.9rem;
-}
-
-.ca-docs-drawer__close {
-  display: grid;
-  width: 2.25rem;
-  height: 2.25rem;
-  place-items: center;
-  border: 1px solid var(--ca-line);
-  border-radius: var(--ca-radius-sm);
-  color: var(--ca-ink-soft);
-  background: var(--ca-bg-panel);
-  cursor: pointer;
-}
-
-.ca-docs-drawer__close span {
-  color: inherit;
-  font: 400 1.45rem/1 var(--ca-font-sans);
-}
-
 .ca-docs-drawer__nav {
-  padding: 0.65rem 0.55rem 2rem;
+  padding: 1rem 0.75rem 2rem;
 }
 
 .ca-docs-drawer__nav ul {
@@ -233,6 +210,11 @@ ca-splash-docs {
 .ca-docs-drawer__nav summary::-webkit-details-marker {
   display: none;
   content: "";
+}
+
+.ca-docs-drawer__nav summary::before {
+  content: none;
+  display: none;
 }
 
 .ca-docs-drawer__nav summary .caret {
@@ -915,21 +897,15 @@ ca-splash-docs {
     background-position: 57% top;
   }
 
-  .ca-docs-rail {
-    width: 31px;
-  }
-
-  .ca-docs-drawer-layer {
-    inset-inline-start: 31px;
+  .ca-docs-tray {
+    --ca-docs-handle-width: 31px;
+    --ca-docs-drawer-width: min(292px, calc(100vw - 31px));
   }
 
   .ca-docs-rail__label {
     font-size: 0.56rem;
   }
 
-  .ca-docs-drawer {
-    width: min(292px, calc(100vw - 31px));
-  }
 }
 
 @media (max-width: 22rem) {
@@ -943,6 +919,10 @@ ca-splash-docs {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .ca-docs-tray {
+    transition: none;
+  }
+
   .ca-lane-card {
     transition: none;
   }

--- a/site/test/generator/diagrams.test.ts
+++ b/site/test/generator/diagrams.test.ts
@@ -186,4 +186,24 @@ describe("concept diagrams (AC-9)", () => {
       ),
     ]);
   });
+
+  it("decodes XML entities exactly once when estimating text width", () => {
+    const svg = `<svg data-diagram-system="ca-v2">
+      <title>Entity decoding fixture</title>
+      <desc>Exercises escaped entity text without double decoding it.</desc>
+      <text
+        x="10"
+        y="20"
+        font-family="Manrope Variable, Segoe UI, Arial, sans-serif"
+        font-size="14"
+        data-max-width="20"
+      >&amp;lt;</text>
+    </svg>`;
+
+    expect(auditDiagram(svg, "entity-decoding.svg")).toEqual([
+      expect.stringMatching(
+        /^entity-decoding\.svg: text width \d+(?:\.\d+)? exceeds declared maximum 20$/,
+      ),
+    ]);
+  });
 });

--- a/site/test/generator/diagrams.test.ts
+++ b/site/test/generator/diagrams.test.ts
@@ -132,4 +132,58 @@ describe("concept diagrams (AC-9)", () => {
       expect(designSystem).toContain(token);
     }
   });
+
+  it("rejects copy that exceeds a generator-declared safe text width", () => {
+    const svg = `<svg data-diagram-system="ca-v2">
+      <title>Bounds fixture</title>
+      <desc>Exercises generated copy bounds.</desc>
+      <text
+        x="10"
+        y="20"
+        font-family="Manrope Variable, Segoe UI, Arial, sans-serif"
+        font-size="14"
+        fill="#c7d0da"
+        data-label-kind="copy"
+        data-max-width="40"
+      >This sentence cannot fit.</text>
+    </svg>`;
+
+    expect(auditDiagram(svg, "bounds-fixture.svg")).toEqual([
+      expect.stringMatching(
+        /^bounds-fixture\.svg: copy width \d+(?:\.\d+)? exceeds declared maximum 40$/,
+      ),
+    ]);
+  });
+
+  it("requires a declared safe width on every generated text node", () => {
+    const svg = `<svg data-diagram-system="ca-v2">
+      <title>Missing bounds fixture</title>
+      <desc>Exercises missing generated text bounds.</desc>
+      <text x="10" y="20" font-family="Arial, sans-serif" font-size="14">Unbounded</text>
+    </svg>`;
+
+    expect(auditDiagram(svg, "missing-bounds.svg")).toContain(
+      "missing-bounds.svg: text has no declared maximum width",
+    );
+  });
+
+  it("uses conservative fallback-font metrics for wide proportional glyphs", () => {
+    const svg = `<svg data-diagram-system="ca-v2">
+      <title>Fallback metrics fixture</title>
+      <desc>Exercises wide glyphs in permitted fallback fonts.</desc>
+      <text
+        x="10"
+        y="20"
+        font-family="Manrope Variable, Segoe UI, Arial, sans-serif"
+        font-size="14"
+        data-max-width="32"
+      >mmmm</text>
+    </svg>`;
+
+    expect(auditDiagram(svg, "fallback-metrics.svg")).toEqual([
+      expect.stringMatching(
+        /^fallback-metrics\.svg: text width \d+(?:\.\d+)? exceeds declared maximum 32$/,
+      ),
+    ]);
+  });
 });

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -40,11 +40,15 @@ describe("first-class product splash", () => {
     );
   });
 
-  it("opens the canonical docs sidebar from the moving edge of one splash tray", () => {
+  it("opens the canonical docs sidebar component from the moving edge of one splash tray", () => {
     expect(indexMdx).toContain("import SplashDocsRail");
     expect(indexMdx).toContain("<SplashDocsRail />");
     expect(docsRail).toContain("Astro.locals.starlightRoute");
-    expect(docsRail).toContain("<SidebarSublist sublist={sidebar} />");
+    expect(docsRail).toContain('import Sidebar from "./Sidebar.astro"');
+    expect(docsRail).toContain('<div class="sidebar-content sl-flex">');
+    expect(docsRail).toContain("<Sidebar />");
+    expect(docsRail).not.toContain("<SidebarSublist");
+    expect(docsRail).not.toContain('<nav aria-label="Documentation sections">');
     expect(docsRail).toContain('class="ca-docs-tray"');
     expect(docsRail).toContain('aria-controls="ca-docs-drawer"');
     expect(docsRail).toContain('aria-expanded="false"');
@@ -84,10 +88,13 @@ describe("first-class product splash", () => {
 
   it("slides the tray and its literal right-edge control as one unit", () => {
     expect(landingCss).toMatch(
-      /\.ca-docs-tray\s*\{[^}]*--ca-docs-handle-width:\s*38px;[^}]*--ca-docs-drawer-width:\s*292px;/s,
+      /\.ca-docs-tray\s*\{[^}]*--ca-docs-handle-width:\s*38px;[^}]*--ca-docs-drawer-width:\s*300px;/s,
     );
     expect(landingCss).toMatch(
-      /\.ca-docs-tray\s*\{[^}]*inset-block:\s*var\(--sl-nav-height\) 0;/s,
+      /\.ca-docs-tray\s*\{[^}]*inset-block:\s*var\(--sl-nav-height\) 0;[^}]*margin:\s*0;/s,
+    );
+    expect(landingCss).toMatch(
+      /\.ca-docs-drawer-layer\s*\{[^}]*inset:\s*var\(--sl-nav-height\) 0 0;[^}]*margin:\s*0;/s,
     );
     expect(landingCss).toMatch(
       /\.ca-docs-tray\s*\{[^}]*grid-template-columns:\s*var\(--ca-docs-drawer-width\) var\(--ca-docs-handle-width\);/s,
@@ -103,7 +110,7 @@ describe("first-class product splash", () => {
       /\.ca-landing::before\s*\{[^}]*inset:\s*var\(--sl-nav-height\) 0 0;/s,
     );
     expect(landingCss).toMatch(
-      /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-docs-tray\s*\{[^}]*--ca-docs-handle-width:\s*31px;[^}]*--ca-docs-drawer-width:\s*min\(292px, calc\(100vw - 31px\)\);/,
+      /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-docs-tray\s*\{[^}]*--ca-docs-handle-width:\s*31px;[^}]*--ca-docs-drawer-width:\s*min\(300px, calc\(100vw - 31px\)\);/,
     );
     expect(landingCss).toMatch(
       /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-landing\s*\{[^}]*padding-inline-start:\s*31px;/,
@@ -113,26 +120,16 @@ describe("first-class product splash", () => {
     );
   });
 
-  it("gives the reused sidebar tree a compact drawer-specific presentation", () => {
+  it("does not fork the canonical sidebar presentation inside the splash drawer", () => {
+    expect(landingCss).not.toContain(".ca-docs-drawer__nav");
     expect(landingCss).toMatch(
-      /\.ca-docs-drawer__nav ul ul li\s*\{[^}]*border-inline-start:\s*0;/s,
+      /\.ca-docs-drawer\s*\{[^}]*scrollbar-gutter:\s*stable;/s,
     );
     expect(landingCss).toMatch(
-      /\.ca-docs-drawer__nav summary\s*\{[^}]*list-style:\s*none;/s,
-    );
-    expect(landingCss).toMatch(
-      /\.ca-docs-drawer__nav summary::before\s*\{[^}]*content:\s*none;[^}]*display:\s*none;/s,
-    );
-    expect(landingCss).toMatch(
-      /\.ca-docs-drawer__nav summary\s*\{[^}]*display:\s*flex;[^}]*justify-content:\s*space-between;/s,
-    );
-    expect(landingCss).toMatch(
-      /\.ca-docs-drawer__nav summary \.caret\s*\{[^}]*margin-inline-start:\s*auto;/s,
+      /\.ca-docs-drawer\s*\{[^}]*border-inline-end:\s*1px solid var\(--sl-color-hairline-shade\);/s,
     );
     expect(docsRail).toContain('class="ca-docs-drawer-layer not-content"');
-    expect(landingCss).toMatch(
-      /\.ca-docs-drawer__nav ul ul a\s*\{[^}]*padding:/s,
-    );
+    expect(docsRail).toContain('class="ca-docs-drawer sidebar-pane not-content"');
     expect(docsRail).toContain('tray.dataset.open = "true"');
     expect(docsRail).toContain("delete tray.dataset.open");
     expect(docsRail).toContain('opener.setAttribute("aria-label", "Close documentation navigation")');

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -40,18 +40,24 @@ describe("first-class product splash", () => {
     );
   });
 
-  it("opens the canonical docs sidebar from a persistent splash-only rail", () => {
+  it("opens the canonical docs sidebar from the moving edge of one splash tray", () => {
     expect(indexMdx).toContain("import SplashDocsRail");
     expect(indexMdx).toContain("<SplashDocsRail />");
     expect(docsRail).toContain("Astro.locals.starlightRoute");
     expect(docsRail).toContain("<SidebarSublist sublist={sidebar} />");
+    expect(docsRail).toContain('class="ca-docs-tray"');
     expect(docsRail).toContain('aria-controls="ca-docs-drawer"');
     expect(docsRail).toContain('aria-expanded="false"');
     expect(docsRail).toContain('id="ca-docs-drawer"');
-    expect(docsRail).toContain('aria-labelledby="ca-docs-drawer-title"');
-    expect(docsRail).toContain('role="dialog"');
-    expect(docsRail).toContain('aria-modal="true"');
+    expect(docsRail).not.toMatch(/<aside[\s\S]*?role="dialog"/);
+    expect(docsRail).toContain('tray.setAttribute("role", "dialog")');
+    expect(docsRail).toContain('tray.setAttribute("aria-modal", "true")');
+    expect(docsRail).toContain('tray.removeAttribute("role")');
+    expect(docsRail).toContain('tray.removeAttribute("aria-modal")');
     expect(docsRail).toContain("OPEN DOCS");
+    expect(docsRail).toContain("CLOSE DOCS");
+    expect(docsRail).not.toContain("Find your next move");
+    expect(docsRail).not.toContain("ca-docs-drawer__close");
   });
 
   it("keeps the docs drawer keyboard-safe and restores page state when it closes", () => {
@@ -76,21 +82,35 @@ describe("first-class product splash", () => {
     expect(docsRail).toContain("overview/");
   });
 
-  it("uses the approved rail and drawer dimensions", () => {
-    expect(landingCss).toMatch(/\.ca-docs-rail\s*\{[^}]*width:\s*38px;/s);
-    expect(landingCss).toMatch(/\.ca-docs-drawer-layer\s*\{[^}]*inset-inline-start:\s*38px;/s);
-    expect(landingCss).toMatch(/\.ca-landing\s*\{[^}]*padding-inline-start:\s*38px;/s);
-    expect(landingCss).toMatch(/\.ca-docs-drawer\s*\{[^}]*width:\s*292px;/s);
+  it("slides the tray and its literal right-edge control as one unit", () => {
     expect(landingCss).toMatch(
-      /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-docs-rail\s*\{[^}]*width:\s*31px;/,
+      /\.ca-docs-tray\s*\{[^}]*--ca-docs-handle-width:\s*38px;[^}]*--ca-docs-drawer-width:\s*292px;/s,
     );
     expect(landingCss).toMatch(
-      /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-docs-drawer-layer\s*\{[^}]*inset-inline-start:\s*31px;/,
+      /\.ca-docs-tray\s*\{[^}]*inset-block:\s*var\(--sl-nav-height\) 0;/s,
+    );
+    expect(landingCss).toMatch(
+      /\.ca-docs-tray\s*\{[^}]*grid-template-columns:\s*var\(--ca-docs-drawer-width\) var\(--ca-docs-handle-width\);/s,
+    );
+    expect(landingCss).toMatch(
+      /\.ca-docs-tray\s*\{[^}]*transform:\s*translateX\(calc\(-1 \* var\(--ca-docs-drawer-width\)\)\);/s,
+    );
+    expect(landingCss).toMatch(
+      /\.ca-docs-tray\[data-open="true"\]\s*\{[^}]*transform:\s*translateX\(0\);/s,
+    );
+    expect(landingCss).toMatch(/\.ca-landing\s*\{[^}]*padding-inline-start:\s*38px;/s);
+    expect(landingCss).toMatch(
+      /\.ca-landing::before\s*\{[^}]*inset:\s*var\(--sl-nav-height\) 0 0;/s,
+    );
+    expect(landingCss).toMatch(
+      /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-docs-tray\s*\{[^}]*--ca-docs-handle-width:\s*31px;[^}]*--ca-docs-drawer-width:\s*min\(292px, calc\(100vw - 31px\)\);/,
     );
     expect(landingCss).toMatch(
       /@media\s*\(max-width:\s*48rem\)[\s\S]*?\.ca-landing\s*\{[^}]*padding-inline-start:\s*31px;/,
     );
-    expect(landingCss).toContain("min(292px, calc(100vw - 31px))");
+    expect(landingCss).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*?\.ca-docs-tray\s*\{[^}]*transition:\s*none;/,
+    );
   });
 
   it("gives the reused sidebar tree a compact drawer-specific presentation", () => {
@@ -99,6 +119,9 @@ describe("first-class product splash", () => {
     );
     expect(landingCss).toMatch(
       /\.ca-docs-drawer__nav summary\s*\{[^}]*list-style:\s*none;/s,
+    );
+    expect(landingCss).toMatch(
+      /\.ca-docs-drawer__nav summary::before\s*\{[^}]*content:\s*none;[^}]*display:\s*none;/s,
     );
     expect(landingCss).toMatch(
       /\.ca-docs-drawer__nav summary\s*\{[^}]*display:\s*flex;[^}]*justify-content:\s*space-between;/s,
@@ -110,8 +133,10 @@ describe("first-class product splash", () => {
     expect(landingCss).toMatch(
       /\.ca-docs-drawer__nav ul ul a\s*\{[^}]*padding:/s,
     );
-    expect(docsRail).toContain('rail.dataset.open = "true"');
-    expect(docsRail).toContain("delete rail.dataset.open");
+    expect(docsRail).toContain('tray.dataset.open = "true"');
+    expect(docsRail).toContain("delete tray.dataset.open");
+    expect(docsRail).toContain('opener.setAttribute("aria-label", "Close documentation navigation")');
+    expect(docsRail).toContain('opener.setAttribute("aria-label", "Open documentation navigation")');
     expect(docsRail).toContain("layer.hidden ? openDrawer() : closeDrawer()");
   });
 

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -49,7 +49,7 @@ describe("first-class product splash", () => {
     expect(docsRail).toContain("<Sidebar />");
     expect(docsRail).not.toContain("<SidebarSublist");
     expect(docsRail).not.toContain('<nav aria-label="Documentation sections">');
-    expect(docsRail).toContain('class="ca-docs-tray"');
+    expect(docsRail).toContain('class="ca-docs-tray not-content"');
     expect(docsRail).toContain('aria-controls="ca-docs-drawer"');
     expect(docsRail).toContain('aria-expanded="false"');
     expect(docsRail).toContain('id="ca-docs-drawer"');


### PR DESCRIPTION
## Summary

- replace the splash overlay with one sliding documentation tray whose `OPEN DOCS >` edge moves with it and becomes `CLOSE DOCS <`
- preserve the real collapsible docs tree without the redundant title bar, top gap, duplicate chevrons, or navigation lifecycle failure
- make the open tray a complete modal boundary, including its visible close handle and focus loop
- regenerate all 15 operational diagrams with explicit text bounds, conservative fallback-font measurement, and layouts that do not clip or intrude into neighboring cards
- repair the invalid Pi promotion workflow expression from Actions run 30583803823 by binding receipt state from `$RUNNER_TEMP` inside the runner before checkout
- ensure workflow-only Pi promotion changes select the CI job that executes their regression suite

## Verification

- `python .github/scripts/test_pi_promotion.py` — 31 passed
- `python .github/scripts/test_ci_impact.py` — 54 passed
- docs contract + site voice checks — passed
- `python tools/sync-core.py --check` — passed
- `python tools/build-surface.py --check` — passed
- `npm run typecheck` — passed
- `npm test` — 495 passed
- `npm run coverage` — passed
- `npm run build` — 134 pages built
- `npm run link-audit` — 20,057 internal links resolved
- `npm run audit:diagrams` — passed
- browser QA — desktop and 390px tray states, keyboard lifecycle, navigation/back recovery, and rendered bounds for every text node across all 15 diagrams
- adversarial follow-up review — clean

Draft by design; do not merge until hosted checks are green on this exact head.