### PR TITLE
fix(release): gate the dispatch preflight to the trigger that feeds it (#654)

### DIFF
--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -113,6 +113,17 @@ AUTO_LANES = {
 AUTO_PUBLISH_JOBS = tuple(AUTO_LANES)
 AUTO_PREFLIGHT_JOB = "auto-preflight"
 
+# #654: two triggers share this one file, and every job belongs to exactly one
+# of them. The manual lane reads dispatch inputs that do not exist on the
+# auto-tag lane, so a job that can start on both is not a lane — it is a bug.
+TRIGGERS = ("workflow_dispatch", "workflow_run")
+JOB_TRIGGER = dict(
+    [(PREFLIGHT_JOB, "workflow_dispatch")]
+    + [(job, "workflow_dispatch") for job in PUBLISH_JOBS]
+    + [(AUTO_PREFLIGHT_JOB, "workflow_run")]
+    + [(job, "workflow_run") for job in AUTO_PUBLISH_JOBS]
+)
+
 # A job-level `if:` that uses one of these status functions opts OUT of the
 # implicit "all `needs` succeeded" gate — which would let a publisher run after
 # its own preflight refused the dispatch.
@@ -131,6 +142,61 @@ def _job_if(block: str) -> str:
     """The job-level `if:` expression (two-space indent), '' when absent."""
     match = re.search(r"(?m)^    if:[ ]*(.+)$", block)
     return match.group(1).strip() if match else ""
+
+
+def _job_needs(block: str) -> tuple:
+    """The job's `needs:` targets — scalar, inline-list, or block-list form.
+
+    Every form is read rather than only the scalar one this file happens to
+    use today, because a `needs:` this helper could not parse would read as
+    "depends on nothing", and a job that depends on nothing is exactly what
+    the trigger-isolation walk below treats as ungated.
+    """
+    scalar = re.search(r"(?m)^    needs:[ ]+([\w.-]+)[ ]*$", block)
+    if scalar:
+        return (scalar.group(1),)
+    inline = re.search(r"(?m)^    needs:[ ]*\[(.+)\][ ]*$", block)
+    if inline:
+        return tuple(name.strip().strip("'\"") for name in inline.group(1).split(","))
+    listed = re.search(r"(?m)^    needs:[ ]*\n((?:      - .+\n)+)", block)
+    if listed:
+        return tuple(re.findall(r"-[ ]+([\w.-]+)", listed.group(1)))
+    if re.search(r"(?m)^    needs:", block):
+        raise AssertionError("a `needs:` edge this suite cannot parse — "
+                             "an unreadable dependency must not read as none")
+    return ()
+
+
+def _gated_triggers(job: str, jobs: dict, chain: tuple = ()) -> set:
+    """Every event name `job` can start on (#654).
+
+    A job's own `if:` pins it when that expression names an event; otherwise
+    it inherits from the jobs it `needs`, because GitHub skips a dependent
+    whose dependency skipped — which is why the four manual publishers carry
+    no event guard of their own and do not need one.
+
+    A job that neither names an event nor reaches one through `needs` starts
+    on every trigger the file declares. That is not a conservative reading:
+    it is precisely what the shipped dispatch preflight did.
+    """
+    if job in chain:
+        raise AssertionError(f"cyclic `needs` chain through {job!r}")
+    if job not in jobs:
+        raise AssertionError(f"`needs` names undeclared job {job!r}")
+    condition = _job_if(jobs[job])
+    named = {t for t in TRIGGERS if f"github.event_name == '{t}'" in condition}
+    if named:
+        # Deliberately the WHOLE set, never the first hit: a guard widened to
+        # `dispatch || workflow_run` still contains the correct clause, and
+        # returning one trigger from it would report the bug as the fix.
+        return named
+    parents = _job_needs(jobs[job])
+    if not parents:
+        return set(TRIGGERS)
+    inherited = set()
+    for parent in parents:
+        inherited |= _gated_triggers(parent, jobs, chain + (job,))
+    return inherited
 
 
 def _extract_run(text: str, name_fragment: str, step_indent: int, where: str) -> str:
@@ -1159,6 +1225,88 @@ class AutoTagLaneTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertEqual(proc.stdout.strip(), "true",
                          "a series with no tag yet is a first introduction")
+
+
+class TriggerIsolationTest(unittest.TestCase):
+    """#654: two triggers share this file — a job written for one must never
+    wake up on the other.
+
+    `workflow_dispatch` supplies the four confirmation inputs the manual
+    preflight resolves its single target from. `workflow_run` supplies none
+    of them. The dispatch preflight shipped with no `if:` at all, so every
+    merge to main also woke it on the auto-tag path, where it read four
+    empty inputs, resolved `none`, and exited 1 — twelve consecutive
+    `release` runs concluded `failure` while the auto-tag lanes beside them
+    tagged correctly.
+
+    Nothing was mis-published: the preflight failed CLOSED, and the manual
+    publishers skipped with it. What it cost is the signal. At the run list
+    a permanently-red `release` is indistinguishable from a genuine
+    auto-tag failure — a tag never created, so npm-publish never fires —
+    which is the one alarm this workflow exists to raise.
+    """
+
+    def test_the_dispatch_preflight_runs_only_on_a_dispatch(self):
+        self.assertEqual(
+            _gated_triggers(PREFLIGHT_JOB, _jobs()), {"workflow_dispatch"},
+            "#654: the preflight reads dispatch inputs that exist on no other "
+            "trigger — it must be gated to the trigger that supplies them")
+
+    def test_every_job_is_bound_to_exactly_one_trigger(self):
+        jobs = _jobs()
+        for job in jobs:
+            with self.subTest(job=job):
+                self.assertEqual(
+                    len(_gated_triggers(job, jobs)), 1,
+                    f"{job} can start on more than one of this file's "
+                    "triggers; each lane must belong to exactly one")
+
+    def test_every_job_is_bound_to_the_trigger_its_own_lane_declares(self):
+        # Exactly-one is not enough on its own: a guard inverted to
+        # `!= 'workflow_run'` binds the preflight to one trigger — the wrong
+        # one. Pin which lane each job belongs to.
+        jobs = _jobs()
+        self.assertEqual(sorted(jobs), sorted(JOB_TRIGGER),
+                         "release.yml declares a job no lane accounts for")
+        for job, trigger in JOB_TRIGGER.items():
+            with self.subTest(job=job):
+                self.assertEqual(_gated_triggers(job, jobs), {trigger},
+                                 f"{job} belongs to the {trigger} lane")
+
+    def test_the_walk_reports_an_ungated_job_as_reachable_from_both(self):
+        # The assertions above earn their keep only if the walk actually
+        # discriminates. Proven against synthetic text, not by mutating the
+        # shipped workflow. This first case is #654 itself: no `if:` at all.
+        jobs = {"preflight": "    name: x\n",
+                "release": "    needs: preflight\n"
+                           "    if: needs.preflight.outputs.target == 'ca'\n"}
+        self.assertEqual(_gated_triggers("preflight", jobs), set(TRIGGERS))
+        self.assertEqual(_gated_triggers("release", jobs), set(TRIGGERS),
+                         "a publisher inherits its preflight's reach")
+
+    def test_the_walk_catches_a_guard_widened_to_both_triggers(self):
+        # The mutant a substring assertion survives: the correct clause is
+        # still there, with the wrong one ORed onto it.
+        jobs = {"preflight": "    if: github.event_name == 'workflow_dispatch'"
+                             " || github.event_name == 'workflow_run'\n"}
+        self.assertEqual(_gated_triggers("preflight", jobs), set(TRIGGERS))
+
+    def test_the_walk_inherits_a_parents_trigger_through_needs(self):
+        jobs = {"preflight": "    if: github.event_name == 'workflow_dispatch'\n",
+                "release": "    needs: preflight\n"}
+        self.assertEqual(_gated_triggers("release", jobs), {"workflow_dispatch"})
+
+    def test_the_walk_raises_rather_than_reading_an_unresolvable_needs(self):
+        # never-fold-unreadable-into-absent: a `needs:` this suite cannot
+        # parse, or one naming a job that does not exist, must stop the test
+        # rather than resolve to "depends on nothing".
+        for block, why in (("    needs: {a: b}\n", "unparseable form"),
+                           ("    needs: ghost\n", "undeclared dependency")):
+            with self.subTest(case=why):
+                with self.assertRaises(AssertionError):
+                    _gated_triggers("a", {"a": block})
+        with self.assertRaises(AssertionError):
+            _gated_triggers("a", {"a": "    needs: b\n", "b": "    needs: a\n"})
 
 
 class RegistrationTest(unittest.TestCase):

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -178,6 +178,13 @@ def _gated_triggers(job: str, jobs: dict, chain: tuple = ()) -> set:
     A job that neither names an event nor reaches one through `needs` starts
     on every trigger the file declares. That is not a conservative reading:
     it is precisely what the shipped dispatch preflight did.
+
+    Only the single-quoted `github.event_name == 'X'` form is recognised. A
+    correct guard written some other way (double quotes, or gating on an
+    input's presence) reads here as "names no event" and turns these tests
+    red — fail-closed, and deliberately so, but it means a red from this
+    helper against a guard you believe is right is a signal to WIDEN the
+    pattern below, not to weaken the guard in release.yml.
     """
     if job in chain:
         raise AssertionError(f"cyclic `needs` chain through {job!r}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,18 @@ jobs:
     name: "[GATE ] | [RELEASE] | Dispatch preflight"
     # Read-only authorization for the write-token publishers below. Fails
     # closed on every path: a refusal here skips both of them.
+    #
+    # Gated to the trigger that supplies its inputs (#654). This job resolves
+    # a target from the four dispatch confirmations, which exist on
+    # `workflow_dispatch` alone — on the auto-tag `workflow_run` path it read
+    # four empty inputs, resolved `none`, and exited 1, concluding every
+    # merge's `release` run `failure` while the auto-tag lanes below it
+    # tagged correctly. Nothing was mis-published (it fails closed, and the
+    # publishers skipped with it); what it destroyed was the signal, since a
+    # permanently-red run is indistinguishable from a real auto-tag failure.
+    # The four publishers need no guard of their own — `needs: preflight`
+    # skips them with it, and their conditions carry no status escape.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Closes #654.

## The defect

`#646` added the auto-tag `workflow_run` lane to `release.yml`. The manual
`preflight` job (`[GATE ] | [RELEASE] | Dispatch preflight`) carried no event
guard at all, so every merge to `main` woke it on the auto-tag path too. It
resolves a release target from the four dispatch confirmation inputs, and
`workflow_run` supplies none of them — four empty values, `none`, `exit 1`:

```
##[error]this dispatch selected no plugin — supply exactly one version input
```

Twelve consecutive `workflow_run` runs concluded `failure`, most recently
[31762127115](https://github.com/arbiterForge/codeArbiter/actions/runs/31762127115),
while `auto-preflight` went green in the same run.

## Why it matters

Nothing was ever mis-published. The preflight fails closed and its four
write-token publishers skip with it through `needs:` — the run was red, not
wrong. What the defect destroyed was the **signal**: at the run list a
permanently-red `release` is indistinguishable from a genuine auto-tag failure
(a tag never created, so npm-publish never fires), which is the one alarm this
workflow exists to raise.

## The fix

One line on `preflight`: `if: github.event_name == 'workflow_dispatch'`, plus
the comment explaining why. The four publishers need no guard of their own —
`needs: preflight` skips them with it, and their conditions carry no
`always()`/`!cancelled()` escape (already asserted by
`test_no_publish_job_escapes_the_needs_success_gate`).

## The regression test

`TriggerIsolationTest` in `.github/scripts/test_release_workflow.py`. It walks
each job's reachable trigger set — a job's own `if:` pins it when that
expression names an event, otherwise it inherits through `needs:` — and asserts
every job resolves to exactly one trigger, and to the one its lane declares.

Proven to discriminate by three mutants, each turning it red:

| mutant | why it matters |
| --- | --- |
| guard removed | the shipped defect |
| `!= 'workflow_run'` | binds one trigger, the wrong one |
| `== 'workflow_dispatch' \|\| == 'workflow_run'` | the correct clause is still present — a substring assertion would survive this |

The walk's own behaviour (inheritance through `needs:`, raising rather than
resolving an unparseable or dangling `needs:`) is pinned against synthetic text
rather than by mutating the shipped workflow.

## Verification

- `test_release_workflow.py`: 94 tests, green (7 new).
- Red before the fix for exactly the defect: `preflight` resolved to
  `{workflow_dispatch, workflow_run}`, and that reach propagated to all four
  publishers.
- Every suite the `hooks` job runs on this diff: green. (`test_mode_compaction.py`
  fails identically on a pristine `origin/main` checkout here — a local `.git/hooks`
  resolution artifact of the git worktree this was authored in, not a regression.)
- YAML re-parsed after the edit; LF endings preserved; no version bump, since
  `payload_version_gate.py` is `plugins/ca`-scoped and this is `.github/`-only.

## What this does *not* prove

The next merge's `release` run will very likely be docs-only: `preflight`
skipped, `auto-preflight` success, all eight lanes skipped → green. That green
proves the spurious failure is gone. It does **not** prove auto-tag still tags —
no manifest will have moved.

Auto-tag survival is argued structurally instead: the diff touches only the
`preflight` job, `needs: auto-preflight` and every auto lane are untouched, and
`AutoTagLaneTest` plus the new `TriggerIsolationTest` both still assert the
`workflow_run` path end to end. Per #654 the next merge's run should be checked
by **log** — `preflight` *skipped*, `auto-preflight` *executed* — not by status.

## Noted, not fixed here

`.github/scripts/test_spike_findings_contract.py` (added by `debb49da`) is
invoked by no workflow and no sibling script, so it has never run;
`test_ci_impact.py`'s `NoOrphanedSuiteTest` is red about it on `origin/main`
today. It does not fire on this PR — the `impact` paths filter does not cover
either file in this diff — and it is a different defect from a different commit.
Filed separately.

https://claude.ai/code/session_018giizu29PwXh3QQ8CEcXQ1
