### PR TITLE
fix(ca-pi): accept Pi 0.84 delta-only RPC message_update events

### DIFF
--- a/.github/pi-promotion-targets.json
+++ b/.github/pi-promotion-targets.json
@@ -7,7 +7,8 @@
   },
   "release": {
     "package_path": "plugins/ca-pi/package.json",
-    "changelog_path": "plugins/ca-pi/CHANGELOG.md"
+    "changelog_path": "plugins/ca-pi/CHANGELOG.md",
+    "root_package_path": "package.json"
   },
   "targets": [
     {

--- a/.github/scripts/pi_promotion.py
+++ b/.github/scripts/pi_promotion.py
@@ -384,10 +384,12 @@ def apply_promotion(
     # snapshots release-file content pre-loop, so a release path doubling as a
     # declared target would be clobbered — refuse the recipe outright.
     if targets.release is not None:
-        release_paths = {targets.release.package_path, targets.release.changelog_path}
+        declared_release_paths = [targets.release.package_path, targets.release.changelog_path]
         if targets.release.root_package_path is not None:
-            release_paths.add(targets.release.root_package_path)
-        overlap = sorted(str(path) for path in release_paths & {target.path for target in targets.targets})
+            declared_release_paths.append(targets.release.root_package_path)
+        if len(set(declared_release_paths)) != len(declared_release_paths):
+            raise PromotionError("release paths must be distinct files")
+        overlap = sorted(str(path) for path in set(declared_release_paths) & {target.path for target in targets.targets})
         if overlap:
             raise PromotionError(f"release path is also a declared promotion target: {overlap[0]}")
     release_plan = None if targets.release is None else _plan_release_metadata(repo, targets.release, candidate, date)

--- a/.github/scripts/pi_promotion.py
+++ b/.github/scripts/pi_promotion.py
@@ -309,7 +309,20 @@ def _enforce_official_write_scope(repo: Path, targets: Targets) -> None:
         raise PromotionError(f"promotion recipe declares unapproved write path: {unknown[0]}")
 
 
-def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, date: str) -> tuple[Path, ...]:
+@dataclass(frozen=True)
+class _ReleasePlan:
+    """Fully-validated release writes, prepared before any file is touched."""
+    writes: tuple[tuple[Path, str], ...]
+    changed: tuple[Path, ...]
+
+
+def _plan_release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, date: str) -> _ReleasePlan:
+    """Read and validate every release input; return the writes without applying them.
+
+    Planning is separated from writing so `apply_promotion` can preflight the
+    release bump before rewriting any declared target — a stale input aborts
+    the promotion with the checkout untouched, never half-applied.
+    """
     package_path = _target_path(repo, PromotionTarget("release-package", release.package_path, "release-metadata", "-", "-", "one"))
     changelog_path = _target_path(repo, PromotionTarget("release-changelog", release.changelog_path, "release-metadata", "-", "-", "one"))
     try:
@@ -321,8 +334,6 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
         raise PromotionError("ca-pi package version must be a stable exact semver")
     major, minor, patch = _semver_key(version)
     next_version = f"{major}.{minor}.{patch + 1}"
-    # Validate every release input before writing any release file, so a stale
-    # or unreadable input cannot leave the checkout with a half-applied bump.
     try:
         changelog = changelog_path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as error:
@@ -330,8 +341,16 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
     marker = "All notable changes to `ca-pi` are documented in this file."
     if changelog.count(marker) != 1:
         raise PromotionError("ca-pi changelog has no unique insertion marker")
-    root_path: Path | None = None
-    root_manifest: dict | None = None
+    package["version"] = next_version
+    entry = (
+        f"\n\n## [{next_version}] - {date}\n\n### Changed\n\n"
+        f"- Promote the verified Pi host window through exact Pi {candidate.version}.\n"
+    )
+    writes: list[tuple[Path, str]] = [
+        (package_path, json.dumps(package, indent=2) + "\n"),
+        (changelog_path, changelog.replace(marker, marker + entry, 1)),
+    ]
+    changed: list[Path] = [release.package_path, release.changelog_path]
     if release.root_package_path is not None:
         root_path = _target_path(repo, PromotionTarget("release-root-package", release.root_package_path, "release-metadata", "-", "-", "one"))
         try:
@@ -343,24 +362,12 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
                 "ca-pi root package version does not match the nested manifest; "
                 "regenerate it before promoting",
             )
-    package["version"] = next_version
-    package_path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8", newline="\n")
-    changed: list[Path] = [release.package_path, release.changelog_path]
-    entry = (
-        f"\n\n## [{next_version}] - {date}\n\n### Changed\n\n"
-        f"- Promote the verified Pi host window through exact Pi {candidate.version}.\n"
-    )
-    changelog_path.write_text(changelog.replace(marker, marker + entry, 1), encoding="utf-8", newline="\n")
-    if root_path is not None and root_manifest is not None:
         root_manifest["version"] = next_version
         # Byte-for-byte the renderer's serialization (tools/build-host-packages.py),
         # so the generated-manifest byte contract keeps holding after the bump.
-        root_path.write_text(
-            json.dumps(root_manifest, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8", newline="\n",
-        )
+        writes.append((root_path, json.dumps(root_manifest, indent=2, ensure_ascii=False) + "\n"))
         changed.append(release.root_package_path)
-    return tuple(changed)
+    return _ReleasePlan(writes=tuple(writes), changed=tuple(changed))
 
 
 def apply_promotion(
@@ -372,6 +379,18 @@ def apply_promotion(
 ) -> tuple[Path, ...]:
     _enforce_official_write_scope(repo, targets)
     policy = read_policy(repo, targets)
+    # Preflight the release bump before any target write: a stale release
+    # input aborts the whole promotion with the checkout untouched. The plan
+    # snapshots release-file content pre-loop, so a release path doubling as a
+    # declared target would be clobbered — refuse the recipe outright.
+    if targets.release is not None:
+        release_paths = {targets.release.package_path, targets.release.changelog_path}
+        if targets.release.root_package_path is not None:
+            release_paths.add(targets.release.root_package_path)
+        overlap = sorted(str(path) for path in release_paths & {target.path for target in targets.targets})
+        if overlap:
+            raise PromotionError(f"release path is also a declared promotion target: {overlap[0]}")
+    release_plan = None if targets.release is None else _plan_release_metadata(repo, targets.release, candidate, date)
     changed = []
     for target in targets.targets:
         path = _target_path(repo, target)
@@ -390,8 +409,10 @@ def apply_promotion(
             newline="\n",
         )
         changed.append(target.path)
-    if targets.release is not None:
-        changed.extend(_release_metadata(repo, targets.release, candidate, date))
+    if release_plan is not None:
+        for path, content in release_plan.writes:
+            path.write_text(content, encoding="utf-8", newline="\n")
+        changed.extend(release_plan.changed)
     return tuple(changed)
 
 

--- a/.github/scripts/pi_promotion.py
+++ b/.github/scripts/pi_promotion.py
@@ -321,9 +321,17 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
         raise PromotionError("ca-pi package version must be a stable exact semver")
     major, minor, patch = _semver_key(version)
     next_version = f"{major}.{minor}.{patch + 1}"
-    package["version"] = next_version
-    package_path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8", newline="\n")
-    changed: list[Path] = [release.package_path, release.changelog_path]
+    # Validate every release input before writing any release file, so a stale
+    # or unreadable input cannot leave the checkout with a half-applied bump.
+    try:
+        changelog = changelog_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise PromotionError(f"cannot read ca-pi changelog: {error}") from error
+    marker = "All notable changes to `ca-pi` are documented in this file."
+    if changelog.count(marker) != 1:
+        raise PromotionError("ca-pi changelog has no unique insertion marker")
+    root_path: Path | None = None
+    root_manifest: dict | None = None
     if release.root_package_path is not None:
         root_path = _target_path(repo, PromotionTarget("release-root-package", release.root_package_path, "release-metadata", "-", "-", "one"))
         try:
@@ -335,6 +343,15 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
                 "ca-pi root package version does not match the nested manifest; "
                 "regenerate it before promoting",
             )
+    package["version"] = next_version
+    package_path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8", newline="\n")
+    changed: list[Path] = [release.package_path, release.changelog_path]
+    entry = (
+        f"\n\n## [{next_version}] - {date}\n\n### Changed\n\n"
+        f"- Promote the verified Pi host window through exact Pi {candidate.version}.\n"
+    )
+    changelog_path.write_text(changelog.replace(marker, marker + entry, 1), encoding="utf-8", newline="\n")
+    if root_path is not None and root_manifest is not None:
         root_manifest["version"] = next_version
         # Byte-for-byte the renderer's serialization (tools/build-host-packages.py),
         # so the generated-manifest byte contract keeps holding after the bump.
@@ -343,18 +360,6 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
             encoding="utf-8", newline="\n",
         )
         changed.append(release.root_package_path)
-    try:
-        changelog = changelog_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError) as error:
-        raise PromotionError(f"cannot read ca-pi changelog: {error}") from error
-    marker = "All notable changes to `ca-pi` are documented in this file."
-    if changelog.count(marker) != 1:
-        raise PromotionError("ca-pi changelog has no unique insertion marker")
-    entry = (
-        f"\n\n## [{next_version}] - {date}\n\n### Changed\n\n"
-        f"- Promote the verified Pi host window through exact Pi {candidate.version}.\n"
-    )
-    changelog_path.write_text(changelog.replace(marker, marker + entry, 1), encoding="utf-8", newline="\n")
     return tuple(changed)
 
 

--- a/.github/scripts/pi_promotion.py
+++ b/.github/scripts/pi_promotion.py
@@ -20,6 +20,7 @@ VERSION_LITERAL = re.compile(r'"(?P<version>[^"\r\n]+)"')
 REPOSITORY = Path(__file__).resolve().parents[2]
 OFFICIAL_PROMOTION_PATHS = frozenset({
     ".codearbiter/specs/pi-support.md",
+    "package.json",
     ".codearbiter/tech-stack.md",
     ".github/scripts/test_host_descriptors.py",
     ".github/scripts/test_pi_child_live.py",
@@ -101,6 +102,9 @@ class PromotionTarget:
 class ReleaseSource:
     package_path: Path
     changelog_path: Path
+    # The repo-root manifest is the published npm unit (ADR-0029), rendered
+    # from the nested version; a release bump must advance both in lockstep.
+    root_package_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -218,6 +222,8 @@ def load_targets(path: Path) -> Targets:
         parsed_release = ReleaseSource(
             _relative_path(release.get("package_path"), "release.package_path"),
             _relative_path(release.get("changelog_path"), "release.changelog_path"),
+            None if release.get("root_package_path") is None
+            else _relative_path(release.get("root_package_path"), "release.root_package_path"),
         )
     return Targets(
         policy=PolicySource(
@@ -296,12 +302,14 @@ def _enforce_official_write_scope(repo: Path, targets: Targets) -> None:
             str(targets.release.package_path).replace("\\", "/"),
             str(targets.release.changelog_path).replace("\\", "/"),
         })
+        if targets.release.root_package_path is not None:
+            paths.add(str(targets.release.root_package_path).replace("\\", "/"))
     unknown = sorted(paths - OFFICIAL_PROMOTION_PATHS)
     if unknown:
         raise PromotionError(f"promotion recipe declares unapproved write path: {unknown[0]}")
 
 
-def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, date: str) -> tuple[Path, Path]:
+def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, date: str) -> tuple[Path, ...]:
     package_path = _target_path(repo, PromotionTarget("release-package", release.package_path, "release-metadata", "-", "-", "one"))
     changelog_path = _target_path(repo, PromotionTarget("release-changelog", release.changelog_path, "release-metadata", "-", "-", "one"))
     try:
@@ -315,6 +323,26 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
     next_version = f"{major}.{minor}.{patch + 1}"
     package["version"] = next_version
     package_path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8", newline="\n")
+    changed: list[Path] = [release.package_path, release.changelog_path]
+    if release.root_package_path is not None:
+        root_path = _target_path(repo, PromotionTarget("release-root-package", release.root_package_path, "release-metadata", "-", "-", "one"))
+        try:
+            root_manifest = json.loads(root_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise PromotionError(f"cannot read ca-pi root package metadata: {error}") from error
+        if not isinstance(root_manifest, dict) or root_manifest.get("version") != version:
+            raise PromotionError(
+                "ca-pi root package version does not match the nested manifest; "
+                "regenerate it before promoting",
+            )
+        root_manifest["version"] = next_version
+        # Byte-for-byte the renderer's serialization (tools/build-host-packages.py),
+        # so the generated-manifest byte contract keeps holding after the bump.
+        root_path.write_text(
+            json.dumps(root_manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8", newline="\n",
+        )
+        changed.append(release.root_package_path)
     try:
         changelog = changelog_path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as error:
@@ -327,7 +355,7 @@ def _release_metadata(repo: Path, release: ReleaseSource, candidate: Candidate, 
         f"- Promote the verified Pi host window through exact Pi {candidate.version}.\n"
     )
     changelog_path.write_text(changelog.replace(marker, marker + entry, 1), encoding="utf-8", newline="\n")
-    return release.package_path, release.changelog_path
+    return tuple(changed)
 
 
 def apply_promotion(

--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -36,6 +36,16 @@ def load_module():
     return module
 
 
+def load_renderer_module():
+    path = REPO / "tools" / "build-host-packages.py"
+    spec = importlib.util.spec_from_file_location("build_host_packages", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("build-host-packages module is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def load_docs_module():
     spec = importlib.util.spec_from_file_location("check_docs_contract", DOCS_MODULE_PATH)
     if spec is None or spec.loader is None:
@@ -205,6 +215,39 @@ class PromotionPatchTests(unittest.TestCase):
             self.assertEqual(json.loads(package.read_text(encoding="utf-8"))["version"], "0.1.1")
             self.assertIn("## [0.1.1] - 2026-07-17", changelog.read_text(encoding="utf-8"))
             self.assertIn("Pi 0.80.10", changelog.read_text(encoding="utf-8"))
+
+    def test_release_metadata_advances_the_generated_root_manifest_in_lockstep(self):
+        """Regression: run 31318743524. Since #653 the repo-root package.json is
+        the published npm manifest, rendered from the nested version; a promotion
+        that bumps only the nested manifest leaves the root a version behind and
+        fails the package byte-contract on every platform."""
+        module = load_module()
+        renderer = load_renderer_module()
+        host = renderer.host_descriptor("pi", str(REPO))
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.fixture_repo(root)
+            package = root / "plugins" / "ca-pi" / "package.json"
+            package.write_text('{"name":"ca-pi","version":"0.1.0"}\n', encoding="utf-8")
+            changelog = root / "plugins" / "ca-pi" / "CHANGELOG.md"
+            changelog.write_text("# Changelog\n\nAll notable changes to `ca-pi` are documented in this file.\n", encoding="utf-8")
+            (root / "package.json").write_bytes(renderer.render_package(host, "0.1.0"))
+            document = json.loads(self.targets(root).read_text(encoding="utf-8"))
+            document["release"] = {
+                "package_path": "plugins/ca-pi/package.json",
+                "changelog_path": "plugins/ca-pi/CHANGELOG.md",
+                "root_package_path": "package.json",
+            }
+            target_path = root / "targets-with-root.json"
+            target_path.write_text(json.dumps(document), encoding="utf-8")
+            changed = module.apply_promotion(
+                root, module.load_targets(target_path), module.Candidate("0.80.10"), date="2026-08-09",
+            )
+            self.assertIn(Path("package.json"), set(changed))
+            self.assertEqual(
+                (root / "package.json").read_bytes(),
+                renderer.render_package(host, "0.1.1"),
+            )
 
     def test_help_delta_rejects_removed_required_flag(self):
         module = load_module()

--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -249,6 +249,37 @@ class PromotionPatchTests(unittest.TestCase):
                 renderer.render_package(host, "0.1.1"),
             )
 
+    def test_release_metadata_writes_nothing_when_root_manifest_disagrees(self):
+        """A stale root manifest must abort the whole release bump before any
+        file is written — not after the nested manifest already advanced."""
+        module = load_module()
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.fixture_repo(root)
+            package = root / "plugins" / "ca-pi" / "package.json"
+            package.write_text('{"name":"ca-pi","version":"0.1.0"}\n', encoding="utf-8")
+            changelog = root / "plugins" / "ca-pi" / "CHANGELOG.md"
+            changelog.write_text("# Changelog\n\nAll notable changes to `ca-pi` are documented in this file.\n", encoding="utf-8")
+            (root / "package.json").write_text('{"name":"@arbiterforge/ca-pi","version":"0.0.9"}\n', encoding="utf-8")
+            before = {
+                path: path.read_bytes()
+                for path in (package, changelog, root / "package.json")
+            }
+            document = json.loads(self.targets(root).read_text(encoding="utf-8"))
+            document["release"] = {
+                "package_path": "plugins/ca-pi/package.json",
+                "changelog_path": "plugins/ca-pi/CHANGELOG.md",
+                "root_package_path": "package.json",
+            }
+            target_path = root / "targets-stale-root.json"
+            target_path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaises(module.PromotionError):
+                module.apply_promotion(
+                    root, module.load_targets(target_path), module.Candidate("0.80.10"), date="2026-08-09",
+                )
+            for path, expected in before.items():
+                self.assertEqual(path.read_bytes(), expected, f"{path.name} was written despite the aborted bump")
+
     def test_help_delta_rejects_removed_required_flag(self):
         module = load_module()
         delta = module.compare_help(

--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -343,6 +343,30 @@ class PromotionPatchTests(unittest.TestCase):
                 )
             self.assertIn("also a declared promotion target", str(caught.exception))
 
+    def test_duplicate_release_paths_are_refused(self):
+        """Two release fields naming one file would queue two writes to it,
+        last-write-wins — the recipe is refused before any plan is made."""
+        module = load_module()
+        collisions = (
+            {"package_path": "plugins/ca-pi/CHANGELOG.md", "changelog_path": "plugins/ca-pi/CHANGELOG.md"},
+            {"package_path": "plugins/ca-pi/package.json", "changelog_path": "plugins/ca-pi/CHANGELOG.md",
+             "root_package_path": "plugins/ca-pi/package.json"},
+        )
+        for release in collisions:
+            with self.subTest(release=release):
+                with tempfile.TemporaryDirectory() as raw:
+                    root = Path(raw)
+                    self.fixture_repo(root)
+                    document = json.loads(self.targets(root).read_text(encoding="utf-8"))
+                    document["release"] = release
+                    target_path = root / "targets-duplicate-release.json"
+                    target_path.write_text(json.dumps(document), encoding="utf-8")
+                    with self.assertRaises(module.PromotionError) as caught:
+                        module.apply_promotion(
+                            root, module.load_targets(target_path), module.Candidate("0.80.10"), date="2026-08-09",
+                        )
+                    self.assertIn("release paths must be distinct", str(caught.exception))
+
     def test_help_delta_rejects_removed_required_flag(self):
         module = load_module()
         delta = module.compare_help(

--- a/.github/scripts/test_pi_promotion.py
+++ b/.github/scripts/test_pi_promotion.py
@@ -280,6 +280,69 @@ class PromotionPatchTests(unittest.TestCase):
             for path, expected in before.items():
                 self.assertEqual(path.read_bytes(), expected, f"{path.name} was written despite the aborted bump")
 
+    def test_stale_release_metadata_aborts_before_any_target_write(self):
+        """Release-input validation must preflight the whole promotion: a stale
+        root manifest may not leave rewritten targets behind in the checkout."""
+        module = load_module()
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.fixture_repo(root)
+            package = root / "plugins" / "ca-pi" / "package.json"
+            package.write_text('{"name":"ca-pi","version":"0.1.0"}\n', encoding="utf-8")
+            changelog = root / "plugins" / "ca-pi" / "CHANGELOG.md"
+            changelog.write_text("# Changelog\n\nAll notable changes to `ca-pi` are documented in this file.\n", encoding="utf-8")
+            (root / "package.json").write_text('{"name":"@arbiterforge/ca-pi","version":"0.0.9"}\n', encoding="utf-8")
+            targets_before = {
+                path: path.read_bytes()
+                for path in (
+                    root / "plugins" / "ca-pi" / "tools" / "src" / "compatibility.ts",
+                    root / "docs" / "pi.md",
+                )
+            }
+            document = json.loads(self.targets(root).read_text(encoding="utf-8"))
+            document["release"] = {
+                "package_path": "plugins/ca-pi/package.json",
+                "changelog_path": "plugins/ca-pi/CHANGELOG.md",
+                "root_package_path": "package.json",
+            }
+            target_path = root / "targets-stale-root-preflight.json"
+            target_path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaises(module.PromotionError):
+                module.apply_promotion(
+                    root, module.load_targets(target_path), module.Candidate("0.80.10"), date="2026-08-09",
+                )
+            for path, expected in targets_before.items():
+                self.assertEqual(path.read_bytes(), expected, f"{path.name} was rewritten despite the aborted release bump")
+
+    def test_release_path_doubling_as_declared_target_is_refused(self):
+        """The release plan snapshots file content before the target loop runs,
+        so a release path that is also a rewrite target would silently lose the
+        loop's rewrite — the recipe must be refused, not half-honored."""
+        module = load_module()
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.fixture_repo(root)
+            package = root / "plugins" / "ca-pi" / "package.json"
+            package.write_text('{"name":"ca-pi","version":"0.1.0"}\n', encoding="utf-8")
+            changelog = root / "plugins" / "ca-pi" / "CHANGELOG.md"
+            changelog.write_text("# Changelog\n\nAll notable changes to `ca-pi` are documented in this file.\nPi 0.80.6\n", encoding="utf-8")
+            document = json.loads(self.targets(root).read_text(encoding="utf-8"))
+            document["release"] = {
+                "package_path": "plugins/ca-pi/package.json",
+                "changelog_path": "plugins/ca-pi/CHANGELOG.md",
+            }
+            document["targets"].append({
+                "id": "overlapping", "path": "plugins/ca-pi/CHANGELOG.md", "class": "current-doc",
+                "before": "Pi 0.80.6", "after": "Pi {candidate}",
+            })
+            target_path = root / "targets-overlap.json"
+            target_path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaises(module.PromotionError) as caught:
+                module.apply_promotion(
+                    root, module.load_targets(target_path), module.Candidate("0.80.10"), date="2026-08-09",
+                )
+            self.assertIn("also a declared promotion target", str(caught.exception))
+
     def test_help_delta_rejects_removed_required_flag(self):
         module = load_module()
         delta = module.compare_help(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-10
+
+### Fixed
+
+- Child dispatch protocol accepts Pi ≥0.84.0's delta-only RPC `message_update`
+  events (pi#7290): the wire event dropped the full `message` record and the
+  `partial` field inside assistant events, which the strict validator rejected,
+  degrading every live child dispatch on Pi 0.84.x. Both window shapes now
+  validate with exact key sets — the fail-closed boundary (ADR-0014) is
+  unchanged, only the newly-documented shape is recognized.
+
 ## [0.6.0] - 2026-08-09
 
 ### Added

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -7652,24 +7652,24 @@ function validPartialAssistantMessage(value) {
 }
 function validAssistantEvent(value) {
   if (!isRecord(value) || typeof value.type !== "string") return false;
-  const partial = () => validPartialAssistantMessage(value.partial);
+  const exactWithOptionalPartial = (base) => "partial" in value ? exactKeys4(value, [...base, "partial"]) && validPartialAssistantMessage(value.partial) : exactKeys4(value, base);
   const contentIndex = () => Number.isSafeInteger(value.contentIndex) && value.contentIndex >= 0;
   switch (value.type) {
     case "start":
-      return exactKeys4(value, ["type", "partial"]) && partial();
+      return exactWithOptionalPartial(["type"]);
     case "text_start":
     case "thinking_start":
     case "toolcall_start":
-      return exactKeys4(value, ["type", "contentIndex", "partial"]) && contentIndex() && partial();
+      return exactWithOptionalPartial(["type", "contentIndex"]) && contentIndex();
     case "text_delta":
     case "thinking_delta":
     case "toolcall_delta":
-      return exactKeys4(value, ["type", "contentIndex", "delta", "partial"]) && contentIndex() && boundedString2(value.delta) && partial();
+      return exactWithOptionalPartial(["type", "contentIndex", "delta"]) && contentIndex() && boundedString2(value.delta);
     case "text_end":
     case "thinking_end":
-      return exactKeys4(value, ["type", "contentIndex", "content", "partial"]) && contentIndex() && boundedString2(value.content) && partial();
+      return exactWithOptionalPartial(["type", "contentIndex", "content"]) && contentIndex() && boundedString2(value.content);
     case "toolcall_end":
-      return exactKeys4(value, ["type", "contentIndex", "toolCall", "partial"]) && contentIndex() && validContentBlock(value.toolCall, "assistant") && partial();
+      return exactWithOptionalPartial(["type", "contentIndex", "toolCall"]) && contentIndex() && validContentBlock(value.toolCall, "assistant");
     case "done":
       return exactKeys4(value, ["type", "reason", "message"]) && ["stop", "length", "toolUse"].includes(value.reason) && validMessage(value.message) && value.message.role === "assistant";
     case "error":
@@ -7712,7 +7712,7 @@ function parseChildJsonLine(line) {
       if (!exactKeys4(record2, ["type", "message"]) || !validMessage(record2.message) && !validPartialAssistantMessage(record2.message)) invalidProtocol();
       break;
     case "message_update":
-      if (!exactKeys4(record2, ["type", "message", "assistantMessageEvent"]) || !validPartialAssistantMessage(record2.message) || !validAssistantEvent(record2.assistantMessageEvent)) invalidProtocol();
+      if ("message" in record2 ? !exactKeys4(record2, ["type", "message", "assistantMessageEvent"]) || !validPartialAssistantMessage(record2.message) || !validAssistantEvent(record2.assistantMessageEvent) : !exactKeys4(record2, ["type", "assistantMessageEvent"]) || !validAssistantEvent(record2.assistantMessageEvent)) invalidProtocol();
       break;
     case "tool_execution_start":
       if (!exactKeys4(record2, ["type", "toolCallId", "toolName", "args"]) || typeof record2.toolCallId !== "string" || typeof record2.toolName !== "string" || !validOpaqueJson(record2.args)) invalidProtocol();

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/runner.ts
+++ b/plugins/ca-pi/tools/src/runner.ts
@@ -452,27 +452,33 @@ function validPartialAssistantMessage(value: unknown): boolean {
 
 function validAssistantEvent(value: unknown): boolean {
   if (!isRecord(value) || typeof value.type !== "string") return false;
-  const partial = () => validPartialAssistantMessage(value.partial);
+  // Pi ≤0.80.10 attaches the accumulating `partial` message to every streaming
+  // event; Pi ≥0.84.0 strips it on the RPC wire (delta-only, pi#7290). Both
+  // window shapes validate strictly: when `partial` is present it must be a
+  // valid partial assistant message, and the key set stays exact either way.
+  const exactWithOptionalPartial = (base: readonly string[]) => ("partial" in value
+    ? exactKeys(value, [...base, "partial"]) && validPartialAssistantMessage(value.partial)
+    : exactKeys(value, base));
   const contentIndex = () => Number.isSafeInteger(value.contentIndex) && (value.contentIndex as number) >= 0;
   switch (value.type) {
     case "start":
-      return exactKeys(value, ["type", "partial"]) && partial();
+      return exactWithOptionalPartial(["type"]);
     case "text_start":
     case "thinking_start":
     case "toolcall_start":
-      return exactKeys(value, ["type", "contentIndex", "partial"]) && contentIndex() && partial();
+      return exactWithOptionalPartial(["type", "contentIndex"]) && contentIndex();
     case "text_delta":
     case "thinking_delta":
     case "toolcall_delta":
-      return exactKeys(value, ["type", "contentIndex", "delta", "partial"])
-        && contentIndex() && boundedString(value.delta) && partial();
+      return exactWithOptionalPartial(["type", "contentIndex", "delta"])
+        && contentIndex() && boundedString(value.delta);
     case "text_end":
     case "thinking_end":
-      return exactKeys(value, ["type", "contentIndex", "content", "partial"])
-        && contentIndex() && boundedString(value.content) && partial();
+      return exactWithOptionalPartial(["type", "contentIndex", "content"])
+        && contentIndex() && boundedString(value.content);
     case "toolcall_end":
-      return exactKeys(value, ["type", "contentIndex", "toolCall", "partial"])
-        && contentIndex() && validContentBlock(value.toolCall, "assistant") && partial();
+      return exactWithOptionalPartial(["type", "contentIndex", "toolCall"])
+        && contentIndex() && validContentBlock(value.toolCall, "assistant");
     case "done":
       return exactKeys(value, ["type", "reason", "message"])
         && ["stop", "length", "toolUse"].includes(value.reason as string)
@@ -526,8 +532,14 @@ export function parseChildJsonLine(line: string): ProtocolRecord {
         || (!validMessage(record.message) && !validPartialAssistantMessage(record.message))) invalidProtocol();
       break;
     case "message_update":
-      if (!exactKeys(record, ["type", "message", "assistantMessageEvent"])
-        || !validPartialAssistantMessage(record.message) || !validAssistantEvent(record.assistantMessageEvent)) invalidProtocol();
+      // Pi ≤0.80.10 carries the full accumulating `message`; Pi ≥0.84.0 sends
+      // the assistant event alone (delta-only RPC, pi#7290). Both key sets are
+      // exact; nothing else passes.
+      if ("message" in record
+        ? (!exactKeys(record, ["type", "message", "assistantMessageEvent"])
+          || !validPartialAssistantMessage(record.message) || !validAssistantEvent(record.assistantMessageEvent))
+        : (!exactKeys(record, ["type", "assistantMessageEvent"])
+          || !validAssistantEvent(record.assistantMessageEvent))) invalidProtocol();
       break;
     case "tool_execution_start":
       if (!exactKeys(record, ["type", "toolCallId", "toolName", "args"])

--- a/plugins/ca-pi/tools/test/runner-isolation.test.ts
+++ b/plugins/ca-pi/tools/test/runner-isolation.test.ts
@@ -328,6 +328,29 @@ describe("Task 6 exact Pi child launch", () => {
       expect(parseChildJsonLine(JSON.stringify(valid))).toEqual(valid);
       expect(() => parseChildJsonLine(JSON.stringify(invalid))).toThrow("schema");
     }
+    // Pi 0.84.0 made RPC message_update delta-only (pi#7290): the wire event
+    // drops the full `message` record and strips `partial` from the assistant
+    // event. Both window shapes are accepted strictly; hybrids of known keys
+    // remain valid, everything else still fails closed.
+    for (const deltaOnly of [
+      { type: "message_update", assistantMessageEvent: { type: "start" } },
+      { type: "message_update", assistantMessageEvent: { type: "toolcall_start", contentIndex: 0 } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hi" } },
+      { type: "message_update", assistantMessageEvent: { type: "text_end", contentIndex: 0, content: "hi" } },
+      { type: "message_update", assistantMessageEvent: { type: "toolcall_end", contentIndex: 0, toolCall: { type: "toolCall", id: "call", name: "bash", arguments: {} } } },
+    ]) {
+      expect(parseChildJsonLine(JSON.stringify(deltaOnly))).toMatchObject({ type: "message_update" });
+    }
+    for (const stillInvalid of [
+      { type: "message_update" },
+      { type: "message_update", assistantMessageEvent: { type: "start" }, extra: 1 },
+      { type: "message_update", assistantMessageEvent: { type: "start", extra: 1 } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hi", injected: true } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", contentIndex: -1, delta: "hi" } },
+      { type: "message_update", assistantMessageEvent: { type: "unknown_event" } },
+    ]) {
+      expect(() => parseChildJsonLine(JSON.stringify(stillInvalid))).toThrow("schema");
+    }
     for (const scratch of [
       { partialArgs: '{"command":"' },
       { partialJson: '{"command":"' },


### PR DESCRIPTION
## What

The real Pi 0.84.1 drift, found by the third promotion dispatch (run 31351445772; all three OS receipts named `platform-contract`, deterministic): **Pi 0.84.0 made RPC `message_update` delta-only** (pi#7290). The wire event drops the full accumulating `message` record and strips `partial` from assistant events. The runner's strict protocol validator rejected the new shape, so every live child dispatch on Pi 0.84.x degraded with "Pi child isolation failed safely; no inline promotion is available".

Shape source-verified from the `@earendil-works/pi-coding-agent@0.84.1` tarball — `dist/modes/json-event.js` `toJsonEvent` strips exactly `message` (record level) and `partial` (event level), nothing else.

## How

- `message_update` accepts both window shapes with **exact key sets**: `{type, message, assistantMessageEvent}` (Pi ≤0.80.10, message validated as before) and `{type, assistantMessageEvent}` (Pi ≥0.84.0).
- `validAssistantEvent` makes `partial` optional-but-validated per event variant, key sets exact either way.
- ADR-0014's fail-closed boundary is unchanged: unknown keys, unknown event types, and malformed values still throw. `message_update` is validation-only in the runner (semantic consumption reads `response`/`agent_end`), so no downstream logic changes.
- ca-pi 0.6.1 (nested + generated root manifests + CHANGELOG).

## Evidence

- New protocol tests: five delta-only shapes accepted, six adversarial variants still rejected — red before the validator change, green after.
- Full ca-pi suite 782 passed / 30 files; typecheck clean; bundle rebuilt and committed.
- `test_pi_package.py` (26), `test_pi_parity.py` (23), `test_public_pi_docs.py` (13), `build-host-packages --check` all green.

## Sequencing

This must land before the next promotion dispatch: hosted validation runs the platform contract against main's runner, so the window promotion PR (0.6.1 → 0.6.2 via the release machinery) can only open once this shape is accepted.

https://claude.ai/code/session_017edPfnVHuwWMQbLHXbaXU8