### PR TITLE
fix(desktop-proof): preserve trusted script bytes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,6 +35,12 @@ docs/**/*.md    text eol=lf
 .github/workflows/*.yml text eol=lf
 .github/actions/**/*.yml text eol=lf
 
+# These scripts are a literal-byte trust boundary: the manifest hashes their
+# tracked Git blobs and the protected Windows runner validates checkout bytes.
+/.github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1 text eol=lf
+/.github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1 text eol=lf
+/.github/scripts/Invoke-CodeArbiterDesktopRouteProbe.ps1 text eol=lf
+
 # TypeScript/JavaScript/JSON across the plugin and site trees. #515 showed this
 # is not cosmetic. An editor pass on Windows flipped farm.ts and
 # farm.unit.test.ts to CRLF, which made git read the ENTIRE file as added — and

--- a/.github/scripts/test_codex_desktop_boundary.py
+++ b/.github/scripts/test_codex_desktop_boundary.py
@@ -27,6 +27,11 @@ BROKER = SCRIPTS / "Invoke-CodeArbiterDesktopCandidate.ps1"
 PROBE = SCRIPTS / "Invoke-CodeArbiterDesktopRouteProbe.ps1"
 DRIVER = SCRIPTS / "Invoke-CodeArbiterDesktopUiDriver.ps1"
 CHECKER = SCRIPTS / "check_codex_skill_resources.py"
+TRUSTED_DESKTOP_SCRIPTS = (
+    ".github/scripts/Invoke-CodeArbiterDesktopCandidate.ps1",
+    ".github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1",
+    ".github/scripts/Invoke-CodeArbiterDesktopRouteProbe.ps1",
+)
 
 
 def sha256_text(value: str) -> str:
@@ -378,6 +383,81 @@ def run_broker_json_fixture(
 
 class DesktopBoundaryContractTest(unittest.TestCase):
     maxDiff = None
+
+    def test_fresh_autocrlf_checkout_preserves_trusted_boundary_bytes(self):
+        with tempfile.TemporaryDirectory() as temp:
+            temp_root = Path(temp)
+            source = temp_root / "source"
+            checkout = temp_root / "checkout"
+            source.mkdir()
+
+            tracked = subprocess.run(
+                ["git", "ls-files", "-z"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                check=True,
+            ).stdout.decode("utf-8").split("\0")
+            for relative in filter(None, tracked):
+                source_path = REPO_ROOT / relative
+                if source_path.is_dir():
+                    continue
+                destination = source / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, destination)
+
+            for command in (
+                ["git", "init", "--quiet"],
+                ["git", "config", "user.name", "CodeArbiter Test"],
+                ["git", "config", "user.email", "codearbiter-test@example.invalid"],
+                ["git", "config", "core.autocrlf", "false"],
+                ["git", "add", "--all"],
+                ["git", "commit", "--quiet", "-m", "fixture"],
+            ):
+                subprocess.run(command, cwd=source, check=True, capture_output=True)
+
+            subprocess.run(
+                [
+                    "git", "-c", "core.autocrlf=true", "clone", "--quiet",
+                    "--no-local", str(source), str(checkout),
+                ],
+                check=True,
+                capture_output=True,
+            )
+
+            mismatches = []
+            for relative in TRUSTED_DESKTOP_SCRIPTS:
+                tracked_blob = subprocess.run(
+                    ["git", "rev-parse", f"HEAD:{relative}"],
+                    cwd=checkout,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                ).stdout.strip()
+                literal_blob = subprocess.run(
+                    ["git", "hash-object", "--no-filters", relative],
+                    cwd=checkout,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                ).stdout.strip()
+                if literal_blob != tracked_blob:
+                    mismatches.append(relative)
+            self.assertEqual(mismatches, [])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(checkout / ".github" / "scripts" / "check_codex_skill_resources.py"),
+                    "--desktop-boundary-contract-only",
+                    "--json",
+                ],
+                cwd=checkout,
+                text=True,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def setUp(self) -> None:
         self.contract = json.loads(CONTRACT.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Keep the trusted desktop broker, UI driver, and route probe byte-identical to their tracked Git blobs after a fresh Windows checkout with `core.autocrlf=true`.
- Add a regression that builds a temporary Git repository, performs a real fresh checkout, compares literal checkout blobs with tracked blobs, and runs the trusted desktop-boundary validator.
- Preserve the existing manifest and trusted script bytes. This changes checkout policy and test coverage only.

## Why

The protected runner checked out the three trusted PowerShell scripts with CRLF line endings. Their tracked blobs and installed copies were still correct, but the working-tree byte hashes no longer matched the manifest, so validation stopped before protected proof dispatch.

This is a prerequisite for #711.

## Verification

- Required RED: the new test reported literal-byte mismatches for all three trusted scripts in a fresh `core.autocrlf=true` checkout.
- Focused GREEN: the unchanged regression passed after the exact-path LF rules were added.
- Desktop boundary suite: 35 tests passed.
- Codex resource suite: 156 tests passed, 1 skipped.
- CI impact suite: 61 tests passed.
- Hook suite: 1,401 tests passed.
- All other test commands declared in `.codearbiter/tech-stack.md` passed.
- `check_codex_skill_resources.py --desktop-boundary-contract-only --json` returned `PASS` with the original broker, driver, probe, and contract hashes.
- Security, coverage, and architecture review returned zero findings. ADR-0011 and ADR-0031 remain confirmed.

## Coverage note

This repository has no coverage tooling for `.github/scripts/*.py`, as documented in `.codearbiter/tech-stack.md`. The Stage 2 numeric coverage floor therefore uses the documented no-tooling exemption. The regression exercises the real Git checkout and validator behavior without mocks.

## Release impact

No shipped plugin payload changed, so no package has an affected version to advance. The commit includes the required repository `CHANGELOG:` record.

## Tradeoff and boundaries

Conflict hierarchy Level 2 applies: byte correctness at the trusted boundary takes priority over the convenience of a broad `*.ps1` rule. The LF contract names exactly three files so unrelated PowerShell checkout behavior remains unchanged.

This PR does not authorize merge, tag, release, publication, or deployment.

Ref: ADR-0031
