### PR TITLE
fix(desktop-proof): normalize null switch bindings

### DIFF
--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3774,3 +3774,4 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-08-30T22:26:51Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-08-31T00:59:14Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-08-31T01:01:10Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-08-31T01:40:25Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3772,3 +3772,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-08-30T21:45:41Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-08-30T21:47:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-08-30T22:26:51Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-08-31T00:59:14Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-08-31T01:01:10Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.github/desktop-proof-boundary.json
+++ b/.github/desktop-proof-boundary.json
@@ -3,7 +3,7 @@
   "broker": {
     "source_path": ".github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1",
     "installed_path": "C:\\codearbiter-runner\\Invoke-CodeArbiterDesktopCandidate.ps1",
-    "sha256": "f30325df920c018de147930632593ecaa0759f5460d678e2137b860f2f931cbb"
+    "sha256": "ced7f11e26e52c80b35d6ba202b8c1037e4c6f58215853b17ec4b79edea73a29"
   },
   "driver": {
     "source_path": ".github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1",

--- a/.github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1
+++ b/.github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1
@@ -313,8 +313,10 @@ function Get-ObservedVmSwitchInventory {
             allow_management_os = [bool]$_.AllowManagementOS
             allow_net_lbfo_teams = [bool]$_.AllowNetLbfoTeams
             physical_adapter_interface_description = $_.NetAdapterInterfaceDescription
-            physical_adapter_interface_descriptions = @($_.NetAdapterInterfaceDescriptions)
-            physical_adapter_interface_guids = @($_.NetAdapterInterfaceGuid | ForEach-Object {
+            physical_adapter_interface_descriptions = @($_.NetAdapterInterfaceDescriptions |
+                Where-Object { $null -ne $_ })
+            physical_adapter_interface_guids = @($_.NetAdapterInterfaceGuid |
+                Where-Object { $null -ne $_ } | ForEach-Object {
                 $_.ToString('D').ToLowerInvariant()
             })
             bandwidth_reservation_mode = [string]$_.BandwidthReservationMode

--- a/.github/scripts/test_codex_desktop_boundary.py
+++ b/.github/scripts/test_codex_desktop_boundary.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 import zipfile
 
 
@@ -100,10 +101,10 @@ $function = $ast.Find({
 }, $true)
 if ($null -eq $function) { throw 'observation function is missing' }
 Invoke-Expression $function.Extent.Text
-$physicalDescription = if ($env:CODEARBITER_PHYSICAL_DESCRIPTION) {
+$physicalDescription = if ($null -ne $env:CODEARBITER_PHYSICAL_DESCRIPTION) {
     $env:CODEARBITER_PHYSICAL_DESCRIPTION
 } else { $null }
-$physicalGuid = if ($env:CODEARBITER_PHYSICAL_GUID) {
+$physicalGuid = if ($null -ne $env:CODEARBITER_PHYSICAL_GUID) {
     [guid]$env:CODEARBITER_PHYSICAL_GUID
 } else { $null }
 function Get-VMSwitch {
@@ -120,6 +121,8 @@ function Get-VMSwitch {
 """
     environment = os.environ.copy()
     environment["CODEARBITER_BROKER_SOURCE"] = str(BROKER)
+    environment.pop("CODEARBITER_PHYSICAL_DESCRIPTION", None)
+    environment.pop("CODEARBITER_PHYSICAL_GUID", None)
     if physical_description is not None:
         environment["CODEARBITER_PHYSICAL_DESCRIPTION"] = physical_description
     if physical_guid is not None:
@@ -890,7 +893,12 @@ class DesktopBoundaryContractTest(unittest.TestCase):
         )
 
     def test_live_null_vm_switch_bindings_normalize_to_empty_collections(self):
-        observed = run_observed_vm_switch_inventory()
+        inherited = {
+            "CODEARBITER_PHYSICAL_DESCRIPTION": "inherited adapter",
+            "CODEARBITER_PHYSICAL_GUID": "77777777-7777-7777-7777-777777777777",
+        }
+        with mock.patch.dict(os.environ, inherited):
+            observed = run_observed_vm_switch_inventory()
         self.assertEqual(observed.returncode, 0, observed.stdout + observed.stderr)
         payload = json.loads(observed.stdout)
         self.assertIsNone(payload["physical_adapter_interface_description"])
@@ -909,6 +917,13 @@ class DesktopBoundaryContractTest(unittest.TestCase):
         self.assertEqual(payload["physical_adapter_interface_description"], description)
         self.assertEqual(payload["physical_adapter_interface_descriptions"], [description])
         self.assertEqual(payload["physical_adapter_interface_guids"], [guid])
+
+    def test_live_empty_vm_switch_description_survives_normalization(self):
+        observed = run_observed_vm_switch_inventory(physical_description="")
+        self.assertEqual(observed.returncode, 0, observed.stdout + observed.stderr)
+        payload = json.loads(observed.stdout)
+        self.assertEqual(payload["physical_adapter_interface_description"], "")
+        self.assertEqual(payload["physical_adapter_interface_descriptions"], [""])
 
     def test_broker_has_no_hyper_v_switch_mutation_commands(self):
         environment = os.environ.copy()

--- a/.github/scripts/test_codex_desktop_boundary.py
+++ b/.github/scripts/test_codex_desktop_boundary.py
@@ -81,6 +81,63 @@ def run_contract_payload(
         contract_path.unlink(missing_ok=True)
 
 
+def run_observed_vm_switch_inventory(
+    *,
+    physical_description: str | None = None,
+    physical_guid: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = r"""
+$tokens = $null
+$errors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile(
+    $env:CODEARBITER_BROKER_SOURCE, [ref]$tokens, [ref]$errors
+)
+if ($errors.Count -ne 0) { throw 'broker parse failed' }
+$function = $ast.Find({
+    param($node)
+    $node -is [Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -ceq 'Get-ObservedVmSwitchInventory'
+}, $true)
+if ($null -eq $function) { throw 'observation function is missing' }
+Invoke-Expression $function.Extent.Text
+$physicalDescription = if ($env:CODEARBITER_PHYSICAL_DESCRIPTION) {
+    $env:CODEARBITER_PHYSICAL_DESCRIPTION
+} else { $null }
+$physicalGuid = if ($env:CODEARBITER_PHYSICAL_GUID) {
+    [guid]$env:CODEARBITER_PHYSICAL_GUID
+} else { $null }
+function Get-VMSwitch {
+    [pscustomobject]@{
+        Id = [guid]'11111111-1111-1111-1111-111111111111'
+        Name = 'Default Switch'
+        SwitchType = 'Internal'
+        NetAdapterInterfaceDescription = $physicalDescription
+        NetAdapterInterfaceDescriptions = $physicalDescription
+        NetAdapterInterfaceGuid = $physicalGuid
+    }
+}
+@(Get-ObservedVmSwitchInventory) | ConvertTo-Json -Depth 5 -Compress
+"""
+    environment = os.environ.copy()
+    environment["CODEARBITER_BROKER_SOURCE"] = str(BROKER)
+    if physical_description is not None:
+        environment["CODEARBITER_PHYSICAL_DESCRIPTION"] = physical_description
+    if physical_guid is not None:
+        environment["CODEARBITER_PHYSICAL_GUID"] = physical_guid
+    return subprocess.run(
+        [
+            powershell(), "-NoLogo", "-NoProfile", "-NonInteractive",
+            "-Command", command,
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+
 def vm_switch_observation(
     name: str = "Default Switch",
     switch_id: str = "11111111-1111-1111-1111-111111111111",
@@ -831,6 +888,27 @@ class DesktopBoundaryContractTest(unittest.TestCase):
             reordered_payload["before_inventory_sha256"],
             reordered_payload["after_inventory_sha256"],
         )
+
+    def test_live_null_vm_switch_bindings_normalize_to_empty_collections(self):
+        observed = run_observed_vm_switch_inventory()
+        self.assertEqual(observed.returncode, 0, observed.stdout + observed.stderr)
+        payload = json.loads(observed.stdout)
+        self.assertIsNone(payload["physical_adapter_interface_description"])
+        self.assertEqual(payload["physical_adapter_interface_descriptions"], [])
+        self.assertEqual(payload["physical_adapter_interface_guids"], [])
+
+    def test_live_non_null_vm_switch_bindings_survive_normalization(self):
+        description = "Intel(R) Wi-Fi 7 BE200"
+        guid = "66666666-6666-6666-6666-666666666666"
+        observed = run_observed_vm_switch_inventory(
+            physical_description=description,
+            physical_guid=guid,
+        )
+        self.assertEqual(observed.returncode, 0, observed.stdout + observed.stderr)
+        payload = json.loads(observed.stdout)
+        self.assertEqual(payload["physical_adapter_interface_description"], description)
+        self.assertEqual(payload["physical_adapter_interface_descriptions"], [description])
+        self.assertEqual(payload["physical_adapter_interface_guids"], [guid])
 
     def test_broker_has_no_hyper_v_switch_mutation_commands(self):
         environment = os.environ.copy()


### PR DESCRIPTION
## Summary

- Normalize null Hyper-V physical adapter descriptions and GUIDs to empty collections before canonical inventory checks.
- Preserve every non-null description and GUID so the broker still rejects any real physical binding.
- Exercise the production observation function with null and non-null live-shaped fixtures, then bind the trusted manifest to the exact broker digest.

## Why

An unbound Internal Default Switch reports these properties as null. PowerShell array coercion previously represented that absence as a populated `[null]` collection, so the broker rejected the approved switch before runner dispatch.

## Verification

- `python .github/scripts/test_codex_desktop_boundary.py` (33 passed)
- `python .github/scripts/test_codex_skill_resources.py` (156 passed, 1 unchanged platform skip)
- `python .github/scripts/test_ci_impact.py` (61 passed)
- Full repository test matrix from `.codearbiter/tech-stack.md`
- `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` (1,401 passed with Git Bash on PATH and `NO_COLOR` unset)
- PowerShell AST parse and exact broker SHA-256 binding
- Coverage, auth/crypto, and security reviewers: zero findings

This is a bounded prerequisite for the protected desktop proof in #711. It does not install the broker, register a runner, dispatch a workflow, or change network configuration.