### PR TITLE
fix(codex): honor wrapped execution workdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.15.3] - 2026-08-21
+
+### Fixed
+
+- Codex desktop wrapped execution now preserves its explicit worktree directory through the shared H-01 guard. A valid feature-worktree commit is no longer evaluated as an unrelated session checkout on `main`; direct protected-branch commits remain blocked.
+
 ## [2.15.2] — 2026-08-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.15.2" src="https://img.shields.io/badge/version-2.15.2-2b7489">
+<img alt="version 2.15.3" src="https://img.shields.io/badge/version-2.15.3-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-38-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-18-555">
@@ -113,7 +113,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.2`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.3`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_bashguardlib.py
+++ b/core/pysrc/_bashguardlib.py
@@ -806,6 +806,7 @@ def git_cwd(cmd, root):
 
 _CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
     "shell_command", "exec_command", "unified_exec",
+    "functions.exec",
 })
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-21
+
+### Fixed
+
+- Codex desktop wrapped execution now carries its explicit worktree directory to H-01. The branch guard allows an intended feature-worktree commit while continuing to block a direct commit on `main`.
+
 ## [0.7.2] — 2026-08-13
 
 ### Fixed

--- a/plugins/ca-codex/hooks/_bashguardlib.py
+++ b/plugins/ca-codex/hooks/_bashguardlib.py
@@ -806,6 +806,7 @@ def git_cwd(cmd, root):
 
 _CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
     "shell_command", "exec_command", "unified_exec",
+    "functions.exec",
 })
 
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-08-21
+
+### Fixed
+
+- Shared hook payload refresh: the explicit-workdir recognition added for Codex desktop wrapped execution is carried by the common guard. Pi does not set this field, so its runtime behavior is unchanged.
+
 ## [0.8.2] - 2026-08-13
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_bashguardlib.py
+++ b/plugins/ca-pi/hooks/_bashguardlib.py
@@ -806,6 +806,7 @@ def git_cwd(cmd, root):
 
 _CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
     "shell_command", "exec_command", "unified_exec",
+    "functions.exec",
 })
 
 

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_bashguardlib.py
+++ b/plugins/ca/hooks/_bashguardlib.py
@@ -806,6 +806,7 @@ def git_cwd(cmd, root):
 
 _CODEX_EXPLICIT_WORKDIR_TOOLS = frozenset({
     "shell_command", "exec_command", "unified_exec",
+    "functions.exec",
 })
 
 

--- a/plugins/ca/hooks/tests/test_repo_resolution.py
+++ b/plugins/ca/hooks/tests/test_repo_resolution.py
@@ -32,6 +32,8 @@ from unittest import mock
 
 HOOKS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PRE_BASH = os.path.join(HOOKS, "pre-bash.py")
+CODEX_PRE_BASH = os.path.join(os.path.dirname(os.path.dirname(HOOKS)),
+                              "ca-codex", "hooks", "pre-bash.py")
 ENFORCE = os.path.join(HOOKS, "git-enforce.py")
 SECURITY_PASS = os.path.join(HOOKS, "security-pass.py")
 
@@ -276,6 +278,41 @@ class TestGitCwdEndToEnd(unittest.TestCase):
                                     "tool_input": {"command": "git commit -m x"}}),
                   env={**os.environ, "CLAUDE_PROJECT_DIR": main_checkout})
         self.assertNotIn("H-01", res.stderr)
+
+
+class TestCodexWrappedExecWorkdir(unittest.TestCase):
+    """Codex desktop may wrap an execution request while retaining its explicit
+    workdir. H-01 must judge the nested command against that worktree, not the
+    session checkout that owns the wrapper."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.main_checkout = os.path.join(self._tmp.name, "main-checkout")
+        _init_repo(self.main_checkout, branch="main")
+        _commit(self.main_checkout)
+        self.feature_worktree = os.path.join(self._tmp.name, "feature-worktree")
+        _git(["worktree", "add", "-b", "feat/wrapped-exec", self.feature_worktree],
+             self.main_checkout)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run_codex(self, workdir):
+        payload = json.dumps({
+            "tool_name": "functions.exec",
+            "tool_input": {"command": "git commit -m x", "workdir": workdir},
+        })
+        return _sh([sys.executable, CODEX_PRE_BASH], self.main_checkout, input=payload,
+                   env={k: v for k, v in os.environ.items() if k != "CLAUDE_PROJECT_DIR"})
+
+    def test_wrapped_exec_commit_on_feature_worktree_is_not_blocked_as_main(self):
+        result = self._run_codex(self.feature_worktree)
+        self.assertNotIn("H-01", result.stderr)
+
+    def test_wrapped_exec_commit_on_main_still_blocks(self):
+        result = self._run_codex(self.main_checkout)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("H-01", result.stderr)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- recognize Codex desktop's wrapped execution surface as carrying an explicit workdir
- resolve H-01 against that declared target worktree instead of the session checkout
- prove a feature worktree is allowed while main remains blocked

## Verification
- python plugins/ca/hooks/tests/test_repo_resolution.py TestCodexWrappedExecWorkdir -v
- python .github/scripts/test_hook_guards.py
- python tools/sync-core.py --check
- python tools/build-surface.py --check
- python .github/scripts/test_pi_parity.py
- git diff --check

The fix preserves H-01 fail-closed behavior for protected branches; it only corrects the target repository used for a wrapped execution request.