### PR TITLE
test(ca-pi): widen the broker close() race budget for loaded runners

### DIFF
--- a/plugins/ca-pi/tools/test/inference-broker.test.ts
+++ b/plugins/ca-pi/tools/test/inference-broker.test.ts
@@ -623,16 +623,19 @@ describe("#455 loopback inference broker", () => {
     await once(socket, "connect");
     const peerClosed = once(socket, "close");
     // `server.close()` alone waits for every open connection, so without the destruction loop the
-    // broker cannot finish closing while any child holds a socket open.
+    // broker cannot finish closing while any child holds a socket open. The budget only has to
+    // separate "destroys promptly" from "waits on the idle keep-alive forever" — a keep-alive
+    // default is measured in minutes, so 15s keeps the discrimination while riding out a loaded
+    // shared CI runner (this raced 3s and flaked three hosted macOS promotion cells in a row).
     const closed = await Promise.race([
       broker.close().then(() => "closed" as const),
-      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 3_000)),
+      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 15_000)),
     ]);
     expect(closed).toBe("closed");
     // ...and the connection is torn down from the broker's end, not merely orphaned.
     await Promise.race([
       peerClosed,
-      new Promise((_resolve, reject) => setTimeout(() => reject(new Error("connection survived close()")), 3_000)),
+      new Promise((_resolve, reject) => setTimeout(() => reject(new Error("connection survived close()")), 15_000)),
     ]);
   });
 });


### PR DESCRIPTION
## What

The #455 broker `close()` test raced against a 3-second timer and failed three consecutive hosted macOS promotion cells (runs 31318743524, 31351445772, 31355284390) — after #659 it is the only remaining blocker in the Pi 0.84.1 promotion lane.

## Why 15s keeps the test honest

The test discriminates "close() destroys open sockets promptly" from "server.close() waits on an idle keep-alive forever". Keep-alive lifetimes are measured in minutes, so a 15-second budget preserves the discrimination — a real regression (the destruction loop deleted) still hangs past the budget and fails — while riding out a loaded shared runner. Both races in the test widen identically; nothing else changes.

`tools/test` is outside the shipped payload scope (payload_scope.py excludes `tools/`), so no version bump rides this.

Suite: inference-broker 26/26 locally.

Sixth promotion dispatch follows once this and #659 merge.

https://claude.ai/code/session_017edPfnVHuwWMQbLHXbaXU8