### PR TITLE
fix(ca-pi): accept the optional message fields Pi 0.84 added

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-08-10
+
+### Fixed
+
+- Child dispatch protocol accepts the three optional message fields Pi 0.84.x
+  added: assistant `rawStopReason` (observed on the live RPC wire, where it
+  degraded every 0.84 child dispatch after the first provider turn), assistant
+  `deferred` (provider deferred-response handle), and toolResult `usage`. Each
+  validates strictly when present; unknown keys still fail closed (ADR-0014).
+  Proven by the live isolated-child contract against real Pi 0.84.1 and
+  0.80.10.
+
 ## [0.6.1] - 2026-08-10
 
 ### Fixed

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -7593,6 +7593,13 @@ function validDiagnostic(value) {
   }
   return value.details === void 0 || validOpaqueJson(value.details);
 }
+function validDeferredHandle(value) {
+  return isRecord(value) && exactKeys4(
+    value,
+    ["provider", "modelId", "api", "id", "expiresAt", "pollAfterMs", "data"],
+    ["provider", "modelId", "api", "id"]
+  ) && ["provider", "modelId", "api", "id"].every((key) => boundedString2(value[key])) && (value.expiresAt === void 0 || typeof value.expiresAt === "number" && Number.isFinite(value.expiresAt)) && (value.pollAfterMs === void 0 || typeof value.pollAfterMs === "number" && Number.isFinite(value.pollAfterMs)) && (value.data === void 0 || validOpaqueJson(value.data));
+}
 function validMessage(value) {
   if (!isRecord(value) || typeof value.role !== "string") return false;
   if (value.role === "user") {
@@ -7601,16 +7608,16 @@ function validMessage(value) {
   if (value.role === "assistant") {
     return exactKeys4(
       value,
-      ["role", "content", "api", "provider", "model", "responseModel", "responseId", "diagnostics", "usage", "stopReason", "errorMessage", "timestamp"],
+      ["role", "content", "api", "provider", "model", "responseModel", "responseId", "diagnostics", "usage", "stopReason", "errorMessage", "rawStopReason", "deferred", "timestamp"],
       ["role", "content", "api", "provider", "model", "usage", "stopReason", "timestamp"]
-    ) && validContent(value.content, "assistant") && ["api", "provider", "model", "stopReason"].every((key) => typeof value[key] === "string") && (value.responseModel === void 0 || boundedString2(value.responseModel)) && (value.responseId === void 0 || boundedString2(value.responseId)) && (value.errorMessage === void 0 || boundedString2(value.errorMessage)) && (value.diagnostics === void 0 || Array.isArray(value.diagnostics) && value.diagnostics.length <= MAX_JSON_ARRAY && value.diagnostics.every(validDiagnostic)) && validUsage(value.usage) && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
+    ) && validContent(value.content, "assistant") && ["api", "provider", "model", "stopReason"].every((key) => typeof value[key] === "string") && (value.responseModel === void 0 || boundedString2(value.responseModel)) && (value.responseId === void 0 || boundedString2(value.responseId)) && (value.errorMessage === void 0 || boundedString2(value.errorMessage)) && (value.rawStopReason === void 0 || boundedString2(value.rawStopReason)) && (value.deferred === void 0 || validDeferredHandle(value.deferred)) && (value.diagnostics === void 0 || Array.isArray(value.diagnostics) && value.diagnostics.length <= MAX_JSON_ARRAY && value.diagnostics.every(validDiagnostic)) && validUsage(value.usage) && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
   }
   if (value.role === "toolResult") {
     return exactKeys4(
       value,
-      ["role", "toolCallId", "toolName", "content", "details", "isError", "timestamp"],
+      ["role", "toolCallId", "toolName", "content", "details", "isError", "usage", "timestamp"],
       ["role", "toolCallId", "toolName", "content", "isError", "timestamp"]
-    ) && typeof value.toolCallId === "string" && typeof value.toolName === "string" && validContent(value.content, "toolResult") && (value.details === void 0 || validOpaqueJson(value.details)) && typeof value.isError === "boolean" && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
+    ) && typeof value.toolCallId === "string" && typeof value.toolName === "string" && validContent(value.content, "toolResult") && (value.details === void 0 || validOpaqueJson(value.details)) && (value.usage === void 0 || validUsage(value.usage)) && typeof value.isError === "boolean" && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
   }
   return false;
 }

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/runner.ts
+++ b/plugins/ca-pi/tools/src/runner.ts
@@ -370,6 +370,19 @@ function validDiagnostic(value: unknown): boolean {
   return value.details === undefined || validOpaqueJson(value.details);
 }
 
+/** Pi ≥0.84.0 attaches a provider-deferred-response handle to assistant
+ * messages. Validated strictly when present; never consumed by the runner. */
+function validDeferredHandle(value: unknown): boolean {
+  return isRecord(value)
+    && exactKeys(value,
+      ["provider", "modelId", "api", "id", "expiresAt", "pollAfterMs", "data"],
+      ["provider", "modelId", "api", "id"])
+    && ["provider", "modelId", "api", "id"].every((key) => boundedString(value[key]))
+    && (value.expiresAt === undefined || (typeof value.expiresAt === "number" && Number.isFinite(value.expiresAt)))
+    && (value.pollAfterMs === undefined || (typeof value.pollAfterMs === "number" && Number.isFinite(value.pollAfterMs)))
+    && (value.data === undefined || validOpaqueJson(value.data));
+}
+
 function validMessage(value: unknown): boolean {
   if (!isRecord(value) || typeof value.role !== "string") return false;
   if (value.role === "user") {
@@ -378,26 +391,33 @@ function validMessage(value: unknown): boolean {
       && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
   }
   if (value.role === "assistant") {
+    // `rawStopReason` and `deferred` entered the schema in Pi 0.84.x
+    // (rawStopReason observed on the live RPC wire; promotion run
+    // 31352831520 degraded every 0.84 child dispatch on it).
     return exactKeys(value,
-      ["role", "content", "api", "provider", "model", "responseModel", "responseId", "diagnostics", "usage", "stopReason", "errorMessage", "timestamp"],
+      ["role", "content", "api", "provider", "model", "responseModel", "responseId", "diagnostics", "usage", "stopReason", "errorMessage", "rawStopReason", "deferred", "timestamp"],
       ["role", "content", "api", "provider", "model", "usage", "stopReason", "timestamp"])
       && validContent(value.content, "assistant")
       && ["api", "provider", "model", "stopReason"].every((key) => typeof value[key] === "string")
       && (value.responseModel === undefined || boundedString(value.responseModel))
       && (value.responseId === undefined || boundedString(value.responseId))
       && (value.errorMessage === undefined || boundedString(value.errorMessage))
+      && (value.rawStopReason === undefined || boundedString(value.rawStopReason))
+      && (value.deferred === undefined || validDeferredHandle(value.deferred))
       && (value.diagnostics === undefined || (Array.isArray(value.diagnostics) && value.diagnostics.length <= MAX_JSON_ARRAY && value.diagnostics.every(validDiagnostic)))
       && validUsage(value.usage)
       && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
   }
   if (value.role === "toolResult") {
+    // `usage` (tool-execution usage) entered the toolResult schema in Pi 0.84.x.
     return exactKeys(value,
-      ["role", "toolCallId", "toolName", "content", "details", "isError", "timestamp"],
+      ["role", "toolCallId", "toolName", "content", "details", "isError", "usage", "timestamp"],
       ["role", "toolCallId", "toolName", "content", "isError", "timestamp"])
       && typeof value.toolCallId === "string"
       && typeof value.toolName === "string"
       && validContent(value.content, "toolResult")
       && (value.details === undefined || validOpaqueJson(value.details))
+      && (value.usage === undefined || validUsage(value.usage))
       && typeof value.isError === "boolean"
       && typeof value.timestamp === "number" && Number.isFinite(value.timestamp);
   }

--- a/plugins/ca-pi/tools/test/runner-isolation.test.ts
+++ b/plugins/ca-pi/tools/test/runner-isolation.test.ts
@@ -328,6 +328,41 @@ describe("Task 6 exact Pi child launch", () => {
       expect(parseChildJsonLine(JSON.stringify(valid))).toEqual(valid);
       expect(() => parseChildJsonLine(JSON.stringify(invalid))).toThrow("schema");
     }
+    // Pi 0.84.x widened the message schema with three optional fields:
+    // assistant `rawStopReason` (observed on the live wire rejecting every
+    // 0.84 child dispatch — promotion run 31352831520), assistant `deferred`
+    // (a DeferredHandle), and toolResult `usage`. Each validates strictly
+    // when present; unknown keys still fail closed.
+    const rawStopMessage = {
+      ...assistantMessage,
+      content: [{ type: "toolCall", id: "call-live", name: "bash", arguments: { command: "git add -A" } }],
+      stopReason: "toolUse",
+      responseId: "chatcmpl-live-tool",
+      rawStopReason: "tool_calls",
+    };
+    expect(parseChildJsonLine(JSON.stringify({ type: "message_end", message: rawStopMessage })))
+      .toMatchObject({ type: "message_end" });
+    const deferredMessage = {
+      ...assistantMessage,
+      deferred: { provider: "openai", modelId: "gpt-test", api: "openai-completions", id: "resp-1", expiresAt: 1, pollAfterMs: 5, data: { row: 1 } },
+    };
+    expect(parseChildJsonLine(JSON.stringify({ type: "message_end", message: deferredMessage })))
+      .toMatchObject({ type: "message_end" });
+    const usageToolResult = {
+      role: "toolResult", toolCallId: "call", toolName: "bash", content: [],
+      isError: false, timestamp: 1, usage: assistantMessage.usage,
+    };
+    expect(parseChildJsonLine(JSON.stringify({ type: "turn_end", message: assistantMessage, toolResults: [usageToolResult] })))
+      .toMatchObject({ type: "turn_end" });
+    for (const widenedInvalid of [
+      { type: "message_end", message: { ...assistantMessage, rawStopReason: 7 } },
+      { type: "message_end", message: { ...assistantMessage, deferred: { provider: "openai", modelId: "m", api: "a", id: "i", injected: true } } },
+      { type: "message_end", message: { ...assistantMessage, deferred: { provider: "openai", modelId: "m", api: "a" } } },
+      { type: "turn_end", message: assistantMessage, toolResults: [{ ...usageToolResult, usage: { input: "ten" } }] },
+      { type: "message_end", message: { ...assistantMessage, futureField: true } },
+    ]) {
+      expect(() => parseChildJsonLine(JSON.stringify(widenedInvalid))).toThrow("schema");
+    }
     // Pi 0.84.0 made RPC message_update delta-only (pi#7290): the wire event
     // drops the full `message` record and strips `partial` from the assistant
     // event. Both window shapes are accepted strictly; hybrids of known keys


### PR DESCRIPTION
## What

The remaining Pi 0.84 drift behind the promotion run 31352831520 failures. After #657 (delta-only `message_update`), the live child still degraded after one provider turn. A faithful local replica of the hosted cell — node 22.19.0, real Pi 0.84.1, post-apply checkout, instrumented runner — captured the rejected wire line: the child's first `message_end` carries assistant **`rawStopReason: "tool_calls"`**, which the strict message validator rejects.

Diffing `@earendil-works/pi-ai` between the installed 0.80.10 and 0.84.1 shows exactly three message-schema additions, all optional:
- assistant `rawStopReason?: string` (the live killer)
- assistant `deferred?: DeferredHandle`
- toolResult `usage?: Usage`

## How

All three validate strictly when present (bounded string / exact-key handle shape / the existing usage validator); unknown keys still fail closed per ADR-0014. The rejected wire line is pinned as a protocol test fixture — red before the change — plus adversarial variants (non-string rawStopReason, unknown key in deferred, malformed toolResult usage, arbitrary future field) all still rejected.

## Proof

- **Live isolated-child contract passes against real Pi 0.84.1** (node 22.19.0, post-apply clone with this runner) — the exact hosted platform-contract assertion that failed on all three OS cells.
- **Live contract also passes against real Pi 0.80.10** in this checkout — no legacy-window regression.
- Full ca-pi suite 782 passed / 30 files; typecheck clean; bundle rebuilt; `test_pi_package.py` 26/26; root/nested manifests at 0.6.2.

## Confession from the diagnosis

An earlier local "pass" that seemed to clear 0.84.1 came from a broken Git-Bash PATH prepend (Windows `C:/` paths split at the drive colon) silently resolving the global Pi 0.80.10 — which is also why #657 looked sufficient. The repro now asserts `pi --version` and `node --version` inline before trusting any result.

Fifth promotion dispatch follows this merge.

https://claude.ai/code/session_017edPfnVHuwWMQbLHXbaXU8