### PR TITLE
chore(deps): bump transitive nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/plugins/ca-sandbox/tools/package-lock.json
+++ b/plugins/ca-sandbox/tools/package-lock.json
@@ -1617,9 +1617,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
The freshly published nanoid advisory (GHSA-2v37-7h3g-55p8, high) fails the sandbox driver contract's `npm audit` on **every** branch since it landed — it is blocking #661 among others.

`npm audit fix --ignore-scripts` moved the one transitive devDependency (`vitest → vite → postcss → nanoid`) to **3.3.18**, the maintained 3.x backport (postcss's `^3.3.16` range satisfies it; no sibling moved — 6 lockfile lines).

Dependency-reviewer verdict: **PASS** — `dist.integrity`/`resolved` match the live registry exactly, MIT, zero install scripts, both `npm audit` gates (dev-inclusive and `--omit=dev`) report 0 vulnerabilities. Sandbox suite 259 passed / 32 docker-skipped locally.

https://claude.ai/code/session_017edPfnVHuwWMQbLHXbaXU8