### PR TITLE
fix(release): classify npm signature verification failures

### DIFF
--- a/.github/scripts/_npm_publishlib.py
+++ b/.github/scripts/_npm_publishlib.py
@@ -282,6 +282,32 @@ def validate_attestation_document(
     return source_sha
 
 
+def _signature_failure_detail(evidence: object) -> str:
+    """Expose only fixed categories, never registry text or npm stderr."""
+    if not isinstance(evidence, dict):
+        return "schema=invalid"
+    allowed = (
+        "EINTEGRITYSIGNATURE", "EATTESTATIONVERIFY", "E503", "E502",
+        "E504", "E429", "ETIMEDOUT", "ECONNRESET", "EAI_AGAIN",
+    )
+
+    def code(item: object) -> str:
+        value = item.get("code") if isinstance(item, dict) else None
+        return value if isinstance(value, str) and value in allowed else "unknown"
+
+    invalid = evidence.get("invalid")
+    if not isinstance(invalid, list):
+        invalid_detail = "malformed"
+    elif len(invalid) > 8:
+        invalid_detail = "over-limit"
+    else:
+        invalid_detail = ",".join(sorted({code(item) for item in invalid})) or "none"
+    missing = evidence.get("missing")
+    missing_detail = ("yes" if missing else "no") if isinstance(missing, list) else "malformed"
+    error_detail = code(evidence.get("error")) if "error" in evidence else "none"
+    return f"invalid={invalid_detail}; missing={missing_detail}; error={error_detail}"
+
+
 def verify_registry_authenticity(npm: str, version: str) -> dict:
     """Use npm's supported Sigstore verifier; do not hand-roll bundle crypto."""
 
@@ -368,7 +394,10 @@ def verify_registry_authenticity(npm: str, version: str) -> dict:
             or evidence.get("invalid") != []
             or evidence.get("missing") != []
         ):
-            raise ValueError("npm signature or provenance verification failed")
+            raise ValueError(
+                "npm signature or provenance verification failed: "
+                + _signature_failure_detail(evidence)
+            )
         verified = evidence.get("verified")
         if not isinstance(verified, list) or len(verified) != 1:
             raise ValueError("npm signature verification did not identify one exact package")

--- a/.github/scripts/test_pi_package.py
+++ b/.github/scripts/test_pi_package.py
@@ -2742,6 +2742,69 @@ class NpmPublishContractTest(unittest.TestCase):
                     document(changed), version, integrity, trusted_sha
                 )
 
+    def test_registry_authenticity_failure_has_safe_actionable_diagnostics(self):
+        helper = self._helper()
+        installed = subprocess.CompletedProcess(["npm", "install"], 0, "", "")
+        hostile = "PRIVATE-VALUE\n::warning::injected https://user:pass@invalid/"
+        cases = (
+            ({"invalid": [{"code": "EATTESTATIONVERIFY", "message": hostile}], "missing": []},
+             "invalid=EATTESTATIONVERIFY"),
+            ({"invalid": [{"code": "EINTEGRITYSIGNATURE", "name": hostile}], "missing": []},
+             "invalid=EINTEGRITYSIGNATURE"),
+            ({"invalid": [], "missing": [hostile]}, "missing=yes"),
+            ({"error": {"code": "E503", "summary": hostile}}, "error=E503"),
+            ({"error": {"code": hostile}}, "error=unknown"),
+        )
+        for evidence, expected in cases:
+            with self.subTest(expected=expected):
+                audited = subprocess.CompletedProcess(
+                    ["npm", "audit", "signatures"], 1, json.dumps(evidence), hostile
+                )
+                with mock.patch.object(helper.subprocess, "run", side_effect=[installed, audited]), \
+                        self.assertRaises(ValueError) as failure:
+                    helper.verify_registry_authenticity("npm", "0.10.0")
+                diagnostic = str(failure.exception)
+                self.assertIn(expected, diagnostic)
+                self.assertNotIn("PRIVATE-VALUE", diagnostic)
+                self.assertNotIn("::warning::", diagnostic)
+                self.assertNotIn("user:pass", diagnostic)
+                self.assertLessEqual(len(diagnostic), 256)
+
+    def test_signature_diagnostics_bound_and_classify_malformed_evidence(self):
+        helper = self._helper()
+        cases = (
+            (None, "schema=invalid"),
+            ([], "schema=invalid"),
+            ({"invalid": None}, "invalid=malformed"),
+            ({"invalid": [None, [], {"code": []}]}, "invalid=unknown"),
+            ({"missing": {}}, "missing=malformed"),
+            ({"error": []}, "error=unknown"),
+            ({"invalid": [{"code": "E503"}] * 8}, "invalid=E503"),
+            ({"invalid": [{"code": "E503"}] * 9}, "invalid=over-limit"),
+        )
+        for evidence, expected in cases:
+            with self.subTest(expected=expected, evidence=evidence):
+                self.assertIn(expected, helper._signature_failure_detail(evidence))
+
+        class UnreadableOverLimit(list):
+            def __iter__(self):
+                raise AssertionError("over-limit diagnostic entries were traversed")
+
+        self.assertIn("invalid=over-limit", helper._signature_failure_detail({
+            "invalid": UnreadableOverLimit([None] * 9),
+        }))
+        maximal = {
+            "invalid": [{"code": code} for code in (
+                "EINTEGRITYSIGNATURE", "EATTESTATIONVERIFY", "ETIMEDOUT",
+                "ECONNRESET", "EAI_AGAIN", "E503", "E502", "E504",
+            )],
+            "missing": None,
+            "error": {"code": "EINTEGRITYSIGNATURE"},
+        }
+        diagnostic = "npm signature or provenance verification failed: " + helper._signature_failure_detail(maximal)
+        self.assertLessEqual(len(diagnostic), 256)
+        self.assertIn("EATTESTATIONVERIFY", diagnostic)
+
     def test_registry_authenticity_rejects_unsigned_or_invalid_packages(self):
         helper = self._helper()
         installed = subprocess.CompletedProcess(["npm", "install"], 0, "", "")


### PR DESCRIPTION
## Summary

Report fixed, bounded categories when npm signature or provenance verification fails. The 0.10.2 publication run discarded the category behind a generic error, preventing diagnosis.

The formatter never emits registry messages, npm stderr, URLs, or unknown error text. It bounds invalid-entry traversal and preserves every existing rejection and exact-package/provenance check. This does not claim the original registry failure is fixed, authorize a blind retry, or change published tags.

## Validation

- Five diagnostic regression cases failed before the fix and pass unchanged afterward.
- All 20 npm publication contract tests pass, including malformed evidence, the eight-entry boundary, output bounds, and hostile log content.
- The repository script/check chain passes; the hook suite passes 1,457 tests with three existing skips.
- Full Pi package suite passes all 45 tests on the final commit, including the boundary-test addition.
- Syntax, reference graph, whitespace, secret classification, and scoped provenance checks pass. Independent security and coverage reviews pass; the boundary mutation is detected.

Python coverage follows `.codearbiter/tech-stack.md`: “There is **no coverage tooling for the Python hooks** (`plugins/*/hooks/*.py`, `.github/scripts/*.py`). No numeric floor exists for those surfaces”. Hosted CI remains required.
