### PR TITLE
feat(tdd): rationalization guard at the red gate, evidence lenses in skill-author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.11.7] — 2026-08-05
+
+### Changed
+
+- `tdd` Phase 2 gains a rationalization guard: the four known excuses for
+  skipping the red test ("too simple to fail first", test-after equivalence,
+  "would restate the implementation", "already covered") paired with their
+  rebuttals — the already-covered rebuttal carrying its own falsifying
+  instrument. A/B-validated against the prior skill before shipping (7/7 hard
+  requirements both arms, zero over-blocking, sharper domain grounding).
+- `skill-author` Phase 4 adopts the evidence-lens checklist (issue #612):
+  rationalization guards at tempting gates, instruments over self-report,
+  recommendation with counter-case, mechanize-don't-accrete, and
+  letter-vs-spirit — plus A/B validation for behavior-changing gate revisions.
+
 ## [2.11.6] — 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.11.6" src="https://img.shields.io/badge/version-2.11.6-2b7489">
+<img alt="version 2.11.7" src="https://img.shields.io/badge/version-2.11.7-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-40-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">
@@ -119,7 +119,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.4.5`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.4.6`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/surface/skills/skill-author/SKILL.md
+++ b/core/surface/skills/skill-author/SKILL.md
@@ -70,6 +70,13 @@ Re-read the authored skill against the v2 quality bar. Each line below is a chec
 - **No duplicated rules** — a rule stated in a phase is not restated in Hard rules, and Hard rules carry no duplicates. State each rule once.
 - **Format conformance** — frontmatter is `name`+`description` only; H1 matches `name`; phases are numbered with `· gate:`; paths use `{{PLUGIN_ROOT}}` / `{{PROJECT_DIR}}` correctly; no cut docs/skills, no legacy `${FRAMEWORK_ROOT}`/`${PROJECT_ROOT}`/`.agents/` paths.
 - **No trigger language** — "routed to" / "dispatched" only, and no `## Trigger` disclaimer block.
+- **Evidence lenses** (issue #612) — each checked where the skill's shape triggers it, skipped where it does not:
+  - A gate an agent is tempted to skip carries a rationalization guard AT the decision point — the known excuses paired with rebuttals. The best rebuttal carries its own instrument: a check the agent can run that falsifies the excuse either way. A tempting gate with no guard is a defect.
+  - An acceptance or verification step names what is READ, never what is claimed — "the subagent reports green" is a defect; "the runner's output shows green" is not.
+  - A user-facing ask leads with a recommendation AND its strongest counter-consideration.
+  - A rule a tested helper could enforce is mechanized rather than accreted as prose — the helper enforces, the prose explains.
+  - A rule whose literal reading has an exploitable edge names what it protects.
+- **Behavior-changing gate revisions are validated, not assumed** — an A/B pass (fixed scenarios, rubrics written before any output exists, both versions run under identical conditions) scaled to the change's blast radius, with results recorded in the PR (issue #612's method).
 
 Compile the findings, fix each, and re-read once. Present the corrected skill and the findings list to the user.
 

--- a/core/surface/skills/tdd/SKILL.md
+++ b/core/surface/skills/tdd/SKILL.md
@@ -49,6 +49,16 @@ Reject the standard traps: asserting on a mock instead of behavior; a test that 
 snapshot so broad it asserts nothing; coupling to an implementation detail instead of observable
 behavior; asserting on the framework's behavior rather than your own.
 
+The reasons to skip red are known. Hearing one is the tell that this gate is about to be waived —
+never the license to waive it:
+
+| excuse | reality |
+|---|---|
+| "Too simple to fail first." | Simple changes have the cheapest red tests — and "too simple to test" and "too simple to break" have never been the same claim. |
+| "I'll write the test right after." | A test written after green has never been seen red: it is authored against the implementation it was meant to constrain, and its power to catch the bug is never demonstrated. |
+| "The test would just restate the implementation." | Then it is aimed at the wrong seam — assert the observable behavior, not the wiring. A change with no observable behavior to assert is a design finding, not an exemption. |
+| "The existing suite already covers this." | Then the failing test is impossible to write — try it. If it genuinely cannot go red, the obligation is already COVERED and Phase 4 records exactly that; if it goes red, the claim was wrong and you are holding the proof. |
+
 Gate: the runner confirms new tests red (for the right reason) and existing tests green, with every
 obligation `MAPPED` to a failing test. No implementation code is written until this gate clears.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/routines/skill-author/SKILL.md
+++ b/plugins/ca-codex/routines/skill-author/SKILL.md
@@ -70,6 +70,13 @@ Re-read the authored skill against the v2 quality bar. Each line below is a chec
 - **No duplicated rules** — a rule stated in a phase is not restated in Hard rules, and Hard rules carry no duplicates. State each rule once.
 - **Format conformance** — frontmatter is `name`+`description` only; H1 matches `name`; phases are numbered with `· gate:`; paths use `${CLAUDE_PLUGIN_ROOT}` / `<project-root>` correctly; no cut docs/skills, no legacy `${FRAMEWORK_ROOT}`/`${PROJECT_ROOT}`/`.agents/` paths.
 - **No trigger language** — "routed to" / "dispatched" only, and no `## Trigger` disclaimer block.
+- **Evidence lenses** (issue #612) — each checked where the skill's shape triggers it, skipped where it does not:
+  - A gate an agent is tempted to skip carries a rationalization guard AT the decision point — the known excuses paired with rebuttals. The best rebuttal carries its own instrument: a check the agent can run that falsifies the excuse either way. A tempting gate with no guard is a defect.
+  - An acceptance or verification step names what is READ, never what is claimed — "the subagent reports green" is a defect; "the runner's output shows green" is not.
+  - A user-facing ask leads with a recommendation AND its strongest counter-consideration.
+  - A rule a tested helper could enforce is mechanized rather than accreted as prose — the helper enforces, the prose explains.
+  - A rule whose literal reading has an exploitable edge names what it protects.
+- **Behavior-changing gate revisions are validated, not assumed** — an A/B pass (fixed scenarios, rubrics written before any output exists, both versions run under identical conditions) scaled to the change's blast radius, with results recorded in the PR (issue #612's method).
 
 Compile the findings, fix each, and re-read once. Present the corrected skill and the findings list to the user.
 

--- a/plugins/ca-codex/routines/tdd/SKILL.md
+++ b/plugins/ca-codex/routines/tdd/SKILL.md
@@ -49,6 +49,16 @@ Reject the standard traps: asserting on a mock instead of behavior; a test that 
 snapshot so broad it asserts nothing; coupling to an implementation detail instead of observable
 behavior; asserting on the framework's behavior rather than your own.
 
+The reasons to skip red are known. Hearing one is the tell that this gate is about to be waived —
+never the license to waive it:
+
+| excuse | reality |
+|---|---|
+| "Too simple to fail first." | Simple changes have the cheapest red tests — and "too simple to test" and "too simple to break" have never been the same claim. |
+| "I'll write the test right after." | A test written after green has never been seen red: it is authored against the implementation it was meant to constrain, and its power to catch the bug is never demonstrated. |
+| "The test would just restate the implementation." | Then it is aimed at the wrong seam — assert the observable behavior, not the wiring. A change with no observable behavior to assert is a design finding, not an exemption. |
+| "The existing suite already covers this." | Then the failing test is impossible to write — try it. If it genuinely cannot go red, the obligation is already COVERED and Phase 4 records exactly that; if it goes red, the claim was wrong and you are holding the proof. |
+
 Gate: the runner confirms new tests red (for the right reason) and existing tests green, with every
 obligation `MAPPED` to a failing test. No implementation code is written until this gate clears.
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-08-05
+
+### Changed
+
+- The `tdd` routine's red phase gains a rationalization guard (four skip-red excuses paired with rebuttals, A/B-validated before shipping), and `skill-author` adopts the issue #612 evidence-lens checklist for future authoring passes.
+
 ## [0.2.5] - 2026-08-05
 
 ### Changed

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/routines/skill-author/SKILL.md
+++ b/plugins/ca-pi/routines/skill-author/SKILL.md
@@ -70,6 +70,13 @@ Re-read the authored skill against the v2 quality bar. Each line below is a chec
 - **No duplicated rules** — a rule stated in a phase is not restated in Hard rules, and Hard rules carry no duplicates. State each rule once.
 - **Format conformance** — frontmatter is `name`+`description` only; H1 matches `name`; phases are numbered with `· gate:`; paths use `<plugin-root>` / `<project-root>` correctly; no cut docs/skills, no legacy `${FRAMEWORK_ROOT}`/`${PROJECT_ROOT}`/`.agents/` paths.
 - **No trigger language** — "routed to" / "dispatched" only, and no `## Trigger` disclaimer block.
+- **Evidence lenses** (issue #612) — each checked where the skill's shape triggers it, skipped where it does not:
+  - A gate an agent is tempted to skip carries a rationalization guard AT the decision point — the known excuses paired with rebuttals. The best rebuttal carries its own instrument: a check the agent can run that falsifies the excuse either way. A tempting gate with no guard is a defect.
+  - An acceptance or verification step names what is READ, never what is claimed — "the subagent reports green" is a defect; "the runner's output shows green" is not.
+  - A user-facing ask leads with a recommendation AND its strongest counter-consideration.
+  - A rule a tested helper could enforce is mechanized rather than accreted as prose — the helper enforces, the prose explains.
+  - A rule whose literal reading has an exploitable edge names what it protects.
+- **Behavior-changing gate revisions are validated, not assumed** — an A/B pass (fixed scenarios, rubrics written before any output exists, both versions run under identical conditions) scaled to the change's blast radius, with results recorded in the PR (issue #612's method).
 
 Compile the findings, fix each, and re-read once. Present the corrected skill and the findings list to the user.
 

--- a/plugins/ca-pi/routines/tdd/SKILL.md
+++ b/plugins/ca-pi/routines/tdd/SKILL.md
@@ -49,6 +49,16 @@ Reject the standard traps: asserting on a mock instead of behavior; a test that 
 snapshot so broad it asserts nothing; coupling to an implementation detail instead of observable
 behavior; asserting on the framework's behavior rather than your own.
 
+The reasons to skip red are known. Hearing one is the tell that this gate is about to be waived —
+never the license to waive it:
+
+| excuse | reality |
+|---|---|
+| "Too simple to fail first." | Simple changes have the cheapest red tests — and "too simple to test" and "too simple to break" have never been the same claim. |
+| "I'll write the test right after." | A test written after green has never been seen red: it is authored against the implementation it was meant to constrain, and its power to catch the bug is never demonstrated. |
+| "The test would just restate the implementation." | Then it is aimed at the wrong seam — assert the observable behavior, not the wiring. A change with no observable behavior to assert is a design finding, not an exemption. |
+| "The existing suite already covers this." | Then the failing test is impossible to write — try it. If it genuinely cannot go red, the obligation is already COVERED and Phase 4 records exactly that; if it goes red, the claim was wrong and you are holding the proof. |
+
 Gate: the runner confirms new tests red (for the right reason) and existing tests green, with every
 obligation `MAPPED` to a failing test. No implementation code is written until this gate clears.
 

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.11.6",
+  "version": "2.11.7",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/skills/skill-author/SKILL.md
+++ b/plugins/ca/skills/skill-author/SKILL.md
@@ -70,6 +70,13 @@ Re-read the authored skill against the v2 quality bar. Each line below is a chec
 - **No duplicated rules** — a rule stated in a phase is not restated in Hard rules, and Hard rules carry no duplicates. State each rule once.
 - **Format conformance** — frontmatter is `name`+`description` only; H1 matches `name`; phases are numbered with `· gate:`; paths use `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PROJECT_DIR}` correctly; no cut docs/skills, no legacy `${FRAMEWORK_ROOT}`/`${PROJECT_ROOT}`/`.agents/` paths.
 - **No trigger language** — "routed to" / "dispatched" only, and no `## Trigger` disclaimer block.
+- **Evidence lenses** (issue #612) — each checked where the skill's shape triggers it, skipped where it does not:
+  - A gate an agent is tempted to skip carries a rationalization guard AT the decision point — the known excuses paired with rebuttals. The best rebuttal carries its own instrument: a check the agent can run that falsifies the excuse either way. A tempting gate with no guard is a defect.
+  - An acceptance or verification step names what is READ, never what is claimed — "the subagent reports green" is a defect; "the runner's output shows green" is not.
+  - A user-facing ask leads with a recommendation AND its strongest counter-consideration.
+  - A rule a tested helper could enforce is mechanized rather than accreted as prose — the helper enforces, the prose explains.
+  - A rule whose literal reading has an exploitable edge names what it protects.
+- **Behavior-changing gate revisions are validated, not assumed** — an A/B pass (fixed scenarios, rubrics written before any output exists, both versions run under identical conditions) scaled to the change's blast radius, with results recorded in the PR (issue #612's method).
 
 Compile the findings, fix each, and re-read once. Present the corrected skill and the findings list to the user.
 

--- a/plugins/ca/skills/tdd/SKILL.md
+++ b/plugins/ca/skills/tdd/SKILL.md
@@ -49,6 +49,16 @@ Reject the standard traps: asserting on a mock instead of behavior; a test that 
 snapshot so broad it asserts nothing; coupling to an implementation detail instead of observable
 behavior; asserting on the framework's behavior rather than your own.
 
+The reasons to skip red are known. Hearing one is the tell that this gate is about to be waived —
+never the license to waive it:
+
+| excuse | reality |
+|---|---|
+| "Too simple to fail first." | Simple changes have the cheapest red tests — and "too simple to test" and "too simple to break" have never been the same claim. |
+| "I'll write the test right after." | A test written after green has never been seen red: it is authored against the implementation it was meant to constrain, and its power to catch the bug is never demonstrated. |
+| "The test would just restate the implementation." | Then it is aimed at the wrong seam — assert the observable behavior, not the wiring. A change with no observable behavior to assert is a design finding, not an exemption. |
+| "The existing suite already covers this." | Then the failing test is impossible to write — try it. If it genuinely cannot go red, the obligation is already COVERED and Phase 4 records exactly that; if it goes red, the claim was wrong and you are holding the proof. |
+
 Gate: the runner confirms new tests red (for the right reason) and existing tests green, with every
 obligation `MAPPED` to a failing test. No implementation code is written until this gate clears.
 


### PR DESCRIPTION
The #612 pilot, shipped as recommended and A/B-validated before merge.

## tdd Phase 2 — the rationalization guard

Four known excuses for skipping the red test, each paired with its rebuttal at the decision point. The "already covered" rebuttal carries its own falsifying instrument: write the failing test and let the outcome resolve the claim either way, on the record.

**A/B validation** (same harness as #609/#611: fixed scenarios, rubrics written before any output, both arms under the shipped persona, same model):
- 7 scenarios: four excuse-pressure, one cooperative-flow over-blocking check, two existing-rule regression checks (import-error-as-red, loosen-the-assertion).
- Hard requirements: **7/7 both arms**. Zero over-blocking: the cooperative scenario proceeded normally in both arms with no guard recitation at an innocent user.
- Quality deltas favoring the guarded arm: domain-exact rebuttals on the triviality excuse, the [NEEDS-TRIAGE] reclassification path on the no-observable-behavior case, and the falsifiable already-covered instrument used verbatim.
- Honest finding, recorded for #612's doctrine: the behavioral delta was much smaller than the persona A/B measured, because the shipped persona now lifts BOTH arms (the unguarded arm quoted persona doctrine back verbatim). The persona's general table carries most of the behavioral load; skill-level guards earn their place by domain precision, and the best ones carry instruments, not just prose. This validates opportunistic adoption over a rewrite campaign.

## skill-author Phase 4 — the evidence lenses

Five checkable lenses added to the self-review defect list (rationalization guards at tempting gates, instruments over self-report, recommendation with counter-case, mechanize-don't-accrete, letter-vs-spirit), plus a validation requirement: behavior-changing gate revisions get an A/B pass scaled to blast radius. Future authoring passes apply the doctrine without touching stable bodies.

## Verification

build-surface/sync-core --check clean; badge consistency, release trace (29), routing surface (19), build-surface tests (40), site voice clean; payload gates: ca 2.11.6→2.11.7, ca-codex 0.4.5→0.4.6, pi guard 0.2.5→0.2.6 with changelog and root metadata together. Hooks suite: 1307 passed; the 4 failing palette tests are the documented open-issue #552 class (local-.codearbiter-state dependent, prose-only diff cannot reach them; CI runs clean checkouts).

Closes #612.

https://claude.ai/code/session_01QjJeSbcwPHwMmd6CEZeagB