### PR TITLE
fix(update-notifier): isolate host release state

### DIFF
--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -4,27 +4,27 @@
   "entries": [
     {
       "drift_trigger": true,
-      "hash": "712ca25562baee8f2398c297c943fe0591a0075d",
+      "hash": "41c77ed97eeb6d1fdbe0a1f26331a02b3b513268",
       "path": "CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "48237a315db1a8ad73eccd89f6c38ff5ba6cfa41",
+      "hash": "7f20253b313fc2274638c7bbccd8e03bddb4db34",
       "path": "package.json"
     },
     {
       "drift_trigger": true,
-      "hash": "41b5d0dfba1afb8c47c6953b49e4257c6d269b71",
+      "hash": "ce8c81ba6b1fd17294067afe1ce3c6e9c4cf3700",
       "path": "plugins/ca-codex/.codex-plugin/plugin.json"
     },
     {
       "drift_trigger": true,
-      "hash": "cce5698a70567d16a9cab88e3ffc6bd0172f9c23",
+      "hash": "d995a66621e2f9d22810397905d6635537ca1c5f",
       "path": "plugins/ca-codex/CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "0614f8f18516ec58ff5419c25b8b8ed7cf78361c",
+      "hash": "47656ce14c4f9a09edfaa3bdfd69de7075524088",
       "path": "plugins/ca-pi/CHANGELOG.md"
     },
     {
@@ -39,7 +39,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "69d97f491de4b27f067d0f9b2e0ea60b99108720",
+      "hash": "7e60942870e9dc0f5dfb10522e25278ca3a84649",
       "path": "plugins/ca-pi/package.json"
     },
     {
@@ -64,7 +64,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "cfbd3b4e71b6f13bf94e986f860b3a6efbb83283",
+      "hash": "9a8423ae77a0ad9b692aeec746ba7ab9ebcf6be5",
       "path": "plugins/ca/.claude-plugin/plugin.json"
     },
     {

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3785,3 +3785,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-01T22:01:51Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-01T22:03:20Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-01T22:05:40Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:10:01Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:16:07Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3780,3 +3780,8 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-01T19:35:54Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-01T19:51:10Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-01T21:49:53Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:00:00Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:00:36Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:01:51Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:03:20Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:05:40Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3775,3 +3775,8 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-08-31T00:59:14Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-08-31T01:01:10Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-08-31T01:40:25Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T19:26:05.228Z] | HOST: pi | RULE: PI-PERMISSION | CORRELATION: 4047ab7aa31412688a86815437372595d7ce3bb4d71d3035ecb5b32632bf11ef | TOOL_CLASS: READ | ACTION_CLASSES: read | DECISION: allow
+[2026-09-01T19:34:33Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T19:35:54Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T19:51:10Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T21:49:53Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3787,3 +3787,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-01T22:05:40Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-01T22:10:01Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-01T22:16:07Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:29:33Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-01T22:30:46Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -253,18 +253,23 @@ This supersedes the prior parse-time check that covered only `plan.meta.apiBaseU
 
 **Outbound surface — the update-available notifier.** The update-notifier
 (`plugins/ca/hooks/_updatelib.py`, run detached by `update-refresh.py`) makes one
-outbound call: an **unauthenticated HTTPS GET** to
-`https://api.github.com/repos/arbiterForge/codeArbiter/releases/latest`, at most
-once per day (cached in the user-global `~/.codearbiter/update-state.json`). It is
-the plugin's only routine outbound call outside the farm dispatcher. Posture per
-ADR-0003: `https://` is asserted on the initial URL *and* re-asserted on any 3xx
-via a custom redirect handler that refuses an `https://`→`http://` downgrade;
+outbound operation: bounded **unauthenticated HTTPS GETs** to the GitHub Releases
+collection (`/repos/arbiterForge/codeArbiter/releases?per_page=100`), at most once
+per day for each independently versioned release target. A refresh follows at
+most ten collection pages (up to 1,000 recent releases) so quiet host series can
+be found beyond the first page; exhausting that bound produces no new cached
+result rather than trusting a partial enumeration. Target-keyed results are cached in the user-global
+`~/.codearbiter/update-state.json`; unrelated tag prefixes are ignored. It is the
+plugin's only routine outbound operation outside the farm dispatcher. Posture
+per ADR-0003: `https://` is asserted on the initial URL *and* re-asserted on any
+3xx via a custom redirect handler that refuses an `https://`→`http://` downgrade;
 stdlib `urllib` only (ADR-0004), default verifying TLS, no `rejectUnauthorized`
 equivalent. It **sends no repo content, no PII, and no secret** (User-Agent +
 Accept headers only) and is **fail-silent** — any network/parse/cache error
-degrades to "no notice" and never raises into the SessionStart or statusline hook.
-It adds **no synchronous network call** to the SessionStart hot path (those hooks
-only read the cache; the fetch runs in the detached refresh child).
+degrades to the last known target-specific result or "no notice" and never
+raises into the SessionStart or statusline hook. It adds **no synchronous network
+call** to the SessionStart hot path (those hooks only read the cache; the fetch
+runs in the detached refresh child).
 
 ---
 

--- a/.github/scripts/test_codex_static_package.py
+++ b/.github/scripts/test_codex_static_package.py
@@ -49,7 +49,7 @@ class StaticPackageContractTest(unittest.TestCase):
     def test_accepts_the_exact_shipped_package(self):
         result = self.checker.candidate_static_contract(self.package)
         self.assertEqual(result["verdict"], "PASS")
-        self.assertEqual(result["plugin_version"], "0.7.5")
+        self.assertEqual(result["plugin_version"], "0.7.6")
 
     def test_rejects_missing_or_ambiguous_manifest_identity(self):
         manifest_path = self.package / ".codex-plugin" / "plugin.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.15.7] - 2026-09-01
+
+### Fixed
+
+- Update notices now select only the Claude `v*` release series, keep cache
+  freshness and latest-version state separate from Codex and Pi, and retain
+  the Claude marketplace update command.
+
 ## [2.15.6] - 2026-08-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.15.6" src="https://img.shields.io/badge/version-2.15.6-2b7489">
+<img alt="version 2.15.7" src="https://img.shields.io/badge/version-2.15.7-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-38-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-18-555">
@@ -113,7 +113,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.5`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.6`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_updatelib.py
+++ b/core/pysrc/_updatelib.py
@@ -5,15 +5,17 @@
 # auto-update by default (only official Anthropic marketplaces get that). This
 # module backs a lightweight notifier so a stale install is surfaced instead of
 # running forever unnoticed: it reads the installed plugin.json version, reads
-# a small user-global cache of the latest published GitHub release, and — when
-# the cache says a newer version exists — hands back a single notice line. Both
+# a small user-global cache keyed by independently versioned release target,
+# and — when that target's cache says a newer version exists — hands back a
+# single host-native notice line. Both
 # SessionStart and the statusline render from that SAME cache; neither makes a
 # network call on its own hot path (issue #194's constraint).
 #
 # The only network call this module makes (fetch_latest_tag) is invoked from
 # the OFF-hot-path detached refresh (see hooks/update-refresh.py, spawned by
 # session-start.py). refresh_if_stale() gates that call to at most once per
-# day via the cached `checked_at`, and is fail-silent end to end: any network
+# day per target via the cached `checked_at`, and is fail-silent end to end:
+# any network
 # error, timeout, non-200, or unparseable body degrades to "keep the last-known
 # latest" — never a traceback, never a crash of the host hook.
 #
@@ -34,18 +36,24 @@
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
-#   notice_line(installed, latest) -> str|None    the SessionStart/statusline notice text
-#   read_state(path=None) -> dict            {latest, checked_at} cache, or {} on any failure
+#   update_descriptor(host=None) -> dict|None validated host update descriptor
+#   target_state(state, host=None) -> dict    one target's cache row, or {}
+#   notice_line(installed, latest, host=None) -> str|None host-native notice text
+#   read_state(path=None) -> dict            target-keyed cache, or {} on any failure
 #   write_state(state, path=None) -> None    atomic cache write; best-effort, never raises
 #   is_stale(checked_at, now, interval=ONE_DAY) -> bool   True iff a refresh is due
-#   fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None) -> str|None   HTTPS GET, fail-silent
-#   refresh_if_stale(now=None, fetcher=None, path=None) -> dict   best-effort cache refresh
+#   select_latest_tag(releases, tag_prefix) -> str|None target-series selection
+#   fetch_latest_tag(tag_prefix=None, url=..., timeout=3.0,
+#                    opener=None, host=None) -> str|None
+#   refresh_if_stale(now=None, fetcher=None, path=None, host=None) -> dict
 
 import json
+import math
 import os
 import re
 import sys
 import time
+import urllib.parse
 import urllib.request
 
 # Reuse the ONE atomic-write helper defined in _hooklib.py (same rationale as
@@ -54,16 +62,23 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+from _hooklib import (  # noqa: E402 — sys.path mount above
+    acquire_lock,
+    get_host,
+    release_lock,
+    write_text_atomic,
+)
 # hostapi is not imported directly here (#257): plugin_root()/installed_version()
 # resolve the Host via _hooklib.get_host() (the DI seam every entry script's
 # run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
-# The repo's own GitHub Releases API — unauthenticated GET, HTTPS only (ADR-0003).
-# The release tag equals plugin.json's version (an established repo invariant).
-UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases/latest"
+# The repo's GitHub Releases collection — unauthenticated GET, HTTPS only
+# (ADR-0003). A collection is required because each host publishes an
+# independent tag series; /releases/latest can represent only one of them.
+UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases?per_page=100"
+MAX_RELEASE_PAGES = 10
 
 _VERSION_STRIP_RE = re.compile(r"^[vV]")
 
@@ -147,15 +162,52 @@ def update_available(installed, latest):
     return version_gt(latest, installed)
 
 
-def notice_line(installed, latest):
+def update_descriptor(host=None):
+    """Validated update descriptor for `host` (or the active host), else None.
+    A partially defined or multi-line descriptor disables the notifier rather
+    than falling back to another host's release series or command."""
+    host = host or get_host()
+    target = getattr(host, "update_target", None)
+    prefix = getattr(host, "update_tag_prefix", None)
+    command = getattr(host, "update_command", None)
+    if not all(isinstance(value, str) and value.strip()
+               for value in (target, prefix, command)):
+        return None
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", target.strip()):
+        return None
+    if "\n" in command or "\r" in command:
+        return None
+    return {
+        "target": target.strip(),
+        "tag_prefix": prefix.strip(),
+        "command": command.strip(),
+    }
+
+
+def target_state(state, host=None):
+    """The active host target's `{latest, checked_at}` row, or {}.
+    Legacy unkeyed cache data is deliberately not attributed to any host: its
+    `latest` may belong to an unrelated release series (the RA-02 defect)."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not isinstance(state, dict) or state.get("schema") != 1:
+        return {}
+    targets = state.get("targets")
+    if not isinstance(targets, dict):
+        return {}
+    row = targets.get(descriptor["target"])
+    return row if isinstance(row, dict) else {}
+
+
+def notice_line(installed, latest, host=None):
     """The single-line SessionStart/statusline notice, or None when no update is due
-    (AC-1/AC-2): `codeArbiter: update available X -> Y (run /plugin marketplace update
-    codearbiter)`. Never multi-line; never emitted for equal, lesser, missing, or
-    malformed `latest`."""
-    if not update_available(installed, latest):
+    (AC-1/AC-2): `codeArbiter: update available X -> Y (run <host command>)`.
+    Never multi-line; never emitted for equal, lesser, missing, or malformed
+    `latest`."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not update_available(installed, latest):
         return None
     return (f"codeArbiter: update available {installed} -> {latest} "
-            f"(run /plugin marketplace update codearbiter)")
+            f"(run {descriptor['command']})")
 
 
 def read_state(path=None):
@@ -190,7 +242,10 @@ def is_stale(checked_at, now, interval=ONE_DAY):
     if checked_at is None:
         return True
     try:
-        return (now - float(checked_at)) >= interval
+        checked_at = float(checked_at)
+        if not math.isfinite(checked_at):
+            return True
+        return (now - checked_at) >= interval
     except (TypeError, ValueError):
         return True
 
@@ -220,8 +275,34 @@ def _build_opener():
     return urllib.request.build_opener(_HTTPSOnlyRedirectHandler())
 
 
-def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
-    """GET the GitHub Releases API and return `tag_name`, or None on ANY problem
+def select_latest_tag(releases, tag_prefix):
+    """Highest stable numeric version in `releases` for exact `tag_prefix`.
+    Drafts, prereleases, malformed rows, and every sibling series are ignored."""
+    if not isinstance(releases, list) or not isinstance(tag_prefix, str) or not tag_prefix:
+        return None
+    selected = None
+    selected_tuple = None
+    for release in releases:
+        if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+            continue
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not tag.startswith(tag_prefix):
+            continue
+        version = tag[len(tag_prefix):]
+        if not re.fullmatch(r"\d+(?:\.\d+)*", version):
+            continue
+        parsed = parse_version(version)
+        if parsed is not None and (selected_tuple is None or parsed > selected_tuple):
+            selected = version
+            selected_tuple = parsed
+    return selected
+
+
+def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
+                     opener=None, host=None):
+    """GET bounded pages of the GitHub Releases API and return the active
+    series' highest stable numeric version, or
+    None on ANY problem
     (AC-5): non-https url, network error, timeout, non-200, an unparseable/absent
     body, or a redirect to a non-https target. HTTPS-only per ADR-0003 — a
     non-https INITIAL url is refused before any connection is attempted, and a
@@ -229,27 +310,54 @@ def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
     since urllib's default opener would otherwise follow an https->http
     downgrade transparently). `opener` is injectable (tests); production builds
     the hardened opener via `_build_opener()`."""
-    if not isinstance(url, str) or not url.lower().startswith("https://"):
+    if tag_prefix is None:
+        descriptor = update_descriptor(host)
+        tag_prefix = descriptor.get("tag_prefix") if descriptor else None
+    if (not isinstance(tag_prefix, str) or not tag_prefix
+            or not isinstance(url, str) or not url.lower().startswith("https://")):
         return None
     try:
-        req = urllib.request.Request(url, headers={
-            "User-Agent": "codeArbiter-update-check",
-            "Accept": "application/vnd.github+json",
-        })
         op = opener or _build_opener()
-        with op.open(req, timeout=timeout) as resp:
-            status = getattr(resp, "status", None) or getattr(resp, "code", None)
-            if status != 200:
+        parsed_url = urllib.parse.urlsplit(url)
+        query = dict(urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True))
+        try:
+            page_size = int(query.get("per_page", "100"))
+        except (TypeError, ValueError):
+            page_size = 100
+        if page_size < 1:
+            page_size = 100
+
+        releases = []
+        for page in range(1, MAX_RELEASE_PAGES + 1):
+            page_query = dict(query)
+            page_query["page"] = str(page)
+            page_url = urllib.parse.urlunsplit(parsed_url._replace(
+                query=urllib.parse.urlencode(page_query)))
+            req = urllib.request.Request(page_url, headers={
+                "User-Agent": "codeArbiter-update-check",
+                "Accept": "application/vnd.github+json",
+            })
+            with op.open(req, timeout=timeout) as resp:
+                status = getattr(resp, "status", None) or getattr(resp, "code", None)
+                if status != 200:
+                    return None
+                body = resp.read()
+            page_data = json.loads(body.decode("utf-8", "replace"))
+            if not isinstance(page_data, list):
                 return None
-            body = resp.read()
-        data = json.loads(body.decode("utf-8", "replace"))
-        tag = data.get("tag_name") if isinstance(data, dict) else None
-        return tag.strip() if isinstance(tag, str) and tag.strip() else None
+            releases.extend(page_data)
+            if len(page_data) < page_size:
+                break
+        else:
+            # Every bounded page was full, so more releases may exist. Do not
+            # cache a result whose series enumeration is known to be incomplete.
+            return None
+        return select_latest_tag(releases, tag_prefix)
     except Exception:  # noqa: BLE001 — AC-5: fail-silent on any network/parse error
         return None
 
 
-def refresh_if_stale(now=None, fetcher=None, path=None):
+def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
     Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
@@ -262,17 +370,55 @@ def refresh_if_stale(now=None, fetcher=None, path=None):
     now = time.time() if now is None else now
     path = path or state_path()
     state = read_state(path)
-    checked_at = state.get("checked_at") if isinstance(state, dict) else None
+    descriptor = update_descriptor(host)
+    if descriptor is None:
+        return state
+    row = target_state(state, host=host)
+    checked_at = row.get("checked_at")
     if not is_stale(checked_at, now):
         return state
-    fetch = fetcher or fetch_latest_tag
+    fetch = fetcher or (lambda: fetch_latest_tag(
+        tag_prefix=descriptor["tag_prefix"], host=host))
     try:
         latest = fetch()
     except Exception:  # noqa: BLE001 — AC-3/AC-5: never propagate a fetch failure
         latest = None
-    new_state = {
-        "latest": latest if latest else state.get("latest"),
-        "checked_at": now,
-    }
-    write_state(new_state, path)
-    return new_state
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        # Re-read under the write lock. Another independently versioned host
+        # may have refreshed while this process was waiting on GitHub; merging
+        # the pre-fetch snapshot would silently erase that target's row.
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+
+        current_latest = current_row.get("latest")
+        if parse_version(latest) is None:
+            merged_latest = current_latest
+        elif (parse_version(current_latest) is not None
+              and version_gt(current_latest, latest)):
+            merged_latest = current_latest
+        else:
+            merged_latest = latest
+
+        current_checked_at = current_row.get("checked_at")
+        finite_checked_at = []
+        for value in (current_checked_at, now):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                finite_checked_at.append(value)
+        targets[descriptor["target"]] = {
+            "latest": merged_latest,
+            "checked_at": max(finite_checked_at) if finite_checked_at else None,
+        }
+        new_state = {"schema": 1, "targets": targets}
+        write_state(new_state, path)
+        return new_state
+    finally:
+        release_lock(lock)

--- a/core/pysrc/_updatelib.py
+++ b/core/pysrc/_updatelib.py
@@ -211,9 +211,9 @@ def notice_line(installed, latest, host=None):
 
 
 def read_state(path=None):
-    """The cached `{latest, checked_at}` state, or {} on ANY failure (missing file,
-    corrupt JSON, non-dict content) — a corrupt cache degrades to 'no notice', never
-    a crash of the host hook."""
+    """The target-keyed cache state, or {} on ANY failure (missing file, corrupt
+    JSON, non-dict content) — a corrupt cache degrades to 'no notice', never a
+    crash of the host hook."""
     path = path or state_path()
     try:
         with open(path, encoding="utf-8") as f:
@@ -360,23 +360,57 @@ def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
 def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
-    Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
-    UNCHANGED and calls the fetcher NOT AT ALL (AC-4 — at most one fetch per day).
-    Otherwise calls `fetcher()` (default fetch_latest_tag): on success the new
+    Reads the cache under the write lock; if `checked_at` is still fresh
+    (is_stale() False), returns it UNCHANGED and calls the fetcher NOT AT ALL.
+    Otherwise it reserves that target's daily refresh before releasing the lock,
+    so a concurrent same-target process observes a fresh row and also makes no
+    call (AC-4 — at most one fetch per day). It then calls `fetcher()` (default
+    fetch_latest_tag): on success the new
     `latest` is cached; on ANY exception or a None/falsy return, the PRIOR `latest`
     is preserved (fail-silent — a network hiccup never blanks a known-good notice)
     and `checked_at` still advances, so a persistently-unreachable network is not
     retried every single session that day. Never raises (AC-3)."""
     now = time.time() if now is None else now
     path = path or state_path()
-    state = read_state(path)
     descriptor = update_descriptor(host)
     if descriptor is None:
-        return state
-    row = target_state(state, host=host)
-    checked_at = row.get("checked_at")
-    if not is_stale(checked_at, now):
-        return state
+        return read_state(path)
+
+    # Reserve this target's refresh under the cache lock before any network
+    # work. Without the re-read and reservation here, concurrent detached
+    # SessionStart refreshes can all observe the same stale row and each issue
+    # a bounded release-page fetch before the later merge lock serializes them.
+    try:
+        reservation_at = float(now)
+    except (TypeError, ValueError):
+        return read_state(path)
+    if not math.isfinite(reservation_at):
+        return read_state(path)
+
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        if not is_stale(current_row.get("checked_at"), reservation_at):
+            return current
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+        targets[descriptor["target"]] = {
+            "latest": current_row.get("latest"),
+            "checked_at": reservation_at,
+        }
+        reserved_state = {"schema": 1, "targets": targets}
+        write_state(reserved_state, path)
+        confirmed_row = target_state(read_state(path), host=host)
+        if confirmed_row.get("checked_at") != reservation_at:
+            # A failed reservation cannot safely authorize network egress. The
+            # notifier remains fail-silent and will retry on a later session.
+            return read_state(path)
+    finally:
+        release_lock(lock)
+
     fetch = fetcher or (lambda: fetch_latest_tag(
         tag_prefix=descriptor["tag_prefix"], host=host))
     try:

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -234,7 +234,16 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.15.6"
+    adapter_version = "2.15.7"
+
+    # Update-notifier descriptor. Each independently versioned host overrides
+    # these three values in its per-plugin _host.py. Keeping the target,
+    # release prefix, and remediation command together on the active Host
+    # prevents the shared notifier from comparing or instructing for a sibling
+    # product line (RA-02).
+    update_target = "ca"
+    update_tag_prefix = "v"
+    update_command = "/plugin marketplace update codearbiter"
 
     # Capability flags — what surfaces this host actually has. A hook that
     # heals/queries a statusline gates on has_statusline; a hook registered
@@ -509,6 +518,9 @@ class FailClosedHost(Host):
     silent (observability-002)."""
 
     name = "unknown"
+    update_target = None
+    update_tag_prefix = None
+    update_command = None
     has_statusline = False
     has_read_tool = False
     has_prunable_transcript = False

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -885,7 +885,7 @@ def update_notice_line(plugin):
     no network call itself."""
     try:
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         return _updatelib.notice_line(installed, latest) or ""
     except Exception:  # noqa: BLE001 — never crash session startup

--- a/core/pysrc/statusline.py
+++ b/core/pysrc/statusline.py
@@ -431,7 +431,7 @@ def seg_update(plugin=None):
     try:
         plugin = plugin if plugin is not None else plugin_root_for_render()
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         if not _updatelib.update_available(installed, latest):
             return None

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-09-01
+
+### Fixed
+
+- The update notifier now ignores Claude, Pi, and sandbox tags, caches the
+  `ca-codex-v*` series independently, and points users to Codex's native
+  plugin reinstall command.
+
 ## [0.7.5] - 2026-08-26
 
 ### Added

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -172,9 +172,13 @@ def parse_apply_patch(text):
 class CodexHost(hostapi.Host):
     """OpenAI Codex CLI (>= rust-v0.143.0) — the second host (ADR-0011)."""
 
+    update_target = "ca-codex"
+    update_tag_prefix = "ca-codex-v"
+    update_command = "codex plugin add ca-codex@codearbiter"
+
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.7.5"
+    adapter_version = "0.7.6"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/_updatelib.py
+++ b/plugins/ca-codex/hooks/_updatelib.py
@@ -5,15 +5,17 @@
 # auto-update by default (only official Anthropic marketplaces get that). This
 # module backs a lightweight notifier so a stale install is surfaced instead of
 # running forever unnoticed: it reads the installed plugin.json version, reads
-# a small user-global cache of the latest published GitHub release, and — when
-# the cache says a newer version exists — hands back a single notice line. Both
+# a small user-global cache keyed by independently versioned release target,
+# and — when that target's cache says a newer version exists — hands back a
+# single host-native notice line. Both
 # SessionStart and the statusline render from that SAME cache; neither makes a
 # network call on its own hot path (issue #194's constraint).
 #
 # The only network call this module makes (fetch_latest_tag) is invoked from
 # the OFF-hot-path detached refresh (see hooks/update-refresh.py, spawned by
 # session-start.py). refresh_if_stale() gates that call to at most once per
-# day via the cached `checked_at`, and is fail-silent end to end: any network
+# day per target via the cached `checked_at`, and is fail-silent end to end:
+# any network
 # error, timeout, non-200, or unparseable body degrades to "keep the last-known
 # latest" — never a traceback, never a crash of the host hook.
 #
@@ -34,18 +36,24 @@
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
-#   notice_line(installed, latest) -> str|None    the SessionStart/statusline notice text
-#   read_state(path=None) -> dict            {latest, checked_at} cache, or {} on any failure
+#   update_descriptor(host=None) -> dict|None validated host update descriptor
+#   target_state(state, host=None) -> dict    one target's cache row, or {}
+#   notice_line(installed, latest, host=None) -> str|None host-native notice text
+#   read_state(path=None) -> dict            target-keyed cache, or {} on any failure
 #   write_state(state, path=None) -> None    atomic cache write; best-effort, never raises
 #   is_stale(checked_at, now, interval=ONE_DAY) -> bool   True iff a refresh is due
-#   fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None) -> str|None   HTTPS GET, fail-silent
-#   refresh_if_stale(now=None, fetcher=None, path=None) -> dict   best-effort cache refresh
+#   select_latest_tag(releases, tag_prefix) -> str|None target-series selection
+#   fetch_latest_tag(tag_prefix=None, url=..., timeout=3.0,
+#                    opener=None, host=None) -> str|None
+#   refresh_if_stale(now=None, fetcher=None, path=None, host=None) -> dict
 
 import json
+import math
 import os
 import re
 import sys
 import time
+import urllib.parse
 import urllib.request
 
 # Reuse the ONE atomic-write helper defined in _hooklib.py (same rationale as
@@ -54,16 +62,23 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+from _hooklib import (  # noqa: E402 — sys.path mount above
+    acquire_lock,
+    get_host,
+    release_lock,
+    write_text_atomic,
+)
 # hostapi is not imported directly here (#257): plugin_root()/installed_version()
 # resolve the Host via _hooklib.get_host() (the DI seam every entry script's
 # run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
-# The repo's own GitHub Releases API — unauthenticated GET, HTTPS only (ADR-0003).
-# The release tag equals plugin.json's version (an established repo invariant).
-UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases/latest"
+# The repo's GitHub Releases collection — unauthenticated GET, HTTPS only
+# (ADR-0003). A collection is required because each host publishes an
+# independent tag series; /releases/latest can represent only one of them.
+UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases?per_page=100"
+MAX_RELEASE_PAGES = 10
 
 _VERSION_STRIP_RE = re.compile(r"^[vV]")
 
@@ -147,15 +162,52 @@ def update_available(installed, latest):
     return version_gt(latest, installed)
 
 
-def notice_line(installed, latest):
+def update_descriptor(host=None):
+    """Validated update descriptor for `host` (or the active host), else None.
+    A partially defined or multi-line descriptor disables the notifier rather
+    than falling back to another host's release series or command."""
+    host = host or get_host()
+    target = getattr(host, "update_target", None)
+    prefix = getattr(host, "update_tag_prefix", None)
+    command = getattr(host, "update_command", None)
+    if not all(isinstance(value, str) and value.strip()
+               for value in (target, prefix, command)):
+        return None
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", target.strip()):
+        return None
+    if "\n" in command or "\r" in command:
+        return None
+    return {
+        "target": target.strip(),
+        "tag_prefix": prefix.strip(),
+        "command": command.strip(),
+    }
+
+
+def target_state(state, host=None):
+    """The active host target's `{latest, checked_at}` row, or {}.
+    Legacy unkeyed cache data is deliberately not attributed to any host: its
+    `latest` may belong to an unrelated release series (the RA-02 defect)."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not isinstance(state, dict) or state.get("schema") != 1:
+        return {}
+    targets = state.get("targets")
+    if not isinstance(targets, dict):
+        return {}
+    row = targets.get(descriptor["target"])
+    return row if isinstance(row, dict) else {}
+
+
+def notice_line(installed, latest, host=None):
     """The single-line SessionStart/statusline notice, or None when no update is due
-    (AC-1/AC-2): `codeArbiter: update available X -> Y (run /plugin marketplace update
-    codearbiter)`. Never multi-line; never emitted for equal, lesser, missing, or
-    malformed `latest`."""
-    if not update_available(installed, latest):
+    (AC-1/AC-2): `codeArbiter: update available X -> Y (run <host command>)`.
+    Never multi-line; never emitted for equal, lesser, missing, or malformed
+    `latest`."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not update_available(installed, latest):
         return None
     return (f"codeArbiter: update available {installed} -> {latest} "
-            f"(run /plugin marketplace update codearbiter)")
+            f"(run {descriptor['command']})")
 
 
 def read_state(path=None):
@@ -190,7 +242,10 @@ def is_stale(checked_at, now, interval=ONE_DAY):
     if checked_at is None:
         return True
     try:
-        return (now - float(checked_at)) >= interval
+        checked_at = float(checked_at)
+        if not math.isfinite(checked_at):
+            return True
+        return (now - checked_at) >= interval
     except (TypeError, ValueError):
         return True
 
@@ -220,8 +275,34 @@ def _build_opener():
     return urllib.request.build_opener(_HTTPSOnlyRedirectHandler())
 
 
-def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
-    """GET the GitHub Releases API and return `tag_name`, or None on ANY problem
+def select_latest_tag(releases, tag_prefix):
+    """Highest stable numeric version in `releases` for exact `tag_prefix`.
+    Drafts, prereleases, malformed rows, and every sibling series are ignored."""
+    if not isinstance(releases, list) or not isinstance(tag_prefix, str) or not tag_prefix:
+        return None
+    selected = None
+    selected_tuple = None
+    for release in releases:
+        if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+            continue
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not tag.startswith(tag_prefix):
+            continue
+        version = tag[len(tag_prefix):]
+        if not re.fullmatch(r"\d+(?:\.\d+)*", version):
+            continue
+        parsed = parse_version(version)
+        if parsed is not None and (selected_tuple is None or parsed > selected_tuple):
+            selected = version
+            selected_tuple = parsed
+    return selected
+
+
+def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
+                     opener=None, host=None):
+    """GET bounded pages of the GitHub Releases API and return the active
+    series' highest stable numeric version, or
+    None on ANY problem
     (AC-5): non-https url, network error, timeout, non-200, an unparseable/absent
     body, or a redirect to a non-https target. HTTPS-only per ADR-0003 — a
     non-https INITIAL url is refused before any connection is attempted, and a
@@ -229,27 +310,54 @@ def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
     since urllib's default opener would otherwise follow an https->http
     downgrade transparently). `opener` is injectable (tests); production builds
     the hardened opener via `_build_opener()`."""
-    if not isinstance(url, str) or not url.lower().startswith("https://"):
+    if tag_prefix is None:
+        descriptor = update_descriptor(host)
+        tag_prefix = descriptor.get("tag_prefix") if descriptor else None
+    if (not isinstance(tag_prefix, str) or not tag_prefix
+            or not isinstance(url, str) or not url.lower().startswith("https://")):
         return None
     try:
-        req = urllib.request.Request(url, headers={
-            "User-Agent": "codeArbiter-update-check",
-            "Accept": "application/vnd.github+json",
-        })
         op = opener or _build_opener()
-        with op.open(req, timeout=timeout) as resp:
-            status = getattr(resp, "status", None) or getattr(resp, "code", None)
-            if status != 200:
+        parsed_url = urllib.parse.urlsplit(url)
+        query = dict(urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True))
+        try:
+            page_size = int(query.get("per_page", "100"))
+        except (TypeError, ValueError):
+            page_size = 100
+        if page_size < 1:
+            page_size = 100
+
+        releases = []
+        for page in range(1, MAX_RELEASE_PAGES + 1):
+            page_query = dict(query)
+            page_query["page"] = str(page)
+            page_url = urllib.parse.urlunsplit(parsed_url._replace(
+                query=urllib.parse.urlencode(page_query)))
+            req = urllib.request.Request(page_url, headers={
+                "User-Agent": "codeArbiter-update-check",
+                "Accept": "application/vnd.github+json",
+            })
+            with op.open(req, timeout=timeout) as resp:
+                status = getattr(resp, "status", None) or getattr(resp, "code", None)
+                if status != 200:
+                    return None
+                body = resp.read()
+            page_data = json.loads(body.decode("utf-8", "replace"))
+            if not isinstance(page_data, list):
                 return None
-            body = resp.read()
-        data = json.loads(body.decode("utf-8", "replace"))
-        tag = data.get("tag_name") if isinstance(data, dict) else None
-        return tag.strip() if isinstance(tag, str) and tag.strip() else None
+            releases.extend(page_data)
+            if len(page_data) < page_size:
+                break
+        else:
+            # Every bounded page was full, so more releases may exist. Do not
+            # cache a result whose series enumeration is known to be incomplete.
+            return None
+        return select_latest_tag(releases, tag_prefix)
     except Exception:  # noqa: BLE001 — AC-5: fail-silent on any network/parse error
         return None
 
 
-def refresh_if_stale(now=None, fetcher=None, path=None):
+def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
     Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
@@ -262,17 +370,55 @@ def refresh_if_stale(now=None, fetcher=None, path=None):
     now = time.time() if now is None else now
     path = path or state_path()
     state = read_state(path)
-    checked_at = state.get("checked_at") if isinstance(state, dict) else None
+    descriptor = update_descriptor(host)
+    if descriptor is None:
+        return state
+    row = target_state(state, host=host)
+    checked_at = row.get("checked_at")
     if not is_stale(checked_at, now):
         return state
-    fetch = fetcher or fetch_latest_tag
+    fetch = fetcher or (lambda: fetch_latest_tag(
+        tag_prefix=descriptor["tag_prefix"], host=host))
     try:
         latest = fetch()
     except Exception:  # noqa: BLE001 — AC-3/AC-5: never propagate a fetch failure
         latest = None
-    new_state = {
-        "latest": latest if latest else state.get("latest"),
-        "checked_at": now,
-    }
-    write_state(new_state, path)
-    return new_state
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        # Re-read under the write lock. Another independently versioned host
+        # may have refreshed while this process was waiting on GitHub; merging
+        # the pre-fetch snapshot would silently erase that target's row.
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+
+        current_latest = current_row.get("latest")
+        if parse_version(latest) is None:
+            merged_latest = current_latest
+        elif (parse_version(current_latest) is not None
+              and version_gt(current_latest, latest)):
+            merged_latest = current_latest
+        else:
+            merged_latest = latest
+
+        current_checked_at = current_row.get("checked_at")
+        finite_checked_at = []
+        for value in (current_checked_at, now):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                finite_checked_at.append(value)
+        targets[descriptor["target"]] = {
+            "latest": merged_latest,
+            "checked_at": max(finite_checked_at) if finite_checked_at else None,
+        }
+        new_state = {"schema": 1, "targets": targets}
+        write_state(new_state, path)
+        return new_state
+    finally:
+        release_lock(lock)

--- a/plugins/ca-codex/hooks/_updatelib.py
+++ b/plugins/ca-codex/hooks/_updatelib.py
@@ -211,9 +211,9 @@ def notice_line(installed, latest, host=None):
 
 
 def read_state(path=None):
-    """The cached `{latest, checked_at}` state, or {} on ANY failure (missing file,
-    corrupt JSON, non-dict content) — a corrupt cache degrades to 'no notice', never
-    a crash of the host hook."""
+    """The target-keyed cache state, or {} on ANY failure (missing file, corrupt
+    JSON, non-dict content) — a corrupt cache degrades to 'no notice', never a
+    crash of the host hook."""
     path = path or state_path()
     try:
         with open(path, encoding="utf-8") as f:
@@ -360,23 +360,57 @@ def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
 def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
-    Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
-    UNCHANGED and calls the fetcher NOT AT ALL (AC-4 — at most one fetch per day).
-    Otherwise calls `fetcher()` (default fetch_latest_tag): on success the new
+    Reads the cache under the write lock; if `checked_at` is still fresh
+    (is_stale() False), returns it UNCHANGED and calls the fetcher NOT AT ALL.
+    Otherwise it reserves that target's daily refresh before releasing the lock,
+    so a concurrent same-target process observes a fresh row and also makes no
+    call (AC-4 — at most one fetch per day). It then calls `fetcher()` (default
+    fetch_latest_tag): on success the new
     `latest` is cached; on ANY exception or a None/falsy return, the PRIOR `latest`
     is preserved (fail-silent — a network hiccup never blanks a known-good notice)
     and `checked_at` still advances, so a persistently-unreachable network is not
     retried every single session that day. Never raises (AC-3)."""
     now = time.time() if now is None else now
     path = path or state_path()
-    state = read_state(path)
     descriptor = update_descriptor(host)
     if descriptor is None:
-        return state
-    row = target_state(state, host=host)
-    checked_at = row.get("checked_at")
-    if not is_stale(checked_at, now):
-        return state
+        return read_state(path)
+
+    # Reserve this target's refresh under the cache lock before any network
+    # work. Without the re-read and reservation here, concurrent detached
+    # SessionStart refreshes can all observe the same stale row and each issue
+    # a bounded release-page fetch before the later merge lock serializes them.
+    try:
+        reservation_at = float(now)
+    except (TypeError, ValueError):
+        return read_state(path)
+    if not math.isfinite(reservation_at):
+        return read_state(path)
+
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        if not is_stale(current_row.get("checked_at"), reservation_at):
+            return current
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+        targets[descriptor["target"]] = {
+            "latest": current_row.get("latest"),
+            "checked_at": reservation_at,
+        }
+        reserved_state = {"schema": 1, "targets": targets}
+        write_state(reserved_state, path)
+        confirmed_row = target_state(read_state(path), host=host)
+        if confirmed_row.get("checked_at") != reservation_at:
+            # A failed reservation cannot safely authorize network egress. The
+            # notifier remains fail-silent and will retry on a later session.
+            return read_state(path)
+    finally:
+        release_lock(lock)
+
     fetch = fetcher or (lambda: fetch_latest_tag(
         tag_prefix=descriptor["tag_prefix"], host=host))
     try:

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -234,7 +234,16 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.15.6"
+    adapter_version = "2.15.7"
+
+    # Update-notifier descriptor. Each independently versioned host overrides
+    # these three values in its per-plugin _host.py. Keeping the target,
+    # release prefix, and remediation command together on the active Host
+    # prevents the shared notifier from comparing or instructing for a sibling
+    # product line (RA-02).
+    update_target = "ca"
+    update_tag_prefix = "v"
+    update_command = "/plugin marketplace update codearbiter"
 
     # Capability flags — what surfaces this host actually has. A hook that
     # heals/queries a statusline gates on has_statusline; a hook registered
@@ -509,6 +518,9 @@ class FailClosedHost(Host):
     silent (observability-002)."""
 
     name = "unknown"
+    update_target = None
+    update_tag_prefix = None
+    update_command = None
     has_statusline = False
     has_read_tool = False
     has_prunable_transcript = False

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -885,7 +885,7 @@ def update_notice_line(plugin):
     no network call itself."""
     try:
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         return _updatelib.notice_line(installed, latest) or ""
     except Exception:  # noqa: BLE001 — never crash session startup

--- a/plugins/ca-codex/hooks/statusline.py
+++ b/plugins/ca-codex/hooks/statusline.py
@@ -431,7 +431,7 @@ def seg_update(plugin=None):
     try:
         plugin = plugin if plugin is not None else plugin_root_for_render()
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         if not _updatelib.update_available(installed, latest):
             return None

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-09-01
+
+### Fixed
+
+- The update notifier now ignores unrelated release series, keeps `ca-pi-v*`
+  state independent from Claude and Codex, and emits Pi's native package
+  update command.
+
 ## [0.8.5] - 2026-08-26
 
 ### Changed

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,10 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.8.5"
+    adapter_version = "0.8.6"
+    update_target = "ca-pi"
+    update_tag_prefix = "ca-pi-v"
+    update_command = "pi update npm:@arbiterforge/ca-pi"
     command_noun = "command"
     has_statusline = False
     has_read_tool = True

--- a/plugins/ca-pi/hooks/_updatelib.py
+++ b/plugins/ca-pi/hooks/_updatelib.py
@@ -5,15 +5,17 @@
 # auto-update by default (only official Anthropic marketplaces get that). This
 # module backs a lightweight notifier so a stale install is surfaced instead of
 # running forever unnoticed: it reads the installed plugin.json version, reads
-# a small user-global cache of the latest published GitHub release, and — when
-# the cache says a newer version exists — hands back a single notice line. Both
+# a small user-global cache keyed by independently versioned release target,
+# and — when that target's cache says a newer version exists — hands back a
+# single host-native notice line. Both
 # SessionStart and the statusline render from that SAME cache; neither makes a
 # network call on its own hot path (issue #194's constraint).
 #
 # The only network call this module makes (fetch_latest_tag) is invoked from
 # the OFF-hot-path detached refresh (see hooks/update-refresh.py, spawned by
 # session-start.py). refresh_if_stale() gates that call to at most once per
-# day via the cached `checked_at`, and is fail-silent end to end: any network
+# day per target via the cached `checked_at`, and is fail-silent end to end:
+# any network
 # error, timeout, non-200, or unparseable body degrades to "keep the last-known
 # latest" — never a traceback, never a crash of the host hook.
 #
@@ -34,18 +36,24 @@
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
-#   notice_line(installed, latest) -> str|None    the SessionStart/statusline notice text
-#   read_state(path=None) -> dict            {latest, checked_at} cache, or {} on any failure
+#   update_descriptor(host=None) -> dict|None validated host update descriptor
+#   target_state(state, host=None) -> dict    one target's cache row, or {}
+#   notice_line(installed, latest, host=None) -> str|None host-native notice text
+#   read_state(path=None) -> dict            target-keyed cache, or {} on any failure
 #   write_state(state, path=None) -> None    atomic cache write; best-effort, never raises
 #   is_stale(checked_at, now, interval=ONE_DAY) -> bool   True iff a refresh is due
-#   fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None) -> str|None   HTTPS GET, fail-silent
-#   refresh_if_stale(now=None, fetcher=None, path=None) -> dict   best-effort cache refresh
+#   select_latest_tag(releases, tag_prefix) -> str|None target-series selection
+#   fetch_latest_tag(tag_prefix=None, url=..., timeout=3.0,
+#                    opener=None, host=None) -> str|None
+#   refresh_if_stale(now=None, fetcher=None, path=None, host=None) -> dict
 
 import json
+import math
 import os
 import re
 import sys
 import time
+import urllib.parse
 import urllib.request
 
 # Reuse the ONE atomic-write helper defined in _hooklib.py (same rationale as
@@ -54,16 +62,23 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+from _hooklib import (  # noqa: E402 — sys.path mount above
+    acquire_lock,
+    get_host,
+    release_lock,
+    write_text_atomic,
+)
 # hostapi is not imported directly here (#257): plugin_root()/installed_version()
 # resolve the Host via _hooklib.get_host() (the DI seam every entry script's
 # run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
-# The repo's own GitHub Releases API — unauthenticated GET, HTTPS only (ADR-0003).
-# The release tag equals plugin.json's version (an established repo invariant).
-UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases/latest"
+# The repo's GitHub Releases collection — unauthenticated GET, HTTPS only
+# (ADR-0003). A collection is required because each host publishes an
+# independent tag series; /releases/latest can represent only one of them.
+UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases?per_page=100"
+MAX_RELEASE_PAGES = 10
 
 _VERSION_STRIP_RE = re.compile(r"^[vV]")
 
@@ -147,15 +162,52 @@ def update_available(installed, latest):
     return version_gt(latest, installed)
 
 
-def notice_line(installed, latest):
+def update_descriptor(host=None):
+    """Validated update descriptor for `host` (or the active host), else None.
+    A partially defined or multi-line descriptor disables the notifier rather
+    than falling back to another host's release series or command."""
+    host = host or get_host()
+    target = getattr(host, "update_target", None)
+    prefix = getattr(host, "update_tag_prefix", None)
+    command = getattr(host, "update_command", None)
+    if not all(isinstance(value, str) and value.strip()
+               for value in (target, prefix, command)):
+        return None
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", target.strip()):
+        return None
+    if "\n" in command or "\r" in command:
+        return None
+    return {
+        "target": target.strip(),
+        "tag_prefix": prefix.strip(),
+        "command": command.strip(),
+    }
+
+
+def target_state(state, host=None):
+    """The active host target's `{latest, checked_at}` row, or {}.
+    Legacy unkeyed cache data is deliberately not attributed to any host: its
+    `latest` may belong to an unrelated release series (the RA-02 defect)."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not isinstance(state, dict) or state.get("schema") != 1:
+        return {}
+    targets = state.get("targets")
+    if not isinstance(targets, dict):
+        return {}
+    row = targets.get(descriptor["target"])
+    return row if isinstance(row, dict) else {}
+
+
+def notice_line(installed, latest, host=None):
     """The single-line SessionStart/statusline notice, or None when no update is due
-    (AC-1/AC-2): `codeArbiter: update available X -> Y (run /plugin marketplace update
-    codearbiter)`. Never multi-line; never emitted for equal, lesser, missing, or
-    malformed `latest`."""
-    if not update_available(installed, latest):
+    (AC-1/AC-2): `codeArbiter: update available X -> Y (run <host command>)`.
+    Never multi-line; never emitted for equal, lesser, missing, or malformed
+    `latest`."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not update_available(installed, latest):
         return None
     return (f"codeArbiter: update available {installed} -> {latest} "
-            f"(run /plugin marketplace update codearbiter)")
+            f"(run {descriptor['command']})")
 
 
 def read_state(path=None):
@@ -190,7 +242,10 @@ def is_stale(checked_at, now, interval=ONE_DAY):
     if checked_at is None:
         return True
     try:
-        return (now - float(checked_at)) >= interval
+        checked_at = float(checked_at)
+        if not math.isfinite(checked_at):
+            return True
+        return (now - checked_at) >= interval
     except (TypeError, ValueError):
         return True
 
@@ -220,8 +275,34 @@ def _build_opener():
     return urllib.request.build_opener(_HTTPSOnlyRedirectHandler())
 
 
-def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
-    """GET the GitHub Releases API and return `tag_name`, or None on ANY problem
+def select_latest_tag(releases, tag_prefix):
+    """Highest stable numeric version in `releases` for exact `tag_prefix`.
+    Drafts, prereleases, malformed rows, and every sibling series are ignored."""
+    if not isinstance(releases, list) or not isinstance(tag_prefix, str) or not tag_prefix:
+        return None
+    selected = None
+    selected_tuple = None
+    for release in releases:
+        if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+            continue
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not tag.startswith(tag_prefix):
+            continue
+        version = tag[len(tag_prefix):]
+        if not re.fullmatch(r"\d+(?:\.\d+)*", version):
+            continue
+        parsed = parse_version(version)
+        if parsed is not None and (selected_tuple is None or parsed > selected_tuple):
+            selected = version
+            selected_tuple = parsed
+    return selected
+
+
+def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
+                     opener=None, host=None):
+    """GET bounded pages of the GitHub Releases API and return the active
+    series' highest stable numeric version, or
+    None on ANY problem
     (AC-5): non-https url, network error, timeout, non-200, an unparseable/absent
     body, or a redirect to a non-https target. HTTPS-only per ADR-0003 — a
     non-https INITIAL url is refused before any connection is attempted, and a
@@ -229,27 +310,54 @@ def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
     since urllib's default opener would otherwise follow an https->http
     downgrade transparently). `opener` is injectable (tests); production builds
     the hardened opener via `_build_opener()`."""
-    if not isinstance(url, str) or not url.lower().startswith("https://"):
+    if tag_prefix is None:
+        descriptor = update_descriptor(host)
+        tag_prefix = descriptor.get("tag_prefix") if descriptor else None
+    if (not isinstance(tag_prefix, str) or not tag_prefix
+            or not isinstance(url, str) or not url.lower().startswith("https://")):
         return None
     try:
-        req = urllib.request.Request(url, headers={
-            "User-Agent": "codeArbiter-update-check",
-            "Accept": "application/vnd.github+json",
-        })
         op = opener or _build_opener()
-        with op.open(req, timeout=timeout) as resp:
-            status = getattr(resp, "status", None) or getattr(resp, "code", None)
-            if status != 200:
+        parsed_url = urllib.parse.urlsplit(url)
+        query = dict(urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True))
+        try:
+            page_size = int(query.get("per_page", "100"))
+        except (TypeError, ValueError):
+            page_size = 100
+        if page_size < 1:
+            page_size = 100
+
+        releases = []
+        for page in range(1, MAX_RELEASE_PAGES + 1):
+            page_query = dict(query)
+            page_query["page"] = str(page)
+            page_url = urllib.parse.urlunsplit(parsed_url._replace(
+                query=urllib.parse.urlencode(page_query)))
+            req = urllib.request.Request(page_url, headers={
+                "User-Agent": "codeArbiter-update-check",
+                "Accept": "application/vnd.github+json",
+            })
+            with op.open(req, timeout=timeout) as resp:
+                status = getattr(resp, "status", None) or getattr(resp, "code", None)
+                if status != 200:
+                    return None
+                body = resp.read()
+            page_data = json.loads(body.decode("utf-8", "replace"))
+            if not isinstance(page_data, list):
                 return None
-            body = resp.read()
-        data = json.loads(body.decode("utf-8", "replace"))
-        tag = data.get("tag_name") if isinstance(data, dict) else None
-        return tag.strip() if isinstance(tag, str) and tag.strip() else None
+            releases.extend(page_data)
+            if len(page_data) < page_size:
+                break
+        else:
+            # Every bounded page was full, so more releases may exist. Do not
+            # cache a result whose series enumeration is known to be incomplete.
+            return None
+        return select_latest_tag(releases, tag_prefix)
     except Exception:  # noqa: BLE001 — AC-5: fail-silent on any network/parse error
         return None
 
 
-def refresh_if_stale(now=None, fetcher=None, path=None):
+def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
     Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
@@ -262,17 +370,55 @@ def refresh_if_stale(now=None, fetcher=None, path=None):
     now = time.time() if now is None else now
     path = path or state_path()
     state = read_state(path)
-    checked_at = state.get("checked_at") if isinstance(state, dict) else None
+    descriptor = update_descriptor(host)
+    if descriptor is None:
+        return state
+    row = target_state(state, host=host)
+    checked_at = row.get("checked_at")
     if not is_stale(checked_at, now):
         return state
-    fetch = fetcher or fetch_latest_tag
+    fetch = fetcher or (lambda: fetch_latest_tag(
+        tag_prefix=descriptor["tag_prefix"], host=host))
     try:
         latest = fetch()
     except Exception:  # noqa: BLE001 — AC-3/AC-5: never propagate a fetch failure
         latest = None
-    new_state = {
-        "latest": latest if latest else state.get("latest"),
-        "checked_at": now,
-    }
-    write_state(new_state, path)
-    return new_state
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        # Re-read under the write lock. Another independently versioned host
+        # may have refreshed while this process was waiting on GitHub; merging
+        # the pre-fetch snapshot would silently erase that target's row.
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+
+        current_latest = current_row.get("latest")
+        if parse_version(latest) is None:
+            merged_latest = current_latest
+        elif (parse_version(current_latest) is not None
+              and version_gt(current_latest, latest)):
+            merged_latest = current_latest
+        else:
+            merged_latest = latest
+
+        current_checked_at = current_row.get("checked_at")
+        finite_checked_at = []
+        for value in (current_checked_at, now):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                finite_checked_at.append(value)
+        targets[descriptor["target"]] = {
+            "latest": merged_latest,
+            "checked_at": max(finite_checked_at) if finite_checked_at else None,
+        }
+        new_state = {"schema": 1, "targets": targets}
+        write_state(new_state, path)
+        return new_state
+    finally:
+        release_lock(lock)

--- a/plugins/ca-pi/hooks/_updatelib.py
+++ b/plugins/ca-pi/hooks/_updatelib.py
@@ -211,9 +211,9 @@ def notice_line(installed, latest, host=None):
 
 
 def read_state(path=None):
-    """The cached `{latest, checked_at}` state, or {} on ANY failure (missing file,
-    corrupt JSON, non-dict content) — a corrupt cache degrades to 'no notice', never
-    a crash of the host hook."""
+    """The target-keyed cache state, or {} on ANY failure (missing file, corrupt
+    JSON, non-dict content) — a corrupt cache degrades to 'no notice', never a
+    crash of the host hook."""
     path = path or state_path()
     try:
         with open(path, encoding="utf-8") as f:
@@ -360,23 +360,57 @@ def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
 def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
-    Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
-    UNCHANGED and calls the fetcher NOT AT ALL (AC-4 — at most one fetch per day).
-    Otherwise calls `fetcher()` (default fetch_latest_tag): on success the new
+    Reads the cache under the write lock; if `checked_at` is still fresh
+    (is_stale() False), returns it UNCHANGED and calls the fetcher NOT AT ALL.
+    Otherwise it reserves that target's daily refresh before releasing the lock,
+    so a concurrent same-target process observes a fresh row and also makes no
+    call (AC-4 — at most one fetch per day). It then calls `fetcher()` (default
+    fetch_latest_tag): on success the new
     `latest` is cached; on ANY exception or a None/falsy return, the PRIOR `latest`
     is preserved (fail-silent — a network hiccup never blanks a known-good notice)
     and `checked_at` still advances, so a persistently-unreachable network is not
     retried every single session that day. Never raises (AC-3)."""
     now = time.time() if now is None else now
     path = path or state_path()
-    state = read_state(path)
     descriptor = update_descriptor(host)
     if descriptor is None:
-        return state
-    row = target_state(state, host=host)
-    checked_at = row.get("checked_at")
-    if not is_stale(checked_at, now):
-        return state
+        return read_state(path)
+
+    # Reserve this target's refresh under the cache lock before any network
+    # work. Without the re-read and reservation here, concurrent detached
+    # SessionStart refreshes can all observe the same stale row and each issue
+    # a bounded release-page fetch before the later merge lock serializes them.
+    try:
+        reservation_at = float(now)
+    except (TypeError, ValueError):
+        return read_state(path)
+    if not math.isfinite(reservation_at):
+        return read_state(path)
+
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        if not is_stale(current_row.get("checked_at"), reservation_at):
+            return current
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+        targets[descriptor["target"]] = {
+            "latest": current_row.get("latest"),
+            "checked_at": reservation_at,
+        }
+        reserved_state = {"schema": 1, "targets": targets}
+        write_state(reserved_state, path)
+        confirmed_row = target_state(read_state(path), host=host)
+        if confirmed_row.get("checked_at") != reservation_at:
+            # A failed reservation cannot safely authorize network egress. The
+            # notifier remains fail-silent and will retry on a later session.
+            return read_state(path)
+    finally:
+        release_lock(lock)
+
     fetch = fetcher or (lambda: fetch_latest_tag(
         tag_prefix=descriptor["tag_prefix"], host=host))
     try:

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -234,7 +234,16 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.15.6"
+    adapter_version = "2.15.7"
+
+    # Update-notifier descriptor. Each independently versioned host overrides
+    # these three values in its per-plugin _host.py. Keeping the target,
+    # release prefix, and remediation command together on the active Host
+    # prevents the shared notifier from comparing or instructing for a sibling
+    # product line (RA-02).
+    update_target = "ca"
+    update_tag_prefix = "v"
+    update_command = "/plugin marketplace update codearbiter"
 
     # Capability flags — what surfaces this host actually has. A hook that
     # heals/queries a statusline gates on has_statusline; a hook registered
@@ -509,6 +518,9 @@ class FailClosedHost(Host):
     silent (observability-002)."""
 
     name = "unknown"
+    update_target = None
+    update_tag_prefix = None
+    update_command = None
     has_statusline = False
     has_read_tool = False
     has_prunable_transcript = False

--- a/plugins/ca-pi/hooks/session-start.py
+++ b/plugins/ca-pi/hooks/session-start.py
@@ -885,7 +885,7 @@ def update_notice_line(plugin):
     no network call itself."""
     try:
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         return _updatelib.notice_line(installed, latest) or ""
     except Exception:  # noqa: BLE001 — never crash session startup

--- a/plugins/ca-pi/hooks/statusline.py
+++ b/plugins/ca-pi/hooks/statusline.py
@@ -431,7 +431,7 @@ def seg_update(plugin=None):
     try:
         plugin = plugin if plugin is not None else plugin_root_for_render()
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         if not _updatelib.update_available(installed, latest):
             return None

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.15.6"
+    adapter_version = "2.15.7"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/_updatelib.py
+++ b/plugins/ca/hooks/_updatelib.py
@@ -5,15 +5,17 @@
 # auto-update by default (only official Anthropic marketplaces get that). This
 # module backs a lightweight notifier so a stale install is surfaced instead of
 # running forever unnoticed: it reads the installed plugin.json version, reads
-# a small user-global cache of the latest published GitHub release, and — when
-# the cache says a newer version exists — hands back a single notice line. Both
+# a small user-global cache keyed by independently versioned release target,
+# and — when that target's cache says a newer version exists — hands back a
+# single host-native notice line. Both
 # SessionStart and the statusline render from that SAME cache; neither makes a
 # network call on its own hot path (issue #194's constraint).
 #
 # The only network call this module makes (fetch_latest_tag) is invoked from
 # the OFF-hot-path detached refresh (see hooks/update-refresh.py, spawned by
 # session-start.py). refresh_if_stale() gates that call to at most once per
-# day via the cached `checked_at`, and is fail-silent end to end: any network
+# day per target via the cached `checked_at`, and is fail-silent end to end:
+# any network
 # error, timeout, non-200, or unparseable body degrades to "keep the last-known
 # latest" — never a traceback, never a crash of the host hook.
 #
@@ -34,18 +36,24 @@
 #   parse_version(s) -> tuple|None           numeric-tuple parse; None if malformed/absent
 #   version_gt(a, b) -> bool                 True iff semver a > b (numeric-tuple compare)
 #   update_available(installed, latest) -> bool   True iff latest > installed
-#   notice_line(installed, latest) -> str|None    the SessionStart/statusline notice text
-#   read_state(path=None) -> dict            {latest, checked_at} cache, or {} on any failure
+#   update_descriptor(host=None) -> dict|None validated host update descriptor
+#   target_state(state, host=None) -> dict    one target's cache row, or {}
+#   notice_line(installed, latest, host=None) -> str|None host-native notice text
+#   read_state(path=None) -> dict            target-keyed cache, or {} on any failure
 #   write_state(state, path=None) -> None    atomic cache write; best-effort, never raises
 #   is_stale(checked_at, now, interval=ONE_DAY) -> bool   True iff a refresh is due
-#   fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None) -> str|None   HTTPS GET, fail-silent
-#   refresh_if_stale(now=None, fetcher=None, path=None) -> dict   best-effort cache refresh
+#   select_latest_tag(releases, tag_prefix) -> str|None target-series selection
+#   fetch_latest_tag(tag_prefix=None, url=..., timeout=3.0,
+#                    opener=None, host=None) -> str|None
+#   refresh_if_stale(now=None, fetcher=None, path=None, host=None) -> dict
 
 import json
+import math
 import os
 import re
 import sys
 import time
+import urllib.parse
 import urllib.request
 
 # Reuse the ONE atomic-write helper defined in _hooklib.py (same rationale as
@@ -54,16 +62,23 @@ import urllib.request
 _HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
-from _hooklib import get_host, write_text_atomic  # noqa: E402 — sys.path mount above
+from _hooklib import (  # noqa: E402 — sys.path mount above
+    acquire_lock,
+    get_host,
+    release_lock,
+    write_text_atomic,
+)
 # hostapi is not imported directly here (#257): plugin_root()/installed_version()
 # resolve the Host via _hooklib.get_host() (the DI seam every entry script's
 # run(host) primes via set_host()), never a fresh hostapi.load_host().
 
 ONE_DAY = 24 * 60 * 60
 
-# The repo's own GitHub Releases API — unauthenticated GET, HTTPS only (ADR-0003).
-# The release tag equals plugin.json's version (an established repo invariant).
-UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases/latest"
+# The repo's GitHub Releases collection — unauthenticated GET, HTTPS only
+# (ADR-0003). A collection is required because each host publishes an
+# independent tag series; /releases/latest can represent only one of them.
+UPDATE_API_URL = "https://api.github.com/repos/arbiterForge/codeArbiter/releases?per_page=100"
+MAX_RELEASE_PAGES = 10
 
 _VERSION_STRIP_RE = re.compile(r"^[vV]")
 
@@ -147,15 +162,52 @@ def update_available(installed, latest):
     return version_gt(latest, installed)
 
 
-def notice_line(installed, latest):
+def update_descriptor(host=None):
+    """Validated update descriptor for `host` (or the active host), else None.
+    A partially defined or multi-line descriptor disables the notifier rather
+    than falling back to another host's release series or command."""
+    host = host or get_host()
+    target = getattr(host, "update_target", None)
+    prefix = getattr(host, "update_tag_prefix", None)
+    command = getattr(host, "update_command", None)
+    if not all(isinstance(value, str) and value.strip()
+               for value in (target, prefix, command)):
+        return None
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", target.strip()):
+        return None
+    if "\n" in command or "\r" in command:
+        return None
+    return {
+        "target": target.strip(),
+        "tag_prefix": prefix.strip(),
+        "command": command.strip(),
+    }
+
+
+def target_state(state, host=None):
+    """The active host target's `{latest, checked_at}` row, or {}.
+    Legacy unkeyed cache data is deliberately not attributed to any host: its
+    `latest` may belong to an unrelated release series (the RA-02 defect)."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not isinstance(state, dict) or state.get("schema") != 1:
+        return {}
+    targets = state.get("targets")
+    if not isinstance(targets, dict):
+        return {}
+    row = targets.get(descriptor["target"])
+    return row if isinstance(row, dict) else {}
+
+
+def notice_line(installed, latest, host=None):
     """The single-line SessionStart/statusline notice, or None when no update is due
-    (AC-1/AC-2): `codeArbiter: update available X -> Y (run /plugin marketplace update
-    codearbiter)`. Never multi-line; never emitted for equal, lesser, missing, or
-    malformed `latest`."""
-    if not update_available(installed, latest):
+    (AC-1/AC-2): `codeArbiter: update available X -> Y (run <host command>)`.
+    Never multi-line; never emitted for equal, lesser, missing, or malformed
+    `latest`."""
+    descriptor = update_descriptor(host)
+    if descriptor is None or not update_available(installed, latest):
         return None
     return (f"codeArbiter: update available {installed} -> {latest} "
-            f"(run /plugin marketplace update codearbiter)")
+            f"(run {descriptor['command']})")
 
 
 def read_state(path=None):
@@ -190,7 +242,10 @@ def is_stale(checked_at, now, interval=ONE_DAY):
     if checked_at is None:
         return True
     try:
-        return (now - float(checked_at)) >= interval
+        checked_at = float(checked_at)
+        if not math.isfinite(checked_at):
+            return True
+        return (now - checked_at) >= interval
     except (TypeError, ValueError):
         return True
 
@@ -220,8 +275,34 @@ def _build_opener():
     return urllib.request.build_opener(_HTTPSOnlyRedirectHandler())
 
 
-def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
-    """GET the GitHub Releases API and return `tag_name`, or None on ANY problem
+def select_latest_tag(releases, tag_prefix):
+    """Highest stable numeric version in `releases` for exact `tag_prefix`.
+    Drafts, prereleases, malformed rows, and every sibling series are ignored."""
+    if not isinstance(releases, list) or not isinstance(tag_prefix, str) or not tag_prefix:
+        return None
+    selected = None
+    selected_tuple = None
+    for release in releases:
+        if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+            continue
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not tag.startswith(tag_prefix):
+            continue
+        version = tag[len(tag_prefix):]
+        if not re.fullmatch(r"\d+(?:\.\d+)*", version):
+            continue
+        parsed = parse_version(version)
+        if parsed is not None and (selected_tuple is None or parsed > selected_tuple):
+            selected = version
+            selected_tuple = parsed
+    return selected
+
+
+def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
+                     opener=None, host=None):
+    """GET bounded pages of the GitHub Releases API and return the active
+    series' highest stable numeric version, or
+    None on ANY problem
     (AC-5): non-https url, network error, timeout, non-200, an unparseable/absent
     body, or a redirect to a non-https target. HTTPS-only per ADR-0003 — a
     non-https INITIAL url is refused before any connection is attempted, and a
@@ -229,27 +310,54 @@ def fetch_latest_tag(url=UPDATE_API_URL, timeout=3.0, opener=None):
     since urllib's default opener would otherwise follow an https->http
     downgrade transparently). `opener` is injectable (tests); production builds
     the hardened opener via `_build_opener()`."""
-    if not isinstance(url, str) or not url.lower().startswith("https://"):
+    if tag_prefix is None:
+        descriptor = update_descriptor(host)
+        tag_prefix = descriptor.get("tag_prefix") if descriptor else None
+    if (not isinstance(tag_prefix, str) or not tag_prefix
+            or not isinstance(url, str) or not url.lower().startswith("https://")):
         return None
     try:
-        req = urllib.request.Request(url, headers={
-            "User-Agent": "codeArbiter-update-check",
-            "Accept": "application/vnd.github+json",
-        })
         op = opener or _build_opener()
-        with op.open(req, timeout=timeout) as resp:
-            status = getattr(resp, "status", None) or getattr(resp, "code", None)
-            if status != 200:
+        parsed_url = urllib.parse.urlsplit(url)
+        query = dict(urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True))
+        try:
+            page_size = int(query.get("per_page", "100"))
+        except (TypeError, ValueError):
+            page_size = 100
+        if page_size < 1:
+            page_size = 100
+
+        releases = []
+        for page in range(1, MAX_RELEASE_PAGES + 1):
+            page_query = dict(query)
+            page_query["page"] = str(page)
+            page_url = urllib.parse.urlunsplit(parsed_url._replace(
+                query=urllib.parse.urlencode(page_query)))
+            req = urllib.request.Request(page_url, headers={
+                "User-Agent": "codeArbiter-update-check",
+                "Accept": "application/vnd.github+json",
+            })
+            with op.open(req, timeout=timeout) as resp:
+                status = getattr(resp, "status", None) or getattr(resp, "code", None)
+                if status != 200:
+                    return None
+                body = resp.read()
+            page_data = json.loads(body.decode("utf-8", "replace"))
+            if not isinstance(page_data, list):
                 return None
-            body = resp.read()
-        data = json.loads(body.decode("utf-8", "replace"))
-        tag = data.get("tag_name") if isinstance(data, dict) else None
-        return tag.strip() if isinstance(tag, str) and tag.strip() else None
+            releases.extend(page_data)
+            if len(page_data) < page_size:
+                break
+        else:
+            # Every bounded page was full, so more releases may exist. Do not
+            # cache a result whose series enumeration is known to be incomplete.
+            return None
+        return select_latest_tag(releases, tag_prefix)
     except Exception:  # noqa: BLE001 — AC-5: fail-silent on any network/parse error
         return None
 
 
-def refresh_if_stale(now=None, fetcher=None, path=None):
+def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
     Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
@@ -262,17 +370,55 @@ def refresh_if_stale(now=None, fetcher=None, path=None):
     now = time.time() if now is None else now
     path = path or state_path()
     state = read_state(path)
-    checked_at = state.get("checked_at") if isinstance(state, dict) else None
+    descriptor = update_descriptor(host)
+    if descriptor is None:
+        return state
+    row = target_state(state, host=host)
+    checked_at = row.get("checked_at")
     if not is_stale(checked_at, now):
         return state
-    fetch = fetcher or fetch_latest_tag
+    fetch = fetcher or (lambda: fetch_latest_tag(
+        tag_prefix=descriptor["tag_prefix"], host=host))
     try:
         latest = fetch()
     except Exception:  # noqa: BLE001 — AC-3/AC-5: never propagate a fetch failure
         latest = None
-    new_state = {
-        "latest": latest if latest else state.get("latest"),
-        "checked_at": now,
-    }
-    write_state(new_state, path)
-    return new_state
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        # Re-read under the write lock. Another independently versioned host
+        # may have refreshed while this process was waiting on GitHub; merging
+        # the pre-fetch snapshot would silently erase that target's row.
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+
+        current_latest = current_row.get("latest")
+        if parse_version(latest) is None:
+            merged_latest = current_latest
+        elif (parse_version(current_latest) is not None
+              and version_gt(current_latest, latest)):
+            merged_latest = current_latest
+        else:
+            merged_latest = latest
+
+        current_checked_at = current_row.get("checked_at")
+        finite_checked_at = []
+        for value in (current_checked_at, now):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                finite_checked_at.append(value)
+        targets[descriptor["target"]] = {
+            "latest": merged_latest,
+            "checked_at": max(finite_checked_at) if finite_checked_at else None,
+        }
+        new_state = {"schema": 1, "targets": targets}
+        write_state(new_state, path)
+        return new_state
+    finally:
+        release_lock(lock)

--- a/plugins/ca/hooks/_updatelib.py
+++ b/plugins/ca/hooks/_updatelib.py
@@ -211,9 +211,9 @@ def notice_line(installed, latest, host=None):
 
 
 def read_state(path=None):
-    """The cached `{latest, checked_at}` state, or {} on ANY failure (missing file,
-    corrupt JSON, non-dict content) — a corrupt cache degrades to 'no notice', never
-    a crash of the host hook."""
+    """The target-keyed cache state, or {} on ANY failure (missing file, corrupt
+    JSON, non-dict content) — a corrupt cache degrades to 'no notice', never a
+    crash of the host hook."""
     path = path or state_path()
     try:
         with open(path, encoding="utf-8") as f:
@@ -360,23 +360,57 @@ def fetch_latest_tag(tag_prefix=None, url=UPDATE_API_URL, timeout=3.0,
 def refresh_if_stale(now=None, fetcher=None, path=None, host=None):
     """Best-effort, once-daily, fail-silent cache refresh (AC-3/AC-4/AC-5).
 
-    Reads the cache; if `checked_at` is still fresh (is_stale() False), returns it
-    UNCHANGED and calls the fetcher NOT AT ALL (AC-4 — at most one fetch per day).
-    Otherwise calls `fetcher()` (default fetch_latest_tag): on success the new
+    Reads the cache under the write lock; if `checked_at` is still fresh
+    (is_stale() False), returns it UNCHANGED and calls the fetcher NOT AT ALL.
+    Otherwise it reserves that target's daily refresh before releasing the lock,
+    so a concurrent same-target process observes a fresh row and also makes no
+    call (AC-4 — at most one fetch per day). It then calls `fetcher()` (default
+    fetch_latest_tag): on success the new
     `latest` is cached; on ANY exception or a None/falsy return, the PRIOR `latest`
     is preserved (fail-silent — a network hiccup never blanks a known-good notice)
     and `checked_at` still advances, so a persistently-unreachable network is not
     retried every single session that day. Never raises (AC-3)."""
     now = time.time() if now is None else now
     path = path or state_path()
-    state = read_state(path)
     descriptor = update_descriptor(host)
     if descriptor is None:
-        return state
-    row = target_state(state, host=host)
-    checked_at = row.get("checked_at")
-    if not is_stale(checked_at, now):
-        return state
+        return read_state(path)
+
+    # Reserve this target's refresh under the cache lock before any network
+    # work. Without the re-read and reservation here, concurrent detached
+    # SessionStart refreshes can all observe the same stale row and each issue
+    # a bounded release-page fetch before the later merge lock serializes them.
+    try:
+        reservation_at = float(now)
+    except (TypeError, ValueError):
+        return read_state(path)
+    if not math.isfinite(reservation_at):
+        return read_state(path)
+
+    lock = acquire_lock(path)
+    if lock is None:
+        return read_state(path)
+    try:
+        current = read_state(path)
+        current_row = target_state(current, host=host)
+        if not is_stale(current_row.get("checked_at"), reservation_at):
+            return current
+        prior_targets = current.get("targets") if isinstance(current, dict) else None
+        targets = dict(prior_targets) if isinstance(prior_targets, dict) else {}
+        targets[descriptor["target"]] = {
+            "latest": current_row.get("latest"),
+            "checked_at": reservation_at,
+        }
+        reserved_state = {"schema": 1, "targets": targets}
+        write_state(reserved_state, path)
+        confirmed_row = target_state(read_state(path), host=host)
+        if confirmed_row.get("checked_at") != reservation_at:
+            # A failed reservation cannot safely authorize network egress. The
+            # notifier remains fail-silent and will retry on a later session.
+            return read_state(path)
+    finally:
+        release_lock(lock)
+
     fetch = fetcher or (lambda: fetch_latest_tag(
         tag_prefix=descriptor["tag_prefix"], host=host))
     try:

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -234,7 +234,16 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.15.6"
+    adapter_version = "2.15.7"
+
+    # Update-notifier descriptor. Each independently versioned host overrides
+    # these three values in its per-plugin _host.py. Keeping the target,
+    # release prefix, and remediation command together on the active Host
+    # prevents the shared notifier from comparing or instructing for a sibling
+    # product line (RA-02).
+    update_target = "ca"
+    update_tag_prefix = "v"
+    update_command = "/plugin marketplace update codearbiter"
 
     # Capability flags — what surfaces this host actually has. A hook that
     # heals/queries a statusline gates on has_statusline; a hook registered
@@ -509,6 +518,9 @@ class FailClosedHost(Host):
     silent (observability-002)."""
 
     name = "unknown"
+    update_target = None
+    update_tag_prefix = None
+    update_command = None
     has_statusline = False
     has_read_tool = False
     has_prunable_transcript = False

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -885,7 +885,7 @@ def update_notice_line(plugin):
     no network call itself."""
     try:
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         return _updatelib.notice_line(installed, latest) or ""
     except Exception:  # noqa: BLE001 — never crash session startup

--- a/plugins/ca/hooks/statusline.py
+++ b/plugins/ca/hooks/statusline.py
@@ -431,7 +431,7 @@ def seg_update(plugin=None):
     try:
         plugin = plugin if plugin is not None else plugin_root_for_render()
         state = _updatelib.read_state(_updatelib.state_path())
-        latest = state.get("latest") if isinstance(state, dict) else None
+        latest = _updatelib.target_state(state).get("latest")
         installed = _updatelib.installed_version(plugin)
         if not _updatelib.update_available(installed, latest):
             return None

--- a/plugins/ca/hooks/tests/test_host_update_target.py
+++ b/plugins/ca/hooks/tests/test_host_update_target.py
@@ -1,0 +1,48 @@
+"""Tests for host-owned update release targets and native remediation commands."""
+import os
+import sys
+import unittest
+
+_HOOKS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+import hostapi
+
+
+class HostUpdateTargetTests(unittest.TestCase):
+    def _load_sibling(self, name):
+        hooks = os.path.abspath(os.path.join(
+            _HOOKS_DIR, "..", "..", name, "hooks"))
+        return hostapi.load_host(hooks)
+
+    def test_claude_descriptor_owns_its_release_series_and_command(self):
+        host = hostapi.Host()
+        self.assertEqual(host.update_target, "ca")
+        self.assertEqual(host.update_tag_prefix, "v")
+        self.assertEqual(host.update_command,
+                         "/plugin marketplace update codearbiter")
+
+    def test_codex_descriptor_owns_its_release_series_and_command(self):
+        host = self._load_sibling("ca-codex")
+        self.assertEqual(host.update_target, "ca-codex")
+        self.assertEqual(host.update_tag_prefix, "ca-codex-v")
+        self.assertEqual(host.update_command,
+                         "codex plugin add ca-codex@codearbiter")
+
+    def test_pi_descriptor_owns_its_release_series_and_command(self):
+        host = self._load_sibling("ca-pi")
+        self.assertEqual(host.update_target, "ca-pi")
+        self.assertEqual(host.update_tag_prefix, "ca-pi-v")
+        self.assertEqual(host.update_command,
+                         "pi update npm:@arbiterforge/ca-pi")
+
+    def test_unknown_host_disables_update_notices(self):
+        host = hostapi.FailClosedHost()
+        self.assertIsNone(host.update_target)
+        self.assertIsNone(host.update_tag_prefix)
+        self.assertIsNone(host.update_command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_plugin_root_resolution.py
+++ b/plugins/ca/hooks/tests/test_plugin_root_resolution.py
@@ -268,9 +268,9 @@ class ResolverContractTests(unittest.TestCase):
 
     def test_every_shipped_adapter_binds_its_exact_manifest_version(self):
         cases = (
-            ("ca", "2.15.6", ".claude-plugin/plugin.json"),
-            ("ca-codex", "0.7.5", ".codex-plugin/plugin.json"),
-            ("@arbiterforge/ca-pi", "0.8.5", "package.json"),
+            ("ca", "2.15.7", ".claude-plugin/plugin.json"),
+            ("ca-codex", "0.7.6", ".codex-plugin/plugin.json"),
+            ("@arbiterforge/ca-pi", "0.8.6", "package.json"),
         )
         for adapter, expected, manifest in cases:
             with self.subTest(adapter=adapter):

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -1270,7 +1270,9 @@ class TestUpdateNoticeLine(unittest.TestCase):
 
     def _write_cache(self, latest, checked_at=1000.0):
         with open(self.state_path, "w") as f:
-            json.dump({"latest": latest, "checked_at": checked_at}, f)
+            json.dump({"schema": 1, "targets": {
+                "ca": {"latest": latest, "checked_at": checked_at},
+            }}, f)
 
     def test_ac1_newer_cached_latest_yields_notice(self):
         self._write_cache("2.10.0")

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -871,7 +871,9 @@ class TestSegUpdate(unittest.TestCase):
 
     def _write_cache(self, latest):
         with open(self.state_path, "w") as f:
-            json.dump({"latest": latest, "checked_at": 1000.0}, f)
+            json.dump({"schema": 1, "targets": {
+                "ca": {"latest": latest, "checked_at": 1000.0},
+            }}, f)
 
     def test_ac1_newer_cached_latest_renders_marker(self):
         self._write_cache("2.10.0")

--- a/plugins/ca/hooks/tests/test_updatelib.py
+++ b/plugins/ca/hooks/tests/test_updatelib.py
@@ -26,6 +26,13 @@ import _updatelib as U
 from _helpers import redirect_home, restore_home
 
 
+class _FakeUpdateHost:
+    def __init__(self, target="ca", prefix="v", command="update ca"):
+        self.update_target = target
+        self.update_tag_prefix = prefix
+        self.update_command = command
+
+
 # =========================================================================== version parsing / compare (AC-6)
 class TestParseVersion(unittest.TestCase):
 
@@ -116,6 +123,23 @@ class TestNoticeLine(unittest.TestCase):
     def test_malformed_latest_no_notice(self):
         self.assertIsNone(U.notice_line("2.9.0", "garbage"))
 
+    def test_notice_uses_the_active_hosts_native_update_command(self):
+        hosts = (
+            _FakeUpdateHost("ca", "v", "/plugin marketplace update codearbiter"),
+            _FakeUpdateHost("ca-codex", "ca-codex-v",
+                            "codex plugin add ca-codex@codearbiter"),
+            _FakeUpdateHost("ca-pi", "ca-pi-v",
+                            "pi update npm:@arbiterforge/ca-pi"),
+        )
+        for host in hosts:
+            with self.subTest(target=host.update_target):
+                line = U.notice_line("0.7.4", "0.7.5", host=host)
+                self.assertIn(f"(run {host.update_command})", line)
+
+    def test_unknown_host_descriptor_suppresses_notice(self):
+        self.assertIsNone(U.notice_line(
+            "1.0.0", "9.0.0", host=_FakeUpdateHost(target=None, prefix=None, command=None)))
+
 
 # =========================================================================== cache read/write + is_stale (AC-4)
 class TestStateCache(unittest.TestCase):
@@ -162,6 +186,16 @@ class TestStateCache(unittest.TestCase):
         except Exception as e:  # noqa: BLE001
             self.fail(f"write_state raised: {e}")
 
+    def test_legacy_unkeyed_cache_is_not_attributed_to_any_host(self):
+        legacy = {"latest": "2.15.6", "checked_at": 1000.0}
+        self.assertEqual(U.target_state(legacy, host=_FakeUpdateHost("ca", "v")), {})
+        self.assertEqual(
+            U.target_state(legacy, host=_FakeUpdateHost("ca-codex", "ca-codex-v")), {})
+
+    def test_malformed_target_rows_degrade_to_empty(self):
+        state = {"schema": 1, "targets": {"ca": "not-an-object"}}
+        self.assertEqual(U.target_state(state, host=_FakeUpdateHost("ca", "v")), {})
+
 
 class TestIsStale(unittest.TestCase):
 
@@ -183,6 +217,10 @@ class TestIsStale(unittest.TestCase):
 
     def test_malformed_checked_at_is_stale(self):
         self.assertTrue(U.is_stale("not-a-number", now=1_000_000))
+
+    def test_non_finite_checked_at_is_stale(self):
+        self.assertTrue(U.is_stale(float("nan"), now=1_000_000))
+        self.assertTrue(U.is_stale(float("inf"), now=1_000_000))
 
 
 # =========================================================================== fetch_latest_tag (AC-5)
@@ -220,6 +258,8 @@ class _FakeOpener:
         self.calls.append((req, timeout))
         if self.exc is not None:
             raise self.exc
+        if isinstance(self.resp, list):
+            return self.resp.pop(0)
         return self.resp
 
 
@@ -232,10 +272,95 @@ class TestFetchLatestTag(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(opener.calls, [], "a non-https url must never reach the opener")
 
-    def test_success_parses_tag_name(self):
-        body = json.dumps({"tag_name": "2.10.0"}).encode("utf-8")
+    def test_success_selects_only_the_active_release_series(self):
+        body = json.dumps([
+            {"tag_name": "ca-pi-v0.8.5"},
+            {"tag_name": "ca-codex-v0.7.5"},
+            {"tag_name": "v2.15.6"},
+            {"tag_name": "ca-sandbox-v1.4.0"},
+        ]).encode("utf-8")
         opener = _FakeOpener(resp=_FakeResp(status=200, body=body))
-        self.assertEqual(U.fetch_latest_tag(opener=opener), "2.10.0")
+        self.assertEqual(U.fetch_latest_tag(tag_prefix="ca-codex-v", opener=opener),
+                         "0.7.5")
+
+    def test_target_series_is_found_beyond_the_first_release_page(self):
+        first_page = json.dumps([
+            {"tag_name": f"v2.{minor}.0"} for minor in range(100)
+        ]).encode("utf-8")
+        second_page = json.dumps([
+            {"tag_name": "ca-codex-v0.7.5"},
+        ]).encode("utf-8")
+        opener = _FakeOpener(resp=[
+            _FakeResp(status=200, body=first_page),
+            _FakeResp(status=200, body=second_page),
+        ])
+
+        self.assertEqual(
+            U.fetch_latest_tag(tag_prefix="ca-codex-v", opener=opener),
+            "0.7.5",
+        )
+        self.assertEqual(len(opener.calls), 2)
+        self.assertIn("page=2", opener.calls[1][0].full_url)
+
+    def test_incomplete_later_page_does_not_cache_a_partial_series_result(self):
+        first_page = json.dumps(
+            [{"tag_name": "ca-codex-v0.7.5"}]
+            + [{"tag_name": f"v2.{minor}.0"} for minor in range(99)]
+        ).encode("utf-8")
+        invalid_second_pages = [
+            _FakeResp(status=500, body=b"[]"),
+            _FakeResp(status=200, body=b"{}"),
+        ]
+
+        for invalid_page in invalid_second_pages:
+            with self.subTest(status=invalid_page.status, body=invalid_page._body):
+                opener = _FakeOpener(resp=[
+                    _FakeResp(status=200, body=first_page),
+                    invalid_page,
+                ])
+                self.assertIsNone(U.fetch_latest_tag(
+                    tag_prefix="ca-codex-v", opener=opener))
+
+    def test_page_bound_does_not_cache_a_known_incomplete_enumeration(self):
+        full_page = json.dumps(
+            [{"tag_name": "ca-codex-v0.7.5"}]
+            + [{"tag_name": f"v2.{minor}.0"} for minor in range(99)]
+        ).encode("utf-8")
+        opener = _FakeOpener(resp=[
+            _FakeResp(status=200, body=full_page)
+            for _ in range(U.MAX_RELEASE_PAGES)
+        ])
+
+        self.assertIsNone(U.fetch_latest_tag(
+            tag_prefix="ca-codex-v", opener=opener))
+        self.assertEqual(len(opener.calls), U.MAX_RELEASE_PAGES)
+
+    def test_simultaneous_release_series_ignore_every_unrelated_tag(self):
+        releases = [
+            {"tag_name": "v2.15.6"},
+            {"tag_name": "ca-codex-v0.7.5"},
+            {"tag_name": "ca-pi-v0.8.5"},
+            {"tag_name": "ca-sandbox-v1.4.0"},
+            {"tag_name": "ca-codex-v0.7.4"},
+        ]
+        expected = {
+            "v": "2.15.6",
+            "ca-codex-v": "0.7.5",
+            "ca-pi-v": "0.8.5",
+            "ca-sandbox-v": "1.4.0",
+        }
+        for prefix, version in expected.items():
+            with self.subTest(prefix=prefix):
+                self.assertEqual(U.select_latest_tag(releases, prefix), version)
+
+    def test_drafts_prereleases_and_malformed_tags_are_not_selected(self):
+        releases = [
+            {"tag_name": "ca-codex-v9.0.0", "draft": True},
+            {"tag_name": "ca-codex-v8.0.0", "prerelease": True},
+            {"tag_name": "ca-codex-vnot-semver"},
+            {"tag_name": "ca-codex-v0.7.5"},
+        ]
+        self.assertEqual(U.select_latest_tag(releases, "ca-codex-v"), "0.7.5")
 
     def test_network_error_fails_silent(self):
         import urllib.error
@@ -256,7 +381,7 @@ class TestFetchLatestTag(unittest.TestCase):
         self.assertIsNone(U.fetch_latest_tag(opener=opener))
 
     def test_missing_tag_name_fails_silent(self):
-        body = json.dumps({"no_tag": True}).encode("utf-8")
+        body = json.dumps([{"no_tag": True}]).encode("utf-8")
         opener = _FakeOpener(resp=_FakeResp(status=200, body=body))
         self.assertIsNone(U.fetch_latest_tag(opener=opener))
 
@@ -265,7 +390,7 @@ class TestFetchLatestTag(unittest.TestCase):
         # HTTPS-only-redirect-hardened factory — not a bare urllib.request.urlopen.
         with mock.patch.object(U, "_build_opener",
                                 return_value=_FakeOpener(resp=_FakeResp(
-                                    body=json.dumps({"tag_name": "2.9.0"}).encode()))) as m:
+                                    body=json.dumps([{"tag_name": "v2.9.0"}]).encode()))) as m:
             self.assertEqual(U.fetch_latest_tag(), "2.9.0")
             m.assert_called_once()
 
@@ -331,13 +456,16 @@ class TestRefreshIfStale(unittest.TestCase):
 
         state = U.refresh_if_stale(now=2_000_000, fetcher=fetcher, path=self.path)
         self.assertEqual(len(calls), 1)
-        self.assertEqual(state["latest"], "2.10.0")
-        self.assertEqual(state["checked_at"], 2_000_000)
+        target = U.target_state(state)
+        self.assertEqual(target["latest"], "2.10.0")
+        self.assertEqual(target["checked_at"], 2_000_000)
         self.assertEqual(U.read_state(self.path), state)
 
     def test_ac4_fresh_cache_same_day_makes_no_fetch_call(self):
         first_now = 2_000_000
-        U.write_state({"latest": "2.9.0", "checked_at": first_now}, self.path)
+        U.write_state({"schema": 1, "targets": {
+            "ca": {"latest": "2.9.0", "checked_at": first_now},
+        }}, self.path)
 
         calls = []
 
@@ -348,8 +476,9 @@ class TestRefreshIfStale(unittest.TestCase):
         second_now = first_now + 3600  # same day, well under ONE_DAY
         state = U.refresh_if_stale(now=second_now, fetcher=fetcher, path=self.path)
         self.assertEqual(calls, [], "a fresh cache must make NO network call")
-        self.assertEqual(state["latest"], "2.9.0")
-        self.assertEqual(state["checked_at"], first_now, "checked_at unchanged on no-op")
+        target = U.target_state(state)
+        self.assertEqual(target["latest"], "2.9.0")
+        self.assertEqual(target["checked_at"], first_now, "checked_at unchanged on no-op")
 
     def test_ac3_fetcher_raising_does_not_propagate(self):
         def bad_fetcher():
@@ -361,24 +490,93 @@ class TestRefreshIfStale(unittest.TestCase):
             self.fail(f"refresh_if_stale must fail-silent, raised: {e}")
         # Cache is still updated (checked_at) so we don't retry every session;
         # latest stays whatever it was before (nothing, here).
-        self.assertIsNone(state.get("latest"))
-        self.assertEqual(state["checked_at"], 3_000_000)
+        target = U.target_state(state)
+        self.assertIsNone(target.get("latest"))
+        self.assertEqual(target["checked_at"], 3_000_000)
 
     def test_fetcher_raising_preserves_prior_latest(self):
-        U.write_state({"latest": "2.9.0", "checked_at": 1_000}, self.path)
+        U.write_state({"schema": 1, "targets": {
+            "ca": {"latest": "2.9.0", "checked_at": 1_000},
+        }}, self.path)
 
         def bad_fetcher():
             raise OSError("network unreachable")
 
         now = 1_000 + U.ONE_DAY + 1
         state = U.refresh_if_stale(now=now, fetcher=bad_fetcher, path=self.path)
-        self.assertEqual(state["latest"], "2.9.0", "a failed refresh keeps the last-known latest")
+        self.assertEqual(U.target_state(state)["latest"], "2.9.0",
+                         "a failed refresh keeps the last-known latest")
 
     def test_fetcher_returning_none_preserves_prior_latest(self):
-        U.write_state({"latest": "2.9.0", "checked_at": 1_000}, self.path)
+        U.write_state({"schema": 1, "targets": {
+            "ca": {"latest": "2.9.0", "checked_at": 1_000},
+        }}, self.path)
         now = 1_000 + U.ONE_DAY + 1
         state = U.refresh_if_stale(now=now, fetcher=lambda: None, path=self.path)
-        self.assertEqual(state["latest"], "2.9.0")
+        self.assertEqual(U.target_state(state)["latest"], "2.9.0")
+
+    def test_each_target_has_an_independent_freshness_and_latest_value(self):
+        codex = _FakeUpdateHost("ca-codex", "ca-codex-v", "codex update")
+        pi = _FakeUpdateHost("ca-pi", "ca-pi-v", "pi update")
+        U.refresh_if_stale(now=1_000, fetcher=lambda: "0.7.5",
+                           path=self.path, host=codex)
+        calls = []
+        state = U.refresh_if_stale(
+            now=1_001, fetcher=lambda: calls.append(1) or "0.8.5",
+            path=self.path, host=pi)
+        self.assertEqual(calls, [1], "a fresh Codex row must not suppress Pi's refresh")
+        self.assertEqual(U.target_state(state, host=codex),
+                         {"latest": "0.7.5", "checked_at": 1_000})
+        self.assertEqual(U.target_state(state, host=pi),
+                         {"latest": "0.8.5", "checked_at": 1_001})
+
+    def test_legacy_cache_refresh_migrates_without_reusing_unrelated_latest(self):
+        U.write_state({"latest": "2.15.6", "checked_at": 999}, self.path)
+        codex = _FakeUpdateHost("ca-codex", "ca-codex-v", "codex update")
+        state = U.refresh_if_stale(now=1_000, fetcher=lambda: None,
+                                   path=self.path, host=codex)
+        self.assertIsNone(U.target_state(state, host=codex).get("latest"))
+        self.assertNotIn("latest", state)
+
+    def test_target_written_during_fetch_is_preserved_by_the_final_merge(self):
+        codex = _FakeUpdateHost("ca-codex", "ca-codex-v", "codex update")
+        claude = _FakeUpdateHost("ca", "v", "claude update")
+
+        def fetcher():
+            U.write_state({"schema": 1, "targets": {
+                "ca": {"latest": "2.15.7", "checked_at": 2_000},
+            }}, self.path)
+            return "0.7.6"
+
+        state = U.refresh_if_stale(now=2_001, fetcher=fetcher,
+                                   path=self.path, host=codex)
+        self.assertEqual(U.target_state(state, host=claude),
+                         {"latest": "2.15.7", "checked_at": 2_000})
+        self.assertEqual(U.target_state(state, host=codex),
+                         {"latest": "0.7.6", "checked_at": 2_001})
+        self.assertEqual(U.read_state(self.path), state)
+
+    def test_newer_same_target_refresh_is_not_overwritten_out_of_order(self):
+        codex = _FakeUpdateHost("ca-codex", "ca-codex-v", "codex update")
+
+        def slower_older_fetcher():
+            U.write_state({"schema": 1, "targets": {
+                "ca-codex": {"latest": "0.7.6", "checked_at": 1_001},
+            }}, self.path)
+            return "0.7.5"
+
+        state = U.refresh_if_stale(
+            now=1_000,
+            fetcher=slower_older_fetcher,
+            path=self.path,
+            host=codex,
+        )
+
+        self.assertEqual(U.target_state(state, host=codex), {
+            "latest": "0.7.6",
+            "checked_at": 1_001,
+        })
+        self.assertEqual(U.read_state(self.path), state)
 
 
 # =========================================================================== installed_version / plugin_root

--- a/plugins/ca/hooks/tests/test_updatelib.py
+++ b/plugins/ca/hooks/tests/test_updatelib.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import unittest
 import urllib.request
 from unittest import mock
@@ -529,6 +530,50 @@ class TestRefreshIfStale(unittest.TestCase):
                          {"latest": "0.7.5", "checked_at": 1_000})
         self.assertEqual(U.target_state(state, host=pi),
                          {"latest": "0.8.5", "checked_at": 1_001})
+
+    def test_concurrent_same_target_refresh_runs_only_one_fetcher(self):
+        first_fetch_entered = threading.Event()
+        release_first_fetch = threading.Event()
+        second_refresh_done = threading.Event()
+        calls = []
+        results = []
+        errors = []
+
+        def fetcher():
+            calls.append(1)
+            if len(calls) == 1:
+                first_fetch_entered.set()
+                if not release_first_fetch.wait(timeout=5):
+                    raise TimeoutError("test did not release first fetch")
+            return "2.10.0"
+
+        def refresh(done=None):
+            try:
+                results.append(U.refresh_if_stale(
+                    now=2_000_000, fetcher=fetcher, path=self.path))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                if done is not None:
+                    done.set()
+
+        first = threading.Thread(target=refresh)
+        first.start()
+        self.assertTrue(first_fetch_entered.wait(timeout=5))
+
+        second = threading.Thread(target=refresh, args=(second_refresh_done,))
+        second.start()
+        self.assertTrue(second_refresh_done.wait(timeout=5))
+        self.assertEqual(len(calls), 1,
+                         "a same-target refresh reservation must suppress a racing fetch")
+
+        release_first_fetch.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 2)
 
     def test_legacy_cache_refresh_migrates_without_reusing_unrelated_latest(self):
         U.write_state({"latest": "2.15.6", "checked_at": 999}, self.path)

--- a/plugins/ca/hooks/tests/test_updatelib.py
+++ b/plugins/ca/hooks/tests/test_updatelib.py
@@ -575,6 +575,30 @@ class TestRefreshIfStale(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(len(results), 2)
 
+    def test_lock_acquisition_failure_suppresses_fetch(self):
+        calls = []
+        with mock.patch.object(U, "acquire_lock", return_value=None):
+            state = U.refresh_if_stale(
+                now=2_000_000,
+                fetcher=lambda: calls.append(1) or "2.10.0",
+                path=self.path,
+            )
+
+        self.assertEqual(calls, [])
+        self.assertEqual(state, {})
+
+    def test_failed_reservation_persistence_suppresses_fetch(self):
+        calls = []
+        with mock.patch.object(U, "write_state", return_value=None):
+            state = U.refresh_if_stale(
+                now=2_000_000,
+                fetcher=lambda: calls.append(1) or "2.10.0",
+                path=self.path,
+            )
+
+        self.assertEqual(calls, [])
+        self.assertEqual(state, {})
+
     def test_legacy_cache_refresh_migrates_without_reusing_unrelated_latest(self):
         U.write_state({"latest": "2.15.6", "checked_at": 999}, self.path)
         codex = _FakeUpdateHost("ca-codex", "ca-codex-v", "codex update")


### PR DESCRIPTION
## Summary

This fixes RA-02 by keeping update discovery, cache freshness, and remediation commands separate for each independently versioned host.

- Select the highest stable release only from the active host tag series across bounded GitHub release pages.
- Store latest version and freshness per target, preserve sibling rows, and merge same-target results monotonically.
- Reserve same-target refreshes before network work so concurrent starts issue only one daily fetch.
- Emit native Claude, Codex, and Pi update commands. Unknown hosts suppress notices.
- Synchronize all generated projections and bump the three affected adapter versions.

## Why

The shared releases/latest cache could compare one host against another host's release and display a Claude-only update command in Codex or Pi. A merge-only lock also allowed concurrent stale starts to duplicate release requests.

## Verification

- All 25 repository script suites pass.
- Full Python hook suite passes, including 77 update-library tests with release-series, pagination, cache migration, concurrency, lock-refusal, and reservation-persistence coverage.
- Pi typecheck, 840-test suite, build, package, parity, and public documentation checks pass.
- Shared core, generated surface, and host-package checks pass byte-for-byte.
- Python syntax, plugin reference graph, JSON manifests, staged secret sweep, and diff checks pass.
- Final security, auth/crypto, dependency, and coverage reviews pass with no findings.

## Coverage note

Python hooks have no numeric coverage tooling. The repository tech-stack record states: "There is no coverage tooling for the Python hooks (plugins/*/hooks/*.py, .github/scripts/*.py). No numeric floor exists for those surfaces." Behavioral coverage is supplied by the focused and whole-suite tests above.

## Tradeoff

Conflict level 2: the repository security controls plus ADR-0003 and ADR-0004 favor bounded, fail-silent HTTPS behavior. Discovery reads at most ten full release pages. If that bound is exhausted, the notifier does not cache a result from a known-incomplete enumeration.