### PR TITLE
chore(deps): bump js-yaml to 4.3.1 for CVE-2026-59870 in the site graph

### DIFF
--- a/.codearbiter/open-tasks.md
+++ b/.codearbiter/open-tasks.md
@@ -5,6 +5,7 @@ per task. Schema and the count rule: see `plugins/ca/hooks/init-codearbiter.py`
 (`OPEN_TASKS`) or `.codearbiter/specs/task-board-lifecycle.md`.
 
 ## In-flight
+- [x] v2.deps.0001 - Bump js-yaml in site/package-lock.json past CVE-2026-59870 (HIGH, quadratic CPU in !!omap): npm audit fix in site/, run site npm test + dependency-reviewer; the production CVE gate reds Deploy docs on every PR until fixed (found on PR #632, unrelated to it)  (done 2026-08-07)
 - [ ] Reconfirm the ca 2.9.0 and ca-codex 0.3.0 version classification against the final merged diff before any release or tag.  (from sprint:auto-safe-open-issues)
 - [ ] Validate the annotated ANSI-free palette evidence format with users; add stable visual captures only if the text artifacts are insufficient.  (from sprint:auto-safe-open-issues)
 - [x] Benchmark the 100 ms statusline dirty-check timeout across representative large repositories and adjust it if fail-soft timeouts hide normal dirty state.  (from sprint:auto-safe-open-issues)  (done 2026-07-20)

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4237,9 +4237,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
GHSA-5p4m-2wfm-xmqj (HIGH): quadratic CPU in `!!omap` resolution, js-yaml ≤4.3.0. `site/` is the only graph here with production deps, so the `npm audit --omit=dev --audit-level=high` gate reds **every** PR's Deploy docs run until this lands (first seen on #632, unrelated to its diff).

- Single-hunk lockfile delta: js-yaml 4.3.0 → 4.3.1 (version/resolved/integrity only; no new transitives, no install scripts).
- **dependency-reviewer PASS**: MIT, registry.npmjs.org, integrity hash verified live against `npm view dist.integrity`, post-bump production audit clean.
- Site verification: 512 vitest, tsc clean, 135-page build, link-audit 20,338 links resolve.
- Board task `v2.deps.0001` done-flip rides (ADR-0008).

Merging this un-reds docs deploy so the recorded-intent governance updates in #632 publish to codearbiter.dev on their merge.

https://claude.ai/code/session_019bCEeBvTc41yf5mdXfGduV