### PR TITLE
fix: diagnose audit and Windows startup failures

### DIFF
--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -34,7 +34,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "75fa047162adae71fc1b9c0aeb6cc819e642d515",
+      "hash": "e33b3c4dfd5eca6a7b4540adcac85b37c7d30d7f",
       "path": "plugins/ca-pi/extensions/codearbiter.js"
     },
     {

--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -34,7 +34,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "e33b3c4dfd5eca6a7b4540adcac85b37c7d30d7f",
+      "hash": "c4c66422477a77c2eabcd545c36485218089550f",
       "path": "plugins/ca-pi/extensions/codearbiter.js"
     },
     {

--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -9,7 +9,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "28c4dd37b61d46011e7d7457ae1c4f779a444be5",
+      "hash": "f745b3e9f4dcadc1254a1f127b5c6a04fc552629",
       "path": "package.json"
     },
     {
@@ -24,7 +24,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "dbdbdb4c39843f0abba3aad7b4ed7c90beaf4c7a",
+      "hash": "a68d16c8f66ec31f0ef547c2523c6146c8e92b00",
       "path": "plugins/ca-pi/CHANGELOG.md"
     },
     {
@@ -39,7 +39,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "d1fc438ac5f6401092a2f8d332cdbdd82c13b302",
+      "hash": "4abd158ac9cf28f3f1f90750017f0c16079d9049",
       "path": "plugins/ca-pi/package.json"
     },
     {

--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -86,6 +86,9 @@ python .github/scripts/test_command_catalog.py
 # Workflow trust separation and exact CI impact routing
 python .github/scripts/test_ci_impact.py
 
+# Cross-host coverage identity/provenance (requires the Pi tools test dependencies)
+python .github/scripts/test_coverage_union.py
+
 # ADR-0033 accepted/planned lifecycle, immutable bindings, and verified-only export
 python .github/scripts/test_adr_lifecycle.py
 python .github/scripts/check_adr_lifecycle.py
@@ -276,11 +279,20 @@ and the POSIX arm on the other.
 CI produces the union for both forked trees — `[CHECK] | [REPO] | Coverage union`
 for `plugins/ca/tools` and `[CHECK] | [PI  ] | Coverage union` for
 `plugins/ca-pi/tools` — one advisory matrix cell per host writing a vitest
-**blob** report, merged with `vitest --merge-reports`. Merging is a
-genuine union of executed code, not the last report winning: verified on two
-disjoint suites, 7 + 65 branches merging to 72 and 18 + 69 lines to 87. The job
-says so when only one host reported, so a partial figure is never mistaken for
-the union.
+**blob** report, merged with `vitest --merge-reports`. Before testing,
+`coverage_union.py prepare` binds each host's source, configuration, lockfile,
+and checkout identity; `prepare --check` rechecks those inputs afterward.
+`coverage_union.py verify` validates the host receipts and compatible coverage
+maps, then writes normalized copies into a fresh merge directory. Original
+reports remain unchanged. Missing-host output is explicitly partial; invalid
+evidence cannot be reported as a union.
+
+Vitest alone does not normalize Windows and Linux absolute source paths. The
+earlier same-host disjoint-suite demonstration did not prove cross-host union:
+PR #740 exposed 41 sources counted as 82 files. The behavioral regression now
+requires complementary host coverage to retain one identity per source, while
+preserving legitimately distinct files. Historical figures below are not
+accepted cross-host evidence until remeasured through the verified path.
 
 Each tree's blobs are namespaced `coverage-blob-<tree>-os-<host>`, so one
 tree's merge cannot collect another's. The naive names collided — a `ca-*` glob
@@ -299,25 +311,24 @@ clear it**; a report satisfying one and not the other does not pass. Putting the
 number in three `vitest.config.ts` files would fork that single source of truth
 and the copies would drift the first time the stage moves.
 
-Measured baseline at stage 2 (≥ 70%), refreshed 2026-07-29 from CI. The two
-platform-forked trees carry their **union** figure; the others are single-host
-because they have nothing to merge. Every row names how it was measured, which
-is the rule #521 exists to enforce:
+Historical baseline at stage 2 (≥ 70%), recorded 2026-07-29 from CI. The two
+platform-forked figures require remeasurement after the cross-host identity
+repair; the other rows are single-host measurements. Each row names its
+measurement scope:
 
 | tree | lines | branches | verdict | host |
 | --- | --- | --- | --- | --- |
-| `plugins/ca/tools` | 76.82% | 73.15% | clears | **union** (ubuntu + windows) |
-| `plugins/ca-pi/tools` | 82.51% | 77.10% | clears | **union** (ubuntu + windows) |
+| `plugins/ca/tools` | 76.82% | 73.15% | unverified historical identity merge | ubuntu + windows, before identity repair |
+| `plugins/ca-pi/tools` | 82.51% | 77.10% | unverified historical identity merge | ubuntu + windows, before identity repair |
 | `plugins/ca-sandbox/tools` | 86.13% | 79.96% | clears | windows |
 | `site` | 91.29% | 84.85% | clears | ubuntu-equivalent (no platform fork) |
 
-**The union changed the answer for `plugins/ca/tools`.** #511 drove that tree
+**Historical motivation for union measurement.** #511 drove `plugins/ca/tools`
 against 66.18% branches on Windows and 65.35% on Linux — both below the floor.
-Merged, it is 73.15%, and clears by three points. The shortfall was never missing
-tests: it was ~7 points of platform-forked `exec.ts` code that cannot execute off
-its own host, scored as uncovered on whichever host happened to run. That is the
-concrete case for the rule, and the reason a single-host figure is no longer
-quotable here.
+The previously reported merged 73.15% is not current proof that the union clears
+the floor: cross-host file identity must first be verified. Platform-forked
+`exec.ts` code still cannot execute off its own host, which is why a single-host
+figure is not a substitute for the required union.
 
 Two caveats when reading a local report:
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,9 @@ hooks/* text eol=lf
 # The generated root Pi manifest is compared byte-for-byte on every host.
 /package.json text eol=lf
 
+# Coverage provenance compares this shared Pi input to its exact Git bytes.
+/core/hosts.json text eol=lf
+
 # Pi release metadata and TypeScript/JavaScript artifacts are also checked as
 # exact UTF-8/LF bytes after checkout and regeneration on every hosted OS.
 plugins/ca-pi/**/*.json text eol=lf

--- a/.github/scripts/coverage_union.py
+++ b/.github/scripts/coverage_union.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# codeArbiter — bind cross-host coverage identities before Vitest merges blobs.
+# snapshot(repo, tree) -> inert provenance; normalize(inputs, expected) -> blobs/status.
+# CI artifacts are data, never executable input. Only coverage schema slots change.
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+MAX_BYTES = 16 * 1024 * 1024
+MAX_NODES = 1_000_000
+HOSTS = frozenset(("ubuntu-latest", "windows-latest"))
+TREES = frozenset(("plugins/ca/tools", "plugins/ca-pi/tools"))
+
+
+def require(condition):
+    if not condition:
+        raise ValueError("coverage-input-invalid")
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def unique_pairs(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result)
+        result[key] = value
+    return result
+
+
+def regular(path):
+    path = Path(path).absolute()
+    require(not any(parent.is_symlink() for parent in (path, *path.parents)))
+    require(path.is_file() and path.stat().st_size <= MAX_BYTES)
+    with path.open("rb") as stream:
+        data = stream.read(MAX_BYTES + 1)
+    require(len(data) <= MAX_BYTES)
+    return data
+
+
+def read_json(path):
+    return json.loads(regular(path), object_pairs_hook=unique_pairs,
+                      parse_constant=lambda _: require(False))
+
+
+def git(repo, *arguments):
+    result = subprocess.run(["git", "-C", str(repo), *arguments], capture_output=True, timeout=30)
+    require(result.returncode == 0 and len(result.stdout) <= MAX_BYTES)
+    return result.stdout
+
+
+def relative_path(path):
+    require(isinstance(path, str) and len(path) <= 1024)
+    require(not path.startswith("/") and "\\" not in path and ":" not in path)
+    require(all(part not in ("", ".", "..") for part in path.split("/")))
+    require(not any(ord(char) < 32 for char in path))
+    return path
+
+
+def snapshot(repo, tree):
+    require(tree in TREES)
+    repo = Path(repo).absolute()
+    require(not any(parent.is_symlink() for parent in (repo, *repo.parents)))
+    repo = repo.resolve()
+    require(Path(git(repo, "rev-parse", "--show-toplevel").decode().strip()).resolve() == repo.resolve())
+    head = git(repo, "rev-parse", "HEAD").decode().strip()
+    require(re.fullmatch(r"[a-f0-9]{40,64}", head))
+    tracked = git(repo, "ls-tree", "-r", "--name-only", head, "--", tree).decode().splitlines()
+    config_paths = {f"{tree}/package.json", f"{tree}/package-lock.json", f"{tree}/vitest.config.ts"}
+    config_paths.update(path for path in tracked if path.endswith((".ts", ".mjs", ".json")))
+    if tree == "plugins/ca-pi/tools":
+        config_paths.update(("core/hosts.json", "plugins/ca/hooks/secret-detection-corpus.json",
+                             "plugins/ca-pi/extensions/codearbiter-child.js"))
+    config, sources = {}, {}
+    config_text = regular(repo / tree / "vitest.config.ts").decode("utf-8")
+    includes = re.findall(r'\binclude\s*:\s*\[([^\]]*)\]', config_text)
+    excludes = re.findall(r'\bexclude\s*:\s*\[([^\]]*)\]', config_text)
+    expected_include = '["src/**/*.ts"]' if tree == "plugins/ca-pi/tools" else '["*.ts"]'
+    require(len(includes) == 1 and json.loads("[" + includes[0] + "]") == json.loads(expected_include))
+    require(excludes == [] if tree == "plugins/ca-pi/tools" else
+            len(excludes) == 1 and json.loads("[" + excludes[0] + "]") == ["*.test.ts", "*.config.ts"])
+    for path in sorted(config_paths):
+        relative_path(path)
+        value = regular(repo / path)
+        require(value == git(repo, "show", f"{head}:{path}"))
+        config[path] = digest(value)
+        if path.startswith(tree + "/") and path.endswith(".ts"):
+            local = path[len(tree) + 1:]
+            included = local.startswith("src/") if tree == "plugins/ca-pi/tools" else (
+                "/" not in local and not local.endswith((".test.ts", ".config.ts")))
+            if included:
+                sources[local] = digest(value)
+    require(sources)
+    lock = read_json(repo / tree / "package-lock.json")
+    version = lock["packages"]["node_modules/vitest"]["version"]
+    require(isinstance(version, str))
+    return {"schema": 1, "head": head, "tree": tree, "vitest": version,
+            "root": (repo / tree).as_posix(), "config": config, "sources": sources}
+
+
+def decode_coverage(graph):
+    require(isinstance(graph, list) and 0 < len(graph) <= MAX_NODES)
+    require(isinstance(graph[0], list) and len(graph[0]) == 6)
+    budget = [MAX_NODES]
+
+    def decode(reference, ancestors=(), depth=0):
+        require(isinstance(reference, str) and re.fullmatch(r"0|[1-9][0-9]*", reference))
+        require(len(reference) <= 7)
+        index = int(reference)
+        require(index < len(graph) and index not in ancestors and depth <= 64)
+        budget[0] -= 1
+        require(budget[0] >= 0)
+        value = graph[index]
+        if isinstance(value, (dict, list)):
+            ancestors = (*ancestors, index)
+            def child(item):
+                budget[0] -= 1
+                require(budget[0] >= 0)
+                require(not isinstance(item, (dict, list)))
+                return decode(item, ancestors, depth + 1) if isinstance(item, str) else item
+            return {key: child(item) for key, item in value.items()} if isinstance(value, dict) else [child(item) for item in value]
+        return value
+
+    coverage = decode(graph[0][3])
+    version = decode(graph[0][0])
+    require(isinstance(coverage, dict) and 0 < len(coverage) <= 2048)
+    return coverage, version
+
+
+def canonical_path(path, root, sources):
+    require(isinstance(path, str) and isinstance(root, str))
+    path, root = path.replace("\\", "/"), root.replace("\\", "/")
+    require(re.fullmatch(r"(?:[A-Za-z]:)?/[^\x00-\x1f]+", root))
+    require(not root.endswith("/") and "//" not in root)
+    require(all(part not in (".", "..") for part in root.split("/")))
+    require(path.startswith(root + "/"))
+    suffix = relative_path(path[len(root) + 1:])
+    require(suffix in sources)
+    return suffix
+
+
+def validate_file(value):
+    require(isinstance(value, dict))
+    for counts, maps in (("s", "statementMap"), ("f", "fnMap"), ("b", "branchMap")):
+        require(isinstance(value.get(counts), dict) and isinstance(value.get(maps), dict))
+        require(set(value[counts]) == set(value[maps]))
+        for key, count in value[counts].items():
+            require(re.fullmatch(r"0|[1-9][0-9]*", key))
+            values = count if counts == "b" else [count]
+            require(isinstance(values, list) and all(type(n) is int and abs(n) <= 2**53 - 1 for n in values))
+            for index, number in enumerate(values):
+                if number < 0:
+                    branch = value[maps][key]
+                    # ast-v8-to-istanbul computes implicit-else hits by
+                    # parent-minus-consequent, which can be negative. Preserve
+                    # observations only in that exact producer shape; below,
+                    # normalize proves addition cannot erase a positive hit.
+                    require(counts == "b" and isinstance(branch, dict) and branch.get("type") == "if"
+                            and len(values) == 2 and index == 1
+                            and branch.get("locations", [None, None])[1] == {"start": {}, "end": {}})
+            if counts == "b":
+                require(isinstance(value[maps][key], dict))
+                locations = value[maps][key].get("locations")
+                require(isinstance(locations, list) and len(locations) == len(values))
+    def location(node):
+        require(isinstance(node, dict) and "start" in node and "end" in node)
+        for kind in ("start", "end"):
+            point = node[kind]
+            require(isinstance(point, dict) and set(point) == {"line", "column"})
+            require(type(point["line"]) is int and 1 <= point["line"] <= 10_000_000)
+            column = point["column"]
+            # V8's open-ended Infinity column is serialized as JSON null in
+            # real Vitest 4.1.9 blobs; preserve that exact end-only convention.
+            require((kind == "end" and column is None) or
+                    (type(column) is int and 0 <= column <= 10_000_000))
+        require(node["end"]["line"] >= node["start"]["line"])
+        if node["end"]["line"] == node["start"]["line"] and node["end"]["column"] is not None:
+            require(node["end"]["column"] >= node["start"]["column"])
+    for node in value["statementMap"].values():
+        location(node)
+    for node in value["fnMap"].values():
+        require(isinstance(node, dict) and isinstance(node.get("name"), str))
+        location(node.get("decl"))
+        location(node.get("loc"))
+    for node in value["branchMap"].values():
+        require(isinstance(node, dict) and isinstance(node.get("type"), str))
+        location(node.get("loc"))
+        require(isinstance(node.get("locations"), list) and node["locations"])
+        for index, point in enumerate(node["locations"]):
+            # Istanbul's implicit else has no source position. Real V8 blobs
+            # encode exactly the second arm of a two-arm if this way.
+            if node["type"] == "if" and len(node["locations"]) == 2 and index == 1 and point == {"start": {}, "end": {}}:
+                continue
+            location(point)
+
+
+def append_graph(graph, value):
+    index = len(graph)
+    require(index < MAX_NODES)
+    graph.append(None)
+    if isinstance(value, dict):
+        graph[index] = {key: append_graph(graph, item) if isinstance(item, (dict, list, str)) else item for key, item in value.items()}
+    elif isinstance(value, list):
+        graph[index] = [append_graph(graph, item) if isinstance(item, (dict, list, str)) else item for item in value]
+    else:
+        graph[index] = value
+    return str(index)
+
+
+def normalize(inputs, expected):
+    require(0 < len(inputs) <= len(HOSTS))
+    seen, baseline, result, prior_counts = set(), None, [], {}
+    for graph, proof in inputs:
+        require(isinstance(proof, dict) and proof.get("host") in HOSTS and proof["host"] not in seen)
+        seen.add(proof["host"])
+        for field in ("schema", "head", "tree", "vitest", "config", "sources"):
+            require(proof.get(field) == expected[field])
+        coverage, version = decode_coverage(graph)
+        require(version == expected["vitest"])
+        normalized, maps, names = {}, {}, set()
+        for path, value in coverage.items():
+            require(isinstance(value, dict) and value.get("path") == path)
+            suffix = canonical_path(path, proof.get("root"), expected["sources"])
+            require(suffix.casefold() not in names)
+            names.add(suffix.casefold())
+            validate_file(value)
+            if suffix in prior_counts:
+                prior = prior_counts[suffix]
+                for field in ("s", "f", "b"):
+                    require(set(prior[field]) == set(value[field]))
+                    for key, number in value[field].items():
+                        left = prior[field][key] if field == "b" else [prior[field][key]]
+                        right = number if field == "b" else [number]
+                        require(len(left) == len(right))
+                        for a, b in zip(left, right):
+                            require(abs(a + b) <= 2**53 - 1)
+                            require(((a + b) > 0) == (a > 0 or b > 0))
+            prior_counts[suffix] = value
+            canonical = expected["root"].replace("\\", "/") + "/" + suffix
+            normalized[canonical] = {**value, "path": canonical}
+            maps[suffix] = {key: value[key] for key in ("statementMap", "fnMap", "branchMap")}
+        require(set(maps) == set(expected["sources"]))
+        if baseline is None:
+            baseline = maps
+        else:
+            require(maps == baseline)
+        # Append a private coverage subgraph: never mutate shared string refs
+        # that may also identify test modules, errors, or environment modules.
+        output = copy.deepcopy(graph)
+        output[0][3] = append_graph(output, normalized)
+        result.append(output)
+    return result, "UNION" if seen == HOSTS else "PARTIAL"
+
+
+def write_new(path, value):
+    path = Path(path).absolute()
+    require(not any(parent.is_symlink() for parent in (path, *path.parents)))
+    encoded = json.dumps(value, separators=(",", ":"), allow_nan=False).encode()
+    require(len(encoded) <= MAX_BYTES)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as stream:
+        stream.write(encoded)
+
+
+def prepare(repo, tree, host, output, check=False):
+    require(host in HOSTS and output.name == f"{host}.provenance.json")
+    proof = {**snapshot(repo, tree), "host": host}
+    if not check:
+        write_new(output, proof)
+        return "PREPARED"
+    require(read_json(output) == proof)
+    blob = output.with_name(f"{host}.json")
+    receipt = {"schema": 1, "host": host, "snapshot_sha256": digest(regular(output)),
+               "blob_sha256": digest(regular(blob))}
+    write_new(output.with_name(f"{host}.checked.json"), receipt)
+    return "CHECKED"
+
+
+def verify(repo, tree, directory, output):
+    require(directory.is_dir() and not directory.is_symlink())
+    require(not output.exists() and not output.is_symlink())
+    entries = {path.name for path in directory.iterdir()}
+    hosts = [host for host in sorted(HOSTS) if f"{host}.json" in entries]
+    required = {f"{host}{suffix}" for host in hosts for suffix in (".json", ".provenance.json", ".checked.json")}
+    require(entries == required and hosts)
+    inputs = []
+    for host in hosts:
+        blob, proof = directory / f"{host}.json", directory / f"{host}.provenance.json"
+        receipt = read_json(directory / f"{host}.checked.json")
+        require(receipt == {"schema": 1, "host": host, "snapshot_sha256": digest(regular(proof)), "blob_sha256": digest(regular(blob))})
+        provenance = read_json(proof)
+        require(provenance.get("host") == host)
+        inputs.append((read_json(blob), provenance))
+    normalized, status = normalize(inputs, snapshot(repo, tree))
+    # Complete validation and serialization before exposing any normalized blob.
+    payloads = [json.dumps(graph, separators=(",", ":"), allow_nan=False).encode() for graph in normalized]
+    require(all(len(payload) <= MAX_BYTES for payload in payloads))
+    require(not any(parent.is_symlink() for parent in (output, *output.parents)))
+    output.mkdir(parents=False, exist_ok=False)
+    for host, payload in zip(hosts, payloads):
+        with (output / f"{host}.json").open("xb") as stream:
+            stream.write(payload)
+    return status
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("prepare", "verify"))
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--tree", choices=sorted(TREES), required=True)
+    parser.add_argument("--host", choices=sorted(HOSTS))
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.mode == "prepare":
+            require(args.host is not None and args.input is None)
+            status = prepare(args.repo, args.tree, args.host, args.output, args.check)
+        else:
+            require(args.input is not None and args.host is None and not args.check)
+            status = verify(args.repo, args.tree, args.input, args.output)
+        print(f"coverage-identity: {status}")
+        return 0
+    except (ValueError, TypeError, KeyError, IndexError, OSError, RecursionError, subprocess.SubprocessError):
+        print("coverage-identity: INVALID", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -1519,6 +1519,25 @@ class WorkflowContractTest(unittest.TestCase):
                     "every audit gate in the repo must use the SAME threshold",
                 )
 
+    def test_every_npm_audit_step_exposes_http_diagnostics(self):
+        # Main CI 33822155490 hid the original bulk-request failure behind
+        # npm's retired quick-endpoint fallback. Keep status/timing visible
+        # without enabling verbose/silly request-body or config diagnostics.
+        audited_steps = 0
+        for workflow in (CI_WORKFLOW, DOCS_WORKFLOW):
+            steps = re.split(r"(?m)^      - ", workflow.read_text(encoding="utf-8"))
+            for step in steps:
+                if not npm_audit_invocations(step):
+                    continue
+                audited_steps += 1
+                with self.subTest(workflow=workflow.name, step=step.splitlines()[0]):
+                    self.assertRegex(
+                        step,
+                        r"(?m)^        env:\n          NPM_CONFIG_LOGLEVEL: http$",
+                        "audit HTTP status/timing must survive a fallback failure",
+                    )
+        self.assertEqual(audited_steps, 7)
+
     def test_each_plugin_tools_graph_is_audited_with_dev_dependencies_included(self):
         """Issue #434 AC-1: a HIGH advisory in a `plugins/*/tools` DEV dependency
         must fail CI.

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -1405,6 +1405,49 @@ class WorkflowContractTest(unittest.TestCase):
                     f"{merge_job}'s pattern does not match its own artifact {own!r}",
                 )
 
+    def test_cross_host_coverage_identity_is_verified_before_union(self):
+        """Absolute runner paths must not turn a union into two disjoint trees."""
+        jobs = workflow_jobs(CI_WORKFLOW.read_text(encoding="utf-8"))
+        for producer, consumer in (
+            ("coverage-union", "coverage-union-merge"),
+            ("coverage-union-pi", "coverage-union-pi-merge"),
+        ):
+            with self.subTest(producer=producer):
+                self.assertRegex(jobs[producer], r"coverage_union\.py\s+prepare",
+                                 "host coverage lacks source-bound canonical identities")
+                self.assertRegex(jobs[consumer], r"coverage_union\.py\s+verify",
+                                 "merge accepts unverified cross-host coverage identities")
+                self.assertLess(jobs[consumer].index("coverage_union.py"),
+                                jobs[consumer].index("--merge-reports"))
+                self.assertIn("--check", jobs[producer],
+                              "pre-test provenance is not rechecked after execution")
+                merge_command = next(line for line in jobs[consumer].splitlines()
+                                     if "npx vitest --merge-reports" in line)
+                verified_output = re.search(r"coverage_union\.py verify[^\n]*--output\s+(\S+)",
+                                            jobs[consumer]).group(1)
+                self.assertEqual(re.search(r"--merge-reports\s+(\S+)", merge_command).group(1),
+                                 verified_output, "Vitest must consume the verified copies")
+                producer_body = jobs[producer]
+                prepare_index = producer_body.index("coverage_union.py prepare")
+                run_index = producer_body.index("npx vitest run")
+                check_index = producer_body.index("coverage_union.py prepare --check")
+                upload_index = producer_body.index("actions/upload-artifact@")
+                self.assertLess(prepare_index, run_index)
+                self.assertLess(run_index, check_index)
+                self.assertLess(check_index, upload_index)
+                self.assertNotIn("|| true", merge_command,
+                                 "invalid coverage must not look like a successful merge")
+                self.assertIn("shell: bash", jobs[consumer],
+                              "explicit bash enables pipefail for the report pipeline")
+        self.assertIn("test_coverage_union.py", jobs["ca-pi-checks"],
+                      "coverage identity regression needs a required test lane")
+        for lane in ("ca", "ca-pi"):
+            for path in (".github/scripts/coverage_union.py",
+                         ".github/scripts/test_coverage_union.py"):
+                self.assertTrue(any(fnmatch.fnmatch(path, pattern) for pattern in
+                                    paths_filter(CI_WORKFLOW.read_text(encoding="utf-8"), lane)),
+                                f"{path} alone skips {lane} coverage validation")
+
     def test_the_coverage_union_artifact_path_is_not_a_hidden_directory(self):
         """The union silently merged NOTHING for every run after it shipped.
 

--- a/.github/scripts/test_coverage_union.py
+++ b/.github/scripts/test_coverage_union.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# codeArbiter — cross-host coverage identity regression and refusal contracts.
+import copy
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = Path(__file__).with_name("coverage_union.py")
+
+
+def flatten(value):
+    """Encode small inert fixtures in Vitest's flatted graph representation."""
+    graph = []
+
+    def put(item):
+        index = len(graph)
+        graph.append(None)
+        if isinstance(item, dict):
+            graph[index] = {key: put(val) if isinstance(val, (dict, list, str)) else val
+                            for key, val in item.items()}
+        elif isinstance(item, list):
+            graph[index] = [put(val) if isinstance(val, (dict, list, str)) else val for val in item]
+        else:
+            graph[index] = item
+        return str(index)
+
+    put(value)
+    return graph
+
+
+def decode(graph, index):
+    value = graph[int(index)]
+    if isinstance(value, dict):
+        return {key: decode(graph, val) if isinstance(val, str) else val for key, val in value.items()}
+    if isinstance(value, list):
+        return [decode(graph, val) if isinstance(val, str) else val for val in value]
+    return value
+
+
+def fixture(path, hits):
+    locations = [{"start": {"line": n, "column": 0}, "end": {"line": n, "column": 3}} for n in (1, 2)]
+    return {"path": path, "statementMap": {"0": locations[0], "1": locations[1]},
+            "fnMap": {}, "branchMap": {"0": {"type": "if", "line": 1, "loc": locations[0], "locations": locations}},
+            "s": {"0": hits[0], "1": hits[1]}, "f": {}, "b": {"0": hits}}
+
+
+class CoverageUnionTest(unittest.TestCase):
+    def setUp(self):
+        self.expected = {"schema": 1, "head": "a" * 40, "tree": "plugins/ca-pi/tools",
+                         "vitest": "4.1.9", "config": {"package-lock.json": "b" * 64, "vitest.config.ts": "c" * 64},
+                         "sources": {"src/a.ts": "d" * 64, "src/b.ts": "e" * 64},
+                         "root": "/current/plugins/ca-pi/tools"}
+        self.inputs = []
+        for host, root, hits in [("windows-latest", "D:/a/repo/plugins/ca-pi/tools", [1, 0]),
+                                 ("ubuntu-latest", "/home/runner/repo/plugins/ca-pi/tools", [0, 1])]:
+            proof = {**copy.deepcopy(self.expected), "host": host, "root": root}
+            coverage = {f"{root}/{path}": fixture(f"{root}/{path}", hits) for path in self.expected["sources"]}
+            self.inputs.append((flatten(["4.1.9", [], [], coverage, 0, {}]), proof))
+
+    def normalize(self, inputs=None):
+        values = self.inputs if inputs is None else inputs
+        if os.environ.get("COVERAGE_UNION_BASELINE") == "1":
+            # Explicit diagnostic mode reproduces the existing workflow's raw
+            # Istanbul merge. Never used by the production helper or normal CI.
+            return [graph for graph, _ in values], "UNION"
+        spec = importlib.util.spec_from_file_location("coverage_union", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.normalize(values, self.expected)
+
+    def summary(self, graphs):
+        maps = [decode(graph, graph[0][3]) for graph in graphs]
+        javascript = "const{createCoverageMap}=require('istanbul-lib-coverage');let s='';process.stdin.on('data',x=>s+=x);process.stdin.on('end',()=>{const m=createCoverageMap();for(const c of JSON.parse(s))m.merge(c);console.log(JSON.stringify({files:m.files(),summary:m.getCoverageSummary().toJSON()}));});"
+        result = subprocess.run(["node", "-e", javascript], input=json.dumps(maps), text=True,
+                                capture_output=True, cwd=REPO / "plugins/ca-pi/tools", timeout=30, check=True)
+        return json.loads(result.stdout)
+
+    def test_complementary_hosts_union_without_doubling_distinct_files(self):
+        # CU-01: exact defect, executed against installed Istanbul, not a mock.
+        graphs, status = self.normalize()
+        result = self.summary(graphs)
+        self.assertEqual(len(result["files"]), 2, "host checkout paths duplicated source identities")
+        self.assertEqual(result["summary"]["lines"]["total"], 4)
+        self.assertEqual(result["summary"]["lines"]["covered"], 4)
+        self.assertEqual(result["summary"]["branches"]["total"], 4)
+        self.assertEqual(result["summary"]["branches"]["covered"], 4)
+        self.assertEqual(status, "UNION")
+
+    def test_single_host_is_partial_and_no_hosts_refuses(self):
+        graphs, status = self.normalize(self.inputs[:1])
+        self.assertEqual(status, "PARTIAL")
+        self.assertEqual(self.summary(graphs)["summary"]["lines"]["covered"], 2)
+        with self.assertRaises(ValueError):
+            self.normalize([])
+
+    def test_mismatched_provenance_refuses(self):
+        for field, value in [("head", "f" * 40), ("tree", "plugins/ca/tools"), ("vitest", "0.0.0"),
+                             ("config", {}), ("sources", {}), ("host", "other")]:
+            with self.subTest(field=field):
+                inputs = copy.deepcopy(self.inputs)
+                inputs[1][1][field] = value
+                with self.assertRaises(ValueError):
+                    self.normalize(inputs)
+
+    def test_duplicate_host_and_source_aliases_refuse(self):
+        with self.assertRaises(ValueError):
+            self.normalize([self.inputs[0], self.inputs[0]])
+        for path in ["src/../src/a.ts", "src//a.ts", "src/A.ts", "../outside.ts"]:
+            with self.subTest(path=path):
+                inputs = copy.deepcopy(self.inputs)
+                graph, proof = inputs[0]
+                coverage = decode(graph, graph[0][3])
+                alias = proof["root"] + "/" + path
+                coverage[alias] = fixture(alias, [1, 0])
+                inputs[0] = (flatten(["4.1.9", [], [], coverage, 0, {}]), proof)
+                with self.assertRaises(ValueError):
+                    self.normalize(inputs)
+
+    def test_different_instrumentation_and_key_path_refuse(self):
+        for mode in ("map", "path", "missing-source"):
+            with self.subTest(mode=mode):
+                inputs = copy.deepcopy(self.inputs)
+                graph, proof = inputs[1]
+                coverage = decode(graph, graph[0][3])
+                entry = next(iter(coverage.values()))
+                if mode == "map":
+                    entry["statementMap"]["0"]["start"]["line"] = 9
+                elif mode == "path":
+                    entry["path"] += ".other"
+                else:
+                    coverage.pop(next(iter(coverage)))
+                inputs[1] = (flatten(["4.1.9", [], [], coverage, 0, {}]), proof)
+                with self.assertRaises(ValueError):
+                    self.normalize(inputs)
+
+    def test_malformed_graph_and_unsafe_counts_refuse(self):
+        for mode in ("cycle", "reference", "negative"):
+            with self.subTest(mode=mode):
+                inputs = copy.deepcopy(self.inputs)
+                graph, proof = inputs[0]
+                if mode == "cycle":
+                    graph[int(graph[0][3])]["cycle"] = graph[0][3]
+                elif mode == "reference":
+                    graph[0][3] = "999999999"
+                else:
+                    coverage = decode(graph, graph[0][3])
+                    next(iter(coverage.values()))["s"]["0"] = -1
+                    graph = flatten(["4.1.9", [], [], coverage, 0, {}])
+                inputs[0] = (graph, proof)
+                with self.assertRaises(ValueError):
+                    self.normalize(inputs)
+
+    def test_identical_missing_source_and_missing_location_refuse(self):
+        for mode in ("source", "location"):
+            inputs = copy.deepcopy(self.inputs)
+            for index, (graph, proof) in enumerate(inputs):
+                coverage = decode(graph, graph[0][3])
+                if mode == "source":
+                    coverage.pop(next(iter(coverage)))
+                else:
+                    next(iter(coverage.values()))["statementMap"]["0"] = {}
+                inputs[index] = (flatten(["4.1.9", [], [], coverage, 0, {}]), proof)
+            with self.subTest(mode=mode), self.assertRaises(ValueError):
+                self.normalize(inputs)
+
+    def test_real_v8_null_end_column_remains_supported(self):
+        inputs = copy.deepcopy(self.inputs)
+        for index, (graph, proof) in enumerate(inputs):
+            coverage = decode(graph, graph[0][3])
+            for value in coverage.values():
+                value["statementMap"]["0"]["end"]["column"] = None
+            inputs[index] = (flatten(["4.1.9", [], [], coverage, 0, {}]), proof)
+        self.assertEqual(self.normalize(inputs)[1], "UNION")
+
+    def test_real_v8_implicit_else_location_remains_supported(self):
+        inputs = copy.deepcopy(self.inputs)
+        for index, (graph, proof) in enumerate(inputs):
+            coverage = decode(graph, graph[0][3])
+            for value in coverage.values():
+                value["branchMap"]["0"]["locations"][1] = {"start": {}, "end": {}}
+            inputs[index] = (flatten(["4.1.9", [], [], coverage, 0, {}]), proof)
+        self.assertEqual(self.normalize(inputs)[1], "UNION")
+
+    def signed_inputs(self, left, right):
+        inputs = copy.deepcopy(self.inputs)
+        for index, (graph, proof) in enumerate(inputs):
+            coverage = decode(graph, graph[0][3])
+            for value in coverage.values():
+                value["branchMap"]["0"]["locations"][1] = {"start": {}, "end": {}}
+                value["b"]["0"][1] = (left, right)[index]
+            inputs[index] = (flatten(["4.1.9", [], [], coverage, 0, {}]), proof)
+        return inputs
+
+    def test_real_negative_implicit_else_counts_preserved_without_inventing_hits(self):
+        graphs, status = self.normalize(self.signed_inputs(-27, -27))
+        self.assertEqual(status, "UNION")
+        for graph in graphs:
+            for value in decode(graph, graph[0][3]).values():
+                self.assertEqual(value["b"]["0"][1], -27)
+        self.assertEqual(self.summary(graphs)["summary"]["branches"]["covered"], 2)
+
+    def test_branch_cancellation_and_unsafe_sum_refuse(self):
+        for left, right in ((1, -1), (1, -2), (2**53 - 1, 1)):
+            with self.subTest(left=left, right=right), self.assertRaises(ValueError):
+                self.normalize(self.signed_inputs(left, right))
+
+
+class CoverageUnionCliTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="coverage-union-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.repo = Path(self.temp.name) / "repo"
+        self.repo.mkdir()
+        self.tree = self.repo / "plugins/ca/tools"
+        self.tree.mkdir(parents=True)
+        for name, content in {"a.ts": "const a = 1;\nconst b = 2;\n",
+                              "vitest.config.ts": 'export default {test:{coverage:{include: ["*.ts"], exclude: ["*.test.ts", "*.config.ts"]}}};\n',
+                              "package.json": '{"private":true}\n',
+                              "package-lock.json": '{"packages":{"node_modules/vitest":{"version":"4.1.9"}}}\n'}.items():
+            target = self.tree / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8", newline="\n")
+        for command in (["init", "-q"], ["add", "."],
+                        ["-c", "user.name=Coverage fixture", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "fixture"]):
+            subprocess.run(["git", "-C", str(self.repo), *command], capture_output=True, check=True, timeout=30)
+        self.inputs = Path(self.temp.name) / "inputs"
+        self.inputs.mkdir()
+        self.output = Path(self.temp.name) / "verified"
+
+    def cli(self, mode, *extra):
+        return subprocess.run([sys.executable, str(SCRIPT), mode, "--repo", str(self.repo),
+                               "--tree", "plugins/ca/tools", *map(str, extra)], text=True,
+                              capture_output=True, timeout=30)
+
+    def prepared(self, host="ubuntu-latest", seal=True):
+        proof = self.inputs / f"{host}.provenance.json"
+        result = self.cli("prepare", "--host", host, "--output", proof)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        path = self.tree.as_posix() + "/a.ts"
+        graph = flatten(["4.1.9", [], [], {path: fixture(path, [1, 0])}, 0, {}])
+        (self.inputs / f"{host}.json").write_text(json.dumps(graph), encoding="utf-8")
+        if seal:
+            result = self.cli("prepare", "--host", host, "--output", proof, "--check")
+            self.assertEqual(result.returncode, 0, result.stderr)
+        return proof
+
+    def verify(self):
+        return self.cli("verify", "--input", self.inputs, "--output", self.output)
+
+    def test_prepare_check_verify_partial_and_no_overwrite(self):
+        proof = self.prepared()
+        before = proof.read_bytes()
+        result = self.verify()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "coverage-identity: PARTIAL")
+        self.assertEqual([path.name for path in self.output.iterdir()], ["ubuntu-latest.json"])
+        self.assertEqual(proof.read_bytes(), before)
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.assertNotEqual(self.cli("prepare", "--host", "ubuntu-latest", "--output", proof).returncode, 0)
+
+    def test_workflow_relative_repo_path_is_canonical(self):
+        proof = self.inputs / "ubuntu-latest.provenance.json"
+        result = subprocess.run([sys.executable, str(SCRIPT), "prepare", "--repo", "../../..",
+                                 "--tree", "plugins/ca/tools", "--host", "ubuntu-latest", "--output", str(proof)],
+                                cwd=self.tree, text=True, capture_output=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(proof.read_text())["root"], self.tree.as_posix())
+
+    def test_posttest_source_mutation_prevents_seal(self):
+        proof = self.prepared(seal=False)
+        (self.tree / "a.ts").write_text("changed\n", encoding="utf-8")
+        result = self.cli("prepare", "--host", "ubuntu-latest", "--output", proof, "--check")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.inputs / "ubuntu-latest.checked.json").exists())
+
+    def test_missing_seal_refuses_without_output(self):
+        self.prepared(seal=False)
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_blob_mutation_after_seal_refuses_without_output(self):
+        self.prepared()
+        blob = self.inputs / "ubuntu-latest.json"
+        blob.write_bytes(blob.read_bytes() + b" ")
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_extra_input_and_duplicate_json_keys_refuse(self):
+        self.prepared()
+        extra = self.inputs / "unexpected.json"
+        extra.write_text("{}", encoding="utf-8")
+        self.assertNotEqual(self.verify().returncode, 0)
+        extra.unlink()
+        receipt = self.inputs / "ubuntu-latest.checked.json"
+        receipt.write_text('{"schema":1,"schema":1}', encoding="utf-8")
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_changed_config_and_symlinked_input_refuse(self):
+        self.prepared()
+        config = self.tree / "vitest.config.ts"
+        original = config.read_bytes()
+        config.write_bytes(original + b"// change\n")
+        self.assertNotEqual(self.verify().returncode, 0)
+        config.write_bytes(original)
+        link = Path(self.temp.name) / "linked"
+        try:
+            link.symlink_to(self.inputs, target_is_directory=True)
+        except OSError:
+            return  # Optional OS privilege, config refusal above still exercised.
+        self.assertNotEqual(self.cli("verify", "--input", link, "--output", self.output).returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_coverage_union.py
+++ b/.github/scripts/test_coverage_union.py
@@ -272,6 +272,41 @@ class CoverageUnionCliTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(json.loads(proof.read_text())["root"], self.tree.as_posix())
 
+    def test_pi_snapshot_matches_git_with_windows_checkout_conversion(self):
+        # CU-05: the real attribute policy must preserve every Pi snapshot input,
+        # including shared configuration outside the plugin tree.
+        files = {
+            ".gitattributes": (REPO / ".gitattributes").read_bytes(),
+            "core/hosts.json": (REPO / "core/hosts.json").read_bytes(),
+            "plugins/ca/hooks/secret-detection-corpus.json": b"{}\n",
+            "plugins/ca-pi/extensions/codearbiter-child.js": b"export {};\n",
+            "plugins/ca-pi/tools/src/a.ts": b"export const a = 1;\n",
+            "plugins/ca-pi/tools/package.json": b'{"private":true}\n',
+            "plugins/ca-pi/tools/package-lock.json": b'{"packages":{"node_modules/vitest":{"version":"4.1.9"}}}\n',
+            "plugins/ca-pi/tools/vitest.config.ts": b'export default {test:{coverage:{include: ["src/**/*.ts"]}}};\n',
+        }
+        for name, data in files.items():
+            target = self.repo / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+        for args in (["add", "."], ["-c", "user.name=Coverage fixture", "-c",
+                     "user.email=fixture@example.invalid", "commit", "-qm", "Pi fixture"]):
+            subprocess.run(["git", "-C", str(self.repo), *args], check=True, capture_output=True, timeout=30)
+        for autocrlf in ("true", "false"):
+            with self.subTest(autocrlf=autocrlf):
+                checkout = Path(self.temp.name) / ("checkout-" + autocrlf)
+                subprocess.run(["git", "-c", "core.autocrlf=" + autocrlf, "clone", "--local",
+                                str(self.repo), str(checkout)], check=True, capture_output=True, timeout=30)
+                for name, expected in files.items():
+                    if name != ".gitattributes":
+                        self.assertEqual((checkout / name).read_bytes(), expected,
+                                         "checkout changed coverage input bytes: " + name)
+                output = checkout / "windows-latest.provenance.json"
+                result = subprocess.run([sys.executable, str(SCRIPT), "prepare", "--repo", str(checkout),
+                                         "--tree", "plugins/ca-pi/tools", "--host", "windows-latest",
+                                         "--output", str(output)], capture_output=True, text=True, timeout=30)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_posttest_source_mutation_prevents_seal(self):
         proof = self.prepared(seal=False)
         (self.tree / "a.ts").write_text("changed\n", encoding="utf-8")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
             all:
               - '**'
             ca:
+              - '.github/scripts/coverage_union.py'
+              - '.github/scripts/test_coverage_union.py'
               - 'plugins/ca/**'
               - 'core/**'
               - 'README.md'
@@ -167,6 +169,8 @@ jobs:
               - '.github/scripts/test_codex_candidate_provenance.py'
               - '.github/workflows/ci.yml'
             ca-pi:
+              - '.github/scripts/coverage_union.py'
+              - '.github/scripts/test_coverage_union.py'
               - 'plugins/ca-pi/**'
               - 'core/**'
               # The ca-pi extension bundles EMBED the shared farm redactor
@@ -498,17 +502,25 @@ jobs:
         # the `tools` job, which runs under the identical `ca` path filter - the
         # derived audited-graph rule in test_ci_impact.py checks exactly that.
         run: npm ci --ignore-scripts
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+      - name: Bind coverage inputs
+        run: python ../../../.github/scripts/coverage_union.py prepare --repo ../../.. --tree plugins/ca/tools --host ${{ matrix.os }} --output coverage-inputs/${{ matrix.os }}.provenance.json
       - name: Coverage (blob)
         # A BLOB report is what `--merge-reports` recombines, and vitest
-        # recomputes coverage across blobs rather than letting the last one win.
-        # Verified on two disjoint suites - 7 + 65 branches merge to 72, 18 + 69
-        # lines to 87.
+        # recomputes coverage across blobs after the merge job verifies and
+        # normalizes host-specific source identities. Raw absolute paths alone
+        # would count Windows and Linux as two separate source trees.
         #
         # `default` is requested ALONGSIDE it because blob REPLACES the console
         # reporter: the first run of this job failed on Windows and the log
         # showed only "exit code 1" with no summary, no failing test name and no
         # assertion. A cell that cannot say what broke is not worth having.
-        run: npx vitest run --coverage --reporter=blob --reporter=default --outputFile.blob=coverage-blobs/${{ matrix.os }}.json
+        run: npx vitest run --coverage --reporter=blob --reporter=default --outputFile.blob=coverage-inputs/${{ matrix.os }}.json
+      - name: Recheck coverage inputs after execution
+        if: always()
+        run: python ../../../.github/scripts/coverage_union.py prepare --check --repo ../../.. --tree plugins/ca/tools --host ${{ matrix.os }} --output coverage-inputs/${{ matrix.os }}.provenance.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # NOT vitest's default `.vitest-reports/`: upload-artifact defaults to
         # `include-hidden-files: false`, so a dot-directory uploads NOTHING and
@@ -522,7 +534,7 @@ jobs:
         if: always()
         with:
           name: coverage-blob-ca-os-${{ matrix.os }}
-          path: plugins/ca/tools/coverage-blobs/
+          path: plugins/ca/tools/coverage-inputs/
           retention-days: 5
 
   coverage-union-merge:
@@ -545,21 +557,26 @@ jobs:
           cache-dependency-path: plugins/ca/tools/package-lock.json
       - name: Install (locked)
         run: npm ci --ignore-scripts
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-blob-ca-os-*
           merge-multiple: true
-          path: plugins/ca/tools/coverage-blobs/
+          path: plugins/ca/tools/coverage-inputs/
       - name: Merge and report the union
+        shell: bash
         # A missing blob (a cancelled or flaked host cell) degrades to "report
         # what we have and name what is missing" rather than failing a lane
         # nothing gates on - the same thing maturity-coverage.md tells a human
         # reading a partial local report.
         run: |
           echo "### Coverage union - plugins/ca/tools" >> "$GITHUB_STEP_SUMMARY"
-          blobs=$(ls coverage-blobs/*.json 2>/dev/null | wc -l)
+          python ../../../.github/scripts/coverage_union.py verify --repo ../../.. --tree plugins/ca/tools --input coverage-inputs --output coverage-verified
+          blobs=$(ls coverage-verified/*.json 2>/dev/null | wc -l)
           echo "blobs merged: $blobs" | tee -a "$GITHUB_STEP_SUMMARY"
-          ls coverage-blobs/ 2>/dev/null | sed 's/^/  - /' >> "$GITHUB_STEP_SUMMARY" || true
+          ls coverage-verified/ 2>/dev/null | sed 's/^/  - /' >> "$GITHUB_STEP_SUMMARY" || true
           if [ "$blobs" -eq 0 ]; then
             echo "no host produced a blob - nothing to merge (advisory)" | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -568,7 +585,7 @@ jobs:
             echo "PARTIAL: only $blobs of 2 hosts reported - this is NOT the union figure"               | tee -a "$GITHUB_STEP_SUMMARY"
           fi
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          npx vitest --merge-reports coverage-blobs --coverage --coverage.reporter=text-summary             2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          npx vitest --merge-reports coverage-verified --coverage --coverage.reporter=text-summary             2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   coverage-union-pi:
@@ -639,17 +656,22 @@ jobs:
         # the `ca-pi-checks` job, which runs under the identical `ca-pi` path filter - the
         # derived audited-graph rule in test_ci_impact.py checks exactly that.
         run: npm ci --ignore-scripts
+      - name: Bind coverage inputs
+        run: python ../../../.github/scripts/coverage_union.py prepare --repo ../../.. --tree plugins/ca-pi/tools --host ${{ matrix.os }} --output coverage-inputs/${{ matrix.os }}.provenance.json
       - name: Coverage (blob)
         # A BLOB report is what `--merge-reports` recombines, and vitest
-        # recomputes coverage across blobs rather than letting the last one win.
-        # Verified on two disjoint suites - 7 + 65 branches merge to 72, 18 + 69
-        # lines to 87.
+        # recomputes coverage across blobs after the merge job verifies and
+        # normalizes host-specific source identities. Raw absolute paths alone
+        # would count Windows and Linux as two separate source trees.
         #
         # `default` is requested ALONGSIDE it because blob REPLACES the console
         # reporter: the first run of this job failed on Windows and the log
         # showed only "exit code 1" with no summary, no failing test name and no
         # assertion. A cell that cannot say what broke is not worth having.
-        run: npx vitest run --coverage --reporter=blob --reporter=default --outputFile.blob=coverage-blobs/${{ matrix.os }}.json
+        run: npx vitest run --coverage --reporter=blob --reporter=default --outputFile.blob=coverage-inputs/${{ matrix.os }}.json
+      - name: Recheck coverage inputs after execution
+        if: always()
+        run: python ../../../.github/scripts/coverage_union.py prepare --check --repo ../../.. --tree plugins/ca-pi/tools --host ${{ matrix.os }} --output coverage-inputs/${{ matrix.os }}.provenance.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # NOT vitest's default `.vitest-reports/`: upload-artifact defaults to
         # `include-hidden-files: false`, so a dot-directory uploads NOTHING and
@@ -663,7 +685,7 @@ jobs:
         if: always()
         with:
           name: coverage-blob-ca-pi-os-${{ matrix.os }}
-          path: plugins/ca-pi/tools/coverage-blobs/
+          path: plugins/ca-pi/tools/coverage-inputs/
           retention-days: 5
 
   coverage-union-pi-merge:
@@ -696,17 +718,19 @@ jobs:
         with:
           pattern: coverage-blob-ca-pi-os-*
           merge-multiple: true
-          path: plugins/ca-pi/tools/coverage-blobs/
+          path: plugins/ca-pi/tools/coverage-inputs/
       - name: Merge and report the union
+        shell: bash
         # A missing blob (a cancelled or flaked host cell) degrades to "report
         # what we have and name what is missing" rather than failing a lane
         # nothing gates on - the same thing maturity-coverage.md tells a human
         # reading a partial local report.
         run: |
           echo "### Coverage union - plugins/ca-pi/tools" >> "$GITHUB_STEP_SUMMARY"
-          blobs=$(ls coverage-blobs/*.json 2>/dev/null | wc -l)
+          python ../../../.github/scripts/coverage_union.py verify --repo ../../.. --tree plugins/ca-pi/tools --input coverage-inputs --output coverage-verified
+          blobs=$(ls coverage-verified/*.json 2>/dev/null | wc -l)
           echo "blobs merged: $blobs" | tee -a "$GITHUB_STEP_SUMMARY"
-          ls coverage-blobs/ 2>/dev/null | sed 's/^/  - /' >> "$GITHUB_STEP_SUMMARY" || true
+          ls coverage-verified/ 2>/dev/null | sed 's/^/  - /' >> "$GITHUB_STEP_SUMMARY" || true
           if [ "$blobs" -eq 0 ]; then
             echo "no host produced a blob - nothing to merge (advisory)" | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -715,7 +739,7 @@ jobs:
             echo "PARTIAL: only $blobs of 2 hosts reported - this is NOT the union figure"               | tee -a "$GITHUB_STEP_SUMMARY"
           fi
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          npx vitest --merge-reports coverage-blobs --coverage --coverage.reporter=text-summary             2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          npx vitest --merge-reports coverage-verified --coverage --coverage.reporter=text-summary             2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   tools:
@@ -1023,6 +1047,9 @@ jobs:
         run: npm run typecheck
       - name: Test the complete Pi adapter suite
         run: npm test
+      - name: Test cross-host coverage identity and provenance
+        working-directory: .
+        run: python .github/scripts/test_coverage_union.py
       - name: Test adversarial Pi security promotion contract
         working-directory: .
         run: python .github/scripts/test_pi_security.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,8 @@ jobs:
         # One threshold applies to every audited graph (farm, sandbox, ca-pi,
         # docs site); test_ci_impact.py asserts that.
         run: npm audit --omit=dev --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Audit build toolchain (CVE gate - fail on HIGH, dev deps included)
         # Issue #434. The step above is `--omit=dev`, and all three tools graphs
         # declare no production dependencies - so on its own it audits an empty
@@ -778,6 +780,8 @@ jobs:
         # the repo; test_ci_impact.py asserts that no audit step in this
         # workflow uses a different one.
         run: npm audit --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Typecheck
         run: npm run typecheck
       - name: Rebuild farm.js
@@ -854,6 +858,8 @@ jobs:
         # dependencies either, so this audits an empty graph today and is a
         # durability setting rather than a live gate.
         run: npm audit --omit=dev --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Audit build toolchain (CVE gate - fail on HIGH, dev deps included)
         # Issue #434. The step above is `--omit=dev`, and all three tools graphs
         # declare no production dependencies - so on its own it audits an empty
@@ -874,6 +880,8 @@ jobs:
         # the repo; test_ci_impact.py asserts that no audit step in this
         # workflow uses a different one.
         run: npm audit --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Typecheck
         run: npm run typecheck
       - name: Docker preflight (REQUIRED prerequisite - fail, never skip)
@@ -984,6 +992,8 @@ jobs:
         # rather than in the six-cell ca-pi-tools matrix - the verdict does not
         # depend on OS or Pi version.
         run: npm audit --omit=dev --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Audit build toolchain (CVE gate - fail on HIGH, dev deps included)
         # Issue #434. The step above is `--omit=dev`, and all three tools graphs
         # declare no production dependencies - so on its own it audits an empty
@@ -1004,6 +1014,8 @@ jobs:
         # the repo; test_ci_impact.py asserts that no audit step in this
         # workflow uses a different one.
         run: npm audit --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Check generated root package metadata
         working-directory: .
         run: python tools/build-host-packages.py --check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,6 +85,8 @@ jobs:
         # gates in ci.yml; --omit=dev scopes it to what the built site actually
         # ships, keeping routine Astro/vitest dev advisories non-blocking.
         run: npm audit --omit=dev --audit-level=high
+        env:
+          NPM_CONFIG_LOGLEVEL: http
       - name: Typecheck
         run: npm run typecheck
       - name: Enforce site/VOICE.md punctuation (issue #338)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-09-03
+
+### Fixed
+
+- Report precise Windows containment startup stages and reject output-overflow admission races.
+
 ## [0.10.1] - 2026-09-03
 
 ### Fixed

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -1546,10 +1546,14 @@ public static class CodeArbiterJob {
 '@
 try {
   Add-Type -TypeDefinition $source -Language CSharp | Out-Null
+  [Console]::Out.WriteLine('COMPILED')
+  [Console]::Out.Flush()
   $line = [Console]::In.ReadLine()
   if ($null -eq $line -or $line -notmatch '^([1-9][0-9]*) ([1-9][0-9]*)$') { exit 40 }
   [UInt32]$target = $Matches[1]
   [UInt32]$parent = $Matches[2]
+  [Console]::Out.WriteLine('PID_ACCEPTED')
+  [Console]::Out.Flush()
   $job = [CodeArbiterJob]::CreateAndAssign($target)
   if ($job -eq [IntPtr]::Zero) { exit 41 }
   try {
@@ -1642,12 +1646,31 @@ async function awaitProgressTokens(readLine, expected, options) {
   if (idleMs > ceilingMs) throw new Error("progress idleMs must be bounded by the progress ceiling");
   const now = options.now ?? Date.now;
   const deadline = now() + ceilingMs;
+  if (options.windowsJobStages && (expected.length !== 2 || expected[0] !== WINDOWS_JOB_STARTING || expected[1] !== WINDOWS_JOB_READY)) {
+    throw new Error("Windows startup diagnostics require the bounded admission sequence");
+  }
+  let lastStage = "WAITING";
   for (const token of expected) {
-    const remaining = deadline - now();
-    if (remaining <= 0) return Object.freeze({ state: "stalled", phase: token, waitedMs: 0 });
     const started = now();
-    const line = await readLine(Math.min(idleMs, remaining));
-    if (line !== token) return Object.freeze({ state: "stalled", phase: token, waitedMs: now() - started });
+    const phaseDeadline = Math.min(deadline, started + idleMs);
+    const stalled = () => Object.freeze({
+      state: "stalled",
+      phase: token,
+      waitedMs: now() - started,
+      ...options.windowsJobStages ? { lastStage } : {}
+    });
+    const diagnostics = options.windowsJobStages && token === WINDOWS_JOB_READY ? ["COMPILED", "PID_ACCEPTED"] : [];
+    for (const diagnostic of diagnostics) {
+      const remaining2 = phaseDeadline - now();
+      if (remaining2 <= 0) return stalled();
+      if (await readLine(remaining2) !== diagnostic) return stalled();
+      lastStage = diagnostic;
+    }
+    const remaining = phaseDeadline - now();
+    if (remaining <= 0) return stalled();
+    const line = await readLine(remaining);
+    if (line !== token) return stalled();
+    if (options.windowsJobStages && token === WINDOWS_JOB_STARTING) lastStage = "STARTING";
   }
   return Object.freeze({ state: "ready" });
 }
@@ -1831,7 +1854,9 @@ function startWindowsJobGuard(pid, timing) {
   let closePending;
   let armed = false;
   let outputEnded = false;
+  let protocolFailed = false;
   let outputBuffer = "";
+  let queuedOutputBytes = 0;
   const outputLines = [];
   const outputWaiters = [];
   let resolveExitCode;
@@ -1851,7 +1876,11 @@ function startWindowsJobGuard(pid, timing) {
     settleExitCode();
   };
   const readOutputLine = (timeoutMs) => {
-    if (outputLines.length > 0) return Promise.resolve(outputLines.shift());
+    if (outputLines.length > 0) {
+      const line = outputLines.shift();
+      queuedOutputBytes -= Buffer.byteLength(line, "utf8") + 1;
+      return Promise.resolve(line);
+    }
     if (outputEnded) return Promise.resolve(void 0);
     return new Promise((resolveLine) => {
       let timer;
@@ -1870,8 +1899,11 @@ function startWindowsJobGuard(pid, timing) {
   helper.stdout.setEncoding("utf8");
   helper.stdout.on("data", (chunk) => {
     if (outputEnded) return;
-    outputBuffer += chunk;
-    if (Buffer.byteLength(outputBuffer, "utf8") > MAX_JOB_PROTOCOL_BYTES) {
+    if (queuedOutputBytes + Buffer.byteLength(outputBuffer, "utf8") + Buffer.byteLength(chunk, "utf8") > MAX_JOB_PROTOCOL_BYTES) {
+      protocolFailed = true;
+      outputLines.length = 0;
+      queuedOutputBytes = 0;
+      outputBuffer = "";
       finishOutput();
       try {
         helper.stdin.end();
@@ -1879,13 +1911,16 @@ function startWindowsJobGuard(pid, timing) {
       }
       return;
     }
+    outputBuffer += chunk;
     let newline = outputBuffer.indexOf("\n");
     while (newline >= 0) {
       const line = outputBuffer.slice(0, newline).replace(/\r$/u, "");
       outputBuffer = outputBuffer.slice(newline + 1);
       const waiter = outputWaiters.shift();
-      if (waiter === void 0) outputLines.push(line);
-      else waiter(line);
+      if (waiter === void 0) {
+        outputLines.push(line);
+        queuedOutputBytes += Buffer.byteLength(line, "utf8") + 1;
+      } else waiter(line);
       newline = outputBuffer.indexOf("\n");
     }
   });
@@ -1912,8 +1947,9 @@ function startWindowsJobGuard(pid, timing) {
     const finish = (accepted) => {
       if (settled) return false;
       settled = true;
-      resolveReady(accepted);
-      if (!accepted) {
+      const admitted = accepted && !protocolFailed;
+      resolveReady(admitted);
+      if (!admitted) {
         try {
           helper.stdin.end();
         } catch {
@@ -1930,9 +1966,9 @@ function startWindowsJobGuard(pid, timing) {
       if (!intentional) finish(false);
     });
     helper.once("error", () => finish(false));
-    void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs }).then((outcome) => {
+    void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs, windowsJobStages: true }).then((outcome) => {
       const refused = finish(outcome.state === "ready");
-      if (refused && outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
+      if (refused && outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms; last startup stage ${outcome.lastStage}`;
     }, () => finish(false));
     try {
       helper.stdin.write(`${pid} ${process.pid}
@@ -1950,7 +1986,7 @@ function startWindowsJobGuard(pid, timing) {
       return stallDiagnostic;
     },
     async arm(rootPid) {
-      if (armed || !positivePid(rootPid) || !await ready || closed) return false;
+      if (armed || !positivePid(rootPid) || !await ready || closed || protocolFailed) return false;
       armed = true;
       const watched = readOutputLine(idleMs);
       const written = await new Promise((resolveWrite) => {

--- a/plugins/ca-pi/extensions/codearbiter.js
+++ b/plugins/ca-pi/extensions/codearbiter.js
@@ -1877,8 +1877,8 @@ function startWindowsJobGuard(pid, timing) {
   };
   const readOutputLine = (timeoutMs) => {
     if (outputLines.length > 0) {
-      const line = outputLines.shift();
-      queuedOutputBytes -= Buffer.byteLength(line, "utf8") + 1;
+      const { line, bytes } = outputLines.shift();
+      queuedOutputBytes -= bytes;
       return Promise.resolve(line);
     }
     if (outputEnded) return Promise.resolve(void 0);
@@ -1914,12 +1914,13 @@ function startWindowsJobGuard(pid, timing) {
     outputBuffer += chunk;
     let newline = outputBuffer.indexOf("\n");
     while (newline >= 0) {
+      const bytes = Buffer.byteLength(outputBuffer.slice(0, newline + 1), "utf8");
       const line = outputBuffer.slice(0, newline).replace(/\r$/u, "");
       outputBuffer = outputBuffer.slice(newline + 1);
       const waiter = outputWaiters.shift();
       if (waiter === void 0) {
-        outputLines.push(line);
-        queuedOutputBytes += Buffer.byteLength(line, "utf8") + 1;
+        outputLines.push({ line, bytes });
+        queuedOutputBytes += bytes;
       } else waiter(line);
       newline = outputBuffer.indexOf("\n");
     }

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.1"
+    adapter_version = "0.10.2"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/tools/src/process-tree.ts
+++ b/plugins/ca-pi/tools/src/process-tree.ts
@@ -22,7 +22,7 @@ const MAX_POLL_MS = 1_000;
 // hung helper - it refused containment twice in one day on windows-latest.
 //
 // The budget is therefore a NO-PROGRESS budget per observable phase, not a total.
-// Each protocol token the helper emits refreshes it, so a slow-but-advancing
+// Only STARTING and ATTACHED refresh it; diagnostic milestones do not. A slow-but-advancing
 // helper is admitted while a silent one still fails closed inside the absolute
 // ceiling with the stalled phase named. Measured phase cost on an idle Windows 11
 // dev box over 6 runs: host start 107-127ms, Add-Type compile 101-158ms; 15s per
@@ -151,10 +151,14 @@ public static class CodeArbiterJob {
 '@
 try {
   Add-Type -TypeDefinition $source -Language CSharp | Out-Null
+  [Console]::Out.WriteLine('COMPILED')
+  [Console]::Out.Flush()
   $line = [Console]::In.ReadLine()
   if ($null -eq $line -or $line -notmatch '^([1-9][0-9]*) ([1-9][0-9]*)$') { exit 40 }
   [UInt32]$target = $Matches[1]
   [UInt32]$parent = $Matches[2]
+  [Console]::Out.WriteLine('PID_ACCEPTED')
+  [Console]::Out.Flush()
   $job = [CodeArbiterJob]::CreateAndAssign($target)
   if ($job -eq [IntPtr]::Zero) { exit 41 }
   try {
@@ -290,15 +294,18 @@ export type ProcessTreeTerminationStep =
   | Readonly<{ kind: "close-job"; timeoutMs: number }>
   | Readonly<{ kind: "wait-until-exited" | "verify-exited"; timeoutMs: number }>;
 
+type WindowsJobStartupStage = "WAITING" | "STARTING" | "COMPILED" | "PID_ACCEPTED";
 export type ProgressWaitOutcome =
   | Readonly<{ state: "ready" }>
-  | Readonly<{ state: "stalled"; phase: string; waitedMs: number }>;
+  | Readonly<{ state: "stalled"; phase: string; waitedMs: number; lastStage?: WindowsJobStartupStage }>;
 export interface ProgressWaitOptions {
-  /** No-progress budget for a single token. Refreshed by every token that arrives. */
+  /** No-progress budget refreshed only by admission tokens, never diagnostic milestones. */
   readonly idleMs: number;
   /** Hard absolute bound on the whole sequence, however much progress arrives. */
   readonly ceilingMs: number;
   readonly now?: () => number;
+  /** Fixed Windows diagnostics are ordered but never refresh admission deadlines. */
+  readonly windowsJobStages?: boolean;
 }
 
 interface NormalizedTiming { graceMs: number; verifyMs: number; pollMs: number }
@@ -352,12 +359,32 @@ export async function awaitProgressTokens(
   if (idleMs > ceilingMs) throw new Error("progress idleMs must be bounded by the progress ceiling");
   const now = options.now ?? Date.now;
   const deadline = now() + ceilingMs;
+  if (options.windowsJobStages && (expected.length !== 2 || expected[0] !== WINDOWS_JOB_STARTING || expected[1] !== WINDOWS_JOB_READY)) {
+    throw new Error("Windows startup diagnostics require the bounded admission sequence");
+  }
+  let lastStage: WindowsJobStartupStage = "WAITING";
   for (const token of expected) {
-    const remaining = deadline - now();
-    if (remaining <= 0) return Object.freeze({ state: "stalled" as const, phase: token, waitedMs: 0 });
     const started = now();
-    const line = await readLine(Math.min(idleMs, remaining));
-    if (line !== token) return Object.freeze({ state: "stalled" as const, phase: token, waitedMs: now() - started });
+    const phaseDeadline = Math.min(deadline, started + idleMs);
+    const stalled = (): ProgressWaitOutcome => Object.freeze({
+      state: "stalled" as const, phase: token, waitedMs: now() - started,
+      ...(options.windowsJobStages ? { lastStage } : {}),
+    });
+    // The fixed two-element diagnostic list bounds reads even if a producer
+    // floods valid-looking tokens without advancing the clock.
+    const diagnostics = options.windowsJobStages && token === WINDOWS_JOB_READY
+      ? ["COMPILED", "PID_ACCEPTED"] as const : [];
+    for (const diagnostic of diagnostics) {
+      const remaining = phaseDeadline - now();
+      if (remaining <= 0) return stalled();
+      if (await readLine(remaining) !== diagnostic) return stalled();
+      lastStage = diagnostic;
+    }
+    const remaining = phaseDeadline - now();
+    if (remaining <= 0) return stalled();
+    const line = await readLine(remaining);
+    if (line !== token) return stalled();
+    if (options.windowsJobStages && token === WINDOWS_JOB_STARTING) lastStage = "STARTING";
   }
   return Object.freeze({ state: "ready" as const });
 }
@@ -547,7 +574,9 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
   let closePending: Promise<boolean> | undefined;
   let armed = false;
   let outputEnded = false;
+  let protocolFailed = false;
   let outputBuffer = "";
+  let queuedOutputBytes = 0;
   const outputLines: string[] = [];
   const outputWaiters: Array<(line?: string) => void> = [];
   let resolveExitCode!: (code?: number) => void;
@@ -565,7 +594,11 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
     settleExitCode();
   };
   const readOutputLine = (timeoutMs?: number): Promise<string | undefined> => {
-    if (outputLines.length > 0) return Promise.resolve(outputLines.shift());
+    if (outputLines.length > 0) {
+      const line = outputLines.shift()!;
+      queuedOutputBytes -= Buffer.byteLength(line, "utf8") + 1;
+      return Promise.resolve(line);
+    }
     if (outputEnded) return Promise.resolve(undefined);
     return new Promise((resolveLine) => {
       let timer: NodeJS.Timeout | undefined;
@@ -584,18 +617,27 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
   helper.stdout.setEncoding("utf8");
   helper.stdout.on("data", (chunk: string) => {
     if (outputEnded) return;
-    outputBuffer += chunk;
-    if (Buffer.byteLength(outputBuffer, "utf8") > MAX_JOB_PROTOCOL_BYTES) {
+    if (queuedOutputBytes + Buffer.byteLength(outputBuffer, "utf8") + Buffer.byteLength(chunk, "utf8") > MAX_JOB_PROTOCOL_BYTES) {
+      // A line waiter may already hold ATTACHED while its continuation has not
+      // run. Latch refusal synchronously so buffered success cannot admit launch.
+      protocolFailed = true;
+      outputLines.length = 0;
+      queuedOutputBytes = 0;
+      outputBuffer = "";
       finishOutput();
       try { helper.stdin.end(); } catch {}
       return;
     }
+    outputBuffer += chunk;
     let newline = outputBuffer.indexOf("\n");
     while (newline >= 0) {
       const line = outputBuffer.slice(0, newline).replace(/\r$/u, "");
       outputBuffer = outputBuffer.slice(newline + 1);
       const waiter = outputWaiters.shift();
-      if (waiter === undefined) outputLines.push(line);
+      if (waiter === undefined) {
+        outputLines.push(line);
+        queuedOutputBytes += Buffer.byteLength(line, "utf8") + 1;
+      }
       else waiter(line);
       newline = outputBuffer.indexOf("\n");
     }
@@ -616,19 +658,20 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
     const finish = (accepted: boolean): boolean => {
       if (settled) return false;
       settled = true;
-      resolveReady(accepted);
-      if (!accepted) { try { helper.stdin.end(); } catch {} terminateWindowsHelperTree(helper, closed); }
+      const admitted = accepted && !protocolFailed;
+      resolveReady(admitted);
+      if (!admitted) { try { helper.stdin.end(); } catch {} terminateWindowsHelperTree(helper, closed); }
       return true;
     };
     helper.stderr.on("data", (chunk: Buffer | string) => { stderrBytes += Buffer.byteLength(chunk); if (stderrBytes > MAX_JOB_PROTOCOL_BYTES) finish(false); });
     helper.once("close", () => { if (!intentional) finish(false); });
     helper.once("error", () => finish(false));
-    void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs }).then((outcome) => {
+    void awaitProgressTokens(readOutputLine, WINDOWS_JOB_READY_TOKENS, { ceilingMs, idleMs, windowsJobStages: true }).then((outcome) => {
       // Attribute the stall ONLY when the progress wait is what refused. A helper
       // that crashed or flooded stderr has already settled `ready`, and reporting
       // "stalled at ..." for it would be a lie.
       const refused = finish(outcome.state === "ready");
-      if (refused && outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms`;
+      if (refused && outcome.state === "stalled") stallDiagnostic = `stalled at ${outcome.phase} after ${outcome.waitedMs}ms; last startup stage ${outcome.lastStage}`;
     }, () => finish(false));
     try { helper.stdin.write(`${pid} ${process.pid}\n`, "utf8", (error) => { if (error) finish(false); }); } catch { finish(false); }
   });
@@ -637,7 +680,7 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
     exitCode,
     stall(): string | undefined { return stallDiagnostic; },
     async arm(rootPid: number): Promise<boolean> {
-      if (armed || !positivePid(rootPid) || !await ready || closed) return false;
+      if (armed || !positivePid(rootPid) || !await ready || closed || protocolFailed) return false;
       armed = true;
       const watched = readOutputLine(idleMs);
       const written = await new Promise<boolean>((resolveWrite) => {

--- a/plugins/ca-pi/tools/src/process-tree.ts
+++ b/plugins/ca-pi/tools/src/process-tree.ts
@@ -577,7 +577,7 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
   let protocolFailed = false;
   let outputBuffer = "";
   let queuedOutputBytes = 0;
-  const outputLines: string[] = [];
+  const outputLines: Array<{ line: string; bytes: number }> = [];
   const outputWaiters: Array<(line?: string) => void> = [];
   let resolveExitCode!: (code?: number) => void;
   let exitCodeSettled = false;
@@ -595,8 +595,8 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
   };
   const readOutputLine = (timeoutMs?: number): Promise<string | undefined> => {
     if (outputLines.length > 0) {
-      const line = outputLines.shift()!;
-      queuedOutputBytes -= Buffer.byteLength(line, "utf8") + 1;
+      const { line, bytes } = outputLines.shift()!;
+      queuedOutputBytes -= bytes;
       return Promise.resolve(line);
     }
     if (outputEnded) return Promise.resolve(undefined);
@@ -631,12 +631,13 @@ function startWindowsJobGuard(pid: number, timing: NormalizedTiming): WindowsJob
     outputBuffer += chunk;
     let newline = outputBuffer.indexOf("\n");
     while (newline >= 0) {
+      const bytes = Buffer.byteLength(outputBuffer.slice(0, newline + 1), "utf8");
       const line = outputBuffer.slice(0, newline).replace(/\r$/u, "");
       outputBuffer = outputBuffer.slice(newline + 1);
       const waiter = outputWaiters.shift();
       if (waiter === undefined) {
-        outputLines.push(line);
-        queuedOutputBytes += Buffer.byteLength(line, "utf8") + 1;
+        outputLines.push({ line, bytes });
+        queuedOutputBytes += bytes;
       }
       else waiter(line);
       newline = outputBuffer.indexOf("\n");

--- a/plugins/ca-pi/tools/test/process-tree.test.ts
+++ b/plugins/ca-pi/tools/test/process-tree.test.ts
@@ -1,9 +1,13 @@
 import { spawn, spawnSync } from "node:child_process";
-import { Writable } from "node:stream";
+import * as childProcess from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { win32 } from "node:path";
 
 import { describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", { spy: true });
 
 import {
   PROCESS_TREE_CLEANUP_REASONS,
@@ -145,6 +149,162 @@ describe("Windows inert-supervisor refusal reason protocol", () => {
     expect(windowsRefusalReasonFromMessage("Windows contained Pi launch was refused")).toBeUndefined();
     expect(windowsRefusalReasonFromMessage("some other error: not-a-reason-code")).toBeUndefined();
   });
+});
+
+describe("Windows startup stage diagnostics", () => {
+  const options = { idleMs: 15_000, ceilingMs: 30_000, windowsJobStages: true };
+
+  // DG-01/02: diagnostic stages name the last completed operation but do not
+  // renew either admission deadline or replace ATTACHED as admission proof.
+  test.each([
+    [[], "STARTING", "WAITING", 15_000],
+    [["STARTING"], "ATTACHED", "STARTING", 15_010],
+    [["STARTING", "COMPILED"], "ATTACHED", "COMPILED", 15_010],
+    [["STARTING", "COMPILED", "PID_ACCEPTED"], "ATTACHED", "PID_ACCEPTED", 15_010],
+  ] as const)("names the last stage after %j without admitting a silent helper", async (lines, phase, lastStage, totalMs) => {
+    const handshake = scriptedHandshake(lines.map((line) => ({ afterMs: 10, line })));
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], {
+      ...options, now: handshake.now,
+    })).resolves.toEqual({ state: "stalled", phase, lastStage, waitedMs: 15_000 });
+    expect(handshake.clock.value).toBe(totalMs);
+  });
+
+  test("admits only the ordered complete diagnostic handshake", async () => {
+    const handshake = scriptedHandshake(["STARTING", "COMPILED", "PID_ACCEPTED", "ATTACHED"].map((line) => ({ afterMs: 100, line })));
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], {
+      ...options, now: handshake.now,
+    })).resolves.toEqual({ state: "ready" });
+    expect(handshake.clock.value).toBe(400);
+  });
+
+  test("rejects Windows diagnostics on a different admission sequence", async () => {
+    await expect(awaitProgressTokens(async () => "ATTACHED", ["ATTACHED"], options))
+      .rejects.toThrow("bounded admission sequence");
+  });
+
+  test.each([
+    ["COMPILED", "COMPILED"], ["PID_ACCEPTED", "STARTING"],
+    ["ATTACHED", "STARTING"], ["COMPILED\nPID_ACCEPTED", "STARTING"],
+    ["PRIVATE_INPUT_SENTINEL".repeat(100), "STARTING"],
+  ])("rejects malformed or out-of-order stage %s without echoing it", async (line, lastStage) => {
+    const lines = line === "COMPILED" ? ["STARTING", "COMPILED", line] : ["STARTING", line];
+    const handshake = scriptedHandshake(lines.map((value) => ({ afterMs: 10, line: value })));
+    const result = await awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], { ...options, now: handshake.now });
+    expect(result).toMatchObject({ state: "stalled", phase: "ATTACHED", lastStage });
+    expect(JSON.stringify(result)).not.toContain("PRIVATE_INPUT_SENTINEL");
+  });
+
+  test("does not extend the idle deadline with late diagnostic progress", async () => {
+    const handshake = scriptedHandshake([
+      { afterMs: 1_000, line: "STARTING" }, { afterMs: 10_000, line: "COMPILED" },
+      { afterMs: 4_000, line: "PID_ACCEPTED" }, { afterMs: 2_000, line: "ATTACHED" },
+    ]);
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], { ...options, now: handshake.now }))
+      .resolves.toEqual({ state: "stalled", phase: "ATTACHED", lastStage: "PID_ACCEPTED", waitedMs: 15_000 });
+    expect(handshake.clock.value).toBe(16_000);
+  });
+
+  test("does not extend the absolute ceiling with diagnostic progress", async () => {
+    const handshake = scriptedHandshake([
+      { afterMs: 12_000, line: "STARTING" }, { afterMs: 4_000, line: "COMPILED" },
+      { afterMs: 3_000, line: "PID_ACCEPTED" }, { afterMs: 2_000, line: "ATTACHED" },
+    ]);
+    await expect(awaitProgressTokens(handshake.readLine, ["STARTING", "ATTACHED"], { ...options, ceilingMs: 20_000, now: handshake.now }))
+      .resolves.toEqual({ state: "stalled", phase: "ATTACHED", lastStage: "PID_ACCEPTED", waitedMs: 8_000 });
+    expect(handshake.clock.value).toBe(20_000);
+  });
+
+  test("bounds a diagnostic flood without refreshing its budget", async () => {
+    let reads = 0;
+    const result = await awaitProgressTokens(async () => ++reads === 1 ? "STARTING" : "COMPILED", ["STARTING", "ATTACHED"], options);
+    expect(result).toMatchObject({ state: "stalled", phase: "ATTACHED", lastStage: "COMPILED" });
+    expect(reads).toBe(3);
+  });
+
+  test.skipIf(process.platform !== "win32")("bounds queued diagnostic bytes across individually small chunks before the reader resumes", async () => {
+    const helper = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(), stderr: new PassThrough(), stdin: new PassThrough(),
+      exitCode: null, signalCode: null, kill: vi.fn(),
+    });
+    const supervisor = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn(), exitCode: null, signalCode: null });
+    const spawnMock = vi.spyOn(childProcess, "spawn")
+      .mockReturnValueOnce(supervisor as never).mockReturnValueOnce(helper as never);
+    const pending = spawnProcessTree(process.execPath, [], {
+      cwd: process.cwd(), env: {}, stdio: ["pipe", "pipe", "pipe", "pipe"],
+    }).catch((error: unknown) => error);
+    try {
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
+      // No microtask yield between chunks: line consumption cannot hide unbounded
+      // queued data. This never starts an OS process or targets a real PID.
+      for (let index = 0; index < 100; index += 1) helper.stdout.emit("data", "COMPILED\n");
+      expect(helper.stdin.writableEnded).toBe(true);
+    } finally {
+      helper.stdout.emit("end");
+      await pending;
+      spawnMock.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform !== "win32").each(["single", "cumulative"])("never writes a launch after ATTACHED races a %s output overflow", async (mode) => {
+    const helper = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(), stderr: new PassThrough(), stdin: new PassThrough(),
+      exitCode: null, signalCode: null, kill: vi.fn(),
+    });
+    const pipes = Array.from({ length: 8 }, () => new PassThrough());
+    const supervisor = Object.assign(new EventEmitter(), {
+      pid: 4242, kill: vi.fn(), exitCode: null, signalCode: null, stdio: pipes,
+    });
+    const spawnMock = vi.spyOn(childProcess, "spawn")
+      .mockReturnValueOnce(supervisor as never).mockReturnValueOnce(helper as never);
+    let settled = false;
+    const pending = spawnProcessTree(process.execPath, [], {
+      cwd: process.cwd(), env: {}, stdio: ["pipe", "pipe", "pipe", "pipe"],
+    }).catch((error: unknown) => error).finally(() => { settled = true; });
+    try {
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
+      helper.stdout.emit("data", "STARTING\nCOMPILED\nPID_ACCEPTED\n");
+      await new Promise<void>((resolveTurn) => setTimeout(resolveTurn, 0));
+      helper.stdout.emit("data", "ATTACHED\n");
+      // The waiter has its ATTACHED value, but no promise continuation has run.
+      if (mode === "single") helper.stdout.emit("data", "x".repeat(65));
+      else for (let index = 0; index < 10; index += 1) helper.stdout.emit("data", "COMPILED\n");
+      await vi.waitFor(() => expect(settled || pipes[4]!.readableLength > 0).toBe(true));
+      expect(pipes[4]!.readableLength).toBe(0);
+      expect(pipes[5]!.readableLength).toBe(0);
+      expect(await pending).toBeInstanceOf(Error);
+    } finally {
+      helper.emit("close");
+      pipes[6]!.end("REFUSED\n");
+      await pending;
+      spawnMock.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform !== "win32")("live helper exposes compilation and accepted PID stages without disclosing input", async () => {
+    const powershell = resolveWindowsPowerShellExecutable();
+    expect(powershell).toBeDefined();
+    const launch = windowsJobHelperArgv(powershell!);
+    const helper = spawn(launch.command, [...launch.args], { shell: false, windowsHide: true, stdio: "pipe" });
+    let output = "";
+    let helperClosed = false;
+    helper.stdout.setEncoding("utf8");
+    helper.stdout.on("data", (chunk: string) => { output += chunk; });
+    helper.stderr.resume();
+    helper.stdin.on("error", () => undefined);
+    const closed = new Promise<void>((resolveClosed, reject) => {
+      helper.once("close", () => { helperClosed = true; resolveClosed(); });
+      helper.once("error", reject);
+    });
+    // A valid UInt32 PID pair with a nonexistent target reaches native assignment
+    // but cannot attach. No real process is placed in a kill-on-close Job.
+    helper.stdin.end(`4294967295 ${process.pid}\n`);
+    try {
+      await closed;
+      expect(output.replace(/\r/g, "")).toBe("STARTING\nCOMPILED\nPID_ACCEPTED\n");
+    } finally {
+      if (!helperClosed && helper.exitCode === null && helper.signalCode === null) forceFixtureCleanup(helper.pid);
+    }
+  }, 30_000);
 });
 
 describe("process-tree cleanup", () => {

--- a/plugins/ca-pi/tools/test/process-tree.test.ts
+++ b/plugins/ca-pi/tools/test/process-tree.test.ts
@@ -245,6 +245,68 @@ describe("Windows startup stage diagnostics", () => {
     }
   });
 
+  test.skipIf(process.platform !== "win32").each([false, true])("charges original CRLF queued bytes at the exact boundary (split=%s)", async (split) => {
+    const helper = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(), stderr: new PassThrough(), stdin: new PassThrough(),
+      exitCode: null, signalCode: null, kill: vi.fn(),
+    });
+    const supervisor = Object.assign(new EventEmitter(), { pid: 4242, kill: vi.fn(), exitCode: null, signalCode: null });
+    const spawnMock = vi.spyOn(childProcess, "spawn")
+      .mockReturnValueOnce(supervisor as never).mockReturnValueOnce(helper as never);
+    const pending = spawnProcessTree(process.execPath, [], {
+      cwd: process.cwd(), env: {}, stdio: ["pipe", "pipe", "pipe", "pipe"],
+    }).catch((error: unknown) => error);
+    try {
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
+      helper.stdout.emit("data", "STARTING\r\n");
+      // STARTING goes directly to its waiter. Without yielding, queue exactly
+      // 64 original bytes; CR removal must not discount their accounting.
+      for (let index = 0; index < 32; index += 1) {
+        if (split) { helper.stdout.emit("data", "\r"); helper.stdout.emit("data", "\n"); }
+        else helper.stdout.emit("data", "\r\n");
+      }
+      expect(helper.stdin.writableEnded).toBe(false);
+      helper.stdout.emit("data", "x");
+      expect(helper.stdin.writableEnded).toBe(true);
+    } finally {
+      helper.stdout.emit("end");
+      await pending;
+      spawnMock.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform !== "win32")("accepts CRLF admission and releases original queued bytes when drained", async () => {
+    const helper = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(), stderr: new PassThrough(), stdin: new PassThrough(),
+      exitCode: null, signalCode: null, kill: vi.fn(),
+    });
+    const pipes = Array.from({ length: 8 }, () => new PassThrough());
+    const supervisor = Object.assign(new EventEmitter(), {
+      pid: 4242, kill: vi.fn(), exitCode: null, signalCode: null, stdio: pipes,
+      stdout: pipes[1], stderr: pipes[2], stdin: pipes[0],
+    });
+    const spawnMock = vi.spyOn(childProcess, "spawn")
+      .mockReturnValueOnce(supervisor as never).mockReturnValueOnce(helper as never);
+    helper.stdin.on("data", (chunk: Buffer) => {
+      if (chunk.toString() === "1234\n") helper.stdout.emit("data", `WATCHING\r\n${"x".repeat(54)}`);
+    });
+    const pending = spawnProcessTree(process.execPath, [], {
+      cwd: process.cwd(), env: {}, stdio: ["pipe", "pipe", "pipe", "pipe"],
+    });
+    try {
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
+      pipes[6]!.write("STARTED 1234\n");
+      helper.stdout.emit("data", "STARTING\r\nCOMPILED\r\nPID_ACCEPTED\r\nATTACHED\r\n");
+      await expect(pending).resolves.toMatchObject({ pid: 1234 });
+      expect(helper.stdin.writableEnded).toBe(false);
+    } finally {
+      helper.emit("close");
+      for (const pipe of pipes) pipe.destroy();
+      await pending.catch(() => undefined);
+      spawnMock.mockRestore();
+    }
+  });
+
   test.skipIf(process.platform !== "win32").each(["single", "cumulative"])("never writes a launch after ATTACHED races a %s output overflow", async (mode) => {
     const helper = Object.assign(new EventEmitter(), {
       stdout: new PassThrough(), stderr: new PassThrough(), stdin: new PassThrough(),


### PR DESCRIPTION
## Summary

Expose npm audit request status and Windows containment startup stages so recurring CI failures identify the failed boundary. Also close a verified output-overflow race that could authorize launch after the helper protocol had already failed.

All seven npm audit steps use step-local `http` logging. Audit commands, scopes, HIGH threshold, and failure propagation are unchanged. The previous PR head demonstrated a hosted bulk POST 200 and zero vulnerabilities; the earlier intermittent registry failure is not proven fixed.

Windows startup now reports fixed COMPILED and PID_ACCEPTED milestones. They do not refresh the 15-second idle or 30-second absolute admission deadlines, and ATTACHED remains required. Pending protocol output is bounded across chunks; a synchronous refusal latch prevents an already-resolved readiness token from admitting launch after overflow. No raw helper input, stderr, or environment is added to diagnostics.

The recurring hosted containment timeout remains unexplained. This change supplies discriminating evidence without increasing timeouts or weakening containment.

## Earlier validation (before the coverage-identity repair)

- npm audit regression: seven expected failures before implementation, then 61 passing contract tests; independent logging mutation and security reviews passed.
- Windows diagnostic regressions failed before implementation; both overflow-race regressions reproduced unauthorized launch-record writes before the correction.
- Fresh focused protocol suite: 66 passed, one existing platform skip. Full Pi suite: 860 passed, one existing skip across 36 files.
- Windows coverage: 86.26% lines and 80.38% branches. Ubuntu contribution and hosted union remain pending.
- Independent security and coverage reviews: zero remaining findings; generated bundle parity verified.
- Required Python script suite passed. Full hook discovery: 1,457 tests, zero failures or errors, three existing skips. Windows test process used Git's shell on PATH and removed ambient NO_COLOR for ANSI assertions; global settings and assertions were unchanged.
- Pi package, parity, public docs, generated surfaces, typecheck, whitespace, staged secret scan, and provenance checks passed.

Exact-head hosted CI and review are required before merge. No release or publication is claimed by these local checks.

## Coverage identity repair (`f0434ac3`)

The previous exact-head CI run was green, but its Pi coverage merge counted 41 sources as 82 files because Windows and Linux absolute paths remained distinct. This repair binds source/configuration snapshots before and after execution, validates both host inputs, and supplies normalized copies to Vitest. Missing-host reports remain explicitly partial; malformed, stale, conflicting, or cancelling evidence is rejected. The jobs remain advisory and the maturity threshold is unchanged.

- Regression RED reproduced four identities instead of two for complementary host fixtures. Final fresh local tests: 18 coverage-identity cases and 62 workflow contracts passed.
- Independent security and coverage reviews passed at the committed helper/test hashes; bypass and ordering mutations fail the workflow guard.
- Required Python script suites and corrected full hook discovery passed. Syntax, whitespace, added-line secret/crypto scans and provenance checks passed. The sole full-file secret scan match was an unchanged test fixture.
- Python coverage exemption: tech-stack.md states, "There is no coverage tooling for the Python hooks (plugins/*/hooks/*.py, .github/scripts/*.py). No numeric floor exists for those surfaces."
- A format-compatibility replay of retained CI blobs, with explicitly synthetic diagnostic provenance, preserved 41 sources and yielded 86.28% lines / 80.88% branches. This is NOT fresh hosted provenance or release proof; no historical receipts were minted.
- Original signed implicit-else counters are preserved only for the observed producer shape; unsafe sums or cancellation of a positive host observation fail closed.

Fresh hosted CI, docs checks, review, and the actual two-host report for this head remain required before merge.

## Windows checkout follow-up (`e9a7c3a1`)

The f0434ac3 Windows Pi producer rejected its pretest snapshot: Git converted the shared `core/hosts.json` from LF to CRLF. A fresh exact-head checkout with `core.autocrlf=true`, without any npm installation, reproduced the byte mismatch. The fix pins only that shared input to LF; the strict provenance validator is unchanged.

The new real-checkout regression failed specifically on that file before the fix and passes with both autocrlf settings afterward. Independent coverage review and removal-of-rule mutation passed. Fresh local validation: 19 coverage-helper tests, 62 workflow-contract tests, the full tech-stack Python test block including hook discovery, syntax, reference graph, whitespace and secret checks passed. No provenance auto-heal work was required. The Python coverage exemption quoted above applies; no fresh hosted TypeScript union or release is claimed yet.
