### PR TITLE
fix(ci): unwedge Pi promotion — enroll broker test, resolve pi shim

### DIFF
--- a/.github/scripts/pi_promotion.py
+++ b/.github/scripts/pi_promotion.py
@@ -47,6 +47,7 @@ OFFICIAL_PROMOTION_PATHS = frozenset({
     "plugins/ca-pi/tools/test/compaction.test.ts",
     "plugins/ca-pi/tools/test/doctor.test.ts",
     "plugins/ca-pi/tools/test/package.test.ts",
+    "plugins/ca-pi/tools/test/runner-broker-lifecycle.test.ts",
     "plugins/ca-pi/tools/test/runner-isolation.test.ts",
 })
 # Issue #388. The receipt's whole value is telling an operator - or an agent
@@ -385,9 +386,12 @@ def normalize_help(raw: str) -> tuple[str, ...]:
 
 def capture_help(executable: str) -> tuple[str, ...]:
     """Run a bounded public-help probe and return its normalized surface."""
+    # Windows npm installs expose only a `pi.cmd` shim, which CreateProcess
+    # cannot exec from a bare argv[0]; PATH-resolve first, like run_contract.
+    resolved = shutil.which(executable) or executable
     try:
         completed = subprocess.run(
-            [executable, "--help"],
+            [resolved, "--help"],
             check=False,
             capture_output=True,
             text=True,

--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
@@ -616,6 +617,50 @@ class DocumentationContractTests(unittest.TestCase):
             contract_path.write_text(json.dumps(document), encoding="utf-8")
             with self.assertRaises(docs.ContractError):
                 docs.load_contract(contract_path)
+
+
+class OfficialWriteScopeTests(unittest.TestCase):
+    """The checked-in recipe must stay executable against its own allowlist.
+
+    Regression: #460 enrolled runner-broker-lifecycle.test.ts in
+    pi-promotion-targets.json without enrolling it in OFFICIAL_PROMOTION_PATHS,
+    which made every hosted promotion run fail at the write-scope gate from
+    2026-07-30 onward — before any Pi contract was ever probed.
+    """
+
+    def test_checked_in_recipe_passes_the_official_write_scope_gate(self):
+        promotion = load_module()
+        targets = promotion.load_targets(REPO / ".github" / "pi-promotion-targets.json")
+        promotion._enforce_official_write_scope(promotion.REPOSITORY, targets)
+
+
+class HelpProbeResolutionTests(unittest.TestCase):
+    """The help probe must launch Pi through PATH resolution, not a raw name.
+
+    Regression: on Windows the npm global install exposes only a `pi.cmd`
+    shim, which CreateProcess cannot exec from a bare argv[0]; the hosted
+    windows-latest promotion cell died with `cannot capture Pi help:
+    FileNotFoundError` before probing anything.
+    """
+
+    def test_capture_help_finds_a_shimmed_executable_on_path(self):
+        promotion = load_module()
+        with tempfile.TemporaryDirectory() as raw:
+            shim_dir = Path(raw)
+            if sys.platform == "win32":
+                shim = shim_dir / "ca-probe-pi.cmd"
+                shim.write_text("@echo   --probe-flag ^<value^>  fake probe flag\r\n", encoding="ascii")
+            else:
+                shim = shim_dir / "ca-probe-pi"
+                shim.write_text("#!/bin/sh\necho '  --probe-flag <value>  fake probe flag'\n", encoding="ascii")
+                shim.chmod(0o755)
+            original_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = str(shim_dir) + os.pathsep + original_path
+            try:
+                surface = promotion.capture_help("ca-probe-pi")
+            finally:
+                os.environ["PATH"] = original_path
+        self.assertTrue(surface, "help probe returned an empty surface")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -654,12 +654,15 @@ class HelpProbeResolutionTests(unittest.TestCase):
                 shim = shim_dir / "ca-probe-pi"
                 shim.write_text("#!/bin/sh\necho '  --probe-flag <value>  fake probe flag'\n", encoding="ascii")
                 shim.chmod(0o755)
-            original_path = os.environ.get("PATH", "")
-            os.environ["PATH"] = str(shim_dir) + os.pathsep + original_path
+            original_path = os.environ.get("PATH")
+            os.environ["PATH"] = str(shim_dir) + os.pathsep + (original_path or "")
             try:
                 surface = promotion.capture_help("ca-probe-pi")
             finally:
-                os.environ["PATH"] = original_path
+                if original_path is None:
+                    os.environ.pop("PATH", None)
+                else:
+                    os.environ["PATH"] = original_path
         self.assertTrue(surface, "help probe returned an empty surface")
 
 


### PR DESCRIPTION
## What

Two independent defects have made **every hosted pi-promotion run fail since 2026-07-30** (all `push`/`schedule`/`workflow_dispatch` runs), before any Pi contract was ever probed:

1. **Write-scope gate rejects the checked-in recipe.** #460 enrolled `plugins/ca-pi/tools/test/runner-broker-lifecycle.test.ts` as a rewrite target in `pi-promotion-targets.json` without enrolling it in `OFFICIAL_PROMOTION_PATHS`, so `_enforce_official_write_scope` raised `promotion recipe declares unapproved write path` on ubuntu/macos (run 31317413822).
2. **Windows help probe cannot exec the npm shim.** `capture_help` spawned Pi from a bare argv[0]; windows-latest's npm global install exposes only `pi.cmd`, which CreateProcess cannot exec → `cannot capture Pi help: FileNotFoundError`. `run_contract` already PATH-resolves via `_resolve_command` for exactly this reason; the help probe now resolves the same way (`shutil.which(...) or executable`, preserving the existing error path when nothing resolves).

## Test-first evidence

- `OfficialWriteScopeTests` runs the **real** write-scope gate against the **real** checked-in recipe — red pre-fix with the exact hosted error string, green post-fix.
- `HelpProbeResolutionTests` executes `capture_help` against a `.cmd`-only executable on PATH — red on Windows pre-fix (`FileNotFoundError`), green post-fix. Backed by a live local proof on Windows against the real npm `pi.cmd` shim: `python .github/scripts/pi_promotion.py help` failed pre-fix and returns the normalized help surface post-fix.
- Full `test_pi_promotion.py`: 33/33 OK.

## Why now

This unblocks the approved Pi 0.84.1 window promotion (spec `pi-window-promotion-0-84-1`): the first dispatch (run 31317413822) failed on these two defects, not on Pi API drift. Once merged, the promotion will be re-dispatched.

Related: #654 tracks the separate release-workflow noise found in the same babysitting pass.

https://claude.ai/code/session_017edPfnVHuwWMQbLHXbaXU8