### PR TITLE
fix(hooks): migrate earlier managed shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.17.4] - 2026-09-05
+
+### Fixed
+
+- Upgrade earlier codeArbiter-managed Git hook shims after ownership-banner wording changes while preserving foreign hooks.
+
 ## [2.17.3] - 2026-09-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.17.3" src="https://img.shields.io/badge/version-2.17.3-2b7489">
+<img alt="version 2.17.4" src="https://img.shields.io/badge/version-2.17.4-2b7489">
 <img alt="core lanes" src="https://img.shields.io/badge/core_lanes-18-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-19-555">
@@ -117,7 +117,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.3`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.4`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_githooks.py
+++ b/core/pysrc/_githooks.py
@@ -863,7 +863,7 @@ def install(root):
         if os.path.exists(dest):
             existing = _read(dest)
             lines = existing.splitlines() if existing is not None else []
-            managed = len(lines) >= 2 and (
+            managed = len(lines) >= 2 and lines[0] == "#!/bin/sh" and (
                 lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
             )
             if existing is not None and not managed:

--- a/core/pysrc/_githooks.py
+++ b/core/pysrc/_githooks.py
@@ -117,8 +117,9 @@ from _durabilitylib import is_ephemeral_path
 from _gitexec import (git_executable, root_bound_git_env,
                       trusted_git_executable, trusted_python_executable)
 
-SENTINEL = (
-    "# codeArbiter-managed git hook (#161) — this SHIM is refreshed by any live "
+SENTINEL = "# codeArbiter-managed git hook (#161)"
+SHIM_NOTICE = (
+    "# This SHIM is refreshed by any live "
     "host's session (it is host-neutral, ADR-0014); the plugin-specific enforcer "
     "entries it dispatches to (.git/codearbiter-hooksd/*.path) each self-heal "
     "only on THAT plugin's own next session (#556) — edits here are overwritten."
@@ -581,6 +582,7 @@ def _shim(dropin_dir, phase):
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
+        f"{SHIM_NOTICE}\n"
         f"D={quote(_shell_path(dropin_dir))}\n"
         f'if [ -e "$D/{_TRUSTED_IDENTITY_FILE}" ] || [ -L "$D/{_TRUSTED_IDENTITY_FILE}" ]; then\n'
         f'  [ -f "$D/{_TRUSTED_IDENTITY_FILE}" ] || exit 1\n'
@@ -860,7 +862,11 @@ def install(root):
         desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
-            if existing is not None and SENTINEL not in existing:
+            lines = existing.splitlines() if existing is not None else []
+            managed = len(lines) >= 2 and (
+                lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
+            )
+            if existing is not None and not managed:
                 _warn(f"an existing {phase} hook is not codeArbiter-managed — leaving it "
                       f"untouched. For git-level enforcement, call "
                       f"'{os.path.basename(enforcer)} {phase}' from it (see includes docs).")

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.3"
+    adapter_version = "2.17.4"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the generated codeArbiter governance surface plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail), sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-09-05
+
+### Fixed
+
+- Upgrade earlier codeArbiter-managed Git hook shims after ownership-banner wording changes while preserving foreign hooks.
+
 ## [0.9.3] - 2026-09-05
 
 ### Fixed

--- a/plugins/ca-codex/hooks/_githooks.py
+++ b/plugins/ca-codex/hooks/_githooks.py
@@ -863,7 +863,7 @@ def install(root):
         if os.path.exists(dest):
             existing = _read(dest)
             lines = existing.splitlines() if existing is not None else []
-            managed = len(lines) >= 2 and (
+            managed = len(lines) >= 2 and lines[0] == "#!/bin/sh" and (
                 lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
             )
             if existing is not None and not managed:

--- a/plugins/ca-codex/hooks/_githooks.py
+++ b/plugins/ca-codex/hooks/_githooks.py
@@ -117,8 +117,9 @@ from _durabilitylib import is_ephemeral_path
 from _gitexec import (git_executable, root_bound_git_env,
                       trusted_git_executable, trusted_python_executable)
 
-SENTINEL = (
-    "# codeArbiter-managed git hook (#161) — this SHIM is refreshed by any live "
+SENTINEL = "# codeArbiter-managed git hook (#161)"
+SHIM_NOTICE = (
+    "# This SHIM is refreshed by any live "
     "host's session (it is host-neutral, ADR-0014); the plugin-specific enforcer "
     "entries it dispatches to (.git/codearbiter-hooksd/*.path) each self-heal "
     "only on THAT plugin's own next session (#556) — edits here are overwritten."
@@ -581,6 +582,7 @@ def _shim(dropin_dir, phase):
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
+        f"{SHIM_NOTICE}\n"
         f"D={quote(_shell_path(dropin_dir))}\n"
         f'if [ -e "$D/{_TRUSTED_IDENTITY_FILE}" ] || [ -L "$D/{_TRUSTED_IDENTITY_FILE}" ]; then\n'
         f'  [ -f "$D/{_TRUSTED_IDENTITY_FILE}" ] || exit 1\n'
@@ -860,7 +862,11 @@ def install(root):
         desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
-            if existing is not None and SENTINEL not in existing:
+            lines = existing.splitlines() if existing is not None else []
+            managed = len(lines) >= 2 and (
+                lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
+            )
+            if existing is not None and not managed:
                 _warn(f"an existing {phase} hook is not codeArbiter-managed — leaving it "
                       f"untouched. For git-level enforcement, call "
                       f"'{os.path.basename(enforcer)} {phase}' from it (see includes docs).")

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -178,7 +178,7 @@ class CodexHost(hostapi.Host):
 
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.9.3"
+    adapter_version = "0.9.4"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.3"
+    adapter_version = "2.17.4"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.5] - 2026-09-05
+
+### Fixed
+
+- Upgrade earlier codeArbiter-managed Git hook shims after ownership-banner wording changes while preserving foreign hooks.
+
 ## [0.10.4] - 2026-09-05
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_githooks.py
+++ b/plugins/ca-pi/hooks/_githooks.py
@@ -863,7 +863,7 @@ def install(root):
         if os.path.exists(dest):
             existing = _read(dest)
             lines = existing.splitlines() if existing is not None else []
-            managed = len(lines) >= 2 and (
+            managed = len(lines) >= 2 and lines[0] == "#!/bin/sh" and (
                 lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
             )
             if existing is not None and not managed:

--- a/plugins/ca-pi/hooks/_githooks.py
+++ b/plugins/ca-pi/hooks/_githooks.py
@@ -117,8 +117,9 @@ from _durabilitylib import is_ephemeral_path
 from _gitexec import (git_executable, root_bound_git_env,
                       trusted_git_executable, trusted_python_executable)
 
-SENTINEL = (
-    "# codeArbiter-managed git hook (#161) — this SHIM is refreshed by any live "
+SENTINEL = "# codeArbiter-managed git hook (#161)"
+SHIM_NOTICE = (
+    "# This SHIM is refreshed by any live "
     "host's session (it is host-neutral, ADR-0014); the plugin-specific enforcer "
     "entries it dispatches to (.git/codearbiter-hooksd/*.path) each self-heal "
     "only on THAT plugin's own next session (#556) — edits here are overwritten."
@@ -581,6 +582,7 @@ def _shim(dropin_dir, phase):
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
+        f"{SHIM_NOTICE}\n"
         f"D={quote(_shell_path(dropin_dir))}\n"
         f'if [ -e "$D/{_TRUSTED_IDENTITY_FILE}" ] || [ -L "$D/{_TRUSTED_IDENTITY_FILE}" ]; then\n'
         f'  [ -f "$D/{_TRUSTED_IDENTITY_FILE}" ] || exit 1\n'
@@ -860,7 +862,11 @@ def install(root):
         desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
-            if existing is not None and SENTINEL not in existing:
+            lines = existing.splitlines() if existing is not None else []
+            managed = len(lines) >= 2 and (
+                lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
+            )
+            if existing is not None and not managed:
                 _warn(f"an existing {phase} hook is not codeArbiter-managed — leaving it "
                       f"untouched. For git-level enforcement, call "
                       f"'{os.path.basename(enforcer)} {phase}' from it (see includes docs).")

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.4"
+    adapter_version = "0.10.5"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.3"
+    adapter_version = "2.17.4"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -863,7 +863,7 @@ def install(root):
         if os.path.exists(dest):
             existing = _read(dest)
             lines = existing.splitlines() if existing is not None else []
-            managed = len(lines) >= 2 and (
+            managed = len(lines) >= 2 and lines[0] == "#!/bin/sh" and (
                 lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
             )
             if existing is not None and not managed:

--- a/plugins/ca/hooks/_githooks.py
+++ b/plugins/ca/hooks/_githooks.py
@@ -117,8 +117,9 @@ from _durabilitylib import is_ephemeral_path
 from _gitexec import (git_executable, root_bound_git_env,
                       trusted_git_executable, trusted_python_executable)
 
-SENTINEL = (
-    "# codeArbiter-managed git hook (#161) — this SHIM is refreshed by any live "
+SENTINEL = "# codeArbiter-managed git hook (#161)"
+SHIM_NOTICE = (
+    "# This SHIM is refreshed by any live "
     "host's session (it is host-neutral, ADR-0014); the plugin-specific enforcer "
     "entries it dispatches to (.git/codearbiter-hooksd/*.path) each self-heal "
     "only on THAT plugin's own next session (#556) — edits here are overwritten."
@@ -581,6 +582,7 @@ def _shim(dropin_dir, phase):
     return (
         "#!/bin/sh\n"
         f"{SENTINEL}\n"
+        f"{SHIM_NOTICE}\n"
         f"D={quote(_shell_path(dropin_dir))}\n"
         f'if [ -e "$D/{_TRUSTED_IDENTITY_FILE}" ] || [ -L "$D/{_TRUSTED_IDENTITY_FILE}" ]; then\n'
         f'  [ -f "$D/{_TRUSTED_IDENTITY_FILE}" ] || exit 1\n'
@@ -860,7 +862,11 @@ def install(root):
         desired = _shim(dropin_dir, phase)
         if os.path.exists(dest):
             existing = _read(dest)
-            if existing is not None and SENTINEL not in existing:
+            lines = existing.splitlines() if existing is not None else []
+            managed = len(lines) >= 2 and (
+                lines[1] == SENTINEL or lines[1].startswith(f"{SENTINEL} — ")
+            )
+            if existing is not None and not managed:
                 _warn(f"an existing {phase} hook is not codeArbiter-managed — leaving it "
                       f"untouched. For git-level enforcement, call "
                       f"'{os.path.basename(enforcer)} {phase}' from it (see includes docs).")

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.17.3"
+    adapter_version = "2.17.4"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.3"
+    adapter_version = "2.17.4"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -333,12 +333,70 @@ class TestInstall(_GitFixture):
     def test_foreign_hook_is_preserved(self):
         dest = os.path.join(self._hooks_dir(), "pre-commit")
         os.makedirs(self._hooks_dir(), exist_ok=True)
-        self._write(dest, "#!/bin/sh\necho husky\n")
+        foreign = (
+            "#!/bin/sh\n"
+            "echo '# codeArbiter-managed git hook (#161)'\n"
+            "echo husky\n"
+        )
+        self._write(dest, foreign)
         _githooks.install(self.root)
         with open(dest, encoding="utf-8") as f:
             body = f.read()
-        self.assertIn("husky", body)
-        self.assertNotIn(_githooks.SENTINEL, body)
+        self.assertEqual(body, foreign)
+
+    def test_previous_managed_shims_are_atomically_upgraded(self):
+        previous_sentinels = (
+            (
+                "# codeArbiter-managed git hook (#161) — refreshed each session; "
+                "edits are overwritten."
+            ),
+            (
+                "# codeArbiter-managed git hook (#161) — this SHIM is refreshed "
+                "by any live host's session (it is host-neutral, ADR-0014); the "
+                "plugin-specific enforcer entries it dispatches to "
+                "(.git/codearbiter-hooksd/*.path) each self-heal only on THAT "
+                "plugin's own next session (#556) — edits here are overwritten."
+            ),
+        )
+        os.makedirs(self._hooks_dir(), exist_ok=True)
+        for previous_sentinel in previous_sentinels:
+            with self.subTest(previous_sentinel=previous_sentinel):
+                destinations = []
+                for phase in _githooks.PHASES:
+                    dest = os.path.join(self._hooks_dir(), phase)
+                    destinations.append(dest)
+                    self._write(
+                        dest,
+                        f"#!/bin/sh\n{previous_sentinel}\necho stale\n",
+                    )
+
+                writes = []
+                original_write = _githooks._hooklib.write_text_atomic
+
+                def write_spy(path, text, **kwargs):
+                    writes.append((path, text, kwargs))
+                    return original_write(path, text, **kwargs)
+
+                with mock.patch.object(
+                        _githooks._hooklib,
+                        "write_text_atomic",
+                        side_effect=write_spy):
+                    actions = _githooks.install(self.root)
+
+                for phase, dest in zip(_githooks.PHASES, destinations):
+                    with self.subTest(phase=phase):
+                        with open(dest, encoding="utf-8") as f:
+                            self.assertEqual(
+                                f.read(),
+                                _githooks._shim(
+                                    _githooks._dropin_dir(self.root), phase),
+                            )
+                        self.assertIn(f"{phase}: installed", actions)
+                        expected = os.path.normcase(os.path.abspath(dest))
+                        self.assertTrue(any(
+                            os.path.normcase(os.path.abspath(path)) == expected
+                            for path, _, _ in writes
+                        ))
 
     def test_uninstall_removes_only_own_dropin_entry(self):
         # ADR-0014: uninstall() removes ONLY this plugin's own drop-in

--- a/plugins/ca/hooks/tests/test_git_hooks.py
+++ b/plugins/ca/hooks/tests/test_git_hooks.py
@@ -344,6 +344,20 @@ class TestInstall(_GitFixture):
             body = f.read()
         self.assertEqual(body, foreign)
 
+    def test_foreign_hook_with_managed_marker_under_other_shebang_is_preserved(self):
+        dest = os.path.join(self._hooks_dir(), "pre-commit")
+        os.makedirs(self._hooks_dir(), exist_ok=True)
+        foreign = (
+            "#!/usr/bin/env bash\n"
+            f"{_githooks.SENTINEL}\n"
+            "echo foreign\n"
+        )
+        self._write(dest, foreign)
+        _githooks.install(self.root)
+        with open(dest, encoding="utf-8") as f:
+            body = f.read()
+        self.assertEqual(body, foreign)
+
     def test_previous_managed_shims_are_atomically_upgraded(self):
         previous_sentinels = (
             (


### PR DESCRIPTION
## Summary

Fix managed Git hook upgrades across codeArbiter banner changes.

- Emit a stable ownership marker separately from mutable shim guidance.
- Recognize prior managed banners only in the generated header position.
- Atomically replace both prior `pre-commit` and `pre-push` shims.
- Preserve foreign hooks byte-for-byte, including hooks that mention the marker later in their body.
- Keep the canonical core and all three governance-host payloads byte-identical.
- Advance the changed Claude, Codex, and Pi payloads to 2.17.4, 0.9.4, and 0.10.5, with each manifest and authenticated adapter identity moving together.

The 0.9.3 fresh-install proof exposed the defect: session startup refreshed the plugin registry entry, but treated an older codeArbiter-managed shim as foreign because its full descriptive sentinel text differed. Doctor then correctly reported stale shared shims.

## Verification

- Regression-first proof: the new migration test failed twice before the implementation because both old shims were preserved as foreign.
- Focused hook contract: 64 tests passed after adding the alternate-shebang preservation case.
- Full hook suite: 1,458 tests passed with 3 existing skips.
- Pi adapter: 863 tests passed with 1 existing skip; typecheck, build, package, parity, docs, security, and fixture-platform checks passed.
- The post-version Pi package suite passed all 45 tests, including a durable index-only package copy whose manifest and host identity must agree.
- Claude and Codex payload gates passed at 2.17.4 and 0.9.4; Pi's independent release guard passed at 0.10.5 with matching generated root metadata and changelog.
- Repository Python and static validation passed, including hermeticity, cold install, generated-surface checks, release workflow, publication receipts, and branch protection.
- `sync-core --check` verified 62 core files across all three governance hosts.
- Python compilation, staged diff validation, and staged secret-pattern scan passed.
- Independent coverage and security reviews found no blocking or advisory findings.
- CodeRabbit's one Major finding was reproduced: a foreign alternate-shebang hook with the marker on line two was replaced. The new regression failed before the correction and passes after requiring the complete generated `#!/bin/sh` plus marker header.

Python hook coverage has no numeric tool. `.codearbiter/tech-stack.md` states that no coverage tooling exists for `plugins/*/hooks/*.py` or `.github/scripts/*.py`; obligation-level tests are the recorded proof.

## Tradeoff and merge method

The marker remains a cooperative same-user ownership convention under ADR-0010, not authentication. Anchoring it to the generated second line prevents incidental body text from authorizing replacement while retaining a durable migration seam.

ADR source ancestry selected `squash` for fetched base `3cb725f01f8b6bf733f4fed7b9e7dd70fdefe2a9` and exact head `b3b84060a167973a96de699c48f983e6c758b1c1`.
