### PR TITLE
chore(release): record 0.9.6 publication receipts

### DIFF
--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3833,3 +3833,4 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-06T14:44:20Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-06T15:59:58Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-06T16:01:43Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-06T16:45:31Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -685,6 +685,21 @@
       "object_sha": "199676d442293cc6940f9fb9c65efbc9305293a3",
       "commit_sha": "1b7063dd5612992719047db477c645c3e673cd70",
       "object_type": "tag"
+    },
+    "v2.17.6": {
+      "object_type": "tag",
+      "commit_sha": "f614620858ac06c4867120987c3bf91b5fa0db10",
+      "object_sha": "dced34b1dc87e14a14a774693f7eb26fa84a605f"
+    },
+    "ca-codex-v0.9.6": {
+      "object_sha": "a39d86836818ee0f6f117e4064c519002f3e7e45",
+      "commit_sha": "f614620858ac06c4867120987c3bf91b5fa0db10",
+      "object_type": "tag"
+    },
+    "ca-pi-v0.10.7": {
+      "commit_sha": "f614620858ac06c4867120987c3bf91b5fa0db10",
+      "object_type": "tag",
+      "object_sha": "d5a13d272182a26301cec0e9194a2f8cdeb8a5eb"
     }
   }
 }

--- a/.github/scripts/check_tag_immutability.py
+++ b/.github/scripts/check_tag_immutability.py
@@ -71,10 +71,10 @@ ca-codex-v0.4.11 ca-codex-v0.4.12 ca-codex-v0.4.13 ca-codex-v0.4.14
 ca-codex-v0.4.15 ca-codex-v0.4.16 ca-codex-v0.4.2 ca-codex-v0.4.3
 ca-codex-v0.4.4 ca-codex-v0.4.5 ca-codex-v0.4.6 ca-codex-v0.4.7
 ca-codex-v0.4.8 ca-codex-v0.4.9 ca-codex-v0.5.0 ca-codex-v0.5.1
-ca-codex-v0.9.1 ca-codex-v0.9.3 ca-codex-v0.9.4 ca-codex-v0.9.5 ca-pi-v0.1.32 ca-pi-v0.1.33
+ca-codex-v0.9.1 ca-codex-v0.9.3 ca-codex-v0.9.4 ca-codex-v0.9.5 ca-codex-v0.9.6 ca-pi-v0.1.32 ca-pi-v0.1.33
 ca-pi-v0.1.34 ca-pi-v0.1.35 ca-pi-v0.1.36 ca-pi-v0.1.38
 ca-pi-v0.1.39 ca-pi-v0.1.40 ca-pi-v0.1.41 ca-pi-v0.1.42
-ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.10.5 ca-pi-v0.10.6 ca-pi-v0.2.0
+ca-pi-v0.1.43 ca-pi-v0.10.2 ca-pi-v0.10.4 ca-pi-v0.10.5 ca-pi-v0.10.6 ca-pi-v0.10.7 ca-pi-v0.2.0
 ca-pi-v0.2.1 ca-pi-v0.2.11 ca-pi-v0.2.12 ca-pi-v0.2.13
 ca-pi-v0.2.14 ca-pi-v0.2.15 ca-pi-v0.2.16 ca-pi-v0.2.17
 ca-pi-v0.2.18 ca-pi-v0.2.19 ca-pi-v0.2.2 ca-pi-v0.2.3
@@ -86,13 +86,13 @@ v2.1.0-beta.4 v2.1.0-beta.5 v2.1.0-beta.6 v2.10.0 v2.10.1 v2.10.2
 v2.10.3 v2.10.4 v2.10.5 v2.10.6 v2.10.7 v2.10.8 v2.11.0 v2.11.1
 v2.11.10 v2.11.11 v2.11.12 v2.11.13 v2.11.14 v2.11.15 v2.11.16
 v2.11.17 v2.11.2 v2.11.3 v2.11.4 v2.11.5 v2.11.6 v2.11.7 v2.11.8
-v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.17.4 v2.17.5 v2.2.0 v2.3.0 v2.3.1 v2.4.0
+v2.11.9 v2.12.0 v2.17.1 v2.17.3 v2.17.4 v2.17.5 v2.17.6 v2.2.0 v2.3.0 v2.3.1 v2.4.0
 v2.4.1 v2.4.2 v2.4.6 v2.5.0 v2.5.1 v2.5.2 v2.6.0 v2.6.1 v2.8.0
 v2.8.11 v2.8.13 v2.9.0 v2.9.1
 """.split())
-ORIGINAL_RECEIPT_BASELINE_COUNT = 130
+ORIGINAL_RECEIPT_BASELINE_COUNT = 133
 ORIGINAL_RECEIPT_BASELINE_SHA256 = (
-    "89a788d7dc037d6faf7f1165f1282cd700060f474fb4a742d0e2576e463b76c1"
+    "52ccf7197aa7a1e83397785ba9a83f4728e9032970a39ada99de8cfd0e92d2fb"
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/.github/scripts/test_tag_immutability.py
+++ b/.github/scripts/test_tag_immutability.py
@@ -232,6 +232,24 @@ class ShippedManifest(unittest.TestCase):
         },
     }
 
+    RUN_34045852722_RECEIPTS = {
+        "v2.17.6": {
+            "object_sha": "dced34b1dc87e14a14a774693f7eb26fa84a605f",
+            "object_type": "tag",
+            "commit_sha": "f614620858ac06c4867120987c3bf91b5fa0db10",
+        },
+        "ca-codex-v0.9.6": {
+            "object_sha": "a39d86836818ee0f6f117e4064c519002f3e7e45",
+            "object_type": "tag",
+            "commit_sha": "f614620858ac06c4867120987c3bf91b5fa0db10",
+        },
+        "ca-pi-v0.10.7": {
+            "object_sha": "d5a13d272182a26301cec0e9194a2f8cdeb8a5eb",
+            "object_type": "tag",
+            "commit_sha": "f614620858ac06c4867120987c3bf91b5fa0db10",
+        },
+    }
+
     def setUp(self):
         self.manifest = json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
 
@@ -293,6 +311,29 @@ class ShippedManifest(unittest.TestCase):
         candidate["tags"].update(self.RUN_34017483772_RECEIPTS)
         module.validate_original_receipt_baseline(module.load_original_manifest(candidate))
         for name in self.RUN_34017483772_RECEIPTS:
+            for change in ("delete", "object_sha", "commit_sha"):
+                with self.subTest(name=name, change=change):
+                    changed = json.loads(json.dumps(candidate))
+                    if change == "delete":
+                        del changed["tags"][name]
+                    else:
+                        changed["tags"][name][change] = "f" * 40
+                    with self.assertRaisesRegex(ValueError, "frozen receipt baseline changed"):
+                        module.validate_original_receipt_baseline(
+                            module.load_original_manifest(changed)
+                        )
+
+    def test_run_34045852722_receipts_are_recorded_and_frozen(self):
+        for name, receipt in self.RUN_34045852722_RECEIPTS.items():
+            with self.subTest(name=name):
+                self.assertEqual(receipt, self.manifest["tags"].get(name))
+                self.assertIn(name, module.ORIGINAL_RECEIPT_BASELINE_TAGS)
+
+    def test_run_34045852722_receipts_cannot_disappear_or_change(self):
+        candidate = json.loads(json.dumps(self.manifest))
+        candidate["tags"].update(self.RUN_34045852722_RECEIPTS)
+        module.validate_original_receipt_baseline(module.load_original_manifest(candidate))
+        for name in self.RUN_34045852722_RECEIPTS:
             for change in ("delete", "object_sha", "commit_sha"):
                 with self.subTest(name=name, change=change):
                     changed = json.loads(json.dumps(candidate))


### PR DESCRIPTION
## Summary

- Record authenticated original-publication receipts for `v2.17.6`, `ca-codex-v0.9.6`, and `ca-pi-v0.10.7`.
- Raise the immutable receipt floor from 130 to 133 and freeze deletion or identity mutation for all three new tags.
- Preserve the append-only gate audit row produced by the mandatory verification run.

This closes the strict next-release guard after the 2.17.6 release family. The ledger was reconstructed through the sanctioned reconciler from authenticated artifacts produced by release run `34045852722`, then compared byte-for-byte with the staged manifest.

## Publication evidence

- Release run: `34045852722`, attempt 1, success on `main` at `f614620858ac06c4867120987c3bf91b5fa0db10`
- `v2.17.6`: artifact `9993065402`, ZIP digest `sha256:65418e61bbcff03bd8751f3392399e4e8f3060b866a3b4f6added5a20657292e`, tag object `dced34b1dc87e14a14a774693f7eb26fa84a605f`
- `ca-codex-v0.9.6`: artifact `9993069144`, ZIP digest `sha256:ec1f291455a351181cb502d7751abac338dd6950539647b5436dc7bd9d4f1010`, tag object `a39d86836818ee0f6f117e4064c519002f3e7e45`
- `ca-pi-v0.10.7`: artifact `9993065709`, ZIP digest `sha256:f271d4d304e990bb280bc60e53780341e5337ddb6d889ddab3df50a574a640f3`, tag object `d5a13d272182a26301cec0e9194a2f8cdeb8a5eb`
- Every annotated tag peels to `f614620858ac06c4867120987c3bf91b5fa0db10`.
- Canonical 133-record identity digest: `52ccf7197aa7a1e83397785ba9a83f4728e9032970a39ada99de8cfd0e92d2fb`

## Test plan

- [x] Full repository verification suite from `.codearbiter/tech-stack.md`
- [x] `python -B .github/scripts/test_tag_immutability.py` (74 passed)
- [x] `python -B .github/scripts/test_tag_publication_receipt.py` (16 passed)
- [x] `python -B .github/scripts/test_reconcile_tag_receipt.py` (20 passed)
- [x] `python -B .github/scripts/test_ci_impact.py` (63 passed)
- [x] `python -B .github/scripts/test_release_workflow.py` (124 passed)
- [x] Strict authenticated live check over 133 receipts and 44 legacy baselines
- [x] Gitleaks scan over 23.47 MB with no findings
- [x] Independent Astra/xhigh security and coverage review with no findings

## Merge evidence

- Exact base: `f614620858ac06c4867120987c3bf91b5fa0db10`
- Exact reviewed head: `59f567c178fc945f37220e36589a95d467194389`
- Installed ADR ancestry verifier result: `squash`

Closes #689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded publication provenance for three newly published release tags.
  * Updated the release integrity baseline to include the additional tags.

* **Tests**
  * Added coverage confirming the new publication receipts are recorded correctly.
  * Added safeguards to detect deletion or changes to their recorded release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->