### PR TITLE
fix(release): make ca-pi npm publication synchronous

### DIFF
--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -39,6 +39,31 @@ project. This is an explicit exception to a general "no process.env for secrets"
 rule: the project has no vault, the key is short-lived per-session, and the
 deployment model is a single-developer CLI tool.
 
+### ca-pi npm publication boundary
+
+ADR-0029 authorizes one release credential, `NPMJS_TOKEN`, sourced only from the
+repository or organization Actions secret store. The reusable publisher forwards
+that named secret explicitly—never through `secrets: inherit`—to the single
+`npm publish` step as `NODE_AUTH_TOKEN`. Its authority is limited to publishing
+the public `@arbiterforge/ca-pi` package at the approved npm registry. Candidate
+tag content is inert data: its scripts are never executed, packing and publishing
+use `--ignore-scripts`, and trusted verifier code is pinned to the protected-main
+workflow commit.
+
+Registry success is not inferred from metadata alone. The verifier installs the
+exact registry version into a disposable directory with scripts disabled, runs
+npm's supported `npm audit signatures` Sigstore verification, and then separately
+binds the registry-served SLSA subject digest, repository, main ref, workflow,
+protected-main source commit, and GitHub-hosted builder to the expected release.
+
+The publish job also receives GitHub's short-lived OIDC identity solely for npm
+OIDC provenance. GitHub's ephemeral `github.token` has read-only repository
+permissions and is scoped to checkout and Release evidence lookup; credentials
+are not persisted by checkout. Neither token is logged, written to an output, or
+retained after the job. Credential rotation or revocation of `NPMJS_TOKEN` occurs in the
+organization Actions secret store; no repository change or fallback credential
+is permitted.
+
 A second secret exists in the `ca-sandbox` plugin (ADR-0007): the
 `CLAUDE_CODE_OAUTH_TOKEN` used by `--with-claude` to authenticate Claude Code
 *inside* a sandbox box.

--- a/.github/scripts/_npm_publishlib.py
+++ b/.github/scripts/_npm_publishlib.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""codeArbiter — fail-closed helpers for exact ca-pi npm publication.
+
+The release workflow owns orchestration and credentials. This module validates
+the immutable Git/GitHub/package boundary, packs one exact tarball with scripts
+disabled, distinguishes registry absence from registry failure, and requires
+matching integrity plus npm provenance before success.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+PACKAGE = "@arbiterforge/ca-pi"
+REGISTRY = "https://registry.npmjs.org/"
+REPOSITORY_URL = "git+https://github.com/arbiterForge/codeArbiter.git"
+TAG_RE = re.compile(r"ca-pi-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\Z")
+SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+PROVENANCE_PREDICATE = "https://slsa.dev/provenance/v1"
+REGISTRY_TIMEOUT_SECONDS = 30
+ATTESTATION_MAX_BYTES = 2 * 1024 * 1024
+SOURCE_REPOSITORY = "https://github.com/arbiterForge/codeArbiter"
+SOURCE_REF = "refs/heads/main"
+SOURCE_WORKFLOWS = {
+    ".github/workflows/release.yml",
+    ".github/workflows/npm-publish.yml",
+}
+
+
+def validate_inputs(tag: str, expected_sha: str) -> str:
+    match = TAG_RE.fullmatch(tag)
+    if match is None:
+        raise ValueError("release tag must be canonical ca-pi-vMAJOR.MINOR.PATCH")
+    if SHA_RE.fullmatch(expected_sha) is None:
+        raise ValueError("expected SHA must be exactly 40 lowercase hexadecimal characters")
+    return ".".join(match.groups())
+
+
+def validate_sha(value: str, label: str) -> None:
+    if SHA_RE.fullmatch(value) is None:
+        raise ValueError(f"{label} must be exactly 40 lowercase hexadecimal characters")
+
+
+def validate_package_identity(root: dict, nested: dict, version: str) -> None:
+    if root.get("name") != PACKAGE:
+        raise ValueError("root package name does not match the public ca-pi package")
+    if root.get("version") != version or nested.get("version") != version:
+        raise ValueError("tag and synchronized manifest versions do not match")
+    if nested.get("name") != PACKAGE or nested.get("private") is not True:
+        raise ValueError("nested manifest must retain the private ca-pi package identity")
+    repository = root.get("repository")
+    if not isinstance(repository, dict) or repository != {
+        "type": "git",
+        "url": REPOSITORY_URL,
+    }:
+        raise ValueError("root package repository identity does not match codeArbiter")
+    publish = root.get("publishConfig")
+    if not isinstance(publish, dict):
+        raise ValueError("root publishConfig is missing")
+    if publish.get("access") != "public" or publish.get("provenance") is not True:
+        raise ValueError("root publishConfig must require public provenance publication")
+    if "registry" in publish:
+        raise ValueError("publishConfig.registry must not override the approved npm registry")
+
+
+def validate_project_registry(repo: Path) -> None:
+    if (repo / ".npmrc").exists():
+        raise ValueError("project .npmrc is forbidden at the publication boundary")
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def validate_git_identity(
+    repo: Path, tag: str, expected_sha: str, *, main_ref: str = "origin/main"
+) -> None:
+    validate_inputs(tag, expected_sha)
+    tag_ref = f"refs/tags/{tag}"
+    kind = _git(repo, "cat-file", "-t", tag_ref)
+    if kind.returncode != 0 or kind.stdout.strip() != "tag":
+        raise ValueError("release ref must exist as an annotated tag object")
+    peeled = _git(repo, "rev-parse", f"{tag_ref}^{{commit}}")
+    if peeled.returncode != 0 or peeled.stdout.strip() != expected_sha:
+        raise ValueError("annotated release tag does not peel to the expected commit")
+    checked_out = _git(repo, "rev-parse", "HEAD")
+    if checked_out.returncode != 0 or checked_out.stdout.strip() != expected_sha:
+        raise ValueError("checked-out package does not equal the expected release commit")
+    ancestor = _git(repo, "merge-base", "--is-ancestor", expected_sha, main_ref)
+    if ancestor.returncode != 0:
+        raise ValueError("expected release commit is not contained in protected main")
+
+
+def validate_main_commit(repo: Path, commit: str, main_ref: str = "origin/main") -> None:
+    validate_sha(commit, "attested workflow SHA")
+    ancestor = _git(repo, "merge-base", "--is-ancestor", commit, main_ref)
+    if ancestor.returncode != 0:
+        raise ValueError("attested workflow commit is not contained in protected main")
+
+
+def validate_release_document(document: dict, tag: str) -> None:
+    if document.get("tag_name") != tag:
+        raise ValueError("GitHub Release does not name the exact ca-pi tag")
+    if document.get("draft") is not False:
+        raise ValueError("GitHub Release is missing or remains a draft")
+
+
+def _registry_document(stdout: str) -> dict:
+    try:
+        document = json.loads(stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("npm registry returned malformed JSON") from exc
+    if not isinstance(document, dict):
+        raise ValueError("npm registry returned a non-object response")
+    return document
+
+
+def classify_registry_lookup(
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    expected_version: str,
+    expected_integrity: str,
+) -> str:
+    if returncode != 0:
+        codes = {
+            code.upper()
+            for code in re.findall(r"\bE[0-9]{3}\b", f"{stdout}\n{stderr}")
+        }
+        try:
+            error_document = _registry_document(stdout)
+        except ValueError:
+            error_document = {}
+        error = error_document.get("error")
+        exact_404 = isinstance(error, dict) and error.get("code") == "E404"
+        if codes == {"E404"} and exact_404:
+            return "absent"
+        raise ValueError("npm registry lookup failed without a confirmed 404")
+    document = _registry_document(stdout)
+    if document.get("version") != expected_version:
+        raise ValueError("npm registry version does not match the release")
+    dist = document.get("dist")
+    if not isinstance(dist, dict) or dist.get("integrity") != expected_integrity:
+        raise ValueError("npm registry tarball integrity does not match the packed payload")
+    attestations = dist.get("attestations")
+    provenance = attestations.get("provenance") if isinstance(attestations, dict) else None
+    expected_attestation_url = (
+        "https://registry.npmjs.org/-/npm/v1/attestations/"
+        f"@arbiterforge%2fca-pi@{expected_version}"
+    )
+    if not isinstance(attestations, dict) or attestations.get("url") != expected_attestation_url:
+        raise ValueError("npm provenance attestation URL is missing or untrusted")
+    if not isinstance(provenance, dict) or provenance.get("predicateType") != PROVENANCE_PREDICATE:
+        raise ValueError("npm registry has no matching SLSA provenance attestation")
+    return "present"
+
+
+def _integrity_hex(integrity: str) -> str:
+    if not integrity.startswith("sha512-"):
+        raise ValueError("expected integrity is not SHA-512")
+    try:
+        digest = base64.b64decode(integrity.removeprefix("sha512-"), validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("expected integrity has malformed base64") from exc
+    if len(digest) != 64:
+        raise ValueError("expected integrity is not a complete SHA-512 digest")
+    return digest.hex()
+
+
+def validate_attestation_document(
+    document: dict,
+    version: str,
+    integrity: str,
+    trusted_sha: str | None,
+) -> str:
+    if trusted_sha is not None:
+        validate_sha(trusted_sha, "trusted workflow SHA")
+    attestations = document.get("attestations")
+    if not isinstance(attestations, list) or len(attestations) > 8:
+        raise ValueError("npm attestation response has an invalid bounded list")
+    provenance = [
+        item
+        for item in attestations
+        if isinstance(item, dict) and item.get("predicateType") == PROVENANCE_PREDICATE
+    ]
+    if len(provenance) != 1:
+        raise ValueError("npm response must contain exactly one SLSA provenance attestation")
+    try:
+        encoded = provenance[0]["bundle"]["dsseEnvelope"]["payload"]
+        payload = base64.b64decode(encoded, validate=True)
+        if len(payload) > ATTESTATION_MAX_BYTES:
+            raise ValueError("npm provenance payload exceeds the evidence bound")
+        statement = json.loads(payload.decode("utf-8"))
+    except (KeyError, TypeError, UnicodeDecodeError, binascii.Error, json.JSONDecodeError) as exc:
+        raise ValueError("npm provenance bundle is malformed") from exc
+    if not isinstance(statement, dict) or statement.get("_type") != "https://in-toto.io/Statement/v1":
+        raise ValueError("npm provenance statement type is not trusted")
+    if statement.get("predicateType") != PROVENANCE_PREDICATE:
+        raise ValueError("npm provenance statement predicate is not trusted")
+    expected_subject = {
+        "name": f"pkg:npm/%40arbiterforge/ca-pi@{version}",
+        "digest": {"sha512": _integrity_hex(integrity)},
+    }
+    if statement.get("subject") != [expected_subject]:
+        raise ValueError("npm provenance subject does not match the exact package tarball")
+    try:
+        build = statement["predicate"]["buildDefinition"]
+        workflow = build["externalParameters"]["workflow"]
+        dependencies = build["resolvedDependencies"]
+        builder = statement["predicate"]["runDetails"]["builder"]["id"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError("npm provenance source identity is incomplete") from exc
+    if not isinstance(workflow, dict):
+        raise ValueError("npm provenance workflow identity is not approved")
+    if workflow != {
+        "repository": SOURCE_REPOSITORY,
+        "ref": SOURCE_REF,
+        "path": workflow.get("path"),
+    } or workflow.get("path") not in SOURCE_WORKFLOWS:
+        raise ValueError("npm provenance workflow identity is not approved")
+    if not isinstance(dependencies, list) or len(dependencies) != 1:
+        raise ValueError("npm provenance does not bind the trusted workflow commit")
+    dependency = dependencies[0]
+    if not isinstance(dependency, dict) or dependency.get("uri") != (
+        f"git+{SOURCE_REPOSITORY}@{SOURCE_REF}"
+    ):
+        raise ValueError("npm provenance does not bind the trusted workflow commit")
+    digest = dependency.get("digest")
+    if not isinstance(digest, dict) or set(digest) != {"gitCommit"}:
+        raise ValueError("npm provenance does not bind the trusted workflow commit")
+    source_sha = digest["gitCommit"]
+    if not isinstance(source_sha, str):
+        raise ValueError("npm provenance does not bind the trusted workflow commit")
+    validate_sha(source_sha, "attested workflow SHA")
+    if trusted_sha is not None and source_sha != trusted_sha:
+        raise ValueError("npm provenance does not bind the trusted workflow commit")
+    if builder != "https://github.com/actions/runner/github-hosted":
+        raise ValueError("npm provenance builder is not GitHub-hosted")
+    return source_sha
+
+
+def verify_registry_authenticity(npm: str, version: str) -> dict:
+    """Use npm's supported Sigstore verifier; do not hand-roll bundle crypto."""
+
+    with tempfile.TemporaryDirectory(prefix="codearbiter-npm-signatures-") as tmp:
+        root = Path(tmp)
+        (root / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "codearbiter-npm-signature-verifier",
+                    "version": "1.0.0",
+                    "private": True,
+                },
+                separators=(",", ":"),
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        try:
+            installed = subprocess.run(
+                [
+                    npm,
+                    "install",
+                    "--ignore-scripts",
+                    "--no-audit",
+                    "--no-fund",
+                    "--save-exact",
+                    f"{PACKAGE}@{version}",
+                    f"--registry={REGISTRY}",
+                ],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=60,
+            )
+            if installed.returncode != 0:
+                raise ValueError("npm signature verification install failed")
+            audited = subprocess.run(
+                [
+                    npm,
+                    "audit",
+                    "signatures",
+                    "--json",
+                    "--include-attestations",
+                    f"--registry={REGISTRY}",
+                ],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ValueError("npm signature verification timed out") from exc
+        try:
+            evidence = json.loads(audited.stdout)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError("npm signature verification returned malformed evidence") from exc
+        if (
+            audited.returncode != 0
+            or not isinstance(evidence, dict)
+            or evidence.get("invalid") != []
+            or evidence.get("missing") != []
+        ):
+            raise ValueError("npm signature or provenance verification failed")
+        verified = evidence.get("verified")
+        if not isinstance(verified, list) or len(verified) != 1:
+            raise ValueError("npm signature verification did not identify one exact package")
+        package = verified[0]
+        if not isinstance(package, dict) or {
+            "name": package.get("name"),
+            "version": package.get("version"),
+            "location": package.get("location"),
+            "registry": package.get("registry"),
+        } != {
+            "name": PACKAGE,
+            "version": version,
+            "location": f"node_modules/{PACKAGE}",
+            "registry": REGISTRY,
+        }:
+            raise ValueError("npm signature verification returned the wrong package identity")
+        bundles = package.get("attestationBundles")
+        if not isinstance(bundles, list) or len(bundles) > 8:
+            raise ValueError("npm signature verification returned invalid attestation evidence")
+        provenance = [
+            item
+            for item in bundles
+            if isinstance(item, dict) and item.get("predicateType") == PROVENANCE_PREDICATE
+        ]
+        if len(provenance) != 1:
+            raise ValueError("npm signature verification returned ambiguous provenance evidence")
+        return {"attestations": provenance}
+
+
+def parse_pack_report(stdout: str) -> tuple[str, str]:
+    try:
+        report = json.loads(stdout)
+        item = report[0]
+        filename = item["filename"]
+        integrity = item["integrity"]
+    except (IndexError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("npm pack returned malformed artifact evidence") from exc
+    if (
+        not isinstance(filename, str)
+        or Path(filename).name != filename
+        or re.fullmatch(r"[A-Za-z0-9._-]+\.tgz", filename) is None
+    ):
+        raise ValueError("npm pack returned an unsafe tarball path")
+    if (
+        not isinstance(integrity, str)
+        or re.fullmatch(r"sha512-[A-Za-z0-9+/]+={0,2}", integrity) is None
+    ):
+        raise ValueError("npm pack did not return SHA-512 integrity")
+    return filename, integrity
+
+
+def registry_lookup(npm: str, version: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [
+                npm,
+                "view",
+                f"{PACKAGE}@{version}",
+                "version",
+                "dist",
+                "--json",
+                f"--registry={REGISTRY}",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=REGISTRY_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError("npm registry lookup timed out") from exc
+
+
+def prepare(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    version = validate_inputs(args.tag, args.expected_sha)
+    validate_sha(args.trusted_sha, "trusted workflow SHA")
+    validate_git_identity(repo, args.tag, args.expected_sha)
+    validate_project_registry(repo)
+    root = json.loads((repo / args.root_manifest).read_text(encoding="utf-8"))
+    nested = json.loads((repo / args.plugin_manifest).read_text(encoding="utf-8"))
+    validate_package_identity(root, nested, version)
+    release = json.loads(Path(args.release_json).read_text(encoding="utf-8"))
+    validate_release_document(release, args.tag)
+    packed = subprocess.run(
+        [args.npm, "pack", "--ignore-scripts", "--json", f"--registry={REGISTRY}"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if packed.returncode != 0:
+        raise ValueError("npm pack failed")
+    tarball, integrity = parse_pack_report(packed.stdout)
+    lookup = registry_lookup(args.npm, version)
+    state = classify_registry_lookup(
+        lookup.returncode, lookup.stdout, lookup.stderr, version, integrity
+    )
+    if state == "present":
+        verified_document = verify_registry_authenticity(args.npm, version)
+        source_sha = validate_attestation_document(
+            verified_document, version, integrity, None
+        )
+        validate_main_commit(repo, source_sha, args.trusted_sha)
+    output = Path(args.output)
+    with output.open("a", encoding="utf-8", newline="\n") as stream:
+        stream.write(f"version={version}\n")
+        stream.write(f"tarball={repo / tarball}\n")
+        stream.write(f"integrity={integrity}\n")
+        stream.write(f"skip={'true' if state == 'present' else 'false'}\n")
+        stream.write(f"publication_mode={'existing' if state == 'present' else 'new'}\n")
+    return 0
+
+
+def verify(args: argparse.Namespace) -> int:
+    version = validate_inputs(args.tag, args.expected_sha)
+    validate_sha(args.trusted_sha, "trusted workflow SHA")
+    for attempt in range(args.attempts):
+        lookup = registry_lookup(args.npm, version)
+        try:
+            state = classify_registry_lookup(
+                lookup.returncode,
+                lookup.stdout,
+                lookup.stderr,
+                version,
+                args.integrity,
+            )
+        except ValueError:
+            raise
+        if state == "present":
+            try:
+                verified_document = verify_registry_authenticity(args.npm, version)
+                source_sha = validate_attestation_document(
+                    verified_document,
+                    version,
+                    args.integrity,
+                    args.trusted_sha if args.publication_mode == "new" else None,
+                )
+                if args.publication_mode == "existing":
+                    validate_main_commit(Path(args.repo), source_sha, args.trusted_sha)
+            except ValueError:
+                if attempt + 1 >= args.attempts:
+                    raise
+            else:
+                print(f"verified {PACKAGE}@{version} integrity and provenance")
+                return 0
+        if attempt + 1 < args.attempts:
+            time.sleep(args.delay_seconds)
+    raise ValueError("npm publication did not become observable before the evidence deadline")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    sub = result.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--tag", required=True)
+    common.add_argument("--expected-sha", required=True)
+    common.add_argument("--trusted-sha", required=True)
+    common.add_argument("--npm", default="npm")
+    sub.add_parser("validate", parents=[common])
+    prepare_parser = sub.add_parser("prepare", parents=[common])
+    prepare_parser.add_argument("--repo", default=".")
+    prepare_parser.add_argument("--release-json", required=True)
+    prepare_parser.add_argument("--output", required=True)
+    prepare_parser.add_argument("--root-manifest", required=True)
+    prepare_parser.add_argument("--plugin-manifest", required=True)
+    verify_parser = sub.add_parser("verify", parents=[common])
+    verify_parser.add_argument("--repo", default=".")
+    verify_parser.add_argument("--integrity", required=True)
+    verify_parser.add_argument(
+        "--publication-mode", required=True, choices=("new", "existing")
+    )
+    verify_parser.add_argument("--attempts", type=int, default=12)
+    verify_parser.add_argument("--delay-seconds", type=float, default=5.0)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "validate":
+            validate_inputs(args.tag, args.expected_sha)
+            validate_sha(args.trusted_sha, "trusted workflow SHA")
+            return 0
+        return prepare(args) if args.command == "prepare" else verify(args)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"refusing npm publication: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_pi_package.py
+++ b/.github/scripts/test_pi_package.py
@@ -2,6 +2,9 @@
 """Task 2 package, generation, and independent-release contract tests."""
 from __future__ import annotations
 
+import argparse
+import base64
+import copy
 import importlib.util
 import hashlib
 import io
@@ -2063,9 +2066,87 @@ class PiPackageTests(unittest.TestCase):
 
 class NpmPublishContractTest(unittest.TestCase):
     """ADR-0029 / spec npm-publish-ca-pi: the npm channel ships the same payload
-    the Git install serves, from a tag-triggered provenance workflow."""
+    the Git install serves, synchronously inside the release workflow."""
 
     WORKFLOW = REPO / ".github" / "workflows" / "npm-publish.yml"
+
+    def _assert_npm_workflow_security_contract(self, text):
+        workflow_call = text.split("  workflow_call:\n", 1)[1].split(
+            "  workflow_dispatch:\n", 1
+        )[0]
+        secret_declaration = workflow_call.split("    secrets:\n", 1)[1].strip()
+        self.assertEqual(
+            secret_declaration,
+            "NPMJS_TOKEN:\n        required: true",
+            "the reusable publisher must declare exactly one named secret",
+        )
+        checkout_blocks = text.split("uses: actions/checkout@")[1:]
+        self.assertEqual(len(checkout_blocks), 2)
+        for block in checkout_blocks:
+            step = block.split("\n      - ", 1)[0]
+            self.assertEqual(step.count("persist-credentials: false"), 1)
+            self.assertNotIn("persist-credentials: true", step)
+        self.assertNotRegex(
+            text,
+            r"(?m)^\s+(?:-\s+)?(?:uses|working-directory):\s+.*candidate",
+            "candidate content must not become an action or working directory",
+        )
+        run_blocks = re.findall(r"(?ms)^        run: .*?(?=^      - |\Z)", text)
+        candidate_consumers = [
+            line.strip()
+            for block in run_blocks
+            for line in block.splitlines()
+            if re.search(r"\bcandidate(?:[/\\]|\b)", line)
+        ]
+        self.assertEqual(
+            candidate_consumers,
+            [
+                "run: git -C candidate fetch --no-tags origin main:refs/remotes/origin/main",
+                "--repo candidate \\",
+            ],
+            "candidate content reached a command outside the exact inert-data allowlist",
+        )
+        steps_text = text.split("    steps:\n", 1)[1]
+        step_blocks = [
+            block.rstrip() + "\n"
+            for block in re.split(r"(?m)(?=^      - )", steps_text)
+            if block.strip()
+        ]
+        step_contract = [
+            (
+                block.splitlines()[0].strip(),
+                hashlib.sha256(block.encode("utf-8")).hexdigest(),
+            )
+            for block in step_blocks
+        ]
+        self.assertEqual(
+            step_contract,
+            [
+                ("- name: Check out the trusted default-branch verifier", "e5f2364f9cd674ffb2154ccfa5731f2bafc85406538d0154d409c28dbe216f97"),
+                ("- name: Validate untrusted release inputs before use", "fd21e6f82c6dac0b24da721059d653135a44289b46c541cdd4f9eb999e1101c9"),
+                ("- name: Materialize the exact tagged package as inert data", "d2f4e3fe952dc4276ef6cd7169935f52fbd76e30dac74e5a24586e79782e2e1f"),
+                ("- uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0", "70e3f9ff0a4f115a8fed73d3bd8cce496729800f73ba17f3bf6b84dad5c93b74"),
+                ("- name: Fetch protected main without credentials", "eb31d3327ddc305329e5639d95fa6abeb2d2df463f0837c713b7da2d6c9a3730"),
+                ("- name: Capture exact published GitHub Release evidence", "73ed3a2d933eb9ca00bb0d794377d49c328df0813d4307f192932b30749605e8"),
+                ("- name: Validate identity, pack once, and classify exact registry state", "8703fd0c91ca4ad5e5b2ea9ab862f661d7fea6f85faea4a0f314a6d58483fa3d"),
+                ("- name: Publish with provenance", "71904d909dc577e3e536ec22e5a8e5feee91988d22f9cf640cc819e93c586592"),
+                ("- name: Verify exact registry publication evidence", "c4d554f8f9f675cc3cc27084feaacafe35f85e93b38404f33bc4fd33830cf51e"),
+            ],
+            "the complete publisher step contract drifted",
+        )
+    HELPER = REPO / ".github" / "scripts" / "_npm_publishlib.py"
+
+    def _helper(self):
+        self.assertTrue(
+            self.HELPER.is_file(),
+            "the npm publisher has no executable fail-closed verifier",
+        )
+        spec = importlib.util.spec_from_file_location("_npm_publishlib", self.HELPER)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
 
     def test_npm_pack_contents_match_pi_payload(self):
         # AC-2: the tarball is exactly the Pi-served payload — offline dry-run.
@@ -2106,23 +2187,54 @@ class NpmPublishContractTest(unittest.TestCase):
             self.assertEqual(leaked, [], f"tarball leaks {excluded_prefix}")
 
     def test_npm_publish_workflow_contract(self):
-        # AC-3: tag-scoped trigger, least-privilege permissions, provenance
-        # publish, a version guard, and no dependency install at all.
+        # AC-3: reusable exact-tag/SHA publication, least privilege, provenance,
+        # registry read-back, and no candidate build or dependency install.
         self.assertTrue(self.WORKFLOW.is_file(), "npm-publish.yml is missing")
         text = self.WORKFLOW.read_text(encoding="utf-8")
-        self.assertRegex(text, r"(?ms)^on:\n.*push:\n\s+tags:\n\s+- \"ca-pi-v\*\"")
-        self.assertIn("workflow_dispatch:", text)
+        self._assert_npm_workflow_security_contract(text)
+        self.assertNotRegex(text, r"(?m)^  push:")
+        self.assertIn(
+            "workflow_dispatch:",
+            text,
+            "an immutable historical tag needs the same exact-tag/SHA verifier as a recovery path",
+        )
+        dispatch = text.split("  workflow_dispatch:", 1)[1].split("\n\npermissions:", 1)[0]
+        for name in ("tag", "expected_sha"):
+            self.assertRegex(
+                dispatch,
+                rf"(?ms)^      {name}:\n        required: true\n        type: string$",
+            )
+        self.assertRegex(text, r"(?ms)^on:\n  workflow_call:\n    inputs:\n")
+        for name in ("tag", "expected_sha"):
+            self.assertRegex(
+                text,
+                rf"(?ms)^      {name}:\n        required: true\n        type: string$",
+            )
+        self.assertRegex(
+            text,
+            r"(?ms)^    secrets:\n      NPMJS_TOKEN:\n        required: true$",
+        )
         self.assertRegex(text, r"(?ms)^permissions:\n\s+contents: read\n\s+id-token: write\n")
+        self.assertIn("timeout-minutes: 10", text)
         self.assertNotIn("contents: write", text)
-        # A manual dispatch must resolve its input through refs/tags/ so a
-        # branch name can never be checked out and published as a release.
         self.assertIn("format('refs/tags/{0}', inputs.tag)", text)
         # Re-runs are serialized per tag and become no-ops once the exact
-        # version is on the registry (npm versions are immutable; a mismatch
-        # cannot be republished, only investigated).
-        self.assertRegex(text, r"(?ms)^concurrency:\n\s+group: ")
-        self.assertIn("npm view", text)
-        self.assertIn("npm publish --ignore-scripts --provenance --access public", text)
+        # artifact and provenance are proven on the registry.
+        self.assertIn("group: npm-publish-${{ inputs.tag }}", text)
+        self.assertIn("cancel-in-progress: false", text)
+        self.assertNotIn('--tag "${{ inputs.tag }}"', text)
+        self.assertNotIn('--expected-sha "${{ inputs.expected_sha }}"', text)
+        self.assertNotIn('tags/${{ inputs.tag }}', text)
+        self.assertIn("RELEASE_TAG: ${{ inputs.tag }}", text)
+        self.assertIn("EXPECTED_SHA: ${{ inputs.expected_sha }}", text)
+        self.assertIn("TRUSTED_SHA: ${{ github.sha }}", text)
+        self.assertIn('--expected-sha "$EXPECTED_SHA"', text)
+        self.assertIn('--trusted-sha "$TRUSTED_SHA"', text)
+        self.assertIn("--registry=https://registry.npmjs.org/", text)
+        self.assertIn("npm publish", text)
+        self.assertIn("--ignore-scripts", text)
+        self.assertIn("--provenance", text)
+        self.assertIn("Verify exact registry publication evidence", text)
         self.assertIn("NODE_AUTH_TOKEN", text)
         self.assertIn("secrets.NPMJS_TOKEN", text)
         self.assertNotIn("npm ci", text)
@@ -2130,6 +2242,646 @@ class NpmPublishContractTest(unittest.TestCase):
         for manifest in ("package.json", "plugins/ca-pi/package.json"):
             self.assertIn(manifest, text)
         self.assertRegex(text, r"(?is)tag.{0,240}version.{0,240}(mismatch|match|equal)")
+
+    def test_npm_workflow_security_contract_rejects_hostile_drift(self):
+        text = self.WORKFLOW.read_text(encoding="utf-8")
+        mutations = (
+            text.replace(
+                "      NPMJS_TOKEN:\n        required: true\n  workflow_dispatch:",
+                "      NPMJS_TOKEN:\n        required: true\n"
+                "      EXTRA_SECRET:\n        required: true\n  workflow_dispatch:",
+                1,
+            ),
+            text.replace("persist-credentials: false", "persist-credentials: true", 1),
+            text.replace(
+                "run: git -C candidate fetch --no-tags origin main:refs/remotes/origin/main",
+                "run: git -C candidate fetch --no-tags origin main:refs/remotes/origin/main\n"
+                "          python3 candidate/evil.py",
+                1,
+            ),
+            text.replace(
+                "      - uses: actions/setup-node@",
+                "      - uses: ./candidate/evil-action\n"
+                "      - uses: actions/setup-node@",
+                1,
+            ),
+            text.replace(
+                "      - name: Fetch protected main without credentials",
+                "      - name: Hidden candidate execution\n"
+                "        env:\n          EVIL: candidate/evil.py\n"
+                "        run: python3 \"$EVIL\"\n"
+                "      - name: Fetch protected main without credentials",
+                1,
+            ),
+        )
+        for mutation in mutations:
+            with self.subTest(mutation=mutation), self.assertRaises(AssertionError):
+                self._assert_npm_workflow_security_contract(mutation)
+
+    def test_publish_inputs_reject_ref_injection_and_noncanonical_sha(self):
+        helper = self._helper()
+        for tag in (
+            "ca-pi-v0.10.0;echo owned",
+            "refs/heads/main",
+            "ca-pi-v01.2.3",
+            "ca-pi-v1.2",
+            "ca-pi-v1.2.3-rc.1",
+        ):
+            with self.subTest(tag=tag), self.assertRaises(ValueError):
+                helper.validate_inputs(tag, "a" * 40)
+        for sha in ("A" * 40, "a" * 39, "../" + "a" * 40):
+            with self.subTest(sha=sha), self.assertRaises(ValueError):
+                helper.validate_inputs("ca-pi-v0.10.0", sha)
+        self.assertEqual(
+            helper.validate_inputs("ca-pi-v0.10.0", "a" * 40), "0.10.0"
+        )
+
+    def test_publisher_executes_only_trusted_verifier_against_tagged_candidate_data(self):
+        text = self.WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("if: github.ref == 'refs/heads/main'", text)
+        self.assertIn("ref: ${{ github.sha }}", text)
+        self.assertNotIn("ref: refs/heads/main", text)
+        self.assertIn("path: trusted", text)
+        self.assertIn("ref: ${{ format('refs/tags/{0}', inputs.tag) }}", text)
+        self.assertIn("path: candidate", text)
+        self.assertIn(
+            "python3 trusted/.github/scripts/_npm_publishlib.py prepare", text
+        )
+        self.assertIn("--repo candidate", text)
+        self.assertNotIn("python3 .github/scripts/_npm_publishlib.py", text)
+
+    def test_package_identity_requires_both_manifests_and_public_repository(self):
+        helper = self._helper()
+        root = {
+            "name": "@arbiterforge/ca-pi",
+            "version": "0.10.0",
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/arbiterForge/codeArbiter.git",
+            },
+            "publishConfig": {"access": "public", "provenance": True},
+        }
+        nested = {"name": "@arbiterforge/ca-pi", "version": "0.10.0", "private": True}
+        helper.validate_package_identity(root, nested, "0.10.0")
+        mutations = (
+            ({**root, "name": "ca-pi"}, nested),
+            ({**root, "version": "0.9.9"}, nested),
+            (root, {**nested, "version": "0.9.9"}),
+            (root, {**nested, "name": "@attacker/other"}),
+            (root, {**nested, "private": False}),
+            ({**root, "repository": "https://example.invalid/repo"}, nested),
+            ({**root, "publishConfig": {"registry": "https://evil.invalid"}}, nested),
+        )
+        for changed_root, changed_nested in mutations:
+            with self.subTest(root=changed_root), self.assertRaises(ValueError):
+                helper.validate_package_identity(changed_root, changed_nested, "0.10.0")
+
+    def test_project_registry_configuration_cannot_redirect_publication(self):
+        helper = self._helper()
+        self.assertTrue(
+            hasattr(helper, "validate_project_registry"),
+            "the publisher has no testable project-registry guard",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            helper.validate_project_registry(repo)
+            (repo / ".npmrc").write_text("registry=https://evil.invalid/\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                helper.validate_project_registry(repo)
+
+    def test_registry_lookup_distinguishes_absence_from_failure_and_requires_proof(self):
+        helper = self._helper()
+        expected = "sha512-expected"
+        self.assertEqual(
+            helper.classify_registry_lookup(
+                1,
+                '{"error":{"code":"E404"}}',
+                "npm error code E404",
+                "0.10.0",
+                expected,
+            ),
+            "absent",
+        )
+        for stderr in (
+            "npm error code E401",
+            "npm error code E429",
+            "network timeout",
+            "npm error code E404\nnpm error code E401",
+            "npm error code E404",
+        ):
+            with self.subTest(stderr=stderr), self.assertRaises(ValueError):
+                helper.classify_registry_lookup(1, "", stderr, "0.10.0", expected)
+        with self.assertRaises(ValueError):
+            helper.classify_registry_lookup(
+                1,
+                '{"error":{"code":"E404"}}',
+                "npm error code E404\nnpm error code E401",
+                "0.10.0",
+                expected,
+            )
+        matching = json.dumps(
+            {
+                "version": "0.10.0",
+                "dist": {
+                    "integrity": expected,
+                    "attestations": {
+                        "url": "https://registry.npmjs.org/-/npm/v1/attestations/@arbiterforge%2fca-pi@0.10.0",
+                        "provenance": {
+                            "predicateType": "https://slsa.dev/provenance/v1"
+                        }
+                    },
+                },
+            }
+        )
+        self.assertEqual(
+            helper.classify_registry_lookup(0, matching, "", "0.10.0", expected),
+            "present",
+        )
+        for mutation in (
+            {"version": "0.9.9", "dist": json.loads(matching)["dist"]},
+            {"version": "0.10.0", "dist": {"integrity": "sha512-other"}},
+            {"version": "0.10.0", "dist": {"integrity": expected}},
+            {
+                "version": "0.10.0",
+                "dist": {
+                    **json.loads(matching)["dist"],
+                    "attestations": {
+                        **json.loads(matching)["dist"]["attestations"],
+                        "url": "https://evil.invalid/attestation",
+                    },
+                },
+            },
+            {
+                "version": "0.10.0",
+                "dist": {
+                    **json.loads(matching)["dist"],
+                    "attestations": {
+                        **json.loads(matching)["dist"]["attestations"],
+                        "provenance": {"predicateType": "https://example.invalid/predicate"},
+                    },
+                },
+            },
+        ):
+            with self.subTest(mutation=mutation), self.assertRaises(ValueError):
+                helper.classify_registry_lookup(
+                    0, json.dumps(mutation), "", "0.10.0", expected
+                )
+
+    def test_registry_lookup_and_readback_are_time_bounded(self):
+        helper = self._helper()
+        with mock.patch.object(
+            helper.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["npm", "view"], 30),
+        ):
+            with self.assertRaisesRegex(ValueError, "timed out"):
+                helper.registry_lookup("npm", "0.10.0")
+        absent = subprocess.CompletedProcess(
+            ["npm"],
+            1,
+            '{"error":{"code":"E404"}}',
+            "npm error code E404",
+        )
+        args = argparse.Namespace(
+            tag="ca-pi-v0.10.0",
+            expected_sha="a" * 40,
+            trusted_sha="a" * 40,
+            npm="npm",
+            integrity="sha512-expected",
+            attempts=2,
+            delay_seconds=0,
+        )
+        with mock.patch.object(helper, "registry_lookup", return_value=absent):
+            with self.assertRaisesRegex(ValueError, "evidence deadline"):
+                helper.verify(args)
+
+    def test_attestation_evidence_comes_only_from_the_npm_verifier(self):
+        helper = self._helper()
+        self.assertFalse(hasattr(helper, "attestation_lookup"))
+        source = Path(helper.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("urllib", source)
+        self.assertNotIn("urlopen", source)
+
+    def test_pack_report_rejects_output_injection_and_malformed_integrity(self):
+        helper = self._helper()
+        good = [{"filename": "arbiterforge-ca-pi-0.10.0.tgz", "integrity": "sha512-YWJjZA=="}]
+        self.assertEqual(
+            helper.parse_pack_report(json.dumps(good)),
+            ("arbiterforge-ca-pi-0.10.0.tgz", "sha512-YWJjZA=="),
+        )
+        for report in (
+            [{"filename": "$(owned).tgz", "integrity": "sha512-YWJjZA=="}],
+            [{"filename": "safe.tgz", "integrity": 'sha512-good";echo owned'}],
+            {"filename": "safe.tgz", "integrity": "sha512-YWJjZA=="},
+        ):
+            with self.subTest(report=report), self.assertRaises(ValueError):
+                helper.parse_pack_report(json.dumps(report))
+
+    def test_attestation_bundle_binds_subject_and_github_source_identity(self):
+        helper = self._helper()
+        version = "0.10.0"
+        trusted_sha = "a" * 40
+        digest_hex = "ab" * 64
+        integrity = "sha512-" + base64.b64encode(bytes.fromhex(digest_hex)).decode("ascii")
+        statement = {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+                {
+                    "name": "pkg:npm/%40arbiterforge/ca-pi@0.10.0",
+                    "digest": {"sha512": digest_hex},
+                }
+            ],
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {
+                "buildDefinition": {
+                    "externalParameters": {
+                        "workflow": {
+                            "repository": "https://github.com/arbiterForge/codeArbiter",
+                            "ref": "refs/heads/main",
+                            "path": ".github/workflows/release.yml",
+                        }
+                    },
+                    "resolvedDependencies": [
+                        {
+                            "uri": "git+https://github.com/arbiterForge/codeArbiter@refs/heads/main",
+                            "digest": {"gitCommit": trusted_sha},
+                        }
+                    ],
+                },
+                "runDetails": {
+                    "builder": {
+                        "id": "https://github.com/actions/runner/github-hosted"
+                    }
+                },
+            },
+        }
+
+        def document(value):
+            payload = base64.b64encode(
+                json.dumps(value, separators=(",", ":")).encode("utf-8")
+            ).decode("ascii")
+            return {
+                "attestations": [
+                    {
+                        "predicateType": "https://slsa.dev/provenance/v1",
+                        "bundle": {"dsseEnvelope": {"payload": payload}},
+                    }
+                ]
+            }
+
+        self.assertEqual(
+            helper.validate_attestation_document(
+                document(statement), version, integrity, trusted_sha
+            ),
+            trusted_sha,
+        )
+        mutations = []
+        for path, replacement in (
+            (("subject", 0, "name"), "pkg:npm/%40attacker/other@0.10.0"),
+            (("subject", 0, "digest", "sha512"), "00" * 64),
+            (("predicate", "buildDefinition", "externalParameters", "workflow", "repository"), "https://github.com/attacker/repo"),
+            (("predicate", "buildDefinition", "externalParameters", "workflow", "ref"), "refs/heads/evil"),
+            (("predicate", "buildDefinition", "externalParameters", "workflow", "path"), ".github/workflows/evil.yml"),
+            (("predicate", "buildDefinition", "resolvedDependencies", 0, "digest", "gitCommit"), "b" * 40),
+            (("predicate", "runDetails", "builder", "id"), "https://attacker.invalid/runner"),
+        ):
+            changed = json.loads(json.dumps(statement))
+            cursor = changed
+            for segment in path[:-1]:
+                cursor = cursor[segment]
+            cursor[path[-1]] = replacement
+            mutations.append(changed)
+        for changed in mutations:
+            with self.subTest(changed=changed), self.assertRaises(ValueError):
+                helper.validate_attestation_document(
+                    document(changed), version, integrity, trusted_sha
+                )
+
+    def test_registry_authenticity_rejects_unsigned_or_invalid_packages(self):
+        helper = self._helper()
+        installed = subprocess.CompletedProcess(["npm", "install"], 0, "", "")
+        for evidence in (
+            {"invalid": [{"name": "@arbiterforge/ca-pi"}], "missing": []},
+            {"invalid": [], "missing": ["@arbiterforge/ca-pi@0.10.0"]},
+        ):
+            audited = subprocess.CompletedProcess(
+                ["npm", "audit", "signatures"], 1, json.dumps(evidence), ""
+            )
+            with self.subTest(evidence=evidence), mock.patch.object(
+                helper.subprocess, "run", side_effect=[installed, audited]
+            ), self.assertRaisesRegex(ValueError, "signature"):
+                helper.verify_registry_authenticity("npm", "0.10.0")
+        provenance_bundle = {
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "bundle": {"dsseEnvelope": {"payload": "verified"}},
+        }
+        verified_evidence = {
+            "invalid": [],
+            "missing": [],
+            "verified": [
+                {
+                    "name": "@arbiterforge/ca-pi",
+                    "version": "0.10.0",
+                    "location": "node_modules/@arbiterforge/ca-pi",
+                    "registry": "https://registry.npmjs.org/",
+                    "attestationBundles": [
+                        {
+                            "predicateType": "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+                            "bundle": {"dsseEnvelope": {"payload": "publish"}},
+                        },
+                        provenance_bundle,
+                    ],
+                }
+            ],
+        }
+        audited = subprocess.CompletedProcess(
+            ["npm", "audit", "signatures"],
+            0,
+            json.dumps(verified_evidence),
+            "",
+        )
+        with mock.patch.object(
+            helper.subprocess, "run", side_effect=[installed, audited]
+        ) as run:
+            document = helper.verify_registry_authenticity("npm", "0.10.0")
+        self.assertEqual(document, {"attestations": [provenance_bundle]})
+        install_command = run.call_args_list[0].args[0]
+        audit_command = run.call_args_list[1].args[0]
+        self.assertEqual(install_command[:2], ["npm", "install"])
+        self.assertIn("--ignore-scripts", install_command)
+        self.assertIn("--save-exact", install_command)
+        self.assertIn("@arbiterforge/ca-pi@0.10.0", install_command)
+        self.assertEqual(audit_command[:3], ["npm", "audit", "signatures"])
+        self.assertIn("--json", audit_command)
+        self.assertIn("--include-attestations", audit_command)
+
+        hostile_evidence = []
+        for field, value in (
+            ("name", "@attacker/ca-pi"),
+            ("version", "0.9.9"),
+            ("location", "node_modules/attacker"),
+            ("registry", "https://attacker.invalid/"),
+        ):
+            evidence = copy.deepcopy(verified_evidence)
+            evidence["verified"][0][field] = value
+            hostile_evidence.append((field, evidence, "wrong package identity"))
+        evidence = copy.deepcopy(verified_evidence)
+        evidence["verified"].append(copy.deepcopy(evidence["verified"][0]))
+        hostile_evidence.append(("duplicate package", evidence, "one exact package"))
+        for label, bundles in (
+            ("missing provenance", []),
+            ("duplicate provenance", [provenance_bundle, provenance_bundle]),
+        ):
+            evidence = copy.deepcopy(verified_evidence)
+            evidence["verified"][0]["attestationBundles"] = bundles
+            hostile_evidence.append((label, evidence, "ambiguous provenance"))
+        for label, evidence, message in hostile_evidence:
+            audited = subprocess.CompletedProcess(
+                ["npm", "audit", "signatures"], 0, json.dumps(evidence), ""
+            )
+            with self.subTest(label=label), mock.patch.object(
+                helper.subprocess, "run", side_effect=[installed, audited]
+            ), self.assertRaisesRegex(ValueError, message):
+                helper.verify_registry_authenticity("npm", "0.10.0")
+
+    def test_present_publication_orchestration_binds_verified_bundle(self):
+        helper = self._helper()
+        integrity = "sha512-" + base64.b64encode(b"x" * 64).decode("ascii")
+        registry = subprocess.CompletedProcess(
+            ["npm"],
+            0,
+            json.dumps(
+                {
+                    "version": "0.10.0",
+                    "dist": {
+                        "integrity": integrity,
+                        "attestations": {
+                            "url": "https://registry.npmjs.org/-/npm/v1/attestations/@arbiterforge%2fca-pi@0.10.0",
+                            "provenance": {
+                                "predicateType": "https://slsa.dev/provenance/v1"
+                            },
+                        },
+                    },
+                }
+            ),
+            "",
+        )
+        verified_document = {"attestations": [{"verified": True}]}
+        source_sha = "b" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "plugins" / "ca-pi").mkdir(parents=True)
+            root_manifest = {
+                "name": "@arbiterforge/ca-pi",
+                "version": "0.10.0",
+                "repository": {
+                    "type": "git",
+                    "url": "git+https://github.com/arbiterForge/codeArbiter.git",
+                },
+                "publishConfig": {"access": "public", "provenance": True},
+            }
+            (repo / "package.json").write_text(json.dumps(root_manifest), encoding="utf-8")
+            (repo / "plugins" / "ca-pi" / "package.json").write_text(
+                json.dumps(
+                    {
+                        "name": "@arbiterforge/ca-pi",
+                        "version": "0.10.0",
+                        "private": True,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            release_json = repo / "release.json"
+            release_json.write_text(
+                json.dumps({"tag_name": "ca-pi-v0.10.0", "draft": False}),
+                encoding="utf-8",
+            )
+            output = repo / "output.txt"
+            args = argparse.Namespace(
+                repo=str(repo),
+                tag="ca-pi-v0.10.0",
+                expected_sha="a" * 40,
+                trusted_sha="c" * 40,
+                npm="npm",
+                root_manifest="package.json",
+                plugin_manifest="plugins/ca-pi/package.json",
+                release_json=str(release_json),
+                output=str(output),
+            )
+            packed = subprocess.CompletedProcess(
+                ["npm", "pack"],
+                0,
+                json.dumps(
+                    [
+                        {
+                            "filename": "arbiterforge-ca-pi-0.10.0.tgz",
+                            "integrity": integrity,
+                        }
+                    ]
+                ),
+                "",
+            )
+            with mock.patch.object(helper, "validate_git_identity"), mock.patch.object(
+                helper.subprocess, "run", return_value=packed
+            ), mock.patch.object(
+                helper, "registry_lookup", return_value=registry
+            ), mock.patch.object(
+                helper, "verify_registry_authenticity", return_value=verified_document
+            ) as authenticity, mock.patch.object(
+                helper, "validate_attestation_document", return_value=source_sha
+            ) as semantic, mock.patch.object(helper, "validate_main_commit") as ancestry:
+                self.assertEqual(helper.prepare(args), 0)
+            authenticity.assert_called_once_with("npm", "0.10.0")
+            semantic.assert_called_once_with(
+                verified_document, "0.10.0", integrity, None
+            )
+            ancestry.assert_called_once_with(repo.resolve(), source_sha, "c" * 40)
+            output_values = dict(
+                line.split("=", 1)
+                for line in output.read_text(encoding="utf-8").splitlines()
+            )
+            self.assertEqual(output_values["skip"], "true")
+            self.assertEqual(output_values["publication_mode"], "existing")
+
+        for mode, expected_trusted, expect_ancestry in (
+            ("new", "c" * 40, False),
+            ("existing", None, True),
+        ):
+            args = argparse.Namespace(
+                repo="trusted",
+                tag="ca-pi-v0.10.0",
+                expected_sha="a" * 40,
+                trusted_sha="c" * 40,
+                npm="npm",
+                integrity=integrity,
+                publication_mode=mode,
+                attempts=1,
+                delay_seconds=0,
+            )
+            with self.subTest(mode=mode), mock.patch.object(
+                helper, "registry_lookup", return_value=registry
+            ), mock.patch.object(
+                helper, "verify_registry_authenticity", return_value=verified_document
+            ) as authenticity, mock.patch.object(
+                helper, "validate_attestation_document", return_value=source_sha
+            ) as semantic, mock.patch.object(helper, "validate_main_commit") as ancestry:
+                self.assertEqual(helper.verify(args), 0)
+                authenticity.assert_called_once_with("npm", "0.10.0")
+                semantic.assert_called_once_with(
+                    verified_document, "0.10.0", integrity, expected_trusted
+                )
+                if expect_ancestry:
+                    ancestry.assert_called_once_with(
+                        Path("trusted"), source_sha, "c" * 40
+                    )
+                else:
+                    ancestry.assert_not_called()
+
+        args.publication_mode = "new"
+        with mock.patch.object(
+            helper, "registry_lookup", return_value=registry
+        ), mock.patch.object(
+            helper,
+            "verify_registry_authenticity",
+            side_effect=ValueError("signature failure"),
+        ), self.assertRaisesRegex(ValueError, "signature failure"):
+            helper.verify(args)
+
+    def test_historical_attestation_commit_must_remain_on_protected_main(self):
+        helper = self._helper()
+        repo = Path("trusted")
+        with mock.patch.object(
+            helper,
+            "_git",
+            return_value=subprocess.CompletedProcess(["git"], 0, "", ""),
+        ) as git:
+            helper.validate_main_commit(repo, "a" * 40)
+            self.assertEqual(
+                git.call_args.args[1:],
+                ("merge-base", "--is-ancestor", "a" * 40, "origin/main"),
+            )
+        with mock.patch.object(
+            helper,
+            "_git",
+            return_value=subprocess.CompletedProcess(["git"], 1, "", ""),
+        ), self.assertRaisesRegex(ValueError, "protected main"):
+            helper.validate_main_commit(repo, "b" * 40)
+
+    def test_security_policy_and_workflow_guard_the_npm_secret_boundary(self):
+        policy = (REPO / ".codearbiter" / "security-controls.md").read_text(
+            encoding="utf-8"
+        )
+        workflow = self.WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("### ca-pi npm publication boundary", policy)
+        for claim in (
+            "NPMJS_TOKEN",
+            "organization Actions secret",
+            "NODE_AUTH_TOKEN",
+            "@arbiterforge/ca-pi",
+            "OIDC provenance",
+            "npm audit signatures",
+            "rotation",
+        ):
+            self.assertIn(claim, policy)
+        self.assertNotIn("secrets: inherit", workflow)
+        self.assertEqual(workflow.count("NODE_AUTH_TOKEN:"), 1)
+        publish_step = workflow.split("      - name: Publish with provenance", 1)[1].split(
+            "      - name: Verify exact registry publication evidence", 1
+        )[0]
+        self.assertIn("NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}", publish_step)
+        self.assertIn('--ignore-scripts', publish_step)
+
+    def test_release_and_git_identity_require_published_annotated_exact_tag(self):
+        helper = self._helper()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.email", "test@example.invalid"],
+                check=True,
+            )
+            (repo / "payload").write_text("one\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "payload"], check=True)
+            subprocess.run(["git", "-C", str(repo), "commit", "-qm", "one"], check=True)
+            sha = subprocess.check_output(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+            ).strip()
+            subprocess.run(
+                ["git", "-C", str(repo), "tag", "-a", "ca-pi-v0.10.0", "-m", "release"],
+                check=True,
+            )
+            helper.validate_git_identity(repo, "ca-pi-v0.10.0", sha, main_ref="HEAD")
+            with self.assertRaises(ValueError):
+                helper.validate_git_identity(repo, "ca-pi-v0.10.0", "b" * 40, main_ref="HEAD")
+            (repo / "payload").write_text("two\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "commit", "-qam", "two"], check=True)
+            with self.assertRaises(ValueError):
+                helper.validate_git_identity(repo, "ca-pi-v0.10.0", sha, main_ref="HEAD")
+            side_sha = subprocess.check_output(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+            ).strip()
+            subprocess.run(
+                ["git", "-C", str(repo), "tag", "-a", "ca-pi-v0.10.2", "-m", "side"],
+                check=True,
+            )
+            with self.assertRaisesRegex(ValueError, "not contained in protected main"):
+                helper.validate_git_identity(
+                    repo, "ca-pi-v0.10.2", side_sha, main_ref=sha
+                )
+            subprocess.run(["git", "-C", str(repo), "tag", "ca-pi-v0.10.1"], check=True)
+            with self.assertRaises(ValueError):
+                helper.validate_git_identity(repo, "ca-pi-v0.10.1", sha, main_ref="HEAD")
+        helper.validate_release_document(
+            {"tag_name": "ca-pi-v0.10.0", "draft": False}, "ca-pi-v0.10.0"
+        )
+        for doc in (
+            {"tag_name": "ca-pi-v0.10.0", "draft": True},
+            {"tag_name": "ca-pi-v0.9.9", "draft": False},
+            {},
+        ):
+            with self.subTest(doc=doc), self.assertRaises(ValueError):
+                helper.validate_release_document(doc, "ca-pi-v0.10.0")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pi_package.py
+++ b/.github/scripts/test_pi_package.py
@@ -2126,7 +2126,10 @@ class NpmPublishContractTest(unittest.TestCase):
                 ("- name: Validate untrusted release inputs before use", "fd21e6f82c6dac0b24da721059d653135a44289b46c541cdd4f9eb999e1101c9"),
                 ("- name: Materialize the exact tagged package as inert data", "d2f4e3fe952dc4276ef6cd7169935f52fbd76e30dac74e5a24586e79782e2e1f"),
                 ("- uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0", "70e3f9ff0a4f115a8fed73d3bd8cce496729800f73ba17f3bf6b84dad5c93b74"),
-                ("- name: Fetch protected main without credentials", "eb31d3327ddc305329e5639d95fa6abeb2d2df463f0837c713b7da2d6c9a3730"),
+                (
+                    "- name: Fetch protected main without credentials",
+                    "eb31d3327ddc305329e5639d95fa6abeb2d2df463f0837c713b7da2d6c9a3730",
+                ),
                 ("- name: Capture exact published GitHub Release evidence", "73ed3a2d933eb9ca00bb0d794377d49c328df0813d4307f192932b30749605e8"),
                 ("- name: Validate identity, pack once, and classify exact registry state", "8703fd0c91ca4ad5e5b2ea9ab862f661d7fea6f85faea4a0f314a6d58483fa3d"),
                 ("- name: Publish with provenance", "71904d909dc577e3e536ec22e5a8e5feee91988d22f9cf640cc819e93c586592"),

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -115,6 +115,9 @@ AUTO_PREFLIGHT_JOB = "auto-preflight"
 MANUAL_CODEX_PROVENANCE_JOB = "codex-provenance"
 AUTO_CODEX_PROVENANCE_JOB = "auto-codex-provenance"
 AUTO_COMMAND_ROUTE_RELEASE_AUDIT_JOB = "auto-command-route-release-audit"
+MANUAL_PI_NPM_JOB = "publish-pi-npm"
+AUTO_PI_NPM_JOB = "auto-publish-pi-npm"
+NPM_PUBLISH_WORKFLOW_REF = "./.github/workflows/npm-publish.yml"
 
 # #654: two triggers share this one file, and every job belongs to exactly one
 # of them. The manual lane reads dispatch inputs that do not exist on the
@@ -124,9 +127,11 @@ JOB_TRIGGER = dict(
     [(PREFLIGHT_JOB, "workflow_dispatch")]
     + [(job, "workflow_dispatch") for job in PUBLISH_JOBS]
     + [(MANUAL_CODEX_PROVENANCE_JOB, "workflow_dispatch")]
+    + [(MANUAL_PI_NPM_JOB, "workflow_dispatch")]
     + [(AUTO_PREFLIGHT_JOB, "workflow_run")]
     + [(job, "workflow_run") for job in AUTO_PUBLISH_JOBS]
     + [(AUTO_CODEX_PROVENANCE_JOB, "workflow_run")]
+    + [(AUTO_PI_NPM_JOB, "workflow_run")]
     + [(AUTO_COMMAND_ROUTE_RELEASE_AUDIT_JOB, "workflow_run")]
 )
 
@@ -193,7 +198,11 @@ def _condition_triggers(condition: str, *, allow_status_escape: bool = False) ->
         raise AssertionError("a status function bypasses the implicit needs gate")
     if "github.event_name" not in condition:
         return set(TRIGGERS)
-    if "||" in condition:
+    supported_pi_result_guard = (
+        "(needs.auto-preflight.outputs.ca-pi != 'true' || "
+        "needs.auto-publish-pi-npm.result == 'success')"
+    )
+    if "||" in condition.replace(supported_pi_result_guard, "true"):
         raise AssertionError("unsupported boolean event guard")
     named = re.findall(r"github\.event_name == '([\w_]+)'", condition)
     if len(named) != 1 or named[0] not in TRIGGERS:
@@ -1203,6 +1212,31 @@ class LaneIsolationTest(unittest.TestCase):
         self.assertNotIn("merge-readiness", action)
         self.assertNotIn("select-target", action)
 
+    def test_manual_pi_release_synchronously_requires_the_exact_npm_publisher(self):
+        jobs = _jobs()
+        self.assertIn(
+            MANUAL_PI_NPM_JOB,
+            jobs,
+            "manual Pi release can succeed without starting npm publication",
+        )
+        block = jobs[MANUAL_PI_NPM_JOB]
+        self.assertEqual(set(_job_needs(block)), {PREFLIGHT_JOB, "release-pi"})
+        self.assertIn("needs.preflight.outputs.target == 'ca-pi'", _job_if(block))
+        self.assertIn(f"uses: {NPM_PUBLISH_WORKFLOW_REF}", block)
+        self.assertIn("tag: ca-pi-v${{ github.event.inputs.pi_confirm }}", block)
+        self.assertIn("expected_sha: ${{ github.sha }}", block)
+        self.assertIn("contents: read", block)
+        self.assertIn("id-token: write", block)
+        self.assertNotIn("contents: write", block)
+        self.assertNotIn("secrets: inherit", block)
+        self.assertIn("NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}", block)
+
+    def test_event_guard_parser_rejects_unrelated_or_widening(self):
+        with self.assertRaisesRegex(AssertionError, "unsupported boolean event guard"):
+            _condition_triggers(
+                "github.event_name == 'workflow_run' || github.actor == github.actor"
+            )
+
 
 class AutoTagLaneTest(unittest.TestCase):
     """Every eligible manifest advance publishes its tag and GitHub Release
@@ -1334,13 +1368,43 @@ class AutoTagLaneTest(unittest.TestCase):
         block = _jobs()[AUTO_COMMAND_ROUTE_RELEASE_AUDIT_JOB]
         self.assertEqual(
             set(_job_needs(block)),
-            {AUTO_PREFLIGHT_JOB, "auto-release", "auto-release-codex", "auto-release-pi"},
+            {
+                AUTO_PREFLIGHT_JOB,
+                "auto-release",
+                "auto-release-codex",
+                "auto-release-pi",
+                AUTO_PI_NPM_JOB,
+            },
         )
         condition = _job_if(block)
         self.assertIn("always()", condition)
         self.assertIn("github.event_name == 'workflow_run'", condition)
         self.assertIn("github.event.workflow_run.head_branch == 'main'", condition)
         self.assertIn("needs.auto-preflight.result == 'success'", condition)
+        self.assertIn("needs.auto-publish-pi-npm.result == 'success'", condition)
+
+    def test_auto_pi_release_synchronously_requires_the_exact_npm_publisher(self):
+        jobs = _jobs()
+        self.assertIn(
+            AUTO_PI_NPM_JOB,
+            jobs,
+            "auto Pi release can succeed without starting npm publication",
+        )
+        block = jobs[AUTO_PI_NPM_JOB]
+        self.assertEqual(set(_job_needs(block)), {AUTO_PREFLIGHT_JOB, "auto-release-pi"})
+        condition = _job_if(block)
+        self.assertIn("github.event_name == 'workflow_run'", condition)
+        self.assertIn("needs.auto-preflight.outputs.ca-pi == 'true'", condition)
+        self.assertIn(f"uses: {NPM_PUBLISH_WORKFLOW_REF}", block)
+        self.assertIn("tag: ca-pi-v${{ needs.auto-preflight.outputs.ca-pi-version }}", block)
+        self.assertIn(
+            "expected_sha: ${{ github.event.workflow_run.head_sha }}", block
+        )
+        self.assertIn("contents: read", block)
+        self.assertIn("id-token: write", block)
+        self.assertNotIn("contents: write", block)
+        self.assertNotIn("secrets: inherit", block)
+        self.assertIn("NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}", block)
 
     def test_final_command_route_audit_is_read_only_and_pins_the_candidate(self):
         block = _jobs()[AUTO_COMMAND_ROUTE_RELEASE_AUDIT_JOB]

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,83 +1,121 @@
-# npm publish channel for ca-pi (ADR-0029). Every ca-pi-v* tag also publishes
-# the repo-root Pi package as npm:@arbiterforge/ca-pi with npm provenance; the
-# pinned Git tag remains the reproducible install and the evidence anchor.
+# Reusable npm publish channel for ca-pi (ADR-0029). release.yml invokes this
+# synchronously after creating the exact annotated tag and GitHub Release, so a
+# release run cannot turn green while its npm publication is absent or failed.
 #
-# No dependency install runs here on purpose: the package is dependency-free
-# and the extension bundles are committed, reviewed artifacts — there is
-# nothing to build at publish time, and nothing whose lifecycle scripts we
-# would have to trust. The guard step refuses to publish when the tag and the
-# two synchronized manifests disagree, so a mistagged ref cannot ship a
-# mismatched version.
+# No candidate build or dependency install runs here: the published package is
+# dependency-free and the extension bundles are committed, reviewed artifacts.
+# Post-publication proof does install the exact registry version in a disposable
+# directory with lifecycle scripts disabled so npm can verify its signatures and
+# provenance. The guard refuses a tag whose synchronized manifests disagree.
 name: "[SHIP ] | [PI  ] | npm publish"
 
 on:
-  push:
-    tags:
-      - "ca-pi-v*"
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      expected_sha:
+        required: true
+        type: string
+    secrets:
+      NPMJS_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing ca-pi-v* tag to publish (e.g. ca-pi-v0.6.0)"
         required: true
+        type: string
+      expected_sha:
+        required: true
+        type: string
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: "npm-publish-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+  group: npm-publish-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:
   publish:
     name: "[SHIP ] | [PI  ] | Publish @arbiterforge/ca-pi"
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check out the trusted default-branch verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ github.sha }}
+          path: trusted
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate untrusted release inputs before use
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          TRUSTED_SHA: ${{ github.sha }}
+        run: >-
+          python3 trusted/.github/scripts/_npm_publishlib.py validate
+          --tag "$RELEASE_TAG"
+          --expected-sha "$EXPECTED_SHA"
+          --trusted-sha "$TRUSTED_SHA"
+      - name: Materialize the exact tagged package as inert data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ format('refs/tags/{0}', inputs.tag) }}
+          path: candidate
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-      - name: Guard — tag and manifest versions must match
+      - name: Fetch protected main without credentials
+        run: git -C candidate fetch --no-tags origin main:refs/remotes/origin/main
+      - name: Capture exact published GitHub Release evidence
         env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-        run: |
-          python3 - << 'EOF'
-          import json
-          import os
-          import sys
-
-          tag = os.environ["RELEASE_TAG"]
-          prefix = "ca-pi-v"
-          if not tag.startswith(prefix):
-              sys.exit(f"refusing to publish: {tag!r} is not a ca-pi release tag")
-          version = tag[len(prefix):]
-          root = json.load(open("package.json", encoding="utf-8"))
-          nested = json.load(open("plugins/ca-pi/package.json", encoding="utf-8"))
-          if not (version == root["version"] == nested["version"]):
-              sys.exit(
-                  "version mismatch: tag {0}, root {1}, nested {2}".format(
-                      version, root["version"], nested["version"],
-                  )
-              )
-          print(f"tag and manifests are equal: {version}")
-          EOF
-      - name: Preflight — an already-published exact version is success
-        id: preflight
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" > "$RUNNER_TEMP/ca-pi-release.json"
+      - name: Validate identity, pack once, and classify exact registry state
+        id: artifact
+        # The helper requires the tag and both manifest versions to match.
         env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          TRUSTED_SHA: ${{ github.sha }}
         run: |
-          version="${RELEASE_TAG#ca-pi-v}"
-          if npm view "@arbiterforge/ca-pi@${version}" version > /dev/null 2>&1; then
-            echo "@arbiterforge/ca-pi@${version} is already on the registry; npm versions are immutable, so this re-run is a no-op success"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          python3 trusted/.github/scripts/_npm_publishlib.py prepare \
+            --repo candidate \
+            --tag "$RELEASE_TAG" \
+            --expected-sha "$EXPECTED_SHA" \
+            --trusted-sha "$TRUSTED_SHA" \
+            --root-manifest package.json \
+            --plugin-manifest plugins/ca-pi/package.json \
+            --release-json "$RUNNER_TEMP/ca-pi-release.json" \
+            --output "$GITHUB_OUTPUT"
       - name: Publish with provenance
-        if: steps.preflight.outputs.skip != 'true'
-        run: npm publish --ignore-scripts --provenance --access public
+        if: steps.artifact.outputs.skip != 'true'
+        run: npm publish "$TARBALL" --ignore-scripts --provenance --access public --registry=https://registry.npmjs.org/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+          TARBALL: ${{ steps.artifact.outputs.tarball }}
+      - name: Verify exact registry publication evidence
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          TRUSTED_SHA: ${{ github.sha }}
+          EXPECTED_INTEGRITY: ${{ steps.artifact.outputs.integrity }}
+          PUBLICATION_MODE: ${{ steps.artifact.outputs.publication_mode }}
+        run: |
+          python3 trusted/.github/scripts/_npm_publishlib.py verify \
+            --repo trusted \
+            --tag "$RELEASE_TAG" \
+            --expected-sha "$EXPECTED_SHA" \
+            --trusted-sha "$TRUSTED_SHA" \
+            --integrity "$EXPECTED_INTEGRITY" \
+            --publication-mode "$PUBLICATION_MODE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,20 @@ jobs:
           mark-latest: "false"
           github-token: ${{ github.token }}
 
+  publish-pi-npm:
+    name: CA-Pi | [Release] - Publish npm
+    needs: [preflight, release-pi]
+    if: github.ref == 'refs/heads/main' && needs.preflight.outputs.target == 'ca-pi'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      tag: ca-pi-v${{ github.event.inputs.pi_confirm }}
+      expected_sha: ${{ github.sha }}
+    secrets:
+      NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
   # ------------------------------------------------------------------------- #
   # Auto-publish-on-merge. Every push to main that advances a target's manifest
   # past its last published tag creates that tag and its GitHub Release after
@@ -393,6 +407,7 @@ jobs:
       ca-codex: ${{ steps.eligible.outputs.ca-codex }}
       ca-sandbox: ${{ steps.eligible.outputs.ca-sandbox }}
       ca-pi: ${{ steps.eligible.outputs.ca-pi }}
+      ca-pi-version: ${{ steps.eligible.outputs.ca-pi-version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -423,6 +438,9 @@ jobs:
               | python3 .github/scripts/_releaselib.py auto-eligible "$VERSION" "$PREFIX")
             echo "$TARGET: manifest=$VERSION eligible=$ELIGIBLE"
             echo "$TARGET=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+            if [ "$TARGET" = "ca-pi" ]; then
+              echo "ca-pi-version=$VERSION" >> "$GITHUB_OUTPUT"
+            fi
           done
 
   auto-release:
@@ -581,16 +599,30 @@ jobs:
           create-release: "true"
           github-token: ${{ github.token }}
 
+  auto-publish-pi-npm:
+    name: CA-Pi | [Auto-publish npm]
+    needs: [auto-preflight, auto-release-pi]
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && needs.auto-preflight.outputs.ca-pi == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      tag: ca-pi-v${{ needs.auto-preflight.outputs.ca-pi-version }}
+      expected_sha: ${{ github.event.workflow_run.head_sha }}
+    secrets:
+      NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
   auto-command-route-release-audit:
     name: "[GATE ] | [RELEASE] | Command-route publication"
-    needs: [auto-preflight, auto-release, auto-release-codex, auto-release-pi]
+    needs: [auto-preflight, auto-release, auto-release-codex, auto-release-pi, auto-publish-pi-npm]
     # `always()` is required because an ineligible publisher is skipped. This
     # read-only terminal audit still runs after every RA-11 publisher reaches a
     # terminal state, but only for a successful main CI run whose preflight ran.
     # It cannot authorize or mask a failed publisher: those job results remain
     # independently red, and every declared first-containing Release must also
     # read back as published below.
-    if: always() && github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && needs.auto-preflight.result == 'success'
+    if: always() && github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && needs.auto-preflight.result == 'success' && (needs.auto-preflight.outputs.ca-pi != 'true' || needs.auto-publish-pi-npm.result == 'success')
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- make ca-pi npm publication a synchronous reusable step in the release DAG so repository-token tag creation cannot suppress publication
- bind publication and recovery to the exact annotated tag, expected commit, GitHub Release, package manifests, tarball integrity, npm signature verification, and SLSA provenance
- add a narrow protected-main recovery dispatch for the already released `ca-pi-v0.10.0` artifact
- document and mechanically guard the `NPMJS_TOKEN` trust boundary

## Validation

- `python .github/scripts/test_pi_package.py` (42 passed)
- `python .github/scripts/test_release_workflow.py` (110 passed)
- `python .github/scripts/test_ci_impact.py` (60 passed)
- `python .github/scripts/test_release_lib.py` (443 passed)
- `python .github/scripts/test_command_route_release_state.py` (20 passed)
- `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` (1457 passed, 3 skipped)
- live npm Sigstore verification, SLSA semantic binding, and protected-main ancestry proof for `@arbiterforge/ca-pi@0.8.1`
- independent Sol/xhigh security and auth review: PASS, 0 findings
- independent Terra/high coverage review: PASS, 0 findings and no triage

## Decision record

- [ADR-0029: Publish ca-pi to npm under @arbiterforge](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0029-publish-ca-pi-to-npm-under-arbiterforge.md)