### PR TITLE
fix(release): read matching tag refs once

### DIFF
--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -38,9 +38,9 @@ missing credentials, unreadable inventory, or any unrecorded governed tag.
 Ordinary observation policy is unchanged. A new tag is recorded afterward from
 its trusted run receipt through a reviewed PR, before another release is allowed.
 
-READ-ONLY.  Paginated GETs against `/git/refs/tags`.  Nothing is written, and a
-partial listing is discarded rather than audited, because tags missing from a
-truncated page would otherwise read as deletions.
+READ-ONLY.  One GET against `/git/matching-refs/tags/`. Nothing is written, and
+an invalid response is discarded rather than audited, because an incomplete
+inventory would otherwise read as deletions.
 """
 import argparse
 import dataclasses
@@ -63,12 +63,6 @@ MANIFEST_PATH = REPO_ROOT / ".github" / "published-tags.json"
 _API = "https://api.github.com"
 _API_VERSION = "2022-11-28"
 _TIMEOUT_SECONDS = 30
-
-# `GET /git/refs/tags` caps at 100 per page. A reader that stopped at page one
-# would report every later tag as DELETED the moment this repo passes 100 tags.
-PER_PAGE = 100
-# A bound on the paging loop so a misbehaving API cannot spin it forever.
-MAX_PAGES = 50
 
 # A published tag is a namespace prefix followed by a SemVer core, optionally
 # with a pre-release or build suffix (`v2.1.0-beta.2` is a real published tag).
@@ -156,43 +150,36 @@ def unreadable(live: dict[str, str] | None) -> list[str]:
 def read_live_tags(repo: str, *, rest) -> dict[str, str] | None:
     """Every tag ref as name -> object sha, or None if it could not be read.
 
-    All-or-nothing on purpose: a partially-read listing handed to `audit()`
-    would turn the pages it never fetched into fabricated deletion findings.
+    GitHub's matching-refs endpoint returns the complete matching array in one
+    response. All-or-nothing validation prevents malformed or partial data from
+    becoming fabricated deletion findings.
     """
+    status, payload = rest(f"/repos/{repo}/git/matching-refs/tags/")
+    if status != 200 or not isinstance(payload, list):
+        return None
+
     tags: dict[str, str] = {}
-    for page in range(1, MAX_PAGES + 1):
-        status, payload = rest(
-            f"/repos/{repo}/git/refs/tags?per_page={PER_PAGE}&page={page}"
-        )
-        if status == 404 and page == 1:
-            # GitHub answers 404 for `git/refs/tags` on a repository with no
-            # tags at all. That is a definite empty, not a blind spot.
-            return {}
-        if status != 200 or not isinstance(payload, list):
+    for ref in payload:
+        if not isinstance(ref, dict):
             return None
-        for ref in payload:
-            if not isinstance(ref, dict):
-                return None
-            full_name = ref.get("ref")
-            obj = ref.get("object")
-            if not isinstance(full_name, str) or not full_name.startswith("refs/tags/"):
-                return None
-            if not isinstance(obj, dict):
-                return None
-            name = full_name.removeprefix("refs/tags/")
-            sha = obj.get("sha")
-            if (
-                not name or name in tags or not isinstance(sha, str)
-                or re.fullmatch(r"[0-9a-f]{40}", sha) is None
-                # Working tags may legally label blobs or trees. Their presence
-                # must not turn a definite release-tag drift into a skipped audit.
-                or obj.get("type") not in ("tag", "commit", "blob", "tree")
-            ):
-                return None
-            tags[name] = sha
-        if len(payload) < PER_PAGE:
-            return tags
-    return None
+        full_name = ref.get("ref")
+        obj = ref.get("object")
+        if not isinstance(full_name, str) or not full_name.startswith("refs/tags/"):
+            return None
+        if not isinstance(obj, dict):
+            return None
+        name = full_name.removeprefix("refs/tags/")
+        sha = obj.get("sha")
+        if (
+            not name or name in tags or not isinstance(sha, str)
+            or re.fullmatch(r"[0-9a-f]{40}", sha) is None
+            # Working tags may legally label blobs or trees. Their presence
+            # must not turn a definite release-tag drift into a skipped audit.
+            or obj.get("type") not in ("tag", "commit", "blob", "tree")
+        ):
+            return None
+        tags[name] = sha
+    return tags
 
 
 def _send(request: urllib.request.Request) -> tuple[int, object]:
@@ -224,7 +211,7 @@ def _rest_reader(token: str):
 
 _SKIP_NOTE = """SKIP: no token, so published-tag immutability was NOT audited.
 
-This check reads `/repos/{owner}/{repo}/git/refs/tags`, which needs only
+This check reads `/repos/{owner}/{repo}/git/matching-refs/tags/`, which needs only
 contents:read - a permission the default GITHUB_TOKEN DOES grant - so in ordinary
 CI it runs live and this skip should not appear. It exists for local runs and for
 transport failures, because a merge gate must report a settings or history

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -9,8 +9,8 @@ tag provenance plus one read-only listing of the live refs.  Like the
 branch-protection audit it sits beside, every observation is three-valued:
 True, False, or None for "this run could not see it".  A definite mismatch is a
 security finding; an unreadable run is a loud SKIP.  These tests pin both
-halves, the four governed namespaces, the pagination trap that would turn a
-truncated listing into a fake mass-deletion, and the shipped manifest's shape -
+halves, the four governed namespaces, complete matching-ref response handling,
+and the shipped manifest's shape -
 entirely offline, with no network and no token.
 """
 import importlib.util
@@ -146,7 +146,7 @@ class DriftAudit(unittest.TestCase):
 
 
 class LiveRefReader(unittest.TestCase):
-    """Reading the refs: paginated, read-only, and honest about failure."""
+    """Reading the complete matching-refs response honestly and read-only."""
 
     def test_a_single_page_of_refs_is_read_into_a_name_to_sha_map(self):
         page = [
@@ -164,47 +164,44 @@ class LiveRefReader(unittest.TestCase):
             module.read_live_tags("owner/name", rest=rest),
         )
 
-    def test_a_full_page_is_followed_by_the_next_page(self):
-        # THE PAGINATION TRAP.  `GET /git/refs/tags` caps at 100 per page.  A
-        # reader that stops after page 1 would, the moment this repo passes 100
-        # tags, report every tag on page 2 as DELETED - a fabricated mass
-        # security failure that no settings change caused.
-        first = [
+    def test_more_than_100_matching_refs_are_read_in_exactly_one_request(self):
+        # GitHub's matching-refs endpoint returns the complete array and does
+        # not advertise page/per_page parameters. Inventing pagination repeats
+        # the same response and makes a valid inventory look unreadable.
+        response = [
             {"ref": f"refs/tags/v9.0.{index}", "object": {"sha": f"{index:040d}", "type": "tag"}}
-            for index in range(module.PER_PAGE)
+            for index in range(101)
         ]
-        second = [{"ref": "refs/tags/v9.1.0", "object": {"sha": "c" * 40, "type": "tag"}}]
-        pages = [first, second, []]
+        calls = []
 
         def rest(path):
-            return 200, pages.pop(0)
+            calls.append(path)
+            return 200, response
 
         tags = module.read_live_tags("owner/name", rest=rest)
-        self.assertEqual(module.PER_PAGE + 1, len(tags))
-        self.assertIn("v9.1.0", tags)
+        self.assertEqual(101, len(tags))
+        self.assertEqual(
+            ["/repos/owner/name/git/matching-refs/tags/"],
+            calls,
+        )
 
-    def test_a_failed_page_makes_the_whole_read_unreadable(self):
-        # A partial listing must never be handed to the audit: the tags it is
-        # missing would read as deletions.  All-or-nothing is the only safe
-        # reduction.
-        pages = [
-            (200, [{"ref": f"refs/tags/v9.0.{i}", "object": {"sha": f"{i:040d}", "type": "tag"}}
-                   for i in range(module.PER_PAGE)]),
-            (403, {"message": "Forbidden"}),
-        ]
-
-        def rest(path):
-            return pages.pop(0)
-
-        self.assertIsNone(module.read_live_tags("owner/name", rest=rest))
+    def test_a_non_list_response_makes_the_whole_read_unreadable(self):
+        self.assertIsNone(
+            module.read_live_tags(
+                "owner/name", rest=lambda path: (200, {"message": "partial"})
+            )
+        )
 
     def test_a_transport_failure_is_unreadable_rather_than_empty(self):
         self.assertIsNone(module.read_live_tags("owner/name", rest=lambda path: (0, {})))
 
-    def test_an_empty_repository_reads_as_no_tags_not_as_unreadable(self):
-        # GitHub answers 404 for `git/refs/tags` when a repository has no tags
-        # at all.  That is a definite empty, not a blind spot.
-        self.assertEqual({}, module.read_live_tags("owner/name", rest=lambda p: (404, {})))
+    def test_an_empty_matching_response_reads_as_no_tags(self):
+        self.assertEqual({}, module.read_live_tags("owner/name", rest=lambda p: (200, [])))
+
+    def test_a_404_is_unreadable_not_an_empty_repository(self):
+        self.assertIsNone(
+            module.read_live_tags("owner/name", rest=lambda path: (404, {}))
+        )
 
 
 class ShippedManifest(unittest.TestCase):
@@ -256,6 +253,12 @@ class CommandLine(unittest.TestCase):
         code, output = self._run(token="t", rest=lambda path: (0, {}), recorded=RECORDED)
         self.assertEqual(0, code)
         self.assertIn("SKIP", output)
+
+    def test_a_404_listing_skips_loudly_in_ordinary_observation(self):
+        code, output = self._run(token="t", rest=lambda path: (404, {}), recorded=RECORDED)
+        self.assertEqual(0, code)
+        self.assertIn("SKIP", output)
+        self.assertNotIn("no longer exists", output)
 
     def test_a_clean_read_passes_and_names_what_it_verified(self):
         page = [
@@ -344,14 +347,15 @@ class StrictReleaseObservation(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertIn("release requires a repository", output.getvalue())
 
-    def test_partial_later_page_never_authorizes_release(self):
-        page = [{"ref": f"refs/tags/v1.0.{index}", "object": {
-            "sha": "a" * 40, "type": "tag"}} for index in range(module.PER_PAGE)]
-        pages = [(200, page), (503, {})]
-        code, output = self._run(token="t", recorded={}, rest=lambda path: pages.pop(0))
+    def test_large_complete_inventory_reports_real_unrecorded_tags(self):
+        response = [{"ref": f"refs/tags/v1.0.{index}", "object": {
+            "sha": f"{index:040d}", "type": "tag"}} for index in range(101)]
+        code, output = self._run(
+            token="t", recorded={}, rest=lambda path: (200, response)
+        )
         self.assertEqual(code, 1)
-        self.assertEqual(pages, [])
-        self.assertIn("complete live tag inventory", output)
+        self.assertIn("Unrecorded published tag", output)
+        self.assertNotIn("complete live tag inventory", output)
 
     def test_malformed_inventory_shapes_fail_closed(self):
         valid = {"ref": "refs/tags/v1.0.0", "object": {"sha": "a" * 40, "type": "tag"}}
@@ -372,6 +376,12 @@ class StrictReleaseObservation(unittest.TestCase):
         code, output = self._run(token="t", rest=lambda path: (503, {}), recorded=RECORDED)
         self.assertEqual(1, code)
         self.assertIn("::error", output)
+
+    def test_a_404_inventory_refuses_release_as_unreadable(self):
+        code, output = self._run(token="t", rest=lambda path: (404, {}), recorded=RECORDED)
+        self.assertEqual(1, code)
+        self.assertIn("complete live tag inventory", output)
+        self.assertNotIn("no longer exists", output)
 
     def test_unrecorded_tag_refuses_release(self):
         page = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2246,11 +2246,12 @@ jobs:
     # because it happens in refs, not in files.
     #
     # UNLIKE the branch-protection audit beside it, this one runs LIVE in
-    # ordinary CI: listing `/git/refs/tags` needs only contents:read, which the
-    # default GITHUB_TOKEN grants. It still skips loudly rather than failing on
-    # a transport failure or rate limit, because a merge gate must report a
-    # history regression, never a network problem. Read-only: paginated GETs,
-    # no mutations, and a partial listing is discarded rather than audited.
+    # ordinary CI: listing `/git/matching-refs/tags/` needs only contents:read,
+    # which the default GITHUB_TOKEN grants. It still skips loudly rather than
+    # failing on a transport failure or rate limit, because a merge gate must
+    # report a history regression, never a network problem. Read-only: one
+    # complete matching-refs response, no mutations, and invalid inventory is
+    # discarded rather than audited.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

- Read GitHub's complete matching-refs tag array with one request instead of inventing pagination.
- Keep invalid, malformed, duplicate, transport-failed, and 404 inventories unreadable so ordinary observation skips and strict release preflight blocks.
- Update the CI control description and add regression coverage for more than 100 refs, the canonical endpoint, empty responses, and 404 behavior.

The live strict probe now reaches the real provenance boundary: it reports 44 unrecorded historical tags and exits 1. This PR does not record those tags or weaken publication controls.

## Verification

- `python .github/scripts/test_tag_immutability.py` (49 passed)
- `python .github/scripts/test_release_workflow.py` (124 passed)
- `python .github/scripts/test_ci_impact.py` (62 passed)
- `python -m py_compile .github/scripts/check_tag_immutability.py .github/scripts/test_tag_immutability.py`
- Live strict probe: exit 1, 44 unrecorded tags, zero unreadable-inventory messages
- Independent security review: PASS after correcting 404 handling
- Independent coverage audit: PASS, no findings

## Coverage

There is no numeric coverage command for this surface. `.codearbiter/tech-stack.md` states: "There is no coverage tooling for the Python hooks (`plugins/*/hooks/*.py`, `.github/scripts/*.py`)." Direct branch and refusal-path tests provide the executable evidence.