### PR TITLE
fix(academy): align command setup choices

### DIFF
--- a/site/src/components/AcademyCommandPreferences.astro
+++ b/site/src/components/AcademyCommandPreferences.astro
@@ -37,31 +37,30 @@ const shouldRender = shouldRenderCommandPreferences(variants);
   shouldRender && (
     <ca-academy-preferences class="academy-command-preferences" hidden>
       <div class="academy-command-preferences__intro">
-        <strong>Use your setup</strong>
-        <p>Choose an operating system or CodeArbiter host to focus every command example in this lesson. Your choices stay on this device.</p>
+        <strong>Show command examples for</strong>
       </div>
       {
         availableOperatingSystems.length > 0 && (
-          <fieldset class="academy-command-preferences__group">
-            <legend>Operating system</legend>
+          <div class="academy-command-preferences__group" role="group" aria-labelledby="academy-operating-system-label">
+            <span class="academy-command-preferences__label" id="academy-operating-system-label">Operating system</span>
             <div>
               {availableOperatingSystems.map((operatingSystem) => (
                 <button type="button" data-academy-os={operatingSystem} aria-pressed="false">{labels[operatingSystem]}</button>
               ))}
             </div>
-          </fieldset>
+          </div>
         )
       }
       {
         availableHosts.length > 0 && (
-          <fieldset class="academy-command-preferences__group">
-            <legend>CodeArbiter host</legend>
+          <div class="academy-command-preferences__group" role="group" aria-labelledby="academy-codearbiter-host-label">
+            <span class="academy-command-preferences__label" id="academy-codearbiter-host-label">CodeArbiter host</span>
             <div>
               {availableHosts.map((host) => (
                 <button type="button" data-academy-host={host} aria-pressed="false">{labels[host]}</button>
               ))}
             </div>
-          </fieldset>
+          </div>
         )
       }
     </ca-academy-preferences>

--- a/site/src/styles/academy.css
+++ b/site/src/styles/academy.css
@@ -123,7 +123,7 @@
   background: var(--ca-bg-raised);
 }
 
-.academy-command > p {
+.academy-command__label {
   margin: 0;
   padding: var(--ca-space-3) var(--ca-space-4);
   color: var(--ca-ink-muted);
@@ -177,22 +177,22 @@
 }
 
 .academy-command-preferences {
-  display: grid;
-  gap: var(--ca-space-4);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--ca-space-3) var(--ca-space-5);
   margin-block: var(--ca-space-5) var(--ca-space-6);
-  padding: var(--ca-space-4);
-  border: 1px solid var(--ca-line);
-  border-inline-start: 2px solid var(--ca-brand);
-  background: var(--ca-bg-raised);
+  padding-block: var(--ca-space-4);
+  border-block: 1px solid var(--ca-line);
 }
 
 .academy-command-preferences[hidden] { display: none; }
+.academy-command-preferences__intro { display: flex; flex: 0 1 auto; align-items: center; min-height: 2.35rem; }
 .academy-command-preferences__intro strong { color: var(--ca-ink); }
-.academy-command-preferences__intro p { margin: var(--ca-space-1) 0 0; color: var(--ca-ink-muted); font-size: var(--ca-text-sm); }
-.academy-command-preferences__group { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
-.academy-command-preferences__group legend { width: 100%; margin-block-end: var(--ca-space-2); color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
+.academy-command-preferences__group { display: flex; flex: 0 1 auto; flex-wrap: wrap; align-items: center; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
+.academy-command-preferences__label { width: auto; color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
 .academy-command-preferences__group div { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); }
-.academy-command-preferences button { padding: 0.5rem 0.85rem; }
+.academy-command-preferences button { display: inline-flex; inline-size: 7rem; block-size: 2.35rem; align-items: center; justify-content: center; padding: 0.45rem 0.7rem; }
 .academy-command-preferences button[aria-pressed="true"] { border-color: var(--ca-brand); color: var(--ca-brand-bright); box-shadow: inset 0 -0.18rem 0 var(--ca-brand); }
 
 .academy-action__proof {

--- a/site/test/academy-command-preferences-presentation.test.ts
+++ b/site/test/academy-command-preferences-presentation.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const siteRoot = join(import.meta.dirname, "..");
+const component = readFileSync(join(siteRoot, "src", "components", "AcademyCommandPreferences.astro"), "utf8");
+const styles = readFileSync(join(siteRoot, "src", "styles", "academy.css"), "utf8");
+const preferenceRule = styles.match(/\.academy-command-preferences \{([^}]*)\}/)?.[1] ?? "";
+
+describe("Academy command preference presentation", () => {
+  it("keeps the selector as a compact lesson toolbar instead of a raised form panel", () => {
+    expect(component).toContain("Show command examples for");
+    expect(preferenceRule).toContain("border-block: 1px solid var(--ca-line);");
+    expect(preferenceRule).not.toContain("background: var(--ca-bg-raised);");
+  });
+
+  it("keeps each setup group label and its choices on the same compact row when space allows", () => {
+    expect(component).toContain('role="group" aria-labelledby="academy-operating-system-label"');
+    expect(component).toContain('role="group" aria-labelledby="academy-codearbiter-host-label"');
+    expect(styles).toMatch(/\.academy-command-preferences__group \{[\s\S]*align-items: center;/);
+    expect(styles).toMatch(/\.academy-command-preferences__label \{[\s\S]*width: auto;/);
+  });
+
+  it("gives every operating-system and host choice the same stable control width", () => {
+    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*inline-size: 7rem;/);
+    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*block-size: 2\.35rem;/);
+    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*justify-content: center;/);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the Academy command setup selector subordinate to the lesson instead of a separate configuration panel. Operating system and host choices now share one compact control size, making the active setup easy to scan.

## Why

The original mixed control dimensions made the selected setup look uneven. The revised toolbar keeps the surrounding CodeArbiter documentation hierarchy while preserving the two meaningful choice groups.

## Verification

- `npm run typecheck`
- `npm test` (530 tests)
- `npm run coverage`
- `npm run build`
- `npm run link-audit`
- Full repository Python contract suite and hook tests
- 512px live viewport check: all six choices render at 112x44px with no horizontal overflow
- Independent review found no actionable issue