### PR TITLE
fix(ci): cover campaign-era version claims in the promotion recipe

### DIFF
--- a/.github/docs-contract.json
+++ b/.github/docs-contract.json
@@ -85,6 +85,8 @@
   ],
   "version_claim_exempt": [
     ".codearbiter/specs/pi-support.md",
-    ".codearbiter/specs/pi-support-review.md"
+    ".codearbiter/specs/pi-support-review.md",
+    ".codearbiter/open-tasks.md",
+    ".codearbiter/specs/pi-live-experience-parity.md"
   ]
 }

--- a/.github/pi-promotion-targets.json
+++ b/.github/pi-promotion-targets.json
@@ -298,6 +298,27 @@
       "occurrences": "all",
       "before": "if row[\"version\"] in {{\"{minimum}\", \"{last_verified}\"}} and row[\"platform\"] in {{\"windows\", \"linux\", \"macos\"}}:",
       "after": "if row[\"version\"] in {{\"{minimum}\", \"{candidate}\"}} and row[\"platform\"] in {{\"windows\", \"linux\", \"macos\"}}:"
+    },
+    {
+      "id": "readme-promotion-cells-claim",
+      "path": "README.md",
+      "class": "current-doc",
+      "before": "for Pi {minimum} and {last_verified} on Windows",
+      "after": "for Pi {minimum} and {candidate} on Windows"
+    },
+    {
+      "id": "parity-hosted-matrix-claim",
+      "path": "docs/parity.md",
+      "class": "current-doc",
+      "before": "matrix for Pi {minimum}/{last_verified} are green",
+      "after": "matrix for Pi {minimum}/{candidate} are green"
+    },
+    {
+      "id": "site-pi-journey-prerequisite",
+      "path": "site/src/content/docs/getting-started/pi.md",
+      "class": "current-doc",
+      "before": "- \"Pi {minimum} or Pi {last_verified}\"",
+      "after": "- \"Pi {minimum} or Pi {candidate}\""
     }
   ]
 }


### PR DESCRIPTION
## What

The last deterministic promotion blocker. Run 31355284390 (fifth dispatch) showed `platform-contract` **passing on all three OS cells** — the live Pi 0.84.1 child dispatch works after #657+#658 — leaving `docs-contract` (ubuntu/windows) as the only real failure: five files carry `0.80.10` version claims that post-apply staleness scanning rejects, all introduced by the footer-parity/npm campaigns after the recipe was authored.

## How

- **Living claims → rewrite targets** (3): README promotion-cells claim, `docs/parity.md` hosted-matrix claim, site Pi page journey prerequisite. Each has exactly one residual occurrence post-apply (verified in the scratch clone), so `occurrences: one` semantics hold.
- **Historical prose → `version_claim_exempt`** (2): `.codearbiter/open-tasks.md` (board task text is process record; helper-only writes) and the `pi-live-experience-parity` sprint spec — consistent with the existing `pi-support-review.md` exemption.

## Proof

On a scratch clone of current main: `apply --candidate 0.84.1` (46 files changed) + surface rebuild → `check_docs_contract.py` **exit 0**. Pre-apply, the contract stays green in this checkout. `test_pi_promotion.py` 38/38.

## Remaining before the promotion PR can open

Only the macOS `adapter-suite` flake (#455 broker `close()` 3-second race, third occurrence) — deflake PR follows in parallel. Sixth dispatch after both merge.

https://claude.ai/code/session_017edPfnVHuwWMQbLHXbaXU8