### PR TITLE
fix(academy): restore selector hierarchy

### DIFF
--- a/site/src/components/AcademyCommandPreferences.astro
+++ b/site/src/components/AcademyCommandPreferences.astro
@@ -37,30 +37,31 @@ const shouldRender = shouldRenderCommandPreferences(variants);
   shouldRender && (
     <ca-academy-preferences class="academy-command-preferences" hidden>
       <div class="academy-command-preferences__intro">
-        <strong>Show command examples for</strong>
+        <strong>Use your setup</strong>
+        <p>Choose an operating system or CodeArbiter host to focus every command example in this lesson. Your choices stay on this device.</p>
       </div>
       {
         availableOperatingSystems.length > 0 && (
-          <div class="academy-command-preferences__group" role="group" aria-labelledby="academy-operating-system-label">
-            <span class="academy-command-preferences__label" id="academy-operating-system-label">Operating system</span>
+          <fieldset class="academy-command-preferences__group">
+            <legend>Operating system</legend>
             <div>
               {availableOperatingSystems.map((operatingSystem) => (
                 <button type="button" data-academy-os={operatingSystem} aria-pressed="false">{labels[operatingSystem]}</button>
               ))}
             </div>
-          </div>
+          </fieldset>
         )
       }
       {
         availableHosts.length > 0 && (
-          <div class="academy-command-preferences__group" role="group" aria-labelledby="academy-codearbiter-host-label">
-            <span class="academy-command-preferences__label" id="academy-codearbiter-host-label">CodeArbiter host</span>
+          <fieldset class="academy-command-preferences__group">
+            <legend>CodeArbiter host</legend>
             <div>
               {availableHosts.map((host) => (
                 <button type="button" data-academy-host={host} aria-pressed="false">{labels[host]}</button>
               ))}
             </div>
-          </div>
+          </fieldset>
         )
       }
     </ca-academy-preferences>

--- a/site/src/styles/academy.css
+++ b/site/src/styles/academy.css
@@ -177,20 +177,20 @@
 }
 
 .academy-command-preferences {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: var(--ca-space-3) var(--ca-space-5);
+  display: grid;
+  gap: var(--ca-space-4);
   margin-block: var(--ca-space-5) var(--ca-space-6);
-  padding-block: var(--ca-space-4);
-  border-block: 1px solid var(--ca-line);
+  padding: var(--ca-space-4);
+  border: 1px solid var(--ca-line);
+  border-inline-start: 2px solid var(--ca-brand);
+  background: var(--ca-bg-raised);
 }
 
 .academy-command-preferences[hidden] { display: none; }
-.academy-command-preferences__intro { display: flex; flex: 0 1 auto; align-items: center; min-height: 2.35rem; }
 .academy-command-preferences__intro strong { color: var(--ca-ink); }
-.academy-command-preferences__group { display: flex; flex: 0 1 auto; flex-wrap: wrap; align-items: center; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
-.academy-command-preferences__label { width: auto; color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
+.academy-command-preferences__intro p { margin: var(--ca-space-1) 0 0; color: var(--ca-ink-muted); font-size: var(--ca-text-sm); }
+.academy-command-preferences__group { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
+.academy-command-preferences__group legend { width: 100%; margin-block-end: var(--ca-space-2); color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
 .academy-command-preferences__group div { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); }
 .academy-command-preferences button { display: inline-flex; inline-size: 7rem; block-size: 2.35rem; align-items: center; justify-content: center; padding: 0.45rem 0.7rem; }
 .academy-command-preferences button[aria-pressed="true"] { border-color: var(--ca-brand); color: var(--ca-brand-bright); box-shadow: inset 0 -0.18rem 0 var(--ca-brand); }

--- a/site/src/styles/academy.css
+++ b/site/src/styles/academy.css
@@ -192,7 +192,7 @@
 .academy-command-preferences__group { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
 .academy-command-preferences__group legend { width: 100%; margin-block-end: var(--ca-space-2); color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
 .academy-command-preferences__group div { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); }
-.academy-command-preferences button { display: inline-flex; inline-size: 7rem; block-size: 2.35rem; align-items: center; justify-content: center; padding: 0.45rem 0.7rem; }
+.academy-command-preferences button { display: inline-flex; inline-size: 7rem; block-size: 2.75rem; align-items: center; justify-content: center; padding: 0.45rem 0.7rem; }
 .academy-command-preferences button[aria-pressed="true"] { border-color: var(--ca-brand); color: var(--ca-brand-bright); box-shadow: inset 0 -0.18rem 0 var(--ca-brand); }
 
 .academy-action__proof {

--- a/site/test/academy-command-preferences-presentation.test.ts
+++ b/site/test/academy-command-preferences-presentation.test.ts
@@ -8,17 +8,17 @@ const styles = readFileSync(join(siteRoot, "src", "styles", "academy.css"), "utf
 const preferenceRule = styles.match(/\.academy-command-preferences \{([^}]*)\}/)?.[1] ?? "";
 
 describe("Academy command preference presentation", () => {
-  it("keeps the selector as a compact lesson toolbar instead of a raised form panel", () => {
-    expect(component).toContain("Show command examples for");
-    expect(preferenceRule).toContain("border-block: 1px solid var(--ca-line);");
-    expect(preferenceRule).not.toContain("background: var(--ca-bg-raised);");
+  it("keeps the setup explanation and choice groups in the original stacked hierarchy", () => {
+    expect(component).toContain("Use your setup");
+    expect(component).toContain("Choose an operating system or CodeArbiter host to focus every command example in this lesson. Your choices stay on this device.");
+    expect(preferenceRule).toContain("display: grid;");
+    expect(preferenceRule).toContain("background: var(--ca-bg-raised);");
   });
 
-  it("keeps each setup group label and its choices on the same compact row when space allows", () => {
-    expect(component).toContain('role="group" aria-labelledby="academy-operating-system-label"');
-    expect(component).toContain('role="group" aria-labelledby="academy-codearbiter-host-label"');
-    expect(styles).toMatch(/\.academy-command-preferences__group \{[\s\S]*align-items: center;/);
-    expect(styles).toMatch(/\.academy-command-preferences__label \{[\s\S]*width: auto;/);
+  it("uses native legends above each choice row", () => {
+    expect(component).toContain('<fieldset class="academy-command-preferences__group">');
+    expect(component).toContain("<legend>Operating system</legend>");
+    expect(component).toContain("<legend>CodeArbiter host</legend>");
   });
 
   it("gives every operating-system and host choice the same stable control width", () => {

--- a/site/test/academy-command-preferences-presentation.test.ts
+++ b/site/test/academy-command-preferences-presentation.test.ts
@@ -21,9 +21,9 @@ describe("Academy command preference presentation", () => {
     expect(component).toContain("<legend>CodeArbiter host</legend>");
   });
 
-  it("gives every operating-system and host choice the same stable control width", () => {
+  it("gives every operating-system and host choice the same stable control size", () => {
     expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*inline-size: 7rem;/);
-    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*block-size: 2\.35rem;/);
+    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*block-size: 2\.75rem;/);
     expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*justify-content: center;/);
   });
 });


### PR DESCRIPTION
## Summary

Restores the Academy setup selector as a stacked, explanatory form after the compact toolbar made the operating-system and host choices difficult to scan.

All six choices now retain the same 7rem by 2.75rem control size. Native fieldset and legend grouping remains intact.

## Verification

- `npm test` (530 tests)
- `npm run typecheck`
- `npm run build` (154 pages)
- Focused selector presentation regression
- Independent selector hierarchy review