### PR TITLE
docs(readme): add Arbiter Academy entry point

### DIFF
--- a/.github/scripts/test_public_codex_docs.py
+++ b/.github/scripts/test_public_codex_docs.py
@@ -86,6 +86,12 @@ class PublicCodexDocsTest(unittest.TestCase):
         self.assertIn("getting-started/claude-code-and-codex", self.readme)
         self.assertRegex(self.readme, re.compile(r"Codex CLI\s+0\.144\.1"))
 
+    def test_readme_links_to_arbiter_academy_practice(self):
+        self.assertIn(
+            "[Practice in Arbiter Academy](https://arbiterforge.github.io/arbiter-academy/)",
+            self.readme,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ project context. You decide. codeArbiter enforces.
 
 [Start learning](https://arbiterforge.github.io/codeArbiter/learn/)
 &nbsp;&nbsp;·&nbsp;&nbsp;
+[Practice in Arbiter Academy](https://arbiterforge.github.io/arbiter-academy/)
+&nbsp;&nbsp;·&nbsp;&nbsp;
 [Install](https://arbiterforge.github.io/codeArbiter/getting-started/install/)
 &nbsp;&nbsp;·&nbsp;&nbsp;
 [Browse the reference](https://arbiterforge.github.io/codeArbiter/reference/)


### PR DESCRIPTION
## Summary

- Add a concise hero CTA for Arbiter Academy.
- Preserve the existing Academy explainer as the source of course details.
- Add a public-doc contract assertion for the exact live URL.

## Why

Arbiter Academy is live at https://arbiterforge.github.io/arbiter-academy/. Readers can reach the hands-on course directly from the README without duplicating mutable Academy release state in codeArbiter.

## Verification

- `python3 .github/scripts/test_public_codex_docs.py`
- `python3 .github/scripts/check_docs_contract.py` with a temporary `python` to `python3` environment shim
- `python3 .github/scripts/check-plugin-refs.py`
- Repository-wide Python gate from `.codearbiter/tech-stack.md`
- `python3 -m unittest -v test_ci_impact.WorkflowContractTest.test_the_secret_scan_allowlist_stays_narrow_and_value_scoped test_ci_impact.WorkflowContractTest.test_a_broad_secret_scan_waiver_is_rejected_by_the_narrowness_contract`
- `git diff --check` and staged credential-pattern review

The local pinned Gitleaks container could not run because Docker Desktop WSL integration is disabled. Required GitHub Actions secret scanning remains pending.