### PR TITLE
ci(codex): add trusted static candidate verifier

### DIFF
--- a/.github/scripts/check_codex_skill_resources.py
+++ b/.github/scripts/check_codex_skill_resources.py
@@ -2212,15 +2212,20 @@ def _candidate_package_files(path: Path) -> dict[str, bytes]:
         if not package_root.is_dir():
             package_root = path
         package_root = package_root.resolve()
-        entries: list[tuple[str, Path]] = []
+        entries: list[tuple[str, Path, os.stat_result]] = []
         pending = [package_root]
         seen_entries = 0
         while pending:
             directory = pending.pop()
-            for item in sorted(directory.iterdir(), key=lambda candidate: candidate.name):
-                seen_entries += 1
-                if seen_entries > limits["max_entries"]:
-                    raise ValueError("candidate directory exceeds the entry-count limit")
+            names: list[str] = []
+            with os.scandir(directory) as scan:
+                for scanned in scan:
+                    seen_entries += 1
+                    if seen_entries > limits["max_entries"]:
+                        raise ValueError("candidate directory exceeds the entry-count limit")
+                    names.append(scanned.name)
+            for name in sorted(names):
+                item = directory / name
                 metadata = item.lstat()
                 if (
                     item.is_symlink()
@@ -2239,17 +2244,35 @@ def _candidate_package_files(path: Path) -> dict[str, bytes]:
                     relative = resolved.relative_to(package_root).as_posix()
                 except ValueError as error:
                     raise ValueError("candidate package file escapes package root") from error
-                entries.append((relative, item))
-        _validate_candidate_paths(relative for relative, _ in entries)
+                entries.append((relative, item, metadata))
+        _validate_candidate_paths(relative for relative, _, _ in entries)
         total_bytes = 0
-        for relative, item in entries:
-            size = item.stat().st_size
-            if size > limits["max_total_uncompressed_bytes"] - total_bytes:
-                raise ValueError("candidate directory exceeds the total-size limit")
-            total_bytes += size
-            content = item.read_bytes()
+        for relative, item, metadata in entries:
+            output = io.BytesIO()
+            with item.open("rb") as source:
+                opened = os.fstat(source.fileno())
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino)
+                ):
+                    raise ValueError("candidate directory entry changed while being read")
+                size = opened.st_size
+                if size > limits["max_entry_uncompressed_bytes"]:
+                    raise ValueError("candidate directory entry exceeds the size limit")
+                if size > limits["max_total_uncompressed_bytes"] - total_bytes:
+                    raise ValueError("candidate directory exceeds the total-size limit")
+                while True:
+                    remaining_expected = size - output.tell()
+                    chunk = source.read(min(64 * 1024, remaining_expected + 1))
+                    if not chunk:
+                        break
+                    output.write(chunk)
+                    if output.tell() > size:
+                        raise ValueError("candidate directory entry changed while being read")
+            content = output.getvalue()
             if len(content) != size:
                 raise ValueError("candidate directory entry changed while being read")
+            total_bytes += len(content)
             files[relative] = content
         return files
     raise ValueError("candidate package must be a ca-codex directory or ZIP archive")

--- a/.github/scripts/check_codex_skill_resources.py
+++ b/.github/scripts/check_codex_skill_resources.py
@@ -2200,6 +2200,7 @@ def _candidate_package_files(path: Path) -> dict[str, bytes]:
                 files[relative] = output.getvalue()
         return files
     if path.is_dir():
+        limits = _candidate_archive_limits()
         package_root = path / "plugins" / "ca-codex"
         package_metadata = package_root.lstat() if package_root.exists() or package_root.is_symlink() else None
         if (
@@ -2213,9 +2214,13 @@ def _candidate_package_files(path: Path) -> dict[str, bytes]:
         package_root = package_root.resolve()
         entries: list[tuple[str, Path]] = []
         pending = [package_root]
+        seen_entries = 0
         while pending:
             directory = pending.pop()
             for item in sorted(directory.iterdir(), key=lambda candidate: candidate.name):
+                seen_entries += 1
+                if seen_entries > limits["max_entries"]:
+                    raise ValueError("candidate directory exceeds the entry-count limit")
                 metadata = item.lstat()
                 if (
                     item.is_symlink()
@@ -2227,6 +2232,8 @@ def _candidate_package_files(path: Path) -> dict[str, bytes]:
                     continue
                 if not stat.S_ISREG(metadata.st_mode):
                     raise ValueError("candidate package contains a non-regular file")
+                if metadata.st_size > limits["max_entry_uncompressed_bytes"]:
+                    raise ValueError("candidate directory entry exceeds the size limit")
                 resolved = item.resolve()
                 try:
                     relative = resolved.relative_to(package_root).as_posix()
@@ -2234,8 +2241,16 @@ def _candidate_package_files(path: Path) -> dict[str, bytes]:
                     raise ValueError("candidate package file escapes package root") from error
                 entries.append((relative, item))
         _validate_candidate_paths(relative for relative, _ in entries)
+        total_bytes = 0
         for relative, item in entries:
-            files[relative] = item.read_bytes()
+            size = item.stat().st_size
+            if size > limits["max_total_uncompressed_bytes"] - total_bytes:
+                raise ValueError("candidate directory exceeds the total-size limit")
+            total_bytes += size
+            content = item.read_bytes()
+            if len(content) != size:
+                raise ValueError("candidate directory entry changed while being read")
+            files[relative] = content
         return files
     raise ValueError("candidate package must be a ca-codex directory or ZIP archive")
 
@@ -2775,7 +2790,11 @@ def _supported_template_resource(resolved: str) -> bool:
 
 def candidate_resource_contract(path: Path) -> dict[str, Any]:
     """Derive the exact packaged Markdown resource set and contained read graph."""
-    files = _candidate_package_files(path)
+    return _candidate_resource_contract_from_files(_candidate_package_files(path))
+
+
+def _candidate_resource_contract_from_files(files: dict[str, bytes]) -> dict[str, Any]:
+    """Derive the resource graph from one already bounded immutable snapshot."""
     resource_paths = sorted(
         relative
         for relative in files

--- a/.github/scripts/check_codex_static_package.py
+++ b/.github/scripts/check_codex_static_package.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Validate a ca-codex package as inert, bounded static data."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import posixpath
+import re
+import sys
+from typing import Any
+
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+RESOURCE_CHECKER_PATH = SCRIPT_ROOT / "check_codex_skill_resources.py"
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+HOOK_EVENTS = frozenset(("SessionStart", "PreToolUse", "PostToolUse", "UserPromptSubmit"))
+HOOK_GROUP_FIELDS = frozenset(("matcher", "hooks"))
+HOOK_ENTRY_FIELDS = frozenset((
+    "type", "command", "commandWindows", "timeout", "statusMessage",
+    "additionalContextLimit",
+))
+HOOK_COMMAND = {
+    "command": re.compile(
+        r'^python3 "\$\{PLUGIN_ROOT\}/hooks/([A-Za-z0-9._-]+\.py)"$'
+    ),
+    "commandWindows": re.compile(
+        r'^python "\$\{PLUGIN_ROOT\}/hooks/([A-Za-z0-9._-]+\.py)"$'
+    ),
+}
+EXPECTED_HOOK_MANIFEST_SHA256 = (
+    "1a6f938ca91046b9e525e58de6afcfb543fa512e4a541e87b400e74575a7b062"
+)
+
+
+class _DuplicateJsonMember(ValueError):
+    pass
+
+
+def _unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonMember
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON value is not permitted: {value}")
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _load_resource_checker():
+    if not RESOURCE_CHECKER_PATH.is_file():
+        raise ValueError("trusted candidate resource checker is missing")
+    spec = importlib.util.spec_from_file_location(
+        "codearbiter_trusted_candidate_resources", RESOURCE_CHECKER_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError("trusted candidate resource checker cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _candidate_json(files: dict[str, bytes], path: str, label: str) -> object:
+    try:
+        text = files[path].decode("utf-8")
+    except KeyError as error:
+        raise ValueError(f"candidate {label} is missing") from error
+    except UnicodeDecodeError as error:
+        raise ValueError(f"candidate {label} is not UTF-8") from error
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=_unique_json_object,
+            parse_constant=_reject_json_constant,
+        )
+    except _DuplicateJsonMember as error:
+        raise ValueError(f"candidate {label} has a duplicate JSON member") from error
+    except json.JSONDecodeError as error:
+        raise ValueError(f"candidate {label} is invalid JSON") from error
+
+
+def _candidate_front_matter(
+    files: dict[str, bytes], path: str, required_fields: tuple[str, ...]
+) -> dict[str, str]:
+    try:
+        text = files[path].decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"candidate resource is not UTF-8: {path}") from error
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        raise ValueError(f"candidate resource has no front matter: {path}")
+    try:
+        closing = lines.index("---", 1)
+    except ValueError as error:
+        raise ValueError(f"candidate resource has unterminated front matter: {path}") from error
+    fields: dict[str, str] = {}
+    for line in lines[1:closing]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = re.fullmatch(r"([a-z][a-z0-9-]*):[ \t]*(.*)", line)
+        if match is None:
+            raise ValueError(f"candidate resource has invalid front matter: {path}")
+        key = match.group(1)
+        if key in fields:
+            raise ValueError(
+                f"candidate resource has duplicate front matter field {key}: {path}"
+            )
+        value = match.group(2).strip()
+        begins_quoted = value[:1] in {'"', "'"}
+        ends_quoted = value[-1:] in {'"', "'"}
+        if begins_quoted or ends_quoted:
+            if len(value) < 2 or not begins_quoted or value[-1] != value[0]:
+                raise ValueError(
+                    f"candidate resource has malformed quoted front matter: {path}"
+                )
+            if value[0] == '"':
+                try:
+                    decoded = json.loads(value)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        f"candidate resource has malformed quoted front matter: {path}"
+                    ) from error
+                if not isinstance(decoded, str):
+                    raise ValueError(
+                        f"candidate resource has invalid quoted front matter: {path}"
+                    )
+                value = decoded
+            else:
+                interior = value[1:-1]
+                if "'" in interior.replace("''", ""):
+                    raise ValueError(
+                        f"candidate resource has malformed quoted front matter: {path}"
+                    )
+                value = interior.replace("''", "'")
+        fields[key] = value
+    for field in required_fields:
+        if not fields.get(field):
+            raise ValueError(
+                f"candidate resource front matter is missing {field}: {path}"
+            )
+    return fields
+
+
+def _candidate_hook_targets(hooks: object) -> list[str]:
+    if not isinstance(hooks, dict) or set(hooks) != {"hooks"}:
+        raise ValueError("candidate hook manifest schema is invalid")
+    events = hooks["hooks"]
+    if not isinstance(events, dict) or not events or not set(events).issubset(HOOK_EVENTS):
+        raise ValueError("candidate hook manifest schema has invalid events")
+    targets: list[str] = []
+    for groups in events.values():
+        if not isinstance(groups, list) or not groups:
+            raise ValueError("candidate hook manifest event must contain hook groups")
+        for group in groups:
+            if (
+                not isinstance(group, dict)
+                or "hooks" not in group
+                or not set(group).issubset(HOOK_GROUP_FIELDS)
+                or "matcher" in group and not isinstance(group["matcher"], str)
+            ):
+                raise ValueError("candidate hook manifest schema has an invalid group")
+            entries = group["hooks"]
+            if not isinstance(entries, list) or not entries:
+                raise ValueError("candidate hook group must contain hook entries")
+            for entry in entries:
+                if (
+                    not isinstance(entry, dict)
+                    or set(entry) - HOOK_ENTRY_FIELDS
+                    or entry.get("type") != "command"
+                ):
+                    raise ValueError("candidate hook manifest schema has an invalid entry")
+                if "timeout" in entry and (
+                    not isinstance(entry["timeout"], int)
+                    or isinstance(entry["timeout"], bool)
+                    or entry["timeout"] <= 0
+                ):
+                    raise ValueError("candidate hook manifest schema has an invalid timeout")
+                if "statusMessage" in entry and (
+                    not isinstance(entry["statusMessage"], str)
+                    or not entry["statusMessage"].strip()
+                ):
+                    raise ValueError("candidate hook manifest schema has an invalid status")
+                if "additionalContextLimit" in entry and (
+                    not isinstance(entry["additionalContextLimit"], int)
+                    or isinstance(entry["additionalContextLimit"], bool)
+                    or entry["additionalContextLimit"] <= 0
+                ):
+                    raise ValueError("candidate hook manifest schema has an invalid limit")
+                for command_field, grammar in HOOK_COMMAND.items():
+                    command = entry.get(command_field)
+                    match = grammar.fullmatch(command) if isinstance(command, str) else None
+                    if match is None:
+                        raise ValueError(
+                            "candidate hook command grammar is invalid or does not use PLUGIN_ROOT"
+                        )
+                    targets.append(f"hooks/{match.group(1)}")
+    canonical = json.dumps(hooks, separators=(",", ":"), sort_keys=True)
+    if _sha256_text(canonical) != EXPECTED_HOOK_MANIFEST_SHA256:
+        raise ValueError("candidate hook inventory does not match the approved contract")
+    return targets
+
+
+def candidate_static_contract(path: Path) -> dict[str, Any]:
+    resource_checker = _load_resource_checker()
+    files = resource_checker._candidate_package_files(path)
+    manifest = _candidate_json(files, ".codex-plugin/plugin.json", "plugin manifest")
+    if not isinstance(manifest, dict):
+        raise ValueError("candidate plugin manifest must be an object")
+    if manifest.get("name") != "ca-codex":
+        raise ValueError("candidate manifest name must be ca-codex")
+    version = manifest.get("version")
+    if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
+        raise ValueError("candidate plugin manifest version is invalid")
+
+    for relative in sorted(files):
+        if relative.startswith("skills/ca-") and relative.endswith("/SKILL.md"):
+            fields = _candidate_front_matter(files, relative, ("name", "description"))
+            expected_name = posixpath.basename(posixpath.dirname(relative))
+            if fields["name"] != expected_name:
+                raise ValueError(
+                    f"candidate skill front matter name does not match its path: {relative}"
+                )
+        elif relative.startswith("routines/") and relative.endswith("/SKILL.md"):
+            fields = _candidate_front_matter(files, relative, ("name", "description"))
+            expected_name = posixpath.basename(posixpath.dirname(relative))
+            if fields["name"] != expected_name:
+                raise ValueError(
+                    f"candidate routine front matter name does not match its path: {relative}"
+                )
+        elif (
+            relative.startswith("agents/")
+            and relative.endswith(".md")
+            and posixpath.basename(relative) != "INDEX.md"
+        ):
+            fields = _candidate_front_matter(
+                files, relative, ("name", "description", "classification")
+            )
+            expected_name = posixpath.basename(relative)[:-3]
+            if fields["name"] != expected_name:
+                raise ValueError(
+                    f"candidate agent front matter name does not match its path: {relative}"
+                )
+
+    hooks = _candidate_json(files, "hooks/hooks.json", "hook manifest")
+    for target in _candidate_hook_targets(hooks):
+        if target not in files:
+            raise ValueError(f"candidate hook target is missing: {target}")
+
+    resources = resource_checker._candidate_resource_contract_from_files(files)
+    package_manifest = {
+        "files": [
+            {"path": relative, "sha256": hashlib.sha256(content).hexdigest()}
+            for relative, content in sorted(files.items())
+        ]
+    }
+    package_sha256 = _sha256_text(
+        json.dumps(package_manifest, separators=(",", ":"), sort_keys=True)
+    )
+    return {
+        "verdict": "PASS",
+        "package_sha256": package_sha256,
+        "plugin_version": version,
+        "resource_sha256": resources["sha256"],
+        "resource_count": len(resources["selected_paths"]),
+        "relative_read_count": len(resources["relative_reads"]),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-package", required=True, type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        result = candidate_static_contract(args.candidate_package)
+    except (OSError, UnicodeError, ValueError, KeyError) as error:
+        result = {"verdict": "FAIL", "errors": [str(error)]}
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"candidate static contract valid: {result['package_sha256']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -835,7 +835,7 @@ class WorkflowContractTest(unittest.TestCase):
         self.assertIn("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", workflow)
         self.assertIn("actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6", workflow)
         self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", workflow)
-        self.assertIn("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02", workflow)
+        self.assertIn("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", workflow)
 
     def test_codex_desktop_candidate_executes_only_digest_bound_trusted_boundary_code(self):
         """O-01/O-03: candidate bytes stay inert and installed tools match trusted main."""
@@ -903,8 +903,12 @@ class WorkflowContractTest(unittest.TestCase):
             ".github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1",
             ".github/scripts/Invoke-CodeArbiterDesktopRouteProbe.ps1",
             ".github/scripts/check_codex_skill_resources.py",
+            ".github/scripts/check_codex_static_package.py",
             ".github/scripts/test_codex_desktop_boundary.py",
             ".github/scripts/test_codex_skill_resources.py",
+            ".github/scripts/test_codex_static_package.py",
+            ".github/scripts/test_codex_static_candidate.py",
+            ".github/scripts/verify_codex_static_candidate.py",
             "docs/reports/codex-skill-resource-resolution.md",
             "docs/reports/evidence/codex-skill-resource-resolution/**",
             ".github/workflows/codex-desktop-candidate.yml",
@@ -915,6 +919,16 @@ class WorkflowContractTest(unittest.TestCase):
         job = workflow_jobs(ci)["codex-resource-contract"]
         self.assertIn("needs.changes.outputs.codex-resources == 'true'", job)
         self.assertIn("run: python .github/scripts/test_codex_skill_resources.py", job)
+        self.assertIn("run: python .github/scripts/test_codex_static_package.py", job)
+        self.assertIn("run: python .github/scripts/test_codex_static_candidate.py", job)
+        self.assertIn(
+            "git archive --format=zip --output=ca-codex-static.zip HEAD -- plugins/ca-codex",
+            job,
+        )
+        self.assertIn(
+            "python .github/scripts/check_codex_static_package.py --candidate-package ca-codex-static.zip",
+            job,
+        )
         self.assertIn("run: python .github/scripts/test_codex_desktop_boundary.py", job)
         self.assertIn(
             "run: python .github/scripts/check_codex_skill_resources.py --fixtures-only", job

--- a/.github/scripts/test_codex_static_candidate.py
+++ b/.github/scripts/test_codex_static_candidate.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for trusted static ca-codex candidate verification."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / ".github" / "scripts" / "verify_codex_static_candidate.py"
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "ca-codex"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("codex_static_candidate", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git(repo: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments], cwd=repo, check=True, capture_output=True,
+        text=True, encoding="utf-8",
+    )
+    return result.stdout.strip()
+
+
+class StaticCandidateContractTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.repo = Path(self.temporary.name)
+        git(self.repo, "init", "-q")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        git(self.repo, "config", "user.name", "Static Candidate Test")
+        shutil.copytree(PLUGIN_ROOT, self.repo / "plugins" / "ca-codex")
+        fake = self.repo / ".github" / "scripts" / "check_codex_static_package.py"
+        fake.parent.mkdir(parents=True)
+        fake.write_text("raise RuntimeError('candidate verifier executed')\n", encoding="utf-8")
+        git(self.repo, "add", "--", ".")
+        git(self.repo, "commit", "-qm", "candidate")
+        self.commit = git(self.repo, "rev-parse", "HEAD")
+
+    def verify(self, **expectations):
+        return self.module.verify_static_candidate(
+            repo=self.repo, final_ref=self.commit, **expectations
+        )
+
+    def test_binds_exact_commit_tree_archive_and_static_contract(self):
+        first = self.verify()
+        untracked = self.repo / "plugins" / "ca-codex" / "hooks" / "untracked.py"
+        untracked.write_text("raise RuntimeError('must remain unarchived')\n", encoding="utf-8")
+        second = self.verify()
+        self.assertEqual(first, second)
+        self.assertEqual(first["verdict"], "PASS")
+        self.assertEqual(first["source_commit"], self.commit)
+        self.assertEqual(first["source_tree"], git(self.repo, "rev-parse", "HEAD^{tree}"))
+        self.assertRegex(first["archive_sha256"], r"^[0-9a-f]{64}$")
+        self.assertRegex(first["package_sha256"], r"^[0-9a-f]{64}$")
+        self.assertRegex(first["resource_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_candidate_owned_verifier_is_inert_data(self):
+        trusted = self.module._load_trusted_checker()
+        with mock.patch.object(self.module, "_load_trusted_checker", return_value=trusted) as loader:
+            self.verify()
+        loader.assert_called_once_with()
+
+    def test_rejects_option_shaped_and_nonexistent_refs(self):
+        with mock.patch.object(self.module, "_git") as git_call, self.assertRaisesRegex(
+            ValueError, "exact lowercase"
+        ):
+            self.module.verify_static_candidate(repo=self.repo, final_ref="--help")
+        git_call.assert_not_called()
+        with self.assertRaisesRegex(ValueError, "does not resolve"):
+            self.module.verify_static_candidate(repo=self.repo, final_ref="f" * 40)
+
+    def test_rejects_malformed_tree_identity(self):
+        with mock.patch.object(
+            self.module, "_git", side_effect=(self.commit, "not-a-tree-id")
+        ), self.assertRaisesRegex(ValueError, "tree is not an exact Git object ID"):
+            self.module._exact_commit(self.repo, self.commit)
+
+    def test_archive_creation_fails_closed_on_git_error_or_missing_output(self):
+        destination = self.repo / "candidate.zip"
+        cases = (
+            SimpleNamespace(returncode=1, stderr="archive failed", stdout=""),
+            SimpleNamespace(returncode=0, stderr="", stdout=""),
+        )
+        for completed in cases:
+            with self.subTest(returncode=completed.returncode), mock.patch.object(
+                self.module.subprocess, "run", return_value=completed
+            ), self.assertRaises(ValueError):
+                self.module._archive(self.repo, self.commit, destination)
+
+    def test_rejects_malformed_candidate_package(self):
+        manifest = self.repo / "plugins" / "ca-codex" / ".codex-plugin" / "plugin.json"
+        manifest.write_text("not json\n", encoding="utf-8")
+        git(self.repo, "add", "--", str(manifest.relative_to(self.repo)))
+        git(self.repo, "commit", "-qm", "malformed")
+        malformed = git(self.repo, "rev-parse", "HEAD")
+        with self.assertRaises(ValueError):
+            self.module.verify_static_candidate(repo=self.repo, final_ref=malformed)
+
+    def test_rejects_digest_mismatches_and_malformed_expectations(self):
+        result = self.verify()
+        fields = (
+            ("expected_archive_sha256", result["archive_sha256"]),
+            ("expected_package_sha256", result["package_sha256"]),
+            ("expected_resource_sha256", result["resource_sha256"]),
+        )
+        for argument, digest in fields:
+            with self.subTest(argument=argument), self.assertRaisesRegex(ValueError, "does not match"):
+                self.verify(**{argument: ("0" if digest[0] != "0" else "1") + digest[1:]})
+            with self.subTest(argument=f"malformed-{argument}"), self.assertRaisesRegex(
+                ValueError, "exact lowercase SHA-256"
+            ):
+                self.verify(**{argument: "not-a-digest"})
+
+    def test_rejects_oversized_archive_before_hash_or_checker(self):
+        def oversized(_repo, _commit, destination):
+            with destination.open("wb") as stream:
+                stream.truncate(self.module.MAX_ARCHIVE_BYTES + 1)
+
+        with mock.patch.object(self.module, "_archive", side_effect=oversized), mock.patch.object(
+            self.module, "_sha256_file"
+        ) as hasher, mock.patch.object(self.module, "_load_trusted_checker") as checker, self.assertRaisesRegex(
+            ValueError, "archive-byte limit"
+        ):
+            self.verify()
+        hasher.assert_not_called()
+        checker.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_codex_static_package.py
+++ b/.github/scripts/test_codex_static_package.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Adversarial contracts for the trusted static ca-codex package checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / ".github" / "scripts" / "check_codex_static_package.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("codex_static_package", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class StaticPackageContractTest(unittest.TestCase):
+    def setUp(self):
+        self.checker = load_module()
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.package = Path(self.temporary.name) / "ca-codex"
+        shutil.copytree(REPO_ROOT / "plugins" / "ca-codex", self.package)
+
+    def assert_rejects(self, expected: str):
+        with self.assertRaisesRegex(ValueError, expected):
+            self.checker.candidate_static_contract(self.package)
+
+    def hooks(self):
+        path = self.package / "hooks" / "hooks.json"
+        return path, json.loads(path.read_text(encoding="utf-8"))
+
+    def write_hooks(self, value):
+        path = self.package / "hooks" / "hooks.json"
+        path.write_text(json.dumps(value), encoding="utf-8", newline="\n")
+
+    def test_accepts_the_exact_shipped_package(self):
+        result = self.checker.candidate_static_contract(self.package)
+        self.assertEqual(result["verdict"], "PASS")
+        self.assertEqual(result["plugin_version"], "0.7.5")
+
+    def test_rejects_missing_or_ambiguous_manifest_identity(self):
+        manifest_path = self.package / ".codex-plugin" / "plugin.json"
+        cases = {
+            "missing": None,
+            "wrong name": '{"name":"other","version":"0.7.5"}\n',
+            "non semver": '{"name":"ca-codex","version":"0_bad"}\n',
+            "duplicate": '{"name":"ca-codex","name":"other","version":"0.7.5"}\n',
+        }
+        original = manifest_path.read_bytes()
+        for label, content in cases.items():
+            with self.subTest(label=label):
+                if content is None:
+                    manifest_path.unlink()
+                else:
+                    manifest_path.write_text(content, encoding="utf-8", newline="\n")
+                self.assert_rejects("manifest|duplicate")
+                manifest_path.parent.mkdir(parents=True, exist_ok=True)
+                manifest_path.write_bytes(original)
+
+    def test_rejects_missing_duplicate_malformed_or_misnamed_front_matter(self):
+        skill = self.package / "skills" / "ca-add-dep" / "SKILL.md"
+        original = skill.read_text(encoding="utf-8")
+        cases = {
+            "missing": original.split("---\n", 2)[-1],
+            "duplicate": original.replace(
+                "name: ca-add-dep\n", "name: ca-add-dep\nname: ca-add-dep\n", 1
+            ),
+            "malformed quote": original.replace("name: ca-add-dep", 'name: "ca-add-dep', 1),
+            "wrong path name": original.replace("name: ca-add-dep", "name: other", 1),
+        }
+        for label, content in cases.items():
+            with self.subTest(label=label):
+                skill.write_text(content, encoding="utf-8", newline="\n")
+                self.assert_rejects("front matter")
+                skill.write_text(original, encoding="utf-8", newline="\n")
+
+    def test_rejects_agent_without_classification(self):
+        agent = self.package / "agents" / "dependency-reviewer.md"
+        agent.write_text(
+            agent.read_text(encoding="utf-8").replace("classification: reviewer\n", "", 1),
+            encoding="utf-8", newline="\n",
+        )
+        self.assert_rejects("classification")
+
+    def test_rejects_misnamed_routine_and_agent_front_matter(self):
+        cases = (
+            (
+                self.package / "routines" / "commit-gate" / "SKILL.md",
+                "name: commit-gate",
+                "name: other",
+            ),
+            (
+                self.package / "agents" / "dependency-reviewer.md",
+                "name: dependency-reviewer",
+                "name: other",
+            ),
+        )
+        for path, expected, replacement in cases:
+            with self.subTest(path=path.relative_to(self.package)):
+                original = path.read_text(encoding="utf-8")
+                path.write_text(
+                    original.replace(expected, replacement, 1),
+                    encoding="utf-8", newline="\n",
+                )
+                self.assert_rejects("front matter name")
+                path.write_text(original, encoding="utf-8", newline="\n")
+
+    def test_static_wrapper_rejects_missing_and_escaping_resource_links(self):
+        skill = self.package / "skills" / "ca-add-dep" / "SKILL.md"
+        original = skill.read_text(encoding="utf-8")
+        for target in ("missing-resource.md", "../../../outside.md"):
+            with self.subTest(target=target):
+                skill.write_text(
+                    original + f"\n[contract]({target})\n",
+                    encoding="utf-8", newline="\n",
+                )
+                self.assert_rejects("escaped or unresolved")
+                skill.write_text(original, encoding="utf-8", newline="\n")
+
+    def test_rejects_hook_command_injection_and_non_native_roots(self):
+        path, hooks = self.hooks()
+        original = path.read_text(encoding="utf-8")
+        cases = (
+            original.replace(
+                'python3 \\"${PLUGIN_ROOT}/hooks/session-start.py\\"',
+                'python3 \\"${PLUGIN_ROOT}/hooks/session-start.py\\" && external', 1,
+            ),
+            original.replace("${PLUGIN_ROOT}", "${CLAUDE_PLUGIN_ROOT}", 1),
+        )
+        for content in cases:
+            path.write_text(content, encoding="utf-8", newline="\n")
+            self.assert_rejects("hook command")
+            path.write_text(original, encoding="utf-8", newline="\n")
+
+    def test_rejects_missing_hook_target(self):
+        (self.package / "hooks" / "session-start.py").unlink()
+        self.assert_rejects("hook target")
+
+    def test_rejects_duplicate_or_unknown_hook_schema(self):
+        path, hooks = self.hooks()
+        original = path.read_text(encoding="utf-8")
+        hooks["unexpected"] = True
+        self.write_hooks(hooks)
+        self.assert_rejects("schema")
+        path.write_text(
+            original.replace('{\n  "hooks":', '{\n  "hooks": {},\n  "hooks":', 1),
+            encoding="utf-8", newline="\n",
+        )
+        self.assert_rejects("duplicate")
+
+    def test_rejects_removed_security_events(self):
+        for event in ("PreToolUse", "PostToolUse"):
+            with self.subTest(event=event):
+                _path, hooks = self.hooks()
+                del hooks["hooks"][event]
+                self.write_hooks(hooks)
+                self.assert_rejects("hook inventory")
+                shutil.copy2(
+                    REPO_ROOT / "plugins" / "ca-codex" / "hooks" / "hooks.json",
+                    self.package / "hooks" / "hooks.json",
+                )
+
+    def test_rejects_changed_matcher_or_rerouted_security_hook(self):
+        _path, hooks = self.hooks()
+        hooks["hooks"]["PreToolUse"][0]["matcher"] = "NeverMatches"
+        self.write_hooks(hooks)
+        self.assert_rejects("hook inventory")
+
+        shutil.copy2(
+            REPO_ROOT / "plugins" / "ca-codex" / "hooks" / "hooks.json",
+            self.package / "hooks" / "hooks.json",
+        )
+        _path, hooks = self.hooks()
+        entry = hooks["hooks"]["PostToolUse"][0]["hooks"][0]
+        entry["command"] = 'python3 "${PLUGIN_ROOT}/hooks/session-start.py"'
+        entry["commandWindows"] = 'python "${PLUGIN_ROOT}/hooks/session-start.py"'
+        self.write_hooks(hooks)
+        self.assert_rejects("hook inventory")
+
+
+class DirectoryBoundContractTest(unittest.TestCase):
+    def setUp(self):
+        self.checker = load_module()._load_resource_checker()
+        self.limits = {
+            "max_archive_bytes": 8,
+            "max_entries": 2,
+            "max_entry_uncompressed_bytes": 2,
+            "max_total_uncompressed_bytes": 3,
+            "max_compression_ratio": 100,
+        }
+
+    def assert_bounded(self, contents=(), directories=0):
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary) / "ca-codex"
+            package.mkdir()
+            for index, content in enumerate(contents):
+                (package / f"file-{index}.md").write_bytes(content)
+            for index in range(directories):
+                (package / f"empty-{index}").mkdir()
+            with mock.patch.object(
+                self.checker, "_candidate_archive_limits", return_value=self.limits
+            ), self.assertRaises(ValueError):
+                self.checker._candidate_package_files(package)
+
+    def test_rejects_entry_count_per_file_and_total_bytes(self):
+        self.assert_bounded(contents=(b"a", b"b", b"c"))
+        self.assert_bounded(contents=(b"abc",))
+        self.assert_bounded(contents=(b"ab", b"cd"))
+
+    def test_rejects_empty_directories_over_entry_limit(self):
+        self.assert_bounded(directories=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_codex_static_package.py
+++ b/.github/scripts/test_codex_static_package.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 import shutil
 import tempfile
+from types import SimpleNamespace
 import unittest
 from unittest import mock
 
@@ -221,6 +222,126 @@ class DirectoryBoundContractTest(unittest.TestCase):
 
     def test_rejects_empty_directories_over_entry_limit(self):
         self.assert_bounded(directories=3)
+
+    def test_stops_scanning_at_the_entry_limit_before_sorting(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary) / "ca-codex"
+            package.mkdir()
+            for index in range(4):
+                (package / f"file-{index}.md").write_bytes(b"a")
+
+            original_scandir = self.checker.os.scandir
+            observed = {"entries": 0}
+
+            class CountingScandir:
+                def __init__(inner_self, directory):
+                    inner_self._scan = original_scandir(directory)
+
+                def __enter__(inner_self):
+                    inner_self._scan.__enter__()
+                    return inner_self
+
+                def __exit__(inner_self, *arguments):
+                    return inner_self._scan.__exit__(*arguments)
+
+                def __iter__(inner_self):
+                    return inner_self
+
+                def __next__(inner_self):
+                    observed["entries"] += 1
+                    if observed["entries"] > self.limits["max_entries"] + 1:
+                        raise AssertionError("directory traversal read beyond the rejection bound")
+                    return next(inner_self._scan)
+
+            with mock.patch.object(
+                self.checker, "_candidate_archive_limits", return_value=self.limits
+            ), mock.patch.object(self.checker.os, "scandir", CountingScandir), self.assertRaisesRegex(
+                ValueError, "entry-count limit"
+            ):
+                self.checker._candidate_package_files(package)
+            self.assertEqual(observed["entries"], self.limits["max_entries"] + 1)
+
+    def test_rejects_file_growth_using_only_bounded_reads(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary) / "ca-codex"
+            package.mkdir()
+            candidate = package / "growing.md"
+            candidate.write_bytes(b"a")
+            original_open = Path.open
+            initial = candidate.stat()
+
+            class GrowingStream:
+                def __init__(inner_self):
+                    inner_self._chunks = iter((b"ab", b"c"))
+
+                def __enter__(inner_self):
+                    return inner_self
+
+                def __exit__(inner_self, *_arguments):
+                    return False
+
+                def fileno(inner_self):
+                    return 123
+
+                def read(inner_self, size=-1):
+                    if size < 0 or size > self.limits["max_entry_uncompressed_bytes"] + 1:
+                        raise AssertionError("candidate file was read without a hard byte bound")
+                    return next(inner_self._chunks, b"")
+
+            def controlled_open(path, *arguments, **keywords):
+                if path == candidate:
+                    return GrowingStream()
+                return original_open(path, *arguments, **keywords)
+
+            with mock.patch.object(
+                self.checker, "_candidate_archive_limits", return_value=self.limits
+            ), mock.patch.object(Path, "open", controlled_open), mock.patch.object(
+                self.checker.os, "fstat", return_value=initial
+            ), self.assertRaisesRegex(
+                ValueError, "changed while being read"
+            ):
+                self.checker._candidate_package_files(package)
+
+    def test_rechecks_the_per_entry_limit_on_the_opened_file(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary) / "ca-codex"
+            package.mkdir()
+            candidate = package / "growing.md"
+            candidate.write_bytes(b"a")
+            original_validate = self.checker._validate_candidate_paths
+
+            def grow_after_enumeration(paths):
+                result = original_validate(paths)
+                candidate.write_bytes(b"abc")
+                return result
+
+            with mock.patch.object(
+                self.checker, "_candidate_archive_limits", return_value=self.limits
+            ), mock.patch.object(
+                self.checker, "_validate_candidate_paths", grow_after_enumeration
+            ), self.assertRaisesRegex(ValueError, "entry exceeds the size limit"):
+                self.checker._candidate_package_files(package)
+
+    def test_rejects_an_opened_file_with_a_different_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary) / "ca-codex"
+            package.mkdir()
+            candidate = package / "replaced.md"
+            candidate.write_bytes(b"a")
+            initial = candidate.stat()
+            replacement = SimpleNamespace(
+                st_mode=initial.st_mode,
+                st_dev=initial.st_dev,
+                st_ino=initial.st_ino + 1,
+                st_size=initial.st_size,
+            )
+
+            with mock.patch.object(
+                self.checker, "_candidate_archive_limits", return_value=self.limits
+            ), mock.patch.object(
+                self.checker.os, "fstat", return_value=replacement
+            ), self.assertRaisesRegex(ValueError, "changed while being read"):
+                self.checker._candidate_package_files(package)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify_codex_static_candidate.py
+++ b/.github/scripts/verify_codex_static_candidate.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Verify an inert ca-codex package from an exact Git commit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+TRUSTED_CHECKER_PATH = SCRIPT_ROOT / "check_codex_static_package.py"
+COMMIT_ID = re.compile(r"^[0-9a-f]{40}$")
+SHA256_ID = re.compile(r"^[0-9a-f]{64}$")
+MAX_ARCHIVE_BYTES = 8 * 1024 * 1024
+
+
+def _load_trusted_checker():
+    if not TRUSTED_CHECKER_PATH.is_file():
+        raise ValueError("trusted static candidate checker is missing")
+    spec = importlib.util.spec_from_file_location(
+        "codearbiter_trusted_codex_static_checker", TRUSTED_CHECKER_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError("trusted static candidate checker cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments], cwd=repo, check=False, capture_output=True,
+        text=True, encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "git failed"
+        raise ValueError(detail)
+    return completed.stdout.strip()
+
+
+def _exact_commit(repo: Path, final_ref: str) -> tuple[str, str]:
+    if COMMIT_ID.fullmatch(final_ref) is None:
+        raise ValueError("--final-ref must be an exact lowercase 40-character commit ID")
+    try:
+        commit = _git(repo, "rev-parse", "--verify", f"{final_ref}^{{commit}}")
+    except ValueError as error:
+        raise ValueError("--final-ref does not resolve to a commit") from error
+    if commit != final_ref:
+        raise ValueError("--final-ref does not resolve to the exact requested commit")
+    tree = _git(repo, "rev-parse", "--verify", f"{commit}^{{tree}}")
+    if COMMIT_ID.fullmatch(tree) is None:
+        raise ValueError("candidate tree is not an exact Git object ID")
+    return commit, tree
+
+
+def _archive(repo: Path, commit: str, destination: Path) -> None:
+    if COMMIT_ID.fullmatch(commit) is None:
+        raise ValueError("candidate archive source must be a 40-character commit ID")
+    completed = subprocess.run(
+        [
+            "git", "archive", "--format=zip", f"--output={destination}",
+            commit, "--", "plugins/ca-codex",
+        ],
+        cwd=repo, check=False, capture_output=True, text=True, encoding="utf-8",
+    )
+    if completed.returncode != 0 or not destination.is_file():
+        detail = completed.stderr.strip() or completed.stdout.strip() or "git archive failed"
+        raise ValueError(detail)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(64 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _expected_digest(value: str | None, label: str) -> str | None:
+    if value is not None and SHA256_ID.fullmatch(value) is None:
+        raise ValueError(f"expected {label} must be an exact lowercase SHA-256 digest")
+    return value
+
+
+def verify_static_candidate(
+    *, repo: Path, final_ref: str,
+    expected_archive_sha256: str | None = None,
+    expected_package_sha256: str | None = None,
+    expected_resource_sha256: str | None = None,
+) -> dict[str, Any]:
+    if COMMIT_ID.fullmatch(final_ref) is None:
+        raise ValueError("--final-ref must be an exact lowercase 40-character commit ID")
+    repo = repo.resolve()
+    if not repo.is_dir():
+        raise ValueError("--repo must name an existing Git checkout")
+    commit, tree = _exact_commit(repo, final_ref)
+    checker = _load_trusted_checker()
+    with tempfile.TemporaryDirectory(prefix="ca-codex-static-") as temporary:
+        archive = Path(temporary) / "ca-codex.zip"
+        _archive(repo, commit, archive)
+        if archive.stat().st_size > MAX_ARCHIVE_BYTES:
+            raise ValueError("candidate archive exceeds the archive-byte limit")
+        archive_sha256 = _sha256_file(archive)
+        contract = checker.candidate_static_contract(archive)
+    expectations = (
+        (archive_sha256, expected_archive_sha256, "archive sha256"),
+        (contract["package_sha256"], expected_package_sha256, "package sha256"),
+        (contract["resource_sha256"], expected_resource_sha256, "resource sha256"),
+    )
+    for actual, expected, label in expectations:
+        expected = _expected_digest(expected, label)
+        if expected is not None and actual != expected:
+            raise ValueError(f"{label} does not match the expected digest")
+    return {
+        "verdict": "PASS",
+        "source_commit": commit,
+        "source_tree": tree,
+        "archive_sha256": archive_sha256,
+        "package_sha256": contract["package_sha256"],
+        "resource_sha256": contract["resource_sha256"],
+        "plugin_version": contract["plugin_version"],
+        "resource_count": contract["resource_count"],
+        "relative_read_count": contract["relative_read_count"],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--final-ref", required=True)
+    parser.add_argument("--expected-archive-sha256")
+    parser.add_argument("--expected-package-sha256")
+    parser.add_argument("--expected-resource-sha256")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = verify_static_candidate(
+            repo=args.repo, final_ref=args.final_ref,
+            expected_archive_sha256=args.expected_archive_sha256,
+            expected_package_sha256=args.expected_package_sha256,
+            expected_resource_sha256=args.expected_resource_sha256,
+        )
+    except (OSError, ValueError, KeyError) as error:
+        if args.json:
+            print(json.dumps({"verdict": "FAIL", "errors": [str(error)]}, sort_keys=True))
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            "static ca-codex candidate verified: "
+            f"{result['source_commit']} package={result['package_sha256']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,13 @@ on:
       - ".github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1"
       - ".github/scripts/Invoke-CodeArbiterDesktopRouteProbe.ps1"
       - ".github/scripts/check_codex_skill_resources.py"
+      - ".github/scripts/check_codex_static_package.py"
       - ".github/scripts/test_codex_desktop_boundary.py"
       - ".github/scripts/test_codex_skill_resources.py"
+      - ".github/scripts/test_codex_static_package.py"
+      - ".github/scripts/test_codex_static_candidate.py"
       - ".github/scripts/verify_codex_candidate_provenance.py"
+      - ".github/scripts/verify_codex_static_candidate.py"
       - ".github/scripts/test_codex_candidate_provenance.py"
       - "docs/reports/codex-skill-resource-resolution.md"
       - "docs/reports/evidence/codex-skill-resource-resolution/**"
@@ -158,6 +162,10 @@ jobs:
             ca-codex:
               - 'plugins/ca-codex/**'
               - 'core/**'
+              - '.github/scripts/check_codex_static_package.py'
+              - '.github/scripts/test_codex_static_package.py'
+              - '.github/scripts/test_codex_static_candidate.py'
+              - '.github/scripts/verify_codex_static_candidate.py'
               - '.github/scripts/verify_codex_candidate_provenance.py'
               - '.github/scripts/test_codex_candidate_provenance.py'
               - 'docs/reports/codex-desktop-candidate-resolution.json'
@@ -295,9 +303,13 @@ jobs:
               - '.github/scripts/Invoke-CodeArbiterDesktopUiDriver.ps1'
               - '.github/scripts/Invoke-CodeArbiterDesktopRouteProbe.ps1'
               - '.github/scripts/check_codex_skill_resources.py'
+              - '.github/scripts/check_codex_static_package.py'
               - '.github/scripts/test_codex_desktop_boundary.py'
               - '.github/scripts/test_codex_skill_resources.py'
+              - '.github/scripts/test_codex_static_package.py'
+              - '.github/scripts/test_codex_static_candidate.py'
               - '.github/scripts/verify_codex_candidate_provenance.py'
+              - '.github/scripts/verify_codex_static_candidate.py'
               - '.github/scripts/test_codex_candidate_provenance.py'
               - 'docs/reports/codex-skill-resource-resolution.md'
               - 'docs/reports/evidence/codex-skill-resource-resolution/**'
@@ -385,6 +397,14 @@ jobs:
           python-version: "3.x"
       - name: Test Codex skill-resource and receipt contracts
         run: python .github/scripts/test_codex_skill_resources.py
+      - name: Test the trusted static Codex package contract
+        run: python .github/scripts/test_codex_static_package.py
+      - name: Test the trusted static candidate boundary
+        run: python .github/scripts/test_codex_static_candidate.py
+      - name: Build and validate the tracked Codex package without credentials
+        run: |
+          git archive --format=zip --output=ca-codex-static.zip HEAD -- plugins/ca-codex
+          python .github/scripts/check_codex_static_package.py --candidate-package ca-codex-static.zip
       - name: Test the trusted desktop boundary contracts
         run: python .github/scripts/test_codex_desktop_boundary.py
       - name: Validate the tracked fixture without network or credentials


### PR DESCRIPTION
## Summary

- Add a trusted static package checker for the Codex adapter manifest, Markdown front matter, resource graph, hook declarations, hook targets, and deterministic identities.
- Add an exact-commit verifier that archives only `plugins/ca-codex` and treats every candidate byte as inert data.
- Run the new contracts in the existing required Ubuntu resource lane while preserving all legacy desktop verifier interfaces.
- Bound directory-mode validation before reads and derive package and resource identities from one immutable snapshot.

## Why

This is the additive trust bootstrap for [ADR-0032](https://github.com/arbiterForge/codeArbiter/blob/codex/hosted-static-codex-release/.codearbiter/decisions/0032-hosted-static-codex-release-evidence.md). The dependent feature PR will execute verifier code from trusted default-branch content and pass an event-selected plugin commit only as data.

The deliberate compatibility tradeoff is temporary duplication: the existing desktop checker and provenance verifier remain operational until the dependent hosted-static release change lands. Removing them here would make the new trust boundary unavailable on the base revision that must verify that later PR.

## Test plan

- [x] `python .github/scripts/test_codex_static_package.py` (13 tests)
- [x] `python .github/scripts/test_codex_static_candidate.py` (8 tests)
- [x] `python .github/scripts/test_codex_skill_resources.py` (156 tests, 1 expected skip)
- [x] `python .github/scripts/test_codex_candidate_provenance.py` (19 tests)
- [x] `python .github/scripts/test_ci_impact.py` (61 tests)
- [x] Full canonical test list from `.codearbiter/tech-stack.md`, including 1,401 hook tests
- [x] Python syntax compilation and `git diff --check`
- [x] Exact-commit verifier proof for `24e9f4fac38c686bc6b4ec50daf313ce4b432905`
- [x] Independent security, auth-crypto, coverage, and architecture reviews: PASS with zero findings

The exact-commit proof bound tree `cd7822749279dc8b47956d0ac71004e9c0a54965`, archive SHA-256 `ff968f74e5a67b283fbeb9cbd535ed34b45986f7c1302a1543880610ad98682d`, package SHA-256 `400b607b08aa738271ef2dac026bef0ebb6bc30d29f2b546df2a02459f1a1473`, and resource SHA-256 `95e93ca391e6b45b87cc0cc9ee66a5bc16f3521aa61f282dfbe127207e5984fc`.
