### PR TITLE
fix(taskboard): unify first-use archive template

### DIFF
--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -4,27 +4,27 @@
   "entries": [
     {
       "drift_trigger": true,
-      "hash": "55e7d4373c5d9992e7d6c1a1e6ec58f2bfd8c961",
+      "hash": "7b8cbe2a0ed07dde7fb20bd864aa990dc9d869c7",
       "path": "CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "18990c8ca549b13918cadadb8451ffa354c5fbba",
+      "hash": "033c301d3b52f68b4527f68ef304100ab8e28a86",
       "path": "package.json"
     },
     {
       "drift_trigger": true,
-      "hash": "d4b834155c5402d87eb985a83079e4de9386588f",
+      "hash": "9d27576c9673452057bf6c8631a43fe350527e38",
       "path": "plugins/ca-codex/.codex-plugin/plugin.json"
     },
     {
       "drift_trigger": true,
-      "hash": "f2d3c663ee5d28a268c4c450691627af5dea3de2",
+      "hash": "d7bdd2c2d0af6f9e57bcaa607b94fe8fe042d5e1",
       "path": "plugins/ca-codex/CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "2f5d81e1fe52f3a8f5d8c2ceb193d8f59e0cc1db",
+      "hash": "ac6b1ff2efbfd4ae3848bd9d87d95691fc75f112",
       "path": "plugins/ca-pi/CHANGELOG.md"
     },
     {
@@ -39,7 +39,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "2c3c2ed63c214b2d5c9ea920d239a1d8d8e7880d",
+      "hash": "c27a96593d272ae18ee21f8000b1617ef60d8786",
       "path": "plugins/ca-pi/package.json"
     },
     {
@@ -64,7 +64,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "e9dc29f579572c9f758a3b4079411eb8d40e4d93",
+      "hash": "19bd69fccdf17fcebee5a466af46cdbd83913ff5",
       "path": "plugins/ca/.claude-plugin/plugin.json"
     },
     {

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3873,3 +3873,11 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-07T03:24:52Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-07T03:26:07Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-07T03:29:39Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T15:15:00Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T15:22:23Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T15:24:45Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T15:32:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T15:35:50Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-07T15:40:09Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T02:50:51Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T02:55:53Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3881,3 +3881,6 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-07T15:40:09Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T02:50:51Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T02:55:53Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T03:58:17Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T04:02:08Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T04:05:01Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.github/scripts/test_taskwriter.py
+++ b/.github/scripts/test_taskwriter.py
@@ -619,6 +619,13 @@ class ArchiveTransformTest(unittest.TestCase):
         _open, new_done = tb.archive_transform(self.OPEN, "", self._task("a.b.0001"))
         self.assertTrue(new_done.startswith(tb.DONE_TASKS_HEADING))
 
+    def test_done_template_describes_the_complete_archived_task_block(self):
+        self.assertIn(
+            "Each archived task preserves its original lifecycle line and "
+            "indented task block verbatim",
+            tb.DONE_TASKS,
+        )
+
     def test_archive_rerun_does_not_duplicate_by_dotted_id(self):
         # B-21. Dedup is on the ID, not the text.
         #

--- a/.github/scripts/test_taskwriter.py
+++ b/.github/scripts/test_taskwriter.py
@@ -720,6 +720,60 @@ class DoneTasksShapeTest(unittest.TestCase):
             init.FILES["done-tasks.md"].startswith(tb.DONE_TASKS_HEADING),
             "the scaffold heading and DONE_TASKS_HEADING must agree")
 
+    def test_first_archive_uses_the_complete_init_template(self):
+        # #625: equal headings hid a missing append-only/stamp/writer contract.
+        scaffold = self._init_module().FILES["done-tasks.md"]
+        block = "- [x] a.b.0001 - finished (done 2026-07-01)\n  - Desc: kept\n"
+        task = tb.parse_board(block)[0]
+        for empty in ("", " \t\r\n"):
+            with self.subTest(empty=repr(empty)):
+                new_open, done = tb.archive_transform(block, empty, task)
+                self.assertEqual(done.encode("utf-8"), (scaffold + block).encode("utf-8"))
+                self.assertEqual(new_open, "\n")
+
+    def test_real_cli_first_archive_matches_init_bytes_on_every_host(self):
+        # #625: read bytes, not universal-newline text; Windows must prove the
+        # same persisted header as POSIX. Each CLI loads its own generated host.
+        import subprocess
+        import tempfile
+        from pathlib import Path
+
+        block = b"- [x] a.b.0001 - finished (done 2026-07-01)\n  - Desc: kept\n"
+        env = os.environ.copy()
+        for key in list(env):
+            if key.startswith("GIT_") or key == "CLAUDE_PROJECT_DIR":
+                env.pop(key)
+        env.update(GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL=os.devnull,
+                   PYTHONDONTWRITEBYTECODE="1")
+        for host in ("ca", "ca-codex", "ca-pi"):
+            with self.subTest(host=host), tempfile.TemporaryDirectory() as temp:
+                hooks = Path(REPO) / "plugins" / host / "hooks"
+                fresh, legacy = Path(temp).resolve() / "fresh", Path(temp).resolve() / "legacy"
+                for root in (fresh, legacy):
+                    root.mkdir()
+                    result = subprocess.run(["git", "init", "-q"], cwd=root,
+                                            env=env, capture_output=True, timeout=30)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                initialized = subprocess.run(
+                    [sys.executable, "-B", str(hooks / "init-codearbiter.py"),
+                     "--root", str(fresh)], cwd=fresh, env=env,
+                    capture_output=True, timeout=30)
+                self.assertEqual(initialized.returncode, 0, initialized.stderr)
+                scaffold = (fresh / ".codearbiter/done-tasks.md").read_bytes()
+                state = legacy / ".codearbiter"
+                state.mkdir()
+                (state / "open-tasks.md").write_bytes(block)
+                self.assertFalse((state / "done-tasks.md").exists())
+                archived = subprocess.run(
+                    [sys.executable, "-B", str(hooks / "taskwrite.py"),
+                     "archive", "a.b.0001"], cwd=legacy,
+                    env=dict(env, CLAUDE_PROJECT_DIR=str(legacy)),
+                    capture_output=True, timeout=30)
+                self.assertEqual(archived.returncode, 0, archived.stderr)
+                self.assertEqual((state / "done-tasks.md").read_bytes(), scaffold + block)
+                self.assertEqual(scaffold, self._init_module().FILES["done-tasks.md"].encode("utf-8"))
+                self.assertEqual((state / "open-tasks.md").read_bytes(), b"\n")
+
     def test_done_tasks_shape_scaffold_is_a_valid_archive_target(self):
         # The scaffolded text must accept an appended entry without the
         # transform inventing a second heading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.17.9] - 2026-09-07
+
+### Fixed
+
+- Use the same documented done-tasks template for initialization and first-use archiving, with byte-identical UTF-8 headers on Windows and POSIX.
+
 ## [2.17.8] - 2026-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.17.8" src="https://img.shields.io/badge/version-2.17.8-2b7489">
+<img alt="version 2.17.9" src="https://img.shields.io/badge/version-2.17.9-2b7489">
 <img alt="core lanes" src="https://img.shields.io/badge/core_lanes-18-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-19-555">
@@ -117,7 +117,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.8`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.9`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_taskboardlib.py
+++ b/core/pysrc/_taskboardlib.py
@@ -704,6 +704,22 @@ ARCHIVE_CUTOFF_DAYS = 14
 
 DONE_TASKS_HEADING = "# Done tasks"
 
+# The canonical documented archive template, shared by init and first use.
+DONE_TASKS = """\
+# Done tasks
+
+Completed work swept off the board by `taskwrite archive`, newest last.
+APPEND-ONLY: entries are added here and never edited or removed, so a
+finished task has exactly one permanent record.
+
+Each line is the task's original lifecycle line, moved verbatim from
+`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
+what makes an entry ageable, and what `archive` refuses to invent.
+
+Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
+per-item confirmation; nothing sweeps automatically.
+"""
+
 
 def archive_candidates(text, *, today, cutoff_days=ARCHIVE_CUTOFF_DAYS):
     """`(aged, undated)` — done tasks eligible for the archival sweep.
@@ -862,7 +878,7 @@ def archive_transform(open_text, done_text, task):
     if already_archived(done_text, task):
         new_done = done_text
     else:
-        body = done_text if done_text.strip() else DONE_TASKS_HEADING + "\n"
+        body = done_text if done_text.strip() else DONE_TASKS
         if not body.endswith("\n"):
             body += "\n"
         new_done = body + "\n".join(block) + "\n"

--- a/core/pysrc/_taskboardlib.py
+++ b/core/pysrc/_taskboardlib.py
@@ -712,9 +712,10 @@ Completed work swept off the board by `taskwrite archive`, newest last.
 APPEND-ONLY: entries are added here and never edited or removed, so a
 finished task has exactly one permanent record.
 
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
+Each archived task preserves its original lifecycle line and indented task block verbatim
+from `open-tasks.md`. The lifecycle line keeps its `(done YYYY-MM-DD)` stamp
+intact — the stamp is what makes an entry ageable, and what `archive` refuses
+to invent.
 
 Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
 per-item confirmation; nothing sweeps automatically.

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.8"
+    adapter_version = "2.17.9"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/core/pysrc/init-codearbiter.py
+++ b/core/pysrc/init-codearbiter.py
@@ -21,6 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _gitexec import git_executable, root_bound_git_env  # noqa: E402
+from _taskboardlib import DONE_TASKS  # noqa: E402 — shared archive template (#625)
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -91,21 +92,6 @@ OVERRIDES = """\
 # Format: [ISO-8601] | BY: <name> <<email>> | GATE: <gate bypassed> | REASON: <reason>
 # Written only by /override. The statusline counts non-comment lines after the
 # last-checkpoint marker as "overrides since last checkpoint."
-"""
-
-DONE_TASKS = """\
-# Done tasks
-
-Completed work swept off the board by `taskwrite archive`, newest last.
-APPEND-ONLY: entries are added here and never edited or removed, so a
-finished task has exactly one permanent record.
-
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
-
-Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
-per-item confirmation; nothing sweeps automatically.
 """
 
 FILES = {
@@ -209,7 +195,10 @@ def main(argv=None):
     for fname, content in FILES.items():
         fp = os.path.join(cad, fname)
         if not os.path.exists(fp):
-            with open(fp, "w", encoding="utf-8") as f:
+            # Match taskwrite's LF output for this shared append-only template
+            # on Windows too; other scaffold files retain their existing EOLs.
+            newline = "\n" if fname == "done-tasks.md" else None
+            with open(fp, "w", encoding="utf-8", newline=newline) as f:
                 f.write(content)
             created.append(fname)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the generated codeArbiter governance surface plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail), sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.9.9] - 2026-09-07
+
+### Fixed
+
+- Use the same documented done-tasks template for initialization and first-use archiving, with byte-identical UTF-8 headers on Windows and POSIX.
+
 ## [0.9.8] - 2026-09-06
 
 ### Fixed

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -178,7 +178,7 @@ class CodexHost(hostapi.Host):
 
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.9.8"
+    adapter_version = "0.9.9"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/_taskboardlib.py
+++ b/plugins/ca-codex/hooks/_taskboardlib.py
@@ -704,6 +704,22 @@ ARCHIVE_CUTOFF_DAYS = 14
 
 DONE_TASKS_HEADING = "# Done tasks"
 
+# The canonical documented archive template, shared by init and first use.
+DONE_TASKS = """\
+# Done tasks
+
+Completed work swept off the board by `taskwrite archive`, newest last.
+APPEND-ONLY: entries are added here and never edited or removed, so a
+finished task has exactly one permanent record.
+
+Each line is the task's original lifecycle line, moved verbatim from
+`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
+what makes an entry ageable, and what `archive` refuses to invent.
+
+Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
+per-item confirmation; nothing sweeps automatically.
+"""
+
 
 def archive_candidates(text, *, today, cutoff_days=ARCHIVE_CUTOFF_DAYS):
     """`(aged, undated)` — done tasks eligible for the archival sweep.
@@ -862,7 +878,7 @@ def archive_transform(open_text, done_text, task):
     if already_archived(done_text, task):
         new_done = done_text
     else:
-        body = done_text if done_text.strip() else DONE_TASKS_HEADING + "\n"
+        body = done_text if done_text.strip() else DONE_TASKS
         if not body.endswith("\n"):
             body += "\n"
         new_done = body + "\n".join(block) + "\n"

--- a/plugins/ca-codex/hooks/_taskboardlib.py
+++ b/plugins/ca-codex/hooks/_taskboardlib.py
@@ -712,9 +712,10 @@ Completed work swept off the board by `taskwrite archive`, newest last.
 APPEND-ONLY: entries are added here and never edited or removed, so a
 finished task has exactly one permanent record.
 
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
+Each archived task preserves its original lifecycle line and indented task block verbatim
+from `open-tasks.md`. The lifecycle line keeps its `(done YYYY-MM-DD)` stamp
+intact — the stamp is what makes an entry ageable, and what `archive` refuses
+to invent.
 
 Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
 per-item confirmation; nothing sweeps automatically.

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.8"
+    adapter_version = "2.17.9"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-codex/hooks/init-codearbiter.py
+++ b/plugins/ca-codex/hooks/init-codearbiter.py
@@ -21,6 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _gitexec import git_executable, root_bound_git_env  # noqa: E402
+from _taskboardlib import DONE_TASKS  # noqa: E402 — shared archive template (#625)
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -91,21 +92,6 @@ OVERRIDES = """\
 # Format: [ISO-8601] | BY: <name> <<email>> | GATE: <gate bypassed> | REASON: <reason>
 # Written only by /override. The statusline counts non-comment lines after the
 # last-checkpoint marker as "overrides since last checkpoint."
-"""
-
-DONE_TASKS = """\
-# Done tasks
-
-Completed work swept off the board by `taskwrite archive`, newest last.
-APPEND-ONLY: entries are added here and never edited or removed, so a
-finished task has exactly one permanent record.
-
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
-
-Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
-per-item confirmation; nothing sweeps automatically.
 """
 
 FILES = {
@@ -209,7 +195,10 @@ def main(argv=None):
     for fname, content in FILES.items():
         fp = os.path.join(cad, fname)
         if not os.path.exists(fp):
-            with open(fp, "w", encoding="utf-8") as f:
+            # Match taskwrite's LF output for this shared append-only template
+            # on Windows too; other scaffold files retain their existing EOLs.
+            newline = "\n" if fname == "done-tasks.md" else None
+            with open(fp, "w", encoding="utf-8", newline=newline) as f:
                 f.write(content)
             created.append(fname)
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.10] - 2026-09-07
+
+### Fixed
+
+- Use the same documented done-tasks template for initialization and first-use archiving, with byte-identical UTF-8 headers on Windows and POSIX.
+
 ## [0.10.9] - 2026-09-06
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.9"
+    adapter_version = "0.10.10"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/hooks/_taskboardlib.py
+++ b/plugins/ca-pi/hooks/_taskboardlib.py
@@ -704,6 +704,22 @@ ARCHIVE_CUTOFF_DAYS = 14
 
 DONE_TASKS_HEADING = "# Done tasks"
 
+# The canonical documented archive template, shared by init and first use.
+DONE_TASKS = """\
+# Done tasks
+
+Completed work swept off the board by `taskwrite archive`, newest last.
+APPEND-ONLY: entries are added here and never edited or removed, so a
+finished task has exactly one permanent record.
+
+Each line is the task's original lifecycle line, moved verbatim from
+`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
+what makes an entry ageable, and what `archive` refuses to invent.
+
+Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
+per-item confirmation; nothing sweeps automatically.
+"""
+
 
 def archive_candidates(text, *, today, cutoff_days=ARCHIVE_CUTOFF_DAYS):
     """`(aged, undated)` — done tasks eligible for the archival sweep.
@@ -862,7 +878,7 @@ def archive_transform(open_text, done_text, task):
     if already_archived(done_text, task):
         new_done = done_text
     else:
-        body = done_text if done_text.strip() else DONE_TASKS_HEADING + "\n"
+        body = done_text if done_text.strip() else DONE_TASKS
         if not body.endswith("\n"):
             body += "\n"
         new_done = body + "\n".join(block) + "\n"

--- a/plugins/ca-pi/hooks/_taskboardlib.py
+++ b/plugins/ca-pi/hooks/_taskboardlib.py
@@ -712,9 +712,10 @@ Completed work swept off the board by `taskwrite archive`, newest last.
 APPEND-ONLY: entries are added here and never edited or removed, so a
 finished task has exactly one permanent record.
 
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
+Each archived task preserves its original lifecycle line and indented task block verbatim
+from `open-tasks.md`. The lifecycle line keeps its `(done YYYY-MM-DD)` stamp
+intact — the stamp is what makes an entry ageable, and what `archive` refuses
+to invent.
 
 Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
 per-item confirmation; nothing sweeps automatically.

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.8"
+    adapter_version = "2.17.9"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/hooks/init-codearbiter.py
+++ b/plugins/ca-pi/hooks/init-codearbiter.py
@@ -21,6 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _gitexec import git_executable, root_bound_git_env  # noqa: E402
+from _taskboardlib import DONE_TASKS  # noqa: E402 — shared archive template (#625)
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -91,21 +92,6 @@ OVERRIDES = """\
 # Format: [ISO-8601] | BY: <name> <<email>> | GATE: <gate bypassed> | REASON: <reason>
 # Written only by /override. The statusline counts non-comment lines after the
 # last-checkpoint marker as "overrides since last checkpoint."
-"""
-
-DONE_TASKS = """\
-# Done tasks
-
-Completed work swept off the board by `taskwrite archive`, newest last.
-APPEND-ONLY: entries are added here and never edited or removed, so a
-finished task has exactly one permanent record.
-
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
-
-Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
-per-item confirmation; nothing sweeps automatically.
 """
 
 FILES = {
@@ -209,7 +195,10 @@ def main(argv=None):
     for fname, content in FILES.items():
         fp = os.path.join(cad, fname)
         if not os.path.exists(fp):
-            with open(fp, "w", encoding="utf-8") as f:
+            # Match taskwrite's LF output for this shared append-only template
+            # on Windows too; other scaffold files retain their existing EOLs.
+            newline = "\n" if fname == "done-tasks.md" else None
+            with open(fp, "w", encoding="utf-8", newline=newline) as f:
                 f.write(content)
             created.append(fname)
 

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.17.8",
+  "version": "2.17.9",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.17.8"
+    adapter_version = "2.17.9"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/_taskboardlib.py
+++ b/plugins/ca/hooks/_taskboardlib.py
@@ -704,6 +704,22 @@ ARCHIVE_CUTOFF_DAYS = 14
 
 DONE_TASKS_HEADING = "# Done tasks"
 
+# The canonical documented archive template, shared by init and first use.
+DONE_TASKS = """\
+# Done tasks
+
+Completed work swept off the board by `taskwrite archive`, newest last.
+APPEND-ONLY: entries are added here and never edited or removed, so a
+finished task has exactly one permanent record.
+
+Each line is the task's original lifecycle line, moved verbatim from
+`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
+what makes an entry ageable, and what `archive` refuses to invent.
+
+Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
+per-item confirmation; nothing sweeps automatically.
+"""
+
 
 def archive_candidates(text, *, today, cutoff_days=ARCHIVE_CUTOFF_DAYS):
     """`(aged, undated)` — done tasks eligible for the archival sweep.
@@ -862,7 +878,7 @@ def archive_transform(open_text, done_text, task):
     if already_archived(done_text, task):
         new_done = done_text
     else:
-        body = done_text if done_text.strip() else DONE_TASKS_HEADING + "\n"
+        body = done_text if done_text.strip() else DONE_TASKS
         if not body.endswith("\n"):
             body += "\n"
         new_done = body + "\n".join(block) + "\n"

--- a/plugins/ca/hooks/_taskboardlib.py
+++ b/plugins/ca/hooks/_taskboardlib.py
@@ -712,9 +712,10 @@ Completed work swept off the board by `taskwrite archive`, newest last.
 APPEND-ONLY: entries are added here and never edited or removed, so a
 finished task has exactly one permanent record.
 
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
+Each archived task preserves its original lifecycle line and indented task block verbatim
+from `open-tasks.md`. The lifecycle line keeps its `(done YYYY-MM-DD)` stamp
+intact — the stamp is what makes an entry ageable, and what `archive` refuses
+to invent.
 
 Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
 per-item confirmation; nothing sweeps automatically.

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.8"
+    adapter_version = "2.17.9"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca/hooks/init-codearbiter.py
+++ b/plugins/ca/hooks/init-codearbiter.py
@@ -21,6 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _gitexec import git_executable, root_bound_git_env  # noqa: E402
+from _taskboardlib import DONE_TASKS  # noqa: E402 — shared archive template (#625)
 import hostapi  # noqa: E402 — host seam (ADR-0011)
 import _hooklib  # noqa: E402 — set_host DI seam (#257)
 import _entrylib  # noqa: E402 — shared run() dispatch (jscpd dedup)
@@ -91,21 +92,6 @@ OVERRIDES = """\
 # Format: [ISO-8601] | BY: <name> <<email>> | GATE: <gate bypassed> | REASON: <reason>
 # Written only by /override. The statusline counts non-comment lines after the
 # last-checkpoint marker as "overrides since last checkpoint."
-"""
-
-DONE_TASKS = """\
-# Done tasks
-
-Completed work swept off the board by `taskwrite archive`, newest last.
-APPEND-ONLY: entries are added here and never edited or removed, so a
-finished task has exactly one permanent record.
-
-Each line is the task's original lifecycle line, moved verbatim from
-`open-tasks.md` with its `(done YYYY-MM-DD)` stamp intact — the stamp is
-what makes an entry ageable, and what `archive` refuses to invent.
-
-Written only by `taskwrite archive`. `/ca:standup` proposes the sweep with
-per-item confirmation; nothing sweeps automatically.
 """
 
 FILES = {
@@ -209,7 +195,10 @@ def main(argv=None):
     for fname, content in FILES.items():
         fp = os.path.join(cad, fname)
         if not os.path.exists(fp):
-            with open(fp, "w", encoding="utf-8") as f:
+            # Match taskwrite's LF output for this shared append-only template
+            # on Windows too; other scaffold files retain their existing EOLs.
+            newline = "\n" if fname == "done-tasks.md" else None
+            with open(fp, "w", encoding="utf-8", newline=newline) as f:
                 f.write(content)
             created.append(fname)
 


### PR DESCRIPTION
## Summary

- Define one canonical done-task archive template and use it for both repository initialization and first-use archival.
- Preserve existing archive content while making new archive files byte-identical across Claude, Codex, and Pi hosts.
- Add direct missing-input and real CLI journey tests, then synchronize package metadata and changelogs for all affected hosts.

## Why

First-use archival created only a heading, while initialization created the documented explanatory template. This change removes that split behavior and closes #625 with one generated source of truth.

## Test plan

- `python .github/scripts/test_taskwriter.py` (86 passed)
- Full Python discovery suite (1533 passed, 4 skipped)
- Pi test suite (863 passed, 1 skipped), typecheck, and build
- `python tools/sync-core.py --check` (63 files across 3 hosts byte-identical)
- Host package, public documentation, platform fixture, JSON, provenance, and sensitive-diff checks
- Production and development npm audits (0 vulnerabilities)
- Exact-head payload version gates for `ca`, `ca-codex`, and `ca-pi`
- Independent security, dependency, and coverage reviews, followed by triage and verdict (PASS, 0 findings)

## Merge proof

- Exact base: `96a5d5b4e5a5e74bcb1b4db3184cd0cd482751b1`
- Exact head: `3fa5b37138881f458c0aa6dfc859a7f8ee822964`
- Installed ADR lifecycle verifier selected `squash`; all required sources are already in base ancestry.

Closes #625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initialization and first-use archiving now use the same documented `done-tasks.md` template.
  * Archived tasks preserve their original lifecycle lines and indented task blocks.
  * Archive headers now use consistent UTF-8 formatting and line endings across Windows and POSIX systems.

* **Documentation**
  * Updated release notes and version references.

* **Chores**
  * Updated application and plugin version numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->