### PR TITLE
chore(release): record publication receipts

### DIFF
--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -635,6 +635,26 @@
       "object_sha": "f9027d5ba53ca0918e50b4df866f687262256c13",
       "object_type": "tag",
       "commit_sha": "d11c74568fe581850872d3ae01e3502dc65ef654"
+    },
+    "v2.17.3": {
+      "object_sha": "c43498f2547777011043273577b16a02fbbfa7f0",
+      "object_type": "tag",
+      "commit_sha": "a3d76cf117e52de9d3c60e095ffb6a340cc04826"
+    },
+    "ca-codex-v0.9.3": {
+      "object_type": "tag",
+      "object_sha": "bfb929001ce73e034584c1673ad3434272a6ed46",
+      "commit_sha": "a3d76cf117e52de9d3c60e095ffb6a340cc04826"
+    },
+    "ca-pi-v0.10.4": {
+      "object_type": "tag",
+      "commit_sha": "a3d76cf117e52de9d3c60e095ffb6a340cc04826",
+      "object_sha": "f8dc79c47d0d8b8ab6ead5a351cbac4c442b4a4d"
+    },
+    "ca-sandbox-v0.1.6": {
+      "object_sha": "25746afaf6b7f0c9b7baac34e9c1810eecede572",
+      "object_type": "tag",
+      "commit_sha": "a3d76cf117e52de9d3c60e095ffb6a340cc04826"
     }
   }
 }

--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -62,6 +62,41 @@ from pathlib import Path
 # anything else in refs/tags is a working tag this audit has no opinion about.
 NAMESPACES = ("v*", "ca-sandbox-v*", "ca-codex-v*", "ca-pi-v*")
 
+# Closed floor for the original-publication ledger as reconciled on 2026-09-05.
+# New trusted publication receipts may be appended, but none of these reviewed
+# identities may disappear or change without tripping this offline guard.
+ORIGINAL_RECEIPT_BASELINE_TAGS = frozenset("""
+ca-codex-v0.2.4 ca-codex-v0.3.0 ca-codex-v0.3.1 ca-codex-v0.3.2
+ca-codex-v0.3.3 ca-codex-v0.3.4 ca-codex-v0.3.5 ca-codex-v0.3.6
+ca-codex-v0.3.7 ca-codex-v0.4.0 ca-codex-v0.4.1 ca-codex-v0.4.10
+ca-codex-v0.4.11 ca-codex-v0.4.12 ca-codex-v0.4.13 ca-codex-v0.4.14
+ca-codex-v0.4.15 ca-codex-v0.4.16 ca-codex-v0.4.2 ca-codex-v0.4.3
+ca-codex-v0.4.4 ca-codex-v0.4.5 ca-codex-v0.4.6 ca-codex-v0.4.7
+ca-codex-v0.4.8 ca-codex-v0.4.9 ca-codex-v0.5.0 ca-codex-v0.5.1
+ca-codex-v0.9.1 ca-codex-v0.9.3 ca-pi-v0.1.32 ca-pi-v0.1.33
+ca-pi-v0.1.34 ca-pi-v0.1.35 ca-pi-v0.1.36 ca-pi-v0.1.38
+ca-pi-v0.1.39 ca-pi-v0.1.40 ca-pi-v0.1.41 ca-pi-v0.1.42
+ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.2.0
+ca-pi-v0.2.1 ca-pi-v0.2.11 ca-pi-v0.2.12 ca-pi-v0.2.13
+ca-pi-v0.2.14 ca-pi-v0.2.15 ca-pi-v0.2.16 ca-pi-v0.2.17
+ca-pi-v0.2.18 ca-pi-v0.2.19 ca-pi-v0.2.2 ca-pi-v0.2.3
+ca-pi-v0.2.4 ca-pi-v0.2.5 ca-pi-v0.2.6 ca-pi-v0.2.7
+ca-pi-v0.2.8 ca-pi-v0.2.9 ca-pi-v0.3.0 ca-pi-v0.3.1
+ca-sandbox-v0.1.0 ca-sandbox-v0.1.3 ca-sandbox-v0.1.4 ca-sandbox-v0.1.5
+ca-sandbox-v0.1.6 v2.0.0 v2.0.1 v2.1.0 v2.1.0-beta.2 v2.1.0-beta.3
+v2.1.0-beta.4 v2.1.0-beta.5 v2.1.0-beta.6 v2.10.0 v2.10.1 v2.10.2
+v2.10.3 v2.10.4 v2.10.5 v2.10.6 v2.10.7 v2.10.8 v2.11.0 v2.11.1
+v2.11.10 v2.11.11 v2.11.12 v2.11.13 v2.11.14 v2.11.15 v2.11.16
+v2.11.17 v2.11.2 v2.11.3 v2.11.4 v2.11.5 v2.11.6 v2.11.7 v2.11.8
+v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.2.0 v2.3.0 v2.3.1 v2.4.0
+v2.4.1 v2.4.2 v2.4.6 v2.5.0 v2.5.1 v2.5.2 v2.6.0 v2.6.1 v2.8.0
+v2.8.11 v2.8.13 v2.9.0 v2.9.1
+""".split())
+ORIGINAL_RECEIPT_BASELINE_COUNT = 124
+ORIGINAL_RECEIPT_BASELINE_SHA256 = (
+    "88b7d3f58a1304fabf1835d0442ccc224827e3458816e1f9bc3ff9d2a9bd5509"
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = REPO_ROOT / ".github" / "published-tags.json"
 LEGACY_MANIFEST_PATH = REPO_ROOT / ".github" / "legacy-published-tags.json"
@@ -168,6 +203,26 @@ def load_original_manifest(document: object) -> dict[str, Provenance]:
             raise ValueError("invalid original-publication tag")
         result[name] = _identity(entry, label="original-publication record")
     return result
+
+
+def validate_original_receipt_baseline(records: dict[str, Provenance]) -> None:
+    """Require every receipt frozen at the 2026-09-05 reconciliation identity."""
+    if len(ORIGINAL_RECEIPT_BASELINE_TAGS) != ORIGINAL_RECEIPT_BASELINE_COUNT:
+        raise RuntimeError("invalid frozen receipt baseline metadata")
+    if not ORIGINAL_RECEIPT_BASELINE_TAGS.issubset(records):
+        raise ValueError("frozen receipt baseline changed")
+    canonical = [
+        {
+            "tag": name,
+            "object_sha": records[name].object_sha,
+            "object_type": records[name].object_type,
+            "commit_sha": records[name].commit_sha,
+        }
+        for name in sorted(ORIGINAL_RECEIPT_BASELINE_TAGS)
+    ]
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if hashlib.sha256(payload).hexdigest() != ORIGINAL_RECEIPT_BASELINE_SHA256:
+        raise ValueError("frozen receipt baseline changed")
 
 
 def load_legacy_manifest(document: object) -> dict[str, LegacyProvenance]:
@@ -426,6 +481,8 @@ def main(argv=None, *, token=None, rest=None, recorded=None, legacy=None) -> int
     try:
         provenance = (load_recorded(recorded) if injected_original
                       else load_original_manifest(_read_json(arguments.manifest)))
+        if not injected_original:
+            validate_original_receipt_baseline(provenance)
         legacy = ({} if injected_original and legacy is None else legacy)
         legacy_provenance = (load_legacy_manifest(_read_json(arguments.legacy_manifest))
                              if legacy is None else legacy)

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -470,7 +470,13 @@ class LegacyEpochContract(unittest.TestCase):
 
     def test_main_clean_union_summary_keeps_evidence_class_labels_and_counts(self):
         complete = self._complete_inventory()
-        expected = "OK: 120 original-publication receipts and 44 legacy baselines"
+        original = module.load_original_manifest(
+            json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
+        )
+        expected = (
+            f"OK: {len(original)} original-publication receipts and "
+            f"{len(self.records)} legacy baselines"
+        )
         for strict in (False, True):
             with self.subTest(strict=strict):
                 code, output = self._run_full_ledger_main(complete, strict=strict)

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -241,6 +241,31 @@ class ShippedManifest(unittest.TestCase):
             set(self.manifest["tags"]), set(module.load_recorded(self.manifest["tags"]))
         )
 
+    def test_original_receipt_baseline_rejects_deletion_but_allows_append(self):
+        appended = json.loads(json.dumps(self.manifest))
+        appended["tags"]["v99.0.0"] = {
+            "object_sha": "a" * 40,
+            "object_type": "tag",
+            "commit_sha": "b" * 40,
+        }
+        appended_records = module.load_original_manifest(appended)
+        module.validate_original_receipt_baseline(appended_records)
+        self.assertIn("v99.0.0", appended_records)
+
+        deleted = json.loads(json.dumps(self.manifest))
+        del deleted["tags"]["v2.17.3"]
+        with self.assertRaisesRegex(ValueError, "frozen receipt baseline changed"):
+            module.validate_original_receipt_baseline(module.load_original_manifest(deleted))
+
+        for field in ("object_sha", "commit_sha"):
+            with self.subTest(field=field):
+                mutated = json.loads(json.dumps(self.manifest))
+                mutated["tags"]["v2.17.3"][field] = "f" * 40
+                with self.assertRaisesRegex(ValueError, "frozen receipt baseline changed"):
+                    module.validate_original_receipt_baseline(
+                        module.load_original_manifest(mutated)
+                    )
+
 
 class LegacyEpochContract(unittest.TestCase):
     """ADR-0034's closed historical observation epoch, without provenance laundering."""
@@ -442,6 +467,7 @@ class LegacyEpochContract(unittest.TestCase):
         original = module.load_original_manifest(
             json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
         )
+        module.validate_original_receipt_baseline(original)
         return [
             {"ref": f"refs/tags/{tag}", "object": {
                 "sha": entry.object_sha, "type": entry.object_type,
@@ -473,6 +499,7 @@ class LegacyEpochContract(unittest.TestCase):
         original = module.load_original_manifest(
             json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
         )
+        module.validate_original_receipt_baseline(original)
         expected = (
             f"OK: {len(original)} original-publication receipts and "
             f"{len(self.records)} legacy baselines"


### PR DESCRIPTION
Records the four authenticated publication receipts emitted by hosted run 33996441808 and fixes the summary contract so append-only receipt growth does not create count-only drift.

## Summary

- append exact tag-object and peeled-commit identities for v2.17.3, ca-codex-v0.9.3, ca-pi-v0.10.4, and ca-sandbox-v0.1.6
- preserve all 120 prior original-publication receipts and the separate 44-tag legacy baseline ledger
- derive summary counts from validated ledgers while keeping evidence-class labels literal

Ref: ADR-0034

## Test plan

- `python .github/scripts/test_tag_immutability.py` (68 passed)
- `python .github/scripts/test_tag_publication_receipt.py` (16 passed)
- `python .github/scripts/test_reconcile_tag_receipt.py` (20 passed)
- authenticated live strict audit (124 receipts and 44 legacy baselines)
- complete repository commit-gate suite, including 1,457 hook tests and coverage-union prerequisites
- independent coverage and provenance reviews, both PASS with zero findings

Python files under `.github/scripts/` use the repository's documented no-numeric-coverage exemption.