### PR TITLE
Fix ADR acceptance lifecycle transition

### DIFF
--- a/.codearbiter/tech-stack.md
+++ b/.codearbiter/tech-stack.md
@@ -192,6 +192,21 @@ python .github/scripts/test_mode_surface.py
 python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"
 ```
 
+For the first commit of the two-commit ADR acceptance protocol, create the
+worktree-local, content-bound transition packet with
+`.github/scripts/prepare_adr_acceptance.py`. It binds the exact HEAD and staged
+index, accepted ADR bytes, decision-log append, sealed obligation set, expiry,
+and independent reviewer identity. The two lifecycle commands above recognize
+only that exact pending transition locally; explicit-revision, export,
+clean-tree, and GitHub-event validation remain strict. After the source commit,
+stage its acceptance binding immediately, run both mandatory lifecycle commands,
+and commit that sole ledger append through the commit gate. Only after the
+binding commit succeeds, clear the packet with
+`python .github/scripts/prepare_adr_acceptance.py --clear`.
+Legacy `baseline` bindings remain closed to the original migration snapshot
+`10d9b012d91681498bdf911dd82ffa28e112407f`; later commits cannot acquire
+legacy status instead of using this acceptance protocol.
+
 Only when `plugins/ca/tools/**` changed:
 
 ```sh

--- a/.github/scripts/check_adr_lifecycle.py
+++ b/.github/scripts/check_adr_lifecycle.py
@@ -110,9 +110,11 @@ def _valid_decision_log_append(base, current, stem):
         "### Decision", "### SMARTS rationale", "### Implementation implication",
     )
     positions = []
-    for token in required:
+    for required_line in required:
+        exact = required_line.startswith("### ")
         matches = [index for index, line in enumerate(suffix)
-                   if line == token or line.startswith(token)]
+                   if line == required_line or
+                   (not exact and line.startswith(required_line))]
         if len(matches) != 1:
             return False
         positions.append(matches[0])

--- a/.github/scripts/check_adr_lifecycle.py
+++ b/.github/scripts/check_adr_lifecycle.py
@@ -2,8 +2,11 @@
 """Validate ADR-0033 lifecycle bindings; optionally emit Verified claims."""
 
 import argparse
+import datetime as dt
+import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -11,10 +14,13 @@ REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 sys.path.insert(0, os.path.join(REPO, "core", "pysrc"))
 
 import adr_lifecycle as al
+import prepare_adr_acceptance as paa
 from _gitexec import root_bound_git_env
 
 
 LEDGER_REL = ".codearbiter/decisions/adr-lifecycle.jsonl"
+DECISION_LOG_REL = ".codearbiter/decisions/decision-log.md"
+LEGACY_BASELINE_OBSERVED_COMMIT = "10d9b012d91681498bdf911dd82ffa28e112407f"
 
 
 def select_base_ref(event_name, event):
@@ -33,7 +39,8 @@ def select_base_ref(event_name, event):
 
 def _git(root, *args):
     return subprocess.run(
-        ["git", "-C", root, *args], capture_output=True, check=False,
+        ["git", "--no-replace-objects", "-C", root, *args],
+        capture_output=True, check=False,
         env=root_bound_git_env(),
     )
 
@@ -58,6 +65,356 @@ def _ledger_at(root, commit):
     if blob is None:
         raise ValueError("could not read lifecycle ledger at %s" % commit)
     return blob
+
+
+def _index_blob(root, path):
+    result = _git(root, "show", ":%s" % path)
+    return result.stdout if result.returncode == 0 else None
+
+
+def _valid_decision_log_append(base, current, stem):
+    """Accept one canonical, sequential, accepted decision entry for the ADR."""
+    try:
+        base_text = base.decode("utf-8")
+        current_text = current.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    if not current_text.startswith(base_text) or current_text == base_text:
+        return False
+    suffix = current_text[len(base_text):].strip("\n").splitlines()
+    if len(suffix) < 24 or suffix[-1] != "---":
+        return False
+    prior = re.findall(r"(?m)^## DECISION-(\d{4}) — ", base_text)
+    header = re.fullmatch(
+        r"## DECISION-(\d{4}) — adr-(\d{4})-ratified — .+", suffix[0])
+    if not prior or header is None:
+        return False
+    number = stem.split("-", 1)[0]
+    if int(header.group(1)) != int(prior[-1]) + 1 or header.group(2) != number:
+        return False
+    fixed = (
+        r"\*\*Date:\*\* \d{4}-\d{2}-\d{2}",
+        r"\*\*Status:\*\* accepted",
+        r"\*\*Supersedes:\*\* .+",
+        r"\*\*Decided by:\*\* .+",
+        r"\*\*Decision category:\*\* .+",
+        r"\*\*Artifact-section-hash:\*\* (?:n/a|[0-9a-f]{64})",
+    )
+    if len(suffix) < 9 or suffix[1] != "" or any(
+            re.fullmatch(pattern, suffix[index + 2]) is None
+            for index, pattern in enumerate(fixed)):
+        return False
+    required = (
+        "### Variance summary", "- **Artifact position:** ",
+        "- **Scaffold position:** ", "- **Status type:** ",
+        "### Decision", "### SMARTS rationale", "### Implementation implication",
+    )
+    positions = []
+    for token in required:
+        matches = [index for index, line in enumerate(suffix)
+                   if line == token or line.startswith(token)]
+        if len(matches) != 1:
+            return False
+        positions.append(matches[0])
+    if positions != sorted(positions) or any(
+            line.startswith("## DECISION-") for line in suffix[1:]):
+        return False
+    for heading in ("### Decision", "### SMARTS rationale", "### Implementation implication"):
+        start = suffix.index(heading) + 1
+        end = next((index for index in range(start, len(suffix))
+                    if suffix[index].startswith("### ") or suffix[index] == "---"), len(suffix))
+        if not any(line.strip() for line in suffix[start:end]):
+            return False
+    return True
+
+
+def _local_pending_acceptance(root, events, blobs):
+    """Return one exact staged first-leg ADR stem, or None.
+
+    This is deliberately index-bound and local-only. A clean checkout, mixed
+    staged set, unstaged decision edit, existing accepted HEAD, or incomplete
+    decision-log append receives no transition allowance and remains strict.
+    """
+    bindings = {event.get("adr") for event in events if isinstance(event, dict)
+                and event.get("event") in ("acceptance", "baseline")
+                and isinstance(event.get("adr"), str)}
+    accepted = {adr for adr, blob in blobs.items()
+                if al.parse_adr(blob)["status"] == "accepted"}
+    missing = sorted(accepted - bindings)
+    if len(missing) != 1:
+        return None
+    stem = missing[0]
+    adr_rel = ".codearbiter/decisions/%s.md" % stem
+    expected_paths = {adr_rel, DECISION_LOG_REL}
+
+    staged = _git(root, "diff", "--cached", "--name-only", "-z", "--no-renames")
+    if staged.returncode != 0:
+        return None
+    try:
+        staged_paths = {path.decode("utf-8").replace("\\", "/")
+                        for path in staged.stdout.split(b"\0") if path}
+    except UnicodeDecodeError:
+        return None
+    if staged_paths != expected_paths:
+        return None
+
+    status = _git(
+        root, "status", "--porcelain=v1", "-z", "--untracked-files=all",
+        "--", ".codearbiter/decisions")
+    if status.returncode != 0:
+        return None
+    seen = set()
+    for raw in status.stdout.split(b"\0"):
+        if not raw:
+            continue
+        try:
+            entry = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        if (len(entry) < 4 or entry[0] not in ("A", "M") or
+                entry[1] not in (" ", "M")):
+            return None
+        seen.add(entry[3:].replace("\\", "/"))
+    if seen != expected_paths:
+        return None
+
+    index_adr = _index_blob(root, adr_rel)
+    index_log = _index_blob(root, DECISION_LOG_REL)
+    try:
+        with open(os.path.join(root, *DECISION_LOG_REL.split("/")), "rb") as handle:
+            worktree_log = handle.read()
+    except OSError:
+        return None
+    if (index_adr is None or index_log is None or stem not in blobs or
+            al._normalized_text(blobs[stem]) != al._normalized_text(index_adr) or
+            al._normalized_text(worktree_log) != al._normalized_text(index_log)):
+        return None
+    try:
+        if al.parse_adr(index_adr)["status"] != "accepted":
+            return None
+    except (UnicodeError, ValueError):
+        return None
+
+    head_adr = _git_blob(root, "HEAD", adr_rel)
+    if head_adr is not None:
+        try:
+            if (al.parse_adr(head_adr)["status"] == "accepted" or
+                    paa.transition_body(head_adr) != paa.transition_body(index_adr)):
+                return None
+        except (UnicodeError, ValueError):
+            return None
+
+    head_log = _git_blob(root, "HEAD", DECISION_LOG_REL)
+    if head_log is None or not _valid_decision_log_append(
+            head_log, index_log, stem):
+        return None
+
+    packet = paa.read_packet(root)
+    if packet is None:
+        return None
+    expected_fields = {
+        "schema", "repository", "head", "index_tree", "adr",
+        "adr_blob_sha256", "transition_body_sha256",
+        "decision_log_base_sha256", "decision_log_index_sha256",
+        "obligations", "obligations_sha256", "reviewed_by",
+        "reviewed_at", "valid_until",
+    }
+    if set(packet) != expected_fields or packet.get("schema") != paa.SCHEMA:
+        return None
+    digest = lambda value: hashlib.sha256(value).hexdigest()
+    try:
+        now = dt.datetime.now(dt.timezone.utc)
+        reviewed_at = al._parse_time(packet.get("reviewed_at"))
+        valid_until = al._parse_time(packet.get("valid_until"))
+        index_tree = _git(root, "write-tree")
+        if index_tree.returncode != 0:
+            return None
+        obligations = packet.get("obligations")
+        synthetic = {
+            "schema": "adr-lifecycle/v1", "event": "acceptance", "adr": stem,
+            "recorded_at": packet["reviewed_at"], "source_commit": "0" * 40,
+            "blob_sha256": digest(index_adr),
+            "body_sha256": digest(al.immutable_body(index_adr)),
+            "obligations": obligations,
+            "obligations_sha256": al.obligation_set_digest(obligations),
+            "obligations_sealed": True,
+        }
+        if (packet["repository"] != paa.repository_identity(root) or
+                packet["head"] != _git(root, "rev-parse", "HEAD").stdout.decode().strip() or
+                packet["index_tree"] != index_tree.stdout.decode().strip() or
+                packet["adr"] != stem or
+                packet["adr_blob_sha256"] != digest(index_adr) or
+                packet["transition_body_sha256"] != digest(paa.transition_body(index_adr)) or
+                packet["decision_log_base_sha256"] != digest(head_log) or
+                packet["decision_log_index_sha256"] != digest(index_log) or
+                packet["obligations_sha256"] != synthetic["obligations_sha256"] or
+                not isinstance(packet["reviewed_by"], list) or
+                not packet["reviewed_by"] or
+                any(not isinstance(item, str) or not item.strip()
+                    for item in packet["reviewed_by"]) or
+                reviewed_at > now or now > valid_until or
+                valid_until - reviewed_at > paa.MAX_LIFETIME or
+                al.validate_events([synthetic], {stem: index_adr})):
+            return None
+    except (KeyError, TypeError, UnicodeError, ValueError):
+        return None
+    return stem
+
+
+def _local_binding_transition_error(root, events, blobs):
+    """Bind the staged second leg to the reviewed first-leg packet."""
+    staged = _git(root, "diff", "--cached", "--name-only", "-z", "--no-renames")
+    if staged.returncode != 0:
+        return "could not inspect staged ADR acceptance binding"
+    try:
+        paths = {path.decode("utf-8").replace("\\", "/")
+                 for path in staged.stdout.split(b"\0") if path}
+    except UnicodeDecodeError:
+        return "staged ADR acceptance binding paths are not UTF-8"
+    head_ledger = _ledger_at(root, "HEAD")
+    index_ledger = _index_blob(root, LEDGER_REL)
+    ledger_path = os.path.join(root, *LEDGER_REL.split("/"))
+    try:
+        with open(ledger_path, "rb") as handle:
+            worktree_ledger = handle.read()
+    except OSError:
+        return "staged ADR acceptance binding ledger is unreadable"
+    try:
+        head_events = [json.loads(line.decode("utf-8"))
+                       for line in (head_ledger or b"").splitlines() if line.strip()]
+        head_acceptances = [json.dumps(event, sort_keys=True, separators=(",", ":"))
+                            for event in head_events if isinstance(event, dict)
+                            and event.get("event") == "acceptance"]
+        work_acceptances = [json.dumps(event, sort_keys=True, separators=(",", ":"))
+                            for event in events if isinstance(event, dict)
+                            and event.get("event") == "acceptance"]
+        new_work_acceptance = any(
+            work_acceptances.count(item) > head_acceptances.count(item)
+            for item in set(work_acceptances))
+    except (TypeError, UnicodeError, ValueError):
+        new_work_acceptance = False
+    if LEDGER_REL not in paths:
+        return ("ADR acceptance binding is present only in unstaged working-tree bytes"
+                if new_work_acceptance else None)
+    if head_ledger is None or index_ledger is None or not index_ledger.startswith(head_ledger):
+        return "staged ADR lifecycle ledger is not an exact append"
+    appended = [line for line in index_ledger[len(head_ledger):].splitlines() if line.strip()]
+    try:
+        new_events = [json.loads(line.decode("utf-8")) for line in appended]
+    except (UnicodeError, ValueError):
+        return "staged ADR acceptance binding append is malformed"
+    acceptances = [event for event in new_events if isinstance(event, dict)
+                   and event.get("event") == "acceptance"]
+    if not acceptances:
+        return ("ADR acceptance binding is not fully staged"
+                if new_work_acceptance else None)
+    if (paths != {LEDGER_REL} or
+            al._normalized_text(worktree_ledger) != al._normalized_text(index_ledger)):
+        return "staged ADR acceptance binding is not the sole exact append"
+    if len(new_events) != 1 or len(acceptances) != 1:
+        return "staged ADR acceptance binding must append exactly one acceptance"
+
+    event = acceptances[0]
+    packet = paa.read_packet(root)
+    if packet is None:
+        return "staged ADR acceptance binding has no reviewed pending packet"
+    stem = event.get("adr")
+    if not isinstance(stem, str):
+        return "staged ADR acceptance binding has no ADR stem"
+    adr_blob = _git_blob(root, "HEAD", ".codearbiter/decisions/%s.md" % stem)
+    decision_log = _git_blob(root, "HEAD", DECISION_LOG_REL)
+    head = _git(root, "rev-parse", "HEAD")
+    parent = _git(root, "rev-parse", "HEAD^")
+    tree = _git(root, "rev-parse", "HEAD^{tree}")
+    if (adr_blob is None or decision_log is None or head.returncode != 0 or
+            parent.returncode != 0 or tree.returncode != 0):
+        return "could not resolve the pending ADR acceptance source commit"
+    head_text = head.stdout.decode().strip()
+    try:
+        expected_packet_fields = {
+            "schema", "repository", "head", "index_tree", "adr",
+            "adr_blob_sha256", "transition_body_sha256",
+            "decision_log_base_sha256", "decision_log_index_sha256",
+            "obligations", "obligations_sha256", "reviewed_by",
+            "reviewed_at", "valid_until",
+        }
+        reviewed_at = al._parse_time(packet.get("reviewed_at"))
+        valid_until = al._parse_time(packet.get("valid_until"))
+        recorded_at = al._parse_time(event.get("recorded_at"))
+        now = dt.datetime.now(dt.timezone.utc)
+        packet_head_ledger = _ledger_at(root, packet.get("head"))
+        packet_head_log = _git_blob(root, packet.get("head"), DECISION_LOG_REL)
+        expected_event_fields = {
+            "schema", "event", "adr", "recorded_at", "source_commit",
+            "blob_sha256", "body_sha256", "obligations",
+            "obligations_sha256", "obligations_sealed",
+        }
+        if (set(packet) != expected_packet_fields or
+                set(event) != expected_event_fields or
+                packet.get("schema") != paa.SCHEMA or
+                packet.get("repository") != paa.repository_identity(root) or
+                packet.get("adr") != stem or
+                packet.get("head") != parent.stdout.decode().strip() or
+                packet.get("index_tree") != tree.stdout.decode().strip() or
+                packet.get("adr_blob_sha256") != hashlib.sha256(adr_blob).hexdigest() or
+                packet.get("transition_body_sha256") != hashlib.sha256(
+                    paa.transition_body(adr_blob)).hexdigest() or
+                packet.get("decision_log_index_sha256") != hashlib.sha256(
+                    decision_log).hexdigest() or
+                packet_head_log is None or
+                packet.get("decision_log_base_sha256") != hashlib.sha256(
+                    packet_head_log).hexdigest() or
+                packet_head_ledger != head_ledger or
+                not isinstance(packet.get("reviewed_by"), list) or
+                not packet.get("reviewed_by") or
+                any(not isinstance(item, str) or not item.strip()
+                    for item in packet.get("reviewed_by")) or
+                packet.get("obligations_sha256") != al.obligation_set_digest(
+                    packet.get("obligations")) or
+                event.get("schema") != "adr-lifecycle/v1" or
+                event.get("source_commit") != head_text or
+                event.get("blob_sha256") != packet.get("adr_blob_sha256") or
+                event.get("body_sha256") != hashlib.sha256(
+                    al.immutable_body(adr_blob)).hexdigest() or
+                event.get("obligations") != packet.get("obligations") or
+                event.get("obligations_sha256") != packet.get("obligations_sha256") or
+                event.get("obligations_sealed") is not True or
+                reviewed_at > now or
+                valid_until - reviewed_at > paa.MAX_LIFETIME or
+                recorded_at < reviewed_at or recorded_at > now or
+                recorded_at > valid_until or now > valid_until):
+            return "staged ADR acceptance binding does not match its reviewed pending packet"
+    except (KeyError, TypeError, UnicodeError, ValueError):
+        return "staged ADR acceptance binding packet is malformed or stale"
+    return None
+
+
+def accepted_binding_errors(root, events, blobs, allow_local_pending=False):
+    """Validate accepted-ADR binding completeness for a repository state."""
+    bindings = {event.get("adr") for event in events if isinstance(event, dict)
+                and event.get("event") in ("acceptance", "baseline")
+                and isinstance(event.get("adr"), str)}
+    accepted = {adr for adr, blob in blobs.items()
+                if al.parse_adr(blob)["status"] == "accepted"}
+    pending = (_local_pending_acceptance(root, events, blobs)
+               if allow_local_pending else None)
+    errors = ["%s: accepted ADR has no lifecycle binding" % adr
+              for adr in sorted(accepted - bindings - ({pending} if pending else set()))]
+    for event in events:
+        if not isinstance(event, dict) or event.get("event") != "baseline":
+            continue
+        stem = event.get("adr")
+        observed = event.get("observed_commit")
+        if not isinstance(stem, str) or not isinstance(observed, str):
+            continue
+        if observed != LEGACY_BASELINE_OBSERVED_COMMIT:
+            errors.append(
+                "%s: legacy baseline lies outside the closed migration epoch" % stem)
+    if allow_local_pending:
+        transition_error = _local_binding_transition_error(root, events, blobs)
+        if transition_error:
+            errors.append(transition_error)
+    return errors, pending
 
 
 def main(argv=None):
@@ -86,14 +443,16 @@ def main(argv=None):
     events = al.read_jsonl(ledger)
     errors = [event_error] if event_error else []
     blobs = al.read_adrs(args.root, errors=errors)
-    accepted = {adr: blob for adr, blob in blobs.items()
-                if al.parse_adr(blob)["status"] == "accepted"}
     errors.extend(al.validate_events(events, blobs))
-    bindings = {event.get("adr") for event in events if isinstance(event, dict)
-                and event.get("event") in ("acceptance", "baseline")
-                and isinstance(event.get("adr"), str)}
-    for adr in sorted(set(accepted) - bindings):
-        errors.append("%s: accepted ADR has no lifecycle binding" % adr)
+    allow_pending = (args.base_ref is None and args.current_ref is None and
+                     not args.github_event and not args.verified_json)
+    try:
+        binding_errors, pending = accepted_binding_errors(
+            args.root, events, blobs, allow_local_pending=allow_pending)
+    except (OSError, UnicodeError, ValueError):
+        binding_errors, pending = accepted_binding_errors(
+            args.root, events, blobs, allow_local_pending=False)
+    errors.extend(binding_errors)
 
     source_blobs = {}
     source_inputs = {}
@@ -168,7 +527,11 @@ def main(argv=None):
         for diagnostic in diagnostics:
             print("::warning::" + diagnostic, file=sys.stderr)
     else:
-        print("ADR lifecycle bindings valid; accepted plans are distinct from Verified evidence")
+        if pending:
+            print("ADR lifecycle valid pending acceptance source commit for %s; "
+                  "binding is not yet recorded" % pending)
+        else:
+            print("ADR lifecycle bindings valid; accepted plans are distinct from Verified evidence")
     return 0
 
 

--- a/.github/scripts/prepare_adr_acceptance.py
+++ b/.github/scripts/prepare_adr_acceptance.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Create a content-bound local packet for ADR acceptance commit leg one."""
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, os.path.join(REPO, "core", "pysrc"))
+
+import adr_lifecycle as al
+from _gitexec import root_bound_git_env
+
+
+SCHEMA = "adr-acceptance-pending/v1"
+MAX_LIFETIME = dt.timedelta(hours=4)
+ADR_PREFIX = ".codearbiter/decisions/"
+LOG_REL = ADR_PREFIX + "decision-log.md"
+
+
+def _sha(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git(root, *args):
+    return subprocess.run(
+        ["git", "--no-replace-objects", "-C", root, *args],
+        capture_output=True, check=False,
+        env=root_bound_git_env(),
+    )
+
+
+def _git_text(root, *args):
+    result = _git(root, *args)
+    if result.returncode != 0:
+        raise ValueError("git %s failed" % " ".join(args))
+    return result.stdout.decode("utf-8").strip()
+
+
+def _index_blob(root, path):
+    result = _git(root, "show", ":%s" % path)
+    if result.returncode != 0:
+        raise ValueError("staged path is unavailable: %s" % path)
+    return result.stdout
+
+
+def _head_blob(root, path):
+    result = _git(root, "show", "HEAD:%s" % path)
+    return result.stdout if result.returncode == 0 else None
+
+
+def transition_body(blob):
+    """Bind every ADR byte except its two recognized status-value tokens."""
+    return al.immutable_body(blob)
+
+
+def packet_path(root):
+    git_dir = os.path.normcase(os.path.realpath(
+        _git_text(root, "rev-parse", "--absolute-git-dir")))
+    admin_dir = os.path.abspath(os.path.join(git_dir, "codearbiter"))
+    if os.path.commonpath((git_dir, admin_dir)) != git_dir:
+        raise ValueError("packet directory escapes the worktree Git administration directory")
+    if os.path.lexists(admin_dir):
+        if (not os.path.isdir(admin_dir) or os.path.islink(admin_dir) or
+                os.path.normcase(os.path.realpath(admin_dir)) != os.path.normcase(admin_dir)):
+            raise ValueError("packet directory is redirected")
+    return os.path.join(admin_dir, "adr-acceptance-pending.json")
+
+
+def repository_identity(root):
+    return {
+        "root": os.path.normcase(os.path.realpath(root)),
+        "git_dir": os.path.normcase(os.path.realpath(_git_text(
+            root, "rev-parse", "--absolute-git-dir"))),
+        "common_dir": os.path.normcase(os.path.realpath(_git_text(
+            root, "rev-parse", "--path-format=absolute", "--git-common-dir"))),
+    }
+
+
+def _install_packet(destination, packet):
+    """Atomically install packet without replacing any concurrent writer."""
+    os.makedirs(os.path.dirname(destination), exist_ok=True)
+    if (os.path.islink(os.path.dirname(destination)) or
+            os.path.normcase(os.path.realpath(os.path.dirname(destination))) !=
+            os.path.normcase(os.path.dirname(destination))):
+        raise ValueError("packet directory is redirected")
+    descriptor, temporary = tempfile.mkstemp(
+        prefix="adr-acceptance-", suffix=".json", dir=os.path.dirname(destination))
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(packet, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, destination)
+        except FileExistsError as exc:
+            raise FileExistsError(
+                "pending acceptance packet already exists; clear it explicitly") from exc
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def write_packet(root, adr, obligations, reviewed_by, reviewed_at, valid_until):
+    """Validate inputs and atomically write one ephemeral acceptance packet."""
+    if not al.ADR_RE.fullmatch(adr + ".md"):
+        raise ValueError("invalid ADR stem")
+    if (not isinstance(reviewed_by, list) or not reviewed_by or
+            any(not isinstance(item, str) or not item.strip() for item in reviewed_by)):
+        raise ValueError("independent reviewer evidence is required")
+    reviewed_moment = al._parse_time(reviewed_at)
+    expiry = al._parse_time(valid_until)
+    if reviewed_moment >= expiry or expiry - reviewed_moment > MAX_LIFETIME:
+        raise ValueError("packet lifetime must be positive and no more than four hours")
+
+    adr_rel = ADR_PREFIX + adr + ".md"
+    adr_blob = _index_blob(root, adr_rel)
+    if al.parse_adr(adr_blob)["status"] != "accepted":
+        raise ValueError("staged ADR is not accepted")
+    log_blob = _index_blob(root, LOG_REL)
+    base_log = _head_blob(root, LOG_REL)
+    if base_log is None:
+        raise ValueError("HEAD decision log is unavailable")
+
+    synthetic = {
+        "schema": "adr-lifecycle/v1", "event": "acceptance", "adr": adr,
+        "recorded_at": reviewed_at, "source_commit": "0" * 40,
+        "blob_sha256": _sha(adr_blob),
+        "body_sha256": _sha(al.immutable_body(adr_blob)),
+        "obligations": obligations,
+        "obligations_sha256": al.obligation_set_digest(obligations),
+        "obligations_sealed": True,
+    }
+    errors = al.validate_events([synthetic], {adr: adr_blob})
+    if errors:
+        raise ValueError("invalid sealed obligations: %s" % "; ".join(errors))
+
+    packet = {
+        "schema": SCHEMA,
+        "repository": repository_identity(root),
+        "head": _git_text(root, "rev-parse", "HEAD"),
+        "index_tree": _git_text(root, "write-tree"),
+        "adr": adr,
+        "adr_blob_sha256": _sha(adr_blob),
+        "transition_body_sha256": _sha(transition_body(adr_blob)),
+        "decision_log_base_sha256": _sha(base_log),
+        "decision_log_index_sha256": _sha(log_blob),
+        "obligations": obligations,
+        "obligations_sha256": synthetic["obligations_sha256"],
+        "reviewed_by": reviewed_by,
+        "reviewed_at": reviewed_at,
+        "valid_until": valid_until,
+    }
+    destination = packet_path(root)
+    _install_packet(destination, packet)
+    return destination
+
+
+def read_packet(root):
+    try:
+        path = packet_path(root)
+        if os.path.islink(path) or not os.path.isfile(path):
+            return None
+        with open(path, encoding="utf-8") as handle:
+            packet = json.load(handle)
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return packet if isinstance(packet, dict) else None
+
+
+def clear_packet(root):
+    """Remove only this worktree's ephemeral packet, when present."""
+    path = packet_path(root)
+    if os.path.lexists(path) and (os.path.islink(path) or not os.path.isfile(path)):
+        raise ValueError("pending acceptance packet is not a regular file")
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=REPO)
+    parser.add_argument("--clear", action="store_true")
+    parser.add_argument("--adr")
+    parser.add_argument("--obligations-json")
+    parser.add_argument("--reviewed-by", action="append")
+    parser.add_argument("--reviewed-at")
+    parser.add_argument("--valid-until")
+    args = parser.parse_args(argv)
+    if args.clear:
+        print("cleared" if clear_packet(args.root) else "already absent")
+        return 0
+    for field in ("adr", "obligations_json", "reviewed_by", "reviewed_at", "valid_until"):
+        if not getattr(args, field):
+            parser.error("--%s is required unless --clear is used" % field.replace("_", "-"))
+    with open(args.obligations_json, encoding="utf-8") as handle:
+        obligations = json.load(handle)
+    print(write_packet(
+        args.root, args.adr, obligations, args.reviewed_by,
+        args.reviewed_at, args.valid_until))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_adr_lifecycle.py
+++ b/.github/scripts/test_adr_lifecycle.py
@@ -1650,6 +1650,13 @@ class LifecycleContractTest(unittest.TestCase):
         errors.extend(binding_errors)
         self.assertEqual(errors, [], "\n".join(errors))
 
+    def test_decision_log_append_rejects_extended_section_heading_without_raising(self):
+        base = b"# Decision log\n" + _decision_entry(1, 9999).encode()
+        extended = _decision_entry(2, 1).replace(
+            "### Decision\n", "### Decision extended\n")
+        self.assertFalse(cal._valid_decision_log_append(
+            base, base + extended.encode(), "0001-test"))
+
     def test_pending_packet_is_isolated_to_the_exact_worktree_git_directory(self):
         self.assertIsNotNone(paa, "pending-acceptance packet helper is missing")
         with tempfile.TemporaryDirectory() as container:

--- a/.github/scripts/test_adr_lifecycle.py
+++ b/.github/scripts/test_adr_lifecycle.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """ADR-0033 lifecycle integrity contract."""
 
+import concurrent.futures
+import datetime as dt
 import hashlib
 import io
 import json
@@ -22,6 +24,11 @@ try:
 except ImportError:
     al = None
     cal = None
+
+try:
+    import prepare_adr_acceptance as paa
+except ImportError:
+    paa = None
 
 
 def _sha(data):
@@ -65,6 +72,35 @@ def _ci_checker_commands(text):
         if "check_adr_lifecycle.py" in value:
             commands.append(value)
     return commands
+
+
+def _decision_entry(sequence, adr_number):
+    return """
+## DECISION-%04d — adr-%04d-ratified — Accept test ADR
+
+**Date:** 2026-09-02
+**Status:** accepted
+**Supersedes:** none
+**Decided by:** user@example.com
+**Decision category:** governance-integrity
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** Proposed.
+- **Scaffold position:** Accepted.
+- **Status type:** open-decision-closure
+
+### Decision
+Accept the test ADR.
+
+### SMARTS rationale
+The bounded test decision is specific and testable.
+
+### Implementation implication
+Bind the accepted ADR in a subsequent commit.
+
+---
+""" % (sequence, adr_number)
 
 
 class LifecycleContractTest(unittest.TestCase):
@@ -1122,13 +1158,537 @@ class LifecycleContractTest(unittest.TestCase):
             self.assertEqual(errors, ["invalid lifecycle event: " + events[0]["_error"]])
             self.assertIn("line 2:", errors[0])
 
+    def test_local_checker_requires_a_bound_packet_for_the_first_acceptance_leg(self):
+        self.assertIsNotNone(paa, "pending-acceptance packet helper is missing")
+        proposed = ADR.replace(b"status: accepted", b"status: proposed").replace(
+            b"## Status\nAccepted", b"## Status\nProposed")
+        self.assertEqual(paa.transition_body(proposed), paa.transition_body(ADR))
+        self.assertNotEqual(
+            paa.transition_body(proposed),
+            paa.transition_body(ADR.replace(
+                b"## Status\nAccepted", b"## Status\nAccepted by somebody else")),
+        )
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-b", "main")
+            decisions = os.path.join(root, ".codearbiter", "decisions")
+            os.makedirs(decisions)
+            adr_path = os.path.join(decisions, "0001-test.md")
+            with open(adr_path, "wb") as handle:
+                handle.write(proposed)
+            with open(os.path.join(decisions, "adr-lifecycle.jsonl"), "wb") as handle:
+                handle.write(b"")
+            log_path = os.path.join(decisions, "decision-log.md")
+            with open(log_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write("# Decision log\n" + _decision_entry(1, 9999))
+            self._git(root, "add", ".codearbiter/decisions")
+            self._git(root, "commit", "-m", "seed proposed ADR")
+
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR)
+            with open(log_path, "a", encoding="utf-8", newline="\n") as handle:
+                handle.write(_decision_entry(2, 1))
+            with open(log_path, "rb") as handle:
+                first_leg_log = handle.read()
+            self._git(
+                root, "add", ".codearbiter/decisions/0001-test.md",
+                ".codearbiter/decisions/decision-log.md")
+
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+
+            reviewed_at = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=1)
+            valid_until = reviewed_at + dt.timedelta(hours=1)
+            packet_path = paa.write_packet(
+                root=root,
+                adr="0001-test",
+                obligations=self._acceptance()["obligations"],
+                reviewed_by=["independent-reviewer:test"],
+                reviewed_at=reviewed_at.isoformat(),
+                valid_until=valid_until.isoformat(),
+            )
+            self.assertTrue(os.path.isfile(packet_path))
+            with self.assertRaises(FileExistsError):
+                paa.write_packet(
+                    root=root,
+                    adr="0001-test",
+                    obligations=self._acceptance()["obligations"],
+                    reviewed_by=["independent-reviewer:test"],
+                    reviewed_at=reviewed_at.isoformat(),
+                    valid_until=valid_until.isoformat(),
+                )
+            result, stdout, stderr = self._run_checker(root)
+            self.assertEqual((result, stderr), (0, ""))
+            self.assertIn("pending acceptance", stdout)
+            for selector in ("--current-ref", "--base-ref"):
+                with self.subTest(empty_explicit_selector=selector):
+                    result, _stdout, stderr = self._run_checker(root, selector, "")
+                    self.assertEqual(result, 1)
+                    self.assertIn("accepted ADR has no lifecycle binding", stderr)
+
+            self._git(root, "config", "core.autocrlf", "true")
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR.replace(b"\n", b"\r\n"))
+            result, stdout, stderr = self._run_checker(root)
+            self.assertEqual((result, stderr), (0, ""))
+            self.assertIn("pending acceptance", stdout)
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR)
+            with open(packet_path, "rb") as handle:
+                valid_packet_bytes = handle.read()
+            valid_packet = json.loads(valid_packet_bytes)
+            self.assertEqual(valid_packet["repository"], paa.repository_identity(root))
+            with tempfile.TemporaryDirectory() as foreign:
+                with mock.patch.dict(os.environ, {
+                        "GIT_DIR": os.path.join(foreign, ".git"),
+                        "GIT_WORK_TREE": foreign,
+                        "GIT_OBJECT_DIRECTORY": os.path.join(foreign, "objects")}, clear=False):
+                    self.assertEqual(
+                        valid_packet["repository"], paa.repository_identity(root))
+                    self.assertEqual(paa.read_packet(root), valid_packet)
+
+            mutants = (
+                ("head", "f" * 40),
+                ("index_tree", "f" * 40),
+                ("adr", "9999-other"),
+                ("adr_blob_sha256", "f" * 64),
+                ("transition_body_sha256", "f" * 64),
+                ("decision_log_base_sha256", "f" * 64),
+                ("decision_log_index_sha256", "f" * 64),
+                ("obligations_sha256", "f" * 64),
+                ("reviewed_by", []),
+                ("reviewed_at", (reviewed_at + dt.timedelta(hours=2)).isoformat()),
+                ("valid_until", (reviewed_at + dt.timedelta(hours=5)).isoformat()),
+            )
+            for field, value in mutants:
+                with self.subTest(packet_field=field):
+                    mutant = dict(valid_packet)
+                    mutant[field] = value
+                    with open(packet_path, "w", encoding="utf-8", newline="\n") as handle:
+                        json.dump(mutant, handle, sort_keys=True, separators=(",", ":"))
+                        handle.write("\n")
+                    result, _stdout, stderr = self._run_checker(root)
+                    self.assertEqual(result, 1)
+                    self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            with open(packet_path, "wb") as handle:
+                handle.write(valid_packet_bytes)
+
+            obligations_mutant = dict(valid_packet)
+            obligations_mutant["obligations"] = [dict(
+                valid_packet["obligations"][0], text="Different")]
+            with open(packet_path, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(obligations_mutant, handle, sort_keys=True, separators=(",", ":"))
+                handle.write("\n")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            with open(packet_path, "wb") as handle:
+                handle.write(valid_packet_bytes)
+
+            self.assertTrue(cal._valid_decision_log_append(
+                b"# Decision log\n" + _decision_entry(1, 9999).encode(),
+                (b"# Decision log\n" + _decision_entry(1, 9999).encode() +
+                 _decision_entry(2, 1).encode()),
+                "0001-test"))
+            for invalid_entry in (
+                _decision_entry(2, 1).replace("**Status:** accepted", "**Status:** Accepted"),
+                _decision_entry(3, 1),
+                _decision_entry(2, 2),
+                _decision_entry(2, 1) + _decision_entry(3, 1),
+            ):
+                with self.subTest(invalid_log_entry=invalid_entry[:80]):
+                    base_log = b"# Decision log\n" + _decision_entry(1, 9999).encode()
+                    self.assertFalse(cal._valid_decision_log_append(
+                        base_log, base_log + invalid_entry.encode(), "0001-test"))
+
+            event_path = os.path.join(root, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump({"pull_request": {"base": {"sha": self._git(
+                    root, "rev-parse", "HEAD")}}}, handle)
+            result, _stdout, stderr = self._run_checker(
+                root, "--github-event", "--current-ref", "HEAD",
+                env={"GITHUB_EVENT_NAME": "pull_request", "GITHUB_EVENT_PATH": event_path})
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            result, stdout, stderr = self._run_checker(
+                root, "--verified-json", "--current-ref", "HEAD",
+                "--now", dt.datetime.now(dt.timezone.utc).isoformat())
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout, "[]\n")
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+
+            with open(packet_path, encoding="utf-8") as handle:
+                stale_packet = json.load(handle)
+            stale_packet["valid_until"] = (
+                reviewed_at + dt.timedelta(seconds=30)).isoformat()
+            with open(packet_path, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(stale_packet, handle, sort_keys=True, separators=(",", ":"))
+                handle.write("\n")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            self.assertTrue(paa.clear_packet(root))
+
+            foreign_target = os.path.join(root, "foreign-packet-target.json")
+            with open(foreign_target, "w", encoding="utf-8") as handle:
+                handle.write("do not remove")
+            try:
+                os.symlink(foreign_target, packet_path)
+            except OSError:
+                pass
+            else:
+                with self.assertRaises(ValueError):
+                    paa.clear_packet(root)
+                self.assertTrue(os.path.isfile(foreign_target))
+                os.unlink(packet_path)
+
+            packet_args = dict(
+                root=root,
+                adr="0001-test",
+                obligations=self._acceptance()["obligations"],
+                reviewed_by=["independent-reviewer:test"],
+                reviewed_at=reviewed_at.isoformat(),
+                valid_until=valid_until.isoformat(),
+            )
+
+            def competing_writer():
+                try:
+                    paa._install_packet(packet_path, valid_packet)
+                    return "created"
+                except FileExistsError:
+                    return "collision"
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                outcomes = sorted(executor.map(lambda _index: competing_writer(), range(2)))
+            self.assertEqual(outcomes, ["collision", "created"])
+            self.assertTrue(paa.clear_packet(root))
+            paa.write_packet(
+                **packet_args,
+            )
+
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR.replace(b"## Decision\nD", b"## Decision\nDrift"))
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR)
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md")
+
+            extra_path = os.path.join(decisions, "extra.txt")
+            with open(extra_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write("mixed staged change\n")
+            self._git(root, "add", ".codearbiter/decisions/extra.txt")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            self._git(root, "rm", "--cached", ".codearbiter/decisions/extra.txt")
+            os.remove(extra_path)
+
+            outside_path = os.path.join(root, "outside.txt")
+            with open(outside_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write("unrelated staged change\n")
+            self._git(root, "add", "outside.txt")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            self._git(root, "rm", "--cached", "outside.txt")
+            os.remove(outside_path)
+
+            self._git(root, "restore", "--staged", ".codearbiter/decisions/decision-log.md")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+            self._git(root, "add", ".codearbiter/decisions/decision-log.md")
+
+            result, _stdout, stderr = self._run_checker(root, "--current-ref", "HEAD")
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+
+            second_path = os.path.join(decisions, "0002-test.md")
+            with open(second_path, "wb") as handle:
+                handle.write(ADR.replace(b"# ADR-0001", b"# ADR-0002"))
+            with open(log_path, "a", encoding="utf-8", newline="\n") as handle:
+                handle.write(_decision_entry(3, 2))
+            self._git(
+                root, "add", ".codearbiter/decisions/0002-test.md",
+                ".codearbiter/decisions/decision-log.md")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+
+            self._git(root, "rm", "--cached", ".codearbiter/decisions/0002-test.md")
+            os.remove(second_path)
+            with open(log_path, "wb") as handle:
+                handle.write(first_leg_log)
+            self._git(root, "add", ".codearbiter/decisions/decision-log.md")
+            self._git(root, "commit", "-m", "accept ADR")
+
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("accepted ADR has no lifecycle binding", stderr)
+
+            acceptance = self._acceptance()
+            acceptance["source_commit"] = self._git(root, "rev-parse", "HEAD")
+            acceptance["recorded_at"] = reviewed_at.isoformat()
+
+            self._write_ledger(root, [acceptance])
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("only in unstaged working-tree bytes", stderr)
+            self._git(root, "restore", ".codearbiter/decisions/adr-lifecycle.jsonl")
+
+            with open(packet_path, "rb") as handle:
+                source_packet_bytes = handle.read()
+            self.assertTrue(paa.clear_packet(root))
+            baseline = json.loads(json.dumps(acceptance))
+            baseline["event"] = "baseline"
+            baseline["observed_commit"] = baseline.pop("source_commit")
+            baseline["obligations"] = []
+            baseline["obligations_sha256"] = al.obligation_set_digest([])
+            baseline["obligations_sealed"] = False
+            self._write_ledger(root, [baseline])
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("outside the closed migration epoch", stderr)
+            paa._install_packet(packet_path, json.loads(source_packet_bytes))
+
+            substituted = json.loads(json.dumps(acceptance))
+            substituted["obligations"][0]["text"] = "Different reviewed obligation"
+            substituted["obligations"][0]["text_sha256"] = _sha(
+                b"Different reviewed obligation")
+            substituted["obligations_sha256"] = al.obligation_set_digest(
+                substituted["obligations"])
+            self._write_ledger(root, [substituted])
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("does not match its reviewed pending packet", stderr)
+
+            future_acceptance = json.loads(json.dumps(acceptance))
+            future_acceptance["recorded_at"] = (
+                dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=15)).isoformat()
+            self._write_ledger(root, [future_acceptance])
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("does not match its reviewed pending packet", stderr)
+
+            self._write_ledger(root, [acceptance])
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+
+            with open(packet_path, "rb") as handle:
+                second_leg_packet_bytes = handle.read()
+            second_leg_packet = json.loads(second_leg_packet_bytes)
+            second_leg_packet["unexpected"] = "field"
+            with open(packet_path, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(second_leg_packet, handle, sort_keys=True, separators=(",", ":"))
+                handle.write("\n")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("does not match its reviewed pending packet", stderr)
+            with open(packet_path, "wb") as handle:
+                handle.write(second_leg_packet_bytes)
+
+            self.assertTrue(paa.clear_packet(root))
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("has no reviewed pending packet", stderr)
+            paa._install_packet(packet_path, json.loads(second_leg_packet_bytes))
+
+            outside_path = os.path.join(root, "outside-second-leg.txt")
+            with open(outside_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write("unrelated staged change\n")
+            self._git(root, "add", "outside-second-leg.txt")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("not the sole exact append", stderr)
+            self._git(root, "rm", "--cached", "outside-second-leg.txt")
+            os.remove(outside_path)
+
+            with open(os.path.join(decisions, "adr-lifecycle.jsonl"), "rb") as handle:
+                second_leg_ledger = handle.read()
+            with open(os.path.join(decisions, "adr-lifecycle.jsonl"), "wb") as handle:
+                handle.write(second_leg_ledger.replace(b"\n", b"\r\n"))
+            result, stdout, stderr = self._run_checker(root)
+            self.assertEqual((result, stderr), (0, ""))
+            self.assertIn("bindings valid", stdout)
+            with open(os.path.join(decisions, "adr-lifecycle.jsonl"), "wb") as handle:
+                handle.write(second_leg_ledger)
+            self._git(root, "commit", "-m", "bind ADR acceptance")
+            result, stdout, stderr = self._run_checker(root, "--current-ref", "HEAD")
+            self.assertEqual((result, stderr), (0, ""))
+            self.assertIn("bindings valid", stdout)
+            self.assertTrue(paa.clear_packet(root))
+            self.assertFalse(os.path.exists(packet_path))
+
+    def test_git_replacement_refs_cannot_substitute_lifecycle_evidence(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-b", "main")
+            decisions = os.path.join(root, ".codearbiter", "decisions")
+            os.makedirs(decisions)
+            adr_path = os.path.join(decisions, "0001-test.md")
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR)
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md")
+            self._git(root, "commit", "-m", "accepted evidence")
+            accepted_commit = self._git(root, "rev-parse", "HEAD")
+
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR.replace(b"status: accepted", b"status: proposed").replace(
+                    b"## Status\nAccepted", b"## Status\nProposed"))
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md")
+            self._git(root, "commit", "-m", "replacement evidence")
+            replacement_commit = self._git(root, "rev-parse", "HEAD")
+            self._git(root, "reset", "--hard", accepted_commit)
+            self._git(root, "replace", accepted_commit, replacement_commit)
+
+            replaced = subprocess.run(
+                ["git", "-C", root, "show", "HEAD:.codearbiter/decisions/0001-test.md"],
+                capture_output=True, check=False).stdout
+            self.assertIn(b"status: proposed", replaced)
+            self.assertEqual(
+                cal._git_blob(root, "HEAD", ".codearbiter/decisions/0001-test.md"), ADR)
+            self.assertEqual(
+                paa._head_blob(root, ".codearbiter/decisions/0001-test.md"), ADR)
+
+    def test_non_acceptance_ledger_append_does_not_claim_acceptance_packet_scope(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-b", "main")
+            decisions = os.path.join(root, ".codearbiter", "decisions")
+            os.makedirs(decisions)
+            ledger_path = os.path.join(decisions, "adr-lifecycle.jsonl")
+            with open(ledger_path, "wb") as handle:
+                handle.write(b"")
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+            self._git(root, "commit", "-m", "seed ledger")
+            with open(ledger_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(json.dumps({"event": "verified"}) + "\n")
+            outside_path = os.path.join(root, "ordinary-evidence.txt")
+            with open(outside_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write("ordinary evidence\n")
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl",
+                      "ordinary-evidence.txt")
+            self.assertIsNone(cal._local_binding_transition_error(root, [], {}))
+
+    def test_local_acceptance_cannot_replace_the_committed_ledger_without_a_packet(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-b", "main")
+            decisions = os.path.join(root, ".codearbiter", "decisions")
+            os.makedirs(decisions)
+            adr_path = os.path.join(decisions, "0001-test.md")
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR)
+            ledger_path = os.path.join(decisions, "adr-lifecycle.jsonl")
+            with open(ledger_path, "wb") as handle:
+                handle.write(b"\n")
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md",
+                      ".codearbiter/decisions/adr-lifecycle.jsonl")
+            self._git(root, "commit", "-m", "accepted source")
+
+            acceptance = self._acceptance()
+            acceptance["source_commit"] = self._git(root, "rev-parse", "HEAD")
+            self._write_ledger(root, [acceptance])
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+            result, _stdout, stderr = self._run_checker(root)
+            self.assertEqual(result, 1)
+            self.assertIn("lifecycle ledger is not an exact append", stderr)
+
+    def test_strict_ref_rejects_baseline_for_a_freshly_accepted_adr(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-b", "main")
+            decisions = os.path.join(root, ".codearbiter", "decisions")
+            os.makedirs(decisions)
+            adr_path = os.path.join(decisions, "0001-test.md")
+            proposed = ADR.replace(b"status: accepted", b"status: proposed").replace(
+                b"## Status\nAccepted", b"## Status\nProposed")
+            with open(adr_path, "wb") as handle:
+                handle.write(proposed)
+            ledger_path = os.path.join(decisions, "adr-lifecycle.jsonl")
+            with open(ledger_path, "wb") as handle:
+                handle.write(b"")
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md",
+                      ".codearbiter/decisions/adr-lifecycle.jsonl")
+            self._git(root, "commit", "-m", "proposed ADR")
+            proposed_commit = self._git(root, "rev-parse", "HEAD")
+            with open(adr_path, "wb") as handle:
+                handle.write(ADR)
+            self._git(root, "add", ".codearbiter/decisions/0001-test.md")
+            self._git(root, "commit", "-m", "accepted source")
+            unrelated_path = os.path.join(root, "unrelated.txt")
+            with open(unrelated_path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write("intervening commit\n")
+            self._git(root, "add", "unrelated.txt")
+            self._git(root, "commit", "-m", "intervening change")
+            observed_commit = self._git(root, "rev-parse", "HEAD")
+
+            baseline = self._acceptance()
+            baseline["event"] = "baseline"
+            baseline["observed_commit"] = observed_commit
+            baseline.pop("source_commit")
+            baseline["obligations"] = []
+            baseline["obligations_sha256"] = al.obligation_set_digest([])
+            baseline["obligations_sealed"] = False
+            self._write_ledger(root, [baseline])
+            self._git(root, "add", ".codearbiter/decisions/adr-lifecycle.jsonl")
+            self._git(root, "commit", "-m", "invalid fresh baseline")
+            result, _stdout, stderr = self._run_checker(
+                root, "--base-ref", proposed_commit, "--current-ref", "HEAD")
+            self.assertEqual(result, 1)
+            self.assertIn("outside the closed migration epoch", stderr)
+
     def test_repository_ledger_and_all_accepted_adrs_validate(self):
         root = os.path.dirname(os.path.dirname(HERE))
         events = al.read_jsonl(os.path.join(
             root, ".codearbiter", "decisions", "adr-lifecycle.jsonl"))
-        blobs = al.read_accepted_adrs(root)
-        errors = al.validate_events(events, blobs, require_all_accepted=True)
+        blobs = al.read_adrs(root)
+        errors = al.validate_events(events, blobs)
+        binding_errors, _pending = cal.accepted_binding_errors(
+            root, events, blobs, allow_local_pending=True)
+        errors.extend(binding_errors)
         self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_pending_packet_is_isolated_to_the_exact_worktree_git_directory(self):
+        self.assertIsNotNone(paa, "pending-acceptance packet helper is missing")
+        with tempfile.TemporaryDirectory() as container:
+            root = os.path.join(container, "root")
+            linked = os.path.join(container, "linked")
+            os.makedirs(root)
+            self._git(root, "init", "-b", "main")
+            with open(os.path.join(root, "seed.txt"), "w", encoding="utf-8") as handle:
+                handle.write("seed\n")
+            self._git(root, "add", "seed.txt")
+            self._git(root, "commit", "-m", "seed")
+            self._git(root, "worktree", "add", "-b", "linked", linked, "HEAD")
+
+            root_identity = paa.repository_identity(root)
+            linked_identity = paa.repository_identity(linked)
+            self.assertEqual(root_identity["common_dir"], linked_identity["common_dir"])
+            self.assertNotEqual(root_identity["git_dir"], linked_identity["git_dir"])
+            self.assertNotEqual(paa.packet_path(root), paa.packet_path(linked))
+
+            with mock.patch.dict(os.environ, {
+                    "GIT_DIR": root_identity["git_dir"],
+                    "GIT_WORK_TREE": root}, clear=False):
+                self.assertEqual(paa.repository_identity(linked), linked_identity)
+
+            admin_dir = os.path.dirname(paa.packet_path(linked))
+            foreign = os.path.join(container, "foreign")
+            os.makedirs(foreign)
+            try:
+                os.symlink(foreign, admin_dir, target_is_directory=True)
+            except OSError:
+                pass
+            else:
+                with self.assertRaises(ValueError):
+                    paa.packet_path(linked)
+                try:
+                    os.unlink(admin_dir)
+                except IsADirectoryError:
+                    os.rmdir(admin_dir)
+            self._git(root, "worktree", "remove", "--force", linked)
 
     def test_canonical_adr_skill_distinguishes_acceptance_from_delivery(self):
         root = os.path.dirname(os.path.dirname(HERE))
@@ -1181,6 +1741,8 @@ class LifecycleContractTest(unittest.TestCase):
         with open(os.path.join(root, ".codearbiter", "tech-stack.md"), encoding="utf-8") as handle:
             tech_stack = handle.read()
         self.assertIn("python .github/scripts/test_adr_lifecycle.py", tech_stack)
+        self.assertIn(".github/scripts/prepare_adr_acceptance.py", tech_stack)
+        self.assertIn("GitHub-event validation remain strict", tech_stack)
         local_command = "python .github/scripts/check_adr_lifecycle.py"
         self.assertEqual(_tech_checker_commands(tech_stack), [local_command])
         self.assertIn("python .github/scripts/check_destructive_registry.py", tech_stack)


### PR DESCRIPTION
## Summary

Make the documented two-commit ADR acceptance protocol executable without weakening strict lifecycle validation.

- Add a short-lived, worktree-local review packet bound to repository identity, HEAD, staged tree, ADR bytes, decision-log append, sealed obligations, reviewer identities, and freshness.
- Require the second commit's sole lifecycle-ledger append to match that reviewed packet exactly.
- Reject replacement-ref evidence substitution, unstaged or rewritten bindings, obligation changes, future timestamps, and new legacy baselines outside the closed migration epoch.
- Document the correct create, validate, commit, and clear ordering.

## Why

The existing checker required every accepted ADR to have a committed lifecycle binding before it allowed the source ADR commit. That contradicted ADR-0033's required two-commit protocol and made the first commit impossible. The local allowance is limited to the exact staged transition; explicit-ref, export, GitHub-event, and final binding checks remain strict.

Tradeoff: reviewer identity is a cooperative process attestation in the ephemeral packet, consistent with the existing governance trust model. This change does not introduce a new cryptographic reviewer identity system.

Ref: ADR-0033

## Test plan

- `python .github/scripts/test_adr_lifecycle.py` (49 passed)
- `python .github/scripts/check_adr_lifecycle.py`
- Full required Python matrix from `.codearbiter/tech-stack.md`
- `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"` with Git Bash on PATH (1,457 passed, 3 skipped)
- `python -m py_compile .github/scripts/check_adr_lifecycle.py .github/scripts/prepare_adr_acceptance.py .github/scripts/test_adr_lifecycle.py`
- `git diff --cached --check`

Independent adversarial review: PASS with zero BLOCK findings on the committed file hashes.