### PR TITLE
fix(academy): align setup control rows

### DIFF
--- a/site/src/styles/academy.css
+++ b/site/src/styles/academy.css
@@ -189,10 +189,11 @@
 .academy-command-preferences[hidden] { display: none; }
 .academy-command-preferences__intro strong { color: var(--ca-ink); }
 .academy-command-preferences__intro p { margin: var(--ca-space-1) 0 0; color: var(--ca-ink-muted); font-size: var(--ca-text-sm); }
-.academy-command-preferences__group { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
-.academy-command-preferences__group legend { width: 100%; margin-block-end: var(--ca-space-2); color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
-.academy-command-preferences__group div { display: flex; flex-wrap: wrap; gap: var(--ca-space-2); }
-.academy-command-preferences button { display: inline-flex; inline-size: 7rem; block-size: 2.75rem; align-items: center; justify-content: center; padding: 0.45rem 0.7rem; }
+.academy-command-preferences__group { display: grid; gap: var(--ca-space-2); margin: 0; padding: 0; border: 0; }
+.academy-command-preferences__group legend { margin-block-end: var(--ca-space-2); color: var(--ca-ink-muted); font: 650 var(--ca-text-xs)/1 var(--ca-font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
+.academy-command-preferences__group div { display: grid; grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr)); gap: var(--ca-space-2); }
+.academy-command-preferences button { display: inline-flex; inline-size: 100%; block-size: 2.75rem; align-items: center; justify-content: center; padding: 0.45rem 0.7rem; }
+.academy-command-preferences__group div button + button { margin-block-start: 0; }
 .academy-command-preferences button[aria-pressed="true"] { border-color: var(--ca-brand); color: var(--ca-brand-bright); box-shadow: inset 0 -0.18rem 0 var(--ca-brand); }
 
 .academy-action__proof {

--- a/site/test/academy-command-preferences-presentation.test.ts
+++ b/site/test/academy-command-preferences-presentation.test.ts
@@ -22,8 +22,15 @@ describe("Academy command preference presentation", () => {
   });
 
   it("gives every operating-system and host choice the same stable control size", () => {
-    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*inline-size: 7rem;/);
+    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*inline-size: 100%;/);
     expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*block-size: 2\.75rem;/);
     expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*justify-content: center;/);
+  });
+
+  it("keeps each legend above one aligned responsive control grid", () => {
+    expect(styles).toMatch(/\.academy-command-preferences__group \{[^}]*display: grid;/);
+    expect(styles).toMatch(/\.academy-command-preferences__group div \{[^}]*display: grid;[^}]*grid-template-columns: repeat\(auto-fit, minmax\(7rem, 1fr\)\);/);
+    expect(styles).toMatch(/\.academy-command-preferences button \{[\s\S]*inline-size: 100%;/);
+    expect(styles).toMatch(/\.academy-command-preferences__group div button \+ button \{ margin-block-start: 0; \}/);
   });
 });


### PR DESCRIPTION
## Summary

Align the operating-system and CodeArbiter host controls in each Academy setup row.

Starlight's adjacent-button article spacing was adding a 16px top margin to the second and third controls. The setup groups now use a responsive equal-column grid and explicitly reset that inherited spacing.

## Verification

- `npm test` (531 tests)
- `npm run typecheck`
- `npm run build` (154 pages)
- Browser geometry check at desktop and 390px widths
- Focused presentation regression