### PR TITLE
docs(codex): reconcile packaged-agent support evidence

### DIFF
--- a/.codearbiter/plans/codex-support.md
+++ b/.codearbiter/plans/codex-support.md
@@ -14,12 +14,14 @@ This is newly feasible: Codex v0.142.x (verified July 2026) has near-parity exte
 
 **Approval caveat (2026-07-08):** approved as **beta only** — the maintainer has no Codex subscription until ~2026-07-09, so live-fire spike items (stdout injection, trust review, exit-2 feedback) are deferred to a live-verification pass; source-level verification against `openai/codex` proceeds immediately. `ca-codex` carries a beta / Feature Forge preview label until live verification completes.
 
-## Campaign status (reconciled 2026-07-20)
+## Campaign status (reconciled 2026-09-02)
 
-The beta gate is complete, but the full M0-M5 campaign is not. Codex 0.144.1 loaded the trusted
-plugin, injected the SessionStart persona, and surfaced the live H-03 block. Stable release
-`ca-codex-v0.2.4` was tagged and published on 2026-07-12. Those receipts remove the beta label;
-they do not silently waive the remaining host-parity milestones.
+The beta gate is complete, but the full M0-M5 campaign remains open on two evidence obligations.
+Codex 0.144.1 established the initial trusted startup and live H-03 block. Published release
+`ca-codex-v0.7.5` closed the missing-charter package defect with the complete generated role set for
+that release plus hosted static-package and route-closure gates. ADR-0031 governs host-native roots
+and packaged charters. ADR-0032 replaces only its retired desktop-proof requirement with the
+hosted-static contract.
 
 | Milestone | Current status | Authoritative evidence or remaining obligation |
 |---|---|---|
@@ -27,17 +29,14 @@ they do not silently waive the remaining host-parity milestones.
 | M1 shared-core extraction | ACCEPTED | `core/pysrc/`, `tools/sync-core.py`, and the byte-identity CI contract shipped in PR #254. |
 | M2 Codex enforcement core | ACCEPTED | The trusted hooks, host adapter, doctor probe, shared-store contract, and live H-03 block shipped in PR #254. |
 | M3 command/skill surface | ACCEPTED | The generated standalone `$ca-*` surface and Codex-only initialization path shipped through PR #295 and PR #254. |
-| M4 agents + review chains | PENDING | `docs/parity.md` still records the 28 agents and review chains as M4 work. Roles run inline; generated `.codex/agents/*.toml`, `ca-init` scaffolding, staleness diagnosis, and review-chain validation remain. |
-| M5 distribution/release/docs | PARTIAL | Stable 0.2.4 release and public install documentation shipped through PRs #301 and #302. The Codex worker-backend package remains absent and degrades to the premium path. |
+| M4 agents + review chains | DEGRADED | ADR-0031 replaced the abandoned `.codex/agents/*.toml` scaffold with packaged Markdown resource charters and host-provided threads. Release 0.7.5 contains the then-complete 18-charter set plus `INDEX.md`; current source and 0.7.9 contain 19. Generated route and policy checks close every declared dispatch path, but no committed exact-release receipt proves actual host-thread dispatch. |
+| M5 distribution/release/docs | PARTIAL | The initial Stable release and public install documentation shipped through PRs #301 and #302. ADR-0032 and the 0.7.5 release add the hosted-static distribution contract. The optional Codex farm backend is a separately labeled preview limitation, not a Stable-host blocker. `.github/published-tags.json` still stops at `ca-codex-v0.5.1`, so the newer published tags lack the declared committed provenance witness. |
 
-`codex.feature.0001` remains in progress until M4 is accepted and the remaining M5 distribution
-decision is implemented or explicitly re-scoped through a user-attributed decision. Later 0.3.x
-version work is maintenance on the shipped host and is not evidence that these two obligations closed.
-
-`.codearbiter/CONTEXT.md` still carries the superseded beta wording. A 2026-07-20 attempt to correct
-that sentence was blocked by H-18 because `CONTEXT.md` is the activation switch. Correcting it needs
-the sanctioned protected-file path or an explicit `$ca-override`; this reconciliation does not bypass
-that gate.
+`codex.feature.0001` remains in progress until an exact published package has durable host-thread
+dispatch evidence and the declared published-tag witness is current or explicitly dispositioned.
+The task row's beta clause records the original gate; this section records the current residual.
+`.codearbiter/CONTEXT.md` now assigns the canonical kernel and all three host adapters without the
+superseded beta wording.
 
 ## Architecture
 

--- a/.codearbiter/plans/codex-support.md
+++ b/.codearbiter/plans/codex-support.md
@@ -2,13 +2,13 @@
 
 ## Context
 
-codeArbiter today enforces its rigor only under Claude Code: the `ca` plugin's stdlib-Python hooks (SessionStart persona injection, exit-2 blocking PreToolUse gates), 44 commands, 23 skills, and 30 agents. The goal is to enforce the **same rigor under OpenAI Codex CLI**, sharing the **same `.codearbiter/` project context folder** — one governance store, two hosts.
+When this plan began, codeArbiter enforced its rigor only under Claude Code: the `ca` plugin's stdlib-Python hooks (SessionStart persona injection, exit-2 blocking PreToolUse gates), 44 commands, 23 skills, and 30 agents. The goal was to enforce the **same rigor under OpenAI Codex CLI**, sharing the **same `.codearbiter/` project context folder** as one governance store across two hosts.
 
-This is newly feasible: Codex v0.142.x (verified July 2026) has near-parity extension points — a plugin system (`.codex-plugin/plugin.json` + marketplace catalogs) bundling **hooks (Claude-Code-like `hooks.json`, blocking via exit 2 + stderr), skills (Anthropic's SKILL.md format), and MCP servers**; SessionStart/PreToolUse/PostToolUse/UserPromptSubmit events; project-scoped `.codex/config.toml`; repo-shippable subagents (`.codex/agents/*.toml`, `sandbox_mode` per role). Custom prompts are deprecated in favor of skills. No statusline analogue.
+The original July 2026 spike treated repo-shippable `.codex/agents/*.toml` files as a candidate mechanism. ADR-0031 later replaced that unshipped design with packaged Markdown resource charters and host-provided threads. The other extension points remain a plugin system (`.codex-plugin/plugin.json` + marketplace catalogs) bundling **hooks (Claude-Code-like `hooks.json`, blocking via exit 2 + stderr), skills (Anthropic's SKILL.md format), and MCP servers**; SessionStart/PreToolUse/PostToolUse/UserPromptSubmit events; and project-scoped `.codex/config.toml`. Custom prompts are deprecated in favor of skills. No statusline analogue.
 
-**User decisions (locked):** full parity as the end state · shared core + thin adapters packaging · prune-transcript ledgered out of parity (like statusline) · AGENTS.md fallback acceptable if SessionStart stdout injection fails on Codex · `ca-` prefix for all Codex skill names · independent SemVer for `ca-codex` starting 0.1.0 (ADR-0007 precedent). Agent-scaffolding via `ca-init` is the default if plugins can't ship subagents (user expressed no preference; spike-contingent).
+**User decisions (locked):** full parity as the end state · shared core + thin adapters packaging · prune-transcript ledgered out of parity (like statusline) · AGENTS.md fallback acceptable if SessionStart stdout injection fails on Codex · `ca-` prefix for all Codex skill names · independent SemVer for `ca-codex` starting 0.1.0 (ADR-0007 precedent). The spike-contingent `ca-init` agent-scaffolding proposal is historical and was superseded by ADR-0031's packaged-charter design.
 
-**Governance prerequisite:** `.codearbiter/CONTEXT.md` currently declares "Claude Code only" as a scope statement. An ADR must amend it before anything user-visible ships (M0). → Recorded as ADR-0011 (2026-07-08).
+**Governance prerequisite (satisfied):** `.codearbiter/CONTEXT.md` originally declared "Claude Code only" as a scope statement. ADR-0011 authorized the multi-host model, and the current file assigns the canonical kernel and all three host adapters.
 
 **Branch strategy (2026-07-08, user-directed):** all milestones stack on `feat/codex-support-m0` (PR #254) until ca-codex is functional; no merge before the user's live Codex test.
 
@@ -79,9 +79,9 @@ Canonical templates in `core/surface/{commands,skills,agents,includes}/` with th
 | `_githooks.py` git backstop | Identical, host-agnostic; add idempotence test for dual-plugin installs |
 | 44 commands | 44 generated Codex skills `ca-commit`, `ca-feature`, … (skills are un-namespaced; prefix prevents collisions) |
 | 23 skills | Same SKILL.md format, `ca-` prefixed, near-verbatim after tokens |
-| 30 agents (`tools:` allowlist) | Generated `.codex/agents/*.toml`; reviewers `sandbox_mode="read-only"` (mechanically STRONGER than Claude's Bash-permitting allowlist), authors `workspace-write`. Shipped in-plugin if possible, else scaffolded by `ca-init` with doctor staleness check |
+| Current generated agents (`tools:` allowlist) | Packaged Markdown resource charters with generated dispatch policy; host-provided threads enforce available isolation and write containment, while required isolation blocks when unavailable |
 | Review chains (checkpoint/tribunal/SDD) | Codex subagents; batch dispatch under `max_threads 6` (tribunal has 11 lenses); `max_depth 1` may force the orchestrator to drive tdd phases instead of nesting |
-| doctor | Shared core + per-host probe list (trust state, hooks live-fire, `.codex/agents` staleness, config.toml wiring) |
+| doctor | Shared core + per-host probe list (trust state, hooks live-fire, packaged-resource integrity, config.toml wiring) |
 | marketplace | `.agents/plugins/marketplace.json` at repo root alongside the existing `.claude-plugin/marketplace.json` |
 | farm | Reused as-is (already host-orthogonal) |
 
@@ -99,7 +99,7 @@ Canonical templates in `core/surface/{commands,skills,agents,includes}/` with th
 
 **M3 — Command/skill surface.** Markdown → `core/surface/` templates; `build-surface.py`; regenerated `plugins/ca/{commands,skills,includes}` **byte-identical to today** (CI-diff proves zero Claude-side change), plus the Codex skill tree. Extend `check-plugin-refs.py` (already plugin-parameterized) to `ca-codex`; Codex COMMANDS.md analogue.
 
-**M4 — Agents + review chains.** Agent templates → Claude `agents/*.md` (unchanged) + Codex TOMLs; ship-in-plugin vs `ca-init` scaffold per M0 finding ⑥. Validate checkpoint/tribunal/subagent-driven-development under `max_threads 6`/`max_depth 1`; adapt dispatch batching in affected skills.
+**M4: Agents + review chains.** Agent templates render unchanged Claude `agents/*.md` files and Codex packaged Markdown resource charters governed by ADR-0031. Generated route and policy checks cover the declared dispatch surface; exact-release host-thread dispatch still requires a durable receipt.
 
 **M5 — Distribution/release/docs.** Parameterize `.github/workflows/release.yml` over plugin (currently hard-coded to `plugins/ca/`); `_releaselib.py` bump-guard path-scoped to `plugins/ca-codex/`; CI path filters — `core/**` triggers **both** plugin suites (new rule). Site/README/install docs; **`docs/parity.md` ledger** (statusline, prune-transcript, M0-discovered gaps).
 

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -15,10 +15,10 @@ this file is the stale one; fix it here.
   stdlib only; the dispatcher is TypeScript tested with Vitest and ships built
   `farm.js`.
 - **Codex adapter** (`plugins/ca-codex/`) — Codex manifest and hook shims plus
-  generated skills and packaged resource charters. The source candidate packages
-  those resources for host-provided thread dispatch; exact-candidate proof gates
-  release, and older adapters retain the bounded inline fallback. They are not
-  native Codex plugin-agent registrations.
+  generated skills and packaged resource charters. Published releases from 0.7.5
+  contain the complete charter set for host-provided thread dispatch. The hosted
+  static package gate verifies release bytes, resource closure, and dispatch routes.
+  These charters are not native Codex plugin-agent registrations.
 - **Pi adapter** (`plugins/ca-pi/`) — generated Python/policy payload plus its thin
   TypeScript host extension and supervised child-process boundary.
 - **Infrastructure sibling** (`plugins/ca-sandbox/`) — isolated exploration tools;

--- a/.github/scripts/test_public_codex_docs.py
+++ b/.github/scripts/test_public_codex_docs.py
@@ -112,8 +112,8 @@ class PublicCodexDocsTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIn(path, tech_stack)
         self.assertIn("canonical shared source", tech_stack)
-        self.assertIn("source candidate", tech_stack)
-        self.assertNotIn("Host dispatch loads those resources", tech_stack)
+        self.assertIn("Published releases from 0.7.5", tech_stack)
+        self.assertNotIn("source candidate", tech_stack)
 
     def test_contributor_and_security_guides_describe_the_multi_host_product(self):
         """Contributor, security, and install prose matches the host topology."""
@@ -234,7 +234,16 @@ class PublicCodexDocsTest(unittest.TestCase):
         )
         self.assertIn("plugins/ca-codex/agents/", parity)
         self.assertNotIn("plugins/ca-codex/resources/agents/", parity)
-        self.assertIn("source candidate", parity)
+        self.assertIn("published releases from 0.7.5", parity)
+        self.assertIn("exact-release receipt", parity)
+        self.assertNotIn("source candidate", parity)
+
+        overview = (
+            ROOT / "site" / "src" / "content" / "docs" / "overview.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Until exact-release thread dispatch is durably proven", overview)
+        self.assertIn("bounded inline fallback", overview)
+        self.assertNotIn("Adapters before 0.7.5 may use", overview)
 
         public_role_docs = (
             "site/src/content/docs/overview.md",
@@ -249,9 +258,13 @@ class PublicCodexDocsTest(unittest.TestCase):
         for path in public_role_docs:
             with self.subTest(candidate_path=path):
                 text = (ROOT / path).read_text(encoding="utf-8")
-                self.assertRegex(text, re.compile(r"(?is)source candidate.{0,160}packaged.{0,80}resource charter"))
-                self.assertNotIn("Current Codex releases load", text)
-                self.assertNotIn("On current Codex hosts", text)
+                self.assertRegex(
+                    text,
+                    re.compile(r"(?is)published releases from 0\.7\.5.{0,160}packaged.{0,80}resource charter"),
+                )
+                self.assertNotIn("source candidate", text)
+                self.assertNotIn("exact-candidate proof gates release", text)
+                self.assertIn("inline", text)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_public_codex_docs.py
+++ b/.github/scripts/test_public_codex_docs.py
@@ -238,13 +238,6 @@ class PublicCodexDocsTest(unittest.TestCase):
         self.assertIn("exact-release receipt", parity)
         self.assertNotIn("source candidate", parity)
 
-        overview = (
-            ROOT / "site" / "src" / "content" / "docs" / "overview.md"
-        ).read_text(encoding="utf-8")
-        self.assertIn("Until exact-release thread dispatch is durably proven", overview)
-        self.assertIn("bounded inline fallback", overview)
-        self.assertNotIn("Adapters before 0.7.5 may use", overview)
-
         public_role_docs = (
             "site/src/content/docs/overview.md",
             "site/src/content/docs/concepts/persona-and-context.md",
@@ -258,13 +251,32 @@ class PublicCodexDocsTest(unittest.TestCase):
         for path in public_role_docs:
             with self.subTest(candidate_path=path):
                 text = (ROOT / path).read_text(encoding="utf-8")
+                normalized = " ".join(text.split())
                 self.assertRegex(
                     text,
                     re.compile(r"(?is)published releases from 0\.7\.5.{0,160}packaged.{0,80}resource charter"),
                 )
                 self.assertNotIn("source candidate", text)
                 self.assertNotIn("exact-candidate proof gates release", text)
-                self.assertIn("inline", text)
+                self.assertRegex(
+                    normalized,
+                    re.compile(
+                        r"(?i)until exact-release thread dispatch is durably proven"
+                        r".{0,180}bounded inline fallback.{0,180}canonical workflow"
+                        r".{0,100}(?:isolation is not mandatory|non-isolated)"
+                    ),
+                )
+                self.assertNotIn("Adapters before 0.7.5 may use", text)
+
+        for path in (
+            "site/src/content/docs/overview.md",
+            "site/src/content/docs/concepts/persona-and-context.md",
+            "site/src/content/docs/glossary.md",
+        ):
+            with self.subTest(release_scoped_charters_path=path):
+                text = (ROOT / path).read_text(encoding="utf-8")
+                normalized = " ".join(text.split())
+                self.assertIn("complete packaged resource charter set for that release", normalized)
 
 
 if __name__ == "__main__":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ capabilities, and tool classes without copying governance policy.
 | Host | Adapter entry | Public command form | Runtime boundary |
 |---|---|---|---|
 | Claude Code (`ca`) | `hooks/hooks.json` | `/ca:<name>` | native hook events and Claude agents |
-| Codex CLI (`ca-codex`) | `.codex-plugin/plugin.json` + generated hooks | `$ca-<name>` | compatible hook events; the source candidate includes packaged resource charters (not native agent registrations) for host-provided threads, while runtime promotion remains exact-candidate gated and older releases retain a bounded inline fallback |
+| Codex CLI (`ca-codex`) | `.codex-plugin/plugin.json` + generated hooks | `$ca-<name>` | compatible hook events; published releases from 0.7.5 include packaged resource charters (not native agent registrations) for host-provided threads, with exact static-package and route-closure release gates |
 | Pi (`ca-pi`) | `extensions/codearbiter.js` | `/ca-<name>` with `/skill:ca-<name>` fallback | TypeScript lifecycle/tool wrappers call the bounded Python bridge; roles use hardened child Pi processes |
 
 Pi's parent extension stays dormant until the repository is enabled and Pi

--- a/docs/codex-parity-testing.md
+++ b/docs/codex-parity-testing.md
@@ -35,13 +35,13 @@ Verified baseline: **Codex CLI 0.144.1**, `ca-codex` **0.2.4**, Windows, 2026-07
 The installed hook set was approved through `/hooks`; SessionStart persona injection completed,
 and `$ca-doctor`'s staged-everything dry-run probe was blocked with `[H-03]`.
 
-> **STALE.** This baseline predates `ca-codex` 0.3.x. The continuously-verified half above has
+> **STALE.** This baseline predates `ca-codex` 0.3.x. The continuously verified half above has
 > not lapsed, but the live-firing half has not been re-confirmed since 0.2.4.
 
 Requirements: **Python 3 on PATH**, **Codex CLI ≥ rust-v0.143.0** (the source-verified
 structured-deny baseline; plugin-bundled hooks came on by default earlier, at 0.134.0),
-this repo checked out on `feat/codex-support-m0`, and —
-for the side-by-side comparison — Claude Code with the `ca` plugin installed.
+this repo checked out on `main` or the exact candidate under review, and Claude Code with the
+`ca` plugin installed for the side-by-side comparison.
 
 Everything below runs against **throwaway fixture repos**, never this repo or a real project.
 
@@ -218,11 +218,10 @@ In order of likelihood:
    guards go dormant. Re-scaffold with a fresh fixture. (In the `--bare` fixture, dormant
    before `$ca-init` is the **expected** starting state, not a failure — O1/O2 run dormant.)
 
-## 8. What a PASS unblocks
+## 8. What a future PASS updates
 
 Seven-for-seven enforcement parity (§4), six-for-six onboarding parity (§5), plus persona
-injection (§3) is the live confirmation the campaign has been waiting on. It clears
-`feat/codex-support-m0` to merge to `main` (whose PR should list `Closes #255…#270`) and
-gives #287 its answer from observed behavior. Capture the LIVE-PENDING items from the spike
-as you go: the trust-review UX, the real exit-2 stderr surfaced to the model, and
-`commandWindows` on a Windows install.
+injection (§3) produces the next version-qualified live baseline. Record the exact Codex CLI and
+`ca-codex` versions, platform, trust-review behavior, surfaced block output, and Windows command
+registration. Do not use a static package or route-closure pass as a substitute for this live
+record.

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -31,7 +31,7 @@ presenting the deliberately nonblocking unsupported-latest canary as supported.
 |---|---|---|---|---|
 | Public entries | 38 `/ca:*` commands | 36 `$ca-*` entry skills | 37 `/ca-*` aliases with `/skill:ca-*` fallback | `plugins/*/COMMANDS.md`, `plugins/ca-pi/SKILLS.md` |
 | Orchestrator routines | 22 generated skills | 22 generated routines | 22 generated routines | `python tools/build-surface.py --check` |
-| Role charters | 18 plugin agents | source candidate contains 18 packaged resource charters for host-provided threads; runtime release remains exact-candidate gated and older releases retain the inline fallback | 18 generated roles used by hardened child dispatch | `core/surface/agents/`, `plugins/ca-codex/agents/`, `plugins/ca-pi/generated/roles.json` |
+| Role charters | 19 current plugin agents | published releases from 0.7.5 contain the complete packaged resource charter set for their release; current source and 0.7.9 contain 19 | 19 current generated roles used by hardened child dispatch | `core/surface/agents/`, `plugins/ca-codex/agents/`, `plugins/ca-pi/generated/roles.json` |
 | Shared Python | stdlib-only core | byte-identical vendored core | byte-identical vendored core behind bounded bridge | `python tools/sync-core.py --check` |
 | Project store | `.codearbiter/` | same store | same store with `HOST: pi` attribution | `.github/scripts/test_pi_shared_store.py` |
 
@@ -54,8 +54,8 @@ surface it describes, and an uncompared count drifts silently.
 | Git backstop | shared `.git/hooks` installer | same | same through Pi bridge |
 | Status | complete Claude statusline | startup state only | rich footer globally with a per-message burn sparkline and up to four activity rows (both wide-layout only); refresh-time git repository/dirty enrichment is trusted-only; governance row only when enabled and affirmatively trusted; rate windows omitted; optional probe-gated right sidebar (`/ca-sidebar`, auto-on at ≥120 columns) with session, subagents, workspace, and todos panels |
 | Prune/compaction | shared policy plus Claude transcript codec | transcript engine unavailable; audit warning remains | shared policy plus Pi native compaction; no active-session rewrite |
-| Role dispatch | Claude subagents | source candidate supplies packaged resource charters for host-provided threads; exact-candidate proof gates release, and older releases retain a bounded inline fallback | fresh Pi RPC children: single, chain, parallel |
-| Process cleanup | host-managed subagents | host-managed agent threads (or current-thread lifecycle for an inline fallback) | bounded cancellation/timeout plus verified whole-tree cleanup; unhealthy latch on failure |
+| Role dispatch | Claude subagents | published releases from 0.7.5 supply packaged resource charters for host-provided threads; static route closure is enforced, but exact-release live dispatch proof remains absent | fresh Pi RPC children: single, chain, parallel |
+| Process cleanup | host-managed subagents | bounded inline fallback where isolation is not mandatory; exact-release host-thread cleanup proof remains pending | bounded cancellation/timeout plus verified whole-tree cleanup; unhealthy latch on failure |
 | Doctor | interpreter, payload, hooks, live H-03 probe | trusted hook/origin diagnostics | package/origin/trust/collision/core/child/wrapper plus footer/sidebar/background health |
 
 ## Pi live surface classifications
@@ -106,7 +106,7 @@ Every exception has a status and a source-visible evidence pointer.
 | Codex native Read event | HOST-IMPOSSIBLE | Codex exposes no equivalent read hook; governed notices still run after writes. | `plugins/ca-codex/includes/codex-host-notes.md` |
 | Codex transcript compaction | HOST-IMPOSSIBLE | Claude transcript JSONL is not a Codex session format. | `plugins/ca-codex/includes/codex-host-notes.md` |
 | Codex statusline | HOST-IMPOSSIBLE | Codex exposes no plugin statusline surface. | `plugins/ca-codex/includes/codex-host-notes.md` |
-| Codex packaged agents | DEGRADED | The source candidate contains 18 packaged resource charters for host-provided threads, but exact-candidate desktop proof gates release and older releases retain the bounded inline fallback. | `plugins/ca-codex/agents/`, `docs/codex-parity-testing.md` |
+| Codex packaged agents | DEGRADED | Published releases from 0.7.5 contain the complete generated charter set for their release; current source and 0.7.9 contain 19. Hosted static-package, resource-closure, and route-closure evidence replaced the retired desktop gate, but no committed exact-release receipt proves host-thread dispatch. | `plugins/ca-codex/agents/`, `.codearbiter/decisions/0032-hosted-static-codex-release-evidence.md`, `docs/codex-parity-testing.md` |
 | Pi rate-window telemetry | HOST-IMPOSSIBLE | Pi exposes no supported provider rate-window source, so the rich footer omits it rather than fabricating data. | `plugins/ca-pi/tools/src/footer-state.ts` |
 | Pi active-dispatch doctor self-test | DEGRADED | Public 0.80.5/0.84.1 APIs cannot submit the deterministic wrapper probe through active dispatch. | `plugins/ca-pi/tools/src/doctor.ts` |
 | Pi farm route | PREVIEW | Uses the shared backend but awaits real-run promotion under CONFIRM-05. | `plugins/ca-pi/tools/src/farm.ts` |

--- a/site/src/content/docs/concepts/persona-and-context.md
+++ b/site/src/content/docs/concepts/persona-and-context.md
@@ -63,10 +63,11 @@ Start at the public command reference and follow its owning skill. The skill bod
 may dispatch and the condition that activates it. Then open the generated agent page to inspect that
 role's tools, model tier, constraints, and exact source.
 
-Claude Code can dispatch packaged agents through its native task tool. The Codex source candidate
-includes the same packaged resource charters for reviewers and authors for use in host-provided
-agent threads; exact-candidate proof gates release, and older adapters retain an inline fallback
-where isolation is not mandatory. Pi uses its supervised child path where supported. That host
+Claude Code can dispatch packaged agents through its native task tool. Published releases from 0.7.5
+include the same packaged resource charters for Codex reviewers and authors in host-provided agent
+threads, with exact static-package and route-closure checks at release. Until exact-release thread
+dispatch is durably proven, workflows use the bounded inline fallback only where isolation is not
+mandatory. Pi uses its supervised child path where supported. That host
 difference changes isolation mechanics, not ownership or the gate that consumes the result. The
 [compatibility matrix](/getting-started/compatibility/#host-differences)
 records the current boundary.

--- a/site/src/content/docs/concepts/persona-and-context.md
+++ b/site/src/content/docs/concepts/persona-and-context.md
@@ -64,10 +64,11 @@ may dispatch and the condition that activates it. Then open the generated agent 
 role's tools, model tier, constraints, and exact source.
 
 Claude Code can dispatch packaged agents through its native task tool. Published releases from 0.7.5
-include the same packaged resource charters for Codex reviewers and authors in host-provided agent
-threads, with exact static-package and route-closure checks at release. Until exact-release thread
-dispatch is durably proven, workflows use the bounded inline fallback only where isolation is not
-mandatory. Pi uses its supervised child path where supported. That host
+include the complete packaged resource charter set for that release for Codex reviewers and authors
+in host-provided agent threads, with exact static-package and route-closure checks at release. Until
+exact-release thread dispatch is durably proven, workflows use the bounded inline fallback only
+where the canonical workflow explicitly permits it and isolation is not mandatory. Pi uses its
+supervised child path where supported. That host
 difference changes isolation mechanics, not ownership or the gate that consumes the result. The
 [compatibility matrix](/getting-started/compatibility/#host-differences)
 records the current boundary.

--- a/site/src/content/docs/getting-started/claude-code-and-codex.md
+++ b/site/src/content/docs/getting-started/claude-code-and-codex.md
@@ -140,7 +140,7 @@ absence. That closes the public-installation gate with the same GitHub-slug comm
 | Statusline | Available | No Codex statusline surface; startup state carries governance status |
 | Transcript pruning | Claude transcript-pruning engine available | No transcript pruning; the host-neutral audit-staleness warning remains |
 | Governed-file Read hook | Available on Claude's Read tool | No Codex Read hook; reads happen through shell, while write-time notices remain |
-| Reviewer roles | Packaged plugin agents can be dispatched | The source candidate includes packaged resource charters for host-provided agent threads; exact-candidate proof gates release, and older adapters may fall back inline, except context creation requires isolated scouts |
+| Reviewer roles | Packaged plugin agents can be dispatched | Published releases from 0.7.5 include packaged resource charters for host-provided agent threads; exact static-package and route-closure checks gate release, while the bounded inline fallback remains for non-isolated work until exact-release thread dispatch is durably proven |
 
 These differences are host capabilities and packaging choices. They do not create a second project
 context, weaken the blocking shell/write gates, or split the audit trail.

--- a/site/src/content/docs/getting-started/claude-code-and-codex.md
+++ b/site/src/content/docs/getting-started/claude-code-and-codex.md
@@ -140,7 +140,7 @@ absence. That closes the public-installation gate with the same GitHub-slug comm
 | Statusline | Available | No Codex statusline surface; startup state carries governance status |
 | Transcript pruning | Claude transcript-pruning engine available | No transcript pruning; the host-neutral audit-staleness warning remains |
 | Governed-file Read hook | Available on Claude's Read tool | No Codex Read hook; reads happen through shell, while write-time notices remain |
-| Reviewer roles | Packaged plugin agents can be dispatched | Published releases from 0.7.5 include packaged resource charters for host-provided agent threads; exact static-package and route-closure checks gate release, while the bounded inline fallback remains for non-isolated work until exact-release thread dispatch is durably proven |
+| Reviewer roles | Packaged plugin agents can be dispatched | Published releases from 0.7.5 include packaged resource charters for host-provided agent threads; exact static-package and route-closure checks gate release. Until exact-release thread dispatch is durably proven, the bounded inline fallback remains only where the canonical workflow explicitly permits it and the work is non-isolated |
 
 These differences are host capabilities and packaging choices. They do not create a second project
 context, weaken the blocking shell/write gates, or split the audit trail.

--- a/site/src/content/docs/glossary.md
+++ b/site/src/content/docs/glossary.md
@@ -28,9 +28,11 @@ See [Enforcement & Security](/enforcement/#advisory-non-blocking-reminders).
 
 A focused author or reviewer role dispatched by a [skill](#skill). An agent is not a public
 command and not a second orchestrator; it receives only the tools and context its role needs.
-Claude Code dispatches packaged plugin agents. The Codex source candidate includes equivalent
-packaged resource charters for host-provided agent threads; exact-candidate proof gates release,
-and older adapters retain inline execution as a fallback. Pi uses hardened child dispatch. See the
+Claude Code dispatches packaged plugin agents. Published releases from 0.7.5 include equivalent
+packaged resource charters for Codex host-provided agent threads, with exact static-package and
+route-closure checks at release. Until exact-release thread dispatch is durably proven, workflows
+use the bounded inline fallback only where isolation is not mandatory. Pi uses hardened child
+dispatch. See the
 [Agents reference](/reference/#agents).
 
 ## Arbiter (enabled flag)

--- a/site/src/content/docs/glossary.md
+++ b/site/src/content/docs/glossary.md
@@ -28,11 +28,11 @@ See [Enforcement & Security](/enforcement/#advisory-non-blocking-reminders).
 
 A focused author or reviewer role dispatched by a [skill](#skill). An agent is not a public
 command and not a second orchestrator; it receives only the tools and context its role needs.
-Claude Code dispatches packaged plugin agents. Published releases from 0.7.5 include equivalent
-packaged resource charters for Codex host-provided agent threads, with exact static-package and
-route-closure checks at release. Until exact-release thread dispatch is durably proven, workflows
-use the bounded inline fallback only where isolation is not mandatory. Pi uses hardened child
-dispatch. See the
+Claude Code dispatches packaged plugin agents. Published releases from 0.7.5 include the complete
+packaged resource charter set for that release for Codex host-provided agent threads, with exact
+static-package and route-closure checks at release. Until exact-release thread dispatch is durably
+proven, workflows use the bounded inline fallback only where the canonical workflow explicitly
+permits it and isolation is not mandatory. Pi uses hardened child dispatch. See the
 [Agents reference](/reference/#agents).
 
 ## Arbiter (enabled flag)

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -38,11 +38,11 @@ your behalf.
 2. **Route.** The orchestrator hands the command to the workflow that owns that lane.
    `/ca:fix` and `$ca-fix` both reach the same test-first obligations.
 3. **Execute the roles.** The owning skill selects the author and reviewer roles the change actually
-   demands. Claude Code dispatches plugin agents. Published releases from 0.7.5 include the same
-   packaged resource charters for Codex host-provided agent threads, with exact static-package and
-   route-closure checks at release. Until exact-release thread dispatch is durably proven, adapters
-   may use the bounded inline fallback where the canonical workflow allows it and isolation is not
-   mandatory.
+   demands. Claude Code dispatches plugin agents. Published releases from 0.7.5 include the complete
+   packaged resource charter set for that release for Codex host-provided agent threads, with exact
+   static-package and route-closure checks at release. Until exact-release thread dispatch is
+   durably proven, adapters may use the bounded inline fallback only where the canonical workflow
+   explicitly permits it and isolation is not mandatory.
    Pi launches hardened child processes through its trusted parent. The policy stays shared even
    though each host's mechanism differs.
 4. **Gate.** Nothing advances until its gates are green. A failing test, a CRITICAL

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -38,9 +38,11 @@ your behalf.
 2. **Route.** The orchestrator hands the command to the workflow that owns that lane.
    `/ca:fix` and `$ca-fix` both reach the same test-first obligations.
 3. **Execute the roles.** The owning skill selects the author and reviewer roles the change actually
-   demands. Claude Code dispatches plugin agents. The Codex source candidate includes the same
-   packaged resource charters for host-provided agent threads; exact-candidate proof gates their
-   release, while older adapters may use an inline fallback unless the workflow requires isolation.
+   demands. Claude Code dispatches plugin agents. Published releases from 0.7.5 include the same
+   packaged resource charters for Codex host-provided agent threads, with exact static-package and
+   route-closure checks at release. Until exact-release thread dispatch is durably proven, adapters
+   may use the bounded inline fallback where the canonical workflow allows it and isolation is not
+   mandatory.
    Pi launches hardened child processes through its trusted parent. The policy stays shared even
    though each host's mechanism differs.
 4. **Gate.** Nothing advances until its gates are green. A failing test, a CRITICAL

--- a/site/src/curated/commands/checkpoint.md
+++ b/site/src/curated/commands/checkpoint.md
@@ -17,9 +17,10 @@ re-zeros the `over:N` overrides-since-checkpoint counter the statusline shows, b
 current `overrides.log` line count to `.codearbiter/last-checkpoint`. This is a report, not a
 promotion gate — it surfaces findings and enforces no sign-off.
 
-The Codex source candidate includes each packaged reviewer resource charter for host-provided agent
-threads; exact-candidate proof gates release. An older adapter may run a review role inline rather
-than skip it — see
+Published releases from 0.7.5 include each packaged reviewer resource charter for Codex
+host-provided agent threads. Exact static-package and route-closure checks gate release. Until
+exact-release thread dispatch is durably proven, the bounded inline fallback applies only where
+isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/checkpoint.md
+++ b/site/src/curated/commands/checkpoint.md
@@ -19,8 +19,8 @@ promotion gate — it surfaces findings and enforces no sign-off.
 
 Published releases from 0.7.5 include each packaged reviewer resource charter for Codex
 host-provided agent threads. Exact static-package and route-closure checks gate release. Until
-exact-release thread dispatch is durably proven, the bounded inline fallback applies only where
-isolation is not mandatory. See
+exact-release thread dispatch is durably proven, the bounded inline fallback applies only where the
+canonical workflow explicitly permits it and isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/pr.md
+++ b/site/src/curated/commands/pr.md
@@ -27,8 +27,8 @@ babysitting, a watcher attaches to follow the checks through to green.
 
 Published releases from 0.7.5 include each packaged reviewer resource charter for Codex
 host-provided agent threads. Exact static-package and route-closure checks gate release. Until
-exact-release thread dispatch is durably proven, the bounded inline fallback applies only where
-isolation is not mandatory. See
+exact-release thread dispatch is durably proven, the bounded inline fallback applies only where the
+canonical workflow explicitly permits it and isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/pr.md
+++ b/site/src/curated/commands/pr.md
@@ -25,9 +25,10 @@ draft cold until it's addressed. Once everything clears, the PR itself gets writ
 summary, a test plan, and links to any decision record it touches — then, if you've opted into CI
 babysitting, a watcher attaches to follow the checks through to green.
 
-The Codex source candidate includes each packaged reviewer resource charter for host-provided agent
-threads; exact-candidate proof gates release. An older adapter may run a review role inline rather
-than skip it — see
+Published releases from 0.7.5 include each packaged reviewer resource charter for Codex
+host-provided agent threads. Exact static-package and route-closure checks gate release. Until
+exact-release thread dispatch is durably proven, the bounded inline fallback applies only where
+isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/review.md
+++ b/site/src/curated/commands/review.md
@@ -26,8 +26,8 @@ per-reviewer output is never consumed directly; only the triaged, aggregated ver
 
 Published releases from 0.7.5 include each packaged reviewer resource charter for Codex
 host-provided agent threads. Exact static-package and route-closure checks gate release. Until
-exact-release thread dispatch is durably proven, the bounded inline fallback applies only where
-isolation is not mandatory. See
+exact-release thread dispatch is durably proven, the bounded inline fallback applies only where the
+canonical workflow explicitly permits it and isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/review.md
+++ b/site/src/curated/commands/review.md
@@ -24,9 +24,10 @@ Findings are surfaced by severity (CRITICAL/HIGH/MEDIUM/LOW), file:line, remedia
 security findings — the specific control in `.codearbiter/security-controls.md` they map to. Raw
 per-reviewer output is never consumed directly; only the triaged, aggregated verdict is.
 
-The Codex source candidate includes each packaged reviewer resource charter for host-provided agent
-threads; exact-candidate proof gates release. An older adapter may run a review role inline rather
-than skip it — see
+Published releases from 0.7.5 include each packaged reviewer resource charter for Codex
+host-provided agent threads. Exact static-package and route-closure checks gate release. Until
+exact-release thread dispatch is durably proven, the bounded inline fallback applies only where
+isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/tribunal.md
+++ b/site/src/curated/commands/tribunal.md
@@ -46,8 +46,8 @@ that mapping work stays off the orchestrator's own context.
 
 Published releases from 0.7.5 include each packaged lens resource charter for Codex host-provided
 agent threads. Exact static-package and route-closure checks gate release. Until exact-release
-thread dispatch is durably proven, the bounded inline fallback applies only where isolation is not
-mandatory. See
+thread dispatch is durably proven, the bounded inline fallback applies only where the canonical
+workflow explicitly permits it and isolation is not mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 

--- a/site/src/curated/commands/tribunal.md
+++ b/site/src/curated/commands/tribunal.md
@@ -44,9 +44,10 @@ On a large repo, two optional read-only mappers ([`map-structure`](/reference/ag
 and [`map-deps`](/reference/agents/map-deps/)) build the codebase inventory ahead of the lenses, so
 that mapping work stays off the orchestrator's own context.
 
-The Codex source candidate includes each packaged lens resource charter for host-provided agent
-threads; exact-candidate proof gates release. An older adapter may run a lens inline rather than
-silently omit it — see
+Published releases from 0.7.5 include each packaged lens resource charter for Codex host-provided
+agent threads. Exact static-package and route-closure checks gate release. Until exact-release
+thread dispatch is durably proven, the bounded inline fallback applies only where isolation is not
+mandatory. See
 [Claude Code + Codex → Intentional host
 differences](/getting-started/claude-code-and-codex/#intentional-host-differences).
 


### PR DESCRIPTION
## Summary
- reconcile the Codex support plan and public documentation with release evidence
- distinguish the 18-charter ca-codex 0.7.5 package from the 19-charter 0.7.9/current set
- keep M4 DEGRADED until exact-release host-thread dispatch is durably proven
- keep M5 PARTIAL while the declared published-tags provenance witness stops at ca-codex 0.5.1
- intentionally retain codex.feature.0001 in progress

## Validation
- python .github/scripts/test_public_codex_docs.py (9 passed)
- npm --prefix site test (53 files, 550 tests; Academy non-root-base passed)
- npm --prefix site run build (155 pages)
- npm --prefix site run link-audit (26,331 internal links across 172 pages)
- python .github/scripts/test_codex_static_package.py (17 passed)
- python .github/scripts/check_codex_static_package.py --candidate-package plugins/ca-codex --json (PASS)
- python .github/scripts/test_check_routing_index_parity.py (23 passed)
- python tools/build-surface.py --check (PASS)
- python tools/sync-core.py --check (PASS)
- python .github/scripts/check_adr_lifecycle.py (PASS)
- python .github/scripts/test_taskboardlib.py (104 passed)
- python .github/scripts/test_taskwriter.py (84 passed)
- python .github/scripts/check_docs_contract.py (PASS)
- git diff --check (PASS)

## Review
Independent coordinator review: PASS with no actionable findings after one evidence-boundary correction and regression assertion.