### PR TITLE
chore(provenance): record 0.9.4 publication receipts

### DIFF
--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -655,6 +655,21 @@
       "object_sha": "25746afaf6b7f0c9b7baac34e9c1810eecede572",
       "object_type": "tag",
       "commit_sha": "a3d76cf117e52de9d3c60e095ffb6a340cc04826"
+    },
+    "v2.17.4": {
+      "object_sha": "b036de47cd6d33bc037c7fd5166a22fc70358717",
+      "object_type": "tag",
+      "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26"
+    },
+    "ca-codex-v0.9.4": {
+      "object_sha": "9b8ef86a60143588febeaaeacdf90435f204b020",
+      "object_type": "tag",
+      "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26"
+    },
+    "ca-pi-v0.10.5": {
+      "object_sha": "038760c8b101c61c9a6f9835c78c2d98b5cb8139",
+      "object_type": "tag",
+      "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26"
     }
   }
 }

--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -206,7 +206,7 @@ def load_original_manifest(document: object) -> dict[str, Provenance]:
 
 
 def validate_original_receipt_baseline(records: dict[str, Provenance]) -> None:
-    """Require every receipt frozen at the 2026-09-05 reconciliation identity."""
+    """Require every receipt frozen at the 2026-09-06 reconciliation identity."""
     if len(ORIGINAL_RECEIPT_BASELINE_TAGS) != ORIGINAL_RECEIPT_BASELINE_COUNT:
         raise RuntimeError("invalid frozen receipt baseline metadata")
     if not ORIGINAL_RECEIPT_BASELINE_TAGS.issubset(records):

--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -62,7 +62,7 @@ from pathlib import Path
 # anything else in refs/tags is a working tag this audit has no opinion about.
 NAMESPACES = ("v*", "ca-sandbox-v*", "ca-codex-v*", "ca-pi-v*")
 
-# Closed floor for the original-publication ledger as reconciled on 2026-09-05.
+# Closed floor for the original-publication ledger as reconciled on 2026-09-06.
 # New trusted publication receipts may be appended, but none of these reviewed
 # identities may disappear or change without tripping this offline guard.
 ORIGINAL_RECEIPT_BASELINE_TAGS = frozenset("""
@@ -73,10 +73,10 @@ ca-codex-v0.4.11 ca-codex-v0.4.12 ca-codex-v0.4.13 ca-codex-v0.4.14
 ca-codex-v0.4.15 ca-codex-v0.4.16 ca-codex-v0.4.2 ca-codex-v0.4.3
 ca-codex-v0.4.4 ca-codex-v0.4.5 ca-codex-v0.4.6 ca-codex-v0.4.7
 ca-codex-v0.4.8 ca-codex-v0.4.9 ca-codex-v0.5.0 ca-codex-v0.5.1
-ca-codex-v0.9.1 ca-codex-v0.9.3 ca-pi-v0.1.32 ca-pi-v0.1.33
+ca-codex-v0.9.1 ca-codex-v0.9.3 ca-codex-v0.9.4 ca-pi-v0.1.32 ca-pi-v0.1.33
 ca-pi-v0.1.34 ca-pi-v0.1.35 ca-pi-v0.1.36 ca-pi-v0.1.38
 ca-pi-v0.1.39 ca-pi-v0.1.40 ca-pi-v0.1.41 ca-pi-v0.1.42
-ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.2.0
+ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.10.5 ca-pi-v0.2.0
 ca-pi-v0.2.1 ca-pi-v0.2.11 ca-pi-v0.2.12 ca-pi-v0.2.13
 ca-pi-v0.2.14 ca-pi-v0.2.15 ca-pi-v0.2.16 ca-pi-v0.2.17
 ca-pi-v0.2.18 ca-pi-v0.2.19 ca-pi-v0.2.2 ca-pi-v0.2.3
@@ -88,13 +88,13 @@ v2.1.0-beta.4 v2.1.0-beta.5 v2.1.0-beta.6 v2.10.0 v2.10.1 v2.10.2
 v2.10.3 v2.10.4 v2.10.5 v2.10.6 v2.10.7 v2.10.8 v2.11.0 v2.11.1
 v2.11.10 v2.11.11 v2.11.12 v2.11.13 v2.11.14 v2.11.15 v2.11.16
 v2.11.17 v2.11.2 v2.11.3 v2.11.4 v2.11.5 v2.11.6 v2.11.7 v2.11.8
-v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.2.0 v2.3.0 v2.3.1 v2.4.0
+v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.17.4 v2.2.0 v2.3.0 v2.3.1 v2.4.0
 v2.4.1 v2.4.2 v2.4.6 v2.5.0 v2.5.1 v2.5.2 v2.6.0 v2.6.1 v2.8.0
 v2.8.11 v2.8.13 v2.9.0 v2.9.1
 """.split())
-ORIGINAL_RECEIPT_BASELINE_COUNT = 124
+ORIGINAL_RECEIPT_BASELINE_COUNT = 127
 ORIGINAL_RECEIPT_BASELINE_SHA256 = (
-    "88b7d3f58a1304fabf1835d0442ccc224827e3458816e1f9bc3ff9d2a9bd5509"
+    "27ff1368b51a69be3de05fba921127e2cb22ad45790180d736f1ecf5011e3ab9"
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -236,6 +236,29 @@ class ShippedManifest(unittest.TestCase):
         for name, entry in RECORDED.items():
             self.assertEqual(entry, self.manifest["tags"][name], name)
 
+    def test_2026_09_06_publication_receipts_are_frozen(self):
+        expected = {
+            "v2.17.4": {
+                "object_sha": "b036de47cd6d33bc037c7fd5166a22fc70358717",
+                "object_type": "tag",
+                "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26",
+            },
+            "ca-codex-v0.9.4": {
+                "object_sha": "9b8ef86a60143588febeaaeacdf90435f204b020",
+                "object_type": "tag",
+                "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26",
+            },
+            "ca-pi-v0.10.5": {
+                "object_sha": "038760c8b101c61c9a6f9835c78c2d98b5cb8139",
+                "object_type": "tag",
+                "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26",
+            },
+        }
+        for name, receipt in expected.items():
+            with self.subTest(name=name):
+                self.assertEqual(receipt, self.manifest["tags"][name])
+                self.assertIn(name, module.ORIGINAL_RECEIPT_BASELINE_TAGS)
+
     def test_the_manifest_loads_through_the_tool_it_feeds(self):
         self.assertEqual(
             set(self.manifest["tags"]), set(module.load_recorded(self.manifest["tags"]))


### PR DESCRIPTION
## Summary

Record the three original-publication receipts created by the ca-codex 0.9.4 release and freeze their identities in the offline immutability baseline.

- Add exact annotated-tag and peeled-commit identities for `v2.17.4`, `ca-codex-v0.9.4`, and `ca-pi-v0.10.5`.
- Advance the closed receipt floor from 124 to 127 entries with a recomputed canonical digest.
- Add a focused regression that binds each new receipt to the shipped manifest and frozen set.

## Why

Release workflow run 34003209984 published these tags from exact main `07f8f475203876561561fa107d110e82d85c2c26`. Publication and durable ledger reconciliation are separate states. Recording the authenticated receipts now lets the offline guard reject future deletion or identity mutation without treating current release metadata as original-publication proof.

## Validation

- Red proof: the focused receipt regression failed for all three absent tags before the manifest and baseline update.
- `python .github/scripts/test_tag_immutability.py` (70 passed)
- `python .github/scripts/test_tag_publication_receipt.py` (16 passed)
- `python .github/scripts/test_reconcile_tag_receipt.py` (20 passed)
- Authenticated strict live audit: 127 original-publication receipts and 44 legacy baselines resolve to their separately recorded identities.
- Full commit-gate test inventory passed. The whole hook suite passed 1,459 tests with 3 skips after adding Git for Windows `sh` to `PATH`, as required by the repository support contract.
- Manual staged-diff secret scan and `git diff --check` passed.
- Independent gpt-6-astra/high review found no correctness, security, provenance, or coverage findings. It recomputed digest `27ff1368b51a69be3de05fba921127e2cb22ad45790180d736f1ecf5011e3ab9`, preserved all 124 prior receipts, rejected 508 deletion or identity mutations, and confirmed future appends remain allowed.

## Merge contract

- Exact base: `07f8f475203876561561fa107d110e82d85c2c26`
- Exact head: `f3b70564b4c3fd846bf1a1c63383267a45858510`
- ADR source-ancestry verifier selected `squash`.
