### PR TITLE
docs(readme): add Arbiter Academy entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ project context. You decide. codeArbiter enforces.
 <img alt="license AGPL v3" src="https://img.shields.io/badge/license-AGPL_v3-3da639">
 
 [Start learning](https://arbiterforge.github.io/codeArbiter/learn/)
+&nbsp;&nbsp;&#183;&nbsp;&nbsp;
+[Practice in Arbiter Academy](https://arbiterforge.github.io/arbiter-academy/)
 &nbsp;&nbsp;·&nbsp;&nbsp;
 [Install](https://arbiterforge.github.io/codeArbiter/getting-started/install/)
 &nbsp;&nbsp;·&nbsp;&nbsp;
@@ -187,6 +189,18 @@ live-fire probe before you treat the repository as governed.
 Follow the complete
 [first-repository walkthrough](https://arbiterforge.github.io/codeArbiter/getting-started/quickstart/)
 for expected output, proof, and recovery.
+
+## Practice in Arbiter Academy
+
+[Arbiter Academy](https://arbiterforge.github.io/arbiter-academy/) is the hands-on course for
+codeArbiter. In Preview 0.6, only F01 and F02 are currently published and guided. Start from your
+own GitHub fork so every exercise branch, reset, and commit remains
+in a repository you control. Each published lesson identifies the exact surface for a step: the
+browser, native terminal, active CodeArbiter harness, or the Academy helper.
+
+Use the Academy before applying the same workflow to a production repository. It preserves failed
+attempts for inspection and gives you an explicit recovery path instead of asking you to recreate
+state by hand.
 
 ## The docs are the operating manual
 


### PR DESCRIPTION
Adds a factual README route to Arbiter Academy after the first-repository walkthrough.

Preview 0.6 scope is explicit: F01 and F02 are currently the published guided lessons. The link directs readers to the course without implying that later material is available.

Validation:

- Staged diff review and whitespace check
- Shared diff secret scan with no findings
- Independent documentation review and anti-slop copy pass
- Live Academy and README links return HTTP 200

This remains a draft and is not part of the Academy merge queue.