### PR TITLE
fix(taskboard): preserve the retained lock with local exclusion

### DIFF
--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -4,27 +4,27 @@
   "entries": [
     {
       "drift_trigger": true,
-      "hash": "7d6cdc7142d1bcb08676b937ec6e933b2a64feb7",
+      "hash": "55e7d4373c5d9992e7d6c1a1e6ec58f2bfd8c961",
       "path": "CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "9a0531c97cca77787edc9238e1bd6c49e82b9993",
+      "hash": "18990c8ca549b13918cadadb8451ffa354c5fbba",
       "path": "package.json"
     },
     {
       "drift_trigger": true,
-      "hash": "f6bf339091327dbe14431fa1b2c78c216d8b6bb0",
+      "hash": "d4b834155c5402d87eb985a83079e4de9386588f",
       "path": "plugins/ca-codex/.codex-plugin/plugin.json"
     },
     {
       "drift_trigger": true,
-      "hash": "e24e176b8ec3052a3cf7e99ff4125cbe5c9b5813",
+      "hash": "f2d3c663ee5d28a268c4c450691627af5dea3de2",
       "path": "plugins/ca-codex/CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "53f98ced784f5c0c0e98c028a9f6aba63d14c097",
+      "hash": "2f5d81e1fe52f3a8f5d8c2ceb193d8f59e0cc1db",
       "path": "plugins/ca-pi/CHANGELOG.md"
     },
     {
@@ -39,7 +39,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "b5c60b5b353dae72f5571208efccf841b752728d",
+      "hash": "2c3c2ed63c214b2d5c9ea920d239a1d8d8e7880d",
       "path": "plugins/ca-pi/package.json"
     },
     {
@@ -64,7 +64,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "f0e716e58976bfb8878bc773d5ff6649c7ce30ef",
+      "hash": "e9dc29f579572c9f758a3b4079411eb8d40e4d93",
       "path": "plugins/ca/.claude-plugin/plugin.json"
     },
     {

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3869,3 +3869,4 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-07T00:54:47Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-07T00:58:45Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-07T01:31:36Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T02:42:32Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3870,3 +3870,6 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-07T00:58:45Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-07T01:31:36Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-07T02:42:32Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T03:24:52Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T03:26:07Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T03:29:39Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.17.8] - 2026-09-06
+
+### Fixed
+
+- Keep task-board lifecycles Git-clean by locally excluding the retained OS-lock sidecar during initialization, with an explicit repair option for existing repositories.
+
 ## [2.17.7] - 2026-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.17.7" src="https://img.shields.io/badge/version-2.17.7-2b7489">
+<img alt="version 2.17.8" src="https://img.shields.io/badge/version-2.17.8-2b7489">
 <img alt="core lanes" src="https://img.shields.io/badge/core_lanes-18-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-19-555">
@@ -117,7 +117,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.7`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.8`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_taskexcludelib.py
+++ b/core/pysrc/_taskexcludelib.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# codeArbiter — locally exclude the retained task-board OS-lock sidecar.
+#
+# The board lock is intentionally never removed: unlinking a locked inode lets
+# another process acquire a different lock. Only Git's common info/exclude is
+# changed, through its own exclusive create/replace lockfile protocol. Existing
+# bytes and modes survive; no tracked file or Git index is written.
+# Static link/reparse aliases and observed concurrent edits fail closed. This
+# cooperates with writers honoring exclude.lock; it is not a sandbox against a
+# hostile same-user process swapping paths between filesystem operations.
+#
+# Public API:
+#   ensure_task_lock_excluded(root, required=False) -> str | None
+#       "added" / "already present", or None for optional non-Git scaffolding.
+#       Raises TaskExclusionError with a surfaced diagnostic on unsafe/failing IO.
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+from _gitexec import git_executable, root_bound_git_env
+
+
+LOCK_PATH = ".codearbiter/open-tasks.md.lock"
+EXCLUDE_RULE = b"/" + LOCK_PATH.encode("ascii")
+MAX_EXCLUDE_BYTES = 2 * 1024 * 1024
+_REPARSE = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+class TaskExclusionError(RuntimeError):
+    pass
+
+
+def _version(info):
+    # Windows Python can expose creation time via lstat().st_ctime but change
+    # time via fstat().st_ctime. Compare the common birth-time field there;
+    # identity, size, mtime, mode/link count and byte rereads still bind edits.
+    change = getattr(info, "st_birthtime_ns", 0) if os.name == "nt" else info.st_ctime_ns
+    return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns,
+            change, info.st_mode, info.st_nlink)
+
+
+def _regular(info):
+    return (stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+            and not getattr(info, "st_file_attributes", 0) & _REPARSE)
+
+
+def _directories(path):
+    for directory in (*reversed(path.parents), path):
+        info = directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or getattr(info, "st_file_attributes", 0) & _REPARSE:
+            raise TaskExclusionError("unsafe directory in task lock exclusion path")
+
+
+def _git(root, *args, input_bytes=None):
+    return subprocess.run([git_executable(), "-C", str(root), *args],
+                          env=root_bound_git_env(), capture_output=True, timeout=5,
+                          input=input_bytes)
+
+
+def _git_path(root, *args):
+    result = _git(root, "rev-parse", *args)
+    value = os.fsdecode(result.stdout).rstrip("\r\n")
+    if result.returncode or not value or not os.path.isabs(value) or "\n" in value:
+        raise TaskExclusionError("cannot bind task lock exclusion to selected Git")
+    return Path(value)
+
+
+def _same_path(left, right):
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def _binding(root, required):
+    # A failed Git probe in an actual checkout is never mistaken for non-Git.
+    markers = [item / ".git" for item in (root, *root.parents)]
+    has_marker = any(os.path.lexists(path) for path in markers)
+    try:
+        top = _git_path(root, "--show-toplevel")
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        if not required and not has_marker:
+            return None
+        raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
+    if not _same_path(top, root):
+        raise TaskExclusionError("task lock exclusion requires the exact repository root")
+    _directories(root)
+    marker = root / ".git"
+    info = marker.lstat()
+    if (not (stat.S_ISDIR(info.st_mode) or _regular(info))
+            or getattr(info, "st_file_attributes", 0) & _REPARSE):
+        raise TaskExclusionError("unsafe Git marker for task lock exclusion")
+    common = _git_path(root, "--path-format=absolute", "--git-common-dir")
+    exclude = _git_path(root, "--path-format=absolute", "--git-path", "info/exclude")
+    if not _same_path(exclude, common / "info/exclude"):
+        raise TaskExclusionError("task lock exclusion common-directory mismatch")
+    _directories(common)
+    return exclude
+
+
+def _read_exclude(path):
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        return b"", None
+    if not _regular(before):
+        raise TaskExclusionError("task lock exclusion is not a regular single-link file")
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    with os.fdopen(fd, "rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if not _regular(opened) or _version(opened) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while opening")
+        data = handle.read(MAX_EXCLUDE_BYTES + 1)
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion exceeds size limit")
+        if _version(os.fstat(handle.fileno())) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while reading")
+    if _version(path.lstat()) != _version(before):
+        raise TaskExclusionError("task lock exclusion path changed while reading")
+    return data, before
+
+
+def _check_conflicts(root):
+    tracked = _git(root, "ls-files", "--error-unmatch", "--", LOCK_PATH)
+    if tracked.returncode == 0:
+        raise TaskExclusionError("task lock sidecar is tracked; local exclusion cannot untrack it")
+    if tracked.returncode != 1:
+        raise TaskExclusionError("cannot check tracked task lock sidecar")
+    # A file can serve both global and per-directory roles. For this conflict
+    # probe only, disable the lower-priority global source without changing
+    # repository configuration. Effectiveness checks below use actual config.
+    ignored = _git(root, "-c", "core.excludesFile=", "check-ignore", "--no-index", "-z", "-v", "--stdin",
+                   input_bytes=LOCK_PATH.encode("ascii") + b"\0")
+    if ignored.returncode not in (0, 1):
+        raise TaskExclusionError("cannot check task lock exclusion precedence")
+    fields = ignored.stdout.split(b"\0")
+    # Git reports the target's per-directory sources relative to the -C root.
+    if len(fields) == 5 and fields[0].replace(b"\\", b"/") in (
+            b".gitignore", b".codearbiter/.gitignore") \
+            and fields[2].startswith(b"!"):
+        raise TaskExclusionError("a .gitignore negation overrides local task lock exclusion")
+
+
+def _ensure(root, required):
+    root = Path(os.path.abspath(root))
+    exclude = _binding(root, required)
+    if exclude is None:
+        return None
+    # mkdir is exclusive and never follows a preexisting info alias.
+    try:
+        exclude.parent.mkdir()
+    except FileExistsError:
+        pass
+    _directories(exclude.parent)
+    lock = exclude.with_name("exclude.lock")
+    fd = None
+    owned = None
+    try:
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                         | getattr(os, "O_NOFOLLOW", 0), 0o666)
+        except FileExistsError:
+            raise TaskExclusionError("exclude.lock already exists; another writer may own it") from None
+        info = os.fstat(fd)
+        owned = info.st_dev, info.st_ino
+        before, snapshot = _read_exclude(exclude)
+        _check_conflicts(root)
+        if EXCLUDE_RULE in before.splitlines():
+            ignored = _git(root, "check-ignore", "-q", "--", LOCK_PATH)
+            if ignored.returncode == 0:
+                return "already present"
+            if ignored.returncode != 1:
+                raise TaskExclusionError("cannot verify task lock exclusion")
+        newline = b"\r\n" if b"\r\n" in before else b"\n"
+        data = before + (newline if before and not before.endswith(b"\n") else b"")
+        data += EXCLUDE_RULE + newline
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion output exceeds size limit")
+        with os.fdopen(fd, "wb") as handle:
+            fd = None
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if snapshot is not None:
+            os.chmod(lock, stat.S_IMODE(snapshot.st_mode))
+        latest, current = _read_exclude(exclude)
+        if latest != before or ((snapshot is None) != (current is None)) \
+                or snapshot is not None and _version(snapshot) != _version(current):
+            raise TaskExclusionError("task lock exclusion changed before publication")
+        if _binding(root, True) != exclude:
+            raise TaskExclusionError("task lock exclusion binding changed before publication")
+        _directories(exclude.parent)
+        info = lock.lstat()
+        if not _regular(info) or (info.st_dev, info.st_ino) != owned:
+            raise TaskExclusionError("exclude.lock ownership changed before publication")
+        os.replace(lock, exclude)
+        owned = None
+        if _git(root, "check-ignore", "-q", "--", LOCK_PATH).returncode != 0:
+            raise TaskExclusionError("local rule added but task lock exclusion is not effective")
+        return "added"
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if owned is not None:
+            try:
+                info = lock.lstat()
+                if (info.st_dev, info.st_ino) == owned:
+                    lock.unlink()  # Only OUR Git transaction file, NEVER the board OS lock.
+            except FileNotFoundError:
+                pass
+
+
+def ensure_task_lock_excluded(root, required=False):
+    try:
+        return _ensure(root, required)
+    except TaskExclusionError:
+        raise
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        raise TaskExclusionError(f"task lock exclusion failed ({type(exc).__name__})") from None

--- a/core/pysrc/_taskexcludelib.py
+++ b/core/pysrc/_taskexcludelib.py
@@ -5,7 +5,7 @@
 # another process acquire a different lock. Only Git's common info/exclude is
 # changed, through its own exclusive create/replace lockfile protocol. Existing
 # bytes and modes survive; no tracked file or Git index is written.
-# Static link/reparse aliases and observed concurrent edits fail closed. This
+# Static Git-metadata link/reparse aliases and observed concurrent edits fail closed. This
 # cooperates with writers honoring exclude.lock; it is not a sandbox against a
 # hostile same-user process swapping paths between filesystem operations.
 #
@@ -81,7 +81,11 @@ def _binding(root, required):
         if not required and not has_marker:
             return None
         raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
-    if not _same_path(top, root):
+    # Git reports physical roots: /var aliases and Windows 8.3 names can differ
+    # from the caller. Resolve only this identity, never metadata paths whose
+    # unresolved link/reparse attributes the checks below must inspect.
+    root = Path(os.path.realpath(root))
+    if not _same_path(os.path.realpath(top), root):
         raise TaskExclusionError("task lock exclusion requires the exact repository root")
     _directories(root)
     marker = root / ".git"
@@ -141,6 +145,7 @@ def _check_conflicts(root):
 
 
 def _ensure(root, required):
+    # Retain the caller spelling so publication-time binding detects retargeting.
     root = Path(os.path.abspath(root))
     exclude = _binding(root, required)
     if exclude is None:

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.7"
+    adapter_version = "2.17.8"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/core/pysrc/init-codearbiter.py
+++ b/core/pysrc/init-codearbiter.py
@@ -12,6 +12,7 @@
 # Usage:
 #   python init-codearbiter.py [--root PATH] [--stage N]
 #   python init-codearbiter.py --check        # report state, create nothing
+#   python init-codearbiter.py --repair-lock-exclusion [--root PATH]
 
 import argparse
 import subprocess
@@ -19,7 +20,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _gitexec import git_executable  # noqa: E402
+from _gitexec import git_executable, root_bound_git_env  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -126,7 +127,7 @@ def project_root(opt):
     # prefer git toplevel; fall back to cwd
     try:
         out = subprocess.run([git_executable(), "rev-parse", "--show-toplevel"],
-                             capture_output=True, text=True, timeout=2)
+                             env=root_bound_git_env(), capture_output=True, text=True, timeout=2)
         top = out.stdout.strip()
         if out.returncode == 0 and top:
             return os.path.abspath(top)
@@ -138,9 +139,16 @@ def project_root(opt):
 def main(argv=None):
     ap = argparse.ArgumentParser(add_help=True)
     ap.add_argument("--root")
-    ap.add_argument("--stage", type=int, default=1)
+    ap.add_argument("--stage", type=int)
     ap.add_argument("--check", action="store_true")
+    ap.add_argument("--repair-lock-exclusion", action="store_true", help=(
+        "repair only Git-local info/exclude for an existing scaffold; retain the "
+        "task-board OS lock, never rewrite project state (cannot combine with --check/--stage)"))
     args = ap.parse_args(argv)
+    if args.repair_lock_exclusion and (args.check or args.stage is not None):
+        ap.error("--repair-lock-exclusion cannot combine with --check or --stage")
+    if args.stage is None:
+        args.stage = 1
 
     root = project_root(args.root)
     cad = os.path.join(root, ".codearbiter")
@@ -168,10 +176,28 @@ def main(argv=None):
             print(f"NOT SCAFFOLDED: {cad} would be created. Run without --check to scaffold.")
         return
 
+    from _taskexcludelib import ensure_task_lock_excluded, TaskExclusionError
+    if args.repair_lock_exclusion:
+        if not os.path.isfile(ctx) or os.path.islink(ctx):
+            raise SystemExit("REFUSING: task lock exclusion repair requires an existing scaffold.")
+        try:
+            result = ensure_task_lock_excluded(root, required=True)
+        except TaskExclusionError as exc:
+            raise SystemExit(f"REFUSING: {exc}") from None
+        print(f"task lock exclusion: {result}")
+        return
+
     if os.path.exists(ctx):
         raise SystemExit(
             f"REFUSING: {ctx} already exists. .codearbiter/ is already scaffolded here. "
             f"To populate it, run {_cc} or {_dc}; to repair, edit by hand.")
+
+    try:
+        result = ensure_task_lock_excluded(root)
+    except TaskExclusionError as exc:
+        raise SystemExit(f"REFUSING: {exc}") from None
+    if result:
+        print(f"task lock exclusion: {result}")
 
     os.makedirs(cad, exist_ok=True)
     created = []

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -289,13 +289,38 @@ here for completeness.
 | `statusline.py` | the statusline command in `settings.json` | Renders the token-aware statusline (folder, git, rate limits, usage, cost, context, and, in enabled repos, the arbiter governance row). Read-only |
 | `wire-statusline.py` | `/ca:statusline`, and the SessionStart self-heal | Installs/refreshes/removes the ca-owned statusline entry in `~/.claude/settings.json`, backing up and restoring any prior statusline |
 | `doctor.py` | `/ca:doctor` | Verifies the install is actually enforcing: interpreter, payload, cache staleness, a live-fire hook probe. Read-only |
-| `init-codearbiter.py` | `/ca:init` | Scaffolds the repo's `.codearbiter/` state store |
+| `init-codearbiter.py` | `/ca:init`, or its explicit repair flag | Scaffolds the repo's `.codearbiter/` state store and locally excludes the retained task-board OS lock |
 | `prune-transcript.py` | `/ca:prune` (CLI mode) | The same engine as the hook, driven manually with `status`/`dry`/`run`/`audit` subcommands |
 
 Shared, dependency-free library modules (`_hooklib.py`, `_standuplib.py`,
 `_prunelib.py`, `_babysitlib.py`) hold the pure logic the scripts above import; they
 have no side effects of their own. Everything under `plugins/ca/hooks/tests/` is the
 unit-test suite for these scripts. Run it with `pytest` from `plugins/ca/hooks/`.
+
+### Retained task-board lock and local exclusion
+
+`taskwrite` retains `.codearbiter/open-tasks.md.lock` as a one-byte OS-lock sidecar.
+Do not delete it to clean Git status: deleting a locked file can let another process
+acquire a different lock. Fresh Git-backed initialization adds the exact root-anchored
+rule `/.codearbiter/open-tasks.md.lock` to Git's local `info/exclude`, shared by linked
+worktrees. It does not edit a tracked `.gitignore` or hide other lock files.
+
+For an existing scaffold, invoke the installed host package's helper directly:
+
+```sh
+python /path/to/installed/plugin/hooks/init-codearbiter.py --repair-lock-exclusion --root /path/to/repository
+```
+
+Use the actual installed `ca`, `ca-codex`, or `ca-pi` package path. Omitting `--root`
+resolves the current checkout's Git toplevel; an explicit root must name that toplevel.
+This is a helper option, not a new `ca` command. It preserves existing exclusion bytes
+and is idempotent. It never reinitializes project state or changes tracked files, and
+cannot combine with `--check` or `--stage`.
+
+A tracked sidecar, higher-precedence `.gitignore` negation, unsafe file path, or existing
+`exclude.lock` is a reported failure. Resolve that condition before retrying; the helper
+does not untrack files, rewrite conflicting rules, or remove another writer's lock.
+Non-Git scaffolding remains supported; run this repair after creating the Git repository.
 
 ## Verifying for yourself
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the generated codeArbiter governance surface plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail), sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-09-06
+
+### Fixed
+
+- Keep task-board lifecycles Git-clean by locally excluding the retained OS-lock sidecar during initialization, with an explicit repair option for existing repositories.
+
 ## [0.9.7] - 2026-09-06
 
 ### Fixed

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -178,7 +178,7 @@ class CodexHost(hostapi.Host):
 
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.9.7"
+    adapter_version = "0.9.8"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/_taskexcludelib.py
+++ b/plugins/ca-codex/hooks/_taskexcludelib.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# codeArbiter — locally exclude the retained task-board OS-lock sidecar.
+#
+# The board lock is intentionally never removed: unlinking a locked inode lets
+# another process acquire a different lock. Only Git's common info/exclude is
+# changed, through its own exclusive create/replace lockfile protocol. Existing
+# bytes and modes survive; no tracked file or Git index is written.
+# Static link/reparse aliases and observed concurrent edits fail closed. This
+# cooperates with writers honoring exclude.lock; it is not a sandbox against a
+# hostile same-user process swapping paths between filesystem operations.
+#
+# Public API:
+#   ensure_task_lock_excluded(root, required=False) -> str | None
+#       "added" / "already present", or None for optional non-Git scaffolding.
+#       Raises TaskExclusionError with a surfaced diagnostic on unsafe/failing IO.
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+from _gitexec import git_executable, root_bound_git_env
+
+
+LOCK_PATH = ".codearbiter/open-tasks.md.lock"
+EXCLUDE_RULE = b"/" + LOCK_PATH.encode("ascii")
+MAX_EXCLUDE_BYTES = 2 * 1024 * 1024
+_REPARSE = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+class TaskExclusionError(RuntimeError):
+    pass
+
+
+def _version(info):
+    # Windows Python can expose creation time via lstat().st_ctime but change
+    # time via fstat().st_ctime. Compare the common birth-time field there;
+    # identity, size, mtime, mode/link count and byte rereads still bind edits.
+    change = getattr(info, "st_birthtime_ns", 0) if os.name == "nt" else info.st_ctime_ns
+    return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns,
+            change, info.st_mode, info.st_nlink)
+
+
+def _regular(info):
+    return (stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+            and not getattr(info, "st_file_attributes", 0) & _REPARSE)
+
+
+def _directories(path):
+    for directory in (*reversed(path.parents), path):
+        info = directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or getattr(info, "st_file_attributes", 0) & _REPARSE:
+            raise TaskExclusionError("unsafe directory in task lock exclusion path")
+
+
+def _git(root, *args, input_bytes=None):
+    return subprocess.run([git_executable(), "-C", str(root), *args],
+                          env=root_bound_git_env(), capture_output=True, timeout=5,
+                          input=input_bytes)
+
+
+def _git_path(root, *args):
+    result = _git(root, "rev-parse", *args)
+    value = os.fsdecode(result.stdout).rstrip("\r\n")
+    if result.returncode or not value or not os.path.isabs(value) or "\n" in value:
+        raise TaskExclusionError("cannot bind task lock exclusion to selected Git")
+    return Path(value)
+
+
+def _same_path(left, right):
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def _binding(root, required):
+    # A failed Git probe in an actual checkout is never mistaken for non-Git.
+    markers = [item / ".git" for item in (root, *root.parents)]
+    has_marker = any(os.path.lexists(path) for path in markers)
+    try:
+        top = _git_path(root, "--show-toplevel")
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        if not required and not has_marker:
+            return None
+        raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
+    if not _same_path(top, root):
+        raise TaskExclusionError("task lock exclusion requires the exact repository root")
+    _directories(root)
+    marker = root / ".git"
+    info = marker.lstat()
+    if (not (stat.S_ISDIR(info.st_mode) or _regular(info))
+            or getattr(info, "st_file_attributes", 0) & _REPARSE):
+        raise TaskExclusionError("unsafe Git marker for task lock exclusion")
+    common = _git_path(root, "--path-format=absolute", "--git-common-dir")
+    exclude = _git_path(root, "--path-format=absolute", "--git-path", "info/exclude")
+    if not _same_path(exclude, common / "info/exclude"):
+        raise TaskExclusionError("task lock exclusion common-directory mismatch")
+    _directories(common)
+    return exclude
+
+
+def _read_exclude(path):
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        return b"", None
+    if not _regular(before):
+        raise TaskExclusionError("task lock exclusion is not a regular single-link file")
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    with os.fdopen(fd, "rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if not _regular(opened) or _version(opened) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while opening")
+        data = handle.read(MAX_EXCLUDE_BYTES + 1)
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion exceeds size limit")
+        if _version(os.fstat(handle.fileno())) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while reading")
+    if _version(path.lstat()) != _version(before):
+        raise TaskExclusionError("task lock exclusion path changed while reading")
+    return data, before
+
+
+def _check_conflicts(root):
+    tracked = _git(root, "ls-files", "--error-unmatch", "--", LOCK_PATH)
+    if tracked.returncode == 0:
+        raise TaskExclusionError("task lock sidecar is tracked; local exclusion cannot untrack it")
+    if tracked.returncode != 1:
+        raise TaskExclusionError("cannot check tracked task lock sidecar")
+    # A file can serve both global and per-directory roles. For this conflict
+    # probe only, disable the lower-priority global source without changing
+    # repository configuration. Effectiveness checks below use actual config.
+    ignored = _git(root, "-c", "core.excludesFile=", "check-ignore", "--no-index", "-z", "-v", "--stdin",
+                   input_bytes=LOCK_PATH.encode("ascii") + b"\0")
+    if ignored.returncode not in (0, 1):
+        raise TaskExclusionError("cannot check task lock exclusion precedence")
+    fields = ignored.stdout.split(b"\0")
+    # Git reports the target's per-directory sources relative to the -C root.
+    if len(fields) == 5 and fields[0].replace(b"\\", b"/") in (
+            b".gitignore", b".codearbiter/.gitignore") \
+            and fields[2].startswith(b"!"):
+        raise TaskExclusionError("a .gitignore negation overrides local task lock exclusion")
+
+
+def _ensure(root, required):
+    root = Path(os.path.abspath(root))
+    exclude = _binding(root, required)
+    if exclude is None:
+        return None
+    # mkdir is exclusive and never follows a preexisting info alias.
+    try:
+        exclude.parent.mkdir()
+    except FileExistsError:
+        pass
+    _directories(exclude.parent)
+    lock = exclude.with_name("exclude.lock")
+    fd = None
+    owned = None
+    try:
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                         | getattr(os, "O_NOFOLLOW", 0), 0o666)
+        except FileExistsError:
+            raise TaskExclusionError("exclude.lock already exists; another writer may own it") from None
+        info = os.fstat(fd)
+        owned = info.st_dev, info.st_ino
+        before, snapshot = _read_exclude(exclude)
+        _check_conflicts(root)
+        if EXCLUDE_RULE in before.splitlines():
+            ignored = _git(root, "check-ignore", "-q", "--", LOCK_PATH)
+            if ignored.returncode == 0:
+                return "already present"
+            if ignored.returncode != 1:
+                raise TaskExclusionError("cannot verify task lock exclusion")
+        newline = b"\r\n" if b"\r\n" in before else b"\n"
+        data = before + (newline if before and not before.endswith(b"\n") else b"")
+        data += EXCLUDE_RULE + newline
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion output exceeds size limit")
+        with os.fdopen(fd, "wb") as handle:
+            fd = None
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if snapshot is not None:
+            os.chmod(lock, stat.S_IMODE(snapshot.st_mode))
+        latest, current = _read_exclude(exclude)
+        if latest != before or ((snapshot is None) != (current is None)) \
+                or snapshot is not None and _version(snapshot) != _version(current):
+            raise TaskExclusionError("task lock exclusion changed before publication")
+        if _binding(root, True) != exclude:
+            raise TaskExclusionError("task lock exclusion binding changed before publication")
+        _directories(exclude.parent)
+        info = lock.lstat()
+        if not _regular(info) or (info.st_dev, info.st_ino) != owned:
+            raise TaskExclusionError("exclude.lock ownership changed before publication")
+        os.replace(lock, exclude)
+        owned = None
+        if _git(root, "check-ignore", "-q", "--", LOCK_PATH).returncode != 0:
+            raise TaskExclusionError("local rule added but task lock exclusion is not effective")
+        return "added"
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if owned is not None:
+            try:
+                info = lock.lstat()
+                if (info.st_dev, info.st_ino) == owned:
+                    lock.unlink()  # Only OUR Git transaction file, NEVER the board OS lock.
+            except FileNotFoundError:
+                pass
+
+
+def ensure_task_lock_excluded(root, required=False):
+    try:
+        return _ensure(root, required)
+    except TaskExclusionError:
+        raise
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        raise TaskExclusionError(f"task lock exclusion failed ({type(exc).__name__})") from None

--- a/plugins/ca-codex/hooks/_taskexcludelib.py
+++ b/plugins/ca-codex/hooks/_taskexcludelib.py
@@ -5,7 +5,7 @@
 # another process acquire a different lock. Only Git's common info/exclude is
 # changed, through its own exclusive create/replace lockfile protocol. Existing
 # bytes and modes survive; no tracked file or Git index is written.
-# Static link/reparse aliases and observed concurrent edits fail closed. This
+# Static Git-metadata link/reparse aliases and observed concurrent edits fail closed. This
 # cooperates with writers honoring exclude.lock; it is not a sandbox against a
 # hostile same-user process swapping paths between filesystem operations.
 #
@@ -81,7 +81,11 @@ def _binding(root, required):
         if not required and not has_marker:
             return None
         raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
-    if not _same_path(top, root):
+    # Git reports physical roots: /var aliases and Windows 8.3 names can differ
+    # from the caller. Resolve only this identity, never metadata paths whose
+    # unresolved link/reparse attributes the checks below must inspect.
+    root = Path(os.path.realpath(root))
+    if not _same_path(os.path.realpath(top), root):
         raise TaskExclusionError("task lock exclusion requires the exact repository root")
     _directories(root)
     marker = root / ".git"
@@ -141,6 +145,7 @@ def _check_conflicts(root):
 
 
 def _ensure(root, required):
+    # Retain the caller spelling so publication-time binding detects retargeting.
     root = Path(os.path.abspath(root))
     exclude = _binding(root, required)
     if exclude is None:

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.7"
+    adapter_version = "2.17.8"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-codex/hooks/init-codearbiter.py
+++ b/plugins/ca-codex/hooks/init-codearbiter.py
@@ -12,6 +12,7 @@
 # Usage:
 #   python init-codearbiter.py [--root PATH] [--stage N]
 #   python init-codearbiter.py --check        # report state, create nothing
+#   python init-codearbiter.py --repair-lock-exclusion [--root PATH]
 
 import argparse
 import subprocess
@@ -19,7 +20,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _gitexec import git_executable  # noqa: E402
+from _gitexec import git_executable, root_bound_git_env  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -126,7 +127,7 @@ def project_root(opt):
     # prefer git toplevel; fall back to cwd
     try:
         out = subprocess.run([git_executable(), "rev-parse", "--show-toplevel"],
-                             capture_output=True, text=True, timeout=2)
+                             env=root_bound_git_env(), capture_output=True, text=True, timeout=2)
         top = out.stdout.strip()
         if out.returncode == 0 and top:
             return os.path.abspath(top)
@@ -138,9 +139,16 @@ def project_root(opt):
 def main(argv=None):
     ap = argparse.ArgumentParser(add_help=True)
     ap.add_argument("--root")
-    ap.add_argument("--stage", type=int, default=1)
+    ap.add_argument("--stage", type=int)
     ap.add_argument("--check", action="store_true")
+    ap.add_argument("--repair-lock-exclusion", action="store_true", help=(
+        "repair only Git-local info/exclude for an existing scaffold; retain the "
+        "task-board OS lock, never rewrite project state (cannot combine with --check/--stage)"))
     args = ap.parse_args(argv)
+    if args.repair_lock_exclusion and (args.check or args.stage is not None):
+        ap.error("--repair-lock-exclusion cannot combine with --check or --stage")
+    if args.stage is None:
+        args.stage = 1
 
     root = project_root(args.root)
     cad = os.path.join(root, ".codearbiter")
@@ -168,10 +176,28 @@ def main(argv=None):
             print(f"NOT SCAFFOLDED: {cad} would be created. Run without --check to scaffold.")
         return
 
+    from _taskexcludelib import ensure_task_lock_excluded, TaskExclusionError
+    if args.repair_lock_exclusion:
+        if not os.path.isfile(ctx) or os.path.islink(ctx):
+            raise SystemExit("REFUSING: task lock exclusion repair requires an existing scaffold.")
+        try:
+            result = ensure_task_lock_excluded(root, required=True)
+        except TaskExclusionError as exc:
+            raise SystemExit(f"REFUSING: {exc}") from None
+        print(f"task lock exclusion: {result}")
+        return
+
     if os.path.exists(ctx):
         raise SystemExit(
             f"REFUSING: {ctx} already exists. .codearbiter/ is already scaffolded here. "
             f"To populate it, run {_cc} or {_dc}; to repair, edit by hand.")
+
+    try:
+        result = ensure_task_lock_excluded(root)
+    except TaskExclusionError as exc:
+        raise SystemExit(f"REFUSING: {exc}") from None
+    if result:
+        print(f"task lock exclusion: {result}")
 
     os.makedirs(cad, exist_ok=True)
     created = []

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.9] - 2026-09-06
+
+### Fixed
+
+- Keep task-board lifecycles Git-clean by locally excluding the retained OS-lock sidecar during initialization, with an explicit repair option for existing repositories.
+
 ## [0.10.8] - 2026-09-06
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.8"
+    adapter_version = "0.10.9"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/hooks/_taskexcludelib.py
+++ b/plugins/ca-pi/hooks/_taskexcludelib.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# codeArbiter — locally exclude the retained task-board OS-lock sidecar.
+#
+# The board lock is intentionally never removed: unlinking a locked inode lets
+# another process acquire a different lock. Only Git's common info/exclude is
+# changed, through its own exclusive create/replace lockfile protocol. Existing
+# bytes and modes survive; no tracked file or Git index is written.
+# Static link/reparse aliases and observed concurrent edits fail closed. This
+# cooperates with writers honoring exclude.lock; it is not a sandbox against a
+# hostile same-user process swapping paths between filesystem operations.
+#
+# Public API:
+#   ensure_task_lock_excluded(root, required=False) -> str | None
+#       "added" / "already present", or None for optional non-Git scaffolding.
+#       Raises TaskExclusionError with a surfaced diagnostic on unsafe/failing IO.
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+from _gitexec import git_executable, root_bound_git_env
+
+
+LOCK_PATH = ".codearbiter/open-tasks.md.lock"
+EXCLUDE_RULE = b"/" + LOCK_PATH.encode("ascii")
+MAX_EXCLUDE_BYTES = 2 * 1024 * 1024
+_REPARSE = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+class TaskExclusionError(RuntimeError):
+    pass
+
+
+def _version(info):
+    # Windows Python can expose creation time via lstat().st_ctime but change
+    # time via fstat().st_ctime. Compare the common birth-time field there;
+    # identity, size, mtime, mode/link count and byte rereads still bind edits.
+    change = getattr(info, "st_birthtime_ns", 0) if os.name == "nt" else info.st_ctime_ns
+    return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns,
+            change, info.st_mode, info.st_nlink)
+
+
+def _regular(info):
+    return (stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+            and not getattr(info, "st_file_attributes", 0) & _REPARSE)
+
+
+def _directories(path):
+    for directory in (*reversed(path.parents), path):
+        info = directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or getattr(info, "st_file_attributes", 0) & _REPARSE:
+            raise TaskExclusionError("unsafe directory in task lock exclusion path")
+
+
+def _git(root, *args, input_bytes=None):
+    return subprocess.run([git_executable(), "-C", str(root), *args],
+                          env=root_bound_git_env(), capture_output=True, timeout=5,
+                          input=input_bytes)
+
+
+def _git_path(root, *args):
+    result = _git(root, "rev-parse", *args)
+    value = os.fsdecode(result.stdout).rstrip("\r\n")
+    if result.returncode or not value or not os.path.isabs(value) or "\n" in value:
+        raise TaskExclusionError("cannot bind task lock exclusion to selected Git")
+    return Path(value)
+
+
+def _same_path(left, right):
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def _binding(root, required):
+    # A failed Git probe in an actual checkout is never mistaken for non-Git.
+    markers = [item / ".git" for item in (root, *root.parents)]
+    has_marker = any(os.path.lexists(path) for path in markers)
+    try:
+        top = _git_path(root, "--show-toplevel")
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        if not required and not has_marker:
+            return None
+        raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
+    if not _same_path(top, root):
+        raise TaskExclusionError("task lock exclusion requires the exact repository root")
+    _directories(root)
+    marker = root / ".git"
+    info = marker.lstat()
+    if (not (stat.S_ISDIR(info.st_mode) or _regular(info))
+            or getattr(info, "st_file_attributes", 0) & _REPARSE):
+        raise TaskExclusionError("unsafe Git marker for task lock exclusion")
+    common = _git_path(root, "--path-format=absolute", "--git-common-dir")
+    exclude = _git_path(root, "--path-format=absolute", "--git-path", "info/exclude")
+    if not _same_path(exclude, common / "info/exclude"):
+        raise TaskExclusionError("task lock exclusion common-directory mismatch")
+    _directories(common)
+    return exclude
+
+
+def _read_exclude(path):
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        return b"", None
+    if not _regular(before):
+        raise TaskExclusionError("task lock exclusion is not a regular single-link file")
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    with os.fdopen(fd, "rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if not _regular(opened) or _version(opened) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while opening")
+        data = handle.read(MAX_EXCLUDE_BYTES + 1)
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion exceeds size limit")
+        if _version(os.fstat(handle.fileno())) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while reading")
+    if _version(path.lstat()) != _version(before):
+        raise TaskExclusionError("task lock exclusion path changed while reading")
+    return data, before
+
+
+def _check_conflicts(root):
+    tracked = _git(root, "ls-files", "--error-unmatch", "--", LOCK_PATH)
+    if tracked.returncode == 0:
+        raise TaskExclusionError("task lock sidecar is tracked; local exclusion cannot untrack it")
+    if tracked.returncode != 1:
+        raise TaskExclusionError("cannot check tracked task lock sidecar")
+    # A file can serve both global and per-directory roles. For this conflict
+    # probe only, disable the lower-priority global source without changing
+    # repository configuration. Effectiveness checks below use actual config.
+    ignored = _git(root, "-c", "core.excludesFile=", "check-ignore", "--no-index", "-z", "-v", "--stdin",
+                   input_bytes=LOCK_PATH.encode("ascii") + b"\0")
+    if ignored.returncode not in (0, 1):
+        raise TaskExclusionError("cannot check task lock exclusion precedence")
+    fields = ignored.stdout.split(b"\0")
+    # Git reports the target's per-directory sources relative to the -C root.
+    if len(fields) == 5 and fields[0].replace(b"\\", b"/") in (
+            b".gitignore", b".codearbiter/.gitignore") \
+            and fields[2].startswith(b"!"):
+        raise TaskExclusionError("a .gitignore negation overrides local task lock exclusion")
+
+
+def _ensure(root, required):
+    root = Path(os.path.abspath(root))
+    exclude = _binding(root, required)
+    if exclude is None:
+        return None
+    # mkdir is exclusive and never follows a preexisting info alias.
+    try:
+        exclude.parent.mkdir()
+    except FileExistsError:
+        pass
+    _directories(exclude.parent)
+    lock = exclude.with_name("exclude.lock")
+    fd = None
+    owned = None
+    try:
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                         | getattr(os, "O_NOFOLLOW", 0), 0o666)
+        except FileExistsError:
+            raise TaskExclusionError("exclude.lock already exists; another writer may own it") from None
+        info = os.fstat(fd)
+        owned = info.st_dev, info.st_ino
+        before, snapshot = _read_exclude(exclude)
+        _check_conflicts(root)
+        if EXCLUDE_RULE in before.splitlines():
+            ignored = _git(root, "check-ignore", "-q", "--", LOCK_PATH)
+            if ignored.returncode == 0:
+                return "already present"
+            if ignored.returncode != 1:
+                raise TaskExclusionError("cannot verify task lock exclusion")
+        newline = b"\r\n" if b"\r\n" in before else b"\n"
+        data = before + (newline if before and not before.endswith(b"\n") else b"")
+        data += EXCLUDE_RULE + newline
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion output exceeds size limit")
+        with os.fdopen(fd, "wb") as handle:
+            fd = None
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if snapshot is not None:
+            os.chmod(lock, stat.S_IMODE(snapshot.st_mode))
+        latest, current = _read_exclude(exclude)
+        if latest != before or ((snapshot is None) != (current is None)) \
+                or snapshot is not None and _version(snapshot) != _version(current):
+            raise TaskExclusionError("task lock exclusion changed before publication")
+        if _binding(root, True) != exclude:
+            raise TaskExclusionError("task lock exclusion binding changed before publication")
+        _directories(exclude.parent)
+        info = lock.lstat()
+        if not _regular(info) or (info.st_dev, info.st_ino) != owned:
+            raise TaskExclusionError("exclude.lock ownership changed before publication")
+        os.replace(lock, exclude)
+        owned = None
+        if _git(root, "check-ignore", "-q", "--", LOCK_PATH).returncode != 0:
+            raise TaskExclusionError("local rule added but task lock exclusion is not effective")
+        return "added"
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if owned is not None:
+            try:
+                info = lock.lstat()
+                if (info.st_dev, info.st_ino) == owned:
+                    lock.unlink()  # Only OUR Git transaction file, NEVER the board OS lock.
+            except FileNotFoundError:
+                pass
+
+
+def ensure_task_lock_excluded(root, required=False):
+    try:
+        return _ensure(root, required)
+    except TaskExclusionError:
+        raise
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        raise TaskExclusionError(f"task lock exclusion failed ({type(exc).__name__})") from None

--- a/plugins/ca-pi/hooks/_taskexcludelib.py
+++ b/plugins/ca-pi/hooks/_taskexcludelib.py
@@ -5,7 +5,7 @@
 # another process acquire a different lock. Only Git's common info/exclude is
 # changed, through its own exclusive create/replace lockfile protocol. Existing
 # bytes and modes survive; no tracked file or Git index is written.
-# Static link/reparse aliases and observed concurrent edits fail closed. This
+# Static Git-metadata link/reparse aliases and observed concurrent edits fail closed. This
 # cooperates with writers honoring exclude.lock; it is not a sandbox against a
 # hostile same-user process swapping paths between filesystem operations.
 #
@@ -81,7 +81,11 @@ def _binding(root, required):
         if not required and not has_marker:
             return None
         raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
-    if not _same_path(top, root):
+    # Git reports physical roots: /var aliases and Windows 8.3 names can differ
+    # from the caller. Resolve only this identity, never metadata paths whose
+    # unresolved link/reparse attributes the checks below must inspect.
+    root = Path(os.path.realpath(root))
+    if not _same_path(os.path.realpath(top), root):
         raise TaskExclusionError("task lock exclusion requires the exact repository root")
     _directories(root)
     marker = root / ".git"
@@ -141,6 +145,7 @@ def _check_conflicts(root):
 
 
 def _ensure(root, required):
+    # Retain the caller spelling so publication-time binding detects retargeting.
     root = Path(os.path.abspath(root))
     exclude = _binding(root, required)
     if exclude is None:

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.7"
+    adapter_version = "2.17.8"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/hooks/init-codearbiter.py
+++ b/plugins/ca-pi/hooks/init-codearbiter.py
@@ -12,6 +12,7 @@
 # Usage:
 #   python init-codearbiter.py [--root PATH] [--stage N]
 #   python init-codearbiter.py --check        # report state, create nothing
+#   python init-codearbiter.py --repair-lock-exclusion [--root PATH]
 
 import argparse
 import subprocess
@@ -19,7 +20,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _gitexec import git_executable  # noqa: E402
+from _gitexec import git_executable, root_bound_git_env  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -126,7 +127,7 @@ def project_root(opt):
     # prefer git toplevel; fall back to cwd
     try:
         out = subprocess.run([git_executable(), "rev-parse", "--show-toplevel"],
-                             capture_output=True, text=True, timeout=2)
+                             env=root_bound_git_env(), capture_output=True, text=True, timeout=2)
         top = out.stdout.strip()
         if out.returncode == 0 and top:
             return os.path.abspath(top)
@@ -138,9 +139,16 @@ def project_root(opt):
 def main(argv=None):
     ap = argparse.ArgumentParser(add_help=True)
     ap.add_argument("--root")
-    ap.add_argument("--stage", type=int, default=1)
+    ap.add_argument("--stage", type=int)
     ap.add_argument("--check", action="store_true")
+    ap.add_argument("--repair-lock-exclusion", action="store_true", help=(
+        "repair only Git-local info/exclude for an existing scaffold; retain the "
+        "task-board OS lock, never rewrite project state (cannot combine with --check/--stage)"))
     args = ap.parse_args(argv)
+    if args.repair_lock_exclusion and (args.check or args.stage is not None):
+        ap.error("--repair-lock-exclusion cannot combine with --check or --stage")
+    if args.stage is None:
+        args.stage = 1
 
     root = project_root(args.root)
     cad = os.path.join(root, ".codearbiter")
@@ -168,10 +176,28 @@ def main(argv=None):
             print(f"NOT SCAFFOLDED: {cad} would be created. Run without --check to scaffold.")
         return
 
+    from _taskexcludelib import ensure_task_lock_excluded, TaskExclusionError
+    if args.repair_lock_exclusion:
+        if not os.path.isfile(ctx) or os.path.islink(ctx):
+            raise SystemExit("REFUSING: task lock exclusion repair requires an existing scaffold.")
+        try:
+            result = ensure_task_lock_excluded(root, required=True)
+        except TaskExclusionError as exc:
+            raise SystemExit(f"REFUSING: {exc}") from None
+        print(f"task lock exclusion: {result}")
+        return
+
     if os.path.exists(ctx):
         raise SystemExit(
             f"REFUSING: {ctx} already exists. .codearbiter/ is already scaffolded here. "
             f"To populate it, run {_cc} or {_dc}; to repair, edit by hand.")
+
+    try:
+        result = ensure_task_lock_excluded(root)
+    except TaskExclusionError as exc:
+        raise SystemExit(f"REFUSING: {exc}") from None
+    if result:
+        print(f"task lock exclusion: {result}")
 
     os.makedirs(cad, exist_ok=True)
     created = []

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.17.7"
+    adapter_version = "2.17.8"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/_taskexcludelib.py
+++ b/plugins/ca/hooks/_taskexcludelib.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# codeArbiter — locally exclude the retained task-board OS-lock sidecar.
+#
+# The board lock is intentionally never removed: unlinking a locked inode lets
+# another process acquire a different lock. Only Git's common info/exclude is
+# changed, through its own exclusive create/replace lockfile protocol. Existing
+# bytes and modes survive; no tracked file or Git index is written.
+# Static link/reparse aliases and observed concurrent edits fail closed. This
+# cooperates with writers honoring exclude.lock; it is not a sandbox against a
+# hostile same-user process swapping paths between filesystem operations.
+#
+# Public API:
+#   ensure_task_lock_excluded(root, required=False) -> str | None
+#       "added" / "already present", or None for optional non-Git scaffolding.
+#       Raises TaskExclusionError with a surfaced diagnostic on unsafe/failing IO.
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+from _gitexec import git_executable, root_bound_git_env
+
+
+LOCK_PATH = ".codearbiter/open-tasks.md.lock"
+EXCLUDE_RULE = b"/" + LOCK_PATH.encode("ascii")
+MAX_EXCLUDE_BYTES = 2 * 1024 * 1024
+_REPARSE = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+class TaskExclusionError(RuntimeError):
+    pass
+
+
+def _version(info):
+    # Windows Python can expose creation time via lstat().st_ctime but change
+    # time via fstat().st_ctime. Compare the common birth-time field there;
+    # identity, size, mtime, mode/link count and byte rereads still bind edits.
+    change = getattr(info, "st_birthtime_ns", 0) if os.name == "nt" else info.st_ctime_ns
+    return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns,
+            change, info.st_mode, info.st_nlink)
+
+
+def _regular(info):
+    return (stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+            and not getattr(info, "st_file_attributes", 0) & _REPARSE)
+
+
+def _directories(path):
+    for directory in (*reversed(path.parents), path):
+        info = directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or getattr(info, "st_file_attributes", 0) & _REPARSE:
+            raise TaskExclusionError("unsafe directory in task lock exclusion path")
+
+
+def _git(root, *args, input_bytes=None):
+    return subprocess.run([git_executable(), "-C", str(root), *args],
+                          env=root_bound_git_env(), capture_output=True, timeout=5,
+                          input=input_bytes)
+
+
+def _git_path(root, *args):
+    result = _git(root, "rev-parse", *args)
+    value = os.fsdecode(result.stdout).rstrip("\r\n")
+    if result.returncode or not value or not os.path.isabs(value) or "\n" in value:
+        raise TaskExclusionError("cannot bind task lock exclusion to selected Git")
+    return Path(value)
+
+
+def _same_path(left, right):
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def _binding(root, required):
+    # A failed Git probe in an actual checkout is never mistaken for non-Git.
+    markers = [item / ".git" for item in (root, *root.parents)]
+    has_marker = any(os.path.lexists(path) for path in markers)
+    try:
+        top = _git_path(root, "--show-toplevel")
+    except (OSError, RuntimeError, subprocess.SubprocessError):
+        if not required and not has_marker:
+            return None
+        raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
+    if not _same_path(top, root):
+        raise TaskExclusionError("task lock exclusion requires the exact repository root")
+    _directories(root)
+    marker = root / ".git"
+    info = marker.lstat()
+    if (not (stat.S_ISDIR(info.st_mode) or _regular(info))
+            or getattr(info, "st_file_attributes", 0) & _REPARSE):
+        raise TaskExclusionError("unsafe Git marker for task lock exclusion")
+    common = _git_path(root, "--path-format=absolute", "--git-common-dir")
+    exclude = _git_path(root, "--path-format=absolute", "--git-path", "info/exclude")
+    if not _same_path(exclude, common / "info/exclude"):
+        raise TaskExclusionError("task lock exclusion common-directory mismatch")
+    _directories(common)
+    return exclude
+
+
+def _read_exclude(path):
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        return b"", None
+    if not _regular(before):
+        raise TaskExclusionError("task lock exclusion is not a regular single-link file")
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    with os.fdopen(fd, "rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if not _regular(opened) or _version(opened) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while opening")
+        data = handle.read(MAX_EXCLUDE_BYTES + 1)
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion exceeds size limit")
+        if _version(os.fstat(handle.fileno())) != _version(before):
+            raise TaskExclusionError("task lock exclusion changed while reading")
+    if _version(path.lstat()) != _version(before):
+        raise TaskExclusionError("task lock exclusion path changed while reading")
+    return data, before
+
+
+def _check_conflicts(root):
+    tracked = _git(root, "ls-files", "--error-unmatch", "--", LOCK_PATH)
+    if tracked.returncode == 0:
+        raise TaskExclusionError("task lock sidecar is tracked; local exclusion cannot untrack it")
+    if tracked.returncode != 1:
+        raise TaskExclusionError("cannot check tracked task lock sidecar")
+    # A file can serve both global and per-directory roles. For this conflict
+    # probe only, disable the lower-priority global source without changing
+    # repository configuration. Effectiveness checks below use actual config.
+    ignored = _git(root, "-c", "core.excludesFile=", "check-ignore", "--no-index", "-z", "-v", "--stdin",
+                   input_bytes=LOCK_PATH.encode("ascii") + b"\0")
+    if ignored.returncode not in (0, 1):
+        raise TaskExclusionError("cannot check task lock exclusion precedence")
+    fields = ignored.stdout.split(b"\0")
+    # Git reports the target's per-directory sources relative to the -C root.
+    if len(fields) == 5 and fields[0].replace(b"\\", b"/") in (
+            b".gitignore", b".codearbiter/.gitignore") \
+            and fields[2].startswith(b"!"):
+        raise TaskExclusionError("a .gitignore negation overrides local task lock exclusion")
+
+
+def _ensure(root, required):
+    root = Path(os.path.abspath(root))
+    exclude = _binding(root, required)
+    if exclude is None:
+        return None
+    # mkdir is exclusive and never follows a preexisting info alias.
+    try:
+        exclude.parent.mkdir()
+    except FileExistsError:
+        pass
+    _directories(exclude.parent)
+    lock = exclude.with_name("exclude.lock")
+    fd = None
+    owned = None
+    try:
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                         | getattr(os, "O_NOFOLLOW", 0), 0o666)
+        except FileExistsError:
+            raise TaskExclusionError("exclude.lock already exists; another writer may own it") from None
+        info = os.fstat(fd)
+        owned = info.st_dev, info.st_ino
+        before, snapshot = _read_exclude(exclude)
+        _check_conflicts(root)
+        if EXCLUDE_RULE in before.splitlines():
+            ignored = _git(root, "check-ignore", "-q", "--", LOCK_PATH)
+            if ignored.returncode == 0:
+                return "already present"
+            if ignored.returncode != 1:
+                raise TaskExclusionError("cannot verify task lock exclusion")
+        newline = b"\r\n" if b"\r\n" in before else b"\n"
+        data = before + (newline if before and not before.endswith(b"\n") else b"")
+        data += EXCLUDE_RULE + newline
+        if len(data) > MAX_EXCLUDE_BYTES:
+            raise TaskExclusionError("task lock exclusion output exceeds size limit")
+        with os.fdopen(fd, "wb") as handle:
+            fd = None
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if snapshot is not None:
+            os.chmod(lock, stat.S_IMODE(snapshot.st_mode))
+        latest, current = _read_exclude(exclude)
+        if latest != before or ((snapshot is None) != (current is None)) \
+                or snapshot is not None and _version(snapshot) != _version(current):
+            raise TaskExclusionError("task lock exclusion changed before publication")
+        if _binding(root, True) != exclude:
+            raise TaskExclusionError("task lock exclusion binding changed before publication")
+        _directories(exclude.parent)
+        info = lock.lstat()
+        if not _regular(info) or (info.st_dev, info.st_ino) != owned:
+            raise TaskExclusionError("exclude.lock ownership changed before publication")
+        os.replace(lock, exclude)
+        owned = None
+        if _git(root, "check-ignore", "-q", "--", LOCK_PATH).returncode != 0:
+            raise TaskExclusionError("local rule added but task lock exclusion is not effective")
+        return "added"
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if owned is not None:
+            try:
+                info = lock.lstat()
+                if (info.st_dev, info.st_ino) == owned:
+                    lock.unlink()  # Only OUR Git transaction file, NEVER the board OS lock.
+            except FileNotFoundError:
+                pass
+
+
+def ensure_task_lock_excluded(root, required=False):
+    try:
+        return _ensure(root, required)
+    except TaskExclusionError:
+        raise
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        raise TaskExclusionError(f"task lock exclusion failed ({type(exc).__name__})") from None

--- a/plugins/ca/hooks/_taskexcludelib.py
+++ b/plugins/ca/hooks/_taskexcludelib.py
@@ -5,7 +5,7 @@
 # another process acquire a different lock. Only Git's common info/exclude is
 # changed, through its own exclusive create/replace lockfile protocol. Existing
 # bytes and modes survive; no tracked file or Git index is written.
-# Static link/reparse aliases and observed concurrent edits fail closed. This
+# Static Git-metadata link/reparse aliases and observed concurrent edits fail closed. This
 # cooperates with writers honoring exclude.lock; it is not a sandbox against a
 # hostile same-user process swapping paths between filesystem operations.
 #
@@ -81,7 +81,11 @@ def _binding(root, required):
         if not required and not has_marker:
             return None
         raise TaskExclusionError("cannot resolve repository root for task lock exclusion") from None
-    if not _same_path(top, root):
+    # Git reports physical roots: /var aliases and Windows 8.3 names can differ
+    # from the caller. Resolve only this identity, never metadata paths whose
+    # unresolved link/reparse attributes the checks below must inspect.
+    root = Path(os.path.realpath(root))
+    if not _same_path(os.path.realpath(top), root):
         raise TaskExclusionError("task lock exclusion requires the exact repository root")
     _directories(root)
     marker = root / ".git"
@@ -141,6 +145,7 @@ def _check_conflicts(root):
 
 
 def _ensure(root, required):
+    # Retain the caller spelling so publication-time binding detects retargeting.
     root = Path(os.path.abspath(root))
     exclude = _binding(root, required)
     if exclude is None:

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.7"
+    adapter_version = "2.17.8"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca/hooks/init-codearbiter.py
+++ b/plugins/ca/hooks/init-codearbiter.py
@@ -12,6 +12,7 @@
 # Usage:
 #   python init-codearbiter.py [--root PATH] [--stage N]
 #   python init-codearbiter.py --check        # report state, create nothing
+#   python init-codearbiter.py --repair-lock-exclusion [--root PATH]
 
 import argparse
 import subprocess
@@ -19,7 +20,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _gitexec import git_executable  # noqa: E402
+from _gitexec import git_executable, root_bound_git_env  # noqa: E402
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -126,7 +127,7 @@ def project_root(opt):
     # prefer git toplevel; fall back to cwd
     try:
         out = subprocess.run([git_executable(), "rev-parse", "--show-toplevel"],
-                             capture_output=True, text=True, timeout=2)
+                             env=root_bound_git_env(), capture_output=True, text=True, timeout=2)
         top = out.stdout.strip()
         if out.returncode == 0 and top:
             return os.path.abspath(top)
@@ -138,9 +139,16 @@ def project_root(opt):
 def main(argv=None):
     ap = argparse.ArgumentParser(add_help=True)
     ap.add_argument("--root")
-    ap.add_argument("--stage", type=int, default=1)
+    ap.add_argument("--stage", type=int)
     ap.add_argument("--check", action="store_true")
+    ap.add_argument("--repair-lock-exclusion", action="store_true", help=(
+        "repair only Git-local info/exclude for an existing scaffold; retain the "
+        "task-board OS lock, never rewrite project state (cannot combine with --check/--stage)"))
     args = ap.parse_args(argv)
+    if args.repair_lock_exclusion and (args.check or args.stage is not None):
+        ap.error("--repair-lock-exclusion cannot combine with --check or --stage")
+    if args.stage is None:
+        args.stage = 1
 
     root = project_root(args.root)
     cad = os.path.join(root, ".codearbiter")
@@ -168,10 +176,28 @@ def main(argv=None):
             print(f"NOT SCAFFOLDED: {cad} would be created. Run without --check to scaffold.")
         return
 
+    from _taskexcludelib import ensure_task_lock_excluded, TaskExclusionError
+    if args.repair_lock_exclusion:
+        if not os.path.isfile(ctx) or os.path.islink(ctx):
+            raise SystemExit("REFUSING: task lock exclusion repair requires an existing scaffold.")
+        try:
+            result = ensure_task_lock_excluded(root, required=True)
+        except TaskExclusionError as exc:
+            raise SystemExit(f"REFUSING: {exc}") from None
+        print(f"task lock exclusion: {result}")
+        return
+
     if os.path.exists(ctx):
         raise SystemExit(
             f"REFUSING: {ctx} already exists. .codearbiter/ is already scaffolded here. "
             f"To populate it, run {_cc} or {_dc}; to repair, edit by hand.")
+
+    try:
+        result = ensure_task_lock_excluded(root)
+    except TaskExclusionError as exc:
+        raise SystemExit(f"REFUSING: {exc}") from None
+    if result:
+        print(f"task lock exclusion: {result}")
 
     os.makedirs(cad, exist_ok=True)
     created = []

--- a/plugins/ca/hooks/tests/test_task_lock_exclusion.py
+++ b/plugins/ca/hooks/tests/test_task_lock_exclusion.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+# codeArbiter — local task-board lock exclusion and repair regression tests.
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from _helpers import durable_plugin_copy
+
+
+HOOKS = Path(__file__).resolve().parents[1]
+SCRIPT = HOOKS / "init-codearbiter.py"
+WRITER = HOOKS / "taskwrite.py"
+LOCK = ".codearbiter/open-tasks.md.lock"
+RULE = b"/.codearbiter/open-tasks.md.lock"
+
+
+class TaskLockExclusionTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve() / "repo"
+        self.root.mkdir()
+        # Exercise installed native hooks even when this suite itself lives in
+        # an ephemeral worktree; use the existing real-payload fixture builder.
+        self.hooks = Path(durable_plugin_copy(self.temp.name)) / "hooks"
+        self.env = os.environ.copy()
+        for key in list(self.env):
+            if key.startswith("GIT_"):
+                self.env.pop(key)
+        self.env["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.env["GIT_CONFIG_GLOBAL"] = os.devnull
+        self.env["CLAUDE_PROJECT_DIR"] = str(self.root)
+        self.env["PYTHONDONTWRITEBYTECODE"] = "1"
+        self._git("init", "--initial-branch=codex/fixture")
+        self._git("config", "user.name", "Fixture Author")
+        self._git("config", "user.email", "fixture@example.invalid")
+
+    def _run(self, argv, *, ok=True, env=None):
+        result = subprocess.run(argv, cwd=self.root, env=env or self.env,
+                                capture_output=True, timeout=30)
+        if ok:
+            self.assertEqual(result.returncode, 0,
+                             result.stderr.decode("utf-8", errors="replace"))
+        return result
+
+    def _git(self, *args, **kwargs):
+        return self._run(["git", *args], **kwargs)
+
+    def _init(self, *args, **kwargs):
+        return self._run([sys.executable, "-B", str(self.hooks / SCRIPT.name), "--root",
+                          str(self.root), *args], **kwargs)
+
+    def _writer(self, *args, **kwargs):
+        return self._run([sys.executable, "-B", str(self.hooks / WRITER.name), *args], **kwargs)
+
+    def _commit_board(self):
+        self._git("add", "--", ".codearbiter/open-tasks.md")
+        self._git("commit", "-m", "fixture board lifecycle")
+
+    def _existing(self):
+        state = self.root / ".codearbiter"
+        state.mkdir(exist_ok=True)
+        (state / "CONTEXT.md").write_bytes(
+            b"---\narbiter: enabled\nstage: 2\n---\n<!-- INITIALIZED -->\n")
+        (state / "open-tasks.md").write_bytes(b"# Open tasks\n")
+        return self.root / ".git/info/exclude"
+
+    def _repair(self, **kwargs):
+        return self._init("--repair-lock-exclusion", **kwargs)
+
+    def _injected_init(self, injection):
+        # Faults are installed only in this scratch CLI process, never through
+        # production flags. The real entry point still owns refusal/cleanup.
+        code = """
+import os, runpy, subprocess, sys
+from pathlib import Path
+from unittest.mock import patch
+script = sys.argv.pop(1)
+sys.path.insert(0, os.path.dirname(script))
+sys.argv[0] = script
+import _taskexcludelib as helper
+exclude = Path(sys.argv[sys.argv.index('--root') + 1]) / '.git/info/exclude'
+""" + textwrap.dedent(injection) + "\nrunpy.run_path(script, run_name='__main__')\n"
+        return self._run([sys.executable, "-B", "-c", code,
+                          str(self.hooks / SCRIPT.name), "--root", str(self.root)], ok=False)
+
+    def _assert_failed_before_scaffold(self, result, exclude, expected):
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"task lock exclusion", result.stderr)
+        self.assertNotIn(b"Traceback", result.stderr)
+        self.assertEqual(exclude.read_bytes(), expected)
+        self.assertFalse((self.root / ".codearbiter").exists())
+        self.assertFalse(exclude.with_name("exclude.lock").exists())
+
+    def test_fresh_init_excludes_only_the_retained_board_lock(self):
+        self._init()
+        self.assertEqual(self._git("check-ignore", "-q", "--", LOCK,
+                                   ok=False).returncode, 0,
+                         "initialization leaves the task lock visible to Git")
+        exclude = self.root / ".git/info/exclude"
+        self.assertIn(RULE, exclude.read_bytes().splitlines())
+        for path in (".codearbiter/open-tasks.md", ".codearbiter/other.lock",
+                     "nested/.codearbiter/open-tasks.md.lock"):
+            with self.subTest(path=path):
+                self.assertEqual(self._git("check-ignore", "-q", "--", path,
+                                           ok=False).returncode, 1)
+
+    def test_real_start_done_lifecycle_is_git_clean_after_board_commit(self):
+        self._init()
+        self._writer("add", "preserve the retained lock", "--id", "fixture.task")
+        state = self.root / ".codearbiter"
+        tracked = [str(path.relative_to(self.root)).replace("\\", "/")
+                   for path in sorted(state.iterdir()) if path.is_file()
+                   and not path.name.endswith(".lock")]
+        self._git("add", "--", *tracked)
+        self._git("commit", "-m", "fixture initialized board")
+        self._writer("start", "fixture.task.0001", "--date", "2026-09-06")
+        self._writer("done", "fixture.task.0001", "--date", "2026-09-06")
+        self._commit_board()
+        self.assertEqual((self.root / LOCK).read_bytes(), b"\0")
+        self.assertEqual(self._git("status", "--porcelain=v1",
+                                   "--untracked-files=all").stdout, b"",
+                         "the successful lifecycle leaves an untracked lock")
+
+    def test_existing_repair_preserves_bytes_modes_and_is_idempotent(self):
+        exclude = self._existing()
+        self._git("add", "--", ".codearbiter")
+        self._git("commit", "-m", "fixture existing repository")
+        cases = [(b"", b"\n"), (b"# local\n*.local\n", b"\n"),
+                 (b"# local\r\n*.local\r\n", b"\r\n"),
+                 (b"# no final newline", b"\n"), (b"# opaque \xff\r\n", b"\r\n")]
+        for before, newline in cases:
+            with self.subTest(before=before):
+                exclude.write_bytes(before)
+                mode = exclude.stat().st_mode
+                self._repair()
+                expected = before + (newline if before and not before.endswith(b"\n") else b"")
+                expected += RULE + newline
+                self.assertEqual(exclude.read_bytes(), expected)
+                self.assertEqual(exclude.stat().st_mode, mode)
+                identity = exclude.stat().st_ino
+                self._repair()
+                self.assertEqual(exclude.read_bytes(), expected)
+                self.assertEqual(exclude.stat().st_ino, identity)
+                self.assertEqual(self._git("status", "--porcelain=v1").stdout, b"")
+
+    def test_existing_repair_lifecycle_and_normal_reinit_still_refuses(self):
+        self._existing()
+        self._repair()
+        refused = self._init(ok=False)
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn(b"already scaffolded", refused.stderr)
+        self._writer("add", "repaired lifecycle", "--id", "repair.task")
+        self._writer("start", "repair.task.0001", "--date", "2026-09-06")
+        self._writer("done", "repair.task.0001", "--date", "2026-09-06")
+        self._git("add", "--", ".codearbiter")
+        self._git("commit", "-m", "fixture repaired lifecycle")
+        self.assertEqual((self.root / LOCK).read_bytes(), b"\0")
+        self.assertEqual(self._git("status", "--porcelain=v1").stdout, b"")
+
+    def test_size_boundary_never_publishes_an_unreadable_exclude(self):
+        exclude = self._existing()
+        maximum = 2 * 1024 * 1024
+        for size in (maximum - len(RULE) - 1, maximum - len(RULE), maximum, maximum + 1):
+            with self.subTest(size=size):
+                before = b"#" + b"x" * (size - 2) + b"\n"
+                exclude.write_bytes(before)
+                result = self._repair(ok=False)
+                if size + len(RULE) + 1 <= maximum:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    expected = before + RULE + b"\n"
+                    self.assertEqual(exclude.read_bytes(), expected)
+                    identity = exclude.stat().st_ino
+                    self._repair()
+                    self.assertEqual(exclude.read_bytes(), expected)
+                    self.assertEqual(exclude.stat().st_ino, identity)
+                else:
+                    self.assertNotEqual(result.returncode, 0, "published unreadable oversized output")
+                    self.assertIn(b"size limit", result.stderr)
+                    self.assertEqual(exclude.read_bytes(), before)
+                self.assertFalse(exclude.with_name("exclude.lock").exists())
+
+    def test_selected_git_unavailable_fails_closed_in_checkout(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        env = dict(self.env, CODEARBITER_GIT_EXECUTABLE=str(self.root / "missing-git"))
+        result = self._init(ok=False, env=env)
+        self._assert_failed_before_scaffold(result, exclude, before)
+        self.assertIn(b"resolve repository root", result.stderr)
+
+    def test_git_probe_failure_and_common_directory_mismatch_fail_closed(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        injections = {
+            "failed Git": """
+                patch.object(helper, '_git', return_value=subprocess.CompletedProcess(
+                    ['git'], 128, b'', b'fixture Git failure')).start()
+            """,
+            "common mismatch": """
+                original = helper._git_path
+                def resolve(root, *args):
+                    if args[-1] == 'info/exclude':
+                        return exclude.with_name('foreign-exclude')
+                    return original(root, *args)
+                patch.object(helper, '_git_path', side_effect=resolve).start()
+            """,
+            "binding changed": """
+                original = helper._binding
+                calls = 0
+                def bind(root, required):
+                    global calls
+                    calls += 1
+                    answer = original(root, required)
+                    return answer if calls == 1 else exclude.with_name('foreign-exclude')
+                patch.object(helper, '_binding', side_effect=bind).start()
+            """,
+        }
+        for name, injection in injections.items():
+            with self.subTest(fault=name):
+                foreign = exclude.with_name("foreign-exclude")
+                foreign.write_bytes(b"foreign rules\n")
+                result = self._injected_init(injection)
+                self._assert_failed_before_scaffold(result, exclude, before)
+                self.assertEqual(foreign.read_bytes(), b"foreign rules\n")
+
+    def test_external_exclude_edits_and_identity_changes_are_preserved(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        for change in ("bytes", "identity"):
+            with self.subTest(change=change):
+                exclude.write_bytes(before)
+                identity = exclude.stat().st_ino
+                result = self._injected_init(f"""
+                    original = helper._read_exclude
+                    calls = 0
+                    def read(path):
+                        global calls
+                        answer = original(path)
+                        calls += 1
+                        if calls == 1:
+                            if {change!r} == 'bytes':
+                                path.write_bytes(b'# intervening writer\\n')
+                            else:
+                                replacement = path.with_name('external-replacement')
+                                replacement.write_bytes(answer[0])
+                                os.replace(replacement, path)
+                        return answer
+                    patch.object(helper, '_read_exclude', side_effect=read).start()
+                """)
+                expected = b"# intervening writer\n" if change == "bytes" else before
+                self._assert_failed_before_scaffold(result, exclude, expected)
+                self.assertIn(b"changed before publication", result.stderr)
+                if change == "identity":
+                    self.assertNotEqual(exclude.stat().st_ino, identity)
+
+    def test_replaced_transaction_lock_is_never_deleted_or_published(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        result = self._injected_init("""
+            original = helper._binding
+            calls = 0
+            def bind(root, required):
+                global calls
+                answer = original(root, required)
+                calls += 1
+                if calls == 2:
+                    foreign = exclude.with_name('foreign-lock')
+                    foreign.write_bytes(b'another writer owns this')
+                    os.replace(foreign, exclude.with_name('exclude.lock'))
+                return answer
+            patch.object(helper, '_binding', side_effect=bind).start()
+        """)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"ownership changed", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before)
+        self.assertTrue(exclude.with_name("exclude.lock").is_file(), "deleted a foreign transaction lock")
+        self.assertEqual(exclude.with_name("exclude.lock").read_bytes(), b"another writer owns this")
+        self.assertFalse((self.root / ".codearbiter").exists())
+
+    def test_open_read_and_write_failures_preserve_exclude(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        for operation in ("open", "read", "write"):
+            with self.subTest(operation=operation):
+                result = self._injected_init(f"""
+                    operation = {operation!r}
+                    original_open = os.open
+                    original_fdopen = os.fdopen
+                    def open_file(path, flags, *args, **kwargs):
+                        if operation == 'open' and Path(path) == exclude:
+                            raise OSError('fixture exclude open failure')
+                        return original_open(path, flags, *args, **kwargs)
+                    class FaultyStream:
+                        def __init__(self, handle):
+                            self.handle = handle
+                        def __enter__(self):
+                            return self
+                        def __exit__(self, *args):
+                            return self.handle.__exit__(*args)
+                        def __getattr__(self, name):
+                            if name == operation:
+                                raise OSError('fixture stream failure')
+                            return getattr(self.handle, name)
+                    def open_stream(fd, mode, *args, **kwargs):
+                        return FaultyStream(original_fdopen(fd, mode, *args, **kwargs))
+                    patch.object(os, 'open', side_effect=open_file).start()
+                    patch.object(os, 'fdopen', side_effect=open_stream).start()
+                """)
+                self._assert_failed_before_scaffold(result, exclude, before)
+
+    def test_git_check_preserves_absent_or_existing_local_exclusion_and_state(self):
+        exclude = self.root / ".git/info/exclude"
+        state = self.root / ".codearbiter"
+        for initialized in (False, True):
+            if initialized:
+                self._existing()
+            for existing in (False, True):
+                with self.subTest(initialized=initialized, exclude=existing):
+                    if existing:
+                        exclude.write_bytes(b"# local check-only rules\r\n")
+                    elif exclude.exists():
+                        exclude.unlink()
+                    before = (exclude.read_bytes(), exclude.stat().st_ino) if existing else None
+                    scaffold = {p.name: p.read_bytes() for p in state.iterdir()} if initialized else None
+                    result = self._init("--check")
+                    self.assertIn(b"SCAFFOLDED", result.stdout)
+                    after = (exclude.read_bytes(), exclude.stat().st_ino) if exclude.exists() else None
+                    self.assertEqual(after, before)
+                    actual = {p.name: p.read_bytes() for p in state.iterdir()} if state.exists() else None
+                    self.assertEqual(actual, scaffold)
+                    self.assertFalse(exclude.with_name("exclude.lock").exists())
+
+    def test_repair_creates_missing_exclude_without_tracked_writes(self):
+        exclude = self._existing()
+        exclude.unlink()
+        self._repair()
+        self.assertEqual(exclude.read_bytes(), RULE + b"\n")
+
+    def test_repair_ignores_ambient_repository_selectors(self):
+        exclude = self._existing()
+        other = Path(self.temp.name) / "other"
+        other.mkdir()
+        self._git("-C", str(other), "init")
+        other_exclude = other / ".git/info/exclude"
+        untouched = other_exclude.read_bytes()
+        env = dict(self.env, GIT_DIR=str(other / ".git"), GIT_WORK_TREE=str(other),
+                   GIT_COMMON_DIR=str(other / ".git"), GIT_INDEX_FILE=str(other / ".git/index"))
+        self._repair(env=env)
+        self.assertIn(RULE, exclude.read_bytes().splitlines())
+        self.assertEqual(other_exclude.read_bytes(), untouched)
+
+    def test_default_root_discovery_ignores_ambient_repository_selectors(self):
+        exclude = self._existing()
+        other = Path(self.temp.name) / "other"
+        other.mkdir()
+        self._git("-C", str(other), "init")
+        other_exclude = other / ".git/info/exclude"
+        untouched = other_exclude.read_bytes()
+        env = dict(self.env, GIT_DIR=str(other / ".git"), GIT_WORK_TREE=str(other))
+        self._run([sys.executable, "-B", str(self.hooks / SCRIPT.name),
+                   "--repair-lock-exclusion"], env=env)
+        self.assertIn(RULE, exclude.read_bytes().splitlines())
+        self.assertEqual(other_exclude.read_bytes(), untouched)
+
+    def test_linked_worktree_repairs_shared_git_exclude(self):
+        exclude = self._existing()
+        self._git("add", "--", ".codearbiter")
+        self._git("commit", "-m", "fixture primary")
+        linked = Path(self.temp.name) / "linked"
+        self._git("worktree", "add", "-b", "codex/linked", str(linked))
+        result = self._run([sys.executable, "-B", str(self.hooks / SCRIPT.name),
+                            "--root", str(linked), "--repair-lock-exclusion"])
+        self.assertIn(b"task lock exclusion", result.stdout)
+        self.assertIn(RULE, exclude.read_bytes().splitlines())
+        self.assertEqual(self._git("-C", str(linked), "check-ignore", "-q", "--", LOCK).returncode, 0)
+
+    def test_concurrent_repairs_preserve_one_rule_and_unrelated_patterns(self):
+        exclude = self._existing()
+        before = b"# concurrent local rules\r\n*.private\r\n"
+        exclude.write_bytes(before)
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(lambda _: self._repair(ok=False), range(4)))
+        self.assertTrue(any(result.returncode == 0 for result in results),
+                        "no repair process succeeded")
+        for result in results:
+            if result.returncode:
+                self.assertIn(b"exclude.lock", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before + RULE + b"\r\n")
+        self.assertFalse(exclude.with_name("exclude.lock").exists())
+
+    def test_existing_exclude_lock_collision_is_preserved_and_reported(self):
+        exclude = self._existing()
+        before = exclude.read_bytes()
+        lock = exclude.with_name("exclude.lock")
+        lock.write_bytes(b"another writer owns this")
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"exclude.lock", result.stderr)
+        self.assertEqual(lock.read_bytes(), b"another writer owns this")
+        self.assertEqual(exclude.read_bytes(), before)
+
+    def test_directory_exclude_fails_before_fresh_scaffold(self):
+        exclude = self.root / ".git/info/exclude"
+        exclude.unlink()
+        exclude.mkdir()
+        result = self._init(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"task lock exclusion", result.stderr)
+        self.assertTrue(exclude.is_dir())
+        self.assertFalse((self.root / ".codearbiter").exists())
+
+    def test_hardlinked_exclude_is_not_replaced(self):
+        exclude = self._existing()
+        alias = Path(self.temp.name) / "exclude-alias"
+        os.link(exclude, alias)
+        before = alias.read_bytes()
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"task lock exclusion", result.stderr)
+        self.assertEqual(alias.read_bytes(), before)
+        self.assertEqual(exclude.stat().st_ino, alias.stat().st_ino)
+
+    def test_explicit_nested_root_is_not_redirected_to_parent(self):
+        exclude = self._existing()
+        before = exclude.read_bytes()
+        nested = self.root / "nested"
+        nested.mkdir()
+        result = self._run([sys.executable, "-B", str(self.hooks / SCRIPT.name),
+                            "--root", str(nested)], ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"repository root", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before)
+        self.assertFalse((nested / ".codearbiter").exists())
+
+    def test_repair_requires_existing_context(self):
+        before = (self.root / ".git/info/exclude").read_bytes()
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"existing scaffold", result.stderr)
+        self.assertEqual((self.root / ".git/info/exclude").read_bytes(), before)
+        self.assertFalse((self.root / ".codearbiter").exists())
+
+    def test_repair_options_do_not_reinitialize_or_mutate(self):
+        exclude = self._existing()
+        before = exclude.read_bytes()
+        for args in (("--check",), ("--stage", "1"), ("--stage", "3")):
+            with self.subTest(args=args):
+                result = self._init("--repair-lock-exclusion", *args, ok=False)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(b"cannot combine", result.stderr)
+                self.assertEqual(exclude.read_bytes(), before)
+
+    def test_tracked_lock_is_reported_not_untracked(self):
+        exclude = self._existing()
+        (self.root / LOCK).write_bytes(b"\0")
+        self._git("add", "--", LOCK)
+        before = exclude.read_bytes()
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"tracked", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before)
+        self.assertEqual(self._git("ls-files", "--", LOCK).stdout.strip().decode(), LOCK)
+
+    def test_gitignore_negation_is_reported_without_clobbering_rules(self):
+        exclude = self._existing()
+        (self.root / ".gitignore").write_bytes(b"!/.codearbiter/open-tasks.md.lock\n")
+        before = exclude.read_bytes()
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"negation", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before)
+
+    def test_global_gitignore_negation_does_not_block_init_or_repair(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        global_ignore = Path(self.temp.name) / ".gitignore"
+        global_bytes = b"!/.codearbiter/open-tasks.md.lock\n"
+        global_ignore.write_bytes(global_bytes)
+        for index, configured in enumerate((str(global_ignore), "../.gitignore")):
+            with self.subTest(configured=configured):
+                self._git("config", "core.excludesFile", configured)
+                exclude.write_bytes(before)
+                if index == 0:
+                    self._init()
+                else:
+                    self._existing()
+                    self._repair()
+                expected = before + RULE + b"\n"
+                self.assertEqual(exclude.read_bytes(), expected)
+                self.assertEqual(global_ignore.read_bytes(), global_bytes)
+                self._git("check-ignore", "-q", "--", LOCK)
+                identity = exclude.stat().st_ino
+                self._repair()
+                self.assertEqual(exclude.read_bytes(), expected)
+                self.assertEqual(exclude.stat().st_ino, identity)
+
+    def test_nested_repository_negation_still_refuses_before_publication(self):
+        exclude = self._existing()
+        before = exclude.read_bytes()
+        local_ignore = self.root / ".codearbiter/.gitignore"
+        local_bytes = b"!open-tasks.md.lock\n"
+        local_ignore.write_bytes(local_bytes)
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"negation", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before)
+        self.assertEqual(local_ignore.read_bytes(), local_bytes)
+        self.assertFalse(exclude.with_name("exclude.lock").exists())
+
+    def test_repository_file_used_globally_is_not_mistaken_for_local_conflict(self):
+        exclude = self._existing()
+        before = exclude.read_bytes()
+        dual_role = self.root / ".codearbiter/.gitignore"
+        # Matches from global context, but not relative to .codearbiter/.
+        global_bytes = b"!/.codearbiter/open-tasks.md.lock\n"
+        dual_role.write_bytes(global_bytes)
+        configured = ".codearbiter/.gitignore"
+        self._git("config", "core.excludesFile", configured)
+        self._repair()
+        self.assertEqual(exclude.read_bytes(), before + RULE + b"\n")
+        self.assertEqual(dual_role.read_bytes(), global_bytes)
+        self.assertEqual(self._git("config", "--get", "core.excludesFile").stdout.strip().decode(), configured)
+        self._git("check-ignore", "-q", "--", LOCK)
+        identity = exclude.stat().st_ino
+        self._repair()
+        self.assertEqual(exclude.stat().st_ino, identity)
+
+    def test_symlinked_exclude_is_not_followed(self):
+        exclude = self._existing()
+        target = Path(self.temp.name) / "outside-exclude"
+        target.write_bytes(b"outside rules\n")
+        exclude.unlink()
+        try:
+            exclude.symlink_to(target)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"task lock exclusion", result.stderr)
+        self.assertEqual(target.read_bytes(), b"outside rules\n")
+        self.assertTrue(exclude.is_symlink())
+
+    def test_symlinked_state_directory_cannot_authorize_local_repair(self):
+        target = Path(self.temp.name) / "outside-state"
+        target.mkdir()
+        (target / "CONTEXT.md").write_bytes(b"---\narbiter: enabled\n---\n")
+        try:
+            (self.root / ".codearbiter").symlink_to(target, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"task lock exclusion", result.stderr)
+        self.assertEqual(exclude.read_bytes(), before)
+        self.assertEqual(list(target.iterdir()), [target / "CONTEXT.md"])
+
+    def test_non_git_scaffold_under_system_temp_alias_remains_supported(self):
+        target = Path(self.temp.name) / "non-git"
+        target.mkdir()
+        alias = Path(self.temp.name) / "temp-alias"
+        try:
+            alias.symlink_to(target, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+        # macOS commonly exposes its temporary root through /var -> /private/var.
+        # No Git-local file is being repaired in a non-Git scaffold.
+        self._run([sys.executable, "-B", str(self.hooks / SCRIPT.name),
+                   "--root", str(alias)])
+        self.assertTrue((target / ".codearbiter/CONTEXT.md").is_file())
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "POSIX special-file contract")
+    def test_fifo_exclude_is_rejected_without_opening_it(self):
+        exclude = self._existing()
+        exclude.unlink()
+        os.mkfifo(exclude)
+        result = self._repair(ok=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"task lock exclusion", result.stderr)
+
+    def test_fsync_and_replace_failures_preserve_exclude_and_prevent_scaffold(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        for operation in ("fsync", "replace"):
+            with self.subTest(operation=operation):
+                code = (
+                    "import runpy,sys; from unittest.mock import patch; "
+                    "operation=sys.argv.pop(1); script=sys.argv.pop(1); "
+                    "sys.path.insert(0, __import__('os').path.dirname(script)); "
+                    "sys.argv[0]=script; "
+                    "context=patch('os.'+operation,side_effect=OSError('fixture IO failure')); "
+                    "context.start(); runpy.run_path(script,run_name='__main__')"
+                )
+                result = self._run([sys.executable, "-B", "-c", code, operation,
+                                    str(self.hooks / SCRIPT.name), "--root", str(self.root)], ok=False)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(b"task lock exclusion", result.stderr)
+                self.assertEqual(exclude.read_bytes(), before)
+                self.assertFalse((self.root / ".codearbiter").exists())
+                self.assertFalse(exclude.with_name("exclude.lock").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_task_lock_exclusion.py
+++ b/plugins/ca/hooks/tests/test_task_lock_exclusion.py
@@ -128,6 +128,103 @@ exclude = Path(sys.argv[sys.argv.index('--root') + 1]) / '.git/info/exclude'
                                    "--untracked-files=all").stdout, b"",
                          "the successful lifecycle leaves an untracked lock")
 
+    def _assert_root_spelling_lifecycle(self, spelling):
+        exclude = Path(os.fsdecode(self._git("rev-parse", "--path-format=absolute",
+                                            "--git-path", "info/exclude").stdout).strip())
+        before = exclude.read_bytes()
+        argv = [sys.executable, "-B", str(self.hooks / SCRIPT.name), "--root", str(spelling)]
+        self._run(argv)
+        self.assertEqual(exclude.read_bytes(), before + RULE + b"\n")
+        self._writer("add", "aliased root lifecycle", "--id", "alias.task")
+        self._writer("start", "alias.task.0001", "--date", "2026-09-06")
+        self._writer("done", "alias.task.0001", "--date", "2026-09-06")
+        self._git("add", "--", ".codearbiter")
+        self._git("commit", "-m", "fixture aliased root lifecycle")
+        self.assertEqual((self.root / LOCK).read_bytes(), b"\0")
+        self.assertEqual(self._git("status", "--porcelain=v1").stdout, b"")
+        # Exercise existing-repository repair through the same caller spelling.
+        exclude.write_bytes(before)
+        self._run([*argv, "--repair-lock-exclusion"])
+        self.assertEqual(exclude.read_bytes(), before + RULE + b"\n")
+        self.assertEqual(self._git("status", "--porcelain=v1").stdout, b"")
+        identity = exclude.stat().st_ino
+        self._run([*argv, "--repair-lock-exclusion"])
+        self.assertEqual(exclude.stat().st_ino, identity)
+
+    def test_repository_root_under_parent_alias_keeps_lifecycle_git_clean(self):
+        alias = Path(self.temp.name) / "parent-alias"
+        try:
+            alias.symlink_to(self.root.parent, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+        spelling = alias / self.root.name
+        self.assertTrue(os.path.samefile(spelling, self.root))
+        self._assert_root_spelling_lifecycle(spelling)
+
+    @unittest.skipUnless(os.name == "nt", "Windows native short-path contract")
+    def test_native_short_repository_root_keeps_lifecycle_git_clean(self):
+        import ctypes
+        buffer = ctypes.create_unicode_buffer(32768)
+        count = ctypes.windll.kernel32.GetShortPathNameW(str(self.root), buffer, len(buffer))
+        self.assertGreater(count, 0, "GetShortPathNameW failed")
+        self.assertLess(count, len(buffer))
+        spelling = buffer.value
+        if os.path.normcase(spelling) == os.path.normcase(str(self.root)):
+            self.skipTest("fixture volume has no native short-path alias")
+        self.assertTrue(os.path.samefile(spelling, self.root))
+        self._assert_root_spelling_lifecycle(spelling)
+
+    def test_linked_worktree_under_parent_alias_keeps_lifecycle_git_clean(self):
+        self._git("commit", "--allow-empty", "-m", "fixture primary")
+        linked = self.root.parent / "linked"
+        self._git("worktree", "add", "-b", "codex/linked", str(linked))
+        alias = self.root.parent / "linked-parent-alias"
+        try:
+            alias.symlink_to(linked.parent, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+        self.root = linked
+        self.env["CLAUDE_PROJECT_DIR"] = str(linked)
+        self._assert_root_spelling_lifecycle(alias / linked.name)
+
+    def test_retargeted_caller_alias_cannot_publish_to_the_original_repository(self):
+        exclude = self.root / ".git/info/exclude"
+        before = exclude.read_bytes()
+        other = self.root.parent / "other"
+        other.mkdir()
+        self._git("-C", str(other), "init")
+        other_exclude = other / ".git/info/exclude"
+        other_before = other_exclude.read_bytes()
+        alias = self.root.parent / "caller-alias"
+        try:
+            alias.symlink_to(self.root, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+        code = """
+import os, runpy, sys
+from pathlib import Path
+from unittest.mock import patch
+script, alias, other = sys.argv[1:]
+sys.path.insert(0, os.path.dirname(script))
+import _taskexcludelib as helper
+original = helper._read_exclude
+def read(path):
+    answer = original(path)
+    if Path(alias).resolve() != Path(other):
+        Path(alias).unlink()
+        Path(alias).symlink_to(other, target_is_directory=True)
+    return answer
+patch.object(helper, '_read_exclude', side_effect=read).start()
+sys.argv = [script, '--root', alias]
+runpy.run_path(script, run_name='__main__')
+"""
+        result = self._run([sys.executable, "-B", "-c", code,
+                            str(self.hooks / SCRIPT.name), str(alias), str(other)], ok=False)
+        self._assert_failed_before_scaffold(result, exclude, before)
+        self.assertIn(b"binding changed before publication", result.stderr)
+        self.assertEqual(other_exclude.read_bytes(), other_before)
+        self.assertFalse((other / ".codearbiter").exists())
+
     def test_existing_repair_preserves_bytes_modes_and_is_idempotent(self):
         exclude = self._existing()
         self._git("add", "--", ".codearbiter")


### PR DESCRIPTION
## Summary

Fixes #668. Keep the one-byte task-board OS lock and exclude only `/.codearbiter/open-tasks.md.lock` through Git's local `info/exclude` during initialization. Existing scaffolds can use `init-codearbiter.py --repair-lock-exclusion [--root PATH]` without reinitializing tracked state.

The helper binds the selected Git checkout/common directory, uses an exclusive atomic exclusion update, preserves existing bytes and modes, and reports collisions, unsafe paths, higher-priority repository negations, or I/O failures. Global exclusion configuration is suppressed only in the conflict-classification probe; final effectiveness uses the actual configuration.

The user-approved documentation choice retains the frozen init command bodies exactly. Operator instructions live in helper help/usage and `docs/hooks.md`; no command/catalog route changes. Generated host payloads remain byte-identical. Required first-party pre-PR metadata advances ca `2.17.7 -> 2.17.8`, ca-codex `0.9.7 -> 0.9.8`, and ca-pi `0.10.8 -> 0.10.9`. This PR does not create a tag, release, or publication.

## Verification

- Regression-first original-main proof: fresh initialization left the sidecar visible, and a real taskwrite add/start/done plus native board commit left Git dirty. The fixed CLI paths pass with the sidecar retained.
- All 40 mandatory Python commands pass; aggregate hook suite: 1,533 tests, four skips. All 27 supplemental authoritative CI hook commands also pass, including dual-host initialization and suite hermeticity. All 11 additional checks pass, including Pi typecheck/test/build, Python syntax, and generated parity. Secrets scan found no leaks.
- Windows focused suite: 36 tests, 35 passed and one POSIX FIFO skip. Hash-verified Linux-owned WSL scratch repositories: 56 discovered, 55 passed and one Windows-only skip, comprising 36 exclusion, three process-lock, and 17 initialization tests. No native macOS/full-host-matrix claim; Python numeric coverage uses the documented no-tooling exemption.
- Independent non-author Astra/xhigh Security, Coverage, and Dependency reviews passed through dispatched triage/verdict. All eight acceptance obligations are covered. Native committed-head ca/codex payload-version and Pi release-guard checks pass; these local results are not a CI-completion claim.

## CI correction

Run [34078254709](https://github.com/arbiterForge/codeArbiter/actions/runs/34078254709) exposed a canonical-root spelling mismatch on Windows and macOS. The unchanged dual-host suite reproduced both failures locally under a real Windows 8.3 TEMP alias before production edits. The helper now canonicalizes only checkout-root identity while retaining raw Git-metadata checks and the original caller spelling for publication-time rebinding.

Four new tests cover native short paths, parent aliases, linked-worktree aliases, and a real alias retarget during publication. Original-HEAD linked-alias replay and isolated early-canonicalization mutation proofs remain explicitly supplemental evidence. The unchanged dual-host suite now passes under the same short-path environment. Hosted successor CI and CodeRabbit remain separate pending checks.

Python coverage exemption, quoted from [.codearbiter/tech-stack.md:391](.codearbiter/tech-stack.md#coverage): "There is **no coverage tooling for the Python hooks** (`plugins/*/hooks/*.py`, `.github/scripts/*.py`)." No numeric percentage is claimed for this surface.

## Boundaries and evidence

[Conflict hierarchy §2](plugins/ca/includes/safety-core.md#2--conflict-hierarchy), levels 1 and 2: preserve audit integrity and cross-process lock identity instead of deleting the retained board sidecar. The implementation follows [ADR-0011](.codearbiter/decisions/0011-multi-host-codex-plugin-shared-core.md) shared-core generation and retains [ADR-0012](.codearbiter/decisions/0012-dual-host-store-concurrency-parity.md) lock semantics. Filesystem checks cover static unsafe aliases and observed/cooperating writers, not a hostile same-user path-swap sandbox.

Four naturally generated audit warnings are appended without rewriting target history; the CI correction adds three of those rows after the original implementation commit. The two pre-transfer source warnings are preserved separately in the branch-local stash/evidence artifact, not replayed into this target log. Original-main RED, initial-candidate size-boundary RED, and mutation/backfill proofs for already-correct guards remain separate evidence layers. The frozen-command, global-ignore, dual-role-ignore, payload-version, and cold-install metadata failure receipts are preserved with their successful successors.

Exact base: `278bf7aa76e8c97ead022a2902603b14dbd1dc0f`. Reviewed head: `46013a9403d5dfc8981c597282f9c6af14614634`. Tree: `b21914d3a191ebe5c4a6ca74e6593bc1ce062065`. Installed ADR ancestry verifier selects **squash** for this exact base/head. Merge remains a separate controller action after remote checks and exact-head evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Task-board initialization now locally excludes its retained OS-lock sidecar, keeping Git status clean without removing the lock.
  - Added a repair option for existing repositories, with safety checks and clear failure reporting.
  - Existing exclusions and file permissions are preserved during repairs.

- **Documentation**
  - Documented initialization, repair behavior, supported repository scenarios, and failure conditions.

- **Chores**
  - Updated application, plugin, adapter, and package versions and release changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->