### PR TITLE
fix(mode): recover unsettled repeated enter

### DIFF
--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3828,3 +3828,6 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-06T04:23:06Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-06T04:38:01Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-06T06:11:49Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-06T14:28:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-06T14:30:22Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-06T14:44:20Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.github/scripts/test_modelib.py
+++ b/.github/scripts/test_modelib.py
@@ -965,6 +965,33 @@ class TestEnterRowIsLedgerBacked(unittest.TestCase):
             result = _modelib.flip("s1", "dangerous", root=self.root)
         self.assertEqual(result, _modelib.FLIP_FAILED)
 
+    def test_repeat_request_recovers_an_unsettled_enter_instead_of_reporting_noop(self):
+        with self._refuse_appends():
+            first = _modelib.flip("s1", "dangerous", root=self.root)
+        self.assertEqual(first, _modelib.FLIP_FAILED)
+        self.assertFalse(
+            _modelib.ledger_backs(self.root, "dangerous", session_id="s1")
+        )
+
+        repeated = _modelib.flip("s1", "dangerous", root=self.root)
+
+        self.assertEqual(repeated, _modelib.FLIP_FLIPPED)
+        self.assertTrue(
+            _modelib.ledger_backs(self.root, "dangerous", session_id="s1")
+        )
+        self.assertEqual(self._trail_text().count("MODE: dangerous enter"), 1)
+
+    def test_repeat_request_stays_failed_while_the_enter_row_cannot_settle(self):
+        with self._refuse_appends():
+            first = _modelib.flip("s1", "dangerous", root=self.root)
+            repeated = _modelib.flip("s1", "dangerous", root=self.root)
+
+        self.assertEqual(first, _modelib.FLIP_FAILED)
+        self.assertEqual(repeated, _modelib.FLIP_FAILED)
+        self.assertFalse(
+            _modelib.ledger_backs(self.root, "dangerous", session_id="s1")
+        )
+
     def test_the_owed_row_replays_on_the_next_settle(self):
         with self._refuse_appends():
             _modelib.flip("s1", "dangerous", root=self.root)

--- a/.github/scripts/test_modelib.py
+++ b/.github/scripts/test_modelib.py
@@ -992,6 +992,31 @@ class TestEnterRowIsLedgerBacked(unittest.TestCase):
             _modelib.ledger_backs(self.root, "dangerous", session_id="s1")
         )
 
+    def test_repeat_request_stays_failed_when_only_an_older_session_settles(self):
+        with self._refuse_appends():
+            _modelib.flip("older", "dangerous", root=self.root)
+            _modelib.flip("requested", "dangerous", root=self.root)
+
+        real_append = _modelib._append_override_line
+
+        def append_only_the_older_row(root, line):
+            if "| SESSION: older |" in line:
+                return real_append(root, line)
+            return False
+
+        with mock.patch.object(
+                _modelib, "_append_override_line",
+                side_effect=append_only_the_older_row):
+            repeated = _modelib.flip("requested", "dangerous", root=self.root)
+
+        self.assertEqual(repeated, _modelib.FLIP_FAILED)
+        self.assertTrue(
+            _modelib.ledger_backs(self.root, "dangerous", session_id="older")
+        )
+        self.assertFalse(
+            _modelib.ledger_backs(self.root, "dangerous", session_id="requested")
+        )
+
     def test_the_owed_row_replays_on_the_next_settle(self):
         with self._refuse_appends():
             _modelib.flip("s1", "dangerous", root=self.root)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.17.6] - 2026-09-06
+
+### Fixed
+
+- Recover an unsettled mode-enter audit row on a repeated request instead of reporting an ineffective posture as a no-op.
+
 ## [2.17.5] - 2026-09-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.17.5" src="https://img.shields.io/badge/version-2.17.5-2b7489">
+<img alt="version 2.17.6" src="https://img.shields.io/badge/version-2.17.6-2b7489">
 <img alt="core lanes" src="https://img.shields.io/badge/core_lanes-18-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-19-555">
@@ -117,7 +117,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.5`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.6`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_modelib.py
+++ b/core/pysrc/_modelib.py
@@ -353,13 +353,14 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     """Attempt to set `session_id`'s mode to `mode`. Returns one of
     FLIP_FLIPPED / FLIP_NOOP / FLIP_FAILED. Never raises.
 
-    AC-6: a flip TO THE ALREADY-ACTIVE mode is a no-op — no write is even
-    attempted and no audit row is appended, so `overrides.log` is left
-    byte-identical. This is also the mechanism behind T-14's fail-direction
-    asymmetry: once a failed flip has left the session's resolved mode
-    unchanged, any LATER flip back to that same resolved mode is a no-op
-    under ANY filesystem state — including a markers directory that cannot
-    be written to at all — because a no-op never touches disk.
+    AC-6: a flip TO AN ALREADY-ACTIVE, LEDGER-BACKED mode is a no-op — no
+    write is attempted and no audit row is appended, so `overrides.log` is
+    left byte-identical. The default arbiter posture needs no authorizing row.
+    If a prior non-arbiter write landed but its staged enter row did not, a
+    repeat request retries settlement: success reports the effective flip,
+    while another failure stays explicit instead of claiming the posture is
+    already active. This preserves T-14's fail direction because an unbacked
+    non-arbiter marker still cannot authorize persona composition.
 
     On a genuine transition the order is deliberate: write first, audit row
     ONLY on a confirmed write. AC-11's `ledger_backs` exists to catch exactly
@@ -369,7 +370,12 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     root = root if root is not None else marker_root(payload)
     current, _diag = current_mode(session_id, root=root, payload=payload)
     if current == mode:
-        return FLIP_NOOP
+        if mode == MODES[0] or ledger_backs(root, mode, session_id=session_id):
+            return FLIP_NOOP
+        _settle_dev_close(root, host_name=host_name)
+        return (FLIP_FLIPPED
+                if ledger_backs(root, mode, session_id=session_id)
+                else FLIP_FAILED)
     if not write_mode(session_id, mode, root=root, payload=payload):
         return FLIP_FAILED
     # ADR-0030 position 4: EVERY transition row is staged through the #396

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.5"
+    adapter_version = "2.17.6"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the generated codeArbiter governance surface plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail), sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-09-06
+
+### Fixed
+
+- Recover an unsettled mode-enter audit row on a repeated request instead of reporting an ineffective posture as a no-op.
+
 ## [0.9.5] - 2026-09-06
 
 ### Changed

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -178,7 +178,7 @@ class CodexHost(hostapi.Host):
 
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.9.5"
+    adapter_version = "0.9.6"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/_modelib.py
+++ b/plugins/ca-codex/hooks/_modelib.py
@@ -353,13 +353,14 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     """Attempt to set `session_id`'s mode to `mode`. Returns one of
     FLIP_FLIPPED / FLIP_NOOP / FLIP_FAILED. Never raises.
 
-    AC-6: a flip TO THE ALREADY-ACTIVE mode is a no-op — no write is even
-    attempted and no audit row is appended, so `overrides.log` is left
-    byte-identical. This is also the mechanism behind T-14's fail-direction
-    asymmetry: once a failed flip has left the session's resolved mode
-    unchanged, any LATER flip back to that same resolved mode is a no-op
-    under ANY filesystem state — including a markers directory that cannot
-    be written to at all — because a no-op never touches disk.
+    AC-6: a flip TO AN ALREADY-ACTIVE, LEDGER-BACKED mode is a no-op — no
+    write is attempted and no audit row is appended, so `overrides.log` is
+    left byte-identical. The default arbiter posture needs no authorizing row.
+    If a prior non-arbiter write landed but its staged enter row did not, a
+    repeat request retries settlement: success reports the effective flip,
+    while another failure stays explicit instead of claiming the posture is
+    already active. This preserves T-14's fail direction because an unbacked
+    non-arbiter marker still cannot authorize persona composition.
 
     On a genuine transition the order is deliberate: write first, audit row
     ONLY on a confirmed write. AC-11's `ledger_backs` exists to catch exactly
@@ -369,7 +370,12 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     root = root if root is not None else marker_root(payload)
     current, _diag = current_mode(session_id, root=root, payload=payload)
     if current == mode:
-        return FLIP_NOOP
+        if mode == MODES[0] or ledger_backs(root, mode, session_id=session_id):
+            return FLIP_NOOP
+        _settle_dev_close(root, host_name=host_name)
+        return (FLIP_FLIPPED
+                if ledger_backs(root, mode, session_id=session_id)
+                else FLIP_FAILED)
     if not write_mode(session_id, mode, root=root, payload=payload):
         return FLIP_FAILED
     # ADR-0030 position 4: EVERY transition row is staged through the #396

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.5"
+    adapter_version = "2.17.6"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.7] - 2026-09-06
+
+### Fixed
+
+- Recover an unsettled mode-enter audit row on a repeated request instead of reporting an ineffective posture as a no-op.
+
 ## [0.10.6] - 2026-09-06
 
 ### Changed

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.6"
+    adapter_version = "0.10.7"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/hooks/_modelib.py
+++ b/plugins/ca-pi/hooks/_modelib.py
@@ -353,13 +353,14 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     """Attempt to set `session_id`'s mode to `mode`. Returns one of
     FLIP_FLIPPED / FLIP_NOOP / FLIP_FAILED. Never raises.
 
-    AC-6: a flip TO THE ALREADY-ACTIVE mode is a no-op — no write is even
-    attempted and no audit row is appended, so `overrides.log` is left
-    byte-identical. This is also the mechanism behind T-14's fail-direction
-    asymmetry: once a failed flip has left the session's resolved mode
-    unchanged, any LATER flip back to that same resolved mode is a no-op
-    under ANY filesystem state — including a markers directory that cannot
-    be written to at all — because a no-op never touches disk.
+    AC-6: a flip TO AN ALREADY-ACTIVE, LEDGER-BACKED mode is a no-op — no
+    write is attempted and no audit row is appended, so `overrides.log` is
+    left byte-identical. The default arbiter posture needs no authorizing row.
+    If a prior non-arbiter write landed but its staged enter row did not, a
+    repeat request retries settlement: success reports the effective flip,
+    while another failure stays explicit instead of claiming the posture is
+    already active. This preserves T-14's fail direction because an unbacked
+    non-arbiter marker still cannot authorize persona composition.
 
     On a genuine transition the order is deliberate: write first, audit row
     ONLY on a confirmed write. AC-11's `ledger_backs` exists to catch exactly
@@ -369,7 +370,12 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     root = root if root is not None else marker_root(payload)
     current, _diag = current_mode(session_id, root=root, payload=payload)
     if current == mode:
-        return FLIP_NOOP
+        if mode == MODES[0] or ledger_backs(root, mode, session_id=session_id):
+            return FLIP_NOOP
+        _settle_dev_close(root, host_name=host_name)
+        return (FLIP_FLIPPED
+                if ledger_backs(root, mode, session_id=session_id)
+                else FLIP_FAILED)
     if not write_mode(session_id, mode, root=root, payload=payload):
         return FLIP_FAILED
     # ADR-0030 position 4: EVERY transition row is staged through the #396

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.5"
+    adapter_version = "2.17.6"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.17.5"
+    adapter_version = "2.17.6"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/_modelib.py
+++ b/plugins/ca/hooks/_modelib.py
@@ -353,13 +353,14 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     """Attempt to set `session_id`'s mode to `mode`. Returns one of
     FLIP_FLIPPED / FLIP_NOOP / FLIP_FAILED. Never raises.
 
-    AC-6: a flip TO THE ALREADY-ACTIVE mode is a no-op — no write is even
-    attempted and no audit row is appended, so `overrides.log` is left
-    byte-identical. This is also the mechanism behind T-14's fail-direction
-    asymmetry: once a failed flip has left the session's resolved mode
-    unchanged, any LATER flip back to that same resolved mode is a no-op
-    under ANY filesystem state — including a markers directory that cannot
-    be written to at all — because a no-op never touches disk.
+    AC-6: a flip TO AN ALREADY-ACTIVE, LEDGER-BACKED mode is a no-op — no
+    write is attempted and no audit row is appended, so `overrides.log` is
+    left byte-identical. The default arbiter posture needs no authorizing row.
+    If a prior non-arbiter write landed but its staged enter row did not, a
+    repeat request retries settlement: success reports the effective flip,
+    while another failure stays explicit instead of claiming the posture is
+    already active. This preserves T-14's fail direction because an unbacked
+    non-arbiter marker still cannot authorize persona composition.
 
     On a genuine transition the order is deliberate: write first, audit row
     ONLY on a confirmed write. AC-11's `ledger_backs` exists to catch exactly
@@ -369,7 +370,12 @@ def flip(session_id, mode, root=None, payload=None, host_name=None, now=None):
     root = root if root is not None else marker_root(payload)
     current, _diag = current_mode(session_id, root=root, payload=payload)
     if current == mode:
-        return FLIP_NOOP
+        if mode == MODES[0] or ledger_backs(root, mode, session_id=session_id):
+            return FLIP_NOOP
+        _settle_dev_close(root, host_name=host_name)
+        return (FLIP_FLIPPED
+                if ledger_backs(root, mode, session_id=session_id)
+                else FLIP_FAILED)
     if not write_mode(session_id, mode, root=root, payload=payload):
         return FLIP_FAILED
     # ADR-0030 position 4: EVERY transition row is staged through the #396

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.5"
+    adapter_version = "2.17.6"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,


### PR DESCRIPTION
Closes #689.

## Summary

- Retry pending mode-enter settlement when a repeated non-arbiter request finds a persisted marker without session-scoped audit authorization.
- Report flipped only after the requested session is ledger-backed; report failed if settlement remains incomplete.
- Preserve arbiter and already-backed no-op behavior, FIFO audit replay, and exact generated parity across Claude, Codex, and Pi.
- Advance synchronized host payload metadata to ca 2.17.6, ca-codex 0.9.6, and ca-pi 0.10.7.

## Verification

- Causal baseline proof: the two original regressions fail against base because repeated requests return noop.
- Mode library: 67 passed, 1 existing Windows permission skip.
- Hook aggregate: 1,459 passed, 3 intentional skips.
- Cold-install matrix: 286 assertions passed.
- Pi tools: 863 passed, 1 skipped; typecheck and build passed.
- Pi package, parity, and public docs: 45, 26, and 13 tests passed.
- Windows Pi fixture aggregate: all 11 steps passed.
- Core sync, surface generation, host-package generation, payload-version guards, badge consistency, static syntax, diff hygiene, and staged secret scan passed.
- The full repository command matrix in .codearbiter/tech-stack.md passed.

Python hooks and Python test scripts have no configured numeric coverage tooling. The documented no-tooling exemption is in .codearbiter/tech-stack.md under Coverage. Causal branch tests cover recovery, continued failure, and partial settlement where only an older session is paid.

## Review

Independent functional, metadata/parity, dependency, and coverage reviews reported no remaining findings. A medium coverage gap for partial settlement was fixed in the second commit and independently mutation-checked.

No conflict-hierarchy tradeoff is introduced. The repair preserves ADR-0030 session-scoped authorization and existing FIFO settlement while retaining fail-closed effective posture.

## Merge method

ADR lifecycle verifier result: squash.

- Base: 1b7063dd5612992719047db477c645c3e673cd70
- Head: b07d86655222050f4995080b3f8d64d8c284047f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated mode-switch requests now recover previously unsettled audit records when settlement becomes available.
  * Requests correctly report success after recovery, rather than incorrectly indicating that no action was needed.
  * Requests continue to report failure when the requested session remains unsettled or only an unrelated session can be recovered.

* **Release**
  * Updated the application and plugin versions to their latest releases.
  * Added changelog entries documenting the corrected repeated-request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->