### PR TITLE
fix(release): retain and reconcile tag provenance

### DIFF
--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -44,12 +44,12 @@
     },
     {
       "drift_trigger": true,
-      "hash": "4778082d5ea1466d96a6bb0640eeee58bbb30f0e",
+      "hash": "2c1cc323bc3049f6e6abc5124c167d607667a8b4",
       "path": "plugins/ca-sandbox/.claude-plugin/plugin.json"
     },
     {
       "drift_trigger": true,
-      "hash": "d2a8c793bcaaceb3649a06076a27533f79eb7161",
+      "hash": "e214498b4883046287d7dcb15c63014a287dfb27",
       "path": "plugins/ca-sandbox/CHANGELOG.md"
     },
     {

--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -4,27 +4,27 @@
   "entries": [
     {
       "drift_trigger": true,
-      "hash": "0a68be53eabb5e3959f8cd4c3983452ebc49c1ea",
+      "hash": "92badd2d5da20c8df75c0c86ff6e25ab62189ca7",
       "path": "CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "f745b3e9f4dcadc1254a1f127b5c6a04fc552629",
+      "hash": "92c47bfc2e70b22f0896b7c0b6f42f1cf1e448bf",
       "path": "package.json"
     },
     {
       "drift_trigger": true,
-      "hash": "41539528862d39da0df0ac313be3a21f68db2084",
+      "hash": "f3b69f207d61457fdc1fa82786df4b926d2f12e1",
       "path": "plugins/ca-codex/.codex-plugin/plugin.json"
     },
     {
       "drift_trigger": true,
-      "hash": "8773d1247120be481f7fceb192e6115bbc5929c8",
+      "hash": "ff348451ca37735a2d0c0efb60f5d7a9f39c5296",
       "path": "plugins/ca-codex/CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "a68d16c8f66ec31f0ef547c2523c6146c8e92b00",
+      "hash": "a94397fa5ab4d023f3a25d06a014a3b532b01221",
       "path": "plugins/ca-pi/CHANGELOG.md"
     },
     {
@@ -39,7 +39,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "4abd158ac9cf28f3f1f90750017f0c16079d9049",
+      "hash": "3ef5a5ae7d0a8654058c27aa668288ca646cd2d6",
       "path": "plugins/ca-pi/package.json"
     },
     {
@@ -64,7 +64,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "ad192c049e8d23bc06816fb75f7b46182f824e8a",
+      "hash": "53cde6f1c76b1251da390757f6ae47a9359e0527",
       "path": "plugins/ca/.claude-plugin/plugin.json"
     },
     {

--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -59,7 +59,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "937c440af255c8b6aa97a4edcd4283ec7130c665",
+      "hash": "801cc127704b6da8afaff4c429b343f6bab10e48",
       "path": "plugins/ca-sandbox/tools/sandbox.js"
     },
     {

--- a/.github/RELEASE-PROVENANCE.md
+++ b/.github/RELEASE-PROVENANCE.md
@@ -1,0 +1,84 @@
+# Release tag provenance
+
+Published tags never move or disappear. A bad release is corrected by a new
+version, not by changing a recorded identity or retargeting a tag.
+
+The release preflight uses `check_tag_immutability.py --require-recorded` before
+authorizing publication. Missing records or unreadable evidence refuse release.
+Ordinary CI remains an observation: it warns about unrecorded tags and reports
+an explicit skip on unavailable inventory. An automatic run with no eligible
+release does not require a new publication check.
+
+## Capture and retain
+
+The shared publisher captures the exact remote tag object and peeled commit,
+bound to the repository, workflow revision, run ID, and run attempt. Capture and
+artifact upload are attempted even when tag push succeeds but Release creation
+fails. A capture or upload failure is a failed step, not a successful recording.
+Cancellation or loss of the runner can still prevent retention; inspect the
+actual artifact, not just the workflow definition.
+
+Artifacts are named
+`tag-publication-<job>-<run-id>-<run-attempt>` with a requested retention of
+90 days, subject to repository and organization policy. Check the artifact's
+actual expiration and reconcile it through a reviewed PR before it expires and
+before another release.
+Neither the receipt nor the reconciliation helper writes to `main`.
+
+The schema calls this a `hosted-tag-observation`. It proves what a trusted run
+observed, not necessarily where an older tag originally pointed. In particular,
+rerunning capture on an old unrecorded tag cannot manufacture its original
+publication provenance. Preserve unresolved historical gaps separately.
+
+## Authenticate before reconciliation
+
+The offline helper does **not** authenticate a downloaded JSON file. Before
+using it, independently verify all of the following through GitHub's trusted
+Actions run and artifact metadata:
+
+- The run belongs to this repository's release workflow
+  (`.github/workflows/release.yml`), not a pull-request or fork-controlled workflow.
+- Its workflow source revision is the reviewed, protected-main revision expected
+  for that release. Check the workflow identity, event, branch, revision, run ID,
+  and attempt; a matching artifact name alone is insufficient.
+- The artifact belongs to that exact run and attempt and the expected publisher
+  job. Download it from that run, retaining the artifact metadata and digest.
+- The expected tag and commit come from the authorized release record, not from
+  fields supplied by the downloaded receipt. Verify that current remote refs
+  still agree before proposing the ledger addition.
+
+If the original run, artifact, or identity evidence is unavailable or ambiguous,
+stop reconciliation and preserve that uncertainty. Do not substitute current
+refs for original publication evidence or amend an existing entry to hide drift.
+
+## Produce a reviewable candidate
+
+Use an isolated branch with a clean ledger. Hash its exact current bytes using
+SHA-256. Supply independently verified values for every `expected-*` argument;
+do not fill them by copying fields out of the untrusted receipt.
+
+```sh
+python .github/scripts/reconcile_tag_receipt.py \
+  --receipt /path/to/authenticated-receipt.json \
+  --manifest .github/published-tags.json \
+  --output /path/to/new-candidate.json \
+  --expected-manifest-sha256 <current-ledger-sha256> \
+  --expected-repo arbiterForge/codeArbiter \
+  --expected-tag <authorized-tag> \
+  --expected-commit <authorized-commit> \
+  --expected-run-id <verified-run-id> \
+  --expected-run-attempt <verified-attempt> \
+  --expected-workflow-sha <verified-workflow-revision>
+```
+
+The helper validates bounded JSON and exact bindings, rejects conflicting or
+malformed data, and produces an exclusive candidate containing one new identity.
+It preserves existing entries and metadata. An already identical entry is a
+no-op with no output file; an existing output is never replaced. The manifest
+digest prevents accidentally reconciling against a stale source snapshot.
+
+Review the candidate against the original ledger. Apply only the verified
+addition through the governed commit and PR path, retain the authenticated run
+and artifact evidence in that PR, and run the tag audit and its tests. A candidate
+file or a green unit test is not proof of hosted artifact authenticity, successful
+publication, PR merge, or completion of other historical recording obligations.

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -138,6 +138,7 @@ runs:
         echo "---- notes.md ----"; head -1 notes.md
 
     - name: Create the tag and GitHub Release (resumable, mismatch-aborting)
+      id: publish
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -253,6 +254,33 @@ runs:
             exit 1
             ;;
         esac
+
+    # A push can succeed before Release creation fails. Preserve the observed
+    # identity in that case too; never infer a successful publication from it.
+    # Reconciliation requires this run's trusted artifact and a reviewed PR.
+    - name: Capture published tag identity receipt
+      id: receipt
+      if: ${{ always() && steps.publish.outcome != 'skipped' && steps.v.outputs.tag != '' }}
+      shell: bash
+      env:
+        TAG: ${{ steps.v.outputs.tag }}
+        RECEIPT_PATH: ${{ runner.temp }}/tag-publication-${{ github.job }}-${{ github.run_attempt }}.json
+      run: |
+        set -euo pipefail
+        python3 .github/scripts/tag_publication_receipt.py capture \
+          --repo "$GITHUB_REPOSITORY" --tag "$TAG" \
+          --expected-commit "$GITHUB_SHA" --workflow-sha "$GITHUB_SHA" \
+          --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT" \
+          --output "$RECEIPT_PATH"
+
+    - name: Retain published tag identity receipt
+      if: ${{ always() && steps.receipt.outcome != 'skipped' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: tag-publication-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ${{ runner.temp }}/tag-publication-${{ github.job }}-${{ github.run_attempt }}.json
+        if-no-files-found: error
+        retention-days: 90
 
     - name: Verify the published Release names this tag at this commit
       shell: bash

--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -616,6 +616,21 @@
       "object_sha": "3a9f853b1cc92f12e541bbc7fdae382f489f4e6d",
       "object_type": "tag"
     },
+    "v2.17.1": {
+      "object_sha": "09718969bd3cac2dd6ec5a3196782139cbf60664",
+      "object_type": "tag",
+      "commit_sha": "8f10a511fe8aca51d8e8c75d58c7fbf7c12f029b"
+    },
+    "ca-codex-v0.9.1": {
+      "object_sha": "842b3a373ca3ebc7653b3948ed684061a651b0e1",
+      "object_type": "tag",
+      "commit_sha": "8f10a511fe8aca51d8e8c75d58c7fbf7c12f029b"
+    },
+    "ca-pi-v0.10.2": {
+      "object_sha": "b6d8524f73ba0c3a000103d9714b956418151392",
+      "object_type": "tag",
+      "commit_sha": "8f10a511fe8aca51d8e8c75d58c7fbf7c12f029b"
+    },
     "ca-pi-v0.1.32": {
       "object_sha": "f9027d5ba53ca0918e50b4df866f687262256c13",
       "object_type": "tag",

--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -33,6 +33,11 @@ read`, which GITHUB_TOKEN does grant, so it runs LIVE in ordinary CI rather than
 skipping by default.  The skip path exists for transport failures, rate limits,
 and local runs without a token - never as the normal case.
 
+RELEASE PREFLIGHT. --require-recorded is deliberately stricter: it refuses
+missing credentials, unreadable inventory, or any unrecorded governed tag.
+Ordinary observation policy is unchanged. A new tag is recorded afterward from
+its trusted run receipt through a reviewed PR, before another release is allowed.
+
 READ-ONLY.  Paginated GETs against `/git/refs/tags`.  Nothing is written, and a
 partial listing is discarded rather than audited, because tags missing from a
 truncated page would otherwise read as deletions.
@@ -68,7 +73,7 @@ MAX_PAGES = 50
 # A published tag is a namespace prefix followed by a SemVer core, optionally
 # with a pre-release or build suffix (`v2.1.0-beta.2` is a real published tag).
 # Requiring the version shape is what stops `v*` from swallowing `versioned-*`.
-_VERSION = r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?"
+_VERSION = r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
 _GOVERNED = re.compile(
     "^(?:%s)$" % "|".join(re.escape(ns[:-1]) + _VERSION for ns in NAMESPACES)
 )
@@ -133,9 +138,8 @@ def audit(recorded: dict[str, Provenance], live: dict[str, str] | None) -> list[
 def unrecorded(recorded: dict[str, Provenance], live: dict[str, str]) -> list[str]:
     """Governed tags on the remote that the manifest does not yet record.
 
-    This is the NORMAL state right after a release, so it is a notice and never
-    a finding - but an unrecorded tag is an unguarded tag, so it is said out
-    loud until the release adds it.
+    This is expected immediately after a release. Ordinary CI warns; strict
+    release preflight refuses to authorize another release until it is recorded.
     """
     return sorted(
         name for name in live if is_governed(name) and name not in recorded
@@ -167,10 +171,25 @@ def read_live_tags(repo: str, *, rest) -> dict[str, str] | None:
         if status != 200 or not isinstance(payload, list):
             return None
         for ref in payload:
-            name = str(ref.get("ref", "")).removeprefix("refs/tags/")
-            sha = (ref.get("object") or {}).get("sha")
-            if name and sha:
-                tags[name] = sha
+            if not isinstance(ref, dict):
+                return None
+            full_name = ref.get("ref")
+            obj = ref.get("object")
+            if not isinstance(full_name, str) or not full_name.startswith("refs/tags/"):
+                return None
+            if not isinstance(obj, dict):
+                return None
+            name = full_name.removeprefix("refs/tags/")
+            sha = obj.get("sha")
+            if (
+                not name or name in tags or not isinstance(sha, str)
+                or re.fullmatch(r"[0-9a-f]{40}", sha) is None
+                # Working tags may legally label blobs or trees. Their presence
+                # must not turn a definite release-tag drift into a skipped audit.
+                or obj.get("type") not in ("tag", "commit", "blob", "tree")
+            ):
+                return None
+            tags[name] = sha
         if len(payload) < PER_PAGE:
             return tags
     return None
@@ -222,14 +241,24 @@ def main(argv=None, *, token=None, rest=None, recorded=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
     parser.add_argument("--manifest", default=str(MANIFEST_PATH))
+    parser.add_argument(
+        "--require-recorded", action="store_true",
+        help="Refuse release when prior tag records are incomplete or cannot be verified.",
+    )
     arguments = parser.parse_args(argv)
 
     if token is None:
         token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
     if not arguments.repo:
+        if arguments.require_recorded:
+            print("::error title=Tag provenance::release requires a repository to verify")
+            return 1
         print("SKIP: no --repo and no GITHUB_REPOSITORY; nothing to audit.")
         return 0
     if not token and rest is None:
+        if arguments.require_recorded:
+            print("::error title=Tag provenance::release requires authenticated tag evidence")
+            return 1
         print(_SKIP_NOTE)
         print(f"::notice title=Tag immutability::skipped for {arguments.repo} - no GH_TOKEN")
         return 0
@@ -250,14 +279,21 @@ def main(argv=None, *, token=None, rest=None, recorded=None) -> int:
     if findings:
         return 1
     if live is None:
+        if arguments.require_recorded:
+            print("::error title=Tag provenance::release requires a complete live tag inventory")
+            return 1
         return 0
 
-    for name in unrecorded(provenance, live):
+    missing = unrecorded(provenance, live)
+    for name in missing:
+        level = "error" if arguments.require_recorded else "warning"
         print(
-            f"::warning title=Unrecorded published tag::{name} is published but "
+            f"::{level} title=Unrecorded published tag::{name} is published but "
             f"absent from {MANIFEST_PATH.name}, so its target is not being "
             "verified. Add it in the release that published it (issue #386)."
         )
+    if missing and arguments.require_recorded:
+        return 1
     print(
         f"OK: {len(provenance)} published tags in {arguments.repo} still resolve "
         "to the commits they were published at."

--- a/.github/scripts/reconcile_tag_receipt.py
+++ b/.github/scripts/reconcile_tag_receipt.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# codeArbiter — prepare a reviewed, append-only tag provenance candidate.
+# OFFLINE CANDIDATE ONLY: this neither authenticates receipt provenance nor edits
+# the source manifest. Before invoking it, the caller MUST authenticate the
+# downloaded artifact and its repository, workflow, run and attempt independently,
+# then supply those expected values from that trusted evidence. JSON claims are
+# not authority. A hosted observation does not establish original tag history.
+#
+# reconcile(manifest, receipt, expected) -> dict | None: pure append or no-op.
+# main(argv=None) -> int: bounded input verification and exclusive candidate write.
+
+import copy
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+
+from tag_publication_receipt import REPO_RE, _Parser, _output_path, _positive_integer, _sha, _tag
+
+
+RECEIPT_LIMIT = 16 * 1024
+MANIFEST_LIMIT = 2 * 1024 * 1024
+IDENTITY_KEYS = {"object_sha", "object_type", "commit_sha"}
+EXPECTED_KEYS = {"repo", "tag", "commit", "run_id", "run_attempt", "workflow_sha"}
+
+
+def _keys(value, wanted):
+    if not isinstance(value, dict) or set(value) != wanted:
+        raise ValueError("invalid object schema")
+
+
+def _identity(value, *, exact=False):
+    if not isinstance(value, dict) or not IDENTITY_KEYS.issubset(value):
+        raise ValueError("invalid tag identity")
+    if exact:
+        _keys(value, IDENTITY_KEYS)
+    _sha(value["object_sha"])
+    _sha(value["commit_sha"])
+    if value["object_type"] not in ("tag", "commit"):
+        raise ValueError("invalid object type")
+    if value["object_type"] == "commit" and value["object_sha"] != value["commit_sha"]:
+        raise ValueError("inconsistent direct commit identity")
+    return {key: value[key] for key in IDENTITY_KEYS}
+
+
+def _bindings(value):
+    _keys(value, EXPECTED_KEYS)
+    repo = value["repo"]
+    if (not isinstance(repo, str) or not REPO_RE.fullmatch(repo)
+            or repo.split("/")[1] in (".", "..") or repo.split("/")[0].endswith("-")):
+        raise ValueError("invalid repository identity")
+    _tag(value["tag"])
+    _sha(value["commit"])
+    _sha(value["workflow_sha"])
+    for key in ("run_id", "run_attempt"):
+        if type(value[key]) is not int or not 0 < value[key] < 10 ** 20:
+            raise ValueError("invalid hosted run identity")
+
+
+def reconcile(manifest, receipt, expected):
+    """Validate all history, then produce one append without mutating inputs."""
+    _bindings(expected)
+    _keys(receipt, {"schema_version", "repo", "tag", "identity", "source"})
+    if type(receipt["schema_version"]) is not int or receipt["schema_version"] != 1:
+        raise ValueError("unsupported receipt schema")
+    source = receipt["source"]
+    _keys(source, {"kind", "run_id", "run_attempt", "workflow_sha"})
+    if source["kind"] != "hosted-tag-observation":
+        raise ValueError("unsupported evidence kind")
+    identity = _identity(receipt["identity"], exact=True)
+    actual = {"repo": receipt["repo"], "tag": receipt["tag"], "commit": identity["commit_sha"],
+              "run_id": source["run_id"], "run_attempt": source["run_attempt"],
+              "workflow_sha": source["workflow_sha"]}
+    _bindings(actual)
+    if actual != expected:
+        raise ValueError("receipt does not match independently supplied bindings")
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("tags"), dict):
+        raise ValueError("invalid manifest")
+    for tag, entry in manifest["tags"].items():
+        _tag(tag)
+        _identity(entry)
+    tag = expected["tag"]
+    if tag in manifest["tags"]:
+        if _identity(manifest["tags"][tag]) != identity:
+            raise ValueError("existing tag identity conflicts; history cannot be replaced")
+        return None
+    result = copy.deepcopy(manifest)
+    result["tags"][tag] = identity
+    return result
+
+
+def _read_bytes(path, limit):
+    # Inputs and output live in caller-controlled private directories. Reject
+    # static link/reparse aliases; hostile same-user filesystem races are outside
+    # this cooperative offline tool's boundary, not claimed atomic protection.
+    path = Path(os.path.abspath(path))
+    for item in (path, *path.parents):
+        info = item.lstat()
+        if stat.S_ISLNK(info.st_mode) or getattr(info, "st_file_attributes", 0) & 0x400:
+            raise ValueError("unsafe input path")
+    if not stat.S_ISREG(path.stat().st_mode):
+        raise ValueError("input is not a regular file")
+    with path.open("rb") as stream:
+        if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+            raise ValueError("input is not a regular file")
+        data = stream.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError("input exceeds size limit")
+    return data
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _nonfinite(value):
+    raise ValueError("nonfinite JSON number")
+
+
+def _finite_float(value):
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("nonfinite JSON number")
+    return result
+
+
+def _decode(data):
+    document = json.loads(data.decode("utf-8"), object_pairs_hook=_unique_object,
+                          parse_constant=_nonfinite, parse_float=_finite_float)
+    if not isinstance(document, dict):
+        raise ValueError("JSON root must be an object")
+    return document
+
+
+def _write_candidate(output, payload, verify_current):
+    # No partial candidate or overwrite, even when a collision appears after
+    # validation. Recheck the source after writing/fsync and immediately before
+    # exclusive publication. This detects drift, not adversarial lock-free races.
+    descriptor, temporary = tempfile.mkstemp(prefix=".tag-candidate-", dir=output.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        verify_current()
+        os.link(temporary, output)
+    finally:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            print("tag candidate: temporary file cleanup failed", file=sys.stderr)
+
+
+def _arguments(argv):
+    parser = _Parser(description="Prepare an offline candidate from independently authenticated evidence",
+                     allow_abbrev=False)
+    flags = ("receipt", "manifest", "output", "expected-manifest-sha256", "expected-repo",
+             "expected-tag", "expected-commit", "expected-run-id", "expected-run-attempt",
+             "expected-workflow-sha")
+    for flag in flags:
+        parser.add_argument("--" + flag, required=True)
+    values = list(sys.argv[1:] if argv is None else argv)
+    if len(values) > 20 or any(len(value) > 4096 for value in values):
+        raise ValueError("invalid candidate arguments")
+    for flag in flags:
+        if sum(value == "--" + flag or value.startswith("--" + flag + "=")
+               for value in values) > 1:
+            raise ValueError("duplicate candidate arguments")
+    return parser.parse_args(values)
+
+
+def main(argv=None):
+    """Create a review candidate, never an authenticated or installed baseline."""
+    try:
+        args = _arguments(argv)
+    except ValueError:
+        print("tag candidate: invalid arguments", file=sys.stderr)
+        return 2
+    try:
+        if not re.fullmatch(r"[0-9a-f]{64}", args.expected_manifest_sha256):
+            raise ValueError("invalid expected manifest digest")
+        expected = {"repo": args.expected_repo, "tag": args.expected_tag,
+                    "commit": args.expected_commit,
+                    "run_id": _positive_integer(args.expected_run_id),
+                    "run_attempt": _positive_integer(args.expected_run_attempt),
+                    "workflow_sha": args.expected_workflow_sha}
+        _bindings(expected)
+        output = _output_path(args.output)
+        manifest_bytes = _read_bytes(args.manifest, MANIFEST_LIMIT)
+        if hashlib.sha256(manifest_bytes).hexdigest() != args.expected_manifest_sha256:
+            raise ValueError("stale manifest digest")
+        receipt = _decode(_read_bytes(args.receipt, RECEIPT_LIMIT))
+        result = reconcile(_decode(manifest_bytes), receipt, expected)
+
+        def verify_current():
+            if _read_bytes(args.manifest, MANIFEST_LIMIT) != manifest_bytes:
+                raise ValueError("manifest changed during reconciliation")
+
+        if result is None:
+            verify_current()
+            return 0
+        payload = (json.dumps(result, indent=2, ensure_ascii=True, allow_nan=False) + "\n").encode("utf-8")
+        if len(payload) > MANIFEST_LIMIT:
+            raise ValueError("candidate exceeds manifest size limit")
+        _write_candidate(output, payload, verify_current)
+    except (ValueError, OSError, RecursionError):
+        print("tag candidate: validation failed; no new candidate accepted", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tag_publication_receipt.py
+++ b/.github/scripts/tag_publication_receipt.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# codeArbiter — capture an exact hosted tag observation.
+# This is a current observation, NOT proof of original publication. The caller
+# owns the trusted checkout/origin, hosted metadata, and private output directory.
+# No tag is created, moved, or deleted. Diagnostics never include transport data.
+#
+# parse_remote_refs(text, tag, expected_commit) -> dict: strict identity parser.
+# main(argv=None, *, run=None) -> int: capture CLI, injectable Git boundary.
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+
+
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+REPO_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9_.-]{1,100}")
+NUMBER = r"(?:0|[1-9][0-9]*)"
+PRERELEASE = r"(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+TAG_RE = re.compile(
+    rf"(?:ca-(?:sandbox|codex|pi)-)?v{NUMBER}\.{NUMBER}\.{NUMBER}"
+    rf"(?:-{PRERELEASE}(?:\.{PRERELEASE})*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
+MAX_REF_OUTPUT = 4096
+
+
+def _sha(value):
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value) or value == "0" * 40:
+        raise ValueError("invalid commit or object identity")
+    return value
+
+
+def _tag(value):
+    if not isinstance(value, str) or len(value) > 256 or not TAG_RE.fullmatch(value):
+        raise ValueError("invalid governed version tag")
+    return value
+
+
+def _positive_integer(value):
+    if not re.fullmatch(r"[1-9][0-9]{0,19}", value):
+        raise ValueError("invalid hosted run metadata")
+    return int(value)
+
+def parse_remote_refs(text, tag, expected_commit):
+    """Reject any observation other than one exact ref and optional peeled ref."""
+    _tag(tag)
+    _sha(expected_commit)
+    if not isinstance(text, str) or not text or len(text) > MAX_REF_OUTPUT:
+        raise ValueError("missing or oversized remote observation")
+    ref = "refs/tags/" + tag
+    records = text.removesuffix("\n").split("\n")
+    if len(records) not in (1, 2):
+        raise ValueError("ambiguous remote observation")
+    observed = {}
+    for record in records:
+        fields = record.split("\t")
+        if len(fields) != 2:
+            raise ValueError("malformed remote observation")
+        object_sha, name = fields
+        _sha(object_sha)
+        if name not in (ref, ref + "^{}") or name in observed:
+            raise ValueError("unexpected or duplicate remote ref")
+        observed[name] = object_sha
+    if ref not in observed:
+        raise ValueError("missing exact remote ref")
+    commit_sha = observed.get(ref + "^{}", observed[ref])
+    if commit_sha != expected_commit:
+        raise ValueError("remote commit does not match expected commit")
+    return {"object_sha": observed[ref],
+            "object_type": "tag" if ref + "^{}" in observed else "commit",
+            "commit_sha": commit_sha}
+
+
+def _output_path(value):
+    if not value or len(value) > 4096 or any(ord(char) < 32 for char in value):
+        raise ValueError("invalid output path")
+    path = Path(os.path.abspath(value))
+    # Inspect lexical ancestors without resolving links. The hosted output root
+    # must be private: these checks do not defend against same-user rename races.
+    for parent in path.parents:
+        info = parent.lstat()
+        if not stat.S_ISDIR(info.st_mode) or getattr(info, "st_file_attributes", 0) & 0x400:
+            raise ValueError("unsafe output parent")
+    if os.path.lexists(path):
+        raise ValueError("output already exists")
+    return path
+
+
+def _write_exclusive(path, payload):
+    # Linking a fully-written file provides no-replace publication on Windows and
+    # POSIX. Unsupported filesystems fail closed; never downgrade to overwrite.
+    descriptor, temporary = tempfile.mkstemp(prefix=".tag-receipt-", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            # A complete, exclusively published receipt remains valid even if
+            # its temporary hardlink cannot be removed. Never call that failure.
+            print("tag receipt: temporary file cleanup failed", file=sys.stderr)
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message):
+        # argparse's normal error message can repeat caller-supplied values.
+        raise ValueError("invalid capture arguments")
+
+
+def _arguments(argv):
+    parser = _Parser(description="Capture a hosted tag observation (not original publication proof)",
+                     allow_abbrev=False)
+    parser.add_argument("command", choices=("capture",))
+    flags = ("repo", "tag", "expected-commit", "run-id", "run-attempt", "workflow-sha", "output")
+    for flag in flags:
+        parser.add_argument("--" + flag, required=True)
+    values = list(sys.argv[1:] if argv is None else argv)
+    if len(values) > 15 or any(len(value) > 4096 for value in values):
+        raise ValueError("invalid capture arguments")
+    # Exactly one of each required flag; repeated metadata must not be last-wins.
+    for flag in flags:
+        if sum(value == "--" + flag or value.startswith("--" + flag + "=")
+               for value in values) > 1:
+            raise ValueError("duplicate capture argument")
+    return parser.parse_args(values)
+
+
+def main(argv=None, *, run=None):
+    """Capture immutable local evidence only after all claims and refs validate."""
+    try:
+        args = _arguments(argv)
+    except ValueError:
+        print("tag receipt: invalid capture arguments", file=sys.stderr)
+        return 2
+    try:
+        if (not REPO_RE.fullmatch(args.repo) or args.repo.split("/")[1] in (".", "..")
+                or args.repo.split("/")[0].endswith("-")):
+            raise ValueError("invalid repository identity")
+        _tag(args.tag)
+        _sha(args.expected_commit)
+        _sha(args.workflow_sha)
+        run_id = _positive_integer(args.run_id)
+        run_attempt = _positive_integer(args.run_attempt)
+        output = _output_path(args.output)
+        ref = "refs/tags/" + args.tag
+        runner = subprocess.run if run is None else run
+        result = runner(["git", "ls-remote", "--tags", "origin", ref, ref + "^{}"],
+                        stdin=subprocess.DEVNULL, capture_output=True, text=True,
+                        encoding="ascii", errors="strict", timeout=30, check=False, shell=False)
+        if result.returncode != 0:
+            raise ValueError("remote observation failed")
+        identity = parse_remote_refs(result.stdout, args.tag, args.expected_commit)
+        document = {"schema_version": 1, "repo": args.repo, "tag": args.tag, "identity": identity,
+                    "source": {"kind": "hosted-tag-observation", "run_id": run_id,
+                               "run_attempt": run_attempt, "workflow_sha": args.workflow_sha}}
+        payload = (json.dumps(document, sort_keys=True, indent=2) + "\n").encode("utf-8")
+        _write_exclusive(output, payload)
+    except (ValueError, OSError, subprocess.SubprocessError):
+        print("tag receipt: capture failed; no new observation accepted", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_reconcile_tag_receipt.py
+++ b/.github/scripts/test_reconcile_tag_receipt.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# codeArbiter — offline provenance candidate regression tests (LG03).
+
+import contextlib
+import copy
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import reconcile_tag_receipt as candidate
+
+
+COMMIT = "a" * 40
+OBJECT = "b" * 40
+WORKFLOW = "c" * 40
+TAG = "ca-codex-v0.7.5"
+IDENTITY = {"object_sha": OBJECT, "object_type": "tag", "commit_sha": COMMIT}
+EXPECTED = {"repo": "arbiterForge/codeArbiter", "tag": TAG, "commit": COMMIT,
+            "run_id": 123, "run_attempt": 2, "workflow_sha": WORKFLOW}
+RECEIPT = {"schema_version": 1, "repo": EXPECTED["repo"], "tag": TAG,
+           "identity": IDENTITY, "source": {"kind": "hosted-tag-observation",
+           "run_id": 123, "run_attempt": 2, "workflow_sha": WORKFLOW}}
+MANIFEST = {"$comment": ["Historical metadata remains unchanged."],
+            "verified_at": "2026-08-08", "namespaces": ["v*", "ca-codex-v*"],
+            "extension": {"arbitrary": [1, True, None, "kept"]},
+            "tags": {"v1.0.0": {"object_sha": "d" * 40, "object_type": "commit",
+                     "commit_sha": "d" * 40, "note": "preserve per-entry metadata"}}}
+
+
+class ReconcileTests(unittest.TestCase):
+    # LG03-APPEND: preserve every prior field and add precisely one identity.
+    def test_append_preserves_metadata_entries_and_inputs(self):
+        manifest, receipt = copy.deepcopy(MANIFEST), copy.deepcopy(RECEIPT)
+        result = candidate.reconcile(manifest, receipt, EXPECTED)
+        wanted = copy.deepcopy(MANIFEST)
+        wanted["tags"][TAG] = IDENTITY
+        self.assertEqual(result, wanted)
+        self.assertEqual(manifest, MANIFEST)
+        self.assertEqual(receipt, RECEIPT)
+
+    # LG03-NOOP: equal identity is idempotent; conflict never updates history.
+    def test_equal_existing_identity_is_noop_preserving_extra_metadata(self):
+        manifest = copy.deepcopy(MANIFEST)
+        manifest["tags"][TAG] = {**IDENTITY, "note": "untouched"}
+        self.assertIsNone(candidate.reconcile(manifest, RECEIPT, EXPECTED))
+
+    def test_conflicting_existing_identity_refuses(self):
+        for field, value in (("object_sha", "e" * 40), ("commit_sha", "e" * 40),
+                             ("object_type", "commit")):
+            with self.subTest(field=field):
+                manifest = copy.deepcopy(MANIFEST)
+                manifest["tags"][TAG] = {**IDENTITY, field: value}
+                with self.assertRaises(ValueError):
+                    candidate.reconcile(manifest, RECEIPT, EXPECTED)
+
+    # LG03-BIND: caller expectations are required, not copied from receipt claims.
+    def test_every_expected_binding_must_match(self):
+        for field, value in (("repo", "other/repo"), ("tag", "v1.0.1"), ("commit", "d" * 40),
+                             ("run_id", 124), ("run_attempt", 3), ("workflow_sha", "d" * 40)):
+            with self.subTest(field=field):
+                with self.assertRaises(ValueError):
+                    candidate.reconcile(MANIFEST, RECEIPT, {**EXPECTED, field: value})
+
+    def test_exact_receipt_schema_and_types(self):
+        variants = []
+        for field, value in (("schema_version", True), ("schema_version", 2),
+                             ("repo", None), ("tag", "v01.0.0"), ("identity", []), ("source", [])):
+            variants.append({**RECEIPT, field: value})
+        variants.extend([{**RECEIPT, "extra": 1}, {k: v for k, v in RECEIPT.items() if k != "tag"}])
+        for field, value in (("kind", "original-publication"), ("run_id", True), ("run_id", "123"),
+                             ("run_attempt", 0), ("workflow_sha", WORKFLOW.upper()), ("extra", 1)):
+            variants.append({**RECEIPT, "source": {**RECEIPT["source"], field: value}})
+        for field, value in (("object_sha", "0" * 40), ("object_type", "blob"),
+                             ("commit_sha", "A" * 40), ("extra", 1)):
+            variants.append({**RECEIPT, "identity": {**IDENTITY, field: value}})
+        variants.append({**RECEIPT, "identity": {**IDENTITY, "object_type": "commit"}})
+        for receipt in variants:
+            with self.subTest(receipt=receipt):
+                with self.assertRaises(ValueError):
+                    candidate.reconcile(MANIFEST, receipt, EXPECTED)
+
+    # LG03-HISTORY: validate all existing identities, not only the proposed entry.
+    def test_invalid_existing_manifest_entries_refuse(self):
+        entries = [None, [], {}, {**IDENTITY, "object_sha": "0" * 40},
+                   {**IDENTITY, "object_type": "blob"}, {**IDENTITY, "commit_sha": "no"},
+                   {**IDENTITY, "object_type": "commit"}]
+        for entry in entries:
+            with self.subTest(entry=entry):
+                manifest = copy.deepcopy(MANIFEST)
+                manifest["tags"]["v1.0.0"] = entry
+                with self.assertRaises(ValueError):
+                    candidate.reconcile(manifest, RECEIPT, EXPECTED)
+        for manifest in ([], {}, {"tags": []}, {"tags": {"invalid": IDENTITY}}):
+            with self.subTest(manifest=manifest):
+                with self.assertRaises(ValueError):
+                    candidate.reconcile(manifest, RECEIPT, EXPECTED)
+
+
+class CliTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.receipt = self.root / "receipt.json"
+        self.manifest = self.root / "manifest.json"
+        self.output = self.root / "candidate.json"
+        self.receipt.write_text(json.dumps(RECEIPT), encoding="utf-8")
+        self.manifest.write_text(json.dumps(MANIFEST, indent=3) + "\n", encoding="utf-8")
+
+    def args(self):
+        result = ["--receipt", str(self.receipt), "--manifest", str(self.manifest),
+                  "--output", str(self.output), "--expected-manifest-sha256",
+                  hashlib.sha256(self.manifest.read_bytes()).hexdigest()]
+        for key, value in EXPECTED.items():
+            result.extend(["--expected-" + key.replace("_", "-"), str(value)])
+        return result
+
+    def invoke(self, args=None):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            result = candidate.main(self.args() if args is None else args)
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    # LG03-CLI: real external Python CLI, no network or process mock.
+    def test_real_cli_creates_candidate_and_preserves_source_bytes(self):
+        originals = self.manifest.read_bytes(), self.receipt.read_bytes()
+        result = subprocess.run([sys.executable, str(Path(candidate.__file__)), *self.args()],
+                                capture_output=True, text=True, timeout=15)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        expected = copy.deepcopy(MANIFEST)
+        expected["tags"][TAG] = IDENTITY
+        self.assertEqual(json.loads(self.output.read_bytes()), expected)
+        self.assertEqual((self.manifest.read_bytes(), self.receipt.read_bytes()), originals)
+
+    def test_equal_receipt_noop_creates_no_output(self):
+        manifest = copy.deepcopy(MANIFEST)
+        manifest["tags"][TAG] = IDENTITY
+        self.manifest.write_text(json.dumps(manifest), encoding="utf-8")
+        original = self.manifest.read_bytes()
+        for _ in range(2):
+            self.assertEqual(self.invoke()[0], 0)
+            self.assertFalse(self.output.exists())
+            self.assertEqual(self.manifest.read_bytes(), original)
+
+    # LG03-JSON: bounded strict JSON, including nested duplicate keys/nonfinite values.
+    def test_malformed_json_refuses_without_candidate(self):
+        for path in (self.receipt, self.manifest):
+            original = path.read_bytes()
+            for payload in (b"[]", b"null", b"{", b'{"tags":{},"tags":{}}',
+                            b'{"nested":{"x":1,"x":2}}', b'{"n":NaN}',
+                            b'{"n":Infinity}', b'{"n":1e999}', b"\xff"):
+                with self.subTest(path=path.name, payload=payload):
+                    path.write_bytes(payload)
+                    self.assertEqual(self.invoke()[0], 1)
+                    self.assertFalse(self.output.exists())
+            path.write_bytes(original)
+
+    def test_oversize_documents_refuse(self):
+        for path, bound in ((self.receipt, 16 * 1024), (self.manifest, 2 * 1024 * 1024)):
+            original = path.read_bytes()
+            path.write_bytes(b" " * (bound + 1))
+            self.assertEqual(self.invoke()[0], 1)
+            self.assertFalse(self.output.exists())
+            path.write_bytes(original)
+
+    # LG03-STALE: expected source bytes and recheck at publication are mandatory.
+    def test_stale_or_malformed_expected_digest_refuses(self):
+        for digest in ("d" * 64, "A" * 64, "x", "0" * 63):
+            args = self.args()
+            args[args.index("--expected-manifest-sha256") + 1] = digest
+            self.assertEqual(self.invoke(args)[0], 1)
+            self.assertFalse(self.output.exists())
+
+    def test_manifest_change_while_candidate_is_being_written_refuses(self):
+        args = self.args()
+        changed = self.manifest.read_bytes() + b" "
+        with patch.object(os, "fsync", side_effect=lambda _: self.manifest.write_bytes(changed)):
+            self.assertEqual(self.invoke(args)[0], 1)
+        self.assertFalse(self.output.exists())
+        self.assertEqual(self.manifest.read_bytes(), changed)
+        self.assertEqual(sorted(p.name for p in self.root.iterdir()), ["manifest.json", "receipt.json"])
+
+    # LG03-EXCLUSIVE: no overwrite, aliases or symlink output escape.
+    def test_output_cannot_replace_input_or_existing_output(self):
+        self.output.write_text("prior candidate", encoding="utf-8")
+        for path in (self.output, self.manifest, self.receipt):
+            original = path.read_bytes()
+            args = self.args()
+            args[args.index("--output") + 1] = str(path)
+            self.assertEqual(self.invoke(args)[0], 1)
+            self.assertEqual(path.read_bytes(), original)
+
+    def test_symlink_input_and_output_refuse(self):
+        link = self.root / "link"
+        try:
+            link.symlink_to(self.manifest)
+        except OSError as error:
+            self.skipTest(f"Symlink unavailable: {error.errno}")
+        for flag in ("--manifest", "--output"):
+            args = self.args()
+            args[args.index(flag) + 1] = str(link)
+            self.assertEqual(self.invoke(args)[0], 1)
+            self.assertFalse(self.output.exists())
+
+    def test_missing_duplicate_unknown_cli_flags_refuse(self):
+        for args in ([], self.args()[:-2], self.args() + ["--unknown"],
+                     self.args() + ["--expected-run-id", "123"]):
+            self.assertEqual(self.invoke(args)[0], 2)
+            self.assertFalse(self.output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -34,6 +34,7 @@ contract in this directory. The two execution classes need a POSIX shell and
 so are skipped on Windows — the structural classes above run everywhere, and
 the hooks job's ubuntu/macos cells run all of it.
 """
+import json
 import os
 import re
 import shutil
@@ -1853,6 +1854,73 @@ class NameKeyedTargetSelectionTest(unittest.TestCase):
 
 
 @POSIX_ONLY
+class TagReceiptExecutionTest(_ShellHarness):
+    """Run the shipped capture shell and helper with only Git transport faked.
+
+    GitHub's always-step scheduling/upload is structurally checked separately;
+    this fixture cannot prove the external artifact service retained anything.
+    """
+
+    def _sandbox(self):
+        root = super()._sandbox()
+        scripts = root / ".github/scripts"
+        shutil.copy(HERE / "tag_publication_receipt.py", scripts / "_fixture_tag_receipt.py")
+        shutil.copy(HERE / "check_tag_immutability.py", scripts / "check_tag_immutability.py")
+        (scripts / "tag_publication_receipt.py").write_text(
+            "import os, subprocess, sys\n"
+            "from _fixture_tag_receipt import main\n"
+            "def run(args, **kwargs):\n"
+            "    tag = os.environ['TAG']\n"
+            "    assert args == ['git', 'ls-remote', '--tags', 'origin', "
+            "'refs/tags/' + tag, 'refs/tags/' + tag + '^{}']\n"
+            "    commit = os.environ.get('STUB_RECEIPT_COMMIT', os.environ['GITHUB_SHA'])\n"
+            "    refs = 'a' * 40 + '\\trefs/tags/' + tag + '\\n'\n"
+            "    refs += commit + '\\trefs/tags/' + tag + '^{}\\n'\n"
+            "    return subprocess.CompletedProcess(args, 0, refs, '')\n"
+            "sys.exit(main(run=run))\n",
+            encoding="utf-8", newline="\n")
+        self.receipt_path = root / "receipt.json"
+        return root
+
+    def _capture(self, *, before="", overrides=None):
+        env = {"TAG": "v9.9.9", "RECEIPT_PATH": "receipt.json",
+               "GITHUB_RUN_ID": "12345", "GITHUB_RUN_ATTEMPT": "2",
+               "VER": "9.9.9", "SUMMARY": "", "TITLE_PREFIX": "codeArbiter",
+               "MARK_LATEST": "false"}
+        env.update(overrides or {})
+        return self._run(before + _action_step("Capture published tag identity receipt"), env=env)
+
+    def test_capture_binds_remote_identity_and_hosted_run(self):
+        proc, _, _ = self._capture()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        receipt = json.loads(self.receipt_path.read_text(encoding="utf-8"))
+        self.assertEqual(receipt["repo"], "arbiterForge/codeArbiter")
+        self.assertEqual(receipt["tag"], "v9.9.9")
+        self.assertEqual(receipt["identity"], {"object_sha": "a" * 40,
+                         "object_type": "tag", "commit_sha": self.HEAD})
+        self.assertEqual(receipt["source"], {"kind": "hosted-tag-observation",
+                         "run_id": 12345, "run_attempt": 2, "workflow_sha": self.HEAD})
+
+    def test_capture_runs_after_push_succeeds_but_release_creation_fails(self):
+        # Execute the real publish body with a failed Release API mutation.
+        # Then model the separately asserted always-step scheduling.
+        before = (
+            "gh() { if [ \"$1\" = api ]; then printf '[[]]\\n'; else return 1; fi; }\n"
+            "set +e\n(\n" + _action_step("Create the tag and GitHub Release") +
+            "\n)\nPUBLISH_EXIT=$?\n[ \"$PUBLISH_EXIT\" -ne 0 ] || exit 99\n")
+        proc, log, _ = self._capture(before=before)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("git push origin refs/tags/v9.9.9", log)
+        self.assertTrue(self.receipt_path.is_file())
+        self.assertEqual(json.loads(self.receipt_path.read_text())["identity"]["commit_sha"], self.HEAD)
+
+    def test_capture_refuses_wrong_commit_without_a_receipt(self):
+        proc, _, _ = self._capture(overrides={"STUB_RECEIPT_COMMIT": "b" * 40})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertFalse(self.receipt_path.exists())
+
+
+@POSIX_ONLY
 class DeclaredPreTagExecutionTest(_ShellHarness):
     """AC-6.8/2.1-2.3: release authorization executes declared checks, not CI.
 
@@ -1863,6 +1931,20 @@ class DeclaredPreTagExecutionTest(_ShellHarness):
 
     def _sandbox(self):
         root = super()._sandbox()
+        # Exercise the real checker and CLI; replace only its network input.
+        # The empty fixture inventory is not evidence about production tags.
+        scripts = root / ".github/scripts"
+        shutil.copy(HERE / "check_tag_immutability.py", scripts / "_fixture_tag_checker.py")
+        (scripts / "check_tag_immutability.py").write_text(
+            "import os, sys\n"
+            "from _fixture_tag_checker import main\n"
+            "def rest(path):\n"
+            "    print('PROVENANCE-CHECK', flush=True)\n"
+            "    if os.environ.get('STUB_PROVENANCE_UNAVAILABLE') == '1':\n"
+            "        return 503, {}\n"
+            "    return 200, []\n"
+            "sys.exit(main(rest=rest, recorded={}))\n",
+            encoding="utf-8", newline="\n")
         shutil.copy(REPO_ROOT / "core/pysrc/_gitexec.py", root / "core/pysrc/_gitexec.py")
         declared = root / ".codearbiter/release-targets.md"
         text = re.sub(r"(?m)^pre-tag:.*\n", "", declared.read_text(encoding="utf-8"))
@@ -1903,7 +1985,35 @@ class DeclaredPreTagExecutionTest(_ShellHarness):
         env.update(overrides or {})
         step = ("Resolve exactly one release target" if lane == "preflight"
                 else "Determine which targets have untagged work")
-        return self._run(_step_run(lane, step), env=env)
+        script = _step_run(lane, step)
+        if lane == "preflight":
+            # GitHub stops the job on a failed earlier step. Model that
+            # boundary explicitly when composing the two real shell bodies.
+            script = "set -e\n" + _step_run(lane, "Require complete prior tag provenance") + "\n" + script
+        return self._run(script, env=env)
+
+    def test_unavailable_provenance_never_emits_publication_authority(self):
+        self.commands = {}
+        for lane in ("preflight", "auto-preflight"):
+            with self.subTest(lane=lane):
+                proc, log, out = self._authorize(
+                    lane, overrides={"STUB_PROVENANCE_UNAVAILABLE": "1"})
+                self.assertNotEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+                self.assertIn("release requires a complete live tag inventory", proc.stdout)
+                self.assertEqual(out, "")
+                self.assertNotIn("git push", log)
+
+    def test_auto_noop_does_not_require_publication_provenance(self):
+        self.commands = {}
+        tags = "v9.9.9\nca-codex-v9.9.9\nca-sandbox-v9.9.9\nca-pi-v9.9.9\n"
+        proc, log, out = self._authorize(
+            "auto-preflight", tags=tags,
+            overrides={"STUB_PROVENANCE_UNAVAILABLE": "1"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("PROVENANCE-CHECK", proc.stdout)
+        self.assertEqual(out, "ca=false\nca-codex=false\nca-sandbox=false\nca-pi=false\n"
+                             "ca-pi-version=9.9.9\n")
+        self.assertNotIn("git push", log)
 
     def test_manual_checks_are_ordered_target_scoped_and_credential_free(self):
         self.commands = {target: [f'"$PY" check.py {target}-first',

--- a/.github/scripts/test_suite_hermeticity.py
+++ b/.github/scripts/test_suite_hermeticity.py
@@ -160,6 +160,22 @@ class TestSuitesStayInsideTheirTempDirs(unittest.TestCase):
             with self.subTest(suite=name):
                 self.assert_home_untouched(name, command)
 
+    def test_color_suites_isolate_and_restore_ambient_no_color(self):
+        # Color assertions must establish their own rendering environment;
+        # intentional NO_COLOR behavior is still tested inside these modules.
+        for value in ("", "1"):
+            with self.subTest(no_color=value):
+                script = (
+                    "import os,sys,unittest;"
+                    f"os.environ['NO_COLOR']={value!r};"
+                    "sys.path.insert(0,'plugins/ca/hooks/tests');"
+                    "suite=unittest.TestSuite([unittest.defaultTestLoader.loadTestsFromName(name) "
+                    "for name in ('test_colorlib','test_statusline')]);"
+                    "result=unittest.TextTestRunner().run(suite);"
+                    f"assert os.environ.get('NO_COLOR')=={value!r}, 'ambient NO_COLOR was not restored';"
+                    "sys.exit(not result.wasSuccessful())")
+                self.assert_home_untouched("color environment isolation", [sys.executable, "-c", script])
+
 
 class TestTheSuiteLeaksNoHandlesOrProcesses(unittest.TestCase):
     """Issue #462 — the intermittent-red half.

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -18,6 +18,7 @@ import io
 import json
 import re
 import unittest
+from unittest.mock import patch
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -212,7 +213,7 @@ class ShippedManifest(unittest.TestCase):
     def setUp(self):
         self.manifest = json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
 
-    def test_the_manifest_records_every_currently_published_tag(self):
+    def test_the_manifest_retains_at_least_the_original_inventory(self):
         self.assertGreaterEqual(len(self.manifest["tags"]), 26)
 
     def test_every_recorded_tag_is_governed_and_fully_specified(self):
@@ -282,9 +283,162 @@ class CommandLine(unittest.TestCase):
         self.assertIn("::error", output)
         self.assertIn("v2.8.13", output)
 
+    def test_legal_working_tag_types_cannot_hide_a_moved_release(self):
+        page = [{"ref": f"refs/tags/{name}", "object": {"sha": _MOVED, "type": "tag"}}
+                for name in RECORDED]
+        for object_type in ("blob", "tree"):
+            with self.subTest(object_type=object_type):
+                inventory = page + [{"ref": "refs/tags/working-object", "object": {
+                    "sha": "d" * 40, "type": object_type}}]
+                code, output = self._run(token="t", rest=lambda path: (200, inventory), recorded=RECORDED)
+                self.assertEqual(code, 1)
+                self.assertIn("MOVED", output)
+                self.assertNotIn("SKIP", output)
+
+
+class StrictReleaseObservation(unittest.TestCase):
+    """LG01: unavailable or incomplete prior provenance cannot authorize release."""
+
+    def _run(self, **kwargs):
+        arguments = module.argparse.Namespace(
+            repo="owner/name", manifest=str(module.MANIFEST_PATH), require_recorded=True,
+        )
+        buffer = io.StringIO()
+        # Isolate the decision from CLI spelling so the baseline fails on its
+        # permissive result, not on argparse rejecting a not-yet-added option.
+        with patch.object(module.argparse.ArgumentParser, "parse_args", return_value=arguments):
+            with redirect_stdout(buffer):
+                result = module.main([], **kwargs)
+        return result, buffer.getvalue()
+
+    def test_missing_credentials_refuses_release(self):
+        code, output = self._run(token="")
+        self.assertEqual(1, code)
+        self.assertIn("::error", output)
+
+    def test_prerelease_with_build_metadata_requires_a_record(self):
+        tag = "ca-pi-v1.2.3-rc.1+build.4"
+        page = [{"ref": "refs/tags/" + tag, "object": {"sha": "a" * 40, "type": "tag"}}]
+        code, output = self._run(token="t", recorded={}, rest=lambda path: (200, page))
+        self.assertEqual(code, 1)
+        self.assertIn(tag, output)
+
+    def test_real_cli_checks_clean_missing_and_moved_inventory(self):
+        page = [{"ref": f"refs/tags/{name}", "object": {
+            "sha": entry["object_sha"], "type": entry["object_type"]}}
+            for name, entry in RECORDED.items()]
+        missing = page + [{"ref": "refs/tags/v99.0.0", "object": {
+            "sha": "a" * 40, "type": "tag"}}]
+        moved = [dict(row, object={"sha": "b" * 40, "type": "tag"}) for row in page]
+        for inventory, expected in ((page, 0), (missing, 1), (moved, 1)):
+            with self.subTest(expected=expected, inventory=inventory):
+                with redirect_stdout(io.StringIO()):
+                    result = module.main(["--repo", "owner/name", "--require-recorded"],
+                                         token="t", recorded=RECORDED,
+                                         rest=lambda path: (200, inventory))
+                self.assertEqual(result, expected)
+
+    def test_real_cli_refuses_absent_repository(self):
+        with redirect_stdout(io.StringIO()) as output:
+            result = module.main(["--repo", "", "--require-recorded"], token="")
+        self.assertEqual(result, 1)
+        self.assertIn("release requires a repository", output.getvalue())
+
+    def test_partial_later_page_never_authorizes_release(self):
+        page = [{"ref": f"refs/tags/v1.0.{index}", "object": {
+            "sha": "a" * 40, "type": "tag"}} for index in range(module.PER_PAGE)]
+        pages = [(200, page), (503, {})]
+        code, output = self._run(token="t", recorded={}, rest=lambda path: pages.pop(0))
+        self.assertEqual(code, 1)
+        self.assertEqual(pages, [])
+        self.assertIn("complete live tag inventory", output)
+
+    def test_malformed_inventory_shapes_fail_closed(self):
+        valid = {"ref": "refs/tags/v1.0.0", "object": {"sha": "a" * 40, "type": "tag"}}
+        invalid = [None, [], "ref", {"ref": 1, "object": valid["object"]},
+                   {"ref": "refs/heads/v1.0.0", "object": valid["object"]},
+                   {"ref": "refs/tags/", "object": valid["object"]},
+                   dict(valid, object=None), dict(valid, object={"sha": 4, "type": "tag"}),
+                   dict(valid, object={"sha": "A" * 40, "type": "tag"}),
+                   dict(valid, object={"sha": "a" * 39, "type": "tag"}),
+                   dict(valid, object={"sha": "a" * 40, "type": "unknown"})]
+        for row in invalid:
+            with self.subTest(row=row):
+                code, output = self._run(token="t", recorded={}, rest=lambda path: (200, [row]))
+                self.assertEqual(code, 1)
+                self.assertIn("complete live tag inventory", output)
+
+    def test_unavailable_inventory_refuses_release(self):
+        code, output = self._run(token="t", rest=lambda path: (503, {}), recorded=RECORDED)
+        self.assertEqual(1, code)
+        self.assertIn("::error", output)
+
+    def test_unrecorded_tag_refuses_release(self):
+        page = [
+            {"ref": f"refs/tags/{name}", "object": {"sha": entry["object_sha"], "type": entry["object_type"]}}
+            for name, entry in RECORDED.items()
+        ]
+        page.append({"ref": "refs/tags/v9.0.0", "object": {"sha": "a" * 40, "type": "tag"}})
+        code, output = self._run(token="t", rest=lambda path: (200, page), recorded=RECORDED)
+        self.assertEqual(1, code)
+        self.assertIn("::error", output)
+        self.assertIn("v9.0.0", output)
+
+    def test_malformed_or_duplicate_inventory_cannot_authorize_release(self):
+        page = [
+            {"ref": f"refs/tags/{name}", "object": {"sha": entry["object_sha"], "type": entry["object_type"]}}
+            for name, entry in RECORDED.items()
+        ]
+        for extra in ({}, page[0]):
+            with self.subTest(extra=extra):
+                code, output = self._run(
+                    token="t", rest=lambda path: (200, page + [extra]), recorded=RECORDED,
+                )
+                self.assertEqual(1, code)
+                self.assertIn("::error", output)
+
 
 class RepositoryWiring(unittest.TestCase):
     """The audit is only a control if something runs it and something says so."""
+
+    def test_release_preflights_require_prior_tag_records(self):
+        workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        for job in ("preflight", "auto-preflight"):
+            with self.subTest(job=job):
+                body = re.search(
+                    rf"(?ms)^  {re.escape(job)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+                    workflow,
+                )
+                self.assertIsNotNone(body, f"missing release preflight {job}")
+                self.assertIn("check_tag_immutability.py", body.group(1))
+                self.assertIn("--require-recorded", body.group(1))
+
+    def test_publisher_retains_tag_identity_receipt_after_partial_failure(self):
+        action = (REPO_ROOT / ".github/actions/publish-release/action.yml").read_text(encoding="utf-8")
+        self.assertIn("Capture published tag identity receipt", action)
+        receipt_steps = action.split("Capture published tag identity receipt", 1)[1]
+        self.assertIn("always()", receipt_steps)
+        self.assertIn("actions/upload-artifact@", receipt_steps)
+        self.assertIn("if-no-files-found: error", receipt_steps)
+
+    def test_receipt_capture_precedes_readback_and_survives_publish_failure(self):
+        action = (REPO_ROOT / ".github/actions/publish-release/action.yml").read_text(encoding="utf-8")
+        self.assertIn("id: publish", action)
+        capture = re.search(
+            r"(?ms)^    - name: Capture published tag identity receipt\n(.*?)(?=^    - |\Z)", action)
+        self.assertIsNotNone(capture, "publication identity must survive a later release failure")
+        body = capture.group(1)
+        self.assertIn("always()", body)
+        self.assertIn("steps.publish.outcome != 'skipped'", body)
+        self.assertNotIn("steps.publish.outcome == 'success'", body)
+        self.assertIn("tag_publication_receipt.py", body)
+        for flag in ("--repo", "--tag", "--expected-commit", "--run-id",
+                     "--run-attempt", "--workflow-sha", "--output"):
+            self.assertIn(flag, body)
+        self.assertLess(action.index("Capture published tag identity receipt"),
+                        action.index("Verify the published Release names"))
+        self.assertLess(action.index("actions/upload-artifact@"),
+                        action.index("Verify the published Release names"))
 
     def test_the_audit_runs_in_a_job_registered_in_the_merge_gate(self):
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
@@ -300,6 +454,16 @@ class RepositoryWiring(unittest.TestCase):
         # The audit skips without a token, so its offline unit tests are the
         # part that is always binding.
         self.assertIn("test_tag_immutability.py", CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    def test_receipt_logic_tests_are_registered_in_required_audit_job(self):
+        job = CI_WORKFLOW.read_text(encoding="utf-8").split("  tag-immutability:", 1)[1].split("  branch-protection:", 1)[0]
+        self.assertTrue("python .github/scripts/test_tag_publication_receipt.py" in job,
+                        "required tag audit must exercise receipt capture failures offline")
+
+    def test_reconciliation_tests_are_registered_in_required_audit_job(self):
+        job = CI_WORKFLOW.read_text(encoding="utf-8").split("  tag-immutability:", 1)[1].split("  branch-protection:", 1)[0]
+        self.assertTrue("python .github/scripts/test_reconcile_tag_receipt.py" in job,
+                        "required tag audit must exercise append-only reconciliation offline")
 
     def test_the_release_skill_documents_recovery_as_a_new_version(self):
         # AC-4.  The people who could move a tag are the people reading this

--- a/.github/scripts/test_tag_publication_receipt.py
+++ b/.github/scripts/test_tag_publication_receipt.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# codeArbiter — exact hosted tag observation regression tests (LG02).
+
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import tag_publication_receipt as receipt
+
+
+COMMIT = "a" * 40
+OBJECT = "b" * 40
+WORKFLOW = "c" * 40
+TAG = "ca-codex-v0.7.5"
+REF = "refs/tags/" + TAG
+DIRECT = f"{COMMIT}\t{REF}\n"
+ANNOTATED = f"{OBJECT}\t{REF}\n{COMMIT}\t{REF}^{{}}\n"
+
+
+class ParserTests(unittest.TestCase):
+    # LG02-IDENTITY: exact object and dereferenced commit, without normalization.
+    def test_lightweight_identity(self):
+        self.assertEqual(receipt.parse_remote_refs(DIRECT, TAG, COMMIT), {
+            "object_sha": COMMIT, "object_type": "commit", "commit_sha": COMMIT,
+        })
+
+    def test_annotated_identity_in_either_order(self):
+        for text in (ANNOTATED, "\n".join(reversed(ANNOTATED.splitlines())) + "\n"):
+            with self.subTest(text=text):
+                self.assertEqual(receipt.parse_remote_refs(text, TAG, COMMIT), {
+                    "object_sha": OBJECT, "object_type": "tag", "commit_sha": COMMIT,
+                })
+
+    # LG02-REFS: no absent, ambiguous, malformed, extra or oversized observations.
+    def test_rejects_untrusted_ref_shapes(self):
+        cases = ["", "\n", DIRECT * 2, ANNOTATED + DIRECT,
+                 f"{COMMIT}\t{REF}^{{}}\n", DIRECT + f"{COMMIT}\trefs/tags/v1.0.0\n",
+                 DIRECT.replace("\t", " "), DIRECT.replace(COMMIT, "g" * 40),
+                 DIRECT.replace(COMMIT, COMMIT.upper()), DIRECT.replace(COMMIT, "0" * 40),
+                 DIRECT.replace(COMMIT, "a" * 39), DIRECT + "\n", " " + DIRECT,
+                 DIRECT + "x" * 4096, DIRECT.replace("\n", "\r\n"),
+                 DIRECT.replace(REF, REF + "-extra")]
+        for text in cases:
+            with self.subTest(text=text[:100]):
+                with self.assertRaises(ValueError):
+                    receipt.parse_remote_refs(text, TAG, COMMIT)
+
+    def test_rejects_expected_commit_mismatch(self):
+        for text in (DIRECT, ANNOTATED):
+            with self.subTest(text=text):
+                with self.assertRaises(ValueError):
+                    receipt.parse_remote_refs(text, TAG, "d" * 40)
+
+    def test_rejects_invalid_parser_identity_arguments(self):
+        for tag, commit in (("other-v1.0.0", COMMIT), (TAG, "0" * 40),
+                            (TAG, "x"), (TAG + "\n", COMMIT)):
+            with self.subTest(tag=tag, commit=commit):
+                with self.assertRaises(ValueError):
+                    receipt.parse_remote_refs(DIRECT, tag, commit)
+
+
+class CliTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.output = Path(self.temp.name) / "receipt.json"
+        self.args = ["capture", "--repo", "arbiterForge/codeArbiter", "--tag", TAG,
+                     "--expected-commit", COMMIT, "--run-id", "12345",
+                     "--run-attempt", "2", "--workflow-sha", WORKFLOW,
+                     "--output", str(self.output)]
+        self.runner = Mock(return_value=subprocess.CompletedProcess([], 0, ANNOTATED, ""))
+
+    def invoke(self, args=None):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            result = receipt.main(self.args if args is None else args, run=self.runner)
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    # LG02-BINDING: real argument parser + JSON serialization, only Git mocked.
+    def test_cli_writes_complete_bound_json_and_exact_bounded_query(self):
+        result, stdout, stderr = self.invoke()
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(self.output.read_text(encoding="utf-8")), {
+            "schema_version": 1, "repo": "arbiterForge/codeArbiter", "tag": TAG,
+            "identity": {"object_sha": OBJECT, "object_type": "tag", "commit_sha": COMMIT},
+            "source": {"kind": "hosted-tag-observation", "run_id": 12345,
+                       "run_attempt": 2, "workflow_sha": WORKFLOW},
+        })
+        command = self.runner.call_args.args[0]
+        self.assertEqual(command, ["git", "ls-remote", "--tags", "origin", REF, REF + "^{}"])
+        options = self.runner.call_args.kwargs
+        self.assertEqual(options["timeout"], 30)
+        self.assertIs(options["shell"], False)
+        self.assertEqual(options["stdin"], subprocess.DEVNULL)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "")
+
+    def test_cli_accepts_each_governed_namespace(self):
+        for tag in ("v1.0.0", "ca-sandbox-v1.0.0", "ca-codex-v1.0.0", "ca-pi-v1.0.0",
+                    "v1.0.0-rc.1+build.3"):
+            with self.subTest(tag=tag):
+                args = self.args.copy()
+                args[args.index("--tag") + 1] = tag
+                self.runner.return_value.stdout = f"{COMMIT}\trefs/tags/{tag}\n"
+                self.assertEqual(self.invoke(args)[0], 0)
+                self.assertEqual(json.loads(self.output.read_text())["tag"], tag)
+                self.output.unlink()
+
+    # LG02-METADATA: malformed/oversized claims stop before observation and output.
+    def test_cli_rejects_bad_metadata_without_query(self):
+        cases = {"--repo": ("repo", "a/b/c", "../repo", "a/..", "a/b\n", "a/" + "b" * 101),
+                 "--tag": ("v01.0.0", "v1.0", "v1.0.0-01", "other-v1.0.0", "v1.0.0\n",
+                           "v1.0.0+" + "a" * 256),
+                 "--expected-commit": ("0" * 40, "a" * 39, "A" * 40),
+                 "--workflow-sha": ("x", "0" * 40, "C" * 40),
+                 "--run-id": ("0", "-1", "01", "1.1", "9" * 21),
+                 "--run-attempt": ("0", "-1", "01", "1\n")}
+        for flag, values in cases.items():
+            for value in values:
+                with self.subTest(flag=flag, value=value):
+                    args = self.args.copy()
+                    args[args.index(flag) + 1] = value
+                    self.assertEqual(self.invoke(args)[0], 1)
+                    self.runner.assert_not_called()
+                    self.assertFalse(self.output.exists())
+
+    def test_cli_rejects_missing_and_unknown_arguments(self):
+        for args in ([], self.args[:-2], self.args + ["--unknown"],
+                     self.args + ["--repo", "other/repo"]):
+            with self.subTest(args=args):
+                self.assertEqual(self.invoke(args)[0], 2)
+                self.runner.assert_not_called()
+                self.assertFalse(self.output.exists())
+
+    # LG02-FAIL-CLOSED: failed observations emit only fixed, non-secret diagnostics.
+    def test_process_failure_timeout_and_spawn_errors_leave_no_receipt(self):
+        secret = "DUMMY_PRIVATE_TRANSPORT_DETAIL"
+        cases = [subprocess.CompletedProcess([], 1, ANNOTATED, secret),
+                 subprocess.TimeoutExpired("git " + secret, 30, output=secret, stderr=secret),
+                 OSError(secret), UnicodeDecodeError("ascii", b"\xff", 0, 1, secret)]
+        for outcome in cases:
+            with self.subTest(outcome=type(outcome).__name__):
+                self.runner.side_effect = outcome if isinstance(outcome, Exception) else None
+                self.runner.return_value = outcome
+                result, stdout, stderr = self.invoke()
+                self.assertEqual(result, 1)
+                self.assertNotIn(secret, stdout + stderr)
+                self.assertFalse(self.output.exists())
+
+    def test_bad_remote_or_mismatched_commit_leaves_no_receipt(self):
+        for text in ("", DIRECT * 2, DIRECT.replace(COMMIT, "d" * 40), "x" * 4097):
+            with self.subTest(text=text[:100]):
+                self.runner.return_value.stdout = text
+                self.assertEqual(self.invoke()[0], 1)
+                self.assertFalse(self.output.exists())
+
+    # LG02-EXCLUSIVE: collisions and unsafe paths cannot replace prior evidence.
+    def test_existing_output_is_not_overwritten(self):
+        self.output.write_text("prior evidence", encoding="utf-8")
+        self.assertEqual(self.invoke()[0], 1)
+        self.assertEqual(self.output.read_text(), "prior evidence")
+
+    def test_missing_parent_or_directory_output_fails(self):
+        for output in (self.output / "missing.json", Path(self.temp.name)):
+            with self.subTest(output=output):
+                args = self.args[:-1] + [str(output)]
+                self.assertEqual(self.invoke(args)[0], 1)
+                self.assertFalse(self.output.exists())
+
+    def test_symlink_leaf_and_parent_are_rejected(self):
+        target = Path(self.temp.name) / "target"
+        target.mkdir()
+        link = Path(self.temp.name) / "link"
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except OSError as error:
+            self.skipTest(f"Symlink creation unavailable on this host: {error.errno}")
+        for output in (link, link / "receipt.json"):
+            with self.subTest(output=output):
+                self.assertEqual(self.invoke(self.args[:-1] + [str(output)])[0], 1)
+                self.assertEqual(list(target.iterdir()), [])
+
+    def test_output_io_failure_leaves_no_receipt(self):
+        with patch.object(os, "fsync", side_effect=OSError("DUMMY_IO_DETAIL")):
+            result, stdout, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertFalse(self.output.exists())
+        self.assertNotIn("DUMMY_IO_DETAIL", stdout + stderr)
+        self.assertEqual(list(Path(self.temp.name).iterdir()), [])
+
+    def test_cleanup_failure_cannot_report_valid_published_receipt_as_failure(self):
+        with patch.object(os, "unlink", side_effect=OSError("DUMMY_CLEANUP_DETAIL")):
+            result, stdout, stderr = self.invoke()
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(self.output.read_text())["identity"]["commit_sha"], COMMIT)
+        self.assertNotIn("DUMMY_CLEANUP_DETAIL", stdout + stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2269,6 +2269,10 @@ jobs:
         # tokenless, and they pin the drift and deletion verdicts against a
         # recorded copy of the live tag provenance.
         run: python .github/scripts/test_tag_immutability.py
+      - name: Test publication identity receipt capture
+        run: python .github/scripts/test_tag_publication_receipt.py
+      - name: Test append-only receipt reconciliation
+        run: python .github/scripts/test_reconcile_tag_receipt.py
 
   branch-protection:
     name: "[CHECK] | [REPO] | Branch protection"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,12 @@ jobs:
             exit 1
           fi
 
+      - name: Require complete prior tag provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/check_tag_immutability.py --repo "$GITHUB_REPOSITORY" --require-recorded
+
       - name: Resolve exactly one release target
         id: target
         env:
@@ -428,6 +434,7 @@ jobs:
       - name: Determine which targets have untagged work
         id: eligible
         env:
+          GH_TOKEN: ${{ github.token }}
           UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
           UPSTREAM_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           UPSTREAM_BRANCH: ${{ github.event.workflow_run.head_branch }}
@@ -452,6 +459,7 @@ jobs:
           TAGS=$(git tag -l)
           PYTHON=$(python3 -c 'import sys; print(sys.executable)')
           OUTPUTS=()
+          ANY_ELIGIBLE=false
           for row in \
             "ca plugins/ca/.claude-plugin/plugin.json v" \
             "ca-codex plugins/ca-codex/.codex-plugin/plugin.json ca-codex-v" \
@@ -465,6 +473,7 @@ jobs:
               | python3 .github/scripts/_releaselib.py auto-eligible "$VERSION" "$PREFIX")
             echo "$TARGET: manifest=$VERSION eligible=$ELIGIBLE"
             if [ "$ELIGIBLE" = "true" ]; then
+              ANY_ELIGIBLE=true
               # Same canonical, check-only release guard as manual dispatch;
               # ineligible siblings need no new per-release evidence.
               env -i PATH="$PATH" SYSTEMROOT="${SYSTEMROOT:-}" \
@@ -475,6 +484,9 @@ jobs:
               OUTPUTS+=("ca-pi-version=$VERSION")
             fi
           done
+          if [ "$ANY_ELIGIBLE" = true ]; then
+            python3 .github/scripts/check_tag_immutability.py --repo "$GITHUB_REPOSITORY" --require-recorded
+          fi
           # A late target failure must not leave earlier authorizations behind.
           printf '%s\n' "${OUTPUTS[@]}" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.17.2] - 2026-09-04
+
+### Fixed
+
+- Retain release tag identity receipts and refuse subsequent publication when prior tag provenance is incomplete.
+
+### Changed
+
+- Isolate rendering tests from ambient color settings and verify that they restore the caller's environment without modifying user state.
+
 ## [2.17.1] - 2026-09-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.1`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.2`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.17.1" src="https://img.shields.io/badge/version-2.17.1-2b7489">
+<img alt="version 2.17.2" src="https://img.shields.io/badge/version-2.17.2-2b7489">
 <img alt="core lanes" src="https://img.shields.io/badge/core_lanes-18-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-19-555">

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.1"
+    adapter_version = "2.17.2"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the generated codeArbiter governance surface plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail), sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-09-04
+
+### Changed
+
+- Synchronize the shared host kernel's adapter identity metadata with the Claude adapter version.
+
 ## [0.9.1] - 2026-09-03
 
 ### Fixed

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -178,7 +178,7 @@ class CodexHost(hostapi.Host):
 
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.9.1"
+    adapter_version = "0.9.2"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.1"
+    adapter_version = "2.17.2"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-09-04
+
+### Changed
+
+- Synchronize the shared host kernel's adapter identity metadata with the Claude adapter version.
+
 ## [0.10.2] - 2026-09-03
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.2"
+    adapter_version = "0.10.3"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.1"
+    adapter_version = "2.17.2"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-sandbox/.claude-plugin/plugin.json
+++ b/plugins/ca-sandbox/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca-sandbox",
   "displayName": "codeArbiter Sandbox",
   "description": "Locally-hosted Codespace equivalent for codeArbiter. Pulls an untrusted repo into an ephemeral, isolated Docker container with no host-filesystem access and configurable egress, caches dependencies by content hash, then tears the box down. Requires Docker and nixpacks on PATH.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": { "name": "arbiterForge" },
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/arbiterForge/codeArbiter",

--- a/plugins/ca-sandbox/CHANGELOG.md
+++ b/plugins/ca-sandbox/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the **ca-sandbox** plugin are recorded here. Format follo
 
 ---
 
+## [0.1.6] - 2026-09-04 - Image-build stage diagnostics
+
+### Fixed
+- **Hosted Docker failures identify the active build stage.** The real build/cache/rebuild contract now emits only fixed, coarse stage labels while an image operation is in flight, so an outer timeout no longer erases whether inspection, builder probing, or the selected build path stalled. Normal callers remain silent, existing deadlines and command data are unchanged, and both synchronous and asynchronous observer failures are contained.
+
 ## [0.1.5] — 2026-07-24 — Teardown failures are surfaced and fail
 
 ### Added

--- a/plugins/ca-sandbox/tools/build.test.ts
+++ b/plugins/ca-sandbox/tools/build.test.ts
@@ -22,7 +22,7 @@
  *      new tag, and proves baked deps resolve from /deps at runtime. It namespaces
  *      and cleans up every docker object it creates.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { dockerGate } from "./docker-gate.ts";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, readFileSync } from "node:fs";
@@ -256,8 +256,9 @@ d("buildOrReuseImage [docker] — real build, cache, rebuild (AC-04/AC-05)", () 
     ];
     // Namespace the dephash with the task id so other tasks' images never collide.
     const hash1 = "t05" + computeDepHash(manifests, "fallback").slice(0, 9);
+    const reportStage = (stage: string) => process.stderr.write(`ca-sandbox build stage: ${stage}\n`);
 
-    const r1: BuildResult = await buildOrReuseImage(repoDir, hash1);
+    const r1: BuildResult = await buildOrReuseImage(repoDir, hash1, undefined, reportStage);
     created.push(r1.tag);
     expect(r1.tag).toBe(imageTag(repoDir, hash1));
     expect(r1.built).toBe(true);
@@ -283,7 +284,7 @@ d("buildOrReuseImage [docker] — real build, cache, rebuild (AC-04/AC-05)", () 
     expect(envCheck.stdout).toMatch(/\/deps\/node_modules/);
 
     // Unchanged rerun: SAME tag, NO build.
-    const r2 = await buildOrReuseImage(repoDir, hash1);
+    const r2 = await buildOrReuseImage(repoDir, hash1, undefined, reportStage);
     expect(r2.tag).toBe(r1.tag);
     expect(r2.reused).toBe(true);
     expect(r2.built).toBe(false);
@@ -294,7 +295,7 @@ d("buildOrReuseImage [docker] — real build, cache, rebuild (AC-04/AC-05)", () 
       "fallback",
     ).slice(0, 9);
     expect(hash2).not.toBe(hash1);
-    const r3 = await buildOrReuseImage(repoDir, hash2);
+    const r3 = await buildOrReuseImage(repoDir, hash2, undefined, reportStage);
     created.push(r3.tag);
     expect(r3.tag).not.toBe(r1.tag);
     expect(r3.built).toBe(true);
@@ -317,6 +318,115 @@ d("buildOrReuseImage [docker] — real build, cache, rebuild (AC-04/AC-05)", () 
 // also the two most likely to hang - and the only ones with no escape.
 // ---------------------------------------------------------------------------
 describe("#394 - build.ts's spawn is bounded too", () => {
+  it("remains silent when no diagnostic sink is supplied", async () => {
+    const stdout = vi.spyOn(process.stdout, "write");
+    const stderr = vi.spyOn(process.stderr, "write");
+    const deps: BuildDeps = {
+      imageInspect: async () => 0,
+      runBuild: async () => ({ code: 0, out: "" }),
+      nixpacksVersion: async () => "1.40.0",
+      ensureNixpacks: async () => ({ available: true }),
+    };
+    try {
+      await buildOrReuseImage("/tmp/no-diagnostic", "deadbeef0000", deps);
+      expect(stdout).not.toHaveBeenCalled();
+      expect(stderr).not.toHaveBeenCalled();
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+    }
+  });
+
+  it("reports a fixed image-inspect stage before the injected effect settles", async () => {
+    const sentinel = "opaque-user-input-must-never-escape";
+    const stages: string[] = [];
+    let inspectStarted = false;
+    let releaseInspect!: () => void;
+    const deps: BuildDeps = {
+      imageInspect: () => new Promise<number>((resolve) => {
+        inspectStarted = true;
+        releaseInspect = () => resolve(0);
+      }),
+      runBuild: async () => ({ code: 0, out: "" }),
+      nixpacksVersion: async () => "1.40.0",
+      ensureNixpacks: async () => ({ available: true }),
+    };
+    const pending = buildOrReuseImage(
+      `/tmp/${sentinel}`,
+      "deadbeef0000",
+      deps,
+      (stage) => {
+        // Entry must be observed before the effect begins, not only on exit.
+        expect(inspectStarted).toBe(false);
+        stages.push(stage);
+      },
+    );
+
+    try {
+      expect(stages).toEqual(["image-inspect"]);
+      expect(JSON.stringify(stages)).not.toContain(sentinel);
+    } finally {
+      releaseInspect();
+      await pending;
+    }
+  });
+
+  it("orders cache-miss stages for both builder branches", async () => {
+    const stages: string[] = [];
+    const observe = (stage: string) => stages.push(stage);
+    const available: BuildDeps = {
+      imageInspect: async () => 1,
+      runBuild: async () => ({ code: 0, out: "" }),
+      nixpacksVersion: async () => "1.40.0",
+      ensureNixpacks: async () => ({ available: true }),
+    };
+    const fallback: BuildDeps = { ...available, ensureNixpacks: async () => ({ available: false }) };
+
+    const nixpacks = await buildOrReuseImage("/tmp/nixpacks", "deadbeef0001", available, observe);
+    expect(nixpacks.builder).toBe("nixpacks");
+    expect(stages).toEqual(["image-inspect", "nixpacks-probe", "nixpacks-build"]);
+
+    stages.length = 0;
+    const dockerfile = await buildOrReuseImage("/tmp/dockerfile", "deadbeef0002", fallback, observe);
+    expect(dockerfile.builder).toBe("dockerfile-fallback");
+    expect(stages).toEqual(["image-inspect", "nixpacks-probe", "dockerfile-build"]);
+  });
+
+  it("ignores a throwing diagnostic observer and preserves a cache hit", async () => {
+    let inspectCalls = 0;
+    const deps: BuildDeps = {
+      imageInspect: async () => { inspectCalls++; return 0; },
+      runBuild: async () => ({ code: 0, out: "" }),
+      nixpacksVersion: async () => "1.40.0",
+      ensureNixpacks: async () => ({ available: true }),
+    };
+
+    const result = await buildOrReuseImage("/tmp/observer-throws", "deadbeef0003", deps, () => {
+      throw new Error("observer failure");
+    });
+    expect(result.reused).toBe(true);
+    expect(inspectCalls).toBe(1);
+  });
+
+  it("absorbs an asynchronously rejected diagnostic observer", async () => {
+    let rejectObserver!: (error: Error) => void;
+    const observer = () => new Promise<void>((_resolve, reject) => {
+      rejectObserver = reject;
+    });
+    const deps: BuildDeps = {
+      imageInspect: async () => 0,
+      runBuild: async () => ({ code: 0, out: "" }),
+      nixpacksVersion: async () => "1.40.0",
+      ensureNixpacks: async () => ({ available: true }),
+    };
+
+    const result = await buildOrReuseImage("/tmp/observer-rejects", "deadbeef0004", deps, observer);
+    rejectObserver(new Error("async observer failure"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.reused).toBe(true);
+  });
+
   it("reuses the shared per-operation deadlines rather than inventing a second policy", async () => {
     // One timeout policy for the whole driver. A second map here would drift
     // from docker.ts's the first time either moved.

--- a/plugins/ca-sandbox/tools/build.ts
+++ b/plugins/ca-sandbox/tools/build.ts
@@ -255,6 +255,22 @@ export type BuildResult = {
   notes: string[];
 };
 
+/** Fixed, coarse progress markers; no command, path, output, or environment data. */
+type BuildStage = "image-inspect" | "nixpacks-probe" | "nixpacks-build" | "dockerfile-build";
+type BuildStageReporter = (stage: BuildStage) => unknown;
+
+function reportBuildStage(reporter: BuildStageReporter | undefined, stage: BuildStage): void {
+  // Observability is advisory: synchronous throws and asynchronous rejections
+  // cannot prevent an effect or alter its exit/error semantics.
+  try {
+    const pending = reporter?.(stage);
+    const thenable = pending as { then?: unknown } | null | undefined;
+    if (typeof thenable?.then === "function") {
+      void Promise.resolve(pending as PromiseLike<unknown>).catch(() => undefined);
+    }
+  } catch { /* observer failure is non-fatal */ }
+}
+
 // --------------------------------------------------------------------------
 // default real-docker effects
 // --------------------------------------------------------------------------
@@ -550,6 +566,7 @@ const defaultDeps = (): BuildDeps => ({
  * @param repoDir absolute path to the cloned repo (its basename names the tag).
  * @param dephash the dependency cache key from computeDepHash (dephash.ts).
  * @param deps injectable docker/build effects (defaults shell real docker/nixpacks).
+ * @param reportStage optional fixed-vocabulary in-flight build marker.
  * @returns the tag plus whether the image was reused or freshly built, the
  *   builder used, and any user-facing notes (e.g. the nixpacks-missing fallback).
  * @throws if a build was attempted and failed (non-zero exit).
@@ -558,11 +575,13 @@ export async function buildOrReuseImage(
   repoDir: string,
   dephash: string,
   deps: BuildDeps = defaultDeps(),
+  reportStage?: BuildStageReporter,
 ): Promise<BuildResult> {
   const tag = imageTag(repoDir, dephash);
   const notes: string[] = [];
 
   // CACHE CHECK (AC-04): an existing tag => reuse, NO build.
+  reportBuildStage(reportStage, "image-inspect");
   const inspectCode = await deps.imageInspect(tag);
   if (inspectCode === 0) {
     return { tag, reused: true, built: false, builder: null, notes };
@@ -570,6 +589,7 @@ export async function buildOrReuseImage(
 
   // CACHE MISS (AC-05): decide the builder. Prefer nixpacks; fall back to the
   // generated Dockerfile (and NOTE the dependency) when nixpacks is unavailable.
+  reportBuildStage(reportStage, "nixpacks-probe");
   const nixpacks = await deps.ensureNixpacks();
   let builder: Builder;
   if (nixpacks.available) {
@@ -583,6 +603,7 @@ export async function buildOrReuseImage(
   }
 
   const ctx: BuildContext = { repoDir, builder, nixpacks: nixpacks.via, notes };
+  reportBuildStage(reportStage, builder === "nixpacks" ? "nixpacks-build" : "dockerfile-build");
   const result = await deps.runBuild(tag, ctx);
   if (result.code !== 0) {
     throw new Error(

--- a/plugins/ca-sandbox/tools/sandbox.js
+++ b/plugins/ca-sandbox/tools/sandbox.js
@@ -337,6 +337,16 @@ function sanitizeRepoName(repoDir) {
 function imageTag(repoDir, dephash) {
   return `${IMAGE_PREFIX}:${sanitizeRepoName(repoDir)}-${dephash}`;
 }
+function reportBuildStage(reporter, stage) {
+  try {
+    const pending = reporter?.(stage);
+    const thenable = pending;
+    if (typeof thenable?.then === "function") {
+      void Promise.resolve(pending).catch(() => void 0);
+    }
+  } catch {
+  }
+}
 async function defaultImageInspect(tag) {
   const r = await run("docker", ["image", "inspect", tag]);
   return r.code;
@@ -506,13 +516,15 @@ var defaultDeps = () => ({
   nixpacksVersion: defaultNixpacksVersion,
   ensureNixpacks: defaultEnsureNixpacks
 });
-async function buildOrReuseImage(repoDir, dephash, deps = defaultDeps()) {
+async function buildOrReuseImage(repoDir, dephash, deps = defaultDeps(), reportStage) {
   const tag = imageTag(repoDir, dephash);
   const notes = [];
+  reportBuildStage(reportStage, "image-inspect");
   const inspectCode = await deps.imageInspect(tag);
   if (inspectCode === 0) {
     return { tag, reused: true, built: false, builder: null, notes };
   }
+  reportBuildStage(reportStage, "nixpacks-probe");
   const nixpacks = await deps.ensureNixpacks();
   let builder;
   if (nixpacks.available) {
@@ -523,6 +535,7 @@ async function buildOrReuseImage(repoDir, dephash, deps = defaultDeps()) {
     if (nixpacks.note) notes.push(nixpacks.note);
   }
   const ctx = { repoDir, builder, nixpacks: nixpacks.via, notes };
+  reportBuildStage(reportStage, builder === "nixpacks" ? "nixpacks-build" : "dockerfile-build");
   const result = await deps.runBuild(tag, ctx);
   if (result.code !== 0) {
     throw new Error(

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.17.1"
+    adapter_version = "2.17.2"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.1"
+    adapter_version = "2.17.2"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca/hooks/tests/test_colorlib.py
+++ b/plugins/ca/hooks/tests/test_colorlib.py
@@ -35,6 +35,12 @@ from _helpers import isolate_user_state, release_user_state
 # backstop that fails if any suite writes outside its temp dirs.
 def setUpModule():
     global _USER_STATE
+    # Color assertions use a controlled default; NO_COLOR cases set it explicitly.
+    # Module cleanup restores the caller's environment even after test failures.
+    color_environment = mock.patch.dict(os.environ)
+    color_environment.start()
+    unittest.addModuleCleanup(color_environment.stop)
+    os.environ.pop("NO_COLOR", None)
     _USER_STATE = isolate_user_state()
 
 

--- a/plugins/ca/hooks/tests/test_statusline.py
+++ b/plugins/ca/hooks/tests/test_statusline.py
@@ -42,6 +42,12 @@ from _helpers import isolate_user_state, redirect_home, release_user_state, rest
 # backstop that fails if any suite writes outside its temp dirs.
 def setUpModule():
     global _USER_STATE
+    # Color assertions use a controlled default; NO_COLOR cases set it explicitly.
+    # Module cleanup restores the caller's environment even after test failures.
+    color_environment = mock.patch.dict(os.environ)
+    color_environment.start()
+    unittest.addModuleCleanup(color_environment.stop)
+    os.environ.pop("NO_COLOR", None)
     _USER_STATE = isolate_user_state()
 
 


### PR DESCRIPTION
## What & why

Retain exact published-tag observations after partial release failures, and require complete prior provenance before authorizing another release. Reconcile independently authenticated receipts through an append-only candidate and reviewed PR, never a direct ledger writer on main.

This campaign slice also records three original-receipt-backed tag identities, fixes ambient `NO_COLOR` contamination in rendering tests, and synchronizes versioned host metadata required by the payload gates.

## Validation

- Full Python hook suite passed after final metadata synchronization. Earlier full run: 1,457 tests, three existing skips.
- Full isolation/resource-leak guard: six tests passed.
- Focused suites: 46 tag checks, 16 capture tests, 15 reconciliation tests, 124 workflow tests, 62 CI-contract tests.
- Root-resolution contract: 17 tests passed; host descriptors: 18 passed; release trace: 29 passed with one existing skip.
- Generated core and root-package parity, badge/catalog checks, and committed ca/Codex/Pi payload-version gates passed.
- Independent security, auth/crypto, dependency and coverage reviews passed. Review-found inventory-blinding and adapter-version defects were reproduced and fixed without weakening guards.
- Local staged-file secret scan reviewed three explicit dummy-fixture matches; no credentials. Diff-bound security pass recorded.
- Python has no numeric coverage floor under `.codearbiter/tech-stack.md`'s Python coverage policy. No coverage percentage is claimed.

## Boundaries and remaining work

The ledger adds only `v2.17.1`, `ca-codex-v0.9.1`, and `ca-pi-v0.10.2`, whose original publication identities were retained. All 117 prior entries are unchanged. **44 historical omissions remain unresolved.** Current remote refs are not substituted for original publication evidence. The strict release gate will refuse publication while these omissions remain; ordinary CI retains its explicit warning/skip policy.

Hosted artifact retention is implemented and locally exercised, not yet proven by a production run. Receipt metadata is not self-authenticating: the documented reconciliation procedure requires independent verification of the trusted workflow, run, attempt, artifact and authorized tag/commit.

No tag, release or npm publication is performed by this PR. The full audit campaign is not complete.

The non-obvious tradeoff follows conflict-hierarchy level 1 (security and correctness of the audit trail): preserve uncertainty and refuse release rather than silently grandfather historical identities. No architecture, permission, dependency or license change is introduced.

## Checklist

- [x] Branch based on main; Conventional Commits used
- [x] Test-first behavior and regression evidence recorded
- [x] Local suite, syntax, parity and applicable metadata checks passed
- [x] Versioned payload metadata and changelogs synchronized
- [x] Existing hook root validation and no-network behavior preserved
- [x] No new architectural decision or dependency requiring approval
- [ ] Exact-head hosted CI and CodeRabbit review complete

CHANGELOG: Retain release tag identity receipts and refuse subsequent publication when prior tag provenance is incomplete.
