### PR TITLE
test(ca-pi): verify cleanup with explicit barriers

### DIFF
--- a/plugins/ca-pi/tools/test/runner-isolation.test.ts
+++ b/plugins/ca-pi/tools/test/runner-isolation.test.ts
@@ -21,6 +21,7 @@ const runnerMocks = vi.hoisted(() => {
   const cleanupReady = vi.fn(async () => true);
   return {
     spawn,
+    environmentCleanupStarted: vi.fn(),
     randomUUID: vi.fn(() => "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"),
     // The runner draws two 16-byte values (nonce, challenge) that the attestation digest pins,
     // so those stay deterministic. The #455 broker draws a 32-byte token; it must stay a REAL
@@ -62,6 +63,23 @@ vi.mock("../src/process-tree.ts", async (importOriginal) => ({
   processTreeSpawnOptions: runnerMocks.processTreeSpawnOptions,
   spawnProcessTree: runnerMocks.spawnProcessTree,
 }));
+
+vi.mock("../src/child-env.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/child-env.ts")>();
+  return {
+    ...actual,
+    prepareChildEnvironment: async (...args: Parameters<typeof actual.prepareChildEnvironment>) => {
+      const prepared = await actual.prepareChildEnvironment(...args);
+      return {
+        ...prepared,
+        cleanup: async () => {
+          runnerMocks.environmentCleanupStarted();
+          await prepared.cleanup();
+        },
+      };
+    },
+  };
+});
 
 type RunnerModule = typeof import("../src/runner.ts");
 type RolesModule = typeof import("../src/roles.ts");
@@ -168,6 +186,7 @@ function validationFor(request: object): Record<string, unknown> {
 }
 
 afterEach(async () => {
+  runnerMocks.environmentCleanupStarted.mockClear();
   runnerMocks.spawn.mockReset();
   runnerMocks.cleanupTerminate.mockReset();
   runnerMocks.cleanupTerminate.mockImplementation(async (reason: string) => ({
@@ -940,6 +959,15 @@ describe("Task 6 exact Pi child launch", () => {
     const child = new FakeChild(false);
     const controller = new AbortController();
     const request = await materializedRequest();
+    let releaseCleanup!: () => void;
+    let cleanupStarted!: () => void;
+    const started = new Promise<void>((resolve) => { cleanupStarted = resolve; });
+    const released = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+    runnerMocks.cleanupTerminate.mockImplementation(async (cleanupReason: string) => {
+      cleanupStarted();
+      await released;
+      return { escalated: false, reason: cleanupReason, state: "terminated", verified: true };
+    });
     runnerMocks.spawn.mockImplementation(() => {
       setImmediate(() => {
         trigger(child, controller);
@@ -947,10 +975,22 @@ describe("Task 6 exact Pi child launch", () => {
       });
       return child;
     });
-    const observed = await Promise.race([
-      runPiChild(request as never, controller.signal),
-      new Promise<"unresolved">((resolve) => setTimeout(() => resolve("unresolved"), 250)),
-    ]);
+    let settled = false;
+    const running = runPiChild(request as never, controller.signal).finally(() => { settled = true; });
+    try {
+      await started;
+      // Observe an event-loop turn with cleanup deliberately pending, rather
+      // than charging real validation, filesystem and broker work to 250ms.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      expect(runnerMocks.environmentCleanupStarted).not.toHaveBeenCalled();
+      expect(runnerMocks.cleanupTerminate).toHaveBeenCalledOnce();
+      expect(runnerMocks.cleanupTerminate).toHaveBeenCalledWith(reason);
+    } finally {
+      releaseCleanup();
+      await running;
+    }
+    const observed = await running;
     expect(observed).toEqual({ terminal: "degraded", diagnostic: "Pi child isolation failed safely; no inline promotion is available; run /ca-doctor." });
     expect(runnerMocks.cleanupTerminate).toHaveBeenCalledOnce();
     expect(runnerMocks.cleanupTerminate).toHaveBeenCalledWith(reason);
@@ -969,10 +1009,7 @@ describe("Task 6 exact Pi child launch", () => {
     const timeoutChild = new FakeChild(false);
     runnerMocks.spawn.mockReturnValue(timeoutChild);
     const timeoutRequest = await materializedRequest();
-    const timeoutObserved = await Promise.race([
-      runPiChild({ ...timeoutRequest, timeoutMs: 1 } as never, new AbortController().signal),
-      new Promise<"unresolved">((resolve) => setTimeout(() => resolve("unresolved"), 250)),
-    ]);
+    const timeoutObserved = await runPiChild({ ...timeoutRequest, timeoutMs: 1 } as never, new AbortController().signal);
     expect(timeoutObserved).toEqual(expected);
     expect(runnerMocks.cleanupTerminate).toHaveBeenCalledWith("timeout");
 
@@ -1085,10 +1122,7 @@ describe("Task 6 exact Pi child launch", () => {
     child.close(7);
     runnerMocks.spawn.mockReturnValue(child);
     const request = await materializedRequest();
-    const observed = await Promise.race([
-      runPiChild(request as never, new AbortController().signal),
-      new Promise<"unresolved">((resolve) => setTimeout(() => resolve("unresolved"), 250)),
-    ]);
+    const observed = await runPiChild(request as never, new AbortController().signal);
     expect(observed).toEqual({
       terminal: "degraded",
       diagnostic: "Pi child isolation failed safely; no inline promotion is available; run /ca-doctor.",


### PR DESCRIPTION
## Summary

Replace setup-sensitive 250 ms races in the Pi runner tests with explicit cleanup barriers. Main CI reported `unresolved` even though a controlled reproduction showed the same runner later returning the correct degraded result with exactly one cleanup.

The tests now hold tree cleanup pending and assert that neither the public result nor environment cleanup advances before release. Duplicate failure triggers still terminate once without requiring a close event. A transparent wrapper calls the real environment preparation and cleanup implementations.

Production code, runtime timeouts, and shipped artifacts are unchanged. The exact slow operation in the original hosted run remains unidentified.

## Validation

- Original assertion reproduced red with a 350 ms runtime-identity delay before spawning; the repaired six cases pass with that delay.
- An early-settlement mutation fails all four cleanup cases at the ordering assertion.
- All 37 declared repository commands pass, including 1,457 hook tests with three existing skips.
- Pi suite: 863 passed, one existing skip; package 45 passed, parity 25 passed, documentation 13 passed.
- Typecheck, build, generated-surface checks, secret classification, and scoped provenance checks pass. Build outputs are unchanged; the release guard requires no version bump.
- Independent security and coverage reviews report no findings.

Windows coverage: 86.26% lines and 80.38% branches. Fresh cross-host union and exact-head hosted checks remain required before merge.
