### PR TITLE
fix(git-enforce): resolve shared gate markers via marker_root in linked worktrees

### DIFF
--- a/core/pysrc/git-enforce.py
+++ b/core/pysrc/git-enforce.py
@@ -27,6 +27,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+from hostapi import git_worktree_main_root  # noqa: E402 — worktree marker-root escalation (#695)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _gitexec import git_executable  # noqa: E402
 from _hooklib import (  # noqa: E402
@@ -185,6 +186,13 @@ def read_worktree(cwd, rel):
         return None
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` names a LINKED git
+    worktree's checkout (#695) — see `hostapi.git_worktree_main_root`'s
+    docstring."""
+    return git_worktree_main_root(root) or root
+
+
 def _marker_set(root, name):
     try:
         with open(os.path.join(root, ".codearbiter", ".markers", name),
@@ -230,11 +238,12 @@ def pre_commit(root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        mroot = _marker_root(root)
+        marker = os.path.join(mroot, ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, MARKER_FRESHNESS_MINUTES):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (#161 git backstop). Run the {skill} gate, then commit.")
-        approved = _marker_set(root, "security-gate-passed")
+        approved = _marker_set(mroot, "security-gate-passed")
         uncovered = [ln for ln in sensitive if line_digest(ln) not in approved]
         if uncovered:
             block(tag, f"{len(uncovered)} {kind} line(s) in this commit are not covered by the "
@@ -248,7 +257,8 @@ def pre_commit(root):
                       "failing closed (ORCHESTRATOR §2).")
     migs = sorted(p for p in names if is_migration_path(p, root))
     if migs:
-        approved = _marker_set(root, "migration-gate-passed")
+        mroot = _marker_root(root)
+        approved = _marker_set(mroot, "migration-gate-passed")
         uncovered = []
         for rel in migs:
             text = read_worktree(cwd, rel)

--- a/plugins/ca-codex/hooks/git-enforce.py
+++ b/plugins/ca-codex/hooks/git-enforce.py
@@ -27,6 +27,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+from hostapi import git_worktree_main_root  # noqa: E402 — worktree marker-root escalation (#695)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _gitexec import git_executable  # noqa: E402
 from _hooklib import (  # noqa: E402
@@ -185,6 +186,13 @@ def read_worktree(cwd, rel):
         return None
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` names a LINKED git
+    worktree's checkout (#695) — see `hostapi.git_worktree_main_root`'s
+    docstring."""
+    return git_worktree_main_root(root) or root
+
+
 def _marker_set(root, name):
     try:
         with open(os.path.join(root, ".codearbiter", ".markers", name),
@@ -230,11 +238,12 @@ def pre_commit(root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        mroot = _marker_root(root)
+        marker = os.path.join(mroot, ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, MARKER_FRESHNESS_MINUTES):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (#161 git backstop). Run the {skill} gate, then commit.")
-        approved = _marker_set(root, "security-gate-passed")
+        approved = _marker_set(mroot, "security-gate-passed")
         uncovered = [ln for ln in sensitive if line_digest(ln) not in approved]
         if uncovered:
             block(tag, f"{len(uncovered)} {kind} line(s) in this commit are not covered by the "
@@ -248,7 +257,8 @@ def pre_commit(root):
                       "failing closed (ORCHESTRATOR §2).")
     migs = sorted(p for p in names if is_migration_path(p, root))
     if migs:
-        approved = _marker_set(root, "migration-gate-passed")
+        mroot = _marker_root(root)
+        approved = _marker_set(mroot, "migration-gate-passed")
         uncovered = []
         for rel in migs:
             text = read_worktree(cwd, rel)

--- a/plugins/ca-pi/hooks/git-enforce.py
+++ b/plugins/ca-pi/hooks/git-enforce.py
@@ -27,6 +27,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+from hostapi import git_worktree_main_root  # noqa: E402 — worktree marker-root escalation (#695)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _gitexec import git_executable  # noqa: E402
 from _hooklib import (  # noqa: E402
@@ -185,6 +186,13 @@ def read_worktree(cwd, rel):
         return None
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` names a LINKED git
+    worktree's checkout (#695) — see `hostapi.git_worktree_main_root`'s
+    docstring."""
+    return git_worktree_main_root(root) or root
+
+
 def _marker_set(root, name):
     try:
         with open(os.path.join(root, ".codearbiter", ".markers", name),
@@ -230,11 +238,12 @@ def pre_commit(root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        mroot = _marker_root(root)
+        marker = os.path.join(mroot, ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, MARKER_FRESHNESS_MINUTES):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (#161 git backstop). Run the {skill} gate, then commit.")
-        approved = _marker_set(root, "security-gate-passed")
+        approved = _marker_set(mroot, "security-gate-passed")
         uncovered = [ln for ln in sensitive if line_digest(ln) not in approved]
         if uncovered:
             block(tag, f"{len(uncovered)} {kind} line(s) in this commit are not covered by the "
@@ -248,7 +257,8 @@ def pre_commit(root):
                       "failing closed (ORCHESTRATOR §2).")
     migs = sorted(p for p in names if is_migration_path(p, root))
     if migs:
-        approved = _marker_set(root, "migration-gate-passed")
+        mroot = _marker_root(root)
+        approved = _marker_set(mroot, "migration-gate-passed")
         uncovered = []
         for rel in migs:
             text = read_worktree(cwd, rel)

--- a/plugins/ca/hooks/git-enforce.py
+++ b/plugins/ca/hooks/git-enforce.py
@@ -27,6 +27,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hostapi  # noqa: E402 — host seam (ADR-0011)
+from hostapi import git_worktree_main_root  # noqa: E402 — worktree marker-root escalation (#695)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
 from _gitexec import git_executable  # noqa: E402
 from _hooklib import (  # noqa: E402
@@ -185,6 +186,13 @@ def read_worktree(cwd, rel):
         return None
 
 
+def _marker_root(root):
+    """`root`, escalated to the MAIN checkout when `root` names a LINKED git
+    worktree's checkout (#695) — see `hostapi.git_worktree_main_root`'s
+    docstring."""
+    return git_worktree_main_root(root) or root
+
+
 def _marker_set(root, name):
     try:
         with open(os.path.join(root, ".codearbiter", ".markers", name),
@@ -230,11 +238,12 @@ def pre_commit(root):
         kind = "crypto/TLS" if touches_crypto else "secret"
         tag = "H-09b" if touches_crypto else "H-10b"
         skill = "crypto-compliance" if touches_crypto else "secret-handling"
-        marker = os.path.join(root, ".codearbiter", ".markers", "security-gate-passed")
+        mroot = _marker_root(root)
+        marker = os.path.join(mroot, ".codearbiter", ".markers", "security-gate-passed")
         if not marker_fresh(marker, MARKER_FRESHNESS_MINUTES):
             block(tag, f"This commit introduces {kind} changes, but no security-gate pass is "
                        f"recorded (#161 git backstop). Run the {skill} gate, then commit.")
-        approved = _marker_set(root, "security-gate-passed")
+        approved = _marker_set(mroot, "security-gate-passed")
         uncovered = [ln for ln in sensitive if line_digest(ln) not in approved]
         if uncovered:
             block(tag, f"{len(uncovered)} {kind} line(s) in this commit are not covered by the "
@@ -248,7 +257,8 @@ def pre_commit(root):
                       "failing closed (ORCHESTRATOR §2).")
     migs = sorted(p for p in names if is_migration_path(p, root))
     if migs:
-        approved = _marker_set(root, "migration-gate-passed")
+        mroot = _marker_root(root)
+        approved = _marker_set(mroot, "migration-gate-passed")
         uncovered = []
         for rel in migs:
             text = read_worktree(cwd, rel)

--- a/plugins/ca/hooks/tests/test_git_enforce_worktree_markers.py
+++ b/plugins/ca/hooks/tests/test_git_enforce_worktree_markers.py
@@ -1,0 +1,93 @@
+"""Issue #695: git-enforce.py must resolve gate markers through marker_root
+(escalating from a linked worktree to the main checkout).
+
+When a developer or agent works in a linked git worktree, gate passes
+(security-pass.py, migration-pass.py) write markers into the main repository's
+`.codearbiter/.markers/` directory because `.codearbiter/.markers/` is gitignored.
+git-enforce.py must read gate markers from `_marker_root(root)` so that pre-commit
+validations in linked worktrees find the recorded gate passes.
+"""
+import os
+import sys
+import unittest
+from unittest import mock
+
+HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, HOOKS)
+import hostapi  # noqa: E402
+import _hooklib  # noqa: E402
+
+import importlib.util as _ilu
+
+
+def _load_git_enforce():
+    path = os.path.join(HOOKS, "git-enforce.py")
+    spec = _ilu.spec_from_file_location("git_enforce_worktree_test", path)
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class GitEnforceWorktreeMarkerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_git_enforce()
+
+    def test_marker_root_plain_repo_returns_root(self):
+        with mock.patch.object(self.mod, "git_worktree_main_root", return_value=None):
+            self.assertEqual(self.mod._marker_root("/repo/plain"), "/repo/plain")
+
+    def test_marker_root_linked_worktree_escalates_to_main_root(self):
+        with mock.patch.object(self.mod, "git_worktree_main_root", return_value="/repo/main"):
+            self.assertEqual(self.mod._marker_root("/repo/worktree-1"), "/repo/main")
+
+    def test_pre_commit_reads_security_marker_from_main_root_in_worktree(self):
+        worktree_root = "/repo/worktree-1"
+        main_root = "/repo/main"
+
+        fake_added = ['const test_secret_token = "dummy_synthetic_testing_token";\n']
+        secret_line = fake_added[0]
+        digest = _hooklib.line_digest(secret_line)
+
+        with mock.patch.object(self.mod, "current_branch", return_value="feature/test"), \
+             mock.patch.object(self.mod, "cached_added_lines", return_value=fake_added), \
+             mock.patch.object(self.mod, "cached_names", return_value=set()), \
+             mock.patch.object(self.mod, "git_worktree_main_root", return_value=main_root), \
+             mock.patch.object(self.mod, "marker_fresh", return_value=True) as mock_fresh, \
+             mock.patch.object(self.mod, "_marker_set", return_value={digest}) as mock_set:
+
+            # Should not raise / block
+            self.mod.pre_commit(worktree_root)
+
+            # Assert marker_fresh was checked against main_root path
+            expected_marker = os.path.join(main_root, ".codearbiter", ".markers", "security-gate-passed")
+            mock_fresh.assert_called_once_with(expected_marker, _hooklib.MARKER_FRESHNESS_MINUTES)
+            mock_set.assert_called_once_with(main_root, "security-gate-passed")
+
+    def test_pre_commit_reads_migration_marker_from_main_root_in_worktree(self):
+        worktree_root = "/repo/worktree-1"
+        main_root = "/repo/main"
+
+        migration_file = "migrations/0001_init.sql"
+        file_content = "CREATE TABLE users (id INT PRIMARY KEY);\n"
+        mig_digest = _hooklib.content_digest(file_content)
+
+        with mock.patch.object(self.mod, "current_branch", return_value="feature/test"), \
+             mock.patch.object(self.mod, "cached_added_lines", return_value=[]), \
+             mock.patch.object(self.mod, "cached_names", return_value={migration_file}), \
+             mock.patch.object(self.mod, "is_migration_path", return_value=True) as mock_is_mig, \
+             mock.patch.object(self.mod, "read_worktree", return_value=file_content), \
+             mock.patch.object(self.mod, "git_worktree_main_root", return_value=main_root), \
+             mock.patch.object(self.mod, "_marker_set", return_value={mig_digest}) as mock_set:
+
+            # Should not raise / block
+            self.mod.pre_commit(worktree_root)
+
+            # Assert is_migration_path used worktree_root
+            mock_is_mig.assert_called_once_with(migration_file, worktree_root)
+            # Assert marker set was loaded from main_root
+            mock_set.assert_called_once_with(main_root, "migration-gate-passed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
In `core/pysrc/git-enforce.py`, `pre_commit(root)` read gate-pass markers directly from `os.path.join(root, ".codearbiter", ".markers", name)`. Because `.codearbiter/.markers/` is gitignored, linked git worktrees do not share local markers on disk. As a result, gate passes recorded by `security-pass.py` and `migration-pass.py` (which write to `marker_root`) were not visible to pre-commit checks executed in linked worktrees (#695).

## Solution
- Add `_marker_root(root)` helper in `git-enforce.py` that escalates to `git_worktree_main_root(root)` when executing in a linked worktree.
- Update `pre_commit()` to resolve `security-gate-passed` and `migration-gate-passed` markers via `_marker_root(root)` while keeping path-level validation (such as `is_migration_path` and `read_worktree`) anchored to the active worktree checkout.
- Run `tools/sync-core.py` to sync canonical core changes to vendored plugin copies (`plugins/ca/hooks/git-enforce.py`, `plugins/ca-codex/hooks/git-enforce.py`, `plugins/ca-pi/hooks/git-enforce.py`).
- Add unit tests in `plugins/ca/hooks/tests/test_git_enforce_worktree_markers.py` verifying marker root resolution and pre-commit marker reads in both plain repositories and linked worktrees.

Fixes #695
