### PR TITLE
fix(desktop-proof): accept symbolic resource templates

### DIFF
--- a/.github/scripts/check_codex_skill_resources.py
+++ b/.github/scripts/check_codex_skill_resources.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+from bisect import bisect_right
 import hashlib
 import io
 import json
@@ -78,6 +79,16 @@ REFERENCE_DEFINITION = re.compile(
 )
 REFERENCE_RESOURCE_LINK = re.compile(
     r"\[(?P<text>[^\]\n]+)\]\[(?P<label>[^\]\n]*)\]"
+)
+SYMBOLIC_SEGMENT = re.compile(r"<[a-z][a-z0-9-]*>")
+SYMBOLIC_TARGET_CHARS = re.compile(r"^[A-Za-z0-9_./<>-]+$")
+SYMBOLIC_SENTINEL = ":codearbiter-symbol:"
+SYMBOLIC_INLINE_LINK = re.compile(
+    r"\[[^\]\r\n]*\]\("
+    r"(?P<target>[A-Za-z0-9_./-]*(?:<[a-z][a-z0-9-]*>"
+    r"[A-Za-z0-9_./-]*)+)"
+    r"(?:[ \t\r\n]+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^\)\r\n]*\)))?"
+    r"[ \t\r\n]*\)"
 )
 NONCE = re.compile(r"(?m)^nonce:\s*([^\s]+)\s*$")
 SHA256 = re.compile(r"^[0-9a-f]{64}$")
@@ -2324,6 +2335,27 @@ def _markdown_html_tag_spans(text: str) -> list[tuple[int, int]]:
 def _mask_markdown_literal_regions(text: str) -> str:
     """Blank CommonMark literal regions while preserving offsets and line breaks."""
     masked = list(text)
+    symbolic_targets = [
+        (match.group("target"), match.start("target"))
+        for match in SYMBOLIC_INLINE_LINK.finditer(text)
+        if not _escaped_at(text, match.start())
+        and not (
+            match.start() > 0
+            and text[match.start() - 1] == "!"
+            and not _escaped_at(text, match.start() - 1)
+        )
+    ]
+    symbolic_targets.extend(
+        (match.group("plain"), match.start("plain"))
+        for match in REFERENCE_DEFINITION.finditer(text)
+        if match.group("plain") is not None
+        and SYMBOLIC_SEGMENT.search(match.group("plain"))
+    )
+    symbolic_segments = {
+        (offset + segment.start(), offset + segment.end())
+        for target, offset in symbolic_targets
+        for segment in SYMBOLIC_SEGMENT.finditer(target)
+    }
 
     def blank(start: int, end: int) -> None:
         for index in range(start, end):
@@ -2333,7 +2365,8 @@ def _mask_markdown_literal_regions(text: str) -> str:
     for match in re.finditer(r"<!--[\s\S]*?-->", text):
         blank(*match.span())
     for span in _markdown_html_tag_spans(text):
-        blank(*span)
+        if span not in symbolic_segments:
+            blank(*span)
 
     offset = 0
     fence: tuple[str, int] | None = None
@@ -2483,7 +2516,8 @@ def _mask_markdown_literal_regions(text: str) -> str:
 
 
 def _inside(span_start: int, spans: list[tuple[int, int]]) -> bool:
-    return any(start <= span_start < end for start, end in spans)
+    index = bisect_right(spans, (span_start, sys.maxsize)) - 1
+    return index >= 0 and span_start < spans[index][1]
 
 
 def _escaped_at(text: str, index: int) -> bool:
@@ -2638,9 +2672,10 @@ def _markdown_resource_links(text: str) -> list[str]:
     inline_spans = [span for _, span in inline_matches]
     links = [_markdown_target(target) for target, _ in inline_matches]
     reference_spans: list[tuple[int, int]] = []
+    definition_or_inline_spans = sorted(definition_spans + inline_spans)
     for match in REFERENCE_RESOURCE_LINK.finditer(visible):
         if (
-            _inside(match.start(), definition_spans + inline_spans)
+            _inside(match.start(), definition_or_inline_spans)
             or _escaped_at(visible, match.start())
             or match.start() > 0
             and visible[match.start() - 1] == "!"
@@ -2652,7 +2687,7 @@ def _markdown_resource_links(text: str) -> list[str]:
             raise ValueError("candidate resource contains an unresolved reference-style link")
         links.append(definitions[label])
         reference_spans.append(match.span())
-    occupied = definition_spans + inline_spans + reference_spans
+    occupied = sorted(definition_or_inline_spans + reference_spans)
     for match in re.finditer(r"\[([^\]\n]+)\]", visible):
         if (
             _inside(match.start(), occupied)
@@ -2691,6 +2726,32 @@ def candidate_resource_contract(path: Path) -> dict[str, Any]:
             raise ValueError(f"candidate resource is not UTF-8: {source}") from error
         for reference in _markdown_resource_links(text):
             target = reference.split("#", 1)[0]
+            if SYMBOLIC_SEGMENT.search(target):
+                if not target.casefold().endswith(".md"):
+                    continue
+                symbolic, symbolic_count = SYMBOLIC_SEGMENT.subn(SYMBOLIC_SENTINEL, target)
+                if (
+                    not SYMBOLIC_TARGET_CHARS.fullmatch(target)
+                    or "<" in symbolic
+                    or ">" in symbolic
+                ):
+                    raise ValueError(
+                        f"candidate resource link has an invalid symbolic target: "
+                        f"{source} -> {reference}"
+                    )
+                resolved = posixpath.normpath(
+                    posixpath.join(posixpath.dirname(source), symbolic)
+                )
+                if resolved.count(SYMBOLIC_SENTINEL) != symbolic_count:
+                    raise ValueError(
+                        f"candidate resource link normalization removes a symbolic segment: "
+                        f"{source} -> {reference}"
+                    )
+                if target.startswith(("/", "\\")) or resolved.startswith("../"):
+                    raise ValueError(
+                        f"candidate resource link is escaped: {source} -> {reference}"
+                    )
+                continue
             if (
                 not target
                 or target.startswith(("#", "/", "\\"))

--- a/.github/scripts/test_codex_skill_resources.py
+++ b/.github/scripts/test_codex_skill_resources.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 import warnings
 import zipfile
@@ -3449,6 +3450,142 @@ class CandidateResourceContractSafetyTest(CheckerPresentMixin, unittest.TestCase
         contract = self.checker.candidate_resource_contract(REPO_ROOT / "plugins" / "ca-codex")
         self.assertTrue(contract["selected_paths"])
         self.assertRegex(contract["sha256"], r"^[0-9a-f]{64}$")
+
+    def test_symbolic_markdown_template_link_is_not_a_runtime_read(self):
+        sources = {
+            "inline": "[Agent template](../agents/<name>.md)\n",
+            "inline title": "[Agent template](../agents/<name>.md 'route')\n",
+            "escaped image marker": "\\![Agent template](../agents/<name>.md)\n",
+            "full reference": (
+                "[Agent template][Template]\n\n"
+                "[Template]: ../agents/<name>.md\n"
+            ),
+            "collapsed reference": (
+                "[Template][]\n\n[Template]: ../agents/<name>.md\n"
+            ),
+        }
+        for label, source in sources.items():
+            with self.subTest(label=label):
+                path = self.write_zip([
+                    ("plugins/ca-codex/skills/probe.md", source),
+                    ("plugins/ca-codex/agents/probe.md", "# Agent\n"),
+                ], name=f"symbolic-{label.replace(' ', '-')}.zip")
+                self.assertEqual(
+                    self.checker.candidate_resource_contract(path)["relative_reads"],
+                    [],
+                )
+
+    def test_symbolic_markdown_template_link_cannot_escape_candidate(self):
+        sources = {
+            "relative inline": "[Agent template](../../../../<name>.md)\n",
+            "root inline": "[Agent template](/agents/<name>.md)\n",
+            "relative reference": (
+                "[Agent template][Template]\n\n"
+                "[Template]: ../../../../<name>.md\n"
+            ),
+        }
+        for label, source in sources.items():
+            with self.subTest(label=label):
+                path = self.write_zip([
+                    ("plugins/ca-codex/skills/probe.md", source),
+                ], name=f"symbolic-escape-{label.replace(' ', '-')}.zip")
+                with self.assertRaisesRegex(
+                    ValueError, "candidate resource link is escaped"
+                ):
+                    self.checker.candidate_resource_contract(path)
+
+    def test_symbolic_markdown_template_survives_path_normalization(self):
+        sources = {
+            "inline": "[Agent template](../agents/<name>/../probe.md)\n",
+            "reference": (
+                "[Agent template][Template]\n\n"
+                "[Template]: ../agents/<name>/../probe.md\n"
+            ),
+        }
+        for label, source in sources.items():
+            with self.subTest(label=label):
+                path = self.write_zip([
+                    ("plugins/ca-codex/skills/probe.md", source),
+                    ("plugins/ca-codex/agents/probe.md", "# Agent\n"),
+                ], name=f"symbolic-normalization-{label}.zip")
+                with self.assertRaisesRegex(
+                    ValueError, "normalization removes a symbolic segment"
+                ):
+                    self.checker.candidate_resource_contract(path)
+
+    def test_symbolic_markdown_link_scan_is_bounded_near_entry_limit(self):
+        source = "[Template](../agents/<name>.md)\n" * 30_000
+        started = time.perf_counter()
+        links = self.checker._markdown_resource_links(source)
+        elapsed = time.perf_counter() - started
+        self.assertEqual(len(links), 30_000)
+        self.assertLess(
+            elapsed,
+            5.0,
+            f"symbolic Markdown link scan took {elapsed:.2f}s near the entry limit",
+        )
+
+    def test_dense_symbolic_target_is_bounded_near_entry_limit(self):
+        target = "../agents/" + "<a>" * 64_000 + ".md"
+        path = self.write_zip([
+            ("plugins/ca-codex/skills/probe.md", f"[Template]({target})\n"),
+        ], name="dense-symbolic-target.zip")
+        started = time.perf_counter()
+        contract = self.checker.candidate_resource_contract(path)
+        elapsed = time.perf_counter() - started
+        self.assertEqual(contract["relative_reads"], [])
+        self.assertLess(
+            elapsed,
+            5.0,
+            f"dense symbolic target validation took {elapsed:.2f}s near the entry limit",
+        )
+
+    def test_symbolic_targets_remain_inert_only_in_supported_markdown_contexts(self):
+        inert_sources = {
+            "non-markdown route": "[Route](../agents/<name>.json)\n",
+            "inline code": "`[Template](../agents/<name>.md)`\n",
+            "fenced code": "```md\n[Template](../agents/<name>.md)\n```\n",
+            "comment": "<!-- [Template](../agents/<name>.md) -->\n",
+            "raw html": '<span title="[Template](../agents/<name>.md)">x</span>\n',
+        }
+        for label, source in inert_sources.items():
+            with self.subTest(label=label):
+                path = self.write_zip([
+                    ("plugins/ca-codex/skills/probe.md", source),
+                ], name=f"symbolic-context-{label.replace(' ', '-')}.zip")
+                self.assertEqual(
+                    self.checker.candidate_resource_contract(path)["relative_reads"],
+                    [],
+                )
+
+        invalid = self.write_zip([
+            (
+                "plugins/ca-codex/skills/probe.md",
+                "[Template][Route]\n\n[Route]: ../agents/<name>@.md\n",
+            ),
+        ], name="invalid-symbolic-target.zip")
+        with self.assertRaisesRegex(ValueError, "invalid symbolic target"):
+            self.checker.candidate_resource_contract(invalid)
+
+    def test_characterizes_malformed_title_and_unresolved_concrete_markdown(self):
+        malformed_title = self.write_zip([
+            (
+                "plugins/ca-codex/skills/probe.md",
+                "[Agent](../agents/probe.md unsupported-title)\n",
+            ),
+            ("plugins/ca-codex/agents/probe.md", "# Agent\n"),
+        ], name="malformed-inline-title.zip")
+        with self.assertRaisesRegex(ValueError, "unsupported inline link title"):
+            self.checker.candidate_resource_contract(malformed_title)
+
+        unresolved = self.write_zip([
+            (
+                "plugins/ca-codex/skills/probe.md",
+                "[Missing](../agents/missing.md)\n",
+            ),
+        ], name="unresolved-concrete-markdown.zip")
+        with self.assertRaisesRegex(ValueError, "escaped or unresolved"):
+            self.checker.candidate_resource_contract(unresolved)
 
     def test_deep_balanced_destination_is_included_and_nonpunctuation_escape_rejected(self):
         balanced = self.write_zip([


### PR DESCRIPTION
## Summary

Accept bounded symbolic Markdown authoring templates as inert candidate data in the trusted default-branch resource validator.

- Preserve concrete Markdown resource reads and the exact candidate manifest.
- Reject symbolic targets that escape containment or lose a placeholder during normalization.
- Keep raw HTML, comments, code literals, images, and non-Markdown routes outside the runtime-read contract.
- Bound adversarial parsing for repeated links and dense single-target placeholders.

## Why

PR #711 packages valid `${PLUGIN_ROOT}` documentation routes such as `../agents/<name>.md`. The trusted pre-merge validator previously masked `<name>` as raw HTML and then rejected the remaining Markdown as a malformed inline title. This blocked the protected desktop proof before device authorization.

## Verification

- Candidate resource suite: 152 tests passed, with one expected platform skip.
- Desktop boundary suite: 24 of 24 passed.
- CI impact suite: 59 of 59 passed.
- Exact PR #711 archive: 138 selected paths, 173 concrete reads, resource manifest SHA-256 `1d5cd931b913f5de8d65a249ad2b5ab910a4389cff1b625acfb7732ed580cf5f`.
- Dense 64,000-placeholder regression: failed at 22.04 seconds before the repair, then passed within the bounded focused suite.
- Independent Auth/Crypto and Coverage/Mutation reviews: zero findings at every severity on staged diff SHA-256 `d7520dd37cd5357a6ef10f48d1aea46083938c763e9623fb664cf85525320a6c`.
- Staged gitleaks, Python compilation, diff integrity, and plugin reference checks passed.

## Release boundary

This changes trusted repository validation tooling only. No shipped plugin payload changed, so no package version or CHANGELOG file advance is required. The commit includes the required `CHANGELOG:` footer.

This PR is prerequisite maintenance for #711. It does not authorize merge, tag, release, publication, deployment, or protected desktop dispatch.

Refs #711