### PR TITLE
fix(hooks): unify gate-marker root across linked worktrees, isolate palette tests from repo state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.11.10] — 2026-08-05
+
+### Fixed
+
+- Linked-worktree sessions could record a security/migration gate pass that
+  the H-09b/H-10b/H-14 commit guards would never see: `security-pass.py` and
+  `migration-pass.py`, run bare via a Bash tool call (no `CLAUDE_PROJECT_DIR`
+  in that shell), wrote their marker under the worktree's own (gitignored)
+  `.codearbiter/.markers/`, while the guards read it from the main checkout.
+  A new `marker_root()` seam (`hostapi.Host`) gives both sides the same
+  main-checkout answer without moving the diff/migration SCAN root, which
+  must stay bound to the tree actually being committed (#604).
+- `test_colorlib.py`'s palette-compatibility tests read the real project's
+  `.codearbiter/` state when rendered via subprocess with no explicit `cwd`,
+  so a maintainer's own accumulated audit-log rows could make a required
+  custom-palette color intermittently disappear from the assertion window.
+  Isolated to a synthetic, in-fixture `.codearbiter/` (or none at all), plus
+  a new test that appends adversarial override/gate-event/task rows and
+  proves the palette-completeness check still holds (#552).
+- Ten `test_git_hooks.py`/`test_repo_resolution.py` tests failed whenever the
+  suite itself ran from inside a linked git worktree (subagents do this
+  routinely): `_githooks`'s own `__file__` resolved to an ephemeral path,
+  which the existing `is_ephemeral_path` safety check (#441/ADR-0014)
+  correctly refused to register into a fixture's shared drop-in dir. Fixtures
+  now resolve `_githooks`'s enforcer path from a durable temp-dir copy of the
+  hooks payload (`durable_plugin_copy`, the #442 fix's existing pattern).
+
 ## [2.11.9] — 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.11.9" src="https://img.shields.io/badge/version-2.11.9-2b7489">
+<img alt="version 2.11.10" src="https://img.shields.io/badge/version-2.11.10-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-40-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-28-555">
@@ -119,7 +119,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.4.8`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.4.9`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_activationlib.py
+++ b/core/pysrc/_activationlib.py
@@ -113,6 +113,19 @@ def _reset_root_cache():
     still-valid (env, cwd) cache entry) call this between scenarios."""
     _ROOT_CACHE.clear()
 
+
+def marker_root(payload=None):
+    """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+    migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to and
+    read from (#604) — see `hostapi.Host.marker_root`'s docstring for why
+    this is NOT the same thing as `project_root()` in a linked worktree.
+
+    Not memoized like `project_root()` above: called at most once or twice
+    per hook process (the marker checks, or a single `security-pass.py` /
+    `migration-pass.py` run), so the extra git spawn a linked-worktree
+    escalation occasionally costs is not worth a second cache to avoid."""
+    return get_host().marker_root(payload)
+
 ARBITER_RE = re.compile(r"^\s*arbiter:\s*enabled\s*$", re.I)
 
 def frontmatter_enabled_text(text):

--- a/core/pysrc/_bashguardlib.py
+++ b/core/pysrc/_bashguardlib.py
@@ -88,6 +88,7 @@ from _hooklib import (
 from _gitexec import git_executable
 import _gitlib  # reused for its spawn-free, worktree-aware (.git-as-a-FILE /
                 # gitdir: pointer) project_root() climb (#223)
+from hostapi import git_worktree_main_root  # noqa: #604 marker-root escalation
 import _protectedstatelib  # H-22's shell flank (T-08, #564) — imported as a
                             # module (not `from ... import REGISTRY`) so
                             # _STATE_WRITE_RES below is built from a live
@@ -1456,6 +1457,23 @@ def _check_h22_state(cmd, root):
                           f"this policy. Use the sanctioned helper.")
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` itself names a
+    LINKED git worktree's own checkout (#604) — see
+    `hostapi.git_worktree_main_root`'s docstring.
+
+    `root` (this file's own `project_root()`-derived parameter, D-2) already
+    names the main checkout in the common case: the harness sets
+    `CLAUDE_PROJECT_DIR` once at session start, before a session's cwd ever
+    moves into a linked worktree, so this is a no-op for the reported bug's
+    own scenario. It matters only when THIS hook process ALSO ran without
+    `CLAUDE_PROJECT_DIR` set (uncommon for a registered hook subprocess, but
+    possible) — without this, that edge case would have the guard read from
+    the worktree while `security-pass.py`'s `marker_root()` (hostapi.py)
+    writes to the main checkout, reopening the exact split this closes."""
+    return git_worktree_main_root(root) or root
+
+
 def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
     """H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     a recorded security-gate pass. The crypto-compliance / secret-handling skills
@@ -1494,7 +1512,7 @@ def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, 30):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (.codearbiter/.markers/security-gate-passed). Run the "
@@ -1556,7 +1574,7 @@ def _check_h14_migration(commit, add, cwd, root):
     staged |= extra
     migs = sorted(p for p in staged if is_migration_path(p, root))
     if migs:
-        marker = os.path.join(root, ".codearbiter", ".markers", "migration-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "migration-gate-passed")
         try:
             with open(marker, encoding="utf-8") as f:
                 approved = set(f.read().split())

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -41,6 +41,10 @@
 #   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
 #                                         (memoized per process, keyed on the
 #                                         inputs that could change it — #260)
+#   marker_root(payload=None) -> str     project_root(payload), escalated to the MAIN
+#                                         checkout when that names a LINKED worktree's
+#                                         own checkout — the root gate MARKERS
+#                                         (.codearbiter/.markers/) live under (#604)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -122,6 +126,7 @@ from _activationlib import (  # noqa: F401
     frontmatter_enabled,
     frontmatter_enabled_text,
     get_host,
+    marker_root,
     project_root,
     reset_host,
     set_host,

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -63,6 +63,63 @@ def git_toplevel(cwd=None):
     return None
 
 
+def git_worktree_main_root(root):
+    """When `root` (an already-resolved project root — a `project_root()`
+    answer, NOT necessarily a fresh `git_toplevel` call) is itself the
+    checkout of a LINKED git worktree, the MAIN checkout's root that owns the
+    shared `.git` directory — else `None`.
+
+    #604: `security-pass.py`/`migration-pass.py` and the H-09b/H-10b/H-14
+    guards were found resolving DIFFERENT roots for GATE MARKERS in a
+    linked-worktree session — a hook subprocess trusts a (possibly stale)
+    `CLAUDE_PROJECT_DIR` naming the MAIN checkout, while `security-pass.py`
+    run bare via Bash (no `CLAUDE_PROJECT_DIR` in that shell) fell through to
+    `git_toplevel()`, which names the WORKTREE's own checkout — so a gate
+    pass recorded by one was never seen by the other. `.codearbiter/
+    .markers/` is gitignored, so a linked worktree's own checkout never has
+    one freshly — the git-hook guard's diff/branch resolution already
+    carries this exact split (`_bashguardlib._effective_exec_root`'s
+    docstring, D-2: gate markers stay pinned to the main checkout regardless
+    of the command's effective exec root).
+
+    Deliberately NOT wired into `Host.project_root()` itself: `project_root()`
+    also backs `security-pass.py`'s DIFF SCAN (`candidate_lines()`), which
+    must stay worktree-local — escalating the general project root to "main"
+    would bind digests to the wrong (unrelated, possibly dirty) tree and
+    silently drop coverage for the diff actually being committed, the exact
+    trap the issue this closes warns against. Callers that specifically need
+    the gate-MARKER root call this as a targeted escalation on top of an
+    already-resolved `project_root()` answer instead — e.g.
+    `git_worktree_main_root(root) or root` — so every OTHER project_root()
+    consumer (diff scans, `arbiter_active`, …) is entirely unaffected, and
+    the two callers agree on marker location without `git_toplevel`'s own
+    `git rev-parse` mechanism being replaced anywhere (deliberate: symlink/
+    8.3 canonicalization, #125).
+
+    Distinguishes a linked worktree from a submodule — both have a `.git`
+    FILE, but only a worktree's `gitdir:` pointer names a path under
+    `.git/worktrees/<name>`; a submodule's names `.git/modules/<name>`, which
+    is not a "main root" to climb to and must fall through untouched (mirrors
+    `_durabilitylib._gitfile_points_at_worktree`'s same distinction)."""
+    git_meta = os.path.join(root, ".git")
+    if not os.path.isfile(git_meta):
+        return None
+    try:
+        with open(git_meta, encoding="utf-8", errors="replace") as f:
+            pointer = f.read().strip()
+    except OSError:
+        return None
+    if not pointer.startswith("gitdir: "):
+        return None
+    gitdir = pointer[len("gitdir: "):].strip().replace("\\", "/")
+    marker = "/.git/worktrees/"
+    idx = gitdir.find(marker)
+    if idx == -1:
+        return None  # not a linked worktree (e.g. a submodule) — nothing to climb to
+    main_git_dir = gitdir[:idx + len("/.git")]
+    return os.path.dirname(main_git_dir) or None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -123,7 +180,11 @@ class Host:
              var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
-        """
+
+        Deliberately climbs no further than the WORKTREE's own toplevel in a
+        linked-worktree session — a caller wanting the gate-MARKER root (which
+        must agree on the MAIN checkout, #604) calls `marker_root()` instead;
+        see its docstring for why the two must not be conflated."""
         env_root = os.environ.get("CLAUDE_PROJECT_DIR")
         if env_root and os.path.isdir(env_root):
             return env_root
@@ -135,6 +196,28 @@ class Host:
         if top:
             return top
         return os.getcwd()
+
+    def marker_root(self, payload=None):
+        """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+        migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to
+        and read from (#604).
+
+        Identical to `project_root(payload)` in every case except one: when
+        that resolves to a LINKED git worktree's own checkout, this escalates
+        to the MAIN checkout that owns the shared `.git` directory instead
+        (`git_worktree_main_root`) — `.codearbiter/.markers/` is gitignored,
+        so a linked worktree's own checkout never has one freshly, and the
+        git-hook guard already anchors every marker READ at the main
+        checkout regardless of a command's real exec root (D-2,
+        `_bashguardlib._effective_exec_root`'s docstring). This gives every
+        marker WRITER that same answer even when it runs without
+        `CLAUDE_PROJECT_DIR` set — `security-pass.py` invoked bare via a Bash
+        tool call, rather than as a registered hook subprocess that inherits
+        it from the harness — closing the loop without touching
+        `project_root()` itself, which other callers (diff scans in
+        particular) need to stay worktree-local."""
+        root = self.project_root(payload)
+        return git_worktree_main_root(root) or root
 
     def plugin_root(self):
         """The plugin payload root: CLAUDE_PLUGIN_ROOT when set, else derived

--- a/core/pysrc/migration-pass.py
+++ b/core/pysrc/migration-pass.py
@@ -29,8 +29,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    content_digest, is_migration_path, marker_root, project_root, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -86,7 +86,13 @@ def main():
         text = read_text(root, rel)
         if text is not None:
             digests.add(content_digest(text))
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: same split as security-pass.py — candidate_paths(root)/read_text(root, …)
+    # above must stay bound to wherever this process is actually running (a
+    # linked worktree's own tree), but the MARKER write goes through
+    # marker_root(), which agrees with the H-14 guard's main-checkout-anchored
+    # read (D-2) even when this process has no CLAUDE_PROJECT_DIR set.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "migration-gate-passed")
     digests = sorted(digests)
@@ -95,7 +101,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"migration-gate pass recorded: {len(digests)} migration file(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/core/pysrc/security-pass.py
+++ b/core/pysrc/security-pass.py
@@ -27,8 +27,8 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
-    line_digest, project_root, sensitive_scan_added_lines, set_host,
-    utf8_stdio, warn, write_text_atomic,
+    line_digest, marker_root, project_root, sensitive_scan_added_lines,
+    set_host, utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -97,7 +97,17 @@ def main():
         sys.exit(1)
     sensitive = [ln for ln in candidate_lines(root)
                  if CRYPTO_RE.search(ln) or SECRET_RE.search(ln)]
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: the MARKER root is deliberately NOT `root` above. `root` (plain
+    # project_root()) must stay wherever this process is actually running —
+    # candidate_lines(root) just scanned exactly that tree's diff, and binding
+    # digests to a DIFFERENT tree would review lines nobody staged. But in a
+    # linked git worktree, `root` names the worktree's own (gitignored,
+    # never-checked-out) `.codearbiter/.markers/`, while the H-09b/H-10b
+    # guard reads the marker from the MAIN checkout (D-2) — marker_root()
+    # gives the write the same main-checkout answer the guard's read already
+    # has, without moving the scan.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "security-gate-passed")
     digests = sorted({line_digest(ln) for ln in sensitive})
@@ -106,7 +116,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"security-gate pass recorded: {len(digests)} sensitive line(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/hooks/_activationlib.py
+++ b/plugins/ca-codex/hooks/_activationlib.py
@@ -113,6 +113,19 @@ def _reset_root_cache():
     still-valid (env, cwd) cache entry) call this between scenarios."""
     _ROOT_CACHE.clear()
 
+
+def marker_root(payload=None):
+    """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+    migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to and
+    read from (#604) — see `hostapi.Host.marker_root`'s docstring for why
+    this is NOT the same thing as `project_root()` in a linked worktree.
+
+    Not memoized like `project_root()` above: called at most once or twice
+    per hook process (the marker checks, or a single `security-pass.py` /
+    `migration-pass.py` run), so the extra git spawn a linked-worktree
+    escalation occasionally costs is not worth a second cache to avoid."""
+    return get_host().marker_root(payload)
+
 ARBITER_RE = re.compile(r"^\s*arbiter:\s*enabled\s*$", re.I)
 
 def frontmatter_enabled_text(text):

--- a/plugins/ca-codex/hooks/_bashguardlib.py
+++ b/plugins/ca-codex/hooks/_bashguardlib.py
@@ -88,6 +88,7 @@ from _hooklib import (
 from _gitexec import git_executable
 import _gitlib  # reused for its spawn-free, worktree-aware (.git-as-a-FILE /
                 # gitdir: pointer) project_root() climb (#223)
+from hostapi import git_worktree_main_root  # noqa: #604 marker-root escalation
 import _protectedstatelib  # H-22's shell flank (T-08, #564) — imported as a
                             # module (not `from ... import REGISTRY`) so
                             # _STATE_WRITE_RES below is built from a live
@@ -1456,6 +1457,23 @@ def _check_h22_state(cmd, root):
                           f"this policy. Use the sanctioned helper.")
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` itself names a
+    LINKED git worktree's own checkout (#604) — see
+    `hostapi.git_worktree_main_root`'s docstring.
+
+    `root` (this file's own `project_root()`-derived parameter, D-2) already
+    names the main checkout in the common case: the harness sets
+    `CLAUDE_PROJECT_DIR` once at session start, before a session's cwd ever
+    moves into a linked worktree, so this is a no-op for the reported bug's
+    own scenario. It matters only when THIS hook process ALSO ran without
+    `CLAUDE_PROJECT_DIR` set (uncommon for a registered hook subprocess, but
+    possible) — without this, that edge case would have the guard read from
+    the worktree while `security-pass.py`'s `marker_root()` (hostapi.py)
+    writes to the main checkout, reopening the exact split this closes."""
+    return git_worktree_main_root(root) or root
+
+
 def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
     """H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     a recorded security-gate pass. The crypto-compliance / secret-handling skills
@@ -1494,7 +1512,7 @@ def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, 30):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (.codearbiter/.markers/security-gate-passed). Run the "
@@ -1556,7 +1574,7 @@ def _check_h14_migration(commit, add, cwd, root):
     staged |= extra
     migs = sorted(p for p in staged if is_migration_path(p, root))
     if migs:
-        marker = os.path.join(root, ".codearbiter", ".markers", "migration-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "migration-gate-passed")
         try:
             with open(marker, encoding="utf-8") as f:
                 approved = set(f.read().split())

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -41,6 +41,10 @@
 #   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
 #                                         (memoized per process, keyed on the
 #                                         inputs that could change it — #260)
+#   marker_root(payload=None) -> str     project_root(payload), escalated to the MAIN
+#                                         checkout when that names a LINKED worktree's
+#                                         own checkout — the root gate MARKERS
+#                                         (.codearbiter/.markers/) live under (#604)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -122,6 +126,7 @@ from _activationlib import (  # noqa: F401
     frontmatter_enabled,
     frontmatter_enabled_text,
     get_host,
+    marker_root,
     project_root,
     reset_host,
     set_host,

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -63,6 +63,63 @@ def git_toplevel(cwd=None):
     return None
 
 
+def git_worktree_main_root(root):
+    """When `root` (an already-resolved project root — a `project_root()`
+    answer, NOT necessarily a fresh `git_toplevel` call) is itself the
+    checkout of a LINKED git worktree, the MAIN checkout's root that owns the
+    shared `.git` directory — else `None`.
+
+    #604: `security-pass.py`/`migration-pass.py` and the H-09b/H-10b/H-14
+    guards were found resolving DIFFERENT roots for GATE MARKERS in a
+    linked-worktree session — a hook subprocess trusts a (possibly stale)
+    `CLAUDE_PROJECT_DIR` naming the MAIN checkout, while `security-pass.py`
+    run bare via Bash (no `CLAUDE_PROJECT_DIR` in that shell) fell through to
+    `git_toplevel()`, which names the WORKTREE's own checkout — so a gate
+    pass recorded by one was never seen by the other. `.codearbiter/
+    .markers/` is gitignored, so a linked worktree's own checkout never has
+    one freshly — the git-hook guard's diff/branch resolution already
+    carries this exact split (`_bashguardlib._effective_exec_root`'s
+    docstring, D-2: gate markers stay pinned to the main checkout regardless
+    of the command's effective exec root).
+
+    Deliberately NOT wired into `Host.project_root()` itself: `project_root()`
+    also backs `security-pass.py`'s DIFF SCAN (`candidate_lines()`), which
+    must stay worktree-local — escalating the general project root to "main"
+    would bind digests to the wrong (unrelated, possibly dirty) tree and
+    silently drop coverage for the diff actually being committed, the exact
+    trap the issue this closes warns against. Callers that specifically need
+    the gate-MARKER root call this as a targeted escalation on top of an
+    already-resolved `project_root()` answer instead — e.g.
+    `git_worktree_main_root(root) or root` — so every OTHER project_root()
+    consumer (diff scans, `arbiter_active`, …) is entirely unaffected, and
+    the two callers agree on marker location without `git_toplevel`'s own
+    `git rev-parse` mechanism being replaced anywhere (deliberate: symlink/
+    8.3 canonicalization, #125).
+
+    Distinguishes a linked worktree from a submodule — both have a `.git`
+    FILE, but only a worktree's `gitdir:` pointer names a path under
+    `.git/worktrees/<name>`; a submodule's names `.git/modules/<name>`, which
+    is not a "main root" to climb to and must fall through untouched (mirrors
+    `_durabilitylib._gitfile_points_at_worktree`'s same distinction)."""
+    git_meta = os.path.join(root, ".git")
+    if not os.path.isfile(git_meta):
+        return None
+    try:
+        with open(git_meta, encoding="utf-8", errors="replace") as f:
+            pointer = f.read().strip()
+    except OSError:
+        return None
+    if not pointer.startswith("gitdir: "):
+        return None
+    gitdir = pointer[len("gitdir: "):].strip().replace("\\", "/")
+    marker = "/.git/worktrees/"
+    idx = gitdir.find(marker)
+    if idx == -1:
+        return None  # not a linked worktree (e.g. a submodule) — nothing to climb to
+    main_git_dir = gitdir[:idx + len("/.git")]
+    return os.path.dirname(main_git_dir) or None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -123,7 +180,11 @@ class Host:
              var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
-        """
+
+        Deliberately climbs no further than the WORKTREE's own toplevel in a
+        linked-worktree session — a caller wanting the gate-MARKER root (which
+        must agree on the MAIN checkout, #604) calls `marker_root()` instead;
+        see its docstring for why the two must not be conflated."""
         env_root = os.environ.get("CLAUDE_PROJECT_DIR")
         if env_root and os.path.isdir(env_root):
             return env_root
@@ -135,6 +196,28 @@ class Host:
         if top:
             return top
         return os.getcwd()
+
+    def marker_root(self, payload=None):
+        """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+        migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to
+        and read from (#604).
+
+        Identical to `project_root(payload)` in every case except one: when
+        that resolves to a LINKED git worktree's own checkout, this escalates
+        to the MAIN checkout that owns the shared `.git` directory instead
+        (`git_worktree_main_root`) — `.codearbiter/.markers/` is gitignored,
+        so a linked worktree's own checkout never has one freshly, and the
+        git-hook guard already anchors every marker READ at the main
+        checkout regardless of a command's real exec root (D-2,
+        `_bashguardlib._effective_exec_root`'s docstring). This gives every
+        marker WRITER that same answer even when it runs without
+        `CLAUDE_PROJECT_DIR` set — `security-pass.py` invoked bare via a Bash
+        tool call, rather than as a registered hook subprocess that inherits
+        it from the harness — closing the loop without touching
+        `project_root()` itself, which other callers (diff scans in
+        particular) need to stay worktree-local."""
+        root = self.project_root(payload)
+        return git_worktree_main_root(root) or root
 
     def plugin_root(self):
         """The plugin payload root: CLAUDE_PLUGIN_ROOT when set, else derived

--- a/plugins/ca-codex/hooks/migration-pass.py
+++ b/plugins/ca-codex/hooks/migration-pass.py
@@ -29,8 +29,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    content_digest, is_migration_path, marker_root, project_root, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -86,7 +86,13 @@ def main():
         text = read_text(root, rel)
         if text is not None:
             digests.add(content_digest(text))
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: same split as security-pass.py — candidate_paths(root)/read_text(root, …)
+    # above must stay bound to wherever this process is actually running (a
+    # linked worktree's own tree), but the MARKER write goes through
+    # marker_root(), which agrees with the H-14 guard's main-checkout-anchored
+    # read (D-2) even when this process has no CLAUDE_PROJECT_DIR set.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "migration-gate-passed")
     digests = sorted(digests)
@@ -95,7 +101,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"migration-gate pass recorded: {len(digests)} migration file(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/plugins/ca-codex/hooks/security-pass.py
+++ b/plugins/ca-codex/hooks/security-pass.py
@@ -27,8 +27,8 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
-    line_digest, project_root, sensitive_scan_added_lines, set_host,
-    utf8_stdio, warn, write_text_atomic,
+    line_digest, marker_root, project_root, sensitive_scan_added_lines,
+    set_host, utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -97,7 +97,17 @@ def main():
         sys.exit(1)
     sensitive = [ln for ln in candidate_lines(root)
                  if CRYPTO_RE.search(ln) or SECRET_RE.search(ln)]
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: the MARKER root is deliberately NOT `root` above. `root` (plain
+    # project_root()) must stay wherever this process is actually running —
+    # candidate_lines(root) just scanned exactly that tree's diff, and binding
+    # digests to a DIFFERENT tree would review lines nobody staged. But in a
+    # linked git worktree, `root` names the worktree's own (gitignored,
+    # never-checked-out) `.codearbiter/.markers/`, while the H-09b/H-10b
+    # guard reads the marker from the MAIN checkout (D-2) — marker_root()
+    # gives the write the same main-checkout answer the guard's read already
+    # has, without moving the scan.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "security-gate-passed")
     digests = sorted({line_digest(ln) for ln in sensitive})
@@ -106,7 +116,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"security-gate pass recorded: {len(digests)} sensitive line(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-08-05
+
+### Fixed
+
+- A linked-worktree session running `security-pass.py`/`migration-pass.py`
+  bare (no `CLAUDE_PROJECT_DIR` in that shell) recorded a gate pass at the
+  worktree's own (gitignored) `.codearbiter/.markers/`, invisible to the
+  H-09b/H-10b/H-14 commit guards, which read markers from the main checkout.
+  A new `marker_root()` host seam gives both sides the same answer without
+  moving the diff/migration scan root itself (#604).
+
 ## [0.2.8] - 2026-08-05
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_activationlib.py
+++ b/plugins/ca-pi/hooks/_activationlib.py
@@ -113,6 +113,19 @@ def _reset_root_cache():
     still-valid (env, cwd) cache entry) call this between scenarios."""
     _ROOT_CACHE.clear()
 
+
+def marker_root(payload=None):
+    """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+    migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to and
+    read from (#604) — see `hostapi.Host.marker_root`'s docstring for why
+    this is NOT the same thing as `project_root()` in a linked worktree.
+
+    Not memoized like `project_root()` above: called at most once or twice
+    per hook process (the marker checks, or a single `security-pass.py` /
+    `migration-pass.py` run), so the extra git spawn a linked-worktree
+    escalation occasionally costs is not worth a second cache to avoid."""
+    return get_host().marker_root(payload)
+
 ARBITER_RE = re.compile(r"^\s*arbiter:\s*enabled\s*$", re.I)
 
 def frontmatter_enabled_text(text):

--- a/plugins/ca-pi/hooks/_bashguardlib.py
+++ b/plugins/ca-pi/hooks/_bashguardlib.py
@@ -88,6 +88,7 @@ from _hooklib import (
 from _gitexec import git_executable
 import _gitlib  # reused for its spawn-free, worktree-aware (.git-as-a-FILE /
                 # gitdir: pointer) project_root() climb (#223)
+from hostapi import git_worktree_main_root  # noqa: #604 marker-root escalation
 import _protectedstatelib  # H-22's shell flank (T-08, #564) — imported as a
                             # module (not `from ... import REGISTRY`) so
                             # _STATE_WRITE_RES below is built from a live
@@ -1456,6 +1457,23 @@ def _check_h22_state(cmd, root):
                           f"this policy. Use the sanctioned helper.")
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` itself names a
+    LINKED git worktree's own checkout (#604) — see
+    `hostapi.git_worktree_main_root`'s docstring.
+
+    `root` (this file's own `project_root()`-derived parameter, D-2) already
+    names the main checkout in the common case: the harness sets
+    `CLAUDE_PROJECT_DIR` once at session start, before a session's cwd ever
+    moves into a linked worktree, so this is a no-op for the reported bug's
+    own scenario. It matters only when THIS hook process ALSO ran without
+    `CLAUDE_PROJECT_DIR` set (uncommon for a registered hook subprocess, but
+    possible) — without this, that edge case would have the guard read from
+    the worktree while `security-pass.py`'s `marker_root()` (hostapi.py)
+    writes to the main checkout, reopening the exact split this closes."""
+    return git_worktree_main_root(root) or root
+
+
 def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
     """H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     a recorded security-gate pass. The crypto-compliance / secret-handling skills
@@ -1494,7 +1512,7 @@ def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, 30):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (.codearbiter/.markers/security-gate-passed). Run the "
@@ -1556,7 +1574,7 @@ def _check_h14_migration(commit, add, cwd, root):
     staged |= extra
     migs = sorted(p for p in staged if is_migration_path(p, root))
     if migs:
-        marker = os.path.join(root, ".codearbiter", ".markers", "migration-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "migration-gate-passed")
         try:
             with open(marker, encoding="utf-8") as f:
                 approved = set(f.read().split())

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -41,6 +41,10 @@
 #   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
 #                                         (memoized per process, keyed on the
 #                                         inputs that could change it — #260)
+#   marker_root(payload=None) -> str     project_root(payload), escalated to the MAIN
+#                                         checkout when that names a LINKED worktree's
+#                                         own checkout — the root gate MARKERS
+#                                         (.codearbiter/.markers/) live under (#604)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -122,6 +126,7 @@ from _activationlib import (  # noqa: F401
     frontmatter_enabled,
     frontmatter_enabled_text,
     get_host,
+    marker_root,
     project_root,
     reset_host,
     set_host,

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -63,6 +63,63 @@ def git_toplevel(cwd=None):
     return None
 
 
+def git_worktree_main_root(root):
+    """When `root` (an already-resolved project root — a `project_root()`
+    answer, NOT necessarily a fresh `git_toplevel` call) is itself the
+    checkout of a LINKED git worktree, the MAIN checkout's root that owns the
+    shared `.git` directory — else `None`.
+
+    #604: `security-pass.py`/`migration-pass.py` and the H-09b/H-10b/H-14
+    guards were found resolving DIFFERENT roots for GATE MARKERS in a
+    linked-worktree session — a hook subprocess trusts a (possibly stale)
+    `CLAUDE_PROJECT_DIR` naming the MAIN checkout, while `security-pass.py`
+    run bare via Bash (no `CLAUDE_PROJECT_DIR` in that shell) fell through to
+    `git_toplevel()`, which names the WORKTREE's own checkout — so a gate
+    pass recorded by one was never seen by the other. `.codearbiter/
+    .markers/` is gitignored, so a linked worktree's own checkout never has
+    one freshly — the git-hook guard's diff/branch resolution already
+    carries this exact split (`_bashguardlib._effective_exec_root`'s
+    docstring, D-2: gate markers stay pinned to the main checkout regardless
+    of the command's effective exec root).
+
+    Deliberately NOT wired into `Host.project_root()` itself: `project_root()`
+    also backs `security-pass.py`'s DIFF SCAN (`candidate_lines()`), which
+    must stay worktree-local — escalating the general project root to "main"
+    would bind digests to the wrong (unrelated, possibly dirty) tree and
+    silently drop coverage for the diff actually being committed, the exact
+    trap the issue this closes warns against. Callers that specifically need
+    the gate-MARKER root call this as a targeted escalation on top of an
+    already-resolved `project_root()` answer instead — e.g.
+    `git_worktree_main_root(root) or root` — so every OTHER project_root()
+    consumer (diff scans, `arbiter_active`, …) is entirely unaffected, and
+    the two callers agree on marker location without `git_toplevel`'s own
+    `git rev-parse` mechanism being replaced anywhere (deliberate: symlink/
+    8.3 canonicalization, #125).
+
+    Distinguishes a linked worktree from a submodule — both have a `.git`
+    FILE, but only a worktree's `gitdir:` pointer names a path under
+    `.git/worktrees/<name>`; a submodule's names `.git/modules/<name>`, which
+    is not a "main root" to climb to and must fall through untouched (mirrors
+    `_durabilitylib._gitfile_points_at_worktree`'s same distinction)."""
+    git_meta = os.path.join(root, ".git")
+    if not os.path.isfile(git_meta):
+        return None
+    try:
+        with open(git_meta, encoding="utf-8", errors="replace") as f:
+            pointer = f.read().strip()
+    except OSError:
+        return None
+    if not pointer.startswith("gitdir: "):
+        return None
+    gitdir = pointer[len("gitdir: "):].strip().replace("\\", "/")
+    marker = "/.git/worktrees/"
+    idx = gitdir.find(marker)
+    if idx == -1:
+        return None  # not a linked worktree (e.g. a submodule) — nothing to climb to
+    main_git_dir = gitdir[:idx + len("/.git")]
+    return os.path.dirname(main_git_dir) or None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -123,7 +180,11 @@ class Host:
              var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
-        """
+
+        Deliberately climbs no further than the WORKTREE's own toplevel in a
+        linked-worktree session — a caller wanting the gate-MARKER root (which
+        must agree on the MAIN checkout, #604) calls `marker_root()` instead;
+        see its docstring for why the two must not be conflated."""
         env_root = os.environ.get("CLAUDE_PROJECT_DIR")
         if env_root and os.path.isdir(env_root):
             return env_root
@@ -135,6 +196,28 @@ class Host:
         if top:
             return top
         return os.getcwd()
+
+    def marker_root(self, payload=None):
+        """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+        migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to
+        and read from (#604).
+
+        Identical to `project_root(payload)` in every case except one: when
+        that resolves to a LINKED git worktree's own checkout, this escalates
+        to the MAIN checkout that owns the shared `.git` directory instead
+        (`git_worktree_main_root`) — `.codearbiter/.markers/` is gitignored,
+        so a linked worktree's own checkout never has one freshly, and the
+        git-hook guard already anchors every marker READ at the main
+        checkout regardless of a command's real exec root (D-2,
+        `_bashguardlib._effective_exec_root`'s docstring). This gives every
+        marker WRITER that same answer even when it runs without
+        `CLAUDE_PROJECT_DIR` set — `security-pass.py` invoked bare via a Bash
+        tool call, rather than as a registered hook subprocess that inherits
+        it from the harness — closing the loop without touching
+        `project_root()` itself, which other callers (diff scans in
+        particular) need to stay worktree-local."""
+        root = self.project_root(payload)
+        return git_worktree_main_root(root) or root
 
     def plugin_root(self):
         """The plugin payload root: CLAUDE_PLUGIN_ROOT when set, else derived

--- a/plugins/ca-pi/hooks/migration-pass.py
+++ b/plugins/ca-pi/hooks/migration-pass.py
@@ -29,8 +29,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    content_digest, is_migration_path, marker_root, project_root, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -86,7 +86,13 @@ def main():
         text = read_text(root, rel)
         if text is not None:
             digests.add(content_digest(text))
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: same split as security-pass.py — candidate_paths(root)/read_text(root, …)
+    # above must stay bound to wherever this process is actually running (a
+    # linked worktree's own tree), but the MARKER write goes through
+    # marker_root(), which agrees with the H-14 guard's main-checkout-anchored
+    # read (D-2) even when this process has no CLAUDE_PROJECT_DIR set.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "migration-gate-passed")
     digests = sorted(digests)
@@ -95,7 +101,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"migration-gate pass recorded: {len(digests)} migration file(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/plugins/ca-pi/hooks/security-pass.py
+++ b/plugins/ca-pi/hooks/security-pass.py
@@ -27,8 +27,8 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
-    line_digest, project_root, sensitive_scan_added_lines, set_host,
-    utf8_stdio, warn, write_text_atomic,
+    line_digest, marker_root, project_root, sensitive_scan_added_lines,
+    set_host, utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -97,7 +97,17 @@ def main():
         sys.exit(1)
     sensitive = [ln for ln in candidate_lines(root)
                  if CRYPTO_RE.search(ln) or SECRET_RE.search(ln)]
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: the MARKER root is deliberately NOT `root` above. `root` (plain
+    # project_root()) must stay wherever this process is actually running —
+    # candidate_lines(root) just scanned exactly that tree's diff, and binding
+    # digests to a DIFFERENT tree would review lines nobody staged. But in a
+    # linked git worktree, `root` names the worktree's own (gitignored,
+    # never-checked-out) `.codearbiter/.markers/`, while the H-09b/H-10b
+    # guard reads the marker from the MAIN checkout (D-2) — marker_root()
+    # gives the write the same main-checkout answer the guard's read already
+    # has, without moving the scan.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "security-gate-passed")
     digests = sorted({line_digest(ln) for ln in sensitive})
@@ -106,7 +116,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"security-gate pass recorded: {len(digests)} sensitive line(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.11.9",
+  "version": "2.11.10",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca/hooks/_activationlib.py
+++ b/plugins/ca/hooks/_activationlib.py
@@ -113,6 +113,19 @@ def _reset_root_cache():
     still-valid (env, cwd) cache entry) call this between scenarios."""
     _ROOT_CACHE.clear()
 
+
+def marker_root(payload=None):
+    """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+    migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to and
+    read from (#604) — see `hostapi.Host.marker_root`'s docstring for why
+    this is NOT the same thing as `project_root()` in a linked worktree.
+
+    Not memoized like `project_root()` above: called at most once or twice
+    per hook process (the marker checks, or a single `security-pass.py` /
+    `migration-pass.py` run), so the extra git spawn a linked-worktree
+    escalation occasionally costs is not worth a second cache to avoid."""
+    return get_host().marker_root(payload)
+
 ARBITER_RE = re.compile(r"^\s*arbiter:\s*enabled\s*$", re.I)
 
 def frontmatter_enabled_text(text):

--- a/plugins/ca/hooks/_bashguardlib.py
+++ b/plugins/ca/hooks/_bashguardlib.py
@@ -88,6 +88,7 @@ from _hooklib import (
 from _gitexec import git_executable
 import _gitlib  # reused for its spawn-free, worktree-aware (.git-as-a-FILE /
                 # gitdir: pointer) project_root() climb (#223)
+from hostapi import git_worktree_main_root  # noqa: #604 marker-root escalation
 import _protectedstatelib  # H-22's shell flank (T-08, #564) — imported as a
                             # module (not `from ... import REGISTRY`) so
                             # _STATE_WRITE_RES below is built from a live
@@ -1456,6 +1457,23 @@ def _check_h22_state(cmd, root):
                           f"this policy. Use the sanctioned helper.")
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` itself names a
+    LINKED git worktree's own checkout (#604) — see
+    `hostapi.git_worktree_main_root`'s docstring.
+
+    `root` (this file's own `project_root()`-derived parameter, D-2) already
+    names the main checkout in the common case: the harness sets
+    `CLAUDE_PROJECT_DIR` once at session start, before a session's cwd ever
+    moves into a linked worktree, so this is a no-op for the reported bug's
+    own scenario. It matters only when THIS hook process ALSO ran without
+    `CLAUDE_PROJECT_DIR` set (uncommon for a registered hook subprocess, but
+    possible) — without this, that edge case would have the guard read from
+    the worktree while `security-pass.py`'s `marker_root()` (hostapi.py)
+    writes to the main checkout, reopening the exact split this closes."""
+    return git_worktree_main_root(root) or root
+
+
 def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
     """H-09b / H-10b: BLOCK a commit that introduces crypto/secret changes without
     a recorded security-gate pass. The crypto-compliance / secret-handling skills
@@ -1494,7 +1512,7 @@ def _check_h09b_h10b_crypto_secret(commit, add, cwd, root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, 30):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (.codearbiter/.markers/security-gate-passed). Run the "
@@ -1556,7 +1574,7 @@ def _check_h14_migration(commit, add, cwd, root):
     staged |= extra
     migs = sorted(p for p in staged if is_migration_path(p, root))
     if migs:
-        marker = os.path.join(root, ".codearbiter", ".markers", "migration-gate-passed")
+        marker = os.path.join(_marker_root(root), ".codearbiter", ".markers", "migration-gate-passed")
         try:
             with open(marker, encoding="utf-8") as f:
                 approved = set(f.read().split())

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -41,6 +41,10 @@
 #   project_root(payload=None) -> str    CLAUDE_PROJECT_DIR, else git repo root, else cwd
 #                                         (memoized per process, keyed on the
 #                                         inputs that could change it — #260)
+#   marker_root(payload=None) -> str     project_root(payload), escalated to the MAIN
+#                                         checkout when that names a LINKED worktree's
+#                                         own checkout — the root gate MARKERS
+#                                         (.codearbiter/.markers/) live under (#604)
 #   repo_rel(fpath, root) -> str         repo-relative POSIX path, or "" if outside root
 #   line_digest(line) -> str             sha256 hex of one diff line (H-09b/H-10b gate)
 #   content_digest(text) -> str          sha256 hex of a whole file's content (H-14 gate)
@@ -122,6 +126,7 @@ from _activationlib import (  # noqa: F401
     frontmatter_enabled,
     frontmatter_enabled_text,
     get_host,
+    marker_root,
     project_root,
     reset_host,
     set_host,

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -63,6 +63,63 @@ def git_toplevel(cwd=None):
     return None
 
 
+def git_worktree_main_root(root):
+    """When `root` (an already-resolved project root — a `project_root()`
+    answer, NOT necessarily a fresh `git_toplevel` call) is itself the
+    checkout of a LINKED git worktree, the MAIN checkout's root that owns the
+    shared `.git` directory — else `None`.
+
+    #604: `security-pass.py`/`migration-pass.py` and the H-09b/H-10b/H-14
+    guards were found resolving DIFFERENT roots for GATE MARKERS in a
+    linked-worktree session — a hook subprocess trusts a (possibly stale)
+    `CLAUDE_PROJECT_DIR` naming the MAIN checkout, while `security-pass.py`
+    run bare via Bash (no `CLAUDE_PROJECT_DIR` in that shell) fell through to
+    `git_toplevel()`, which names the WORKTREE's own checkout — so a gate
+    pass recorded by one was never seen by the other. `.codearbiter/
+    .markers/` is gitignored, so a linked worktree's own checkout never has
+    one freshly — the git-hook guard's diff/branch resolution already
+    carries this exact split (`_bashguardlib._effective_exec_root`'s
+    docstring, D-2: gate markers stay pinned to the main checkout regardless
+    of the command's effective exec root).
+
+    Deliberately NOT wired into `Host.project_root()` itself: `project_root()`
+    also backs `security-pass.py`'s DIFF SCAN (`candidate_lines()`), which
+    must stay worktree-local — escalating the general project root to "main"
+    would bind digests to the wrong (unrelated, possibly dirty) tree and
+    silently drop coverage for the diff actually being committed, the exact
+    trap the issue this closes warns against. Callers that specifically need
+    the gate-MARKER root call this as a targeted escalation on top of an
+    already-resolved `project_root()` answer instead — e.g.
+    `git_worktree_main_root(root) or root` — so every OTHER project_root()
+    consumer (diff scans, `arbiter_active`, …) is entirely unaffected, and
+    the two callers agree on marker location without `git_toplevel`'s own
+    `git rev-parse` mechanism being replaced anywhere (deliberate: symlink/
+    8.3 canonicalization, #125).
+
+    Distinguishes a linked worktree from a submodule — both have a `.git`
+    FILE, but only a worktree's `gitdir:` pointer names a path under
+    `.git/worktrees/<name>`; a submodule's names `.git/modules/<name>`, which
+    is not a "main root" to climb to and must fall through untouched (mirrors
+    `_durabilitylib._gitfile_points_at_worktree`'s same distinction)."""
+    git_meta = os.path.join(root, ".git")
+    if not os.path.isfile(git_meta):
+        return None
+    try:
+        with open(git_meta, encoding="utf-8", errors="replace") as f:
+            pointer = f.read().strip()
+    except OSError:
+        return None
+    if not pointer.startswith("gitdir: "):
+        return None
+    gitdir = pointer[len("gitdir: "):].strip().replace("\\", "/")
+    marker = "/.git/worktrees/"
+    idx = gitdir.find(marker)
+    if idx == -1:
+        return None  # not a linked worktree (e.g. a submodule) — nothing to climb to
+    main_git_dir = gitdir[:idx + len("/.git")]
+    return os.path.dirname(main_git_dir) or None
+
+
 class Host:
     """One host's answers to the host-coupled questions the hooks ask.
 
@@ -123,7 +180,11 @@ class Host:
              var.
           3. `git rev-parse --show-toplevel` from the process cwd.
           4. the process cwd.
-        """
+
+        Deliberately climbs no further than the WORKTREE's own toplevel in a
+        linked-worktree session — a caller wanting the gate-MARKER root (which
+        must agree on the MAIN checkout, #604) calls `marker_root()` instead;
+        see its docstring for why the two must not be conflated."""
         env_root = os.environ.get("CLAUDE_PROJECT_DIR")
         if env_root and os.path.isdir(env_root):
             return env_root
@@ -135,6 +196,28 @@ class Host:
         if top:
             return top
         return os.getcwd()
+
+    def marker_root(self, payload=None):
+        """The root `.codearbiter/.markers/` gate passes (security-pass.py,
+        migration-pass.py, and the H-09b/H-10b/H-14 guards) are written to
+        and read from (#604).
+
+        Identical to `project_root(payload)` in every case except one: when
+        that resolves to a LINKED git worktree's own checkout, this escalates
+        to the MAIN checkout that owns the shared `.git` directory instead
+        (`git_worktree_main_root`) — `.codearbiter/.markers/` is gitignored,
+        so a linked worktree's own checkout never has one freshly, and the
+        git-hook guard already anchors every marker READ at the main
+        checkout regardless of a command's real exec root (D-2,
+        `_bashguardlib._effective_exec_root`'s docstring). This gives every
+        marker WRITER that same answer even when it runs without
+        `CLAUDE_PROJECT_DIR` set — `security-pass.py` invoked bare via a Bash
+        tool call, rather than as a registered hook subprocess that inherits
+        it from the harness — closing the loop without touching
+        `project_root()` itself, which other callers (diff scans in
+        particular) need to stay worktree-local."""
+        root = self.project_root(payload)
+        return git_worktree_main_root(root) or root
 
     def plugin_root(self):
         """The plugin payload root: CLAUDE_PLUGIN_ROOT when set, else derived

--- a/plugins/ca/hooks/migration-pass.py
+++ b/plugins/ca/hooks/migration-pass.py
@@ -29,8 +29,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hooklib import (  # noqa: E402
-    content_digest, is_migration_path, project_root, set_host, utf8_stdio,
-    warn, write_text_atomic,
+    content_digest, is_migration_path, marker_root, project_root, set_host,
+    utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_FILE_BYTES = 1_000_000  # a blob bigger than this is not a reviewable migration
@@ -86,7 +86,13 @@ def main():
         text = read_text(root, rel)
         if text is not None:
             digests.add(content_digest(text))
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: same split as security-pass.py — candidate_paths(root)/read_text(root, …)
+    # above must stay bound to wherever this process is actually running (a
+    # linked worktree's own tree), but the MARKER write goes through
+    # marker_root(), which agrees with the H-14 guard's main-checkout-anchored
+    # read (D-2) even when this process has no CLAUDE_PROJECT_DIR set.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "migration-gate-passed")
     digests = sorted(digests)
@@ -95,7 +101,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"migration-gate pass recorded: {len(digests)} migration file(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/plugins/ca/hooks/security-pass.py
+++ b/plugins/ca/hooks/security-pass.py
@@ -27,8 +27,8 @@ import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _hooklib import (  # noqa: E402
     CRYPTO_RE, SECRET_RE, SECURITY_DIFF_GIT_ARGS, is_sensitive_scan_exempt,
-    line_digest, project_root, sensitive_scan_added_lines, set_host,
-    utf8_stdio, warn, write_text_atomic,
+    line_digest, marker_root, project_root, sensitive_scan_added_lines,
+    set_host, utf8_stdio, warn, write_text_atomic,
 )
 
 MAX_UNTRACKED_BYTES = 1_000_000  # an untracked blob bigger than this is not reviewable prose
@@ -97,7 +97,17 @@ def main():
         sys.exit(1)
     sensitive = [ln for ln in candidate_lines(root)
                  if CRYPTO_RE.search(ln) or SECRET_RE.search(ln)]
-    marker_dir = os.path.join(root, ".codearbiter", ".markers")
+    # #604: the MARKER root is deliberately NOT `root` above. `root` (plain
+    # project_root()) must stay wherever this process is actually running —
+    # candidate_lines(root) just scanned exactly that tree's diff, and binding
+    # digests to a DIFFERENT tree would review lines nobody staged. But in a
+    # linked git worktree, `root` names the worktree's own (gitignored,
+    # never-checked-out) `.codearbiter/.markers/`, while the H-09b/H-10b
+    # guard reads the marker from the MAIN checkout (D-2) — marker_root()
+    # gives the write the same main-checkout answer the guard's read already
+    # has, without moving the scan.
+    write_root = marker_root()
+    marker_dir = os.path.join(write_root, ".codearbiter", ".markers")
     os.makedirs(marker_dir, exist_ok=True)
     marker = os.path.join(marker_dir, "security-gate-passed")
     digests = sorted({line_digest(ln) for ln in sensitive})
@@ -106,7 +116,7 @@ def main():
     # spurious gate re-run.
     write_text_atomic(marker, "\n".join(digests) + ("\n" if digests else ""))
     print(f"security-gate pass recorded: {len(digests)} sensitive line(s) "
-          f"bound to {os.path.relpath(marker, root)}")
+          f"bound to {os.path.relpath(marker, write_root)}")
 
 
 def run(host, argv=None):

--- a/plugins/ca/hooks/tests/test_colorlib.py
+++ b/plugins/ca/hooks/tests/test_colorlib.py
@@ -345,8 +345,74 @@ if sl.V2 != sl._colorlib.V2 or sl._boxlib._V0 != sl._colorlib.V0 \
 """
             env = dict(os.environ, PYTHONPATH=_HOOKS_DIR, CODEARBITER_THEME="custom",
                        CODEARBITER_THEME_FILE=path, COLUMNS="80")
+            # #552: without an explicit cwd, this subprocess inherits the test
+            # RUNNER's cwd, and project_root() (no CLAUDE_PROJECT_DIR, no
+            # payload cwd) falls back to a git-toplevel/`.codearbiter` climb
+            # from THERE — on a maintainer's own checkout (as opposed to a
+            # pristine CI clone) that resolves to the REAL repo, and `combined`
+            # then includes whatever real gate-events.log/overrides.log state
+            # happens to be lying around. `tmp` has neither `.git` nor
+            # `.codearbiter`, so the climb finds nothing and `arb` renders
+            # absent — the "required colors present" assertion below no longer
+            # depends on which segments the maintainer's own audit trail
+            # happens to turn on or off.
             run = subprocess.run([sys.executable, "-c", script], text=True,
-                                 capture_output=True, env=env)
+                                 capture_output=True, env=env, cwd=tmp)
+            self.assertEqual(run.returncode, 0, run.stderr)
+
+    def test_custom_palette_survives_arbitrary_appended_codearbiter_state(self):
+        # #552 AC-2: proven by APPENDING rows in the test's OWN fixture, not by
+        # hoping the maintainer's real repo happens not to trip it. Builds a
+        # `.codearbiter/` with a heavily "dirty" audit trail — many override
+        # rows, many gate-event rows, several in-flight tasks, an unresolved
+        # open question — the exact shape #552 reports growing over a repo's
+        # lifetime, and renders the custom-palette statusline against it. Every
+        # required color must still appear regardless of which segments that
+        # state happens to switch on (the arb line's tasks/q/over counts all
+        # render non-zero here, on purpose — the maximally adversarial case).
+        with tempfile.TemporaryDirectory() as tmp:
+            theme_path = os.path.join(tmp, "theme.json")
+            with open(theme_path, "w", encoding="utf-8") as handle:
+                json.dump({"accent": {"deep": "#010203", "primary": "#040506",
+                                       "bright": "#070809"},
+                           "text": {"muted": "#0a0b0c", "normal": "#0d0e0f"},
+                           "gradient": {"from": "#101112", "to": "#131415"}}, handle)
+            ca = os.path.join(tmp, ".codearbiter")
+            os.makedirs(ca)
+            with open(os.path.join(ca, "CONTEXT.md"), "w", encoding="utf-8") as f:
+                f.write("---\narbiter: enabled\nstage: 2\n---\n<!--INITIALIZED-->\n")
+            with open(os.path.join(ca, "overrides.log"), "w", encoding="utf-8") as f:
+                f.write("".join(f"2026-01-{n:02d} override #{n} logged\n"
+                                for n in range(1, 41)))
+            with open(os.path.join(ca, "gate-events.log"), "w", encoding="utf-8") as f:
+                f.write("".join(f"2026-01-{n:02d} PASS H-09b gate-event #{n}\n"
+                                for n in range(1, 201)))
+            with open(os.path.join(ca, "open-tasks.md"), "w", encoding="utf-8") as f:
+                f.write("- [~] task one (started 2026-01-01)\n"
+                        "- [~] task two (started 2026-01-02)\n"
+                        "- [ ] task three queued\n")
+            with open(os.path.join(ca, "open-questions.md"), "w", encoding="utf-8") as f:
+                f.write("CONFIRM-01: an unresolved open question\n")
+            script = """
+import json, statusline as sl
+payload = json.dumps({'session_id': 'adversarial-state', 'model': {'display_name': 'Test'},
+                      'context_window': {'used_percentage': 20}})
+sl.git_dirty = lambda _root: True
+out = sl.render(payload)
+box = sl._boxlib.Box(40)
+box.top('status')
+combined = out + box.render() + sl._fmtlib.sparkline([1, 2, 3]) \\
+           + sl._segmentslib.seg_pr({'pr': {'number': 1, 'state': 'merged'}})
+required = [(1,2,3), (4,5,6), (7,8,9), (10,11,12), (13,14,15),
+            (16,17,18), (19,20,21)]
+missing = [rgb for rgb in required if sl.fg(*rgb) not in combined]
+if missing:
+    raise AssertionError('missing custom colors under adversarial state: %r' % (missing,))
+"""
+            env = dict(os.environ, PYTHONPATH=_HOOKS_DIR, CODEARBITER_THEME="custom",
+                       CODEARBITER_THEME_FILE=theme_path, COLUMNS="80")
+            run = subprocess.run([sys.executable, "-c", script], text=True,
+                                 capture_output=True, env=env, cwd=tmp)
             self.assertEqual(run.returncode, 0, run.stderr)
 
     def test_concurrent_theme_switches_never_mix_consumer_palettes(self):

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -32,6 +32,7 @@ ENFORCE = os.path.join(HOOKS, "git-enforce.py")
 sys.path.insert(0, HOOKS)
 import _githooks  # noqa: E402
 import _hooklib  # noqa: E402
+from _helpers import durable_plugin_copy  # noqa: E402
 
 
 def _load_git_enforce():
@@ -69,8 +70,26 @@ class _GitFixture(unittest.TestCase):
         _git(["config", "user.name", "harness"], self.root)
         os.makedirs(os.path.join(self.root, ".codearbiter"))
         self._write(os.path.join(self.root, ".codearbiter", "CONTEXT.md"), self.ARBITER)
+        # #604 test-fidelity: this suite may itself be running from inside a
+        # LINKED WORKTREE (subagents do this routinely). `_githooks._enforcer_path()`
+        # resolves from `_githooks.py`'s own `__file__` — when that's the worktree's
+        # copy, `is_ephemeral_path()` (#441/ADR-0014) correctly REFUSES to pin it
+        # into a fixture repo's shared drop-in dir (an ephemeral path must never be
+        # written into a config that is meant to outlive the process), which
+        # silently no-ops every `_githooks.install()` call below and fails every
+        # real-git-hook-firing test here for reasons having nothing to do with what
+        # they assert. `durable_plugin_copy` gives `_githooks` a plain-temp-dir
+        # (never ephemeral) copy of the whole hooks payload to resolve its own
+        # enforcer path from instead — the same #442 fix already applied to the
+        # statusline-pin suites, so "durable" is a property of the FIXTURE, not of
+        # wherever the developer/subagent happened to run the suite from.
+        durable_root = durable_plugin_copy(self._tmp.name)
+        self._enforcer_patch = mock.patch.object(
+            _githooks, "__file__", os.path.join(durable_root, "hooks", "_githooks.py"))
+        self._enforcer_patch.start()
 
     def tearDown(self):
+        self._enforcer_patch.stop()
         self._tmp.cleanup()
 
     def _write(self, path, text):

--- a/plugins/ca/hooks/tests/test_host_project_root.py
+++ b/plugins/ca/hooks/tests/test_host_project_root.py
@@ -144,5 +144,137 @@ class BaseHostProjectRootTests(unittest.TestCase):
             self.assertEqual(os.path.realpath(got), os.path.realpath(payload_dir))
 
 
+def _init_repo(root, branch="main"):
+    os.makedirs(root)
+    r = subprocess.run(["git", "init", "-q", "-b", branch], cwd=root,
+                       capture_output=True, timeout=30)
+    if r.returncode != 0:
+        return False
+    subprocess.run(["git", "config", "user.email", "h@example.com"], cwd=root,
+                   capture_output=True, timeout=30)
+    subprocess.run(["git", "config", "user.name", "h"], cwd=root,
+                   capture_output=True, timeout=30)
+    with open(os.path.join(root, "seed.txt"), "w", encoding="utf-8") as f:
+        f.write("seed\n")
+    subprocess.run(["git", "add", "seed.txt"], cwd=root, capture_output=True, timeout=30)
+    r = subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=root,
+                       capture_output=True, timeout=30)
+    return r.returncode == 0
+
+
+class GitWorktreeMainRootTests(unittest.TestCase):
+    """hostapi.git_worktree_main_root(root) — #604's escalation from a linked
+    worktree's own checkout to the MAIN checkout that owns the shared `.git`
+    directory. Used by Host.marker_root() (below), NOT by Host.project_root()
+    itself — see both docstrings for why the split matters."""
+
+    def setUp(self):
+        if not _git_available():
+            self.skipTest("git unavailable")
+
+    def test_linked_worktree_resolves_to_main_checkout(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            main_checkout = os.path.join(top, "main-checkout")
+            if not _init_repo(main_checkout, branch="main"):
+                self.skipTest("git init/commit failed")
+            wt_dir = os.path.join(top, "linked-worktree")
+            r = subprocess.run(
+                ["git", "worktree", "add", "-b", "feat/x", wt_dir], cwd=main_checkout,
+                capture_output=True, text=True, timeout=30)
+            if r.returncode != 0:
+                self.skipTest(f"git worktree add failed: {r.stderr}")
+            got = hostapi.git_worktree_main_root(wt_dir)
+            self.assertIsNotNone(got)
+            self.assertEqual(os.path.realpath(got), os.path.realpath(main_checkout))
+
+    def test_ordinary_repo_returns_none(self):
+        # An ordinary checkout's `.git` is a DIRECTORY -- nothing to escalate.
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            repo = os.path.join(top, "repo")
+            if not _init_repo(repo):
+                self.skipTest("git init failed")
+            self.assertIsNone(hostapi.git_worktree_main_root(repo))
+
+    def test_non_repo_path_returns_none(self):
+        with tempfile.TemporaryDirectory() as plain:
+            self.assertIsNone(hostapi.git_worktree_main_root(plain))
+
+    def test_submodule_style_gitfile_is_not_mistaken_for_a_worktree(self):
+        # A submodule's `.git` is ALSO a FILE, but its `gitdir:` pointer names
+        # `.git/modules/<name>`, never `.git/worktrees/<name>` -- must return
+        # None, not climb to some unrelated "main root".
+        with tempfile.TemporaryDirectory() as top:
+            fake_submodule = os.path.join(top, "sub")
+            os.makedirs(fake_submodule)
+            with open(os.path.join(fake_submodule, ".git"), "w", encoding="utf-8") as f:
+                f.write(f"gitdir: {top}/.git/modules/sub\n")
+            self.assertIsNone(hostapi.git_worktree_main_root(fake_submodule))
+
+
+class MarkerRootTests(unittest.TestCase):
+    """hostapi.Host.marker_root — #604: agrees with project_root() everywhere
+    EXCEPT a linked worktree with no CLAUDE_PROJECT_DIR, where it climbs to
+    the main checkout instead of the worktree's own (gitignored-markers)
+    checkout — the root security-pass.py/migration-pass.py now write to, and
+    the H-09b/H-10b/H-14 guard now agrees with (see test_security_pass.py /
+    test_repo_resolution.py for the end-to-end proof)."""
+
+    def setUp(self):
+        self.host = hostapi.Host()
+        self._env = os.environ.get("CLAUDE_PROJECT_DIR")
+        self._cwd = os.getcwd()
+        if not _git_available():
+            self.skipTest("git unavailable")
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        if self._env is None:
+            os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        else:
+            os.environ["CLAUDE_PROJECT_DIR"] = self._env
+
+    def test_ordinary_repo_matches_project_root(self):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            repo = os.path.join(top, "repo")
+            if not _init_repo(repo):
+                self.skipTest("git init failed")
+            os.chdir(repo)
+            self.assertEqual(
+                os.path.realpath(self.host.marker_root()),
+                os.path.realpath(self.host.project_root()))
+
+    def test_claude_project_dir_still_wins_first(self):
+        # Byte-identity with project_root()'s own leg 1 -- marker_root() must
+        # not invent a second, different env-var precedence.
+        with tempfile.TemporaryDirectory() as env_dir:
+            os.environ["CLAUDE_PROJECT_DIR"] = env_dir
+            self.assertEqual(os.path.realpath(self.host.marker_root()),
+                             os.path.realpath(env_dir))
+
+    def test_linked_worktree_cwd_escalates_to_main_checkout_when_env_unset(self):
+        # The #604 case: security-pass.py invoked bare via Bash (no
+        # CLAUDE_PROJECT_DIR in that shell), cwd inside a linked worktree --
+        # marker_root() must name the MAIN checkout, not the worktree.
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as top:
+            main_checkout = os.path.join(top, "main-checkout")
+            if not _init_repo(main_checkout, branch="main"):
+                self.skipTest("git init/commit failed")
+            wt_dir = os.path.join(top, "linked-worktree")
+            r = subprocess.run(
+                ["git", "worktree", "add", "-b", "feat/y", wt_dir], cwd=main_checkout,
+                capture_output=True, text=True, timeout=30)
+            if r.returncode != 0:
+                self.skipTest(f"git worktree add failed: {r.stderr}")
+            os.chdir(wt_dir)
+            # project_root() stays worktree-local (the diff-scan contract) --
+            # marker_root() alone climbs.
+            self.assertEqual(os.path.realpath(self.host.project_root()),
+                             os.path.realpath(wt_dir))
+            self.assertEqual(os.path.realpath(self.host.marker_root()),
+                             os.path.realpath(main_checkout))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/ca/hooks/tests/test_repo_resolution.py
+++ b/plugins/ca/hooks/tests/test_repo_resolution.py
@@ -28,13 +28,16 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
 ENFORCE = os.path.join(HOOKS, "git-enforce.py")
+SECURITY_PASS = os.path.join(HOOKS, "security-pass.py")
 
 sys.path.insert(0, HOOKS)
 import _githooks  # noqa: E402
+from _helpers import durable_plugin_copy  # noqa: E402
 
 
 def _load_module(name, path):
@@ -377,8 +380,21 @@ class TestGitEnforceOwnRepoResolution(unittest.TestCase):
         _init_repo(self.session_root, branch="feat/work")  # clean feature branch
         self.other_root = os.path.join(self._tmp.name, "other-repo")
         _init_repo(self.other_root, branch="main")  # the repo actually committing
+        # #604 test-fidelity (mirrors test_git_hooks.py's _GitFixture): this
+        # suite may itself run from inside a linked worktree, which makes
+        # `_githooks`'s own `__file__` ephemeral (#441/ADR-0014) and silently
+        # no-ops `_githooks.install()`'s drop-in write below — durable_plugin_copy
+        # gives it a plain-temp-dir copy to resolve its enforcer path from
+        # instead, so the real end-to-end `git commit` in
+        # test_installed_hook_fires_correctly_in_its_own_repo finds a
+        # genuinely-registered enforcer regardless of where the suite runs.
+        durable_root = durable_plugin_copy(self._tmp.name)
+        self._enforcer_patch = mock.patch.object(
+            _githooks, "__file__", os.path.join(durable_root, "hooks", "_githooks.py"))
+        self._enforcer_patch.start()
 
     def tearDown(self):
+        self._enforcer_patch.stop()
         self._tmp.cleanup()
 
     def _stage(self, root, name, content):
@@ -422,6 +438,116 @@ class TestGitEnforceOwnRepoResolution(unittest.TestCase):
         env = {**os.environ, "CLAUDE_PROJECT_DIR": self.session_root}
         res = _sh([sys.executable, ENFORCE, "pre-commit"], feat_root, env=env)
         self.assertEqual(res.returncode, 0, res.stderr)
+
+
+# ---------------------------------------------------------------------------
+# #604: security-pass.py (invoked bare via Bash, no CLAUDE_PROJECT_DIR in
+# that shell) and pre-bash.py's H-09b/H-10b guard (a hook subprocess that
+# inherits a CLAUDE_PROJECT_DIR pinned to the MAIN checkout even after the
+# session's cwd moves into a linked worktree) used to resolve DIFFERENT
+# project roots for the security-gate marker -- a legitimately-recorded pass
+# was written where the guard never looked. marker_root() (hostapi.py) now
+# gives the producer the same main-checkout answer the guard's
+# CLAUDE_PROJECT_DIR-first read already has.
+# ---------------------------------------------------------------------------
+
+CRYPTO_LINE = "const h = createHash('md5');\n"  # matches CRYPTO_RE
+
+
+class TestGateMarkerAgreesAcrossLinkedWorktree(unittest.TestCase):
+    """End-to-end, in a REAL linked git worktree: a gate pass recorded by
+    security-pass.py (run the way the crypto-compliance/secret-handling
+    skill prose actually invokes it -- bare, no CLAUDE_PROJECT_DIR) is
+    honored by pre-bash.py's H-09b guard (run the way the harness actually
+    invokes it -- CLAUDE_PROJECT_DIR pinned to the main checkout)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.main_checkout = os.path.join(self._tmp.name, "main-checkout")
+        os.makedirs(self.main_checkout)
+        _git(["init", "-q", "-b", "main"], self.main_checkout)
+        _git(["config", "user.email", "h@example.com"], self.main_checkout)
+        _git(["config", "user.name", "harness"], self.main_checkout)
+        os.makedirs(os.path.join(self.main_checkout, ".codearbiter"))
+        # #604: CONTEXT.md must be COMMITTED, not merely present on disk in
+        # main_checkout (as `_init_repo` elsewhere in this file leaves it) --
+        # `git worktree add` only checks out TRACKED content, and
+        # security-pass.py's own arbiter-enabled check reads the WORKTREE's
+        # own (unescalated) root, so an untracked CONTEXT.md would leave
+        # `wt_dir/.codearbiter/` missing entirely and fail this fixture
+        # before the behavior under test ever runs.
+        with open(os.path.join(self.main_checkout, ".codearbiter", "CONTEXT.md"),
+                  "w", encoding="utf-8") as f:
+            f.write(ARBITER)
+        _git(["add", ".codearbiter/CONTEXT.md"], self.main_checkout)
+        _git(["commit", "-q", "-m", "seed"], self.main_checkout)
+        self.wt_dir = os.path.join(self._tmp.name, "linked-worktree")
+        _git(["worktree", "add", "-b", "feat/work", self.wt_dir], self.main_checkout)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _bare_env(self):
+        # Simulates security-pass.py invoked via a raw Bash tool call: no
+        # CLAUDE_PROJECT_DIR in that shell at all (the #604 repro condition).
+        env = dict(os.environ)
+        env.pop("CLAUDE_PROJECT_DIR", None)
+        return env
+
+    def _hook_env(self):
+        # Simulates the harness's own PreToolUse hook subprocess: CLAUDE_PROJECT_DIR
+        # pinned to the MAIN checkout, unrefreshed after the session's cwd
+        # moved into the linked worktree.
+        return {**os.environ, "CLAUDE_PROJECT_DIR": self.main_checkout}
+
+    def _stage_crypto_line(self):
+        path = os.path.join(self.wt_dir, "auth.js")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(CRYPTO_LINE)
+        _git(["add", "auth.js"], self.wt_dir)
+
+    def _commit_payload(self):
+        return json.dumps({"tool_name": "Bash",
+                           "tool_input": {"command": "git commit -m x"}})
+
+    def test_marker_written_by_bare_security_pass_lands_at_main_checkout(self):
+        self._stage_crypto_line()
+        res = _sh([sys.executable, SECURITY_PASS], self.wt_dir, env=self._bare_env())
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertIn("1 sensitive line", res.stdout)
+        main_marker = os.path.join(
+            self.main_checkout, ".codearbiter", ".markers", "security-gate-passed")
+        wt_marker = os.path.join(
+            self.wt_dir, ".codearbiter", ".markers", "security-gate-passed")
+        self.assertTrue(os.path.isfile(main_marker),
+                        "the marker must land at the MAIN checkout (D-2)")
+        self.assertFalse(os.path.isfile(wt_marker),
+                         "the marker must NOT be written to the worktree's own, "
+                         "gitignored (never-shared) .codearbiter/.markers/")
+
+    def test_guard_honors_the_gate_pass_security_pass_actually_recorded(self):
+        # The full loop: record the pass the way the skill prose invokes it,
+        # then attempt the commit the way the harness invokes the guard.
+        self._stage_crypto_line()
+        passed = _sh([sys.executable, SECURITY_PASS], self.wt_dir, env=self._bare_env())
+        self.assertEqual(passed.returncode, 0, passed.stderr)
+
+        res = _sh([sys.executable, PRE_BASH], self.wt_dir,
+                  input=self._commit_payload(), env=self._hook_env())
+        self.assertEqual(res.returncode, 0,
+                         f"H-09b must not block a freshly-recorded, correctly-bound "
+                         f"gate pass: {res.stderr}")
+        self.assertNotIn("H-09b", res.stderr)
+
+    def test_guard_still_blocks_without_a_recorded_pass(self):
+        # No-fail-open converse: the SAME staged crypto line, with NO
+        # security-pass.py run first, must still BLOCK -- proves the fix
+        # didn't turn H-09b into a rubber stamp.
+        self._stage_crypto_line()
+        res = _sh([sys.executable, PRE_BASH], self.wt_dir,
+                  input=self._commit_payload(), env=self._hook_env())
+        self.assertEqual(res.returncode, 2, res.stderr)
+        self.assertIn("H-09b", res.stderr)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes two "works on a clean checkout, breaks in a real environment" defects that have repeatedly polluted this repo's local test runs.

### #604 — gate-marker root mismatch in a linked worktree

`security-pass.py`/`migration-pass.py` (invoked bare via a Bash tool call, no `CLAUDE_PROJECT_DIR` in that shell) and the H-09b/H-10b/H-14 commit guards (a hook subprocess whose `CLAUDE_PROJECT_DIR` names the main checkout) resolved **different** roots for `.codearbiter/.markers/` inside a linked git worktree — a legitimately-recorded gate pass was invisible to the guard.

Fix: a new `hostapi.Host.marker_root()` seam. `git_worktree_main_root(root)` escalates an already-resolved `project_root()` answer to the MAIN checkout **only** when that root is itself a linked worktree's own checkout (distinguished from a submodule via the `gitdir:` pointer's `.git/worktrees/` segment). Wired into both producers (`security-pass.py`, `migration-pass.py`) for the marker WRITE, and both guard checks (`_check_h09b_h10b_crypto_secret`, `_check_h14_migration`) for the marker READ — via `_marker_root()` in `_bashguardlib.py`. Deliberately **not** wired into `project_root()` itself: `security-pass.py`'s diff SCAN must stay bound to the worktree's own tree (the issue's own warning — binding digests to the wrong tree would review lines nobody staged). `git_toplevel`'s `git rev-parse` mechanism is unchanged, per the board history caution (bug #125, symlink/8.3 canonicalization) — the fix makes the two callers agree through the existing seam rather than replacing it.

Also fixes the 10-test pre-existing failure family in `test_git_hooks.py`/`test_repo_resolution.py` that fires whenever the suite itself runs from inside a linked worktree: `_githooks`'s own `__file__` resolves to an ephemeral path, which `is_ephemeral_path` (#441/ADR-0014) correctly refuses to register into a fixture's shared drop-in dir. Fixtures now resolve the enforcer path from a `durable_plugin_copy` (the #442 fix's existing pattern) instead of the live (possibly-ephemeral) checkout.

**Before/after, run inside a real linked worktree of this repo (dirty local state):**

| | before | after |
|---|---|---|
| `test_git_hooks.py` + `test_repo_resolution.py` | 10 failed | 0 failed |
| `plugins/ca/hooks/tests` (full suite) | 10 failed, 1301 passed | 0 failed, 1339 passed |

Proven end-to-end with a real `git worktree add` fixture (`TestGateMarkerAgreesAcrossLinkedWorktree` in `test_repo_resolution.py`): a marker written by `security-pass.py` (bare, no `CLAUDE_PROJECT_DIR`) lands at the main checkout, not the worktree; `pre-bash.py`'s H-09b guard honors it; and the guard still blocks with no recorded pass (no-fail-open converse).

### #552 — palette-compatibility tests read real repo state

`test_colorlib.py`'s palette-compatibility tests render the live statusline against the real repository when a subprocess call has no explicit `cwd` — `project_root()` falls back to a git-toplevel climb from the test runner's own cwd, so a maintainer's own accumulated `.codearbiter/` audit trail (task counts, override counts, gate-event rows) could intermittently drop a required custom-palette color from the assertion window.

Fix: pinned the state-sensitive subprocess render to an isolated temp dir (no `.git`/`.codearbiter` reachable), and added `test_custom_palette_survives_arbitrary_appended_codearbiter_state` — a new test that builds its own `.codearbiter/` fixture, appends 40 override rows, 200 gate-event rows, several in-flight tasks, and an unresolved open question (the exact adversarial shape #552 describes accumulating over a repo's lifetime), and proves the palette-completeness assertion still holds.

## Mutation proofs

- `hostapi.git_worktree_main_root`: forced it to return `None` unconditionally → `GitWorktreeMainRootTests`, `MarkerRootTests`, and both `TestGateMarkerAgreesAcrossLinkedWorktree` positive-proof tests went red with the exact expected assertion failures; the no-fail-open converse test stayed green. Restored, re-verified green, re-synced.
- `_githooks`'s durable-copy fixture patch: disabled `self._enforcer_patch.start()` in both test files → the exact same 10 pre-existing failures reproduced with identical messages. Restored, re-verified green.
- `_colorlib._read_custom`: forced it to return `None` unconditionally → the new adversarial-state test failed with "missing custom colors" for all 7 required colors. Restored, re-synced, re-verified green.

## Version advance

ca 2.11.9 → 2.11.10, ca-codex 0.4.8 → 0.4.9, ca-pi 0.2.8 → 0.2.9 (root `package.json` regenerated). All landed inside this PR's rebase onto the latest `origin/main` (which had independently advanced to 2.11.9/0.4.8/0.2.8 via #614/#615 while this branch was in flight) — the target versions in this PR were already exactly one patch above that new base, so no further bump was needed after resolving the conflict.

## Deviations from plan

- The H-09b crypto/secret gate on this PR's own commit hit a genuinely stale local marketplace-cache install (`~/.claude/plugins/cache/codearbiter/ca/2.10.0`) registered as the git-level `.git/hooks/pre-commit` enforcer — an environment fact unrelated to this fix (predates it, would recur on any PR). Resolved by running the *same stale* `security-pass.py` (not this branch's fixed copy) so its root resolution matched what the stale enforcer checks — no gate was bypassed; `/ca:override` was considered and rejected since it required fabricating user acknowledgement for a security-critical stop that a non-bypass fix cleanly resolved instead.

Closes #604
Closes #552

https://claude.ai/code/session_01QjJeSbcwPHwMmd6CEZeagB