### PR TITLE
fix(site): keep Academy setup cards readable

### DIFF
--- a/site/src/styles/academy.css
+++ b/site/src/styles/academy.css
@@ -340,7 +340,7 @@
 
 .academy-overview__setup-steps {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
   gap: var(--ca-space-3);
   margin: var(--ca-space-3) 0 0;
   padding: 0;
@@ -572,10 +572,6 @@
 }
 
 @media (max-width: 60rem) {
-  .academy-overview__setup-steps {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .academy-overview__tracks {
     grid-template-columns: 1fr;
     gap: var(--ca-space-7);
@@ -629,7 +625,6 @@
     inline-size: 100%;
   }
 
-  .academy-overview__setup-steps,
   .academy-overview__tracks {
     grid-template-columns: 1fr;
   }

--- a/site/test/academy-command-preferences-presentation.test.ts
+++ b/site/test/academy-command-preferences-presentation.test.ts
@@ -8,6 +8,15 @@ const styles = readFileSync(join(siteRoot, "src", "styles", "academy.css"), "utf
 const preferenceRule = styles.match(/\.academy-command-preferences \{([^}]*)\}/)?.[1] ?? "";
 
 describe("Academy command preference presentation", () => {
+  it("keeps setup cards at a readable width instead of forcing five columns", () => {
+    expect(styles).toMatch(
+      /\.academy-overview__setup-steps \{[^}]*grid-template-columns: repeat\(auto-fit, minmax\(min\(100%, 14rem\), 1fr\)\);/,
+    );
+    expect(styles).not.toMatch(
+      /\.academy-overview__setup-steps\s*\{\s*grid-template-columns:\s*repeat\((?:1|2|5),/,
+    );
+  });
+
   it("keeps the setup explanation and choice groups in the original stacked hierarchy", () => {
     expect(component).toContain("Use your setup");
     expect(component).toContain("Choose an operating system or CodeArbiter host to focus every command example in this lesson. Your choices stay on this device.");


### PR DESCRIPTION
## Summary
- Let Academy setup cards adapt to the actual docs-column width, preserving a 14rem card minimum.
- Remove fixed-breakpoint overrides that could reintroduce cramped cards.
- Add regression coverage against fixed 5/2/1-column variants.

## Verification
- npx vitest run --testTimeout=10000 (549 tests)
- npm run test:academy-base
- npm run typecheck
- npm run build (154 pages)
- Local browser geometry at 1024px, 1280px, and 390px; 20 Academy routes showed no horizontal overflow
- git diff --check