### PR TITLE
Clarify shared core and host adapter identity

### DIFF
--- a/.codearbiter/CONTEXT.md
+++ b/.codearbiter/CONTEXT.md
@@ -6,29 +6,35 @@ stage: 2
 
 # Project: codeArbiter
 
-The orchestration framework itself, plus siblings. This repo contains
-**four sibling plugins** (ADR-0007, ADR-0011, ADR-0013): `ca`, the governance/orchestration
-plugin for Claude Code; `ca-codex`, the same governance kernel for Codex CLI;
-`ca-pi`, the same kernel for Pi; and `ca-sandbox`, an infrastructure plugin. The
-first three are the **three governance hosts**. This `.codearbiter/` directory is the v2
+The orchestration framework itself, plus its host adapters and infrastructure sibling.
+The canonical governance kernel lives in `core/`; generated payloads carry it into the
+Claude Code adapter (`ca`), Codex adapter (`ca-codex`), and Pi adapter (`ca-pi`). A
+fourth sibling, `ca-sandbox`, is an infrastructure plugin (ADR-0007, ADR-0011,
+ADR-0013). The first three are the **three governance hosts**. This `.codearbiter/`
+directory is the v2
 project-state store — root-level, outside `.claude/`, so it survives even if the
 codeArbiter plugin is uninstalled. The `arbiter: enabled` frontmatter above is the
 single activation flag: it gates both the persona injection and the arbiter
 statusline segments, and every enforcement hook reads it — never the persona.
 
 ## Identity
-Four sibling plugins in one repository (ADR-0007, ADR-0011, ADR-0013):
+One canonical governance kernel, three generated host adapters, and one infrastructure
+sibling in the repository (ADR-0007, ADR-0011, ADR-0013):
 
-- **`ca` (governance)** — the kernel. A Claude Code plugin that routes work through
+- **`core/` (governance)** — the canonical governance kernel: shared stdlib-only
+  Python and generated markdown sources. It is an internal source boundary, not a
+  separately published or runtime package (ADR-0031).
+- **`ca` (governance, Claude Code host)** — the Claude Code adapter. It routes work through
   gated skills and reviewer agents, enforces spec-driven TDD and commit gates,
   decides via SMARTS, and keeps an append-only audit trail. Decisive, terse,
-  high-authority. Its identity and gates are unchanged by the siblings.
-- **`ca-codex` (governance, Codex CLI host)** — the same kernel targeting Codex CLI.
-  Generated from shared sources (`core/pysrc/`, `core/surface/`) alongside `ca`;
+  high-authority. Its host-native identity and gates are unchanged by the siblings.
+- **`ca-codex` (governance, Codex CLI host)** — the Codex adapter. Generated from
+  shared sources (`core/pysrc/`, `core/surface/`) alongside `ca`; it packages the
+  shared role charters as resources for host-provided thread dispatch rather than
+  registering native plugin agents.
   CI enforces byte-identity between `core/` and each plugin's vendored copy. One
-  `.codearbiter/` store per project serves all three governance hosts. Beta until
-  live-Codex verification (ADR-0011).
-- **`ca-pi` (governance, Pi host)** — the same generated kernel behind a thin
+  `.codearbiter/` store per project serves all three governance hosts (ADR-0011).
+- **`ca-pi` (governance, Pi host)** — the Pi adapter: the same generated kernel behind a thin
   TypeScript extension and the shared stdlib-only Python core. The Git-installed
   package is independently versioned, requires Node 22.19+ and Python 3, and
   shares the project's `.codearbiter/` store with Claude Code and Codex CLI.
@@ -39,7 +45,7 @@ Four sibling plugins in one repository (ADR-0007, ADR-0011, ADR-0013):
   kernel. Independent of `ca`: CI is path-scoped and version bumps are per-plugin.
 
 ## Scope
-- `ca` framework source: `plugins/ca/` — `arbiter.md` (the arbiter mode's body, formerly
+- Claude Code adapter: `plugins/ca/` — `arbiter.md` (the arbiter mode's body, formerly
   `ORCHESTRATOR.md`), `includes/safety-core.md`, `skills/`, `commands/`, `agents/`, `hooks/`,
   `tools/`.
 - Shared kernel sources: `core/pysrc/` (host-neutral hook logic) and `core/surface/`

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -6,14 +6,23 @@ this file is the stale one; fix it here.
 
 ## Stack
 
-- **Hooks** (`plugins/ca/hooks/*.py`) — Python 3, stdlib only. No dependencies,
-  ever: hooks must run on a stock Windows/macOS/Linux Python with nothing
-  installed. The cold-install matrix exists to prove exactly that.
-- **Farm dispatcher** (`plugins/ca/tools/`) — TypeScript on Node 20, tested with
-  vitest. The plugin ships the built `farm.js`, not `farm.ts` — a stale build is
-  a release blocker.
-- **Everything else** — prose (skills, commands, agents, ORCHESTRATOR.md),
-  governed by the plugin's own authoring gates, not by CI.
+- **Canonical shared source** (`core/pysrc/`, `core/surface/`) — these directories
+  are the canonical shared source for stdlib-only Python enforcement logic and
+  markdown templates. Generators materialize this internal kernel into host packages;
+  `core/` is not published as a separate runtime package.
+- **Claude Code adapter** (`plugins/ca/`) — native hooks, commands, skills, agents,
+  and the Node 20 farm dispatcher under `plugins/ca/tools/`. Hooks are Python 3,
+  stdlib only; the dispatcher is TypeScript tested with Vitest and ships built
+  `farm.js`.
+- **Codex adapter** (`plugins/ca-codex/`) — Codex manifest and hook shims plus
+  generated skills and packaged resource charters. The source candidate packages
+  those resources for host-provided thread dispatch; exact-candidate proof gates
+  release, and older adapters retain the bounded inline fallback. They are not
+  native Codex plugin-agent registrations.
+- **Pi adapter** (`plugins/ca-pi/`) — generated Python/policy payload plus its thin
+  TypeScript host extension and supervised child-process boundary.
+- **Infrastructure sibling** (`plugins/ca-sandbox/`) — isolated exploration tools;
+  it is not part of the governance kernel.
 - **Protected Codex desktop proof boundary** (`.github/scripts/Invoke-CodeArbiterDesktop*.ps1`) — PowerShell 7 plus inbox Windows/Hyper-V cmdlets only. The broker runs only on an elevated Windows self-hosted runner; contract-only mode and byte binding run in portable CI. Guest coordination uses authenticated PowerShell Direct over local VMBus, not guest networking or a custom socket service.
 
 ## Pi adapter

--- a/.github/scripts/test_public_codex_docs.py
+++ b/.github/scripts/test_public_codex_docs.py
@@ -86,6 +86,143 @@ class PublicCodexDocsTest(unittest.TestCase):
         self.assertIn("getting-started/claude-code-and-codex", self.readme)
         self.assertRegex(self.readme, re.compile(r"Codex CLI\s+0\.144\.1"))
 
+    def test_project_context_assigns_kernel_and_adapter_ownership(self):
+        context = (ROOT / ".codearbiter" / "CONTEXT.md").read_text(encoding="utf-8")
+        tech_stack = (ROOT / ".codearbiter" / "tech-stack.md").read_text(encoding="utf-8")
+
+        self.assertIn("canonical governance kernel", context)
+        self.assertIn("Claude Code adapter", context)
+        self.assertIn("Codex adapter", context)
+        self.assertIn("Pi adapter", context)
+        self.assertNotIn("— the kernel.", context)
+        self.assertNotIn("Beta until live-Codex verification", context)
+
+        for path in (
+            "core/pysrc/",
+            "core/surface/",
+            "plugins/ca/",
+            "plugins/ca-codex/",
+            "plugins/ca-pi/",
+        ):
+            with self.subTest(path=path):
+                self.assertIn(path, tech_stack)
+        self.assertIn("canonical shared source", tech_stack)
+        self.assertIn("source candidate", tech_stack)
+        self.assertNotIn("Host dispatch loads those resources", tech_stack)
+
+    def test_contributor_and_security_guides_describe_the_multi_host_product(self):
+        contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        security = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+        enforcement = (
+            ROOT / "site" / "src" / "content" / "docs" / "enforcement.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("codeArbiter is a Claude Code plugin", contributing)
+        self.assertNotIn("**both** plugins", contributing)
+        self.assertIn("three governance adapters", contributing)
+        self.assertIn("affected adapter's SemVer", contributing)
+        self.assertIn("Claude Code can leave", contributing)
+        self.assertIn("Codex reports", contributing)
+        self.assertIn("Pi blocks", contributing)
+        self.assertIn("shipped adapter-payload change", contributing)
+
+        self.assertNotIn("codeArbiter is a Claude Code plugin", security)
+        self.assertNotIn("ships from a single plugin", security)
+        self.assertIn("host and adapter version", security)
+        self.assertIn("Older adapter releases", security)
+        self.assertIn("GitHub Releases API", security)
+        self.assertIn("Git common directory", security)
+        self.assertIn("~/.codearbiter/", security)
+        self.assertIn("marketplace release", security)
+        self.assertIn("matching npm release", security)
+        self.assertNotIn("with no network calls", security)
+        for host in ("Claude Code", "Codex", "Pi"):
+            with self.subTest(host=host):
+                self.assertIn(host, security)
+
+        self.assertIn("All three governance adapters", enforcement)
+        self.assertNotIn("Both plugins vendor the same guard core", enforcement)
+
+        for path in (
+            "site/src/content/docs/overview.md",
+            "site/src/content/docs/getting-started/install.md",
+        ):
+            with self.subTest(path=path):
+                text = (ROOT / path).read_text(encoding="utf-8")
+                self.assertIn("one governance product", text)
+                self.assertNotIn("codeArbiter ships four sibling plugins", text)
+                self.assertNotIn("The same marketplace", text)
+
+        overview = (
+            ROOT / "site" / "src" / "content" / "docs" / "overview.md"
+        ).read_text(encoding="utf-8")
+        install = (
+            ROOT / "site" / "src" / "content" / "docs" / "getting-started" / "install.md"
+        ).read_text(encoding="utf-8")
+        for text in (overview, install):
+            self.assertIn("Claude Code marketplace", text)
+            self.assertIn("Codex marketplace", text)
+            self.assertIn("pinned Git", text)
+
+        for path in (
+            "site/src/content/docs/getting-started/pi.md",
+            "site/src/content/docs/guides/uninstalling.md",
+        ):
+            with self.subTest(pi_distribution_path=path):
+                text = (ROOT / path).read_text(encoding="utf-8")
+                self.assertNotIn("Git-only", text)
+                self.assertNotIn("no npm release", text)
+                self.assertIn("npm is the convenience channel", text)
+
+    def test_active_codex_role_docs_name_packaged_resource_charters(self):
+        paths = (
+            "docs/architecture.md",
+            "docs/parity.md",
+            "site/src/content/docs/overview.md",
+            "site/src/content/docs/concepts/persona-and-context.md",
+            "site/src/content/docs/glossary.md",
+            "site/src/content/docs/getting-started/claude-code-and-codex.md",
+            "site/src/curated/commands/checkpoint.md",
+            "site/src/curated/commands/pr.md",
+            "site/src/curated/commands/review.md",
+            "site/src/curated/commands/tribunal.md",
+        )
+        for path in paths:
+            with self.subTest(path=path):
+                text = (ROOT / path).read_text(encoding="utf-8")
+                self.assertRegex(text, re.compile(r"(?is)packaged.{0,80}resource charter"))
+                self.assertNotIn("does not vendor custom agent definitions", text)
+
+        charter_files = sorted(
+            path.name
+            for path in (ROOT / "plugins" / "ca-codex" / "agents").glob("*.md")
+            if path.name != "INDEX.md"
+        )
+        self.assertEqual(18, len(charter_files))
+
+        parity = (ROOT / "docs" / "parity.md").read_text(encoding="utf-8")
+        self.assertNotIn("| Codex packaged agents |", parity)
+        self.assertIn("plugins/ca-codex/agents/", parity)
+        self.assertNotIn("plugins/ca-codex/resources/agents/", parity)
+        self.assertIn("source candidate", parity)
+
+        public_role_docs = (
+            "site/src/content/docs/overview.md",
+            "site/src/content/docs/concepts/persona-and-context.md",
+            "site/src/content/docs/glossary.md",
+            "site/src/content/docs/getting-started/claude-code-and-codex.md",
+            "site/src/curated/commands/checkpoint.md",
+            "site/src/curated/commands/pr.md",
+            "site/src/curated/commands/review.md",
+            "site/src/curated/commands/tribunal.md",
+        )
+        for path in public_role_docs:
+            with self.subTest(candidate_path=path):
+                text = (ROOT / path).read_text(encoding="utf-8")
+                self.assertRegex(text, re.compile(r"(?is)source candidate.{0,160}packaged.{0,80}resource charter"))
+                self.assertNotIn("Current Codex releases load", text)
+                self.assertNotIn("On current Codex hosts", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 # Contributing to codeArbiter
 
-Thanks for considering a contribution. codeArbiter is a Claude Code plugin that
-enforces development discipline through gates, so it holds itself to the same bar.
-This guide explains how to get set up, what the gates expect, and how to get a
-change merged.
+Thanks for considering a contribution. codeArbiter is one repository-owned
+governance product with a shared internal core and three governance adapters for
+Claude Code, Codex, and Pi. It enforces development discipline through gates, so
+it holds itself to the same bar. This guide explains how to get set up, what the
+gates expect, and how to get a change merged.
 
 By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
@@ -23,11 +24,14 @@ By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.m
 ## Prerequisites
 
 - **Python 3 on `PATH`.** Every hook is Python (stdlib only; no third-party
-  packages). Without it the gates and the startup injection silently don't run.
+  packages). Without it, Claude Code can leave an unresolved hook inactive,
+  Codex reports a handler failure, and Pi blocks mutating calls with an
+  interpreter breadcrumb. None of those states is active governance.
 - **`git config user.email` set.** Overrides and ADRs are attributed to that
   identity; the audit trail depends on a real attribution.
-- **Node.js**, only if you touch the cost-arbitrage farm dispatcher under
-  `plugins/ca/tools/` (TypeScript + Vitest).
+- **Node.js**, if you touch the cost-arbitrage farm dispatcher under
+  `plugins/ca/tools/`, the Pi adapter under `plugins/ca-pi/tools/`, or the docs
+  site (TypeScript + Vitest/Astro).
 
 ## Getting set up
 
@@ -36,7 +40,8 @@ git clone https://github.com/arbiterForge/codeArbiter
 cd codeArbiter
 ```
 
-Then load it as a local marketplace in Claude Code to dogfood your changes:
+For example, load the Claude Code adapter as a local marketplace to dogfood that
+host's changes:
 
 ```text
 /plugin marketplace add ./codeArbiter
@@ -77,11 +82,12 @@ codeArbiter governs its own development. Two things follow from that:
    logged to `.codearbiter/overrides.log`. `mode --arbiter` exits it explicitly,
    and a new session always resolves back to `arbiter`.
 
-2. **Everything that ships is a payload change and requires a version bump.** The
-   two-axis model: **SemVer** versions the whole payload (any change to shipped
-   plugin files bumps the version, and CI enforces this), while the **Feature Forge**
-   label marks per-feature previews that are off by default until real-world data
-   earns promotion. New behavior ships `preview` and opt-in first.
+2. **Every shipped adapter-payload change requires that adapter's version bump.**
+   Repository-only docs and tests are not adapter payload. The two-axis model: the
+   affected adapter's SemVer versions its complete payload (any change to shipped
+   adapter files bumps that adapter's version, and CI enforces this), while the
+   **Feature Forge** label marks per-feature previews that are off by default until
+   real-world data earns promotion. New behavior ships `preview` and opt-in first.
 
 ## Submitting a change
 
@@ -107,9 +113,11 @@ through a merged PR, never a direct write.
 ## Working with the hooks
 
 If your change touches the hooks, read [`docs/hooks.md`](./docs/hooks.md) first. It
-documents every hook, what it reads/writes, and the invariant that **no hook makes a
-network call**. Preserve that invariant: hooks are stdlib-only Python, must degrade
-safely on failure, and must exit `0` (do nothing) in a repo that hasn't opted in.
+documents every hook, what it reads/writes, and the two bounded, nonblocking
+background network operations: remote refresh through `git fetch` and the daily
+GitHub Releases check. Preserve those boundaries: hooks are stdlib-only Python,
+must degrade safely on failure, and guard hooks must exit `0` (do nothing) in a
+repo that hasn't opted in.
 
 Hook Python is canonical in `core/pysrc/` and vendored byte-identically into each
 plugin's `hooks/` by `python tools/sync-core.py` (CI gates it with `--check`). Edit
@@ -118,8 +126,8 @@ Python file is `hooks/_host.py`.
 
 ## Working with the markdown surface (generated)
 
-Commands, skills, includes, `COMMANDS.md`, `SPRINT.md`, and `arbiter.md` of
-**both** plugins are rendered from `core/surface/` templates by
+The shared command, skill, include, orchestrator, and role-charter sources are
+rendered from `core/surface/` templates into each applicable host adapter by
 `python tools/build-surface.py` — see [`core/surface/README.md`](./core/surface/README.md)
 for the token/conditional grammar and the house rules. Never edit a rendered file:
 edit the template, run the tool, commit templates and outputs together. CI's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,33 +1,44 @@
 # Security Policy
 
 > This is the GitHub repository security policy: how to report a problem with the
-> codeArbiter plugin. It is distinct from `.codearbiter/security-controls.md`, which
-> is the in-repo governance doc the plugin's gates enforce on *your* code.
+> codeArbiter product. It is distinct from `.codearbiter/security-controls.md`, which
+> is the in-repo governance doc the adapters' gates enforce on *your* code.
 
 ## What codeArbiter runs on your machine
 
-codeArbiter is a Claude Code plugin. It activates through hooks: small Python
-scripts Claude Code runs during a session. For full transparency about what each
-hook reads, writes, and runs, see **[`docs/hooks.md`](./docs/hooks.md)**. In short:
+codeArbiter provides host adapters for Claude Code, Codex, and Pi from one shared
+governance core. Each adapter connects the host's lifecycle and tool events to the
+generated hook payload. For full transparency about what each hook reads, writes,
+and runs, see **[`docs/hooks.md`](./docs/hooks.md)**. In short:
 
 - Hooks are stdlib-only Python, with no third-party packages and no compiled binaries.
-- No hook makes a network call. The only outbound process is a local, read-only
-  `git fetch` against your own configured remote.
+- Hooks make exactly two bounded, nonblocking background network operations: a
+  detached `git fetch` against your configured remote, which never modifies the
+  remote but may update local Git metadata and objects through your configured
+  transport and credential helpers; and an at-most-daily, fail-silent,
+  unauthenticated HTTPS GET to the GitHub Releases API.
 - Guard hooks do nothing in a repo that has not opted in (`arbiter: enabled`).
-- Hooks write only inside your repo's `.codearbiter/` directory, plus a ca-owned
-  statusline entry in `~/.claude/settings.json` (backed up and restored on removal).
+- Hooks write governance state inside your repo's `.codearbiter/` directory and may
+  install or refresh the repository's `pre-commit` and `pre-push` backstops under
+  its Git common directory. Hook-owned user-global state under `~/.codearbiter/`
+  includes the bounded update-check cache. Host-specific setup may also install
+  ca-owned integration state, such as the Claude Code statusline entry in
+  `~/.claude/settings.json` (backed up and restored on removal). Hooks do not write
+  source files.
 
 ## Supported versions
 
-codeArbiter ships from a single plugin in this repository. Fixes are made against
-the latest release on `main`; please reproduce on the current version before
-reporting. The previous v1 framework on the `archive/v1` branch is unmaintained and
-receives no fixes.
+The Claude Code, Codex, and Pi adapters are independently packaged and versioned
+from the same canonical source. Fixes target the latest published release in the
+affected adapter's supported channel; please reproduce there before reporting.
+The previous v1 framework on the `archive/v1` branch is unmaintained and receives
+no fixes.
 
 | Version | Supported |
 |---|---|
-| Latest release on `main` | yes |
-| Older 2.x releases | upgrade to latest |
+| Latest Claude Code or Codex marketplace release | yes |
+| Latest `ca-pi-v*` tag and matching npm release | yes |
+| Older adapter releases | upgrade within the same channel |
 | v1 (`archive/v1`) | no |
 
 ## Reporting a problem
@@ -41,7 +52,7 @@ suspected vulnerability.
 
 Helpful details to include:
 
-- The plugin version and your OS / Python version.
+- The host and adapter version, plus your OS / Python version.
 - A clear description and the smallest steps to reproduce.
 - The impact you observed (for example: a guard that fails to block, an audit-log
   write that should have been rejected, or any data written outside `.codearbiter/`).
@@ -54,7 +65,8 @@ Helpful details to include:
 - An assessment and, for confirmed issues, a fix and a coordinated release.
 - Credit in the release notes if you'd like it.
 
-Because the threat surface is local (hooks run on the contributor's own machine,
-with no network calls and no privilege escalation), most reports will be about a
-guard behaving incorrectly rather than a remote vulnerability. Those still matter
-(a gate that fails open is a real bug) and are very welcome.
+Because the threat surface is primarily local (hooks run on the contributor's own
+machine, expose no inbound network service, and perform no privilege escalation),
+most reports will be about a guard behaving incorrectly rather than a remote
+vulnerability. Those still matter (a gate that fails open is a real bug) and are
+very welcome.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ capabilities, and tool classes without copying governance policy.
 | Host | Adapter entry | Public command form | Runtime boundary |
 |---|---|---|---|
 | Claude Code (`ca`) | `hooks/hooks.json` | `/ca:<name>` | native hook events and Claude agents |
-| Codex CLI (`ca-codex`) | `.codex-plugin/plugin.json` + generated hooks | `$ca-<name>` | compatible hook events; host-provided agent threads load shared charters, with a bounded older-host inline fallback |
+| Codex CLI (`ca-codex`) | `.codex-plugin/plugin.json` + generated hooks | `$ca-<name>` | compatible hook events; the source candidate includes packaged resource charters (not native agent registrations) for host-provided threads, while runtime promotion remains exact-candidate gated and older releases retain a bounded inline fallback |
 | Pi (`ca-pi`) | `extensions/codearbiter.js` | `/ca-<name>` with `/skill:ca-<name>` fallback | TypeScript lifecycle/tool wrappers call the bounded Python bridge; roles use hardened child Pi processes |
 
 Pi's parent extension stays dormant until the repository is enabled and Pi

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -31,7 +31,7 @@ presenting the deliberately nonblocking unsupported-latest canary as supported.
 |---|---|---|---|---|
 | Public entries | 38 `/ca:*` commands | 36 `$ca-*` entry skills | 37 `/ca-*` aliases with `/skill:ca-*` fallback | `plugins/*/COMMANDS.md`, `plugins/ca-pi/SKILLS.md` |
 | Orchestrator routines | 22 generated skills | 22 generated routines | 22 generated routines | `python tools/build-surface.py --check` |
-| Role charters | 18 plugin agents | host-provided agent threads load the shared charters; inline is an older-host fallback | 18 generated roles used by hardened child dispatch | `core/surface/agents/`, `plugins/ca-pi/generated/roles.json` |
+| Role charters | 18 plugin agents | source candidate contains 18 packaged resource charters for host-provided threads; runtime release remains exact-candidate gated and older releases retain the inline fallback | 18 generated roles used by hardened child dispatch | `core/surface/agents/`, `plugins/ca-codex/agents/`, `plugins/ca-pi/generated/roles.json` |
 | Shared Python | stdlib-only core | byte-identical vendored core | byte-identical vendored core behind bounded bridge | `python tools/sync-core.py --check` |
 | Project store | `.codearbiter/` | same store | same store with `HOST: pi` attribution | `.github/scripts/test_pi_shared_store.py` |
 
@@ -54,7 +54,7 @@ surface it describes, and an uncompared count drifts silently.
 | Git backstop | shared `.git/hooks` installer | same | same through Pi bridge |
 | Status | complete Claude statusline | startup state only | rich footer globally with a per-message burn sparkline and up to four activity rows (both wide-layout only); refresh-time git repository/dirty enrichment is trusted-only; governance row only when enabled and affirmatively trusted; rate windows omitted; optional probe-gated right sidebar (`/ca-sidebar`, auto-on at ≥120 columns) with session, subagents, workspace, and todos panels |
 | Prune/compaction | shared policy plus Claude transcript codec | transcript engine unavailable; audit warning remains | shared policy plus Pi native compaction; no active-session rewrite |
-| Role dispatch | Claude subagents | host-provided agent threads with retained receipts; bounded inline fallback on older hosts | fresh Pi RPC children: single, chain, parallel |
+| Role dispatch | Claude subagents | source candidate supplies packaged resource charters for host-provided threads; exact-candidate proof gates release, and older releases retain a bounded inline fallback | fresh Pi RPC children: single, chain, parallel |
 | Process cleanup | host-managed subagents | host-managed agent threads (or current-thread lifecycle for an inline fallback) | bounded cancellation/timeout plus verified whole-tree cleanup; unhealthy latch on failure |
 | Doctor | interpreter, payload, hooks, live H-03 probe | trusted hook/origin diagnostics | package/origin/trust/collision/core/child/wrapper plus footer/sidebar/background health |
 
@@ -106,7 +106,6 @@ Every exception has a status and a source-visible evidence pointer.
 | Codex native Read event | HOST-IMPOSSIBLE | Codex exposes no equivalent read hook; governed notices still run after writes. | `plugins/ca-codex/includes/codex-host-notes.md` |
 | Codex transcript compaction | HOST-IMPOSSIBLE | Claude transcript JSONL is not a Codex session format. | `plugins/ca-codex/includes/codex-host-notes.md` |
 | Codex statusline | HOST-IMPOSSIBLE | Codex exposes no plugin statusline surface. | `plugins/ca-codex/includes/codex-host-notes.md` |
-| Codex packaged agents | DEGRADED | The plugin does not vendor custom agent definitions; current hosts still dispatch host-provided threads loaded with the shared charter, while older hosts may fall back inline. Context creation blocks if isolated scouts are unavailable. | `plugins/ca-codex/includes/codex-host-notes.md` |
 | Pi rate-window telemetry | HOST-IMPOSSIBLE | Pi exposes no supported provider rate-window source, so the rich footer omits it rather than fabricating data. | `plugins/ca-pi/tools/src/footer-state.ts` |
 | Pi active-dispatch doctor self-test | DEGRADED | Public 0.80.5/0.84.1 APIs cannot submit the deterministic wrapper probe through active dispatch. | `plugins/ca-pi/tools/src/doctor.ts` |
 | Pi farm route | PREVIEW | Uses the shared backend but awaits real-run promotion under CONFIRM-05. | `plugins/ca-pi/tools/src/farm.ts` |

--- a/site/src/content/docs/concepts/persona-and-context.md
+++ b/site/src/content/docs/concepts/persona-and-context.md
@@ -63,9 +63,10 @@ Start at the public command reference and follow its owning skill. The skill bod
 may dispatch and the condition that activates it. Then open the generated agent page to inspect that
 role's tools, model tier, constraints, and exact source.
 
-Claude Code can dispatch packaged agents through its native task tool. Codex currently executes the
-same reviewer and author charters in host-provided agent threads, with an inline fallback only on
-older hosts where isolation is not mandatory; Pi uses its supervised child
-path where supported. That host difference changes isolation mechanics, not ownership or the gate
-that consumes the result. The [compatibility matrix](/getting-started/compatibility/#host-differences)
+Claude Code can dispatch packaged agents through its native task tool. The Codex source candidate
+includes the same packaged resource charters for reviewers and authors for use in host-provided
+agent threads; exact-candidate proof gates release, and older adapters retain an inline fallback
+where isolation is not mandatory. Pi uses its supervised child path where supported. That host
+difference changes isolation mechanics, not ownership or the gate that consumes the result. The
+[compatibility matrix](/getting-started/compatibility/#host-differences)
 records the current boundary.

--- a/site/src/content/docs/enforcement.md
+++ b/site/src/content/docs/enforcement.md
@@ -10,11 +10,11 @@ journey:
   proof: "Given a blocked action, you can name its hook flank, gate id, and sanctioned remediation."
 ---
 
-codeArbiter's gates are not advice the model can talk past. They run as Claude Code or Codex
-[hooks](/glossary/#hook) at the tool-call boundary, in Python, with no third-party dependencies.
-Both plugins vendor the same guard core. Claude Code receives its exit-2 verdict directly; Codex's
-`pre-tool-adapter.py` converts the same verdict to a structured deny response so Windows shell exit
-handling cannot weaken the block. See the
+codeArbiter's gates are not advice the model can talk past. They run at each host's tool-call
+boundary with no third-party Python dependencies. All three governance adapters consume the same
+guard core. Claude Code receives its exit-2 verdict directly; Codex's `pre-tool-adapter.py`
+converts the same verdict to a structured deny response so Windows shell exit handling cannot
+weaken the block; Pi's trusted wrapper carries the shared verdict through its bridge. See the
 [Claude Code + Codex evidence](/getting-started/claude-code-and-codex/).
 
 For the per-hook breakdown, see the [Hooks reference](/hooks).

--- a/site/src/content/docs/getting-started/claude-code-and-codex.md
+++ b/site/src/content/docs/getting-started/claude-code-and-codex.md
@@ -15,10 +15,10 @@ result while retaining the public-marketplace smoke test as a release gate.
 
 **Shared enforcement and project-context parity across Claude Code and Codex.**
 
-Of codeArbiter's four sibling plugins, this page covers two: `ca` for Claude Code and `ca-codex` for
+This page covers two adapters of one governance product: `ca` for Claude Code and `ca-codex` for
 OpenAI Codex (see [Pi](/getting-started/pi/) for the third governance host, currently a Feature Forge
-`preview` with real use and feedback welcome, and
-[ca-sandbox](/guides/ca-sandbox/) for the non-governance infrastructure plugin). Both activate from
+`preview` with real use and feedback welcome, and [ca-sandbox](/guides/ca-sandbox/) for the separate
+Claude-marketplace infrastructure plugin). Both activate from
 the same `.codearbiter/CONTEXT.md`, enforce the same project rules, and read and write the same
 checked-in `.codearbiter/` state. One person can alternate between hosts, or two people can use
 different hosts in the same repository, without creating parallel governance state.
@@ -140,7 +140,7 @@ absence. That closes the public-installation gate with the same GitHub-slug comm
 | Statusline | Available | No Codex statusline surface; startup state carries governance status |
 | Transcript pruning | Claude transcript-pruning engine available | No transcript pruning; the host-neutral audit-staleness warning remains |
 | Governed-file Read hook | Available on Claude's Read tool | No Codex Read hook; reads happen through shell, while write-time notices remain |
-| Reviewer roles | Packaged plugin agents can be dispatched | Host-provided agent threads load the role charter and return a retained thread receipt; older hosts may fall back inline, except context creation requires isolated scouts |
+| Reviewer roles | Packaged plugin agents can be dispatched | The source candidate includes packaged resource charters for host-provided agent threads; exact-candidate proof gates release, and older adapters may fall back inline, except context creation requires isolated scouts |
 
 These differences are host capabilities and packaging choices. They do not create a second project
 context, weaken the blocking shell/write gates, or split the audit trail.

--- a/site/src/content/docs/getting-started/install.md
+++ b/site/src/content/docs/getting-started/install.md
@@ -11,12 +11,13 @@ journey:
   proof: "The host lists the adapter, and doctor reports the cached payload version after repository opt-in."
 ---
 
-codeArbiter ships four sibling plugins from one marketplace. Three are governance hosts: `ca` (Claude
-Code), `ca-codex` (Codex), and `ca-pi` (Pi). The fourth, `ca-sandbox`, is an infrastructure plugin
-unrelated to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)). This page covers Claude Code
-and Codex install; Pi has its own dedicated walkthrough at [Install for Pi](/getting-started/pi/) (a
-different distribution model: Git-only, no npm release). All three governance hosts enforce the same
-`.codearbiter/` project store. The
+codeArbiter is one governance product with three host adapters: `ca` (Claude Code), `ca-codex`
+(Codex), and `ca-pi` (Pi). The Claude Code marketplace also carries `ca-sandbox`, an infrastructure
+plugin unrelated to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)); the Codex marketplace
+carries `ca-codex`, while Pi uses npm with pinned Git tags as the reproducible channel. This page
+covers Claude Code and Codex install; Pi has its own dedicated walkthrough at
+[Install for Pi](/getting-started/pi/). All three governance hosts enforce the same `.codearbiter/`
+project store. The
 [Claude Code + Codex evidence](/getting-started/claude-code-and-codex/) defines the verified boundary,
 and [Compatibility](/getting-started/compatibility/) has the full host-differences matrix.
 
@@ -91,12 +92,14 @@ Verify an opted-in repository with `$ca-doctor`.
 
 ### Pi
 
-Pi is a third governance host, `ca-pi`, distributed Git-only (no npm release) with its own version
-line and prerequisites. The complete adapter is a Feature Forge `preview`: it is available and
-welcomed for real use, with broader testing still required before stable status or a claim of 100%
-validation. It is not covered here; see [Install for Pi](/getting-started/pi/) for the full flow,
-  including mechanical tag discovery, an exact pinned `ca-pi-v<version>` install, and the
-  project-trust step Pi requires before it activates.
+Pi is a third governance host, `ca-pi`, distributed through
+`npm:@arbiterforge/ca-pi` as the convenience channel and matching pinned Git tags as the
+reproducible channel, with its own version line and prerequisites. The complete adapter is a
+Feature Forge `preview`: it is available and welcomed for real use, with broader testing still
+required before stable status or a claim of 100% validation. It is not covered here; see
+[Install for Pi](/getting-started/pi/) for the full flow, including npm install, mechanical tag
+discovery, an exact pinned `ca-pi-v<version>` install, and the project-trust step Pi requires before
+it activates.
 
 ## 2. Scaffold and Activate the Repo
 

--- a/site/src/content/docs/getting-started/pi.md
+++ b/site/src/content/docs/getting-started/pi.md
@@ -1,6 +1,6 @@
 ---
 title: Pi
-description: "Install codeArbiter for Pi, grant project trust, and verify enforcement. Covers the ca-pi Git-only install, supported versions, and version pinning."
+description: "Install codeArbiter for Pi, grant project trust, and verify enforcement. Covers the ca-pi npm and pinned-Git channels, supported versions, and version pinning."
 journey:
   level: "Foundation"
   time: "12 minutes"
@@ -32,7 +32,8 @@ Confirm all before installing:
 
 ## 1. Install
 
-Pi distribution is Git-only. First list the repository's published Pi tags; do not guess a version
+Pi's pinned Git tags are the reproducible evidence channel, while npm is the convenience channel.
+First list the repository's published Pi tags; do not guess a version
 or substitute the core plugin's release number:
 
 ```sh

--- a/site/src/content/docs/glossary.md
+++ b/site/src/content/docs/glossary.md
@@ -28,9 +28,10 @@ See [Enforcement & Security](/enforcement/#advisory-non-blocking-reminders).
 
 A focused author or reviewer role dispatched by a [skill](#skill). An agent is not a public
 command and not a second orchestrator; it receives only the tools and context its role needs.
-Claude Code dispatches packaged plugin agents. Current Codex releases load the equivalent charter
-into host-provided agent threads, with inline execution only as an older-host fallback; Pi uses
-hardened child dispatch. See the [Agents reference](/reference/#agents).
+Claude Code dispatches packaged plugin agents. The Codex source candidate includes equivalent
+packaged resource charters for host-provided agent threads; exact-candidate proof gates release,
+and older adapters retain inline execution as a fallback. Pi uses hardened child dispatch. See the
+[Agents reference](/reference/#agents).
 
 ## Arbiter (enabled flag)
 

--- a/site/src/content/docs/guides/uninstalling.md
+++ b/site/src/content/docs/guides/uninstalling.md
@@ -83,8 +83,9 @@ required. H-18 only blocks disabling the switch, not re-enabling it.
 `ca-pi` currently ships as a Feature Forge `preview`. Real use and feedback are
 welcome while broader testing continues before stable status.
 
-`ca-pi` is distributed Git-only, versioned independently as `ca-pi-v<version>` tags (not tied to
-the `ca`/`ca-codex` release cadence). There is no npm release and no auto-update.
+`ca-pi` is versioned independently from the `ca`/`ca-codex` release cadence. Each
+`ca-pi-v<version>` tag is the reproducible evidence channel, while npm is the convenience channel
+at `npm:@arbiterforge/ca-pi`. Pi does not auto-update either channel.
 
 List the published tags, then compare them with the exact source shown by `pi list`:
 
@@ -93,14 +94,29 @@ git ls-remote --tags --refs https://github.com/arbiterForge/codeArbiter.git "ca-
 pi list
 ```
 
-**Upgrade or pin a version:** choose an exact tag from the first command and re-run `pi install`
+**Upgrade through npm:** reinstall the convenience package:
+
+```text
+pi install npm:@arbiterforge/ca-pi
+```
+
+**Upgrade or pin through Git:** choose an exact tag from the first command and re-run `pi install`
 with that full tag:
 
 ```text
 pi install git:github.com/arbiterForge/codeArbiter@ca-pi-v<new-version>
 ```
 
-**Uninstall:** copy the exact installed Git source from `pi list` so the removal target matches:
+**Uninstall:** copy the exact installed source from `pi list` so the removal target matches. Remove
+the npm package or the pinned Git source, whichever is listed.
+
+For an npm install:
+
+```text
+pi remove npm:@arbiterforge/ca-pi
+```
+
+For a pinned-Git install:
 
 ```text
 pi remove git:github.com/arbiterForge/codeArbiter@ca-pi-v<version>
@@ -176,9 +192,11 @@ Codex:
 codex plugin remove ca-codex@codearbiter
 ```
 
-Pi (Git-only; use `pi list` to copy the installed source and the tag lookup in [Pi](#pi) above):
+Pi (use `pi list` to copy the installed npm or pinned-Git source, then run exactly one matching
+command; see [Pi](#pi) above):
 
 ```sh
+pi remove npm:@arbiterforge/ca-pi
 pi remove git:github.com/arbiterForge/codeArbiter@ca-pi-v<version>
 ```
 
@@ -190,8 +208,8 @@ The effect is host-specific:
   behind when the marketplace version string has not changed, so `uninstall` is the clean path.
 - **Codex removes** the `ca-codex@codearbiter` plugin registration and stops discovering its packaged
   skills and hooks in subsequent sessions.
-- **Pi removes** the selected Git package source from Pi's installed packages. New sessions stop
-  loading the codeArbiter extension, skills, prompts, and theme from that source.
+- **Pi removes** the selected npm or pinned-Git package source from Pi's installed packages. New
+  sessions stop loading the codeArbiter extension, skills, prompts, and theme from that source.
 
 The marketplace entry (`codearbiter`) itself was added at install time with
 `/plugin marketplace add arbiterForge/codeArbiter`. If you want that gone too, you can manage it

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -9,11 +9,13 @@ journey:
   proof: "You can identify who routes, who implements, who reviews, and who resolves a gate."
 ---
 
-codeArbiter ships four sibling plugins from one marketplace. Three are governance hosts: `ca` for
-Claude Code, `ca-codex` for Codex, and `ca-pi` for Pi. The fourth is `ca-sandbox`, an infrastructure
-plugin unrelated to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)). All three governance
-hosts inject the same orchestrator responsibilities, enforce the same policy core, and use one
-checked-in `.codearbiter/` directory for project context and audit state. See the
+codeArbiter is one governance product with three host adapters: `ca` for Claude Code, `ca-codex`
+for Codex, and `ca-pi` for Pi. The Claude Code marketplace also carries `ca-sandbox`, an
+infrastructure plugin unrelated to gate enforcement (see [ca-sandbox](/guides/ca-sandbox/)); the
+Codex marketplace carries `ca-codex`, while Pi uses npm with pinned Git tags as the reproducible
+channel. All three governance adapters inject the same orchestrator responsibilities, enforce the
+same policy core, and use one checked-in `.codearbiter/` directory for project context and audit
+state. See the
 [Claude Code + Codex evidence](/getting-started/claude-code-and-codex/) for the verified boundary
 between those two, and [Pi](/getting-started/pi/) for the third host's install and trust model.
 The complete `ca-pi` adapter is currently a Feature Forge `preview`: real use
@@ -36,10 +38,11 @@ your behalf.
 2. **Route.** The orchestrator hands the command to the workflow that owns that lane.
    `/ca:fix` and `$ca-fix` both reach the same test-first obligations.
 3. **Execute the roles.** The owning skill selects the author and reviewer roles the change actually
-   demands. Claude Code dispatches plugin agents. Current Codex releases load the same charters into
-   host-provided agent threads and retain their thread receipts; older hosts may use an inline
-   fallback unless the workflow requires isolation. Pi launches hardened child processes through
-   its trusted parent. The policy stays shared even though each host's mechanism differs.
+   demands. Claude Code dispatches plugin agents. The Codex source candidate includes the same
+   packaged resource charters for host-provided agent threads; exact-candidate proof gates their
+   release, while older adapters may use an inline fallback unless the workflow requires isolation.
+   Pi launches hardened child processes through its trusted parent. The policy stays shared even
+   though each host's mechanism differs.
 4. **Gate.** Nothing advances until its gates are green. A failing test, a CRITICAL
    security finding, an unresolved decision: each is a real stop.
 5. **Ship.** Code reaches version control only through the commit gate, and the default

--- a/site/src/curated/commands/checkpoint.md
+++ b/site/src/curated/commands/checkpoint.md
@@ -17,8 +17,9 @@ re-zeros the `over:N` overrides-since-checkpoint counter the statusline shows, b
 current `overrides.log` line count to `.codearbiter/last-checkpoint`. This is a report, not a
 promotion gate — it surfaces findings and enforces no sign-off.
 
-On current Codex hosts, codeArbiter loads each reviewer charter into a host-provided agent thread and
-retains its thread receipt. An older host may run a review role inline rather than skip it — see
+The Codex source candidate includes each packaged reviewer resource charter for host-provided agent
+threads; exact-candidate proof gates release. An older adapter may run a review role inline rather
+than skip it — see
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/pr.md
+++ b/site/src/curated/commands/pr.md
@@ -25,8 +25,9 @@ draft cold until it's addressed. Once everything clears, the PR itself gets writ
 summary, a test plan, and links to any decision record it touches — then, if you've opted into CI
 babysitting, a watcher attaches to follow the checks through to green.
 
-On current Codex hosts, codeArbiter loads each reviewer charter into a host-provided agent thread and
-retains its thread receipt. An older host may run a review role inline rather than skip it — see
+The Codex source candidate includes each packaged reviewer resource charter for host-provided agent
+threads; exact-candidate proof gates release. An older adapter may run a review role inline rather
+than skip it — see
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/review.md
+++ b/site/src/curated/commands/review.md
@@ -24,8 +24,9 @@ Findings are surfaced by severity (CRITICAL/HIGH/MEDIUM/LOW), file:line, remedia
 security findings — the specific control in `.codearbiter/security-controls.md` they map to. Raw
 per-reviewer output is never consumed directly; only the triaged, aggregated verdict is.
 
-On current Codex hosts, codeArbiter loads each reviewer charter into a host-provided agent thread and
-retains its thread receipt. An older host may run a review role inline rather than skip it — see
+The Codex source candidate includes each packaged reviewer resource charter for host-provided agent
+threads; exact-candidate proof gates release. An older adapter may run a review role inline rather
+than skip it — see
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/tribunal.md
+++ b/site/src/curated/commands/tribunal.md
@@ -44,8 +44,9 @@ On a large repo, two optional read-only mappers ([`map-structure`](/reference/ag
 and [`map-deps`](/reference/agents/map-deps/)) build the codebase inventory ahead of the lenses, so
 that mapping work stays off the orchestrator's own context.
 
-On current Codex hosts, codeArbiter loads each lens charter into a host-provided agent thread and
-retains its thread receipt. An older host may run a lens inline rather than silently omit it — see
+The Codex source candidate includes each packaged lens resource charter for host-provided agent
+threads; exact-candidate proof gates release. An older adapter may run a lens inline rather than
+silently omit it — see
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 


### PR DESCRIPTION
## Summary

- Define `core/` as the internal governance source of truth and describe Claude, Codex, and Pi as separately packaged host adapters.
- Correct active install, uninstall, architecture, parity, enforcement, and security guidance to match the shipped host-specific boundaries.
- Add a focused regression contract for product identity, marketplace topology, Pi distribution, Codex resource-charter claims, and hook network/write disclosures.

## Why

PR #711 shipped the shared root and Codex charter packaging work. Active project and public documentation still mixed the old Claude-centered product identity with outdated Codex and Pi distribution claims. This change brings the active non-payload documentation in line with the shipped architecture without rewriting historical records or changing package bytes.

## Tradeoff

Host-specific terms remain where they describe real host behavior. Cross-host pages use the normalized Arbiter root only as an internal resolved value, not as a promised ambient environment variable. Codex charters are described as packaged resources used through host dispatch, not as native plugin-agent registration. This follows accepted [ADR-0031](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0031-cross-host-plugin-root-and-agent-charter-resolution.md).

## Test plan

- `python .github/scripts/test_public_codex_docs.py` (7 passed)
- `python .github/scripts/test_public_pi_docs.py` (13 passed)
- `python .github/scripts/test_consumer_smoke.py` (71 passed, 1 intentional skip)
- `python .github/scripts/test_mode_surface.py` (5 passed)
- `python .github/scripts/check_skill_portability.py`
- Full required repository Python matrix, including 1,401 hook tests
- Site typecheck, 549 Vitest tests with a 10-second host threshold, 154-page build, and 26,005-link audit
- Site coverage with the same 10-second threshold: 74.11% lines and 73.65% branches, above the Stage 2 floor
- Rendered browser inspection at 1440x900 and 390x844 with no horizontal overflow
- `git diff --check`

The default site test command also reached 548 passing tests before the unchanged `academy-source.test.ts` fixture exceeded its fixed 5-second timeout on this host. That focused test passes unchanged, and the complete suite passes 549 of 549 with the explicit 10-second threshold.

## Scope

This PR changes 18 active Markdown files and one documentation regression test. It changes no plugin payload, runtime core, manifest, version, changelog, workflow, ADR body, historical plan, release receipt, or audit record.
