### PR TITLE
fix(release): gate merges on publication receipts

### DIFF
--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3831,3 +3831,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-06T14:28:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-06T14:30:22Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-06T14:44:20Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-06T15:59:58Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-06T16:01:43Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/security-controls.md
+++ b/.codearbiter/security-controls.md
@@ -879,10 +879,17 @@ version.
 it reports a moved tag, it cannot prevent one. Between the move and the next CI
 run, a consumer can install the substituted payload. Closing that window is what
 layer 1 is for, which is why the ruleset is a maintainer action tracked on #386
-and not satisfied by the check alone. The audit also skips loudly rather than
-failing when it cannot read the refs (transport failure or rate limit); it needs
-only `contents:read`, which `GITHUB_TOKEN` grants, so it runs live in ordinary CI
-and a skip is an exception rather than the normal case.
+and not satisfied by the check alone. Required CI and release preflight both use
+`--require-recorded` and fail closed on missing receipts, credentials, unreadable
+refs, or invalid inventory. This deliberately makes transport failures and rate
+limits merge/release availability blockers. The check remains read-only with
+`contents:read`; it adds no writer or bypass authority. New receipts enter only
+through the independently authenticated, reviewed-PR reconciliation path. A
+receipt-only PR can validate its candidate ledger, but publication and PR merge
+are not transactional: a tag may appear after a PR's green check without changing
+the checked commit. The independent strict release preflight remains necessary
+for that timing race; retry unavailable evidence, never substitute current refs
+for original publication proof.
 
 **GitHub immutable Releases (AC-2).** Measured 2026-07-25: every Release on this
 repository reports `immutable: false`, and the owning organisation is on the

--- a/.github/RELEASE-PROVENANCE.md
+++ b/.github/RELEASE-PROVENANCE.md
@@ -3,11 +3,22 @@
 Published tags never move or disappear. A bad release is corrected by a new
 version, not by changing a recorded identity or retargeting a tag.
 
-The release preflight uses `check_tag_immutability.py --require-recorded` before
-authorizing publication. Missing records or unreadable evidence refuse release.
-Ordinary CI remains an observation: it warns about unrecorded tags and reports
-an explicit skip on unavailable inventory. An automatic run with no eligible
-release does not require a new publication check.
+Required CI and release preflight both use
+`check_tag_immutability.py --require-recorded`. Missing records, credentials,
+or complete readable inventory block merge and release. This deliberately makes
+transport failures and rate limits availability blockers; retry after evidence
+is available, never bypass the check or replace historical identities.
+An automatic run with no eligible release needs no new publication preflight;
+its upstream required CI is still strict.
+
+This gate does not ingest receipts or make publication and PR merge transactional.
+After publication, reconcile the authenticated original receipt through a reviewed
+PR before another merge or release. A receipt-only PR can pass because required
+CI reads its candidate ledger. A tag can nevertheless be published after a PR's
+green check without changing its checked commit, so an already-green PR can race
+publication. The independent strict release preflight remains authoritative.
+Do not call a green check, retained artifact, or candidate file a completed ledger
+handoff: only the reviewed ledger addition merged to main completes ingestion.
 
 ## Closed legacy provenance epoch
 

--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -670,6 +670,21 @@
       "object_sha": "038760c8b101c61c9a6f9835c78c2d98b5cb8139",
       "object_type": "tag",
       "commit_sha": "07f8f475203876561561fa107d110e82d85c2c26"
+    },
+    "v2.17.5": {
+      "object_sha": "da48b6c9ef647abee471ca04113989e18ad3519b",
+      "object_type": "tag",
+      "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70"
+    },
+    "ca-codex-v0.9.5": {
+      "object_type": "tag",
+      "object_sha": "41fcce144b615878aa80a7358d7ba5acdabcfc92",
+      "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70"
+    },
+    "ca-pi-v0.10.6": {
+      "object_sha": "199676d442293cc6940f9fb9c65efbc9305293a3",
+      "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70",
+      "object_type": "tag"
     }
   }
 }

--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -26,25 +26,23 @@ disagreement.  Comparing the REF OBJECT sha (not just the commit) is the
 stronger test: an annotated tag object is content-addressed over its target,
 message, and tagger, so re-annotating the same commit still changes it.
 
-WHY IT SKIPS RATHER THAN FAILS.  Every observation is three-valued - present,
-definitely different, or None for "this run could not see it".  A definite
-mismatch is a security finding; an unreadable run prints a loud SKIP and passes.
-Unlike the branch-protection audit beside it, this one needs only `contents:
-read`, which GITHUB_TOKEN does grant, so it runs LIVE in ordinary CI rather than
-skipping by default.  The skip path exists for transport failures, rate limits,
-and local runs without a token - never as the normal case.
-
-RELEASE PREFLIGHT. --require-recorded is deliberately stricter: it refuses
+REQUIRED CI AND RELEASE PREFLIGHT. Both invoke --require-recorded, which refuses
 missing credentials, unreadable inventory, or any governed tag absent from the
-disjoint union. A new, non-legacy tag must be recorded afterward from its
-trusted run receipt through a reviewed PR before another release is allowed.
-The receipt writer has no legacy-ledger mutation path and there is no
-break-glass path.
+disjoint union. Availability failures therefore block merge as well as release.
+A new, non-legacy tag must be recorded afterward from its trusted run receipt
+through a reviewed PR. This is read-only verification, not automatic receipt
+ingestion or a transaction with publication: a tag published after a green CI
+check can still race a merge, so release preflight remains independently strict.
+The receipt writer has no legacy-ledger mutation path and there is no break-glass.
+
+OPTIONAL OBSERVATION MODE. Without --require-recorded, missing credentials or
+unavailable inventory produce a loud SKIP, and unrecorded tags produce warnings.
+A definite mismatch or invalid inventory still fails. Required CI never opts
+into this non-strict local-audit behavior.
 
 READ-ONLY.  One GET against `/git/matching-refs/tags/`. Nothing is written.
-Transport unavailability remains a loud ordinary-CI skip; a successful but
-malformed or incomplete response fails because it cannot be trusted as the
-complete inventory.
+Missing, unavailable, malformed, or incomplete evidence cannot authorize the
+strict required checks.
 """
 import argparse
 import dataclasses
@@ -73,10 +71,10 @@ ca-codex-v0.4.11 ca-codex-v0.4.12 ca-codex-v0.4.13 ca-codex-v0.4.14
 ca-codex-v0.4.15 ca-codex-v0.4.16 ca-codex-v0.4.2 ca-codex-v0.4.3
 ca-codex-v0.4.4 ca-codex-v0.4.5 ca-codex-v0.4.6 ca-codex-v0.4.7
 ca-codex-v0.4.8 ca-codex-v0.4.9 ca-codex-v0.5.0 ca-codex-v0.5.1
-ca-codex-v0.9.1 ca-codex-v0.9.3 ca-codex-v0.9.4 ca-pi-v0.1.32 ca-pi-v0.1.33
+ca-codex-v0.9.1 ca-codex-v0.9.3 ca-codex-v0.9.4 ca-codex-v0.9.5 ca-pi-v0.1.32 ca-pi-v0.1.33
 ca-pi-v0.1.34 ca-pi-v0.1.35 ca-pi-v0.1.36 ca-pi-v0.1.38
 ca-pi-v0.1.39 ca-pi-v0.1.40 ca-pi-v0.1.41 ca-pi-v0.1.42
-ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.10.5 ca-pi-v0.2.0
+ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.10.5 ca-pi-v0.10.6 ca-pi-v0.2.0
 ca-pi-v0.2.1 ca-pi-v0.2.11 ca-pi-v0.2.12 ca-pi-v0.2.13
 ca-pi-v0.2.14 ca-pi-v0.2.15 ca-pi-v0.2.16 ca-pi-v0.2.17
 ca-pi-v0.2.18 ca-pi-v0.2.19 ca-pi-v0.2.2 ca-pi-v0.2.3
@@ -88,13 +86,13 @@ v2.1.0-beta.4 v2.1.0-beta.5 v2.1.0-beta.6 v2.10.0 v2.10.1 v2.10.2
 v2.10.3 v2.10.4 v2.10.5 v2.10.6 v2.10.7 v2.10.8 v2.11.0 v2.11.1
 v2.11.10 v2.11.11 v2.11.12 v2.11.13 v2.11.14 v2.11.15 v2.11.16
 v2.11.17 v2.11.2 v2.11.3 v2.11.4 v2.11.5 v2.11.6 v2.11.7 v2.11.8
-v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.17.4 v2.2.0 v2.3.0 v2.3.1 v2.4.0
+v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.17.4 v2.17.5 v2.2.0 v2.3.0 v2.3.1 v2.4.0
 v2.4.1 v2.4.2 v2.4.6 v2.5.0 v2.5.1 v2.5.2 v2.6.0 v2.6.1 v2.8.0
 v2.8.11 v2.8.13 v2.9.0 v2.9.1
 """.split())
-ORIGINAL_RECEIPT_BASELINE_COUNT = 127
+ORIGINAL_RECEIPT_BASELINE_COUNT = 130
 ORIGINAL_RECEIPT_BASELINE_SHA256 = (
-    "27ff1368b51a69be3de05fba921127e2cb22ad45790180d736f1ecf5011e3ab9"
+    "89a788d7dc037d6faf7f1165f1282cd700060f474fb4a742d0e2576e463b76c1"
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -353,8 +351,8 @@ def audit_legacy(recorded: dict[str, LegacyProvenance],
 def unrecorded(recorded: dict[str, Provenance], live: dict[str, str]) -> list[str]:
     """Governed tags on the remote that the manifest does not yet record.
 
-    This is expected immediately after a release. Ordinary CI warns; strict
-    release preflight refuses to authorize another release until it is recorded.
+    This is expected immediately after a release. Required CI and release
+    preflight refuse until it is recorded; optional observation mode only warns.
     """
     return sorted(
         name for name in live if is_governed(name) and name not in recorded
@@ -443,10 +441,9 @@ def _rest_reader(token: str):
 _SKIP_NOTE = """SKIP: no token, so published-tag immutability was NOT audited.
 
 This check reads `/repos/{owner}/{repo}/git/matching-refs/tags/`, which needs only
-contents:read - a permission the default GITHUB_TOKEN DOES grant - so in ordinary
-CI it runs live and this skip should not appear. It exists for local runs and for
-transport failures, because a merge gate must report a settings or history
-regression, never a network problem.
+contents:read - a permission the default GITHUB_TOKEN DOES grant. This skip is
+only for optional observation mode. Required CI and release preflight use
+--require-recorded and fail closed on missing credentials or unavailable evidence.
 
 To run the audit by hand:
 

--- a/.github/scripts/test_ci_impact.py
+++ b/.github/scripts/test_ci_impact.py
@@ -11,6 +11,7 @@ import importlib.util
 import json
 import fnmatch
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -733,6 +734,28 @@ class DescriptorSurfaceTest(unittest.TestCase):
 
 
 class WorkflowContractTest(unittest.TestCase):
+    def test_required_tag_immutability_job_requires_recorded_publications(self):
+        # A missing receipt must block the required merge gate, not first surface
+        # after merge when the next automatic release reaches strict preflight.
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("tag-immutability", aggregate_needs(ci))
+        self.assertIn("tag-immutability", aggregate_required_results(ci))
+        job = workflow_jobs(ci)["tag-immutability"]
+        invocation = re.search(
+            r"(?m)^        run: >-\n(?P<command>(?:          [^\n]+\n)+)", job
+        )
+        self.assertIsNotNone(invocation, "the required live tag audit has no run command")
+        argv = shlex.split(
+            " ".join(line.strip() for line in invocation.group("command").splitlines()),
+            comments=True,
+        )
+        self.assertEqual(argv[:2], ["python", ".github/scripts/check_tag_immutability.py"])
+        self.assertIn(
+            "--require-recorded", argv,
+            "required CI only warns about missing publication receipts; "
+            "the same missing receipt then blocks automatic release after merge",
+        )
+
     def test_surface_job_fetches_complete_release_tag_history(self):
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
         job = workflow_jobs(ci)["surface"]

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -214,6 +214,24 @@ class LiveRefReader(unittest.TestCase):
 class ShippedManifest(unittest.TestCase):
     """The committed provenance record itself."""
 
+    RUN_34017483772_RECEIPTS = {
+        "v2.17.5": {
+            "object_sha": "da48b6c9ef647abee471ca04113989e18ad3519b",
+            "object_type": "tag",
+            "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70",
+        },
+        "ca-codex-v0.9.5": {
+            "object_sha": "41fcce144b615878aa80a7358d7ba5acdabcfc92",
+            "object_type": "tag",
+            "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70",
+        },
+        "ca-pi-v0.10.6": {
+            "object_sha": "199676d442293cc6940f9fb9c65efbc9305293a3",
+            "object_type": "tag",
+            "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70",
+        },
+    }
+
     def setUp(self):
         self.manifest = json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
 
@@ -263,6 +281,29 @@ class ShippedManifest(unittest.TestCase):
         self.assertEqual(
             set(self.manifest["tags"]), set(module.load_recorded(self.manifest["tags"]))
         )
+
+    def test_run_34017483772_receipts_are_recorded_and_frozen(self):
+        for name, receipt in self.RUN_34017483772_RECEIPTS.items():
+            with self.subTest(name=name):
+                self.assertEqual(receipt, self.manifest["tags"].get(name))
+                self.assertIn(name, module.ORIGINAL_RECEIPT_BASELINE_TAGS)
+
+    def test_run_34017483772_receipts_cannot_disappear_or_change(self):
+        candidate = json.loads(json.dumps(self.manifest))
+        candidate["tags"].update(self.RUN_34017483772_RECEIPTS)
+        module.validate_original_receipt_baseline(module.load_original_manifest(candidate))
+        for name in self.RUN_34017483772_RECEIPTS:
+            for change in ("delete", "object_sha", "commit_sha"):
+                with self.subTest(name=name, change=change):
+                    changed = json.loads(json.dumps(candidate))
+                    if change == "delete":
+                        del changed["tags"][name]
+                    else:
+                        changed["tags"][name][change] = "f" * 40
+                    with self.assertRaisesRegex(ValueError, "frozen receipt baseline changed"):
+                        module.validate_original_receipt_baseline(
+                            module.load_original_manifest(changed)
+                        )
 
     def test_original_receipt_baseline_rejects_deletion_but_allows_append(self):
         appended = json.loads(json.dumps(self.manifest))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2247,12 +2247,11 @@ jobs:
     #
     # UNLIKE the branch-protection audit beside it, this one runs LIVE in
     # ordinary CI: listing `/git/matching-refs/tags/` needs only contents:read,
-    # which the default GITHUB_TOKEN grants. It still skips loudly rather than
-    # failing on a transport failure or rate limit, because a merge gate must
-    # report a history regression, never a network problem. Read-only: one
-    # complete matching-refs response and no mutations. Transport unavailability
-    # skips loudly; a successful but invalid inventory fails rather than being
-    # mistaken for complete evidence.
+    # which the default GITHUB_TOKEN grants. Required CI uses --require-recorded:
+    # missing receipts, credentials, transport availability, or trustworthy
+    # inventory block merge. This read-only gate adds no receipt writer or
+    # permission to bypass reviewed-PR ingestion. Tag publication after this
+    # check can still race a merge; release preflight remains independently strict.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -2266,13 +2265,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          python .github/scripts/check_tag_immutability.py --repo "$GITHUB_REPOSITORY"
+          python .github/scripts/check_tag_immutability.py --repo "$GITHUB_REPOSITORY" --require-recorded
           --manifest .github/published-tags.json
           --legacy-manifest .github/legacy-published-tags.json
       - name: Test the audit's own logic
-        # The audit can skip; its unit tests cannot. They are offline and
-        # tokenless, and they pin the drift and deletion verdicts against a
-        # recorded copy of the live tag provenance.
+        # The unit tests are offline and tokenless; they pin the strict,
+        # drift, and deletion verdicts without depending on live availability.
         run: python .github/scripts/test_tag_immutability.py
       - name: Test publication identity receipt capture
         run: python .github/scripts/test_tag_publication_receipt.py


### PR DESCRIPTION
## Summary

Required CI now fails closed when governed tag receipts are missing or unverifiable. This prevents an unrelated merge from reaching automatic release before a prior publication receipt is reconciled.

This change also records the three authenticated receipts from successful release run 34017483772, freezes the 130-receipt baseline, and documents the remaining timing race between a green PR and later tag publication.

## Evidence

- Original receipt artifacts bind v2.17.5, ca-codex-v0.9.5, and ca-pi-v0.10.6 to protected-main commit 1b7063dd5612992719047db477c645c3e673cd70.
- The canonical 130-entry receipt digest is 89a788d7dc037d6faf7f1165f1282cd700060f474fb4a742d0e2576e463b76c1.
- The authenticated live audit reports 130 original-publication receipts and 44 legacy baselines matching remote identities.
- Independent Astra/xhigh security and coverage review found zero CRITICAL, HIGH, MEDIUM, or LOW findings.

## Test plan

- Ran every mandatory command in .codearbiter/tech-stack.md.
- Ran 1,459 hook tests on Git for Windows with 3 existing skips.
- Ran the focused required-CI contract regression.
- Ran the authenticated strict tag audit against arbiterForge/codeArbiter.
- Ran Python syntax checks for all three changed scripts.
- Ran gitleaks across 24.85 MB with no findings.
- Ran git diff --check.

## Delivery binding

- Base: c547e9a2079382c6dc1c61eba7257d8b985fb038
- Head: d336d91449600a036e4a216b1360bca6541079fd
- ADR merge method: squash
- Follow-up to #755

Conflict hierarchy: repository security and release-provenance controls outrank merge availability convenience. Transport and rate-limit failures therefore block required CI, while the independent strict release preflight remains authoritative for the post-green publication race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance records for three releases.
  * CI and release checks now require recorded publication receipts and block merges or releases when evidence is missing or unavailable.
  * Documented publication timing behavior and receipt reconciliation requirements.

* **Bug Fixes**
  * Prevented transport failures, rate limits, and incomplete inventory from being silently skipped during tag immutability checks.

* **Tests**
  * Added coverage validating required checks and protecting recorded receipt data from changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->