### PR TITLE
fix(ca-pi): stop bridge.test.ts's hung-tree cancellation flake racing a fixed margin (#580)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-08-06
+
+### Fixed
+
+- `bridge.test.ts`'s hung-tree cancellation tests no longer race a fixed wall-clock margin against real Windows process-launch overhead (#580): the hostile test fixture's mutation delay is widened with real headroom and the fixed post-cancellation sleep is replaced with a fail-fast poll, removing a false-flake window measured (in a controlled trial) to leak 8/8 times once the kill trigger fired late and 0/15 times when it fired on schedule. `bridge.ts`'s Windows tree-kill (`killTree`) is also converted from a blocking `spawnSync` taskkill invocation to a non-blocking async one, matching `process-tree.ts`'s own pattern, so a slow kill can no longer stall the event loop it is itself racing.
+- Several `ca-pi` tests that launch real Windows processes under `--coverage` (package.test.ts's live-Pi-loader case, bridge.test.ts's force-settle case) now carry an explicit timeout headroom instead of relying on vitest's 5s default, addressing the same fixed-margin-vs-real-latency shape reported in #559.
+
 ## [0.2.17] - 2026-08-06
 
 ### Fixed

--- a/plugins/ca-pi/extensions/codearbiter-child.js
+++ b/plugins/ca-pi/extensions/codearbiter-child.js
@@ -351,14 +351,7 @@ function killTree(child, taskkillExecutable) {
       child.kill("SIGKILL");
       return;
     }
-    const result = spawnSync(taskkillExecutable, ["/pid", String(child.pid), "/t", "/f"], {
-      env: minimalEnvironment(),
-      shell: false,
-      stdio: "ignore",
-      timeout: WINDOWS_TASKKILL_TIMEOUT_MS,
-      windowsHide: true
-    });
-    if (result.error !== void 0 || result.status !== 0) child.kill("SIGKILL");
+    void killWindowsTree(child, taskkillExecutable);
     return;
   }
   try {
@@ -366,6 +359,48 @@ function killTree(child, taskkillExecutable) {
   } catch {
     child.kill("SIGKILL");
   }
+}
+function killWindowsTree(child, taskkillExecutable) {
+  return new Promise((resolveKill) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolveKill();
+    };
+    let helper;
+    try {
+      helper = spawn(taskkillExecutable, ["/pid", String(child.pid), "/t", "/f"], {
+        env: minimalEnvironment(),
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true
+      });
+    } catch {
+      child.kill("SIGKILL");
+      finish();
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        helper.kill("SIGKILL");
+      } catch {
+      }
+      child.kill("SIGKILL");
+      finish();
+    }, WINDOWS_TASKKILL_TIMEOUT_MS);
+    timer.unref?.();
+    helper.once("error", () => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      finish();
+    });
+    helper.once("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) child.kill("SIGKILL");
+      finish();
+    });
+  });
 }
 var BRIDGE_CORRELATION_RE = /^[a-f0-9]{64}$/u;
 function normalizedRequest(request) {

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -712,14 +712,7 @@ function killTree(child, taskkillExecutable) {
       child.kill("SIGKILL");
       return;
     }
-    const result3 = spawnSync(taskkillExecutable, ["/pid", String(child.pid), "/t", "/f"], {
-      env: minimalEnvironment(),
-      shell: false,
-      stdio: "ignore",
-      timeout: WINDOWS_TASKKILL_TIMEOUT_MS,
-      windowsHide: true
-    });
-    if (result3.error !== void 0 || result3.status !== 0) child.kill("SIGKILL");
+    void killWindowsTree(child, taskkillExecutable);
     return;
   }
   try {
@@ -727,6 +720,48 @@ function killTree(child, taskkillExecutable) {
   } catch {
     child.kill("SIGKILL");
   }
+}
+function killWindowsTree(child, taskkillExecutable) {
+  return new Promise((resolveKill) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolveKill();
+    };
+    let helper;
+    try {
+      helper = spawn(taskkillExecutable, ["/pid", String(child.pid), "/t", "/f"], {
+        env: minimalEnvironment(),
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true
+      });
+    } catch {
+      child.kill("SIGKILL");
+      finish();
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        helper.kill("SIGKILL");
+      } catch {
+      }
+      child.kill("SIGKILL");
+      finish();
+    }, WINDOWS_TASKKILL_TIMEOUT_MS);
+    timer.unref?.();
+    helper.once("error", () => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      finish();
+    });
+    helper.once("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) child.kill("SIGKILL");
+      finish();
+    });
+  });
 }
 var BRIDGE_CORRELATION_RE = /^[a-f0-9]{64}$/u;
 function normalizedRequest(request) {
@@ -9500,7 +9535,7 @@ async function codeArbiterPi(pi) {
         activeTools: pi.getActiveTools(),
         allTools: pi.getAllTools(),
         expansionFingerprints,
-        childFingerprint: "817a2a7a4789f0ff64053d0c4d01c776d5518504afc992ef81c176fe09b10504"
+        childFingerprint: "9e46ad7e682671a68cd4d2ff02e2610a7251af83664941a5ba903ef120b84d88"
       });
       const wrapperSelfTest = await runPiWrapperSelfTest({
         enabled: enabledForDoctor,

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-pi",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/bridge.ts
+++ b/plugins/ca-pi/tools/src/bridge.ts
@@ -583,17 +583,61 @@ function killTree(child: ReturnType<typeof spawn>, taskkillExecutable: string | 
       child.kill("SIGKILL");
       return;
     }
-    const result = spawnSync(taskkillExecutable, ["/pid", String(child.pid), "/t", "/f"], {
-      env: minimalEnvironment(),
-      shell: false,
-      stdio: "ignore",
-      timeout: WINDOWS_TASKKILL_TIMEOUT_MS,
-      windowsHide: true,
-    });
-    if (result.error !== undefined || result.status !== 0) child.kill("SIGKILL");
+    void killWindowsTree(child, taskkillExecutable);
     return;
   }
   try { process.kill(-child.pid, "SIGKILL"); } catch { child.kill("SIGKILL"); }
+}
+
+/**
+ * Issue #580: this used to run taskkill via spawnSync, which blocks the
+ * entire event loop - including this module's own timers - for up to
+ * WINDOWS_TASKKILL_TIMEOUT_MS. That is the same event loop the cancellation
+ * deadline (the thing racing a hostile tree's own mutation) depends on, so a
+ * synchronous kill could itself widen the exact window it exists to close.
+ * process-tree.ts's runTaskkill already does this the non-blocking way; this
+ * mirrors that shape instead of diverging from it. Falls back to a direct
+ * SIGKILL of the immediate child on any failure to start, a timeout, or a
+ * non-zero exit - the same fallback the synchronous version used.
+ */
+function killWindowsTree(child: ReturnType<typeof spawn>, taskkillExecutable: string): Promise<void> {
+  return new Promise((resolveKill) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolveKill();
+    };
+    let helper: ReturnType<typeof spawn>;
+    try {
+      helper = spawn(taskkillExecutable, ["/pid", String(child.pid), "/t", "/f"], {
+        env: minimalEnvironment(),
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch {
+      child.kill("SIGKILL");
+      finish();
+      return;
+    }
+    const timer = setTimeout(() => {
+      try { helper.kill("SIGKILL"); } catch { /* best-effort: helper may have already exited */ }
+      child.kill("SIGKILL");
+      finish();
+    }, WINDOWS_TASKKILL_TIMEOUT_MS);
+    timer.unref?.();
+    helper.once("error", () => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      finish();
+    });
+    helper.once("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) child.kill("SIGKILL");
+      finish();
+    });
+  });
 }
 
 /** One SHA-256 digest in lowercase hex: the only correlation shape allowed on the wire. */

--- a/plugins/ca-pi/tools/test/bridge.test.ts
+++ b/plugins/ca-pi/tools/test/bridge.test.ts
@@ -202,6 +202,32 @@ function request(tool: string, input: Record<string, unknown>) {
   return { version: 1 as const, event: "tool_call", cwd: projectCwd, tool, input };
 }
 
+// Issue #580: a hostile grandchild's mutation is a single one-way write, not a
+// value that can transition back to "gone" - so this cannot poll for
+// disappearance. What it CAN do is fail the instant the write is observed
+// rather than trusting a fixed sleep to have covered the teardown window
+// (the bug: on a loaded box the real teardown deadline can slip past a fixed
+// wait even though cancellation is still working correctly, because a
+// one-way file write can never be un-written by waiting longer). Polling
+// short-circuits a genuine leak immediately and only asserts "no leak" once
+// the caller-supplied window has fully elapsed with no write observed.
+async function assertNoLeakedMutation(sentinel: string, windowMs: number, pollMs = 40): Promise<void> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    let exists = true;
+    try {
+      await access(sentinel);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") exists = false;
+      else throw error;
+    }
+    if (exists) throw new Error(`cancellation did not prevent the mutation: ${sentinel} was created`);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return;
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, Math.min(pollMs, remaining)));
+  }
+}
+
 async function executeWrappedRead(bridge: BridgePort, cwd: string): Promise<Record<string, unknown>> {
   const definitions = new Map<string, ToolDefinitionPort>();
   const pi: ToolGuardPiPort = {
@@ -537,9 +563,20 @@ describe("BridgeClient", () => {
 
   test("cancels a hung bridge tree and fails mutation closed", async () => {
     const sentinel = resolve(tmpdir(), `ca-pi-bridge-leak-${process.pid}-${Date.now()}`);
+    // Issue #580: this used to be time.sleep(0.8) with a fixed 1,200ms wait
+    // afterward. The hostile grandchild's own launch overhead (two nested
+    // Python interpreter starts) competes with the same process-creation
+    // machinery the bridge's teardown depends on, so on a loaded box that
+    // 0.8s/1.2s pairing left near-zero margin - a leak was observed 8/8 times
+    // in a controlled trial that delayed the kill trigger past ~900ms, while
+    // the kill mechanism itself (once triggered) reliably completed inside
+    // 100-300ms. Widening the hostile delay and polling for an early failure
+    // (rather than trusting a fixed wait to have covered the real deadline)
+    // removes that false-flake margin without weakening what is asserted.
+    const hostileDelayMs = 4_000;
     const source = [
       "import subprocess, sys, time",
-      `subprocess.Popen([sys.executable, '-c', \"import pathlib,sys,time; time.sleep(0.8); pathlib.Path(sys.argv[1]).write_text('leak')\", ${JSON.stringify(sentinel)}])`,
+      `subprocess.Popen([sys.executable, '-c', \"import pathlib,sys,time; time.sleep(${hostileDelayMs / 1000}); pathlib.Path(sys.argv[1]).write_text('leak')\", ${JSON.stringify(sentinel)}])`,
       "time.sleep(30)",
     ].join("\n");
     try {
@@ -547,12 +584,11 @@ describe("BridgeClient", () => {
       const response = await bridge.call(request("edit", { path: "x", edits: [] }), new AbortController().signal);
       expect(response).toMatchObject({ outcome: "block", ruleId: "PI-BRIDGE" });
       expect(response.message).toContain("timed out");
-      await new Promise((done) => setTimeout(done, 1_200));
-      await expect(access(sentinel)).rejects.toThrow();
+      await assertNoLeakedMutation(sentinel, hostileDelayMs + 2_000);
     } finally {
       await rm(sentinel, { force: true });
     }
-  });
+  }, 15_000);
 
   test("rejects a bridge script outside the installed package", async () => {
     const packageRoot = await mkdtemp(resolve(tmpdir(), "ca-pi-package-"));
@@ -632,9 +668,13 @@ describe("BridgeClient", () => {
 
   test("cancellation terminates the bridge tree and blocks mutation", async () => {
     const sentinel = resolve(tmpdir(), `ca-pi-bridge-cancel-leak-${process.pid}-${Date.now()}`);
+    // Issue #580: see the sibling "cancels a hung bridge tree" test for why
+    // the hostile delay was widened from 0.8s and the fixed post-wait
+    // replaced with assertNoLeakedMutation's fail-fast poll.
+    const hostileDelayMs = 4_000;
     const source = [
       "import subprocess, sys, time",
-      `subprocess.Popen([sys.executable, '-c', \"import pathlib,sys,time; time.sleep(0.8); pathlib.Path(sys.argv[1]).write_text('leak')\", ${JSON.stringify(sentinel)}])`,
+      `subprocess.Popen([sys.executable, '-c', \"import pathlib,sys,time; time.sleep(${hostileDelayMs / 1000}); pathlib.Path(sys.argv[1]).write_text('leak')\", ${JSON.stringify(sentinel)}])`,
       "time.sleep(30)",
     ].join("\n");
     try {
@@ -644,12 +684,11 @@ describe("BridgeClient", () => {
       const response = await bridge.call(request("bash", { command: "true" }), controller.signal);
       expect(response).toMatchObject({ outcome: "block", ruleId: "PI-BRIDGE" });
       expect(response.message).toContain("cancelled");
-      await new Promise((done) => setTimeout(done, 1_200));
-      await expect(access(sentinel)).rejects.toThrow();
+      await assertNoLeakedMutation(sentinel, hostileDelayMs + 2_000);
     } finally {
       await rm(sentinel, { force: true });
     }
-  });
+  }, 15_000);
 
   test("force-settles a call whose child never emits close after a failed kill", async () => {
     const bridge = await clientFor("import time\ntime.sleep(30)\n", { timeoutMs: 50 });
@@ -670,7 +709,15 @@ describe("BridgeClient", () => {
     expect(response).toMatchObject({ outcome: "block", ruleId: "PI-BRIDGE" });
     expect(response.message).toContain("timed out");
     expect(elapsed).toBeLessThan(5_000);
-  });
+    // Issue #559: this test's own assertion already bounds the force-settle at
+    // 5s, coincidentally the same number as vitest's per-test default - so the
+    // infra deadline and the thing being asserted were the same value by
+    // accident, not by design. Measured under --coverage on a fast, unloaded
+    // box this case still takes ~2.1s (real path validation plus the
+    // KILL_SETTLE_DEADLINE_MS backstop), leaving too little headroom once a
+    // slower/loaded windows-latest host is added on top. A generous, clearly
+    // separate ceiling here means only the assertion above decides pass/fail.
+  }, 15_000);
 
   test("a rejecting validatePaths produces no unhandledRejection and a later call() still fails with the validation error", async () => {
     let unhandled: unknown;


### PR DESCRIPTION
## Root cause

`bridge.test.ts`'s two hostile-tree cancellation tests (`cancels a hung bridge tree and fails mutation closed`, `cancellation terminates the bridge tree and blocks mutation`) raced real Windows process-launch overhead against a fixed ~0.8s hostile-mutation window and a fixed 1.2s post-response wait.

A controlled trial isolating the mechanism (`plugins/ca-pi/tools/src/bridge.ts`'s `killTree`) showed:
- The kill path itself (`taskkill /pid /t /f`) reliably completes in **100-300ms** once triggered (15/15 trials, 0 leaks).
- Delaying only the trigger past ~900ms (simulating a busier host/loaded event loop) leaked the hostile mutation **8/8 times**.

So the flake is a margin problem, not a broken kill mechanism: on a loaded box the real teardown deadline can slip past the test's fixed wait even though cancellation is working correctly, and because the hostile script's mutation is a one-way file write, no amount of *additional* waiting after the fact can undo a leak that already landed.

## Fix

- `plugins/ca-pi/tools/test/bridge.test.ts`: widened the hostile grandchild's mutation delay (0.8s → 4s, real headroom over the measured kill-completion time) and replaced the fixed 1.2s wait-then-check-once with `assertNoLeakedMutation`, a fail-fast poll bounded by that widened window. Both hostile tests get an explicit 15s vitest-level timeout to match.
- `plugins/ca-pi/tools/src/bridge.ts`: `killTree`'s Windows path now runs `taskkill` via async `spawn` instead of blocking `spawnSync`, mirroring `process-tree.ts`'s own `runTaskkill` shape, so a slow kill can no longer stall the event loop it is itself racing against.
- Rebuilt the committed `extensions/codearbiter.js` / `codearbiter-child.js` bundles (`node build.mjs`), since both import `bridge.ts`.

## Stability-loop proof

- 20/20 consecutive runs of the two affected tests, green (first checkout).
- 8/8 more consecutive runs, green, from a second checkout after a mid-task interruption and relocation (see Deviations).
- Full `bridge.test.ts` (47 tests) green multiple times, including under `--coverage`.
- **28/28 total**, 0 failures post-fix. Pre-fix baseline: the issue's own numbers (~50% local failure rate over two batches of runs) plus the controlled trial above (8/8 leaked once the kill trigger fired late).

## Per-issue disposition

- **#580: fixed**, with the stability-loop proof above. `Closes #580`.
- **#535** (controller pid protocol timeout, `test_pi_process_tree.py`): assessed, **not covered** by this fix — it sits in the Windows Job Object containment stack (`process-tree.ts`'s `spawnProcessTree`) and a nested nested-timeout-budget shape in the Python test harness, code this PR does not touch. Diagnosis posted: https://github.com/arbiterForge/codeArbiter/issues/535#issuecomment-5191220332. Left open.
- **#504** (Git Bash background job resolves with no handle): assessed, **not covered** by this fix — `background-jobs.ts`'s `launch()` has several branches that can return `undefined` after a successful spawn races the child's own `close`/`error` events, none of which this PR touches. Diagnosis posted: https://github.com/arbiterForge/codeArbiter/issues/504#issuecomment-5191223880. Left open.
- **#559** (ca-pi suite marginal against vitest's 5s default under `--coverage` on windows-latest): **partially addressed**. Measured the suite's per-file cost under coverage locally (clean cliff at 8 tests over 800ms); 7 of 8 already carried a generous explicit timeout override, one (`force-settles a call whose child never emits close after a failed kill`, bridge.test.ts) did not and now does (15s). Full measurement and corroborating CI evidence (three more windows-latest 5000ms-default timeouts fired during this work, in `plugins/ca/tools` — outside this PR's scope) posted: https://github.com/arbiterForge/codeArbiter/issues/559#issuecomment-5206164995. AC-4 (union job reports 2/2 hosts) not verified against real CI from this session — left open.

## Version

ca-pi 0.2.17 → 0.2.18. The `tools/` source changes are payload-excluded, but the rebuilt `extensions/codearbiter.js` and `codearbiter-child.js` bundles are not — a real payload change. `python tools/build-host-packages.py --check --release-guard-base origin/main` passes post-commit: `Pi payload, version, changelog, and root metadata advanced together: 0.2.17 -> 0.2.18`.

## Deviations from the original task spec

- Set up via a manually-created `git worktree add` (not under `.claude/worktrees/`) rather than `EnterWorktree`, after the session's original worktree was lost to a mid-task interruption. This caused the session's harness-pinned `CLAUDE_PROJECT_DIR` (the root checkout) to disagree with the actual working directory, producing a false `H-01` ("commit to main") block from the pre-commit hook even on a correctly-checked-out feature branch. Diagnosed (confirmed via direct `hostapi.project_root()` invocation that resolution is cwd/env-dependent and the hook subprocess's cwd was the root checkout, not the worktree) rather than bypassed with `--no-verify`. Resolved by stashing the staged changes, removing the manual worktree, switching the root checkout itself to `fix/580-windows-flakes`, and popping the stash there — after which the hook and the release guard both resolved correctly.
- Python hook suite (`env -u NO_COLOR python -m pytest plugins/ca/hooks/tests -q`): 10 pre-existing failures (`TestDropInMultiPluginFailClosed`, `TestInstall`, `TestPreCommitEnforce`, `TestGitEnforceOwnRepoResolution` families), confirmed identical on stashed origin/main from the same worktree before this fix — the known #604 "worktree families" class, not caused by this change.
- Did not rebase onto the very latest origin/main a second time after the final coordinator status check confirmed no newer merges landed past what this branch already includes (`e3c6a9b2`, later fast-forwarded again once during the session).

https://claude.ai/code/session_01QjJeSbcwPHwMmd6CEZeagB