### PR TITLE
fix(desktop-proof): bind BCDBoot to protected ADK

### DIFF
--- a/.github/desktop-proof-boundary.json
+++ b/.github/desktop-proof-boundary.json
@@ -3,7 +3,7 @@
   "broker": {
     "source_path": ".github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1",
     "installed_path": "C:\\codearbiter-runner\\Invoke-CodeArbiterDesktopCandidate.ps1",
-    "sha256": "26a4f93449590ecdcafcaabe6b4a02d30a097c6f5180c5d6405b0f5141b99063"
+    "sha256": "2ffc8b4ef398b0f5be8f676f4a8ba7c5ddde7f7acc58ac3466c84a4a2acc8005"
   },
   "driver": {
     "source_path": ".github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1",
@@ -25,6 +25,49 @@
     "provisioning_mode": "iso-apply-fresh-vhdx",
     "download_page": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise",
     "hash_document": "https://go.microsoft.com/fwlink/?linkid=2334901"
+  },
+  "deployment_tools": {
+    "product": "Microsoft Windows ADK Deployment Tools",
+    "version": "10.1.26100.2454",
+    "servicing_update": "KB5101684",
+    "protected_root": "C:\\codearbiter-runner\\toolchains\\windows-adk\\10.1.26100.2454-kb5101684",
+    "executable_relative_path": "amd64\\BCDBoot\\bcdboot.exe",
+    "acquisition": {
+      "source_url": "https://download.microsoft.com/download/2/d/9/2d9c8902-3fcd-48a6-a22a-432b08bed61e/ADK/adksetup.exe",
+      "length": 2234632,
+      "sha256": "7f61e29f2314bcdd7e0abf67a8367d83a05aa4a7b9223f85c5fd2582a35cc6f4",
+      "signer_thumbprint": "0bd8c56733fdcc06f8cb919ff5a200e39b1acf71"
+    },
+    "servicing": {
+      "source_url": "https://download.microsoft.com/download/a087a851-4056-4f7f-9791-02a20509b706/Windows_ADK_10.1.26100.2454_Update_KB5101684.zip",
+      "length": 411048362,
+      "sha256": "dc19725a2fb0cce44c32ac14059a85a25257b9534ba21c93b479f4f09fb5af38"
+    },
+    "license": {
+      "spdx": "LicenseRef-Microsoft-Windows-ADK-EULA",
+      "length": 192576,
+      "sha256": "3c0c45033614cd4882ff0195ca7f77c8077f2f4917806ada519855f7f87da595"
+    },
+    "files": [
+      {
+        "path": "amd64\\BCDBoot\\bcdboot.exe",
+        "length": 300608,
+        "sha256": "0395497dfb048791cc52bbaea7c304317d546e06198875bf83e0bb186fb09cc5",
+        "signer_subject": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+      },
+      {
+        "path": "amd64\\BCDBoot\\bcdedit.exe",
+        "length": 525888,
+        "sha256": "9cfb9375debfe6392c1f133d9b0e0b5df1ab68ac2170b70b9e385d7c25b2a965",
+        "signer_subject": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+      },
+      {
+        "path": "amd64\\BCDBoot\\bootsect.exe",
+        "length": 116272,
+        "sha256": "a5f66774b5c72ae0c39ba9a87c38ccc68e58ba4886a6b8348e396e0ba95ab599",
+        "signer_subject": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+      }
+    ]
   },
   "application": {
     "package_name": "OpenAI.Codex",

--- a/.github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1
+++ b/.github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1
@@ -27,6 +27,12 @@ param(
     [string]$ArchiveExtractionDestination,
     [Parameter(Mandatory, ParameterSetName = 'CandidateMetadataFixture')]
     [string]$CandidateMetadataFixturePath,
+    [Parameter(Mandatory, ParameterSetName = 'AdkBoundaryFixture')]
+    [string]$AdkBoundaryFixturePath,
+    [Parameter(Mandatory, ParameterSetName = 'AdkExecutionLeaseFixture')]
+    [string]$AdkExecutionLeaseFixturePath,
+    [Parameter(Mandatory, ParameterSetName = 'CleanupObservationFixture')]
+    [string]$CleanupObservationFixturePath,
     [Parameter(ParameterSetName = 'Contract')]
     [switch]$ContractOnly
 )
@@ -221,6 +227,205 @@ function Assert-ExactFields($Value, [string[]]$Required, [string]$Label) {
     }
 }
 
+function Convert-CanonicalWindowsAbsolutePath([string]$Value) {
+    if ([string]::IsNullOrWhiteSpace($Value) -or $Value.Contains('/') -or
+        $Value -cnotmatch '^(?<drive>[A-Za-z]):\\(?<tail>.+)$') {
+        throw 'Windows boundary path is not an absolute drive path'
+    }
+    $drive = [string]$Matches.drive
+    $tail = [string]$Matches.tail
+    $segments = @($tail -split '\\')
+    if (@($segments | Where-Object { -not $_ -or $_ -in @('.','..') -or $_.Contains(':') }).Count) {
+        throw 'Windows boundary path contains an invalid segment'
+    }
+    $drive.ToUpperInvariant() + ':\' + ($segments -join '\')
+}
+
+function Convert-CanonicalWindowsRelativePath([string]$Value) {
+    if ([string]::IsNullOrWhiteSpace($Value) -or $Value.Contains('/') -or $Value.Contains(':') -or
+        $Value.StartsWith('\',[StringComparison]::Ordinal)) {
+        throw 'Windows boundary relative path is invalid'
+    }
+    $segments = @($Value -split '\\')
+    if (@($segments | Where-Object { -not $_ -or $_ -in @('.','..') }).Count) {
+        throw 'Windows boundary relative path contains an invalid segment'
+    }
+    $segments -join '\'
+}
+
+function Assert-DeploymentToolsContract($Tools) {
+    Assert-ExactFields $Tools @(
+        'product','version','servicing_update','protected_root','executable_relative_path',
+        'acquisition','servicing','license','files'
+    ) 'deployment tools contract'
+    if ([string]$Tools.product -cne 'Microsoft Windows ADK Deployment Tools' -or
+        [string]$Tools.version -cne '10.1.26100.2454' -or
+        [string]$Tools.servicing_update -cne 'KB5101684' -or
+        (Convert-CanonicalWindowsAbsolutePath ([string]$Tools.protected_root)) -cne
+            'C:\codearbiter-runner\toolchains\windows-adk\10.1.26100.2454-kb5101684' -or
+        (Convert-CanonicalWindowsRelativePath ([string]$Tools.executable_relative_path)) -cne
+            'amd64\BCDBoot\bcdboot.exe') {
+        throw 'deployment tools identity is not the reviewed boundary'
+    }
+    Assert-ExactFields $Tools.acquisition @('source_url','length','sha256','signer_thumbprint') 'ADK acquisition'
+    Assert-ExactFields $Tools.servicing @('source_url','length','sha256') 'ADK servicing'
+    Assert-ExactFields $Tools.license @('spdx','length','sha256') 'ADK license'
+    if ([string]$Tools.acquisition.source_url -cne 'https://download.microsoft.com/download/2/d/9/2d9c8902-3fcd-48a6-a22a-432b08bed61e/ADK/adksetup.exe' -or
+        [long]$Tools.acquisition.length -ne 2234632L -or
+        [string]$Tools.acquisition.sha256 -cne '7f61e29f2314bcdd7e0abf67a8367d83a05aa4a7b9223f85c5fd2582a35cc6f4' -or
+        [string]$Tools.acquisition.signer_thumbprint -cne '0bd8c56733fdcc06f8cb919ff5a200e39b1acf71' -or
+        [string]$Tools.servicing.source_url -cne 'https://download.microsoft.com/download/a087a851-4056-4f7f-9791-02a20509b706/Windows_ADK_10.1.26100.2454_Update_KB5101684.zip' -or
+        [long]$Tools.servicing.length -ne 411048362L -or
+        [string]$Tools.servicing.sha256 -cne 'dc19725a2fb0cce44c32ac14059a85a25257b9534ba21c93b479f4f09fb5af38' -or
+        [string]$Tools.license.spdx -cne 'LicenseRef-Microsoft-Windows-ADK-EULA' -or
+        [long]$Tools.license.length -ne 192576L -or
+        [string]$Tools.license.sha256 -cne '3c0c45033614cd4882ff0195ca7f77c8077f2f4917806ada519855f7f87da595') {
+        throw 'deployment tools provenance is not the reviewed boundary'
+    }
+    $expectedFiles = [ordered]@{
+        'amd64\BCDBoot\bcdboot.exe' = @(300608L,'0395497dfb048791cc52bbaea7c304317d546e06198875bf83e0bb186fb09cc5')
+        'amd64\BCDBoot\bcdedit.exe' = @(525888L,'9cfb9375debfe6392c1f133d9b0e0b5df1ab68ac2170b70b9e385d7c25b2a965')
+        'amd64\BCDBoot\bootsect.exe' = @(116272L,'a5f66774b5c72ae0c39ba9a87c38ccc68e58ba4886a6b8348e396e0ba95ab599')
+    }
+    $signer = 'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
+    if (@($Tools.files).Count -ne $expectedFiles.Count) { throw 'deployment tools file closure is incomplete' }
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($file in @($Tools.files)) {
+        Assert-ExactFields $file @('path','length','sha256','signer_subject') 'deployment tools file'
+        $path = Convert-CanonicalWindowsRelativePath ([string]$file.path)
+        if (-not $seen.Add($path) -or -not $expectedFiles.Contains($path) -or
+            [long]$file.length -ne [long]$expectedFiles[$path][0] -or
+            [string]$file.sha256 -cne [string]$expectedFiles[$path][1] -or [string]$file.signer_subject -cne $signer) {
+            throw 'deployment tools file is not in the reviewed closure'
+        }
+    }
+}
+
+function Assert-AdkAclEvidence {
+    param(
+        $Evidence,
+        [string]$RunnerSid,
+        [ValidateSet('Root','Descendant')][string]$Topology,
+        [switch]$ExecutionLocked
+    )
+    Assert-ExactFields $Evidence @('owner_sid','protected','access') 'ADK protected-path ACL evidence'
+    if ([string]$Evidence.owner_sid -notin @('S-1-5-18','S-1-5-32-544')) {
+        throw 'approved ADK boundary is not owned by SYSTEM or Administrators'
+    }
+    if (($Topology -ceq 'Root' -and -not [bool]$Evidence.protected) -or
+        ($Topology -ceq 'Descendant' -and [bool]$Evidence.protected)) {
+        throw 'ADK protected-path DACL inheritance topology is invalid'
+    }
+    if ($RunnerSid -cnotmatch '^S-1-5-(?:21-[0-9-]+|[0-9-]+)$' -or
+        $RunnerSid -in @('S-1-5-18','S-1-5-32-544')) {
+        throw 'ADK runner SID is invalid'
+    }
+    $mutationMask = [Security.AccessControl.FileSystemRights]::Write -bor
+        [Security.AccessControl.FileSystemRights]::Delete -bor
+        [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+        [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+        [Security.AccessControl.FileSystemRights]::TakeOwnership -bor
+        [Security.AccessControl.FileSystemRights]::CreateFiles -bor
+        [Security.AccessControl.FileSystemRights]::CreateDirectories -bor
+        [Security.AccessControl.FileSystemRights]::AppendData -bor
+        [Security.AccessControl.FileSystemRights]::WriteData
+    $approved = @('S-1-5-18','S-1-5-32-544',$RunnerSid)
+    $runnerReadExecute = $false
+    $runnerMutationDenied = $false
+    $privilegedFullControl = [ordered]@{'S-1-5-18'=$false;'S-1-5-32-544'=$false}
+    foreach ($entry in @($Evidence.access)) {
+        Assert-ExactFields $entry @('sid','type','rights','inherited') 'ADK protected-path ACL entry'
+        $sid = [string]$entry.sid
+        $type = [string]$entry.type
+        $rights = [Security.AccessControl.FileSystemRights][string]$entry.rights
+        $isRunnerMutationDeny = $type -ceq 'Deny' -and $sid -ceq $RunnerSid -and
+            -not [bool]$entry.inherited -and (($rights -band $mutationMask) -eq $mutationMask)
+        if ($isRunnerMutationDeny) {
+            if (-not $ExecutionLocked) {
+                throw 'ADK runner mutation deny exists outside the execution lock'
+            }
+            $runnerMutationDenied = $true
+            continue
+        }
+        if ($type -cne 'Allow') { throw 'ADK protected path contains an unapproved deny rule' }
+        if (($Topology -ceq 'Root' -and [bool]$entry.inherited) -or
+            ($Topology -ceq 'Descendant' -and -not [bool]$entry.inherited)) {
+            throw 'ADK protected-path ACE inheritance topology is invalid'
+        }
+        if ($sid -notin $approved) { throw 'ADK protected path contains an unexpected principal' }
+        if ($type -ceq 'Allow' -and ($rights -band $mutationMask) -and
+            $sid -notin @('S-1-5-18','S-1-5-32-544')) {
+            throw 'ADK protected path grants mutation rights outside SYSTEM or Administrators'
+        }
+        if ($type -ceq 'Allow' -and $sid -ceq $RunnerSid -and
+            (($rights -band [Security.AccessControl.FileSystemRights]::ReadAndExecute) -eq
+                [Security.AccessControl.FileSystemRights]::ReadAndExecute)) {
+            $runnerReadExecute = $true
+        }
+        if ($type -ceq 'Allow' -and $sid -in @('S-1-5-18','S-1-5-32-544') -and
+            (($rights -band [Security.AccessControl.FileSystemRights]::FullControl) -eq
+                [Security.AccessControl.FileSystemRights]::FullControl)) {
+            $privilegedFullControl[$sid] = $true
+        }
+    }
+    if (-not $runnerReadExecute -or @($privilegedFullControl.Values | Where-Object { -not $_ }).Count -or
+        ($ExecutionLocked -and -not $runnerMutationDenied)) {
+        throw 'ADK protected path ACL does not contain the exact required access classes'
+    }
+}
+
+function Assert-ApprovedAdkBcdBootObservation($Tools, $Observation, [switch]$ExecutionLocked) {
+    Assert-DeploymentToolsContract $Tools
+    Assert-ExactFields $Observation @(
+        'schema_version','runner_sid','root','root_acl','root_reparse',
+        'executable_path','directories','files'
+    ) 'ADK boundary observation'
+    if ([int]$Observation.schema_version -ne 1) { throw 'ADK boundary observation schema is invalid' }
+    $root = Convert-CanonicalWindowsAbsolutePath ([string]$Observation.root)
+    if ($root -cne [string]$Tools.protected_root) { throw 'ADK boundary root is not approved' }
+    if ([bool]$Observation.root_reparse) { throw 'ADK boundary root is a reparse point' }
+    Assert-AdkAclEvidence $Observation.root_acl ([string]$Observation.runner_sid) 'Root' -ExecutionLocked:$ExecutionLocked
+    $executable = Convert-CanonicalWindowsAbsolutePath ([string]$Observation.executable_path)
+    $expectedExecutable = $root + '\' + [string]$Tools.executable_relative_path
+    if ($executable -cne $expectedExecutable) { throw 'BCDBoot executable is outside the approved toolchain' }
+    $expectedDirectories = @('amd64','amd64\BCDBoot')
+    if (@($Observation.directories).Count -ne $expectedDirectories.Count) {
+        throw 'ADK boundary directory closure is not exact'
+    }
+    foreach ($directory in @($Observation.directories)) {
+        Assert-ExactFields $directory @('path','acl','reparse') 'ADK boundary directory observation'
+        $directoryPath = Convert-CanonicalWindowsRelativePath ([string]$directory.path)
+        if ($directoryPath -notin $expectedDirectories -or
+            @($Observation.directories | Where-Object { [string]$_.path -ceq $directoryPath }).Count -ne 1) {
+            throw 'ADK boundary directory is missing, duplicated, or unapproved'
+        }
+        if ([bool]$directory.reparse) { throw 'ADK boundary directory is a reparse point' }
+        Assert-AdkAclEvidence $directory.acl ([string]$Observation.runner_sid) 'Descendant' -ExecutionLocked:$ExecutionLocked
+    }
+    if (@($Observation.files).Count -ne @($Tools.files).Count) { throw 'ADK boundary file closure is not exact' }
+    foreach ($expected in @($Tools.files)) {
+        $matches = @($Observation.files | Where-Object { [string]$_.path -ceq [string]$expected.path })
+        if ($matches.Count -ne 1) { throw 'ADK boundary file is missing or duplicated' }
+        $actual = $matches[0]
+        Assert-ExactFields $actual @(
+            'path','length','sha256','signature_status','signer_subject','acl','reparse'
+        ) 'ADK boundary file observation'
+        if ([bool]$actual.reparse) { throw 'ADK boundary file is a reparse point' }
+        Assert-AdkAclEvidence $actual.acl ([string]$Observation.runner_sid) 'Descendant' -ExecutionLocked:$ExecutionLocked
+        if ([long]$actual.length -ne [long]$expected.length -or
+            [string]$actual.sha256 -cne [string]$expected.sha256 -or
+            [string]$actual.signature_status -cne 'Valid' -or
+            [string]$actual.signer_subject -cne [string]$expected.signer_subject) {
+            throw 'ADK boundary file evidence does not match the reviewed closure'
+        }
+    }
+    $bcdboot = @($Tools.files | Where-Object {
+        [string]$_.path -ceq [string]$Tools.executable_relative_path
+    })
+    if ($bcdboot.Count -ne 1) { throw 'approved BCDBoot file is not unique' }
+    [ordered]@{bcdboot_path=$executable;bcdboot_sha256=[string]$bcdboot[0].sha256}
+}
+
 function New-ReceiptPolicyAndChannel($Fixture, $Contract) {
     Assert-ExactFields $Fixture @('schema_version','policy','channel') 'receipt contract fixture'
     if ($Fixture.schema_version -ne 1) { throw 'receipt contract fixture schema is invalid' }
@@ -274,6 +479,7 @@ function Get-Contract {
         $contract.channel.transport -cne 'powershell-direct-vmbus') {
         throw 'boundary contract identity is invalid'
     }
+    Assert-DeploymentToolsContract $contract.deployment_tools
     Assert-ExactFields $contract.candidate_archive @(
         'max_archive_bytes','max_entries','max_entry_uncompressed_bytes',
         'max_total_uncompressed_bytes','max_compression_ratio'
@@ -508,6 +714,28 @@ function Get-AclEvidence([string]$LiteralPath) {
     [pscustomobject]@{owner_sid=$ownerSid;access=$access}
 }
 
+function Get-AdkAclEvidence([string]$LiteralPath) {
+    $acl = Get-Acl -LiteralPath $LiteralPath
+    $ownerSid = try {
+        ([Security.Principal.NTAccount]$acl.Owner).Translate([Security.Principal.SecurityIdentifier]).Value
+    } catch { [string]$acl.Owner }
+    $access = @($acl.Access | ForEach-Object {
+        $sid = try { $_.IdentityReference.Translate([Security.Principal.SecurityIdentifier]).Value }
+            catch { [string]$_.IdentityReference.Value }
+        [pscustomobject]@{
+            sid=$sid
+            type=$_.AccessControlType.ToString()
+            rights=$_.FileSystemRights.ToString()
+            inherited=[bool]$_.IsInherited
+        }
+    })
+    [pscustomobject]@{
+        owner_sid=$ownerSid
+        protected=[bool]$acl.AreAccessRulesProtected
+        access=$access
+    }
+}
+
 function Assert-TrustedRunnerPath([string]$LiteralPath, [switch]$Leaf) {
     $full = [IO.Path]::GetFullPath($LiteralPath)
     $root = [IO.Path]::GetFullPath($RunnerRoot).TrimEnd('\')
@@ -535,6 +763,194 @@ function Assert-TrustedRunnerPath([string]$LiteralPath, [switch]$Leaf) {
         Assert-TrustedAclEvidence (Get-AclEvidence $current) $identity
     }
     $full
+}
+
+function Get-ApprovedBcdBootPath($Tools, [switch]$ExecutionLocked) {
+    Assert-DeploymentToolsContract $Tools
+    $root = Assert-TrustedRunnerPath ([string]$Tools.protected_root)
+    $runnerSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $allowedDirectories = @('amd64','amd64\BCDBoot')
+    $observedDirectories = [Collections.Generic.List[object]]::new()
+    $observedFiles = [Collections.Generic.List[object]]::new()
+    foreach ($item in @(Get-ChildItem -LiteralPath $root -Force -Recurse)) {
+        $relative = $item.FullName.Substring($root.Length).TrimStart('\')
+        if ($item.PSIsContainer) {
+            if ($relative -notin $allowedDirectories) { throw 'approved ADK boundary contains an extra directory' }
+            $null = Assert-TrustedRunnerPath $item.FullName
+            $null = $observedDirectories.Add([pscustomobject]@{
+                path = $relative
+                acl = Get-AdkAclEvidence $item.FullName
+                reparse = (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+            })
+            continue
+        }
+        $full = Assert-TrustedRunnerPath $item.FullName -Leaf
+        $signature = Get-AuthenticodeSignature -LiteralPath $full
+        $null = $observedFiles.Add([pscustomobject]@{
+            path = $relative
+            length = [long]$item.Length
+            sha256 = Get-Sha256 $full
+            signature_status = [string]$signature.Status
+            signer_subject = if ($signature.SignerCertificate) { [string]$signature.SignerCertificate.Subject } else { '' }
+            acl = Get-AdkAclEvidence $full
+            reparse = (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+        })
+    }
+    $rootItem = Get-Item -LiteralPath $root -Force
+    $observation = [pscustomobject]@{
+        schema_version = 1
+        runner_sid = $runnerSid
+        root = $root
+        root_acl = Get-AdkAclEvidence $root
+        root_reparse = (($rootItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+        executable_path = Join-Path $root ([string]$Tools.executable_relative_path)
+        directories = @($observedDirectories)
+        files = @($observedFiles)
+    }
+    (Assert-ApprovedAdkBcdBootObservation $Tools $observation -ExecutionLocked:$ExecutionLocked).bcdboot_path
+}
+
+function Initialize-AdkExecutionLeaseNative {
+    if ($null -ne ('CodeArbiterAdkLeaseNative' -as [type])) { return }
+    $source = @'
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+public static class CodeArbiterAdkLeaseNative {
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern SafeFileHandle CreateFileW(
+        string path, uint access, uint share, IntPtr security,
+        uint creation, uint flags, IntPtr template);
+    [DllImport("advapi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetKernelObjectSecurity(
+        SafeFileHandle handle, int securityInformation, byte[] securityDescriptor);
+}
+'@
+    $null = Add-Type -TypeDefinition $source
+}
+
+function Get-AdkSecurityDescriptorBytes([string]$LiteralPath) {
+    $acl = Get-Acl -LiteralPath $LiteralPath
+    $acl.GetSecurityDescriptorBinaryForm()
+}
+
+function Open-AdkExecutionLeaseHandle([string]$LiteralPath) {
+    Initialize-AdkExecutionLeaseNative
+    $desiredAccess = [uint32]2147876864 # GENERIC_READ | READ_CONTROL | WRITE_DAC
+    $handle = [CodeArbiterAdkLeaseNative]::CreateFileW(
+        $LiteralPath, $desiredAccess, [uint32]1, [IntPtr]::Zero,
+        [uint32]3, [uint32]33554432, [IntPtr]::Zero
+    )
+    if ($handle.IsInvalid) {
+        $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        $handle.Dispose()
+        throw "could not acquire ADK execution lease handle: $errorCode"
+    }
+    $handle
+}
+
+function Get-AdkMutationMask {
+    [Security.AccessControl.FileSystemRights]::Write -bor
+        [Security.AccessControl.FileSystemRights]::Delete -bor
+        [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+        [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+        [Security.AccessControl.FileSystemRights]::TakeOwnership -bor
+        [Security.AccessControl.FileSystemRights]::CreateFiles -bor
+        [Security.AccessControl.FileSystemRights]::CreateDirectories -bor
+        [Security.AccessControl.FileSystemRights]::AppendData -bor
+        [Security.AccessControl.FileSystemRights]::WriteData
+}
+
+function Add-AdkRunnerMutationDeny([string]$LiteralPath, [string]$RunnerSid) {
+    $acl = Get-Acl -LiteralPath $LiteralPath
+    $rule = [Security.AccessControl.FileSystemAccessRule]::new(
+        [Security.Principal.SecurityIdentifier]::new($RunnerSid),
+        (Get-AdkMutationMask),
+        [Security.AccessControl.InheritanceFlags]::None,
+        [Security.AccessControl.PropagationFlags]::None,
+        [Security.AccessControl.AccessControlType]::Deny
+    )
+    $null = $acl.AddAccessRule($rule)
+    Set-Acl -LiteralPath $LiteralPath -AclObject $acl
+}
+
+function Restore-AdkExecutionLeaseDescriptors($Lease) {
+    $errors = [Collections.Generic.List[string]]::new()
+    $entries = @($Lease.Entries)
+    [array]::Reverse($entries)
+    foreach ($entry in $entries) {
+        if (-not [CodeArbiterAdkLeaseNative]::SetKernelObjectSecurity(
+            $entry.Handle, 4, $entry.SecurityDescriptor
+        )) {
+            $null = $errors.Add(
+                "$($entry.Path):$([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+            )
+        }
+    }
+    if ($errors.Count) { throw ('could not restore ADK execution ACLs: ' + ($errors -join ',')) }
+}
+
+function Open-AdkExecutionSecurityLease([string[]]$LiteralPaths, [string]$RunnerSid) {
+    if ($null -eq $LiteralPaths -or $LiteralPaths.Count -lt 1) {
+        throw 'ADK execution security lease requires at least one path'
+    }
+    $entries = [Collections.Generic.List[object]]::new()
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    try {
+        foreach ($path in $LiteralPaths) {
+            $full = [IO.Path]::GetFullPath([string]$path)
+            if (-not $seen.Add($full)) { throw 'ADK execution security lease contains a duplicate path' }
+            if (-not (Test-Path -LiteralPath $full)) { throw 'ADK execution security lease path is missing' }
+            $item = Get-Item -LiteralPath $full -Force
+            if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                throw 'ADK execution security lease path is a reparse point'
+            }
+            $null = $entries.Add([pscustomobject]@{
+                Path = $full
+                Handle = Open-AdkExecutionLeaseHandle $full
+                SecurityDescriptor = Get-AdkSecurityDescriptorBytes $full
+            })
+        }
+        foreach ($entry in @($entries)) { Add-AdkRunnerMutationDeny $entry.Path $RunnerSid }
+        [pscustomobject]@{
+            Entries = @($entries)
+            Paths = @($seen)
+            RunnerSid = $RunnerSid
+            Count = $entries.Count
+        }
+    } catch {
+        $lease = [pscustomobject]@{Entries=@($entries)}
+        try { Restore-AdkExecutionLeaseDescriptors $lease } catch { }
+        foreach ($entry in @($entries)) { $entry.Handle.Dispose() }
+        throw
+    }
+}
+
+function Close-ApprovedAdkExecutionLease($Lease) {
+    if ($null -eq $Lease) { return }
+    $failure = $null
+    try { Restore-AdkExecutionLeaseDescriptors $Lease } catch { $failure = $_ }
+    foreach ($entry in @($Lease.Entries)) {
+        if ($null -ne $entry.Handle) { $entry.Handle.Dispose() }
+    }
+    if ($failure) { throw $failure }
+    if ($Lease.PSObject.Properties.Name -contains 'Tools') {
+        $null = Get-ApprovedBcdBootPath $Lease.Tools
+    }
+}
+
+function Open-ApprovedAdkExecutionLease($Tools) {
+    Assert-DeploymentToolsContract $Tools
+    $root = Convert-CanonicalWindowsAbsolutePath ([string]$Tools.protected_root)
+    $paths = @($root, (Join-Path $root 'amd64'), (Join-Path $root 'amd64\BCDBoot')) + @($Tools.files | ForEach-Object {
+        Join-Path $root (Convert-CanonicalWindowsRelativePath ([string]$_.path))
+    })
+    $runnerSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $lease = Open-AdkExecutionSecurityLease $paths $runnerSid
+    $lease | Add-Member -NotePropertyName Tools -NotePropertyValue $Tools
+    $lease | Add-Member -NotePropertyName FileCount -NotePropertyValue @($Tools.files).Count
+    $lease
 }
 
 function Get-CandidateMetadata([string]$PackageRoot, [string]$Checker) {
@@ -732,6 +1148,60 @@ function Invoke-BrokerCleanupStage($Lifecycle, [string]$Name, [scriptblock]$Oper
         $null = $Lifecycle.Errors.Add($_.Exception.Message)
     } finally {
         $Lifecycle.CleanupIndex++
+    }
+}
+
+function Get-FailedIdentityCleanupObservation(
+    $Lifecycle,
+    $Session,
+    $Setup,
+    [string]$Account,
+    [bool]$IdentityCreationAttempted,
+    $ObservedIdentityState
+) {
+    if (-not $IdentityCreationAttempted -and $Lifecycle.Trace -notcontains 'identity-created') {
+        return [pscustomobject]@{disabled=$true;deleted=$true;profile_destroyed=$true}
+    }
+    if ($null -ne $ObservedIdentityState) {
+        if ($env:CODEARBITER_DESKTOP_BOUNDARY_TEST -cne '1') {
+            throw 'injected identity cleanup evidence is test-only'
+        }
+        Assert-ExactFields $ObservedIdentityState @('disabled','deleted','profile_destroyed') 'identity cleanup observation'
+        return [pscustomobject]@{
+            disabled = [bool]$ObservedIdentityState.disabled
+            deleted = [bool]$ObservedIdentityState.deleted
+            profile_destroyed = [bool]$ObservedIdentityState.profile_destroyed
+        }
+    }
+    if (-not $Session) {
+        throw 'guest identity cleanup could not obtain its production session'
+    }
+    $setupSid = if ($Setup) { [string]$Setup.sid } else { '' }
+    Invoke-Command -Session $Session -ArgumentList $Account,$setupSid -ScriptBlock {
+        param($Account,$SetupSid)
+        $user = Get-LocalUser $Account -ErrorAction SilentlyContinue
+        if ($user) { Disable-LocalUser $Account }
+        $disabled = $null -eq (Get-LocalUser $Account -ErrorAction SilentlyContinue) -or
+            -not (Get-LocalUser $Account).Enabled
+        'CodeArbiter-DesktopDriver','CodeArbiter-Desktop','CodeArbiter-DeviceAuth','CodeArbiter-ClearAutologon' |
+            ForEach-Object { Unregister-ScheduledTask $_ -Confirm:$false -ErrorAction SilentlyContinue }
+        Remove-LocalUser $Account -ErrorAction SilentlyContinue
+        $deleted = $null -eq (Get-LocalUser $Account -ErrorAction SilentlyContinue)
+        $sid = if ($user) { [string]$user.Sid.Value } else { $SetupSid }
+        $profilePath = "C:\Users\$Account"
+        $profiles = @(Get-CimInstance Win32_UserProfile | Where-Object {
+            ($sid -and [string]$_.SID -ceq $sid) -or [string]$_.LocalPath -ceq $profilePath
+        })
+        foreach ($profile in $profiles) { Remove-CimInstance $profile }
+        [pscustomobject]@{
+            disabled = $disabled
+            deleted = $deleted
+            profile_destroyed = @(
+                Get-CimInstance Win32_UserProfile | Where-Object {
+                    ($sid -and [string]$_.SID -ceq $sid) -or [string]$_.LocalPath -ceq $profilePath
+                }
+            ).Count -eq 0
+        }
     }
 }
 
@@ -997,7 +1467,12 @@ function Remove-EphemeralVm([string]$VMName, [string]$RunRoot) {
 }
 
 function New-FreshGuestDisk {
-    param([string]$IsoPath, [string]$DiskPath, [string]$BootstrapPassword)
+    param(
+        [string]$IsoPath,
+        [string]$DiskPath,
+        [string]$BootstrapPassword,
+        [Parameter(Mandatory)]$DeploymentTools
+    )
     $mountedIso = $null
     $mountedVhd = $null
     $applied = $null
@@ -1028,8 +1503,15 @@ function New-FreshGuestDisk {
         $efiRoot = "$($efi.DriveLetter):"
         Expand-WindowsImage -ImagePath $imagePath -Index $windowsImage[0].ImageIndex -ApplyPath $osRoot |
             Out-Null
-        & bcdboot.exe "$osRoot`Windows" /s $efiRoot /f UEFI | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw 'could not create the fresh guest boot files' }
+        $adkExecutionLease = $null
+        try {
+            $adkExecutionLease = Open-ApprovedAdkExecutionLease $DeploymentTools
+            $approvedBcdBootPath = Get-ApprovedBcdBootPath $DeploymentTools -ExecutionLocked
+            & $approvedBcdBootPath "$osRoot`Windows" /s $efiRoot /f UEFI | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw 'could not create the fresh guest boot files' }
+        } finally {
+            Close-ApprovedAdkExecutionLease $adkExecutionLease
+        }
 
         $escaped = [Security.SecurityElement]::Escape($BootstrapPassword)
         $unattend = @"
@@ -1095,6 +1577,97 @@ if ($ContractOnly -or $PSCmdlet.ParameterSetName -eq 'Contract') {
         probe_sha256=$contract.probe.sha256; image_sha256=$contract.image.sha256
         provisioning_mode=$contract.image.provisioning_mode; route_corpus_id=$contract.route_corpus.id
     } | ConvertTo-Json -Compress
+    exit 0
+}
+if ($PSCmdlet.ParameterSetName -eq 'AdkBoundaryFixture') {
+    if ($env:CODEARBITER_DESKTOP_BOUNDARY_TEST -cne '1') { throw 'ADK boundary fixture mode is test-only' }
+    $fixture = Get-Content -LiteralPath $AdkBoundaryFixturePath -Raw -Encoding utf8 | ConvertFrom-Json
+    Assert-ApprovedAdkBcdBootObservation $contract.deployment_tools $fixture | ConvertTo-Json -Compress
+    exit 0
+}
+if ($PSCmdlet.ParameterSetName -eq 'AdkExecutionLeaseFixture') {
+    if ($env:CODEARBITER_DESKTOP_BOUNDARY_TEST -cne '1') { throw 'ADK execution lease fixture mode is test-only' }
+    $fixtureRoot = [IO.Path]::GetFullPath($AdkExecutionLeaseFixturePath)
+    $fixtureDirectories = @($fixtureRoot, (Join-Path $fixtureRoot 'amd64'), (Join-Path $fixtureRoot 'amd64\BCDBoot'))
+    $fixtureFiles = @('bcdboot.exe','bcdedit.exe','bootsect.exe') | ForEach-Object {
+        Join-Path $fixtureRoot ("amd64\BCDBoot\" + $_)
+    }
+    $fixtureLease = Open-AdkExecutionSecurityLease (@($fixtureDirectories) + @($fixtureFiles)) ([Security.Principal.WindowsIdentity]::GetCurrent().User.Value)
+    $fileReplacementBlocked = $false
+    $rootReplacementBlocked = $false
+    $siblingDllCreationBlocked = $false
+    $manifestCreationBlocked = $false
+    $localRedirectCreationBlocked = $false
+    $daclMutationBlocked = $false
+    try {
+        try {
+            Move-Item -LiteralPath $fixtureFiles[0] -Destination ($fixtureFiles[0] + '.swapped') -ErrorAction Stop
+        } catch { $fileReplacementBlocked = $true }
+        try {
+            Move-Item -LiteralPath $fixtureRoot -Destination ($fixtureRoot + '.swapped') -ErrorAction Stop
+        } catch { $rootReplacementBlocked = $true }
+        $bcdbootRoot = $fixtureDirectories[2]
+        try { [IO.File]::WriteAllBytes((Join-Path $bcdbootRoot 'unreviewed.dll'), [byte[]](1)) }
+            catch { $siblingDllCreationBlocked = $true }
+        try { [IO.File]::WriteAllText((Join-Path $bcdbootRoot 'bcdboot.exe.manifest'), 'unreviewed') }
+            catch { $manifestCreationBlocked = $true }
+        try { $null = New-Item -ItemType Directory -Path (Join-Path $bcdbootRoot 'bcdboot.exe.local') -ErrorAction Stop }
+            catch { $localRedirectCreationBlocked = $true }
+        try {
+            $fixtureAcl = Get-Acl -LiteralPath $bcdbootRoot
+            $fixtureAcl.SetAccessRuleProtection($true, $true)
+            Set-Acl -LiteralPath $bcdbootRoot -AclObject $fixtureAcl
+        } catch { $daclMutationBlocked = $true }
+    } finally {
+        Close-ApprovedAdkExecutionLease $fixtureLease
+    }
+    $aclRestored = $false
+    try {
+        $restoreProbe = Join-Path $fixtureDirectories[2] 'after-close-fixture.txt'
+        [IO.File]::WriteAllText($restoreProbe, 'restored')
+        Remove-Item -LiteralPath $restoreProbe -Force
+        $aclRestored = $true
+    } catch { }
+    [ordered]@{
+        file_replacement_blocked = $fileReplacementBlocked
+        root_replacement_blocked = $rootReplacementBlocked
+        sibling_dll_creation_blocked = $siblingDllCreationBlocked
+        manifest_creation_blocked = $manifestCreationBlocked
+        local_redirect_creation_blocked = $localRedirectCreationBlocked
+        dacl_mutation_blocked = $daclMutationBlocked
+        acl_restored = $aclRestored
+        leased_file_count = $fixtureFiles.Count
+    } | ConvertTo-Json -Compress
+    exit 0
+}
+if ($PSCmdlet.ParameterSetName -eq 'CleanupObservationFixture') {
+    if ($env:CODEARBITER_DESKTOP_BOUNDARY_TEST -cne '1') { throw 'cleanup observation fixture mode is test-only' }
+    $fixture = Get-Content -LiteralPath $CleanupObservationFixturePath -Raw -Encoding utf8 | ConvertFrom-Json
+    Assert-ExactFields $fixture @(
+        'schema_version','identity_created','identity_creation_attempted','guest_observation'
+    ) 'cleanup observation fixture'
+    if ([int]$fixture.schema_version -ne 1) { throw 'cleanup observation fixture schema is invalid' }
+    $fixtureLifecycle = New-BrokerLifecycle
+    if ([bool]$fixture.identity_created) { $null = $fixtureLifecycle.Trace.Add('identity-created') }
+    $fixtureTorn = Invoke-BrokerCleanupStage $fixtureLifecycle 'account-disabled' {
+        $observation = Get-FailedIdentityCleanupObservation $fixtureLifecycle $null $null `
+            'ca-desktop-disposable-fixture' ([bool]$fixture.identity_creation_attempted) $fixture.guest_observation
+        if (-not $observation.disabled) { throw 'fixture account disable was not observed' }
+        $observation
+    } ''
+    $null = Invoke-BrokerCleanupStage $fixtureLifecycle 'account-deleted' {
+        if ($null -eq $fixtureTorn -or -not $fixtureTorn.deleted) { throw 'fixture account deletion was not observed' }
+        $true
+    } ''
+    $null = Invoke-BrokerCleanupStage $fixtureLifecycle 'profile-destroyed' {
+        if ($null -eq $fixtureTorn -or -not $fixtureTorn.profile_destroyed) { throw 'fixture profile destruction was not observed' }
+        $true
+    } ''
+    if ($fixtureLifecycle.Errors.Count) { throw ($fixtureLifecycle.Errors -join '; ') }
+    [ordered]@{
+        observation = $fixtureTorn
+        cleanup_trace = @($fixtureLifecycle.Trace)
+    } | ConvertTo-Json -Depth 4 -Compress
     exit 0
 }
 if ($PSCmdlet.ParameterSetName -eq 'CandidateSurfaceFixture') {
@@ -1252,6 +1825,7 @@ $preAuthEvidence = $null
 $postAuthEvidence = $null
 $measurements = $null
 $authCompletionObserved = $false
+$identityCreationAttempted = $false
 $torn = $null
 $lifecycle = New-BrokerLifecycle
 
@@ -1268,7 +1842,8 @@ try {
     $candidate = Get-CandidateMetadata $hostPluginRoot (Join-Path $loaded.Root '.github\scripts\check_codex_skill_resources.py')
     $permissionProfile = New-DesktopProofPermissionProfile $contract $account $candidate.Version $proofRepo
     if ((Get-Sha256 $imagePath) -cne $contract.image.sha256) { throw 'approved image changed after boundary verification' }
-    $diskEvidence = New-FreshGuestDisk $imagePath $diskPath $bootstrapPassword
+    $null = Get-ApprovedBcdBootPath $contract.deployment_tools
+    $diskEvidence = New-FreshGuestDisk $imagePath $diskPath $bootstrapPassword $contract.deployment_tools
     $null = Invoke-BrokerStage $lifecycle 'iso-applied-to-fresh-vhdx' {
         if ($diskEvidence.fresh_iso_applied -ne $true) { throw 'fresh ISO application was not measured' }
         $true
@@ -1303,6 +1878,7 @@ try {
     $session = Wait-DirectSession $vmName $bootstrap
     $vmId = (Get-VM -Name $vmName).Id.Guid.ToString('D')
 
+    $identityCreationAttempted = $true
     $setup = Invoke-Command -Session $session -ArgumentList $account,$desktopPassword,$guestTrustedRoot,$guestRunRoot,$guestExchangeRoot,$proofRepo,$contract.network,$permissionProfile.Toml -ScriptBlock {
         param($Account,$Password,$TrustedRoot,$RunRoot,$ExchangeRoot,$Repo,$Network,$PermissionToml)
         Remove-Item -LiteralPath 'C:\Windows\Panther\Unattend.xml' -Force -ErrorAction SilentlyContinue
@@ -1827,24 +2403,11 @@ while(-not `$process.StandardOutput.EndOfStream){`$line=`$process.StandardOutput
         $cleanupName = $script:BrokerCleanupStages[$lifecycle.CleanupIndex]
         switch($cleanupName){
             'account-disabled' {
-                $null = Invoke-BrokerCleanupStage $lifecycle $cleanupName {
-                    if($lifecycle.Trace -notcontains 'identity-created'){
-                        $catchTorn=[pscustomobject]@{disabled=$true;deleted=$true;profile_destroyed=$true}
-                    } elseif($session -and $setup){
-                        $catchTorn=Invoke-Command -Session $session -ArgumentList $account,[string]$setup.sid -ScriptBlock {
-                            param($Account,$Sid)
-                            $user=Get-LocalUser $Account -ErrorAction SilentlyContinue
-                            if($user){Disable-LocalUser $Account}
-                            $disabled=$null-eq(Get-LocalUser $Account -ErrorAction SilentlyContinue)-or-not(Get-LocalUser $Account).Enabled
-                            'CodeArbiter-DesktopDriver','CodeArbiter-Desktop','CodeArbiter-DeviceAuth','CodeArbiter-ClearAutologon'|ForEach-Object{Unregister-ScheduledTask $_ -Confirm:$false -ErrorAction SilentlyContinue}
-                            Remove-LocalUser $Account -ErrorAction SilentlyContinue
-                            $deleted=$null-eq(Get-LocalUser $Account -ErrorAction SilentlyContinue)
-                            $p=Get-CimInstance Win32_UserProfile|Where-Object SID -eq $Sid;if($p){Remove-CimInstance $p}
-                            [pscustomobject]@{disabled=$disabled;deleted=$deleted;profile_destroyed=$null-eq(Get-CimInstance Win32_UserProfile|Where-Object SID -eq $Sid)}
-                        }
-                    } else { throw 'guest identity cleanup could not obtain its production session' }
-                    if(-not$catchTorn.disabled){throw 'failed-run account disable was not observed'}
-                    $true
+                $catchTorn = Invoke-BrokerCleanupStage $lifecycle $cleanupName {
+                    $observation = Get-FailedIdentityCleanupObservation $lifecycle $session $setup `
+                        $account $identityCreationAttempted $null
+                    if(-not$observation.disabled){throw 'failed-run account disable was not observed'}
+                    $observation
                 } ''
             }
             'account-deleted' {

--- a/.github/scripts/check_codex_skill_resources.py
+++ b/.github/scripts/check_codex_skill_resources.py
@@ -117,6 +117,58 @@ EXPECTED_CANDIDATE_ARCHIVE_LIMITS = {
 APPROVED_DESKTOP_IMAGE_SHA256 = (
     "a61adeab895ef5a4db436e0a7011c92a2ff17bb0357f58b13bbc4062e535e7b9"
 )
+EXPECTED_DEPLOYMENT_TOOLS_BOUNDARY = {
+    "product": "Microsoft Windows ADK Deployment Tools",
+    "version": "10.1.26100.2454",
+    "servicing_update": "KB5101684",
+    "protected_root": (
+        r"C:\codearbiter-runner\toolchains\windows-adk\10.1.26100.2454-kb5101684"
+    ),
+    "executable_relative_path": r"amd64\BCDBoot\bcdboot.exe",
+    "acquisition": {
+        "source_url": (
+            "https://download.microsoft.com/download/2/d/9/"
+            "2d9c8902-3fcd-48a6-a22a-432b08bed61e/ADK/adksetup.exe"
+        ),
+        "length": 2234632,
+        "sha256": "7f61e29f2314bcdd7e0abf67a8367d83a05aa4a7b9223f85c5fd2582a35cc6f4",
+        "signer_thumbprint": "0bd8c56733fdcc06f8cb919ff5a200e39b1acf71",
+    },
+    "servicing": {
+        "source_url": (
+            "https://download.microsoft.com/download/"
+            "a087a851-4056-4f7f-9791-02a20509b706/"
+            "Windows_ADK_10.1.26100.2454_Update_KB5101684.zip"
+        ),
+        "length": 411048362,
+        "sha256": "dc19725a2fb0cce44c32ac14059a85a25257b9534ba21c93b479f4f09fb5af38",
+    },
+    "license": {
+        "spdx": "LicenseRef-Microsoft-Windows-ADK-EULA",
+        "length": 192576,
+        "sha256": "3c0c45033614cd4882ff0195ca7f77c8077f2f4917806ada519855f7f87da595",
+    },
+    "files": [
+        {
+            "path": r"amd64\BCDBoot\bcdboot.exe",
+            "length": 300608,
+            "sha256": "0395497dfb048791cc52bbaea7c304317d546e06198875bf83e0bb186fb09cc5",
+            "signer_subject": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+        },
+        {
+            "path": r"amd64\BCDBoot\bcdedit.exe",
+            "length": 525888,
+            "sha256": "9cfb9375debfe6392c1f133d9b0e0b5df1ab68ac2170b70b9e385d7c25b2a965",
+            "signer_subject": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+        },
+        {
+            "path": r"amd64\BCDBoot\bootsect.exe",
+            "length": 116272,
+            "sha256": "a5f66774b5c72ae0c39ba9a87c38ccc68e58ba4886a6b8348e396e0ba95ab599",
+            "signer_subject": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+        },
+    ],
+}
 SECRET_VALUE = re.compile(
     r"(?i)(?:\bBearer\s+\S+|-----BEGIN [A-Z ]*PRIVATE KEY-----|"
     r"\b(?:sk|gh[oprsu])[-_][A-Za-z0-9_-]{8,}|"
@@ -2801,7 +2853,7 @@ def validate_desktop_boundary_contract(
         contract = {}
         errors.append("trusted desktop boundary contract is unreadable")
     top_fields = {
-        "schema_version", "broker", "driver", "probe", "image", "application",
+        "schema_version", "broker", "driver", "probe", "image", "deployment_tools", "application",
         "marketplace", "candidate_surface", "candidate_archive", "route_corpus", "channel", "network", "authentication",
         "evidence",
     }
@@ -2871,6 +2923,9 @@ def validate_desktop_boundary_contract(
     }
     if image != expected_image:
         errors.append("trusted desktop image must be the approved Microsoft evaluation image")
+
+    if contract.get("deployment_tools") != EXPECTED_DEPLOYMENT_TOOLS_BOUNDARY:
+        errors.append("trusted desktop Deployment Tools boundary is invalid")
 
     application = contract.get("application")
     if application != {

--- a/.github/scripts/test_codex_desktop_boundary.py
+++ b/.github/scripts/test_codex_desktop_boundary.py
@@ -7,7 +7,7 @@ import hashlib
 import hmac
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import re
 import shutil
 import stat
@@ -204,6 +204,30 @@ def run_candidate_metadata_fixture(package_root: Path) -> subprocess.CompletedPr
         timeout=30,
         check=False,
     )
+
+
+def run_broker_json_fixture(
+    parameter: str,
+    fixture: dict,
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temp:
+        fixture_path = Path(temp) / "broker-json-fixture.json"
+        fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+        environment = os.environ.copy()
+        environment["CODEARBITER_DESKTOP_BOUNDARY_TEST"] = "1"
+        return subprocess.run(
+            [
+                powershell(), "-NoLogo", "-NoProfile", "-NonInteractive", "-File",
+                str(BROKER), parameter, str(fixture_path),
+                "-ContractPath", str(CONTRACT),
+            ],
+            cwd=REPO_ROOT,
+            env=environment,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
 
 
 class DesktopBoundaryContractTest(unittest.TestCase):
@@ -855,6 +879,316 @@ class DesktopBoundaryContractTest(unittest.TestCase):
         self.assertIn("public InputUnion u", driver_source)
         self.assertIn(".u.ki.", driver_source)
         self.assertNotIn("public KEYBDINPUT ki; }", driver_source)
+
+    def test_broker_executes_only_the_exact_protected_adk_bcdboot_closure(self):
+        toolchain = self.contract["deployment_tools"]
+        root_acl = {
+            "owner_sid": "S-1-5-18",
+            "protected": True,
+            "access": [
+                {"sid": "S-1-5-18", "type": "Allow", "rights": "FullControl", "inherited": False},
+                {"sid": "S-1-5-32-544", "type": "Allow", "rights": "FullControl", "inherited": False},
+                {"sid": self.runner_sid, "type": "Allow", "rights": "ReadAndExecute", "inherited": False},
+            ],
+        }
+        descendant_acl = {
+            "owner_sid": "S-1-5-18",
+            "protected": False,
+            "access": [
+                {"sid": "S-1-5-18", "type": "Allow", "rights": "FullControl", "inherited": True},
+                {"sid": "S-1-5-32-544", "type": "Allow", "rights": "FullControl", "inherited": True},
+                {"sid": self.runner_sid, "type": "Allow", "rights": "ReadAndExecute", "inherited": True},
+            ],
+        }
+        expected_files = [
+            {
+                "path": item["path"],
+                "length": item["length"],
+                "sha256": item["sha256"],
+                "signature_status": "Valid",
+                "signer_subject": item["signer_subject"],
+                "acl": descendant_acl,
+                "reparse": False,
+            }
+            for item in toolchain["files"]
+        ]
+        fixture = {
+            "schema_version": 1,
+            "runner_sid": self.runner_sid,
+            "root": toolchain["protected_root"],
+            "root_acl": root_acl,
+            "root_reparse": False,
+            "executable_path": str(
+                PureWindowsPath(toolchain["protected_root"])
+                / PureWindowsPath(toolchain["executable_relative_path"])
+            ),
+            "directories": [
+                {"path": "amd64", "acl": descendant_acl, "reparse": False},
+                {"path": r"amd64\BCDBoot", "acl": descendant_acl, "reparse": False},
+            ],
+            "files": expected_files,
+        }
+        accepted = run_broker_json_fixture("-AdkBoundaryFixturePath", fixture)
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        accepted_payload = json.loads(accepted.stdout)
+        self.assertEqual(
+            accepted_payload["bcdboot_sha256"],
+            "0395497dfb048791cc52bbaea7c304317d546e06198875bf83e0bb186fb09cc5",
+        )
+
+        mutations = {
+            "ambient host bcdboot": lambda value: value.update(
+                executable_path=r"C:\Windows\System32\bcdboot.exe"
+            ),
+            "applied guest bcdboot": lambda value: value.update(
+                executable_path=r"F:\Windows\System32\bcdboot.exe"
+            ),
+            "protected-root escape": lambda value: value.update(
+                root=r"C:\codearbiter-runner\toolchains\windows-adk\..\escape"
+            ),
+            "missing sibling": lambda value: value["files"].pop(),
+            "extra sibling": lambda value: value["files"].append(
+                {
+                    "path": "amd64/BCDBoot/unreviewed.dll",
+                    "length": 1,
+                    "sha256": "f" * 64,
+                    "signature_status": "Valid",
+                    "signer_subject": "CN=Microsoft Corporation",
+                    "acl": descendant_acl,
+                    "reparse": False,
+                }
+            ),
+            "digest mismatch": lambda value: value["files"][0].update(
+                sha256="f" * 64
+            ),
+            "length mismatch": lambda value: value["files"][0].update(length=1),
+            "signature invalid": lambda value: value["files"][0].update(
+                signature_status="HashMismatch"
+            ),
+            "signer mismatch": lambda value: value["files"][0].update(
+                signer_subject="CN=Unapproved"
+            ),
+            "runner writable root": lambda value: value["root_acl"]["access"][2].update(
+                rights="FullControl"
+            ),
+            "runner writable file": lambda value: value["files"][0]["acl"]["access"][2].update(
+                rights="Modify"
+            ),
+            "unapproved owner": lambda value: value["directories"][0]["acl"].update(
+                owner_sid=self.runner_sid
+            ),
+            "inheritance-enabled root": lambda value: value["root_acl"].update(
+                protected=False
+            ),
+            "inherited root ACE": lambda value: value["root_acl"]["access"][0].update(
+                inherited=True
+            ),
+            "protected descendant": lambda value: value["directories"][0]["acl"].update(
+                protected=True
+            ),
+            "direct descendant ACE": lambda value: value["files"][0]["acl"]["access"][0].update(
+                inherited=False
+            ),
+            "root reparse": lambda value: value.update(root_reparse=True),
+            "directory reparse": lambda value: value["directories"][1].update(
+                reparse=True
+            ),
+            "file reparse": lambda value: value["files"][0].update(reparse=True),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(boundary=label):
+                changed = json.loads(json.dumps(fixture))
+                mutate(changed)
+                rejected = run_broker_json_fixture(
+                    "-AdkBoundaryFixturePath", changed
+                )
+                self.assertNotEqual(rejected.returncode, 0)
+
+        broker_source = BROKER.read_text(encoding="utf-8")
+        self.assertNotRegex(broker_source, r"(?m)&\s+bcdboot(?:\.exe)?\b")
+        self.assertNotIn('"$osRoot`Windows\\System32\\bcdboot.exe"', broker_source)
+        exact_invocation = (
+            '& $approvedBcdBootPath "$osRoot`Windows" /s $efiRoot /f UEFI | Out-Null'
+        )
+        self.assertIn(exact_invocation, broker_source)
+        self.assertNotRegex(
+            broker_source,
+            r"(?im)^\s*&\s+(?:(?:bcdedit|bootsect)(?:\.exe)?|\$\w*(?:bcdedit|bootsect)\w*)\b",
+        )
+        self.assertNotRegex(
+            broker_source,
+            r"(?i)(?:Registry::)?HKEY_LOCAL_MACHINE\\BCD00000000|"
+            r"\breg(?:\.exe)?\s+(?:load|unload|add|delete)\b[^\r\n]*BCD00000000",
+        )
+        approval = broker_source.index(
+            "$null = Get-ApprovedBcdBootPath $contract.deployment_tools"
+        )
+        disk_creation = broker_source.index(
+            "New-FreshGuestDisk $imagePath $diskPath $bootstrapPassword "
+            "$contract.deployment_tools"
+        )
+        invocation = broker_source.index(exact_invocation)
+        self.assertLess(approval, disk_creation)
+        self.assertLess(invocation, disk_creation)
+
+    def test_broker_holds_final_adk_observation_under_nonreplaceable_lease(self):
+        if os.name != "nt":
+            self.skipTest("the ADK namespace lease requires real Windows ACL semantics")
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "toolchain"
+            bcdboot_root = root / "amd64" / "BCDBoot"
+            bcdboot_root.mkdir(parents=True)
+            for name in ("bcdboot.exe", "bcdedit.exe", "bootsect.exe"):
+                (bcdboot_root / name).write_bytes(name.encode("ascii"))
+
+            environment = os.environ.copy()
+            environment["CODEARBITER_DESKTOP_BOUNDARY_TEST"] = "1"
+            result = subprocess.run(
+                [
+                    powershell(), "-NoLogo", "-NoProfile", "-NonInteractive", "-File",
+                    str(BROKER), "-AdkExecutionLeaseFixturePath", str(root),
+                    "-ContractPath", str(CONTRACT),
+                ],
+                cwd=REPO_ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            observed = json.loads(result.stdout)
+            self.assertTrue(observed["file_replacement_blocked"])
+            self.assertTrue(observed["root_replacement_blocked"])
+            self.assertTrue(observed.get("sibling_dll_creation_blocked", False))
+            self.assertTrue(observed.get("manifest_creation_blocked", False))
+            self.assertTrue(observed.get("local_redirect_creation_blocked", False))
+            self.assertTrue(observed.get("dacl_mutation_blocked", False))
+            self.assertTrue(observed.get("acl_restored", False))
+            self.assertEqual(observed["leased_file_count"], 3)
+            self.assertTrue(root.is_dir())
+            self.assertTrue((bcdboot_root / "bcdboot.exe").is_file())
+            restored_probe = bcdboot_root / "after-close.txt"
+            restored_probe.write_text("restored", encoding="utf-8")
+            self.assertEqual(restored_probe.read_text(encoding="utf-8"), "restored")
+
+        broker_source = BROKER.read_text(encoding="utf-8")
+        disk_start = broker_source.index("function New-FreshGuestDisk")
+        disk_end = broker_source.index("function ", disk_start + 1)
+        disk_body = broker_source[disk_start:disk_end]
+        lease = disk_body.index(
+            "$adkExecutionLease = Open-ApprovedAdkExecutionLease $DeploymentTools"
+        )
+        final_observation = disk_body.index(
+            "$approvedBcdBootPath = Get-ApprovedBcdBootPath "
+            "$DeploymentTools -ExecutionLocked",
+            lease,
+        )
+        invocation = disk_body.index(
+            '& $approvedBcdBootPath "$osRoot`Windows" /s $efiRoot /f UEFI | Out-Null',
+            final_observation,
+        )
+        release = disk_body.index(
+            "Close-ApprovedAdkExecutionLease $adkExecutionLease",
+            invocation,
+        )
+        self.assertLess(lease, final_observation)
+        self.assertLess(final_observation, invocation)
+        self.assertLess(invocation, release)
+        self.assertNotIn("[string]$approvedBcdBootPath", disk_body)
+        self.assertIn(
+            "New-FreshGuestDisk $imagePath $diskPath $bootstrapPassword "
+            "$contract.deployment_tools",
+            broker_source,
+        )
+
+    def test_pre_identity_failure_observes_non_creation_without_child_scope_loss(self):
+        result = run_broker_json_fixture(
+            "-CleanupObservationFixturePath",
+            {
+                "schema_version": 1,
+                "identity_created": False,
+                "identity_creation_attempted": False,
+                "guest_observation": None,
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {
+                "observation": {
+                    "disabled": True,
+                    "deleted": True,
+                    "profile_destroyed": True,
+                },
+                "cleanup_trace": [
+                    "account-disabled",
+                    "account-deleted",
+                    "profile-destroyed",
+                ],
+            },
+        )
+        partial_creation = run_broker_json_fixture(
+            "-CleanupObservationFixturePath",
+            {
+                "schema_version": 1,
+                "identity_created": False,
+                "identity_creation_attempted": True,
+                "guest_observation": {
+                    "disabled": True,
+                    "deleted": True,
+                    "profile_destroyed": True,
+                },
+            },
+        )
+        self.assertEqual(
+            partial_creation.returncode,
+            0,
+            partial_creation.stdout + partial_creation.stderr,
+        )
+        self.assertEqual(
+            json.loads(partial_creation.stdout)["cleanup_trace"],
+            ["account-disabled", "account-deleted", "profile-destroyed"],
+        )
+        unobserved_attempt = run_broker_json_fixture(
+            "-CleanupObservationFixturePath",
+            {
+                "schema_version": 1,
+                "identity_created": False,
+                "identity_creation_attempted": True,
+                "guest_observation": None,
+            },
+        )
+        self.assertNotEqual(unobserved_attempt.returncode, 0)
+        failed_cleanup = run_broker_json_fixture(
+            "-CleanupObservationFixturePath",
+            {
+                "schema_version": 1,
+                "identity_created": False,
+                "identity_creation_attempted": True,
+                "guest_observation": {
+                    "disabled": True,
+                    "deleted": False,
+                    "profile_destroyed": True,
+                },
+            },
+        )
+        self.assertNotEqual(failed_cleanup.returncode, 0)
+        broker_source = BROKER.read_text(encoding="utf-8")
+        production_catch = broker_source[broker_source.index("    $failure = $_"):]
+        self.assertIn(
+            "$catchTorn = Invoke-BrokerCleanupStage $lifecycle $cleanupName",
+            production_catch,
+        )
+        account_disabled = production_catch[
+            production_catch.index("'account-disabled'"):
+            production_catch.index("'account-deleted'")
+        ]
+        assignments = re.findall(r"(?m)^\s*\$catchTorn\s*=", account_disabled)
+        self.assertEqual(assignments, ["                $catchTorn ="])
+        setup_start = broker_source.index("$setup = Invoke-Command")
+        attempt_marker = broker_source.index("$identityCreationAttempted = $true")
+        self.assertLess(attempt_marker, setup_start)
 
     def test_driver_reports_exact_x64_windows_input_abi_sizes(self):
         if sys.platform != "win32" or struct.calcsize("P") != 8:


### PR DESCRIPTION
## What & why

Use the reviewed, serviced Microsoft ADK Deployment Tools closure for protected desktop guest boot-file creation. The broker now rejects ambient host and applied-image BCDBoot, holds the exact approved namespace and file observation through process exit, and records failed-run identity cleanup from the parent scope.

This is the prerequisite for PR #711. It does not provision the desktop proof, authorize device login, or merge any branch.

Refs #711
Ref: ADR-0031

## Type of change

- [x] `fix`: bug fix
- [ ] `feat`: new behavior
- [ ] `docs`: documentation only
- [ ] `refactor`: no behavior change
- [ ] `chore`: deps, tooling, reverts

## Checklist

- [x] Branched off `main` (not a direct write to `main`)
- [x] Conventional Commits used in the commit messages
- [x] Tests added/updated for behavioral changes
- [x] Full suite green locally
- [x] No shipped plugin payload changed, so no package version bump is required
- [x] No shipped plugin payload changed, so no CHANGELOG entry is required
- [x] Existing ADR-0031 covers the trusted desktop-proof boundary
- [x] Fixture entry points are test-only and fail closed
- [x] Hooks are unchanged

## Test plan

- `python .github/scripts/test_codex_desktop_boundary.py` (27 passed)
- `python .github/scripts/test_codex_skill_resources.py` (152 passed, 1 expected skip)
- `python .github/scripts/test_ci_impact.py` (59 passed)
- All remaining commands in `.codearbiter/tech-stack.md`
- `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` (1382 passed with documented Windows prerequisites)
- PowerShell parse, Python compile, JSON parse, plugin reference graph, and `git diff --check`
- `gitleaks dir . --redact --no-banner --verbose` (no leaks)

## Notes for the reviewer

The final independent review passed with 0 Critical and 0 High findings. Three Medium test-hardening and cleanup-diagnostic items remain: partial-acquisition rollback diagnostics, production collector and locked-validator mutation coverage, and runtime lifecycle and data-flow mutation coverage.

The DACL lease does not defend against malicious code already running as the trusted elevated broker. That is an accepted trusted-host residual under the current threat model. Expanding that boundary requires a new ADR and privilege separation. Conflict hierarchy Level 1 applies: the review keeps the residual visible without silently changing the accepted attacker model.

Exact head: `5c564010d1675c979549d739b82a6d5afd9cfca8`
