### PR TITLE
ci(release): publish GitHub Releases on version advances

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -70,12 +70,8 @@ inputs:
   create-release:
     description: >
       "false" skips the GitHub Release entirely — only the tag is created and
-      pushed. Used by the auto-tag-on-merge lanes (issue #645-adjacent
-      drift-prevention campaign): every merge that advances a target's
-      manifest gets tagged immediately, but publishing a Release stays a
-      separate, deliberate act a human still triggers via the manual
-      dispatch path. Defaults to "true" so the existing manual dispatch
-      lanes are unchanged.
+      pushed. This is useful only for callers that intentionally need a tag
+      without a public release. Defaults to "true".
     required: false
     default: "true"
   github-token:
@@ -247,9 +243,9 @@ runs:
         # commit the tag installs (#380).
         #
         # The Release-specific checks only apply when one was actually asked
-        # for — the auto-tag lanes (`create-release: "false"`) never call `gh
-        # release create` above, so asserting a Release exists here would fail
-        # every auto-tagged push on the thing it deliberately did not do.
+        # for. A caller that deliberately passes `create-release: "false"`
+        # never calls `gh release create` above, so asserting a Release exists
+        # here would reject its intentional tag-only publication.
         if [ "$CREATE_RELEASE" = "true" ]; then
           gh release view "$TAG" --json url,isDraft,tagName
           DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -101,9 +101,9 @@ LANES = {
 PUBLISH_JOBS = tuple(LANES)
 PREFLIGHT_JOB = "preflight"
 
-# Auto-tag-on-merge (drift-prevention campaign, adjacent to #645): one
-# push-triggered write-token job per target, mirroring LANES/PUBLISH_JOBS but
-# never creating a Release (`create-release: "false"` on every one).
+# Auto-publish-on-merge: one push-triggered write-token job per target,
+# mirroring LANES/PUBLISH_JOBS and creating the corresponding GitHub Release
+# only after the existing eligibility preflight passes.
 AUTO_LANES = {
     "auto-release": {"target": "ca"},
     "auto-release-codex": {"target": "ca-codex"},
@@ -592,7 +592,7 @@ class PublishExecutionTest(_ShellHarness):
         self.assertNotIn("git tag -a", log)
         self.assertIn("gh release create v9.9.9", log)
 
-    # -- #645-adjacent auto-tag-on-merge: create-release="false" ---------------
+    # -- Explicit tag-only action behavior --------------------------------------
     def test_create_release_false_tags_and_pushes_but_never_calls_release_create(self):
         proc, log, _ = self._publish("v9.9.9", create_release="false")
         self.assertEqual(proc.returncode, 0, proc.stderr)
@@ -602,9 +602,8 @@ class PublishExecutionTest(_ShellHarness):
         self.assertNotIn("gh release create", log)
 
     def test_create_release_false_on_an_already_tagged_commit_is_a_no_op(self):
-        # Steady state after the FIRST auto-tag run for a version: the tag
-        # already exists at GITHUB_SHA, and there is deliberately no Release
-        # to create — resume_publish must not retry anything.
+        # A tag-only caller can revisit an existing tag without creating a
+        # Release. `resume_publish` must not retry anything in that mode.
         proc, log, _ = self._publish("v9.9.9", tag_at=self.HEAD,
                                      create_release="false")
         self.assertEqual(proc.returncode, 0, proc.stderr)
@@ -613,8 +612,8 @@ class PublishExecutionTest(_ShellHarness):
         self.assertNotIn("gh release create", log)
 
     def test_create_release_false_still_aborts_on_a_tag_at_the_wrong_commit(self):
-        # The #380 tag-integrity guard applies regardless of create-release —
-        # auto-tag must never silently move an existing tag either.
+        # The #380 tag-integrity guard applies regardless of create-release.
+        # A tag-only caller must never silently move an existing tag either.
         proc, log, _ = self._publish("v9.9.9", tag_at=self.OTHER,
                                      create_release="false")
         self.assertNotEqual(proc.returncode, 0)
@@ -1106,10 +1105,8 @@ class LaneIsolationTest(unittest.TestCase):
 
 
 class AutoTagLaneTest(unittest.TestCase):
-    """Drift-prevention campaign, adjacent to #645: every push to main that
-    advances a target's manifest past its last tag gets tagged immediately,
-    through a `workflow_run`-triggered mirror of the manual dispatch lanes
-    above — never creating a GitHub Release."""
+    """Every eligible manifest advance publishes its tag and GitHub Release
+    through a `workflow_run`-triggered mirror of the manual dispatch lanes."""
 
     def test_the_trigger_is_workflow_run_on_ci_completion_not_a_bare_push(self):
         # A bare `push` trigger here would race ci.yml's OWN concurrent
@@ -1154,13 +1151,13 @@ class AutoTagLaneTest(unittest.TestCase):
                               condition,
                               f"{job} must run only when {target} is eligible")
 
-    def test_every_auto_lane_never_creates_a_release(self):
+    def test_every_auto_lane_creates_a_release_after_eligibility_preflight(self):
         jobs = _jobs()
         for job in AUTO_PUBLISH_JOBS:
             with self.subTest(job=job):
                 inputs = _lane_inputs(job)
-                self.assertEqual(inputs.get("create-release"), '"false"',
-                                 f"{job} must never create a GitHub Release")
+                self.assertEqual(inputs.get("create-release"), '"true"',
+                                 f"{job} must create a GitHub Release after auto-tagging")
 
     def test_every_auto_lane_trusts_the_manifest_rather_than_a_dispatch_input(self):
         jobs = _jobs()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,13 +350,11 @@ jobs:
           github-token: ${{ github.token }}
 
   # ------------------------------------------------------------------------- #
-  # Auto-tag-on-merge (drift-prevention campaign, adjacent to issue #645).
-  # Every push to main that advances a target's manifest past its last
-  # published tag gets that tag created and pushed immediately — no human
-  # dispatch, no batching, no drift to backfill later. Deliberately NEVER
-  # creates a GitHub Release (`create-release: "false"` on every lane below):
-  # publishing a Release stays a separate, human-triggered decision through
-  # the manual dispatch path above. A target whose manifest advanced but
+  # Auto-publish-on-merge. Every push to main that advances a target's manifest
+  # past its last published tag creates that tag and its GitHub Release after
+  # CI completes successfully — no human dispatch, no batching, and no drift
+  # between an installable tag and a visible release. A target whose manifest
+  # advanced but
   # whose CHANGELOG carries no matching section fails loudly (the shared
   # action's own "no CHANGELOG section found" guard) rather than tagging
   # silently or inventing content — the exact gap that let ca-codex drift 11
@@ -433,7 +431,7 @@ jobs:
           requested-version: ""
           summary: ""
           mark-latest: "true"
-          create-release: "false"
+          create-release: "true"
           github-token: ${{ github.token }}
 
   auto-release-codex:
@@ -462,7 +460,7 @@ jobs:
           requested-version: ""
           summary: ""
           mark-latest: "false"
-          create-release: "false"
+          create-release: "true"
           github-token: ${{ github.token }}
 
   auto-release-sandbox:
@@ -491,7 +489,7 @@ jobs:
           requested-version: ""
           summary: ""
           mark-latest: "false"
-          create-release: "false"
+          create-release: "true"
           github-token: ${{ github.token }}
 
   auto-release-pi:
@@ -521,5 +519,5 @@ jobs:
           requested-version: ""
           summary: ""
           mark-latest: "false"
-          create-release: "false"
+          create-release: "true"
           github-token: ${{ github.token }}


### PR DESCRIPTION
## Summary

Publish a GitHub Release whenever a plugin manifest advances and the existing auto-publish eligibility checks pass.

The workflow still requires successful CI on main, resolves eligibility from the exact upstream commit, pins each publisher checkout to that commit, and uses the existing immutable-tag and release read-back checks.

The manual recovery path was also used to publish ca-codex 0.7.4 from its already-valid tag.

## Verification

- python .github/scripts/test_release_workflow.py (94 tests)
- python .github/scripts/test_release_lib.py (396 tests)
- python .github/scripts/test_release_trace.py (29 tests, 2 expected platform skips)
- python .github/scripts/test_ci_impact.py (57 tests)
- gitleaks dir . --redact --no-banner

## Review

- CI/CD security review: PASS, with no CRITICAL or HIGH finding.
- Release-workflow coverage review: PASS, with no HIGH or CRITICAL gap.