### PR TITLE
docs(spike): preserve findings without spike code

### DIFF
--- a/.github/scripts/test_spike_findings_contract.py
+++ b/.github/scripts/test_spike_findings_contract.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""The disposable-spike exit must preserve only findings on the parent branch."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SURFACES = (
+    "core/surface/commands/spike.md",
+    "plugins/ca/commands/spike.md",
+    "plugins/ca-codex/skills/ca-spike/SKILL.md",
+    "plugins/ca-pi/skills/ca-spike/SKILL.md",
+)
+
+
+class SpikeFindingsContractTests(unittest.TestCase):
+    def test_every_host_preserves_only_a_committed_findings_file(self) -> None:
+        for relative in SURFACES:
+            with self.subTest(surface=relative):
+                text = (ROOT / relative).read_text(encoding="utf-8")
+                normalized = " ".join(text.split())
+                commit = normalized.index("commit only that findings file")
+                restore = normalized.index("git restore --source spike/<slug>")
+                parent_commit = normalized.index("commit that one file through")
+                deletion = normalized.casefold().index("then delete the spike branch")
+                prohibition = normalized.index("Do not transfer spike code")
+                self.assertLess(commit, restore)
+                self.assertLess(restore, parent_commit)
+                self.assertLess(parent_commit, deletion)
+                self.assertLess(deletion, prohibition)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_spike_findings_contract.py
+++ b/.github/scripts/test_spike_findings_contract.py
@@ -25,10 +25,13 @@ class SpikeFindingsContractTests(unittest.TestCase):
                 parent_commit = normalized.index("commit that one file through")
                 deletion = normalized.casefold().index("then delete the spike branch")
                 prohibition = normalized.index("Do not transfer spike code")
+                no_merge = normalized.index("no spike commit is merged")
+                self.assertEqual(normalized.count("git restore --source spike/<slug>"), 1)
                 self.assertLess(commit, restore)
                 self.assertLess(restore, parent_commit)
                 self.assertLess(parent_commit, deletion)
                 self.assertLess(deletion, prohibition)
+                self.assertLess(prohibition, no_merge)
 
 
 if __name__ == "__main__":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.15.1] — 2026-08-13
+
+### Changed
+
+- `$ca-spike` now carries only its committed findings file back to the parent before deleting the disposable spike branch. Exploratory code and spike commits remain outside implementation history.
+
 ## [2.15.0] — 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.0`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.1`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.15.0" src="https://img.shields.io/badge/version-2.15.0-2b7489">
+<img alt="version 2.15.1" src="https://img.shields.io/badge/version-2.15.1-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-38-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-18-555">

--- a/core/surface/commands/spike.md
+++ b/core/surface/commands/spike.md
@@ -14,24 +14,31 @@ it never merges, never PRs, and never becomes the implementation. What survives 
 1. **Name the question** — a spike without a falsifiable question is just freelancing. Restate
    `$ARGUMENTS` as the question the spike answers and the timebox (default: one session). STOP for
    the user's confirmation.
-2. **Branch** — create `spike/<slug>` from the current branch. All spike work stays on it.
+2. **Branch** — create `spike/<slug>` from the current branch. All exploratory code and experiments
+   stay on it; only the completed findings file may later cross back to the parent.
 3. **Explore** — no `tdd`, no plan, no review fleet. Two rules survive even here: no secret leaves
    the approved store, and no irreversible operation (prod data, destructive migration) runs from a
    spike.
 4. **Exit — exactly one of:**
    - **Answered** → write the findings to `{{PROJECT_DIR}}/.codearbiter/spikes/<slug>.md`
-     (the question, what was tried, the answer, what it implies), then delete the branch. If the
-     answer warrants building, hand the findings to `{{CMD:feature}}` — the spike file seeds
+     (the question, what was tried, the answer, what it implies), and commit only that findings file
+     on `spike/<slug>`. Return to the parent branch and run
+     `git restore --source spike/<slug> -- .codearbiter/spikes/<slug>.md` to transfer only the
+     committed findings file, review it, and commit that one file through `{{CMD:commit}}`; do not
+     merge the spike branch. Then delete the spike branch. If the answer warrants building, hand the
+     findings to `{{CMD:feature}}` — the spike file seeds
      `brainstorming` (`{{PLUGIN_ROOT}}/skills/brainstorming/SKILL.md`); the spike code is reference material, never the implementation.
-   - **Timebox expired, no answer** → record that too (a dead end is a finding), delete the branch.
+   - **Timebox expired, no answer** → record that in the findings file and use the same findings-only
+     transfer before deleting the spike branch.
 
 ## Hard gate
 
-MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. MUST NOT
-copy spike code into an implementation branch wholesale; implementation re-enters through
+MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. Do not
+transfer spike code: the parent may receive only the committed findings file. MUST NOT copy spike
+code into an implementation branch wholesale; implementation re-enters through
 `{{CMD:feature}}` and `tdd`. Secret-handling and irreversibility rules hold even in a spike. Commits on
-a `spike/*` branch are exempt from `commit-gate` — the exemption is safe precisely because nothing
-on the branch can ever land.
+a `spike/*` branch are exempt from `commit-gate` — the exemption is safe because no spike commit is
+merged and the parent may copy only the committed findings file's contents, never spike code.
 
 ## When NOT to use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-08-13
+
+### Changed
+
+- `$ca-spike` now preserves only the committed findings file on the parent branch before it deletes the disposable spike branch. Exploratory spike code and spike commits never merge into implementation history.
+
 ## [0.7.0] — 2026-08-12
 
 ### Added

--- a/plugins/ca-codex/skills/ca-spike/SKILL.md
+++ b/plugins/ca-codex/skills/ca-spike/SKILL.md
@@ -15,24 +15,31 @@ it never merges, never PRs, and never becomes the implementation. What survives 
 1. **Name the question** — a spike without a falsifiable question is just freelancing. Restate
    `$ARGUMENTS` as the question the spike answers and the timebox (default: one session). STOP for
    the user's confirmation.
-2. **Branch** — create `spike/<slug>` from the current branch. All spike work stays on it.
+2. **Branch** — create `spike/<slug>` from the current branch. All exploratory code and experiments
+   stay on it; only the completed findings file may later cross back to the parent.
 3. **Explore** — no `tdd`, no plan, no review fleet. Two rules survive even here: no secret leaves
    the approved store, and no irreversible operation (prod data, destructive migration) runs from a
    spike.
 4. **Exit — exactly one of:**
    - **Answered** → write the findings to `<project-root>/.codearbiter/spikes/<slug>.md`
-     (the question, what was tried, the answer, what it implies), then delete the branch. If the
-     answer warrants building, hand the findings to `$ca-feature` — the spike file seeds
+     (the question, what was tried, the answer, what it implies), and commit only that findings file
+     on `spike/<slug>`. Return to the parent branch and run
+     `git restore --source spike/<slug> -- .codearbiter/spikes/<slug>.md` to transfer only the
+     committed findings file, review it, and commit that one file through `$ca-commit`; do not
+     merge the spike branch. Then delete the spike branch. If the answer warrants building, hand the
+     findings to `$ca-feature` — the spike file seeds
      `brainstorming` (`${CLAUDE_PLUGIN_ROOT}/routines/brainstorming/SKILL.md`); the spike code is reference material, never the implementation.
-   - **Timebox expired, no answer** → record that too (a dead end is a finding), delete the branch.
+   - **Timebox expired, no answer** → record that in the findings file and use the same findings-only
+     transfer before deleting the spike branch.
 
 ## Hard gate
 
-MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. MUST NOT
-copy spike code into an implementation branch wholesale; implementation re-enters through
+MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. Do not
+transfer spike code: the parent may receive only the committed findings file. MUST NOT copy spike
+code into an implementation branch wholesale; implementation re-enters through
 `$ca-feature` and `tdd`. Secret-handling and irreversibility rules hold even in a spike. Commits on
-a `spike/*` branch are exempt from `commit-gate` — the exemption is safe precisely because nothing
-on the branch can ever land.
+a `spike/*` branch are exempt from `commit-gate` — the exemption is safe because no spike commit is
+merged and the parent may copy only the committed findings file's contents, never spike code.
 
 ## When NOT to use
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-13
+
+### Changed
+
+- `/ca-spike` now preserves only the committed findings file on the parent before deleting its disposable spike branch. Exploratory spike code and commits never land in implementation history.
+
 ## [0.8.0] - 2026-08-12
 
 ### Added

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/skills/ca-spike/SKILL.md
+++ b/plugins/ca-pi/skills/ca-spike/SKILL.md
@@ -15,24 +15,31 @@ it never merges, never PRs, and never becomes the implementation. What survives 
 1. **Name the question** — a spike without a falsifiable question is just freelancing. Restate
    `$ARGUMENTS` as the question the spike answers and the timebox (default: one session). STOP for
    the user's confirmation.
-2. **Branch** — create `spike/<slug>` from the current branch. All spike work stays on it.
+2. **Branch** — create `spike/<slug>` from the current branch. All exploratory code and experiments
+   stay on it; only the completed findings file may later cross back to the parent.
 3. **Explore** — no `tdd`, no plan, no review fleet. Two rules survive even here: no secret leaves
    the approved store, and no irreversible operation (prod data, destructive migration) runs from a
    spike.
 4. **Exit — exactly one of:**
    - **Answered** → write the findings to `<project-root>/.codearbiter/spikes/<slug>.md`
-     (the question, what was tried, the answer, what it implies), then delete the branch. If the
-     answer warrants building, hand the findings to `/ca-feature` — the spike file seeds
+     (the question, what was tried, the answer, what it implies), and commit only that findings file
+     on `spike/<slug>`. Return to the parent branch and run
+     `git restore --source spike/<slug> -- .codearbiter/spikes/<slug>.md` to transfer only the
+     committed findings file, review it, and commit that one file through `/ca-commit`; do not
+     merge the spike branch. Then delete the spike branch. If the answer warrants building, hand the
+     findings to `/ca-feature` — the spike file seeds
      `brainstorming` (`<plugin-root>/routines/brainstorming/SKILL.md`); the spike code is reference material, never the implementation.
-   - **Timebox expired, no answer** → record that too (a dead end is a finding), delete the branch.
+   - **Timebox expired, no answer** → record that in the findings file and use the same findings-only
+     transfer before deleting the spike branch.
 
 ## Hard gate
 
-MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. MUST NOT
-copy spike code into an implementation branch wholesale; implementation re-enters through
+MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. Do not
+transfer spike code: the parent may receive only the committed findings file. MUST NOT copy spike
+code into an implementation branch wholesale; implementation re-enters through
 `/ca-feature` and `tdd`. Secret-handling and irreversibility rules hold even in a spike. Commits on
-a `spike/*` branch are exempt from `commit-gate` — the exemption is safe precisely because nothing
-on the branch can ever land.
+a `spike/*` branch are exempt from `commit-gate` — the exemption is safe because no spike commit is
+merged and the parent may copy only the committed findings file's contents, never spike code.
 
 ## When NOT to use
 

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/commands/spike.md
+++ b/plugins/ca/commands/spike.md
@@ -14,24 +14,31 @@ it never merges, never PRs, and never becomes the implementation. What survives 
 1. **Name the question** — a spike without a falsifiable question is just freelancing. Restate
    `$ARGUMENTS` as the question the spike answers and the timebox (default: one session). STOP for
    the user's confirmation.
-2. **Branch** — create `spike/<slug>` from the current branch. All spike work stays on it.
+2. **Branch** — create `spike/<slug>` from the current branch. All exploratory code and experiments
+   stay on it; only the completed findings file may later cross back to the parent.
 3. **Explore** — no `tdd`, no plan, no review fleet. Two rules survive even here: no secret leaves
    the approved store, and no irreversible operation (prod data, destructive migration) runs from a
    spike.
 4. **Exit — exactly one of:**
    - **Answered** → write the findings to `${CLAUDE_PROJECT_DIR}/.codearbiter/spikes/<slug>.md`
-     (the question, what was tried, the answer, what it implies), then delete the branch. If the
-     answer warrants building, hand the findings to `/ca:feature` — the spike file seeds
+     (the question, what was tried, the answer, what it implies), and commit only that findings file
+     on `spike/<slug>`. Return to the parent branch and run
+     `git restore --source spike/<slug> -- .codearbiter/spikes/<slug>.md` to transfer only the
+     committed findings file, review it, and commit that one file through `/ca:commit`; do not
+     merge the spike branch. Then delete the spike branch. If the answer warrants building, hand the
+     findings to `/ca:feature` — the spike file seeds
      `brainstorming` (`${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/SKILL.md`); the spike code is reference material, never the implementation.
-   - **Timebox expired, no answer** → record that too (a dead end is a finding), delete the branch.
+   - **Timebox expired, no answer** → record that in the findings file and use the same findings-only
+     transfer before deleting the spike branch.
 
 ## Hard gate
 
-MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. MUST NOT
-copy spike code into an implementation branch wholesale; implementation re-enters through
+MUST NOT merge or PR a `spike/*` branch — its only exits are a findings file and deletion. Do not
+transfer spike code: the parent may receive only the committed findings file. MUST NOT copy spike
+code into an implementation branch wholesale; implementation re-enters through
 `/ca:feature` and `tdd`. Secret-handling and irreversibility rules hold even in a spike. Commits on
-a `spike/*` branch are exempt from `commit-gate` — the exemption is safe precisely because nothing
-on the branch can ever land.
+a `spike/*` branch are exempt from `commit-gate` — the exemption is safe because no spike commit is
+merged and the parent may copy only the committed findings file's contents, never spike code.
 
 ## When NOT to use
 


### PR DESCRIPTION
Implements the real findings-only spike workflow used by Academy U05: commit the findings note on the disposable spike branch, restore only that file to the parent, commit it there, then delete the spike branch. No exploratory code or spike commit enters implementation history.

This supersedes #685 after its historical base made GitHub evaluate unrelated main changes. The original draft remains intact; this branch carries the same reviewed content on the current main base plus required ca 2.15.1 and ca-codex 0.7.1 payload advances.