### PR TITLE
fix(codex): honor explicit execution workdir

### DIFF
--- a/.codearbiter/overrides.log
+++ b/.codearbiter/overrides.log
@@ -39,3 +39,7 @@
 [2026-08-07T11:23:13-04:00] | BY: SUaDtL@users.noreply.github.com | DEV: enter | NOTE: —
 [2026-08-07T11:57:47-04:00] | BY: SUaDtL@users.noreply.github.com | DEV: exit | NOTE: routing recorded-intent feature through gated lane
 [2026-08-08T12:22:59Z] | BY: SUaDtL@users.noreply.github.com | GATE: H-05 (pre-bash.py append-only audit log guard) | REASON: local stash-induced git conflict markers in .codearbiter/gate-events.log on branch chore/ca-pi-0.3.1-release (both conflict sides are diagnostic hook-reminder lines only, zero audit data at risk; the ca-codex-branch tail already exists independently via open PR #643) - resetting this one file to clean origin/main HEAD content to unblock the commit.
+[2026-08-11T21:45:16.1457640-04:00] | BY: SUaDtL@users.noreply.github.com | GATE: H-01 | REASON: One-time override to commit the tested H-01 linked-worktree workdir repair; the installed H-01 hook falsely blocks this non-main branch before the repair can be installed.
+[2026-08-11T21:45:16.1457640-04:00] | BY: SUaDtL@users.noreply.github.com | DEV: enter | NOTE: apply verified H-01 worktree-root fix to active local ca-codex runtime so the self-hosting source commit can clear its own guard.
+[2026-08-11T22:05:00-04:00] | BY: SUaDtL@users.noreply.github.com | DEV: exit
+[2026-08-11T22:10:00-04:00] | BY: SUaDtL@users.noreply.github.com | GATE: H-05 | REASON: Bypass H-05 once to remove the two CR bytes unintentionally appended by cmd from the two new H-01 audit records; preserve every prior byte and stage the LF-only tail required by git diff --check.

--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -348,6 +348,74 @@ class TestPreToolAdapterBrokenInstall(unittest.TestCase):
             self.assertEqual(json.loads(res.stdout).get("decision"), "block")
 
 
+class TestPreToolAdapterExecWorkdir(unittest.TestCase):
+    """The Codex exec surface can name a command-specific ``workdir`` that
+    differs from the session's top-level ``cwd``.  H-01 must judge the former:
+    a linked feature worktree must not inherit the main checkout's branch, and
+    an explicit main workdir must not inherit a feature session's branch.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        td = self._tmp.name
+
+        def live_guard(script):
+            with open(os.path.join(CODEX_HOOKS, script), encoding="utf-8") as f:
+                return f.read()
+
+        self.adapter = stage_codex_hooks(td, live_guard)
+        self.main = stage_repo(td, "main", enabled=True)
+        subprocess.run(["git", "config", "core.autocrlf", "false"], cwd=self.main,
+                       check=True, timeout=60)
+        subprocess.run(["git", "checkout", "-q", "-b", "main"], cwd=self.main,
+                       check=True, timeout=60)
+        subprocess.run(["git", "config", "user.email", "h@example.com"],
+                       cwd=self.main, check=True, timeout=60)
+        subprocess.run(["git", "config", "user.name", "harness"],
+                       cwd=self.main, check=True, timeout=60)
+        with open(os.path.join(self.main, "seed.txt"), "w", encoding="utf-8") as f:
+            f.write("seed\n")
+        subprocess.run(["git", "add", ".codearbiter/CONTEXT.md", "seed.txt"],
+                       cwd=self.main, check=True, timeout=60)
+        subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=self.main,
+                       check=True, timeout=60)
+        self.feature = os.path.join(td, "feature-worktree")
+        subprocess.run(["git", "worktree", "add", "-q", "-b", "codex/feature",
+                        self.feature], cwd=self.main, check=True, timeout=60)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run(self, session_cwd, command_workdir):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "exec_command",
+            "cwd": session_cwd,
+            "tool_input": {
+                "command": "git commit -m x",
+                "workdir": command_workdir,
+            },
+        }
+        return subprocess.run(
+            [sys.executable, self.adapter], input=json.dumps(payload), text=True,
+            capture_output=True, timeout=60, cwd=session_cwd, env=adapter_env(),
+        )
+
+    def test_linked_feature_workdir_is_not_blocked_by_main_session_root(self):
+        res = self._run(self.main, self.feature)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout, "", res.stdout)
+        self.assertNotIn("H-01", res.stderr)
+
+    def test_explicit_main_workdir_still_blocks_from_feature_session_root(self):
+        res = self._run(self.feature, self.main)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertNotEqual(res.stdout, "",
+                            "H-01 must inspect the explicit main workdir")
+        self.assertEqual(json.loads(res.stdout).get("decision"), "block")
+        self.assertIn("H-01", res.stdout)
+
+
 class TestPreToolAdapterWriteToolSet(unittest.TestCase):
     """The adapter routes write-vs-exec off its own literal set because it runs
     BEFORE the shared helpers are imported. That copy is only safe if it is

--- a/.github/scripts/test_codex_adapter.py
+++ b/.github/scripts/test_codex_adapter.py
@@ -367,7 +367,11 @@ class TestPreToolAdapterExecWorkdir(unittest.TestCase):
         self.main = stage_repo(td, "main", enabled=True)
         subprocess.run(["git", "config", "core.autocrlf", "false"], cwd=self.main,
                        check=True, timeout=60)
-        subprocess.run(["git", "checkout", "-q", "-b", "main"], cwd=self.main,
+        # `branch -M`, not `checkout -b`: when the developer's `init.defaultBranch`
+        # is already `main`, `git init` created that branch and `checkout -b main`
+        # fails — which would make this whole regression test silently never run.
+        # `-M` renames whatever the initial branch is called, and is idempotent.
+        subprocess.run(["git", "branch", "-M", "main"], cwd=self.main,
                        check=True, timeout=60)
         subprocess.run(["git", "config", "user.email", "h@example.com"],
                        cwd=self.main, check=True, timeout=60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ predate the plugin rewrite and are grouped by date.
 
 ### Fixed
 
-- Codex adapter: an explicit execution workdir is honored, so H-01's branch check reads the
-  repository the command actually runs in rather than the process's own directory.
+- Shared bash guard refresh. `_bashguardlib` is re-vendored here from `core/pysrc/`, so `ca` carries
+  the same guard as its siblings. The behavior it corrects is Codex execution-workdir handling: an
+  explicit workdir is honored, so H-01's branch check reads the repository the command actually runs
+  in rather than the process's own directory. Nothing changes for a Claude session — this host never
+  sets that workdir — but the payload did, so the version advances with it.
 
 ## [2.14.0] — 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.14.1] — 2026-08-12
+
+### Fixed
+
+- Codex adapter: an explicit execution workdir is honored, so H-01's branch check reads the
+  repository the command actually runs in rather than the process's own directory.
+
 ## [2.14.0] — 2026-08-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.14.0" src="https://img.shields.io/badge/version-2.14.0-2b7489">
+<img alt="version 2.14.1" src="https://img.shields.io/badge/version-2.14.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-40-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-18-555">
@@ -119,7 +119,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.6.1`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.6.2`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_bashguardlib.py
+++ b/core/pysrc/_bashguardlib.py
@@ -804,6 +804,11 @@ def git_cwd(cmd, root):
     return acc
 
 
+_CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
+    "shell_command", "exec_command", "unified_exec",
+})
+
+
 def _effective_exec_root(payload, root):
     """The git root that a `-C`-less git command in THIS Bash call actually
     runs against — the command's effective cwd — rather than always the
@@ -841,7 +846,13 @@ def _effective_exec_root(payload, root):
     unchanged — the overwhelmingly common (non-worktree) case sees zero
     behavioral difference. It returns the climbed root only when it names a
     genuinely DIFFERENT filesystem location."""
-    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    data = payload if isinstance(payload, dict) else {}
+    tool_input = data.get("tool_input")
+    workdir = tool_input.get("workdir") if isinstance(tool_input, dict) else None
+    if (data.get("tool_name") in _CODEX_EXPLICIT_WORKDIR_TOOLS
+            and isinstance(workdir, str) and os.path.isdir(workdir)):
+        data = {"cwd": workdir}
+    exec_root = _gitlib.project_root(data)
     if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
         return root
     return exec_root

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-08-12
+
+### Fixed
+
+- Codex adapter: an explicit execution workdir is honored, so H-01's branch check reads the
+  repository the command actually runs in rather than the process's own directory.
+
 ## [0.6.1] — 2026-08-08
 
 ### Changed

--- a/plugins/ca-codex/hooks/_bashguardlib.py
+++ b/plugins/ca-codex/hooks/_bashguardlib.py
@@ -804,6 +804,11 @@ def git_cwd(cmd, root):
     return acc
 
 
+_CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
+    "shell_command", "exec_command", "unified_exec",
+})
+
+
 def _effective_exec_root(payload, root):
     """The git root that a `-C`-less git command in THIS Bash call actually
     runs against — the command's effective cwd — rather than always the
@@ -841,7 +846,13 @@ def _effective_exec_root(payload, root):
     unchanged — the overwhelmingly common (non-worktree) case sees zero
     behavioral difference. It returns the climbed root only when it names a
     genuinely DIFFERENT filesystem location."""
-    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    data = payload if isinstance(payload, dict) else {}
+    tool_input = data.get("tool_input")
+    workdir = tool_input.get("workdir") if isinstance(tool_input, dict) else None
+    if (data.get("tool_name") in _CODEX_EXPLICIT_WORKDIR_TOOLS
+            and isinstance(workdir, str) and os.path.isdir(workdir)):
+        data = {"cwd": workdir}
+    exec_root = _gitlib.project_root(data)
     if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
         return root
     return exec_root

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-12
+
+### Fixed
+
+- Codex adapter: an explicit execution workdir is honored, so H-01's branch check reads the
+  repository the command actually runs in rather than the process's own directory.
+
 ## [0.7.0] - 2026-08-10
 
 ### Added

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -8,8 +8,11 @@ All notable changes to `ca-pi` are documented in this file.
 
 ### Fixed
 
-- Codex adapter: an explicit execution workdir is honored, so H-01's branch check reads the
-  repository the command actually runs in rather than the process's own directory.
+- Shared bash guard refresh. `_bashguardlib` is re-vendored here from `core/pysrc/`, so `ca-pi`
+  carries the same guard as its siblings. The behavior it corrects is Codex execution-workdir
+  handling: an explicit workdir is honored, so H-01's branch check reads the repository the command
+  actually runs in rather than the process's own directory. Nothing changes for a Pi session — this
+  host never sets that workdir — but the payload did, so the version advances with it.
 
 ## [0.7.0] - 2026-08-10
 

--- a/plugins/ca-pi/hooks/_bashguardlib.py
+++ b/plugins/ca-pi/hooks/_bashguardlib.py
@@ -804,6 +804,11 @@ def git_cwd(cmd, root):
     return acc
 
 
+_CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
+    "shell_command", "exec_command", "unified_exec",
+})
+
+
 def _effective_exec_root(payload, root):
     """The git root that a `-C`-less git command in THIS Bash call actually
     runs against — the command's effective cwd — rather than always the
@@ -841,7 +846,13 @@ def _effective_exec_root(payload, root):
     unchanged — the overwhelmingly common (non-worktree) case sees zero
     behavioral difference. It returns the climbed root only when it names a
     genuinely DIFFERENT filesystem location."""
-    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    data = payload if isinstance(payload, dict) else {}
+    tool_input = data.get("tool_input")
+    workdir = tool_input.get("workdir") if isinstance(tool_input, dict) else None
+    if (data.get("tool_name") in _CODEX_EXPLICIT_WORKDIR_TOOLS
+            and isinstance(workdir, str) and os.path.isdir(workdir)):
+        data = {"cwd": workdir}
+    exec_root = _gitlib.project_root(data)
     if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
         return root
     return exec_root

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,10 +2,20 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.14.0",
-  "author": { "name": "arbiterForge" },
+  "version": "2.14.1",
+  "author": {
+    "name": "arbiterForge"
+  },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",
   "repository": "https://github.com/arbiterForge/codeArbiter",
-  "keywords": ["orchestration", "tdd", "commit-gate", "code-review", "adr", "audit-trail", "governance"]
+  "keywords": [
+    "orchestration",
+    "tdd",
+    "commit-gate",
+    "code-review",
+    "adr",
+    "audit-trail",
+    "governance"
+  ]
 }

--- a/plugins/ca/hooks/_bashguardlib.py
+++ b/plugins/ca/hooks/_bashguardlib.py
@@ -804,6 +804,11 @@ def git_cwd(cmd, root):
     return acc
 
 
+_CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
+    "shell_command", "exec_command", "unified_exec",
+})
+
+
 def _effective_exec_root(payload, root):
     """The git root that a `-C`-less git command in THIS Bash call actually
     runs against — the command's effective cwd — rather than always the
@@ -841,7 +846,13 @@ def _effective_exec_root(payload, root):
     unchanged — the overwhelmingly common (non-worktree) case sees zero
     behavioral difference. It returns the climbed root only when it names a
     genuinely DIFFERENT filesystem location."""
-    exec_root = _gitlib.project_root(payload if isinstance(payload, dict) else {})
+    data = payload if isinstance(payload, dict) else {}
+    tool_input = data.get("tool_input")
+    workdir = tool_input.get("workdir") if isinstance(tool_input, dict) else None
+    if (data.get("tool_name") in _CODEX_EXPLICIT_WORKDIR_TOOLS
+            and isinstance(workdir, str) and os.path.isdir(workdir)):
+        data = {"cwd": workdir}
+    exec_root = _gitlib.project_root(data)
     if os.path.normpath(os.path.abspath(exec_root)) == os.path.normpath(os.path.abspath(root)):
         return root
     return exec_root


### PR DESCRIPTION
## Summary
Fix H-01 so Codex uses an explicit command workdir when judging a Git command. A main-rooted session can commit in a linked feature worktree, while a feature-rooted session remains blocked when the command targets main.

The shared guard and all generated hook copies stay in sync. The regression test creates a real linked worktree and proves both directions.

## Verification
- python .github/scripts/test_codex_adapter.py -q
- python plugins/ca/hooks/tests/test_repo_resolution.py -q
- python .github/scripts/test_hook_guards.py
- Python hook compilation
- Pi typecheck, tests, build, and generated-artifact checks
- Independent focused review: PASS

Closes #672