### PR TITLE
fix(hooks): resolve append-only audit conflicts

### DIFF
--- a/.codearbiter/.provenance/release-targets.json
+++ b/.codearbiter/.provenance/release-targets.json
@@ -1,30 +1,30 @@
 {
-  "created": "2026-09-02",
+  "created": "2026-09-08",
   "doc": "release-targets",
   "entries": [
     {
       "drift_trigger": true,
-      "hash": "7b8cbe2a0ed07dde7fb20bd864aa990dc9d869c7",
+      "hash": "ba037e2449106bc4e5df1f3494a553b393abb57a",
       "path": "CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "033c301d3b52f68b4527f68ef304100ab8e28a86",
+      "hash": "8641e4e57970ed5a256e2e11f9b6ecf8bc6334cc",
       "path": "package.json"
     },
     {
       "drift_trigger": true,
-      "hash": "9d27576c9673452057bf6c8631a43fe350527e38",
+      "hash": "6ab6ac3b869b151e588f83797c4fd525ed9ebc32",
       "path": "plugins/ca-codex/.codex-plugin/plugin.json"
     },
     {
       "drift_trigger": true,
-      "hash": "d7bdd2c2d0af6f9e57bcaa607b94fe8fe042d5e1",
+      "hash": "f080686e18a86741fe75227574ea5280a7a20b18",
       "path": "plugins/ca-codex/CHANGELOG.md"
     },
     {
       "drift_trigger": true,
-      "hash": "ac6b1ff2efbfd4ae3848bd9d87d95691fc75f112",
+      "hash": "e38c9a4584f2ebdbc28b1e884e63acdfbc79e097",
       "path": "plugins/ca-pi/CHANGELOG.md"
     },
     {
@@ -39,7 +39,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "c27a96593d272ae18ee21f8000b1617ef60d8786",
+      "hash": "08ecb5780c789d670a0238800a61f71cf3df7ca7",
       "path": "plugins/ca-pi/package.json"
     },
     {
@@ -64,7 +64,7 @@
     },
     {
       "drift_trigger": true,
-      "hash": "19bd69fccdf17fcebee5a466af46cdbd83913ff5",
+      "hash": "69d09585dd153770e08cc2df817dc72636325479",
       "path": "plugins/ca/.claude-plugin/plugin.json"
     },
     {

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3898,3 +3898,7 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T08:37:25Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T09:16:18Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T09:20:26Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T10:13:47Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T10:17:17Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T10:21:13Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T10:25:21Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3891,3 +3891,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T07:02:39Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T07:04:07Z] WARN host=claude hook=test_staleness_warn_entry.py | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T07:06:47Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T07:44:41Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T07:48:04Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3902,3 +3902,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T10:17:17Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T10:21:13Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T10:25:21Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T10:49:19Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T10:53:26Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3893,3 +3893,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T07:06:47Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T07:44:41Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T07:48:04Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T08:13:49Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T08:19:13Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3896,3 +3896,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T08:13:49Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T08:19:13Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T08:37:25Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T09:16:18Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T09:20:26Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3884,3 +3884,10 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T03:58:17Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T04:02:08Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T04:05:01Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T05:25:45Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T05:29:07Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T05:37:37Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T05:54:37Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T07:02:39Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T07:04:07Z] WARN host=claude hook=test_staleness_warn_entry.py | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T07:06:47Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3895,3 +3895,4 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-08T07:48:04Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T08:13:49Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-08T08:19:13Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-08T08:37:25Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -715,6 +715,21 @@
       "object_type": "tag",
       "commit_sha": "cf86fe128728c47714ac0632fafeabdc492ed1c7",
       "object_sha": "d86db1c06d0da3b707f4ff8840b4db17d8d98b4c"
+    },
+    "v2.17.9": {
+      "commit_sha": "08e6ea13da08d4619a87c22f1dc10865212e7eba",
+      "object_sha": "518c08ca46858bfa40d50f380127a96bb43d1707",
+      "object_type": "tag"
+    },
+    "ca-codex-v0.9.9": {
+      "commit_sha": "08e6ea13da08d4619a87c22f1dc10865212e7eba",
+      "object_type": "tag",
+      "object_sha": "5e55b822ec46d2ccd6689d781a43522b35ca1df3"
+    },
+    "ca-pi-v0.10.10": {
+      "object_sha": "5719008d4155b42aa9fe81cd4a2a35efbc9024ce",
+      "commit_sha": "08e6ea13da08d4619a87c22f1dc10865212e7eba",
+      "object_type": "tag"
     }
   }
 }

--- a/.github/scripts/test_modelib.py
+++ b/.github/scripts/test_modelib.py
@@ -43,6 +43,7 @@ class TestSettleDevCloseLedgerReplay(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.ca = os.path.join(self.root, ".codearbiter")
         self.markers = os.path.join(self.ca, ".markers")
         os.makedirs(self.markers)
@@ -150,6 +151,7 @@ class TestCurrentModeResolution(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.markers = os.path.join(self.root, ".codearbiter", ".markers")
         os.makedirs(self.markers)
         self.mode_path = os.path.join(self.markers, "mode")
@@ -228,6 +230,7 @@ class TestWriteMode(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.markers = os.path.join(self.root, ".codearbiter", ".markers")
         self.mode_path = os.path.join(self.markers, "mode")
         self.entry_dir = os.path.join(self.markers, "mode.d")
@@ -306,6 +309,7 @@ class TestSessionKeying(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -402,6 +406,7 @@ class TestFlip(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.log_path = _modelib._overrides_log_path(self.root)
 
     def tearDown(self):
@@ -495,6 +500,7 @@ class TestLedgerBacks(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         os.makedirs(os.path.join(self.root, ".codearbiter"))
         self.log = os.path.join(self.root, ".codearbiter", "overrides.log")
 
@@ -581,6 +587,7 @@ class TestFlipFailsSafeUnderAnUnwritableMarkersDir(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -661,6 +668,7 @@ class TestSettleGenericModeExitRow(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         os.makedirs(os.path.join(self.root, ".codearbiter", ".markers"))
         self.log = os.path.join(self.root, ".codearbiter", "overrides.log")
         with open(self.log, "w", encoding="utf-8") as f:
@@ -761,6 +769,7 @@ class TestWriteModeIsVerified(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -937,6 +946,7 @@ class TestEnterRowIsLedgerBacked(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
 
     def tearDown(self):
         self._tmp.cleanup()

--- a/.github/scripts/test_prompt_submit.py
+++ b/.github/scripts/test_prompt_submit.py
@@ -72,6 +72,7 @@ class _Fixture(unittest.TestCase):
     def setUp(self):
         self._td = tempfile.TemporaryDirectory()
         self.root = self._td.name
+        os.makedirs(os.path.join(self.root, ".git"))
         ca_dir = os.path.join(self.root, ".codearbiter")
         os.makedirs(ca_dir)
         with open(os.path.join(ca_dir, "CONTEXT.md"), "w", encoding="utf-8") as f:

--- a/.github/scripts/test_startup_emitters.py
+++ b/.github/scripts/test_startup_emitters.py
@@ -85,6 +85,7 @@ def _repo(tmp, initialized=True, mode=None, session_id=None):
     """A minimal `.codearbiter` repo under `tmp`. `mode`/`session_id`, when
     given, seed the mode marker directly (bypassing flip()/prompt-submit.py,
     which is Lane B's surface)."""
+    os.makedirs(os.path.join(tmp, ".git"), exist_ok=True)
     cad = os.path.join(tmp, ".codearbiter")
     os.makedirs(cad, exist_ok=True)
     body = "<!--INITIALIZED-->\nstage: 2\n" if initialized else "_stub_\n"
@@ -162,6 +163,7 @@ class TestClearModeMarker(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         os.makedirs(os.path.join(self.root, ".codearbiter"))
 
     def tearDown(self):
@@ -230,6 +232,7 @@ class TestNoDeletedCommandNameStampedIntoOverridesLog(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         os.makedirs(os.path.join(self.root, ".codearbiter"))
 
     def tearDown(self):
@@ -518,6 +521,7 @@ class TestMigrateDevActiveMarker(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.markers = os.path.join(self.root, ".codearbiter", ".markers")
         os.makedirs(self.markers)
         self.legacy = os.path.join(self.markers, "dev-active")
@@ -641,6 +645,8 @@ class TestRootResolutionSplitFixed(unittest.TestCase):
         # the main checkout (`main_root`, what marker_root() escalates to).
         self.worktree_root = os.path.join(self._tmp.name, "worktree")
         self.main_root = os.path.join(self._tmp.name, "main-checkout")
+        os.makedirs(os.path.join(self.worktree_root, ".git"))
+        os.makedirs(os.path.join(self.main_root, ".git"))
         os.makedirs(os.path.join(self.worktree_root, ".codearbiter"))
         os.makedirs(os.path.join(self.main_root, ".codearbiter"))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.17.10] - 2026-09-08
+
+### Fixed
+
+- Resolve genuine append-only audit-log conflicts through a fail-closed helper that preserves both branch histories and records the immediate H-05 authorization, with shared audit-path locks and a locked mandatory-override writer preventing concurrent row loss.
+
 ## [2.17.9] - 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.17.9" src="https://img.shields.io/badge/version-2.17.9-2b7489">
+<img alt="version 2.17.10" src="https://img.shields.io/badge/version-2.17.10-2b7489">
 <img alt="core lanes" src="https://img.shields.io/badge/core_lanes-18-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-19-555">
@@ -117,7 +117,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.9`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.10`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_appendonlyconflictlib.py
+++ b/core/pysrc/_appendonlyconflictlib.py
@@ -265,6 +265,20 @@ def _build_union(root, records):
     return merged
 
 
+def _sync_parent(path):
+    if os.name == "nt":
+        return False
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    parent_fd = os.open(path.parent, flags)
+    try:
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    return True
+
+
 def _write_bytes_atomic(path, raw, *, expected=None):
     original_mode = stat.S_IMODE(path.stat().st_mode)
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
@@ -287,6 +301,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 raise ConcurrentAppendError(path, restored=True, observed=observed)
         os.replace(temporary, path)
         temporary = None
+        _sync_parent(path)
         if witness is not None:
             displaced = Path(witness).read_bytes()
             if displaced != expected:
@@ -294,6 +309,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 try:
                     os.replace(witness, path)
                     witness = None
+                    _sync_parent(path)
                     restored = True
                 finally:
                     raise ConcurrentAppendError(path, restored=restored, observed=displaced)

--- a/core/pysrc/_appendonlyconflictlib.py
+++ b/core/pysrc/_appendonlyconflictlib.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# codeArbiter - fail-closed resolution of genuine H-05 append-only conflicts.
+#
+# The public entry point is resolve-append-only-conflict.py.  This module keeps
+# Git inspection, byte validation, deterministic union construction, atomic
+# replacement, and explicit staging testable and host-neutral.
+#
+# Public API:
+#   resolve(target, reason, cwd=None) -> str  resolve and return repo-relative path
+#   main(argv=None) -> int                    CLI contract
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+from _gitexec import git_executable
+from _protectedlib import classify_protected
+
+
+BOM = b"\xef\xbb\xbf"
+MAX_REASON = 500
+SUPPORTED_AUDIT_PATHS = frozenset(
+    {".codearbiter/overrides.log", ".codearbiter/gate-events.log"}
+)
+
+
+class ResolutionError(RuntimeError):
+    """A surfaced, non-mutating refusal of the conflict-resolution contract."""
+
+
+class ConcurrentAppendError(ResolutionError):
+    """A displaced original inode changed and was restored before refusal."""
+
+    def __init__(self, path, restored, observed=None):
+        super().__init__(f"concurrent append detected while replacing '{Path(path).name}'")
+        self.path = Path(path)
+        self.restored = restored
+        self.observed = observed
+
+
+def _git(cwd, *args, input_bytes=None, check=True):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args],
+            cwd=cwd,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as error:
+        raise ResolutionError(f"git unavailable: {error}") from error
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result
+
+
+def _repository_root(cwd):
+    result = _git(cwd, "rev-parse", "--show-toplevel")
+    try:
+        raw = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise ResolutionError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _relative_target(root, target):
+    candidate = Path(target)
+    if candidate.is_absolute():
+        raise ResolutionError("target must be a repository-relative supported append-only path")
+    normalized = Path(os.path.normpath(str(candidate)))
+    if normalized == Path(".") or ".." in normalized.parts:
+        raise ResolutionError("target must be a contained supported append-only path")
+    path = root / normalized
+    try:
+        path.resolve(strict=False).relative_to(root)
+    except ValueError as error:
+        raise ResolutionError("target escapes the repository root") from error
+    relative = normalized.as_posix()
+    if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
+        str(path), str(root)
+    ):
+        raise ResolutionError(f"'{relative}' is not a supported append-only H-05 path")
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise ResolutionError(f"cannot inspect '{relative}': {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise ResolutionError(f"'{relative}' is not a regular non-link file")
+    return relative, path
+
+
+def _validate_bytes(label, raw):
+    if BOM in raw:
+        raise ResolutionError(f"{label} contains a UTF-8 BOM")
+    if b"\x00" in raw:
+        raise ResolutionError(f"{label} contains a NUL byte")
+    if b"\r" in raw:
+        raise ResolutionError(f"{label} is not canonical LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ResolutionError(f"{label} is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise ResolutionError(f"{label} does not end with LF")
+
+
+def _marker_run(line, marker):
+    if not line.endswith(b"\n"):
+        return 0
+    body = line[:-1]
+    size = 0
+    while size < len(body) and body[size : size + 1] == marker:
+        size += 1
+    if size < 7 or (len(body) > size and body[size : size + 1] != b" "):
+        return 0
+    return size
+
+
+def _validate_conflicted_worktree(raw, base, ours_suffix, theirs_suffix):
+    """Prove the worktree is only Git's rendering of the three index stages."""
+    # Git for Windows may render conflict markers and checked-out blob lines as
+    # CRLF even though every index blob is canonical LF. Normalize only complete
+    # CRLF pairs for comparison; lone CR remains invalid and the original bytes
+    # stay untouched for rollback.
+    normalized = raw.replace(b"\r\n", b"\n")
+    _validate_bytes("conflicted worktree", normalized)
+    if not normalized.startswith(base):
+        raise ResolutionError("conflicted worktree does not preserve the merge-base prefix")
+    lines = normalized[len(base) :].splitlines(keepends=True)
+    starts = [(index, _marker_run(line, b"<")) for index, line in enumerate(lines)]
+    starts = [(index, size) for index, size in starts if size]
+    if len(starts) != 1:
+        raise ResolutionError("conflicted worktree is not one recognized Git conflict rendering")
+    start, marker_size = starts[0]
+    separator_line = (b"=" * marker_size) + b"\n"
+    separators = [index for index, line in enumerate(lines) if line == separator_line]
+    ends = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b">") == marker_size
+    ]
+    base_markers = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b"|") == marker_size
+    ]
+    if len(separators) != 1 or len(ends) != 1 or len(base_markers) > 1:
+        raise ResolutionError("conflicted worktree has ambiguous Git conflict markers")
+    separator = separators[0]
+    end = ends[0]
+    base_marker = base_markers[0] if base_markers else None
+    ours_end = base_marker if base_marker is not None else separator
+    if not (start < ours_end <= separator < end):
+        raise ResolutionError("conflicted worktree has out-of-order Git conflict markers")
+    if base_marker is not None and b"".join(lines[base_marker + 1 : separator]):
+        raise ResolutionError("conflicted worktree has unexpected merge-base conflict bytes")
+
+    common_prefix = b"".join(lines[:start])
+    ours_body = b"".join(lines[start + 1 : ours_end])
+    theirs_body = b"".join(lines[separator + 1 : end])
+    common_suffix = b"".join(lines[end + 1 :])
+    if ours_suffix != common_prefix + ours_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the current-branch index stage")
+    if theirs_suffix != common_prefix + theirs_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the incoming-branch index stage")
+
+
+def _unmerged(root, relative, *, allow_resolved=False):
+    result = _git(root, "ls-files", "-u", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed unmerged index record") from error
+    if allow_resolved and not records:
+        return []
+    if len(records) != 3 or [record[2] for record in records] != [1, 2, 3]:
+        raise ResolutionError("target is not in a complete three-stage conflict")
+    if any(record[3] != relative for record in records):
+        raise ResolutionError("unmerged index path does not match the requested target")
+    if any(record[0] != "100644" for record in records):
+        raise ResolutionError("append-only conflict stages must all be regular 100644 blobs")
+    return records
+
+
+def _tracked_index(root, relative):
+    result = _git(root, "ls-files", "--stage", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed tracked index record") from error
+    return records
+
+
+def _blob(root, oid, label):
+    result = _git(root, "cat-file", "blob", oid)
+    raw = result.stdout
+    _validate_bytes(label, raw)
+    return raw
+
+
+def _authorization(root, reason):
+    reason = reason.strip()
+    if not reason:
+        raise ResolutionError("--reason must contain a non-empty reason")
+    if len(reason) > MAX_REASON or "|" in reason or "\n" in reason or "\r" in reason:
+        raise ResolutionError("--reason must be at most 500 characters with no pipes or newlines")
+    result = _git(root, "config", "--get", "user.email", check=False)
+    if result.returncode != 0:
+        raise ResolutionError("git config user.email is required for the attributed override")
+    try:
+        identity = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git config user.email is not valid UTF-8") from error
+    if not identity or len(identity) > 254 or "|" in identity or "\n" in identity or "\r" in identity:
+        raise ResolutionError("git config user.email is not a valid override identity")
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return f"[{timestamp}] | BY: {identity} | GATE: H-05 | REASON: {reason}\n".encode("utf-8")
+
+
+def _append_parts(root, records):
+    base = _blob(root, records[0][1], "merge base")
+    ours = _blob(root, records[1][1], "current branch")
+    theirs = _blob(root, records[2][1], "incoming branch")
+    if not ours.startswith(base):
+        raise ResolutionError("current branch is not append-only relative to the merge base")
+    if not theirs.startswith(base):
+        raise ResolutionError("incoming branch is not append-only relative to the merge base")
+    ours_suffix = ours[len(base) :]
+    theirs_suffix = theirs[len(base) :]
+    if not ours_suffix or not theirs_suffix:
+        raise ResolutionError("both conflict sides must append non-empty history")
+    return base, ours_suffix, theirs_suffix
+
+
+def _build_union(root, records):
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    merged = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", merged)
+    return merged
+
+
+def _write_bytes_atomic(path, raw, *, expected=None):
+    original_mode = stat.S_IMODE(path.stat().st_mode)
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    witness = None
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, original_mode)
+        if expected is not None:
+            witness_fd, witness = tempfile.mkstemp(
+                dir=path.parent, prefix=path.name + ".", suffix=".witness"
+            )
+            os.close(witness_fd)
+            os.remove(witness)
+            os.link(path, witness)
+            observed = Path(witness).read_bytes()
+            if observed != expected:
+                raise ConcurrentAppendError(path, restored=True, observed=observed)
+        os.replace(temporary, path)
+        temporary = None
+        if witness is not None:
+            displaced = Path(witness).read_bytes()
+            if displaced != expected:
+                restored = False
+                try:
+                    os.replace(witness, path)
+                    witness = None
+                    restored = True
+                finally:
+                    raise ConcurrentAppendError(path, restored=restored, observed=displaced)
+            os.remove(witness)
+            witness = None
+    except Exception:
+        if temporary is not None:
+            try:
+                os.remove(temporary)
+            except OSError:
+                pass
+        if witness is not None:
+            try:
+                os.remove(witness)
+            except OSError:
+                pass
+        raise
+
+
+def _restore_index(root, relative, records):
+    removed = _git(root, "update-index", "--force-remove", "--", relative, check=False)
+    if removed.returncode != 0:
+        detail = removed.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"could not clear staged resolution during rollback: {detail}")
+    index_info = b"".join(
+        f"{mode} {oid} {stage}\t{path}\n".encode("utf-8")
+        for mode, oid, stage, path in records
+    )
+    _git(root, "update-index", "--index-info", input_bytes=index_info)
+
+
+def resolve(target, reason, cwd=None):
+    root = _repository_root(cwd or os.getcwd())
+    relative, path = _relative_target(root, target)
+    records = _unmerged(root, relative)
+    authorization = _authorization(root, reason)
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    proposed = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", proposed)
+    changes = {relative: proposed}
+    paths = {relative: path}
+    originals = {relative: path.read_bytes()}
+    _validate_conflicted_worktree(originals[relative], base, ours_suffix, theirs_suffix)
+    index_records = {relative: records}
+    override_relative = ".codearbiter/overrides.log"
+    if relative == override_relative:
+        changes[relative] += authorization
+    else:
+        override_relative, override_path = _relative_target(root, override_relative)
+        if _unmerged(root, override_relative, allow_resolved=True):
+            raise ResolutionError("the override audit sink is itself unmerged")
+        for diff_args in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+            clean = _git(root, *diff_args, "--", override_relative, check=False)
+            if clean.returncode != 0:
+                raise ResolutionError("the override audit sink must be clean before resolution")
+        override_raw = override_path.read_bytes()
+        _validate_bytes("override audit sink", override_raw)
+        changes[override_relative] = override_raw + authorization
+        paths[override_relative] = override_path
+        originals[override_relative] = override_raw
+        index_records[override_relative] = _tracked_index(root, override_relative)
+    try:
+        common_raw = _git(root, "rev-parse", "--git-common-dir").stdout.decode(
+            "utf-8", errors="strict"
+        ).strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 common directory") from error
+    if not common_raw:
+        raise ResolutionError("git returned an empty common directory")
+    common = Path(common_raw)
+    if not common.is_absolute():
+        common = root / common
+    lock = acquire_lock(str(common.resolve() / "codearbiter-append-only-conflict"))
+    if lock is None:
+        raise ResolutionError("another append-only conflict resolution holds the repository lock")
+    path_locks = []
+    try:
+        for changed_relative in sorted(changes):
+            path_lock = acquire_lock(audit_lock_key(root, paths[changed_relative]))
+            if path_lock is None:
+                raise ResolutionError(
+                    f"another writer holds the audit path lock for '{changed_relative}'"
+                )
+            path_locks.append(path_lock)
+        if _unmerged(root, relative) != records or path.read_bytes() != originals[relative]:
+            raise ResolutionError("conflict state changed during validation; retry from fresh evidence")
+        try:
+            for changed_relative, raw in changes.items():
+                if paths[changed_relative].read_bytes() != originals[changed_relative]:
+                    raise ResolutionError("protected state changed during validation; retry")
+                _write_bytes_atomic(
+                    paths[changed_relative], raw, expected=originals[changed_relative]
+                )
+            staged = _git(root, "add", "--", *changes.keys(), check=False)
+            if staged.returncode != 0:
+                detail = staged.stderr.decode("utf-8", errors="replace").strip()
+                raise ResolutionError(f"git add failed: {detail or 'unknown error'}")
+            if _unmerged(root, relative, allow_resolved=True):
+                raise ResolutionError("git add did not clear the three-stage conflict")
+            for changed_relative, raw in changes.items():
+                index_blob = _git(root, "show", f":0:{changed_relative}").stdout
+                if index_blob != raw:
+                    raise ResolutionError(
+                        f"staged blob does not match validated output for {changed_relative}"
+                    )
+        except Exception as error:
+            # The replacement is atomic; if staging or verification fails, put
+            # the exact conflict-marker worktree bytes and three index stages
+            # back.  This also covers a successful `git add` followed by a
+            # failed staged-blob verification.
+            for changed_relative, raw in originals.items():
+                if isinstance(error, ConcurrentAppendError) and paths[changed_relative] == error.path:
+                    if error.restored:
+                        continue
+                    if error.observed is not None:
+                        raw = error.observed
+                _write_bytes_atomic(paths[changed_relative], raw)
+            for changed_relative, prior_records in index_records.items():
+                _restore_index(root, changed_relative, prior_records)
+            raise
+    finally:
+        for path_lock in reversed(path_locks):
+            release_lock(path_lock)
+        release_lock(lock)
+    return relative
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Resolve one genuine H-05 append-only Git conflict without weakening the guard."
+    )
+    parser.add_argument("target", help="repository-relative protected append-only path")
+    parser.add_argument("--reason", required=True, help="specific immediate H-05 override reason")
+    args = parser.parse_args(argv)
+    try:
+        relative = resolve(args.target, args.reason)
+    except (OSError, ResolutionError) as error:
+        print(f"append-only conflict resolution refused: {error}", file=sys.stderr)
+        return 1
+    print(f"resolved and staged append-only conflict: {relative}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/pysrc/_appendonlyconflictlib.py
+++ b/core/pysrc/_appendonlyconflictlib.py
@@ -84,9 +84,13 @@ def _relative_target(root, target):
         raise ResolutionError("target must be a contained supported append-only path")
     path = root / normalized
     try:
-        path.resolve(strict=False).relative_to(root)
+        resolved_root = os.path.realpath(root)
+        resolved_path = os.path.realpath(path)
+        common = os.path.commonpath((resolved_root, resolved_path))
     except ValueError as error:
         raise ResolutionError("target escapes the repository root") from error
+    if os.path.normcase(common) != os.path.normcase(resolved_root):
+        raise ResolutionError("target escapes the repository root")
     relative = normalized.as_posix()
     if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
         str(path), str(root)

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -529,19 +529,26 @@ def _log_gate_event(kind, tag, msg):
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         log_path = os.path.join(cad, "gate-events.log")
-        audit_lock = acquire_lock(audit_lock_key(root, log_path))
-        if audit_lock is None:
-            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        fd = None
-        os_lock_acquired = False
         try:
             if os.name == "nt":
                 _GATE_EVENTS_WINDOWS_LOCK.acquire()
                 process_lock_acquired = True
+            audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        except Exception:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            raise
+        if audit_lock is None:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            return
+        fd = None
+        os_lock_acquired = False
+        try:
             fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
@@ -567,13 +574,15 @@ def _log_gate_event(kind, tag, msg):
                     msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
                 except Exception:  # noqa: BLE001 — outer sink remains fail-open
                     pass
-            if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
             try:
                 if fd is not None:
                     os.close(fd)
             finally:
-                release_lock(audit_lock)
+                try:
+                    release_lock(audit_lock)
+                finally:
+                    if process_lock_acquired:
+                        _GATE_EVENTS_WINDOWS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -218,8 +218,10 @@ from _sensitivelib import (  # noqa: F401
 )
 
 
-# Serialize same-process Windows writers before taking the cross-process lock.
-_GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
+# Serialize same-process writers before taking the bounded cross-process lock.
+# POSIX flock and Windows byte-range locks are process-scoped, so sibling
+# threads can otherwise burn the shared wait budget contending with each other.
+_GATE_EVENTS_PROCESS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
@@ -534,17 +536,16 @@ def _log_gate_event(kind, tag, msg):
             flags |= os.O_BINARY
         process_lock_acquired = False
         try:
-            if os.name == "nt":
-                _GATE_EVENTS_WINDOWS_LOCK.acquire()
-                process_lock_acquired = True
+            _GATE_EVENTS_PROCESS_LOCK.acquire()
+            process_lock_acquired = True
             audit_lock = acquire_lock(audit_lock_key(root, log_path))
         except Exception:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             raise
         if audit_lock is None:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             return
         fd = None
         os_lock_acquired = False
@@ -582,7 +583,7 @@ def _log_gate_event(kind, tag, msg):
                     release_lock(audit_lock)
                 finally:
                     if process_lock_acquired:
-                        _GATE_EVENTS_WINDOWS_LOCK.release()
+                        _GATE_EVENTS_PROCESS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -96,6 +96,7 @@
 #                                         non-blocking + bounded LOCK_WAIT retry spin,
 #                                         fail-soft None on contention/timeout/OSError
 #   release_lock(handle) -> None          release + close; None handle is a no-op
+#   audit_lock_key(root, path) -> str     trusted Git-owned key for an audit path
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -105,6 +106,7 @@
 
 import datetime
 import errno
+import hashlib
 import json
 import os
 import re
@@ -409,6 +411,63 @@ def release_lock(handle):
             pass
 
 
+def audit_lock_key(root, path):
+    """Return a deterministic audit lock key beneath Git-owned metadata.
+
+    Audit paths and their siblings are repository-controlled, so an adjacent
+    lock can be a checked-out symlink that redirects acquire_lock's seed byte
+    outside the checkout. Linked worktrees resolve to their common Git
+    directory and therefore share one trusted key per repository-relative path.
+    """
+    root = os.path.abspath(os.fspath(root))
+    path = os.path.abspath(os.fspath(path))
+    try:
+        if os.path.normcase(os.path.commonpath((root, path))) != os.path.normcase(root):
+            raise ValueError
+    except (OSError, ValueError) as error:
+        raise OSError("audit lock target is outside the repository root") from error
+
+    dotgit = os.path.join(root, ".git")
+    if os.path.isdir(dotgit):
+        common = dotgit
+    elif os.path.isfile(dotgit):
+        try:
+            with open(dotgit, encoding="utf-8") as handle:
+                pointer = handle.read(4097)
+        except OSError as error:
+            raise OSError("cannot read linked-worktree Git metadata") from error
+        if len(pointer) > 4096 or not pointer.startswith("gitdir:"):
+            raise OSError("linked-worktree Git metadata is malformed")
+        gitdir = pointer[7:].strip()
+        if not gitdir:
+            raise OSError("linked-worktree Git directory is empty")
+        if not os.path.isabs(gitdir):
+            gitdir = os.path.join(root, gitdir)
+        commondir_file = os.path.join(gitdir, "commondir")
+        if os.path.isfile(commondir_file):
+            try:
+                with open(commondir_file, encoding="utf-8") as handle:
+                    relative_common = handle.read(4097).strip()
+            except OSError as error:
+                raise OSError("cannot read Git common-directory metadata") from error
+            if not relative_common or len(relative_common) > 4096:
+                raise OSError("Git common-directory metadata is malformed")
+            common = relative_common if os.path.isabs(relative_common) else os.path.join(
+                gitdir, relative_common
+            )
+        else:
+            common = gitdir
+    else:
+        raise OSError("repository Git metadata is unavailable for audit locking")
+
+    common = os.path.realpath(common)
+    if not os.path.isdir(common):
+        raise OSError("Git common directory is unavailable for audit locking")
+    relative = os.path.relpath(path, root).replace("\\", "/")
+    digest = hashlib.sha256(relative.encode("utf-8")).hexdigest()
+    return os.path.join(common, "codearbiter-audit-locks", digest)
+
+
 # The H-11 authoring-marker freshness window (issue #567) — the single
 # declaration every `marker_fresh(marker, minutes)` call site resolves by
 # import. Previously five independent `30` literals (pre-write.py,
@@ -469,17 +528,21 @@ def _log_gate_event(kind, tag, msg):
             host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
+        log_path = os.path.join(cad, "gate-events.log")
+        audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        if audit_lock is None:
+            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        if os.name == "nt":
-            _GATE_EVENTS_WINDOWS_LOCK.acquire()
-            process_lock_acquired = True
         fd = None
         os_lock_acquired = False
         try:
-            fd = os.open(os.path.join(cad, "gate-events.log"), flags, 0o600)
+            if os.name == "nt":
+                _GATE_EVENTS_WINDOWS_LOCK.acquire()
+                process_lock_acquired = True
+            fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
                 os.lseek(fd, 0, os.SEEK_SET)
@@ -506,8 +569,11 @@ def _log_gate_event(kind, tag, msg):
                     pass
             if process_lock_acquired:
                 _GATE_EVENTS_WINDOWS_LOCK.release()
-            if fd is not None:
-                os.close(fd)
+            try:
+                if fd is not None:
+                    os.close(fd)
+            finally:
+                release_lock(audit_lock)
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/core/pysrc/_modelib.py
+++ b/core/pysrc/_modelib.py
@@ -25,7 +25,7 @@ import os
 import re
 
 from _activationlib import marker_root
-from _hooklib import write_text_atomic
+from _hooklib import acquire_lock, audit_lock_key, release_lock, write_text_atomic
 
 
 # ---------------------------------------------------------------------------
@@ -645,12 +645,21 @@ def _overrides_has_line(root, line):
 
 def _append_override_line(root, line):
     """Append one audit line to overrides.log. True on a confirmed write."""
+    lock = None
     try:
-        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+        path = _overrides_log_path(root)
+        lock = acquire_lock(audit_lock_key(root, path))
+        if lock is None:
+            return False
+        with open(path, "a", encoding="utf-8") as f:
             f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
         return True
-    except OSError:
+    except Exception:  # noqa: BLE001 — mode audit settlement remains fail-soft
         return False
+    finally:
+        release_lock(lock)
 
 
 def _dev_dropped_close_note(count, host_name=None):

--- a/core/pysrc/_overrideappendlib.py
+++ b/core/pysrc/_overrideappendlib.py
@@ -67,13 +67,17 @@ def _identity(root):
     return value
 
 
-def _validate_existing(path, raw):
+def _validate_file_type(path):
     try:
         mode = path.lstat().st_mode
     except OSError as error:
         raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
     if not stat.S_ISREG(mode) or path.is_symlink():
         raise OverrideAppendError("overrides.log is not a regular non-link file")
+
+
+def _validate_existing(path, raw):
+    _validate_file_type(path)
     if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
         raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
     try:
@@ -87,6 +91,7 @@ def _validate_existing(path, raw):
 def append_override(*, gate=None, security_finding=None, reason, cwd=None):
     root = _root(cwd or os.getcwd())
     path = root / ".codearbiter" / "overrides.log"
+    _validate_file_type(path)
     before = path.read_bytes()
     _validate_existing(path, before)
     identity = _identity(root)

--- a/core/pysrc/_overrideappendlib.py
+++ b/core/pysrc/_overrideappendlib.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail-closed, cooperatively locked append for mandatory override records."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+from _gitexec import git_executable
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+
+
+MAX_FIELD = 500
+GATE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class OverrideAppendError(RuntimeError):
+    """The mandatory audit row could not be safely and durably appended."""
+
+
+def _git(cwd, *args):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args], cwd=cwd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False,
+        )
+    except OSError as error:
+        raise OverrideAppendError(f"git unavailable: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise OverrideAppendError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result.stdout
+
+
+def _root(cwd):
+    try:
+        raw = _git(cwd, "rev-parse", "--show-toplevel").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise OverrideAppendError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _field(label, value):
+    if not value or len(value) > MAX_FIELD or any(char in value for char in "|\r\n"):
+        raise OverrideAppendError(
+            f"{label} must be non-empty, at most {MAX_FIELD} characters, and contain no pipe or newline"
+        )
+    return value
+
+
+def _identity(root):
+    try:
+        value = _git(root, "config", "user.email").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git config user.email is not valid UTF-8") from error
+    _field("git config user.email", value)
+    if len(value) > 254 or any(char.isspace() for char in value):
+        raise OverrideAppendError("git config user.email is not a valid override identity")
+    return value
+
+
+def _validate_existing(path, raw):
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise OverrideAppendError("overrides.log is not a regular non-link file")
+    if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
+        raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("overrides.log is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise OverrideAppendError("overrides.log does not end with LF")
+
+
+def append_override(*, gate=None, security_finding=None, reason, cwd=None):
+    root = _root(cwd or os.getcwd())
+    path = root / ".codearbiter" / "overrides.log"
+    before = path.read_bytes()
+    _validate_existing(path, before)
+    identity = _identity(root)
+    reason = _field("reason", reason)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    if gate is not None:
+        if not GATE_RE.fullmatch(gate):
+            raise OverrideAppendError("gate must be a compact gate identifier")
+        body = f"GATE: {gate}"
+    else:
+        body = f"SECURITY-OVERRIDE | FINDING: {_field('security finding', security_finding)}"
+    line = f"[{timestamp}] | BY: {identity} | {body} | REASON: {reason}\n".encode("utf-8")
+
+    lock = acquire_lock(audit_lock_key(root, path))
+    if lock is None:
+        raise OverrideAppendError("another writer holds the overrides.log audit path lock")
+    fd = None
+    try:
+        if path.read_bytes() != before:
+            raise OverrideAppendError("overrides.log changed during validation; retry")
+        flags = os.O_APPEND | os.O_WRONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        fd = os.open(path, flags)
+        offset = 0
+        while offset < len(line):
+            written = os.write(fd, line[offset:])
+            if written <= 0:
+                raise OverrideAppendError("override audit append made no progress")
+            offset += written
+        os.fsync(fd)
+    except OSError as error:
+        raise OverrideAppendError(f"override audit append failed: {error}") from error
+    finally:
+        try:
+            if fd is not None:
+                os.close(fd)
+        finally:
+            release_lock(lock)
+    return path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Append one mandatory override audit row safely.")
+    kind = parser.add_mutually_exclusive_group(required=True)
+    kind.add_argument("--gate", help="gate identifier for an ordinary override")
+    kind.add_argument("--security-finding", help="specific acknowledged security finding")
+    parser.add_argument("--reason", required=True, help="specific justification")
+    args = parser.parse_args(argv)
+    try:
+        path = append_override(
+            gate=args.gate,
+            security_finding=args.security_finding,
+            reason=args.reason,
+        )
+    except (OSError, OverrideAppendError) as error:
+        print(f"override audit append refused: {error}", file=sys.stderr)
+        return 1
+    print(f"appended mandatory override audit row: {path}")
+    return 0

--- a/core/pysrc/append-override.py
+++ b/core/pysrc/append-override.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the locked mandatory override audit append."""
+
+from _overrideappendlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/pysrc/hostapi.py
+++ b/core/pysrc/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.9"
+    adapter_version = "2.17.10"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/core/pysrc/resolve-append-only-conflict.py
+++ b/core/pysrc/resolve-append-only-conflict.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# codeArbiter - sanctioned helper entry point for H-05 append-only conflicts.
+
+from _appendonlyconflictlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/surface/commands/override.md
+++ b/core/surface/commands/override.md
@@ -14,14 +14,40 @@ logged, always visible, never silent. Single identity, single confirm.
    vague reason ("just skip it") and ask for a specific one.
 2. Detect the operator identity from `git config user.email` only. If it is unset, ask the user once
    to state their identity for the log. (No platform ladder, no second confirmation.)
-3. Append one line to `{{PROJECT_DIR}}/.codearbiter/overrides.log`:
+3. For an ordinary override, use the private locked audit helper from the repository root:
+
+   ```sh
+   python3 "{{PLUGIN_ROOT}}/hooks/append-override.py" --gate "<gate bypassed>" --reason "<specific reason>"
+   ```
+
+   It appends one line to `{{PROJECT_DIR}}/.codearbiter/overrides.log`:
 
    ```
    [ISO-8601 timestamp] | BY: <email> | GATE: <gate bypassed> | REASON: <reason>
    ```
 
-   The log is append-only — never edited or deleted, committed as a permanent audit artifact.
-4. Proceed with the overridden action. Note in the response that the override is logged.
+   The log is append-only — never edited or deleted, committed as a permanent audit artifact. The
+   helper fails closed if another official writer or conflict resolver owns the audit-path lock; the
+   overridden action must not proceed unless the row lands. A guard-permitted raw append remains a
+   cooperative operator escape hatch, but it must not run concurrently with conflict resolution.
+4. A genuine three-stage Git conflict on an H-05 append-only path uses the dedicated helper instead
+   of the ordinary step 3 append. Run it once from the conflicted repository, with the specific
+   repo-relative path and the same reason:
+
+   ```sh
+   python3 "{{PLUGIN_ROOT}}/hooks/resolve-append-only-conflict.py" ".codearbiter/overrides.log" --reason "<specific reason>"
+   ```
+
+   The helper derives the same `git config user.email` identity, validates the merge-base and both
+   append suffixes, writes the attributed H-05 record, and explicitly stages only the validated
+   deterministic union. It refuses a missing or malformed three-stage conflict, any edit to prior
+   bytes, unsupported paths, invalid encoding, dirty audit sink, or replay after resolution. This is
+   scoped to the immediate action only; it creates no marker, standing exception, or general H-05
+   bypass. It takes canonical per-audit-path locks and supports only `overrides.log` and the
+   repository-owned `gate-events.log` sink; official writers share those locks. Conflict resolution
+   is an exclusive cooperative operation: do not start a raw append before or during it. Never
+   hand-resolve the protected log with Write, patch, checkout, or restore.
+5. Proceed with the overridden action. Note in the response that the override is logged.
 
 ## Security ceiling — heavier path for security-critical stops
 
@@ -39,8 +65,14 @@ Heavier path (all required, in order):
 2. **Explicit per-finding acknowledgement** — the user must acknowledge *that specific finding* in
    their own words (a bare "yes"/"go ahead"/"I trust you" is declined — this mirrors `decision-variance`).
    Detect identity from `git config user.email`; if unset, ask once.
-3. **Heavier log entry** — append a line tagged `SECURITY-OVERRIDE` that records the specific finding,
-   not just the gate name:
+3. **Heavier log entry** — use the same locked helper so the mandatory row cannot race conflict
+   resolution:
+
+   ```sh
+   python3 "{{PLUGIN_ROOT}}/hooks/append-override.py" --security-finding "<specific finding>" --reason "<reason>"
+   ```
+
+   It appends a line tagged `SECURITY-OVERRIDE` that records the specific finding, not just the gate name:
 
    ```
    [ISO-8601] | BY: <email> | SECURITY-OVERRIDE | FINDING: <specific finding> | REASON: <reason>
@@ -61,7 +93,9 @@ Under `{{CMD:sprint}}`, a security-critical override is a hard-gate STOP: it sur
 MUST write the log line before proceeding — it is not optional. MUST capture an operator identity —
 "codeArbiter" or "automated" are not valid. MUST include a justification. The override is scoped to
 the immediate action only; it creates no standing exception. MUST NOT edit or delete an existing
-`overrides.log` entry. MUST route a security-critical / crypto-secret / irreversible stop through the
+`overrides.log` entry. For an H-05 three-stage conflict, the dedicated helper's validated union and
+audit write are the single immediate action; do not pre-edit the conflicted file. MUST route a
+security-critical / crypto-secret / irreversible stop through the
 **Security ceiling** path — never the single-confirm flow — and MUST NOT auto-decide such an override
 under `{{CMD:sprint}}`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the generated codeArbiter governance surface plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail), sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.9.10] - 2026-09-08
+
+### Fixed
+
+- Resolve genuine append-only audit-log conflicts through a fail-closed helper that preserves both branch histories and records the immediate H-05 authorization, with shared audit-path locks and a locked mandatory-override writer preventing concurrent row loss.
+
 ## [0.9.9] - 2026-09-07
 
 ### Fixed

--- a/plugins/ca-codex/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca-codex/hooks/_appendonlyconflictlib.py
@@ -265,6 +265,20 @@ def _build_union(root, records):
     return merged
 
 
+def _sync_parent(path):
+    if os.name == "nt":
+        return False
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    parent_fd = os.open(path.parent, flags)
+    try:
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    return True
+
+
 def _write_bytes_atomic(path, raw, *, expected=None):
     original_mode = stat.S_IMODE(path.stat().st_mode)
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
@@ -287,6 +301,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 raise ConcurrentAppendError(path, restored=True, observed=observed)
         os.replace(temporary, path)
         temporary = None
+        _sync_parent(path)
         if witness is not None:
             displaced = Path(witness).read_bytes()
             if displaced != expected:
@@ -294,6 +309,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 try:
                     os.replace(witness, path)
                     witness = None
+                    _sync_parent(path)
                     restored = True
                 finally:
                     raise ConcurrentAppendError(path, restored=restored, observed=displaced)

--- a/plugins/ca-codex/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca-codex/hooks/_appendonlyconflictlib.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# codeArbiter - fail-closed resolution of genuine H-05 append-only conflicts.
+#
+# The public entry point is resolve-append-only-conflict.py.  This module keeps
+# Git inspection, byte validation, deterministic union construction, atomic
+# replacement, and explicit staging testable and host-neutral.
+#
+# Public API:
+#   resolve(target, reason, cwd=None) -> str  resolve and return repo-relative path
+#   main(argv=None) -> int                    CLI contract
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+from _gitexec import git_executable
+from _protectedlib import classify_protected
+
+
+BOM = b"\xef\xbb\xbf"
+MAX_REASON = 500
+SUPPORTED_AUDIT_PATHS = frozenset(
+    {".codearbiter/overrides.log", ".codearbiter/gate-events.log"}
+)
+
+
+class ResolutionError(RuntimeError):
+    """A surfaced, non-mutating refusal of the conflict-resolution contract."""
+
+
+class ConcurrentAppendError(ResolutionError):
+    """A displaced original inode changed and was restored before refusal."""
+
+    def __init__(self, path, restored, observed=None):
+        super().__init__(f"concurrent append detected while replacing '{Path(path).name}'")
+        self.path = Path(path)
+        self.restored = restored
+        self.observed = observed
+
+
+def _git(cwd, *args, input_bytes=None, check=True):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args],
+            cwd=cwd,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as error:
+        raise ResolutionError(f"git unavailable: {error}") from error
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result
+
+
+def _repository_root(cwd):
+    result = _git(cwd, "rev-parse", "--show-toplevel")
+    try:
+        raw = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise ResolutionError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _relative_target(root, target):
+    candidate = Path(target)
+    if candidate.is_absolute():
+        raise ResolutionError("target must be a repository-relative supported append-only path")
+    normalized = Path(os.path.normpath(str(candidate)))
+    if normalized == Path(".") or ".." in normalized.parts:
+        raise ResolutionError("target must be a contained supported append-only path")
+    path = root / normalized
+    try:
+        path.resolve(strict=False).relative_to(root)
+    except ValueError as error:
+        raise ResolutionError("target escapes the repository root") from error
+    relative = normalized.as_posix()
+    if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
+        str(path), str(root)
+    ):
+        raise ResolutionError(f"'{relative}' is not a supported append-only H-05 path")
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise ResolutionError(f"cannot inspect '{relative}': {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise ResolutionError(f"'{relative}' is not a regular non-link file")
+    return relative, path
+
+
+def _validate_bytes(label, raw):
+    if BOM in raw:
+        raise ResolutionError(f"{label} contains a UTF-8 BOM")
+    if b"\x00" in raw:
+        raise ResolutionError(f"{label} contains a NUL byte")
+    if b"\r" in raw:
+        raise ResolutionError(f"{label} is not canonical LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ResolutionError(f"{label} is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise ResolutionError(f"{label} does not end with LF")
+
+
+def _marker_run(line, marker):
+    if not line.endswith(b"\n"):
+        return 0
+    body = line[:-1]
+    size = 0
+    while size < len(body) and body[size : size + 1] == marker:
+        size += 1
+    if size < 7 or (len(body) > size and body[size : size + 1] != b" "):
+        return 0
+    return size
+
+
+def _validate_conflicted_worktree(raw, base, ours_suffix, theirs_suffix):
+    """Prove the worktree is only Git's rendering of the three index stages."""
+    # Git for Windows may render conflict markers and checked-out blob lines as
+    # CRLF even though every index blob is canonical LF. Normalize only complete
+    # CRLF pairs for comparison; lone CR remains invalid and the original bytes
+    # stay untouched for rollback.
+    normalized = raw.replace(b"\r\n", b"\n")
+    _validate_bytes("conflicted worktree", normalized)
+    if not normalized.startswith(base):
+        raise ResolutionError("conflicted worktree does not preserve the merge-base prefix")
+    lines = normalized[len(base) :].splitlines(keepends=True)
+    starts = [(index, _marker_run(line, b"<")) for index, line in enumerate(lines)]
+    starts = [(index, size) for index, size in starts if size]
+    if len(starts) != 1:
+        raise ResolutionError("conflicted worktree is not one recognized Git conflict rendering")
+    start, marker_size = starts[0]
+    separator_line = (b"=" * marker_size) + b"\n"
+    separators = [index for index, line in enumerate(lines) if line == separator_line]
+    ends = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b">") == marker_size
+    ]
+    base_markers = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b"|") == marker_size
+    ]
+    if len(separators) != 1 or len(ends) != 1 or len(base_markers) > 1:
+        raise ResolutionError("conflicted worktree has ambiguous Git conflict markers")
+    separator = separators[0]
+    end = ends[0]
+    base_marker = base_markers[0] if base_markers else None
+    ours_end = base_marker if base_marker is not None else separator
+    if not (start < ours_end <= separator < end):
+        raise ResolutionError("conflicted worktree has out-of-order Git conflict markers")
+    if base_marker is not None and b"".join(lines[base_marker + 1 : separator]):
+        raise ResolutionError("conflicted worktree has unexpected merge-base conflict bytes")
+
+    common_prefix = b"".join(lines[:start])
+    ours_body = b"".join(lines[start + 1 : ours_end])
+    theirs_body = b"".join(lines[separator + 1 : end])
+    common_suffix = b"".join(lines[end + 1 :])
+    if ours_suffix != common_prefix + ours_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the current-branch index stage")
+    if theirs_suffix != common_prefix + theirs_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the incoming-branch index stage")
+
+
+def _unmerged(root, relative, *, allow_resolved=False):
+    result = _git(root, "ls-files", "-u", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed unmerged index record") from error
+    if allow_resolved and not records:
+        return []
+    if len(records) != 3 or [record[2] for record in records] != [1, 2, 3]:
+        raise ResolutionError("target is not in a complete three-stage conflict")
+    if any(record[3] != relative for record in records):
+        raise ResolutionError("unmerged index path does not match the requested target")
+    if any(record[0] != "100644" for record in records):
+        raise ResolutionError("append-only conflict stages must all be regular 100644 blobs")
+    return records
+
+
+def _tracked_index(root, relative):
+    result = _git(root, "ls-files", "--stage", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed tracked index record") from error
+    return records
+
+
+def _blob(root, oid, label):
+    result = _git(root, "cat-file", "blob", oid)
+    raw = result.stdout
+    _validate_bytes(label, raw)
+    return raw
+
+
+def _authorization(root, reason):
+    reason = reason.strip()
+    if not reason:
+        raise ResolutionError("--reason must contain a non-empty reason")
+    if len(reason) > MAX_REASON or "|" in reason or "\n" in reason or "\r" in reason:
+        raise ResolutionError("--reason must be at most 500 characters with no pipes or newlines")
+    result = _git(root, "config", "--get", "user.email", check=False)
+    if result.returncode != 0:
+        raise ResolutionError("git config user.email is required for the attributed override")
+    try:
+        identity = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git config user.email is not valid UTF-8") from error
+    if not identity or len(identity) > 254 or "|" in identity or "\n" in identity or "\r" in identity:
+        raise ResolutionError("git config user.email is not a valid override identity")
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return f"[{timestamp}] | BY: {identity} | GATE: H-05 | REASON: {reason}\n".encode("utf-8")
+
+
+def _append_parts(root, records):
+    base = _blob(root, records[0][1], "merge base")
+    ours = _blob(root, records[1][1], "current branch")
+    theirs = _blob(root, records[2][1], "incoming branch")
+    if not ours.startswith(base):
+        raise ResolutionError("current branch is not append-only relative to the merge base")
+    if not theirs.startswith(base):
+        raise ResolutionError("incoming branch is not append-only relative to the merge base")
+    ours_suffix = ours[len(base) :]
+    theirs_suffix = theirs[len(base) :]
+    if not ours_suffix or not theirs_suffix:
+        raise ResolutionError("both conflict sides must append non-empty history")
+    return base, ours_suffix, theirs_suffix
+
+
+def _build_union(root, records):
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    merged = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", merged)
+    return merged
+
+
+def _write_bytes_atomic(path, raw, *, expected=None):
+    original_mode = stat.S_IMODE(path.stat().st_mode)
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    witness = None
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, original_mode)
+        if expected is not None:
+            witness_fd, witness = tempfile.mkstemp(
+                dir=path.parent, prefix=path.name + ".", suffix=".witness"
+            )
+            os.close(witness_fd)
+            os.remove(witness)
+            os.link(path, witness)
+            observed = Path(witness).read_bytes()
+            if observed != expected:
+                raise ConcurrentAppendError(path, restored=True, observed=observed)
+        os.replace(temporary, path)
+        temporary = None
+        if witness is not None:
+            displaced = Path(witness).read_bytes()
+            if displaced != expected:
+                restored = False
+                try:
+                    os.replace(witness, path)
+                    witness = None
+                    restored = True
+                finally:
+                    raise ConcurrentAppendError(path, restored=restored, observed=displaced)
+            os.remove(witness)
+            witness = None
+    except Exception:
+        if temporary is not None:
+            try:
+                os.remove(temporary)
+            except OSError:
+                pass
+        if witness is not None:
+            try:
+                os.remove(witness)
+            except OSError:
+                pass
+        raise
+
+
+def _restore_index(root, relative, records):
+    removed = _git(root, "update-index", "--force-remove", "--", relative, check=False)
+    if removed.returncode != 0:
+        detail = removed.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"could not clear staged resolution during rollback: {detail}")
+    index_info = b"".join(
+        f"{mode} {oid} {stage}\t{path}\n".encode("utf-8")
+        for mode, oid, stage, path in records
+    )
+    _git(root, "update-index", "--index-info", input_bytes=index_info)
+
+
+def resolve(target, reason, cwd=None):
+    root = _repository_root(cwd or os.getcwd())
+    relative, path = _relative_target(root, target)
+    records = _unmerged(root, relative)
+    authorization = _authorization(root, reason)
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    proposed = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", proposed)
+    changes = {relative: proposed}
+    paths = {relative: path}
+    originals = {relative: path.read_bytes()}
+    _validate_conflicted_worktree(originals[relative], base, ours_suffix, theirs_suffix)
+    index_records = {relative: records}
+    override_relative = ".codearbiter/overrides.log"
+    if relative == override_relative:
+        changes[relative] += authorization
+    else:
+        override_relative, override_path = _relative_target(root, override_relative)
+        if _unmerged(root, override_relative, allow_resolved=True):
+            raise ResolutionError("the override audit sink is itself unmerged")
+        for diff_args in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+            clean = _git(root, *diff_args, "--", override_relative, check=False)
+            if clean.returncode != 0:
+                raise ResolutionError("the override audit sink must be clean before resolution")
+        override_raw = override_path.read_bytes()
+        _validate_bytes("override audit sink", override_raw)
+        changes[override_relative] = override_raw + authorization
+        paths[override_relative] = override_path
+        originals[override_relative] = override_raw
+        index_records[override_relative] = _tracked_index(root, override_relative)
+    try:
+        common_raw = _git(root, "rev-parse", "--git-common-dir").stdout.decode(
+            "utf-8", errors="strict"
+        ).strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 common directory") from error
+    if not common_raw:
+        raise ResolutionError("git returned an empty common directory")
+    common = Path(common_raw)
+    if not common.is_absolute():
+        common = root / common
+    lock = acquire_lock(str(common.resolve() / "codearbiter-append-only-conflict"))
+    if lock is None:
+        raise ResolutionError("another append-only conflict resolution holds the repository lock")
+    path_locks = []
+    try:
+        for changed_relative in sorted(changes):
+            path_lock = acquire_lock(audit_lock_key(root, paths[changed_relative]))
+            if path_lock is None:
+                raise ResolutionError(
+                    f"another writer holds the audit path lock for '{changed_relative}'"
+                )
+            path_locks.append(path_lock)
+        if _unmerged(root, relative) != records or path.read_bytes() != originals[relative]:
+            raise ResolutionError("conflict state changed during validation; retry from fresh evidence")
+        try:
+            for changed_relative, raw in changes.items():
+                if paths[changed_relative].read_bytes() != originals[changed_relative]:
+                    raise ResolutionError("protected state changed during validation; retry")
+                _write_bytes_atomic(
+                    paths[changed_relative], raw, expected=originals[changed_relative]
+                )
+            staged = _git(root, "add", "--", *changes.keys(), check=False)
+            if staged.returncode != 0:
+                detail = staged.stderr.decode("utf-8", errors="replace").strip()
+                raise ResolutionError(f"git add failed: {detail or 'unknown error'}")
+            if _unmerged(root, relative, allow_resolved=True):
+                raise ResolutionError("git add did not clear the three-stage conflict")
+            for changed_relative, raw in changes.items():
+                index_blob = _git(root, "show", f":0:{changed_relative}").stdout
+                if index_blob != raw:
+                    raise ResolutionError(
+                        f"staged blob does not match validated output for {changed_relative}"
+                    )
+        except Exception as error:
+            # The replacement is atomic; if staging or verification fails, put
+            # the exact conflict-marker worktree bytes and three index stages
+            # back.  This also covers a successful `git add` followed by a
+            # failed staged-blob verification.
+            for changed_relative, raw in originals.items():
+                if isinstance(error, ConcurrentAppendError) and paths[changed_relative] == error.path:
+                    if error.restored:
+                        continue
+                    if error.observed is not None:
+                        raw = error.observed
+                _write_bytes_atomic(paths[changed_relative], raw)
+            for changed_relative, prior_records in index_records.items():
+                _restore_index(root, changed_relative, prior_records)
+            raise
+    finally:
+        for path_lock in reversed(path_locks):
+            release_lock(path_lock)
+        release_lock(lock)
+    return relative
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Resolve one genuine H-05 append-only Git conflict without weakening the guard."
+    )
+    parser.add_argument("target", help="repository-relative protected append-only path")
+    parser.add_argument("--reason", required=True, help="specific immediate H-05 override reason")
+    args = parser.parse_args(argv)
+    try:
+        relative = resolve(args.target, args.reason)
+    except (OSError, ResolutionError) as error:
+        print(f"append-only conflict resolution refused: {error}", file=sys.stderr)
+        return 1
+    print(f"resolved and staged append-only conflict: {relative}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca-codex/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca-codex/hooks/_appendonlyconflictlib.py
@@ -84,9 +84,13 @@ def _relative_target(root, target):
         raise ResolutionError("target must be a contained supported append-only path")
     path = root / normalized
     try:
-        path.resolve(strict=False).relative_to(root)
+        resolved_root = os.path.realpath(root)
+        resolved_path = os.path.realpath(path)
+        common = os.path.commonpath((resolved_root, resolved_path))
     except ValueError as error:
         raise ResolutionError("target escapes the repository root") from error
+    if os.path.normcase(common) != os.path.normcase(resolved_root):
+        raise ResolutionError("target escapes the repository root")
     relative = normalized.as_posix()
     if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
         str(path), str(root)

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -529,19 +529,26 @@ def _log_gate_event(kind, tag, msg):
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         log_path = os.path.join(cad, "gate-events.log")
-        audit_lock = acquire_lock(audit_lock_key(root, log_path))
-        if audit_lock is None:
-            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        fd = None
-        os_lock_acquired = False
         try:
             if os.name == "nt":
                 _GATE_EVENTS_WINDOWS_LOCK.acquire()
                 process_lock_acquired = True
+            audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        except Exception:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            raise
+        if audit_lock is None:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            return
+        fd = None
+        os_lock_acquired = False
+        try:
             fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
@@ -567,13 +574,15 @@ def _log_gate_event(kind, tag, msg):
                     msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
                 except Exception:  # noqa: BLE001 — outer sink remains fail-open
                     pass
-            if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
             try:
                 if fd is not None:
                     os.close(fd)
             finally:
-                release_lock(audit_lock)
+                try:
+                    release_lock(audit_lock)
+                finally:
+                    if process_lock_acquired:
+                        _GATE_EVENTS_WINDOWS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -218,8 +218,10 @@ from _sensitivelib import (  # noqa: F401
 )
 
 
-# Serialize same-process Windows writers before taking the cross-process lock.
-_GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
+# Serialize same-process writers before taking the bounded cross-process lock.
+# POSIX flock and Windows byte-range locks are process-scoped, so sibling
+# threads can otherwise burn the shared wait budget contending with each other.
+_GATE_EVENTS_PROCESS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
@@ -534,17 +536,16 @@ def _log_gate_event(kind, tag, msg):
             flags |= os.O_BINARY
         process_lock_acquired = False
         try:
-            if os.name == "nt":
-                _GATE_EVENTS_WINDOWS_LOCK.acquire()
-                process_lock_acquired = True
+            _GATE_EVENTS_PROCESS_LOCK.acquire()
+            process_lock_acquired = True
             audit_lock = acquire_lock(audit_lock_key(root, log_path))
         except Exception:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             raise
         if audit_lock is None:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             return
         fd = None
         os_lock_acquired = False
@@ -582,7 +583,7 @@ def _log_gate_event(kind, tag, msg):
                     release_lock(audit_lock)
                 finally:
                     if process_lock_acquired:
-                        _GATE_EVENTS_WINDOWS_LOCK.release()
+                        _GATE_EVENTS_PROCESS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -96,6 +96,7 @@
 #                                         non-blocking + bounded LOCK_WAIT retry spin,
 #                                         fail-soft None on contention/timeout/OSError
 #   release_lock(handle) -> None          release + close; None handle is a no-op
+#   audit_lock_key(root, path) -> str     trusted Git-owned key for an audit path
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -105,6 +106,7 @@
 
 import datetime
 import errno
+import hashlib
 import json
 import os
 import re
@@ -409,6 +411,63 @@ def release_lock(handle):
             pass
 
 
+def audit_lock_key(root, path):
+    """Return a deterministic audit lock key beneath Git-owned metadata.
+
+    Audit paths and their siblings are repository-controlled, so an adjacent
+    lock can be a checked-out symlink that redirects acquire_lock's seed byte
+    outside the checkout. Linked worktrees resolve to their common Git
+    directory and therefore share one trusted key per repository-relative path.
+    """
+    root = os.path.abspath(os.fspath(root))
+    path = os.path.abspath(os.fspath(path))
+    try:
+        if os.path.normcase(os.path.commonpath((root, path))) != os.path.normcase(root):
+            raise ValueError
+    except (OSError, ValueError) as error:
+        raise OSError("audit lock target is outside the repository root") from error
+
+    dotgit = os.path.join(root, ".git")
+    if os.path.isdir(dotgit):
+        common = dotgit
+    elif os.path.isfile(dotgit):
+        try:
+            with open(dotgit, encoding="utf-8") as handle:
+                pointer = handle.read(4097)
+        except OSError as error:
+            raise OSError("cannot read linked-worktree Git metadata") from error
+        if len(pointer) > 4096 or not pointer.startswith("gitdir:"):
+            raise OSError("linked-worktree Git metadata is malformed")
+        gitdir = pointer[7:].strip()
+        if not gitdir:
+            raise OSError("linked-worktree Git directory is empty")
+        if not os.path.isabs(gitdir):
+            gitdir = os.path.join(root, gitdir)
+        commondir_file = os.path.join(gitdir, "commondir")
+        if os.path.isfile(commondir_file):
+            try:
+                with open(commondir_file, encoding="utf-8") as handle:
+                    relative_common = handle.read(4097).strip()
+            except OSError as error:
+                raise OSError("cannot read Git common-directory metadata") from error
+            if not relative_common or len(relative_common) > 4096:
+                raise OSError("Git common-directory metadata is malformed")
+            common = relative_common if os.path.isabs(relative_common) else os.path.join(
+                gitdir, relative_common
+            )
+        else:
+            common = gitdir
+    else:
+        raise OSError("repository Git metadata is unavailable for audit locking")
+
+    common = os.path.realpath(common)
+    if not os.path.isdir(common):
+        raise OSError("Git common directory is unavailable for audit locking")
+    relative = os.path.relpath(path, root).replace("\\", "/")
+    digest = hashlib.sha256(relative.encode("utf-8")).hexdigest()
+    return os.path.join(common, "codearbiter-audit-locks", digest)
+
+
 # The H-11 authoring-marker freshness window (issue #567) — the single
 # declaration every `marker_fresh(marker, minutes)` call site resolves by
 # import. Previously five independent `30` literals (pre-write.py,
@@ -469,17 +528,21 @@ def _log_gate_event(kind, tag, msg):
             host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
+        log_path = os.path.join(cad, "gate-events.log")
+        audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        if audit_lock is None:
+            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        if os.name == "nt":
-            _GATE_EVENTS_WINDOWS_LOCK.acquire()
-            process_lock_acquired = True
         fd = None
         os_lock_acquired = False
         try:
-            fd = os.open(os.path.join(cad, "gate-events.log"), flags, 0o600)
+            if os.name == "nt":
+                _GATE_EVENTS_WINDOWS_LOCK.acquire()
+                process_lock_acquired = True
+            fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
                 os.lseek(fd, 0, os.SEEK_SET)
@@ -506,8 +569,11 @@ def _log_gate_event(kind, tag, msg):
                     pass
             if process_lock_acquired:
                 _GATE_EVENTS_WINDOWS_LOCK.release()
-            if fd is not None:
-                os.close(fd)
+            try:
+                if fd is not None:
+                    os.close(fd)
+            finally:
+                release_lock(audit_lock)
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca-codex/hooks/_host.py
+++ b/plugins/ca-codex/hooks/_host.py
@@ -178,7 +178,7 @@ class CodexHost(hostapi.Host):
 
     name = "codex"
     adapter_name = "ca-codex"
-    adapter_version = "0.9.9"
+    adapter_version = "0.9.10"
     command_noun = "command"
     has_statusline = False   # no statusline surface exists on Codex
     has_read_tool = False    # no read tool; file reads happen via shell

--- a/plugins/ca-codex/hooks/_modelib.py
+++ b/plugins/ca-codex/hooks/_modelib.py
@@ -25,7 +25,7 @@ import os
 import re
 
 from _activationlib import marker_root
-from _hooklib import write_text_atomic
+from _hooklib import acquire_lock, audit_lock_key, release_lock, write_text_atomic
 
 
 # ---------------------------------------------------------------------------
@@ -645,12 +645,21 @@ def _overrides_has_line(root, line):
 
 def _append_override_line(root, line):
     """Append one audit line to overrides.log. True on a confirmed write."""
+    lock = None
     try:
-        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+        path = _overrides_log_path(root)
+        lock = acquire_lock(audit_lock_key(root, path))
+        if lock is None:
+            return False
+        with open(path, "a", encoding="utf-8") as f:
             f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
         return True
-    except OSError:
+    except Exception:  # noqa: BLE001 — mode audit settlement remains fail-soft
         return False
+    finally:
+        release_lock(lock)
 
 
 def _dev_dropped_close_note(count, host_name=None):

--- a/plugins/ca-codex/hooks/_overrideappendlib.py
+++ b/plugins/ca-codex/hooks/_overrideappendlib.py
@@ -67,13 +67,17 @@ def _identity(root):
     return value
 
 
-def _validate_existing(path, raw):
+def _validate_file_type(path):
     try:
         mode = path.lstat().st_mode
     except OSError as error:
         raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
     if not stat.S_ISREG(mode) or path.is_symlink():
         raise OverrideAppendError("overrides.log is not a regular non-link file")
+
+
+def _validate_existing(path, raw):
+    _validate_file_type(path)
     if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
         raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
     try:
@@ -87,6 +91,7 @@ def _validate_existing(path, raw):
 def append_override(*, gate=None, security_finding=None, reason, cwd=None):
     root = _root(cwd or os.getcwd())
     path = root / ".codearbiter" / "overrides.log"
+    _validate_file_type(path)
     before = path.read_bytes()
     _validate_existing(path, before)
     identity = _identity(root)

--- a/plugins/ca-codex/hooks/_overrideappendlib.py
+++ b/plugins/ca-codex/hooks/_overrideappendlib.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail-closed, cooperatively locked append for mandatory override records."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+from _gitexec import git_executable
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+
+
+MAX_FIELD = 500
+GATE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class OverrideAppendError(RuntimeError):
+    """The mandatory audit row could not be safely and durably appended."""
+
+
+def _git(cwd, *args):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args], cwd=cwd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False,
+        )
+    except OSError as error:
+        raise OverrideAppendError(f"git unavailable: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise OverrideAppendError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result.stdout
+
+
+def _root(cwd):
+    try:
+        raw = _git(cwd, "rev-parse", "--show-toplevel").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise OverrideAppendError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _field(label, value):
+    if not value or len(value) > MAX_FIELD or any(char in value for char in "|\r\n"):
+        raise OverrideAppendError(
+            f"{label} must be non-empty, at most {MAX_FIELD} characters, and contain no pipe or newline"
+        )
+    return value
+
+
+def _identity(root):
+    try:
+        value = _git(root, "config", "user.email").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git config user.email is not valid UTF-8") from error
+    _field("git config user.email", value)
+    if len(value) > 254 or any(char.isspace() for char in value):
+        raise OverrideAppendError("git config user.email is not a valid override identity")
+    return value
+
+
+def _validate_existing(path, raw):
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise OverrideAppendError("overrides.log is not a regular non-link file")
+    if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
+        raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("overrides.log is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise OverrideAppendError("overrides.log does not end with LF")
+
+
+def append_override(*, gate=None, security_finding=None, reason, cwd=None):
+    root = _root(cwd or os.getcwd())
+    path = root / ".codearbiter" / "overrides.log"
+    before = path.read_bytes()
+    _validate_existing(path, before)
+    identity = _identity(root)
+    reason = _field("reason", reason)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    if gate is not None:
+        if not GATE_RE.fullmatch(gate):
+            raise OverrideAppendError("gate must be a compact gate identifier")
+        body = f"GATE: {gate}"
+    else:
+        body = f"SECURITY-OVERRIDE | FINDING: {_field('security finding', security_finding)}"
+    line = f"[{timestamp}] | BY: {identity} | {body} | REASON: {reason}\n".encode("utf-8")
+
+    lock = acquire_lock(audit_lock_key(root, path))
+    if lock is None:
+        raise OverrideAppendError("another writer holds the overrides.log audit path lock")
+    fd = None
+    try:
+        if path.read_bytes() != before:
+            raise OverrideAppendError("overrides.log changed during validation; retry")
+        flags = os.O_APPEND | os.O_WRONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        fd = os.open(path, flags)
+        offset = 0
+        while offset < len(line):
+            written = os.write(fd, line[offset:])
+            if written <= 0:
+                raise OverrideAppendError("override audit append made no progress")
+            offset += written
+        os.fsync(fd)
+    except OSError as error:
+        raise OverrideAppendError(f"override audit append failed: {error}") from error
+    finally:
+        try:
+            if fd is not None:
+                os.close(fd)
+        finally:
+            release_lock(lock)
+    return path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Append one mandatory override audit row safely.")
+    kind = parser.add_mutually_exclusive_group(required=True)
+    kind.add_argument("--gate", help="gate identifier for an ordinary override")
+    kind.add_argument("--security-finding", help="specific acknowledged security finding")
+    parser.add_argument("--reason", required=True, help="specific justification")
+    args = parser.parse_args(argv)
+    try:
+        path = append_override(
+            gate=args.gate,
+            security_finding=args.security_finding,
+            reason=args.reason,
+        )
+    except (OSError, OverrideAppendError) as error:
+        print(f"override audit append refused: {error}", file=sys.stderr)
+        return 1
+    print(f"appended mandatory override audit row: {path}")
+    return 0

--- a/plugins/ca-codex/hooks/append-override.py
+++ b/plugins/ca-codex/hooks/append-override.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the locked mandatory override audit append."""
+
+from _overrideappendlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca-codex/hooks/hostapi.py
+++ b/plugins/ca-codex/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.9"
+    adapter_version = "2.17.10"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-codex/hooks/resolve-append-only-conflict.py
+++ b/plugins/ca-codex/hooks/resolve-append-only-conflict.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# codeArbiter - sanctioned helper entry point for H-05 append-only conflicts.
+
+from _appendonlyconflictlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca-codex/skills/ca-override/SKILL.md
+++ b/plugins/ca-codex/skills/ca-override/SKILL.md
@@ -15,14 +15,40 @@ logged, always visible, never silent. Single identity, single confirm.
    vague reason ("just skip it") and ask for a specific one.
 2. Detect the operator identity from `git config user.email` only. If it is unset, ask the user once
    to state their identity for the log. (No platform ladder, no second confirmation.)
-3. Append one line to `<project-root>/.codearbiter/overrides.log`:
+3. For an ordinary override, use the private locked audit helper from the repository root:
+
+   ```sh
+   python3 "${PLUGIN_ROOT}/hooks/append-override.py" --gate "<gate bypassed>" --reason "<specific reason>"
+   ```
+
+   It appends one line to `<project-root>/.codearbiter/overrides.log`:
 
    ```
    [ISO-8601 timestamp] | BY: <email> | GATE: <gate bypassed> | REASON: <reason>
    ```
 
-   The log is append-only — never edited or deleted, committed as a permanent audit artifact.
-4. Proceed with the overridden action. Note in the response that the override is logged.
+   The log is append-only — never edited or deleted, committed as a permanent audit artifact. The
+   helper fails closed if another official writer or conflict resolver owns the audit-path lock; the
+   overridden action must not proceed unless the row lands. A guard-permitted raw append remains a
+   cooperative operator escape hatch, but it must not run concurrently with conflict resolution.
+4. A genuine three-stage Git conflict on an H-05 append-only path uses the dedicated helper instead
+   of the ordinary step 3 append. Run it once from the conflicted repository, with the specific
+   repo-relative path and the same reason:
+
+   ```sh
+   python3 "${PLUGIN_ROOT}/hooks/resolve-append-only-conflict.py" ".codearbiter/overrides.log" --reason "<specific reason>"
+   ```
+
+   The helper derives the same `git config user.email` identity, validates the merge-base and both
+   append suffixes, writes the attributed H-05 record, and explicitly stages only the validated
+   deterministic union. It refuses a missing or malformed three-stage conflict, any edit to prior
+   bytes, unsupported paths, invalid encoding, dirty audit sink, or replay after resolution. This is
+   scoped to the immediate action only; it creates no marker, standing exception, or general H-05
+   bypass. It takes canonical per-audit-path locks and supports only `overrides.log` and the
+   repository-owned `gate-events.log` sink; official writers share those locks. Conflict resolution
+   is an exclusive cooperative operation: do not start a raw append before or during it. Never
+   hand-resolve the protected log with Write, patch, checkout, or restore.
+5. Proceed with the overridden action. Note in the response that the override is logged.
 
 ## Security ceiling — heavier path for security-critical stops
 
@@ -40,8 +66,14 @@ Heavier path (all required, in order):
 2. **Explicit per-finding acknowledgement** — the user must acknowledge *that specific finding* in
    their own words (a bare "yes"/"go ahead"/"I trust you" is declined — this mirrors `decision-variance`).
    Detect identity from `git config user.email`; if unset, ask once.
-3. **Heavier log entry** — append a line tagged `SECURITY-OVERRIDE` that records the specific finding,
-   not just the gate name:
+3. **Heavier log entry** — use the same locked helper so the mandatory row cannot race conflict
+   resolution:
+
+   ```sh
+   python3 "${PLUGIN_ROOT}/hooks/append-override.py" --security-finding "<specific finding>" --reason "<reason>"
+   ```
+
+   It appends a line tagged `SECURITY-OVERRIDE` that records the specific finding, not just the gate name:
 
    ```
    [ISO-8601] | BY: <email> | SECURITY-OVERRIDE | FINDING: <specific finding> | REASON: <reason>
@@ -62,7 +94,9 @@ Under `$ca-sprint`, a security-critical override is a hard-gate STOP: it surface
 MUST write the log line before proceeding — it is not optional. MUST capture an operator identity —
 "codeArbiter" or "automated" are not valid. MUST include a justification. The override is scoped to
 the immediate action only; it creates no standing exception. MUST NOT edit or delete an existing
-`overrides.log` entry. MUST route a security-critical / crypto-secret / irreversible stop through the
+`overrides.log` entry. For an H-05 three-stage conflict, the dedicated helper's validated union and
+audit write are the single immediate action; do not pre-edit the conflicted file. MUST route a
+security-critical / crypto-secret / irreversible stop through the
 **Security ceiling** path — never the single-confirm flow — and MUST NOT auto-decide such an override
 under `$ca-sprint`.
 

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.10.11] - 2026-09-08
+
+### Fixed
+
+- Resolve genuine append-only audit-log conflicts through a fail-closed helper that preserves both branch histories and records the immediate H-05 authorization, with shared audit-path locks and a locked mandatory-override writer preventing concurrent row loss.
+
 ## [0.10.10] - 2026-09-07
 
 ### Fixed

--- a/plugins/ca-pi/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca-pi/hooks/_appendonlyconflictlib.py
@@ -265,6 +265,20 @@ def _build_union(root, records):
     return merged
 
 
+def _sync_parent(path):
+    if os.name == "nt":
+        return False
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    parent_fd = os.open(path.parent, flags)
+    try:
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    return True
+
+
 def _write_bytes_atomic(path, raw, *, expected=None):
     original_mode = stat.S_IMODE(path.stat().st_mode)
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
@@ -287,6 +301,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 raise ConcurrentAppendError(path, restored=True, observed=observed)
         os.replace(temporary, path)
         temporary = None
+        _sync_parent(path)
         if witness is not None:
             displaced = Path(witness).read_bytes()
             if displaced != expected:
@@ -294,6 +309,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 try:
                     os.replace(witness, path)
                     witness = None
+                    _sync_parent(path)
                     restored = True
                 finally:
                     raise ConcurrentAppendError(path, restored=restored, observed=displaced)

--- a/plugins/ca-pi/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca-pi/hooks/_appendonlyconflictlib.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# codeArbiter - fail-closed resolution of genuine H-05 append-only conflicts.
+#
+# The public entry point is resolve-append-only-conflict.py.  This module keeps
+# Git inspection, byte validation, deterministic union construction, atomic
+# replacement, and explicit staging testable and host-neutral.
+#
+# Public API:
+#   resolve(target, reason, cwd=None) -> str  resolve and return repo-relative path
+#   main(argv=None) -> int                    CLI contract
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+from _gitexec import git_executable
+from _protectedlib import classify_protected
+
+
+BOM = b"\xef\xbb\xbf"
+MAX_REASON = 500
+SUPPORTED_AUDIT_PATHS = frozenset(
+    {".codearbiter/overrides.log", ".codearbiter/gate-events.log"}
+)
+
+
+class ResolutionError(RuntimeError):
+    """A surfaced, non-mutating refusal of the conflict-resolution contract."""
+
+
+class ConcurrentAppendError(ResolutionError):
+    """A displaced original inode changed and was restored before refusal."""
+
+    def __init__(self, path, restored, observed=None):
+        super().__init__(f"concurrent append detected while replacing '{Path(path).name}'")
+        self.path = Path(path)
+        self.restored = restored
+        self.observed = observed
+
+
+def _git(cwd, *args, input_bytes=None, check=True):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args],
+            cwd=cwd,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as error:
+        raise ResolutionError(f"git unavailable: {error}") from error
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result
+
+
+def _repository_root(cwd):
+    result = _git(cwd, "rev-parse", "--show-toplevel")
+    try:
+        raw = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise ResolutionError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _relative_target(root, target):
+    candidate = Path(target)
+    if candidate.is_absolute():
+        raise ResolutionError("target must be a repository-relative supported append-only path")
+    normalized = Path(os.path.normpath(str(candidate)))
+    if normalized == Path(".") or ".." in normalized.parts:
+        raise ResolutionError("target must be a contained supported append-only path")
+    path = root / normalized
+    try:
+        path.resolve(strict=False).relative_to(root)
+    except ValueError as error:
+        raise ResolutionError("target escapes the repository root") from error
+    relative = normalized.as_posix()
+    if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
+        str(path), str(root)
+    ):
+        raise ResolutionError(f"'{relative}' is not a supported append-only H-05 path")
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise ResolutionError(f"cannot inspect '{relative}': {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise ResolutionError(f"'{relative}' is not a regular non-link file")
+    return relative, path
+
+
+def _validate_bytes(label, raw):
+    if BOM in raw:
+        raise ResolutionError(f"{label} contains a UTF-8 BOM")
+    if b"\x00" in raw:
+        raise ResolutionError(f"{label} contains a NUL byte")
+    if b"\r" in raw:
+        raise ResolutionError(f"{label} is not canonical LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ResolutionError(f"{label} is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise ResolutionError(f"{label} does not end with LF")
+
+
+def _marker_run(line, marker):
+    if not line.endswith(b"\n"):
+        return 0
+    body = line[:-1]
+    size = 0
+    while size < len(body) and body[size : size + 1] == marker:
+        size += 1
+    if size < 7 or (len(body) > size and body[size : size + 1] != b" "):
+        return 0
+    return size
+
+
+def _validate_conflicted_worktree(raw, base, ours_suffix, theirs_suffix):
+    """Prove the worktree is only Git's rendering of the three index stages."""
+    # Git for Windows may render conflict markers and checked-out blob lines as
+    # CRLF even though every index blob is canonical LF. Normalize only complete
+    # CRLF pairs for comparison; lone CR remains invalid and the original bytes
+    # stay untouched for rollback.
+    normalized = raw.replace(b"\r\n", b"\n")
+    _validate_bytes("conflicted worktree", normalized)
+    if not normalized.startswith(base):
+        raise ResolutionError("conflicted worktree does not preserve the merge-base prefix")
+    lines = normalized[len(base) :].splitlines(keepends=True)
+    starts = [(index, _marker_run(line, b"<")) for index, line in enumerate(lines)]
+    starts = [(index, size) for index, size in starts if size]
+    if len(starts) != 1:
+        raise ResolutionError("conflicted worktree is not one recognized Git conflict rendering")
+    start, marker_size = starts[0]
+    separator_line = (b"=" * marker_size) + b"\n"
+    separators = [index for index, line in enumerate(lines) if line == separator_line]
+    ends = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b">") == marker_size
+    ]
+    base_markers = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b"|") == marker_size
+    ]
+    if len(separators) != 1 or len(ends) != 1 or len(base_markers) > 1:
+        raise ResolutionError("conflicted worktree has ambiguous Git conflict markers")
+    separator = separators[0]
+    end = ends[0]
+    base_marker = base_markers[0] if base_markers else None
+    ours_end = base_marker if base_marker is not None else separator
+    if not (start < ours_end <= separator < end):
+        raise ResolutionError("conflicted worktree has out-of-order Git conflict markers")
+    if base_marker is not None and b"".join(lines[base_marker + 1 : separator]):
+        raise ResolutionError("conflicted worktree has unexpected merge-base conflict bytes")
+
+    common_prefix = b"".join(lines[:start])
+    ours_body = b"".join(lines[start + 1 : ours_end])
+    theirs_body = b"".join(lines[separator + 1 : end])
+    common_suffix = b"".join(lines[end + 1 :])
+    if ours_suffix != common_prefix + ours_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the current-branch index stage")
+    if theirs_suffix != common_prefix + theirs_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the incoming-branch index stage")
+
+
+def _unmerged(root, relative, *, allow_resolved=False):
+    result = _git(root, "ls-files", "-u", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed unmerged index record") from error
+    if allow_resolved and not records:
+        return []
+    if len(records) != 3 or [record[2] for record in records] != [1, 2, 3]:
+        raise ResolutionError("target is not in a complete three-stage conflict")
+    if any(record[3] != relative for record in records):
+        raise ResolutionError("unmerged index path does not match the requested target")
+    if any(record[0] != "100644" for record in records):
+        raise ResolutionError("append-only conflict stages must all be regular 100644 blobs")
+    return records
+
+
+def _tracked_index(root, relative):
+    result = _git(root, "ls-files", "--stage", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed tracked index record") from error
+    return records
+
+
+def _blob(root, oid, label):
+    result = _git(root, "cat-file", "blob", oid)
+    raw = result.stdout
+    _validate_bytes(label, raw)
+    return raw
+
+
+def _authorization(root, reason):
+    reason = reason.strip()
+    if not reason:
+        raise ResolutionError("--reason must contain a non-empty reason")
+    if len(reason) > MAX_REASON or "|" in reason or "\n" in reason or "\r" in reason:
+        raise ResolutionError("--reason must be at most 500 characters with no pipes or newlines")
+    result = _git(root, "config", "--get", "user.email", check=False)
+    if result.returncode != 0:
+        raise ResolutionError("git config user.email is required for the attributed override")
+    try:
+        identity = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git config user.email is not valid UTF-8") from error
+    if not identity or len(identity) > 254 or "|" in identity or "\n" in identity or "\r" in identity:
+        raise ResolutionError("git config user.email is not a valid override identity")
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return f"[{timestamp}] | BY: {identity} | GATE: H-05 | REASON: {reason}\n".encode("utf-8")
+
+
+def _append_parts(root, records):
+    base = _blob(root, records[0][1], "merge base")
+    ours = _blob(root, records[1][1], "current branch")
+    theirs = _blob(root, records[2][1], "incoming branch")
+    if not ours.startswith(base):
+        raise ResolutionError("current branch is not append-only relative to the merge base")
+    if not theirs.startswith(base):
+        raise ResolutionError("incoming branch is not append-only relative to the merge base")
+    ours_suffix = ours[len(base) :]
+    theirs_suffix = theirs[len(base) :]
+    if not ours_suffix or not theirs_suffix:
+        raise ResolutionError("both conflict sides must append non-empty history")
+    return base, ours_suffix, theirs_suffix
+
+
+def _build_union(root, records):
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    merged = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", merged)
+    return merged
+
+
+def _write_bytes_atomic(path, raw, *, expected=None):
+    original_mode = stat.S_IMODE(path.stat().st_mode)
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    witness = None
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, original_mode)
+        if expected is not None:
+            witness_fd, witness = tempfile.mkstemp(
+                dir=path.parent, prefix=path.name + ".", suffix=".witness"
+            )
+            os.close(witness_fd)
+            os.remove(witness)
+            os.link(path, witness)
+            observed = Path(witness).read_bytes()
+            if observed != expected:
+                raise ConcurrentAppendError(path, restored=True, observed=observed)
+        os.replace(temporary, path)
+        temporary = None
+        if witness is not None:
+            displaced = Path(witness).read_bytes()
+            if displaced != expected:
+                restored = False
+                try:
+                    os.replace(witness, path)
+                    witness = None
+                    restored = True
+                finally:
+                    raise ConcurrentAppendError(path, restored=restored, observed=displaced)
+            os.remove(witness)
+            witness = None
+    except Exception:
+        if temporary is not None:
+            try:
+                os.remove(temporary)
+            except OSError:
+                pass
+        if witness is not None:
+            try:
+                os.remove(witness)
+            except OSError:
+                pass
+        raise
+
+
+def _restore_index(root, relative, records):
+    removed = _git(root, "update-index", "--force-remove", "--", relative, check=False)
+    if removed.returncode != 0:
+        detail = removed.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"could not clear staged resolution during rollback: {detail}")
+    index_info = b"".join(
+        f"{mode} {oid} {stage}\t{path}\n".encode("utf-8")
+        for mode, oid, stage, path in records
+    )
+    _git(root, "update-index", "--index-info", input_bytes=index_info)
+
+
+def resolve(target, reason, cwd=None):
+    root = _repository_root(cwd or os.getcwd())
+    relative, path = _relative_target(root, target)
+    records = _unmerged(root, relative)
+    authorization = _authorization(root, reason)
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    proposed = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", proposed)
+    changes = {relative: proposed}
+    paths = {relative: path}
+    originals = {relative: path.read_bytes()}
+    _validate_conflicted_worktree(originals[relative], base, ours_suffix, theirs_suffix)
+    index_records = {relative: records}
+    override_relative = ".codearbiter/overrides.log"
+    if relative == override_relative:
+        changes[relative] += authorization
+    else:
+        override_relative, override_path = _relative_target(root, override_relative)
+        if _unmerged(root, override_relative, allow_resolved=True):
+            raise ResolutionError("the override audit sink is itself unmerged")
+        for diff_args in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+            clean = _git(root, *diff_args, "--", override_relative, check=False)
+            if clean.returncode != 0:
+                raise ResolutionError("the override audit sink must be clean before resolution")
+        override_raw = override_path.read_bytes()
+        _validate_bytes("override audit sink", override_raw)
+        changes[override_relative] = override_raw + authorization
+        paths[override_relative] = override_path
+        originals[override_relative] = override_raw
+        index_records[override_relative] = _tracked_index(root, override_relative)
+    try:
+        common_raw = _git(root, "rev-parse", "--git-common-dir").stdout.decode(
+            "utf-8", errors="strict"
+        ).strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 common directory") from error
+    if not common_raw:
+        raise ResolutionError("git returned an empty common directory")
+    common = Path(common_raw)
+    if not common.is_absolute():
+        common = root / common
+    lock = acquire_lock(str(common.resolve() / "codearbiter-append-only-conflict"))
+    if lock is None:
+        raise ResolutionError("another append-only conflict resolution holds the repository lock")
+    path_locks = []
+    try:
+        for changed_relative in sorted(changes):
+            path_lock = acquire_lock(audit_lock_key(root, paths[changed_relative]))
+            if path_lock is None:
+                raise ResolutionError(
+                    f"another writer holds the audit path lock for '{changed_relative}'"
+                )
+            path_locks.append(path_lock)
+        if _unmerged(root, relative) != records or path.read_bytes() != originals[relative]:
+            raise ResolutionError("conflict state changed during validation; retry from fresh evidence")
+        try:
+            for changed_relative, raw in changes.items():
+                if paths[changed_relative].read_bytes() != originals[changed_relative]:
+                    raise ResolutionError("protected state changed during validation; retry")
+                _write_bytes_atomic(
+                    paths[changed_relative], raw, expected=originals[changed_relative]
+                )
+            staged = _git(root, "add", "--", *changes.keys(), check=False)
+            if staged.returncode != 0:
+                detail = staged.stderr.decode("utf-8", errors="replace").strip()
+                raise ResolutionError(f"git add failed: {detail or 'unknown error'}")
+            if _unmerged(root, relative, allow_resolved=True):
+                raise ResolutionError("git add did not clear the three-stage conflict")
+            for changed_relative, raw in changes.items():
+                index_blob = _git(root, "show", f":0:{changed_relative}").stdout
+                if index_blob != raw:
+                    raise ResolutionError(
+                        f"staged blob does not match validated output for {changed_relative}"
+                    )
+        except Exception as error:
+            # The replacement is atomic; if staging or verification fails, put
+            # the exact conflict-marker worktree bytes and three index stages
+            # back.  This also covers a successful `git add` followed by a
+            # failed staged-blob verification.
+            for changed_relative, raw in originals.items():
+                if isinstance(error, ConcurrentAppendError) and paths[changed_relative] == error.path:
+                    if error.restored:
+                        continue
+                    if error.observed is not None:
+                        raw = error.observed
+                _write_bytes_atomic(paths[changed_relative], raw)
+            for changed_relative, prior_records in index_records.items():
+                _restore_index(root, changed_relative, prior_records)
+            raise
+    finally:
+        for path_lock in reversed(path_locks):
+            release_lock(path_lock)
+        release_lock(lock)
+    return relative
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Resolve one genuine H-05 append-only Git conflict without weakening the guard."
+    )
+    parser.add_argument("target", help="repository-relative protected append-only path")
+    parser.add_argument("--reason", required=True, help="specific immediate H-05 override reason")
+    args = parser.parse_args(argv)
+    try:
+        relative = resolve(args.target, args.reason)
+    except (OSError, ResolutionError) as error:
+        print(f"append-only conflict resolution refused: {error}", file=sys.stderr)
+        return 1
+    print(f"resolved and staged append-only conflict: {relative}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca-pi/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca-pi/hooks/_appendonlyconflictlib.py
@@ -84,9 +84,13 @@ def _relative_target(root, target):
         raise ResolutionError("target must be a contained supported append-only path")
     path = root / normalized
     try:
-        path.resolve(strict=False).relative_to(root)
+        resolved_root = os.path.realpath(root)
+        resolved_path = os.path.realpath(path)
+        common = os.path.commonpath((resolved_root, resolved_path))
     except ValueError as error:
         raise ResolutionError("target escapes the repository root") from error
+    if os.path.normcase(common) != os.path.normcase(resolved_root):
+        raise ResolutionError("target escapes the repository root")
     relative = normalized.as_posix()
     if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
         str(path), str(root)

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -529,19 +529,26 @@ def _log_gate_event(kind, tag, msg):
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         log_path = os.path.join(cad, "gate-events.log")
-        audit_lock = acquire_lock(audit_lock_key(root, log_path))
-        if audit_lock is None:
-            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        fd = None
-        os_lock_acquired = False
         try:
             if os.name == "nt":
                 _GATE_EVENTS_WINDOWS_LOCK.acquire()
                 process_lock_acquired = True
+            audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        except Exception:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            raise
+        if audit_lock is None:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            return
+        fd = None
+        os_lock_acquired = False
+        try:
             fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
@@ -567,13 +574,15 @@ def _log_gate_event(kind, tag, msg):
                     msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
                 except Exception:  # noqa: BLE001 — outer sink remains fail-open
                     pass
-            if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
             try:
                 if fd is not None:
                     os.close(fd)
             finally:
-                release_lock(audit_lock)
+                try:
+                    release_lock(audit_lock)
+                finally:
+                    if process_lock_acquired:
+                        _GATE_EVENTS_WINDOWS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -218,8 +218,10 @@ from _sensitivelib import (  # noqa: F401
 )
 
 
-# Serialize same-process Windows writers before taking the cross-process lock.
-_GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
+# Serialize same-process writers before taking the bounded cross-process lock.
+# POSIX flock and Windows byte-range locks are process-scoped, so sibling
+# threads can otherwise burn the shared wait budget contending with each other.
+_GATE_EVENTS_PROCESS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
@@ -534,17 +536,16 @@ def _log_gate_event(kind, tag, msg):
             flags |= os.O_BINARY
         process_lock_acquired = False
         try:
-            if os.name == "nt":
-                _GATE_EVENTS_WINDOWS_LOCK.acquire()
-                process_lock_acquired = True
+            _GATE_EVENTS_PROCESS_LOCK.acquire()
+            process_lock_acquired = True
             audit_lock = acquire_lock(audit_lock_key(root, log_path))
         except Exception:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             raise
         if audit_lock is None:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             return
         fd = None
         os_lock_acquired = False
@@ -582,7 +583,7 @@ def _log_gate_event(kind, tag, msg):
                     release_lock(audit_lock)
                 finally:
                     if process_lock_acquired:
-                        _GATE_EVENTS_WINDOWS_LOCK.release()
+                        _GATE_EVENTS_PROCESS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -96,6 +96,7 @@
 #                                         non-blocking + bounded LOCK_WAIT retry spin,
 #                                         fail-soft None on contention/timeout/OSError
 #   release_lock(handle) -> None          release + close; None handle is a no-op
+#   audit_lock_key(root, path) -> str     trusted Git-owned key for an audit path
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -105,6 +106,7 @@
 
 import datetime
 import errno
+import hashlib
 import json
 import os
 import re
@@ -409,6 +411,63 @@ def release_lock(handle):
             pass
 
 
+def audit_lock_key(root, path):
+    """Return a deterministic audit lock key beneath Git-owned metadata.
+
+    Audit paths and their siblings are repository-controlled, so an adjacent
+    lock can be a checked-out symlink that redirects acquire_lock's seed byte
+    outside the checkout. Linked worktrees resolve to their common Git
+    directory and therefore share one trusted key per repository-relative path.
+    """
+    root = os.path.abspath(os.fspath(root))
+    path = os.path.abspath(os.fspath(path))
+    try:
+        if os.path.normcase(os.path.commonpath((root, path))) != os.path.normcase(root):
+            raise ValueError
+    except (OSError, ValueError) as error:
+        raise OSError("audit lock target is outside the repository root") from error
+
+    dotgit = os.path.join(root, ".git")
+    if os.path.isdir(dotgit):
+        common = dotgit
+    elif os.path.isfile(dotgit):
+        try:
+            with open(dotgit, encoding="utf-8") as handle:
+                pointer = handle.read(4097)
+        except OSError as error:
+            raise OSError("cannot read linked-worktree Git metadata") from error
+        if len(pointer) > 4096 or not pointer.startswith("gitdir:"):
+            raise OSError("linked-worktree Git metadata is malformed")
+        gitdir = pointer[7:].strip()
+        if not gitdir:
+            raise OSError("linked-worktree Git directory is empty")
+        if not os.path.isabs(gitdir):
+            gitdir = os.path.join(root, gitdir)
+        commondir_file = os.path.join(gitdir, "commondir")
+        if os.path.isfile(commondir_file):
+            try:
+                with open(commondir_file, encoding="utf-8") as handle:
+                    relative_common = handle.read(4097).strip()
+            except OSError as error:
+                raise OSError("cannot read Git common-directory metadata") from error
+            if not relative_common or len(relative_common) > 4096:
+                raise OSError("Git common-directory metadata is malformed")
+            common = relative_common if os.path.isabs(relative_common) else os.path.join(
+                gitdir, relative_common
+            )
+        else:
+            common = gitdir
+    else:
+        raise OSError("repository Git metadata is unavailable for audit locking")
+
+    common = os.path.realpath(common)
+    if not os.path.isdir(common):
+        raise OSError("Git common directory is unavailable for audit locking")
+    relative = os.path.relpath(path, root).replace("\\", "/")
+    digest = hashlib.sha256(relative.encode("utf-8")).hexdigest()
+    return os.path.join(common, "codearbiter-audit-locks", digest)
+
+
 # The H-11 authoring-marker freshness window (issue #567) — the single
 # declaration every `marker_fresh(marker, minutes)` call site resolves by
 # import. Previously five independent `30` literals (pre-write.py,
@@ -469,17 +528,21 @@ def _log_gate_event(kind, tag, msg):
             host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
+        log_path = os.path.join(cad, "gate-events.log")
+        audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        if audit_lock is None:
+            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        if os.name == "nt":
-            _GATE_EVENTS_WINDOWS_LOCK.acquire()
-            process_lock_acquired = True
         fd = None
         os_lock_acquired = False
         try:
-            fd = os.open(os.path.join(cad, "gate-events.log"), flags, 0o600)
+            if os.name == "nt":
+                _GATE_EVENTS_WINDOWS_LOCK.acquire()
+                process_lock_acquired = True
+            fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
                 os.lseek(fd, 0, os.SEEK_SET)
@@ -506,8 +569,11 @@ def _log_gate_event(kind, tag, msg):
                     pass
             if process_lock_acquired:
                 _GATE_EVENTS_WINDOWS_LOCK.release()
-            if fd is not None:
-                os.close(fd)
+            try:
+                if fd is not None:
+                    os.close(fd)
+            finally:
+                release_lock(audit_lock)
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca-pi/hooks/_host.py
+++ b/plugins/ca-pi/hooks/_host.py
@@ -11,7 +11,7 @@ import hostapi  # noqa: E402
 class PiHost(hostapi.Host):
     name = "pi"
     adapter_name = "@arbiterforge/ca-pi"
-    adapter_version = "0.10.10"
+    adapter_version = "0.10.11"
     update_target = "ca-pi"
     update_tag_prefix = "ca-pi-v"
     update_command = "pi update npm:@arbiterforge/ca-pi"

--- a/plugins/ca-pi/hooks/_modelib.py
+++ b/plugins/ca-pi/hooks/_modelib.py
@@ -25,7 +25,7 @@ import os
 import re
 
 from _activationlib import marker_root
-from _hooklib import write_text_atomic
+from _hooklib import acquire_lock, audit_lock_key, release_lock, write_text_atomic
 
 
 # ---------------------------------------------------------------------------
@@ -645,12 +645,21 @@ def _overrides_has_line(root, line):
 
 def _append_override_line(root, line):
     """Append one audit line to overrides.log. True on a confirmed write."""
+    lock = None
     try:
-        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+        path = _overrides_log_path(root)
+        lock = acquire_lock(audit_lock_key(root, path))
+        if lock is None:
+            return False
+        with open(path, "a", encoding="utf-8") as f:
             f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
         return True
-    except OSError:
+    except Exception:  # noqa: BLE001 — mode audit settlement remains fail-soft
         return False
+    finally:
+        release_lock(lock)
 
 
 def _dev_dropped_close_note(count, host_name=None):

--- a/plugins/ca-pi/hooks/_overrideappendlib.py
+++ b/plugins/ca-pi/hooks/_overrideappendlib.py
@@ -67,13 +67,17 @@ def _identity(root):
     return value
 
 
-def _validate_existing(path, raw):
+def _validate_file_type(path):
     try:
         mode = path.lstat().st_mode
     except OSError as error:
         raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
     if not stat.S_ISREG(mode) or path.is_symlink():
         raise OverrideAppendError("overrides.log is not a regular non-link file")
+
+
+def _validate_existing(path, raw):
+    _validate_file_type(path)
     if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
         raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
     try:
@@ -87,6 +91,7 @@ def _validate_existing(path, raw):
 def append_override(*, gate=None, security_finding=None, reason, cwd=None):
     root = _root(cwd or os.getcwd())
     path = root / ".codearbiter" / "overrides.log"
+    _validate_file_type(path)
     before = path.read_bytes()
     _validate_existing(path, before)
     identity = _identity(root)

--- a/plugins/ca-pi/hooks/_overrideappendlib.py
+++ b/plugins/ca-pi/hooks/_overrideappendlib.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail-closed, cooperatively locked append for mandatory override records."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+from _gitexec import git_executable
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+
+
+MAX_FIELD = 500
+GATE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class OverrideAppendError(RuntimeError):
+    """The mandatory audit row could not be safely and durably appended."""
+
+
+def _git(cwd, *args):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args], cwd=cwd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False,
+        )
+    except OSError as error:
+        raise OverrideAppendError(f"git unavailable: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise OverrideAppendError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result.stdout
+
+
+def _root(cwd):
+    try:
+        raw = _git(cwd, "rev-parse", "--show-toplevel").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise OverrideAppendError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _field(label, value):
+    if not value or len(value) > MAX_FIELD or any(char in value for char in "|\r\n"):
+        raise OverrideAppendError(
+            f"{label} must be non-empty, at most {MAX_FIELD} characters, and contain no pipe or newline"
+        )
+    return value
+
+
+def _identity(root):
+    try:
+        value = _git(root, "config", "user.email").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git config user.email is not valid UTF-8") from error
+    _field("git config user.email", value)
+    if len(value) > 254 or any(char.isspace() for char in value):
+        raise OverrideAppendError("git config user.email is not a valid override identity")
+    return value
+
+
+def _validate_existing(path, raw):
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise OverrideAppendError("overrides.log is not a regular non-link file")
+    if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
+        raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("overrides.log is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise OverrideAppendError("overrides.log does not end with LF")
+
+
+def append_override(*, gate=None, security_finding=None, reason, cwd=None):
+    root = _root(cwd or os.getcwd())
+    path = root / ".codearbiter" / "overrides.log"
+    before = path.read_bytes()
+    _validate_existing(path, before)
+    identity = _identity(root)
+    reason = _field("reason", reason)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    if gate is not None:
+        if not GATE_RE.fullmatch(gate):
+            raise OverrideAppendError("gate must be a compact gate identifier")
+        body = f"GATE: {gate}"
+    else:
+        body = f"SECURITY-OVERRIDE | FINDING: {_field('security finding', security_finding)}"
+    line = f"[{timestamp}] | BY: {identity} | {body} | REASON: {reason}\n".encode("utf-8")
+
+    lock = acquire_lock(audit_lock_key(root, path))
+    if lock is None:
+        raise OverrideAppendError("another writer holds the overrides.log audit path lock")
+    fd = None
+    try:
+        if path.read_bytes() != before:
+            raise OverrideAppendError("overrides.log changed during validation; retry")
+        flags = os.O_APPEND | os.O_WRONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        fd = os.open(path, flags)
+        offset = 0
+        while offset < len(line):
+            written = os.write(fd, line[offset:])
+            if written <= 0:
+                raise OverrideAppendError("override audit append made no progress")
+            offset += written
+        os.fsync(fd)
+    except OSError as error:
+        raise OverrideAppendError(f"override audit append failed: {error}") from error
+    finally:
+        try:
+            if fd is not None:
+                os.close(fd)
+        finally:
+            release_lock(lock)
+    return path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Append one mandatory override audit row safely.")
+    kind = parser.add_mutually_exclusive_group(required=True)
+    kind.add_argument("--gate", help="gate identifier for an ordinary override")
+    kind.add_argument("--security-finding", help="specific acknowledged security finding")
+    parser.add_argument("--reason", required=True, help="specific justification")
+    args = parser.parse_args(argv)
+    try:
+        path = append_override(
+            gate=args.gate,
+            security_finding=args.security_finding,
+            reason=args.reason,
+        )
+    except (OSError, OverrideAppendError) as error:
+        print(f"override audit append refused: {error}", file=sys.stderr)
+        return 1
+    print(f"appended mandatory override audit row: {path}")
+    return 0

--- a/plugins/ca-pi/hooks/append-override.py
+++ b/plugins/ca-pi/hooks/append-override.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the locked mandatory override audit append."""
+
+from _overrideappendlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca-pi/hooks/hostapi.py
+++ b/plugins/ca-pi/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.9"
+    adapter_version = "2.17.10"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca-pi/hooks/resolve-append-only-conflict.py
+++ b/plugins/ca-pi/hooks/resolve-append-only-conflict.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# codeArbiter - sanctioned helper entry point for H-05 append-only conflicts.
+
+from _appendonlyconflictlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca-pi/skills/ca-override/SKILL.md
+++ b/plugins/ca-pi/skills/ca-override/SKILL.md
@@ -15,14 +15,40 @@ logged, always visible, never silent. Single identity, single confirm.
    vague reason ("just skip it") and ask for a specific one.
 2. Detect the operator identity from `git config user.email` only. If it is unset, ask the user once
    to state their identity for the log. (No platform ladder, no second confirmation.)
-3. Append one line to `<project-root>/.codearbiter/overrides.log`:
+3. For an ordinary override, use the private locked audit helper from the repository root:
+
+   ```sh
+   python3 "<plugin-root>/hooks/append-override.py" --gate "<gate bypassed>" --reason "<specific reason>"
+   ```
+
+   It appends one line to `<project-root>/.codearbiter/overrides.log`:
 
    ```
    [ISO-8601 timestamp] | BY: <email> | GATE: <gate bypassed> | REASON: <reason>
    ```
 
-   The log is append-only — never edited or deleted, committed as a permanent audit artifact.
-4. Proceed with the overridden action. Note in the response that the override is logged.
+   The log is append-only — never edited or deleted, committed as a permanent audit artifact. The
+   helper fails closed if another official writer or conflict resolver owns the audit-path lock; the
+   overridden action must not proceed unless the row lands. A guard-permitted raw append remains a
+   cooperative operator escape hatch, but it must not run concurrently with conflict resolution.
+4. A genuine three-stage Git conflict on an H-05 append-only path uses the dedicated helper instead
+   of the ordinary step 3 append. Run it once from the conflicted repository, with the specific
+   repo-relative path and the same reason:
+
+   ```sh
+   python3 "<plugin-root>/hooks/resolve-append-only-conflict.py" ".codearbiter/overrides.log" --reason "<specific reason>"
+   ```
+
+   The helper derives the same `git config user.email` identity, validates the merge-base and both
+   append suffixes, writes the attributed H-05 record, and explicitly stages only the validated
+   deterministic union. It refuses a missing or malformed three-stage conflict, any edit to prior
+   bytes, unsupported paths, invalid encoding, dirty audit sink, or replay after resolution. This is
+   scoped to the immediate action only; it creates no marker, standing exception, or general H-05
+   bypass. It takes canonical per-audit-path locks and supports only `overrides.log` and the
+   repository-owned `gate-events.log` sink; official writers share those locks. Conflict resolution
+   is an exclusive cooperative operation: do not start a raw append before or during it. Never
+   hand-resolve the protected log with Write, patch, checkout, or restore.
+5. Proceed with the overridden action. Note in the response that the override is logged.
 
 ## Security ceiling — heavier path for security-critical stops
 
@@ -40,8 +66,14 @@ Heavier path (all required, in order):
 2. **Explicit per-finding acknowledgement** — the user must acknowledge *that specific finding* in
    their own words (a bare "yes"/"go ahead"/"I trust you" is declined — this mirrors `decision-variance`).
    Detect identity from `git config user.email`; if unset, ask once.
-3. **Heavier log entry** — append a line tagged `SECURITY-OVERRIDE` that records the specific finding,
-   not just the gate name:
+3. **Heavier log entry** — use the same locked helper so the mandatory row cannot race conflict
+   resolution:
+
+   ```sh
+   python3 "<plugin-root>/hooks/append-override.py" --security-finding "<specific finding>" --reason "<reason>"
+   ```
+
+   It appends a line tagged `SECURITY-OVERRIDE` that records the specific finding, not just the gate name:
 
    ```
    [ISO-8601] | BY: <email> | SECURITY-OVERRIDE | FINDING: <specific finding> | REASON: <reason>
@@ -62,7 +94,9 @@ Under `/ca-sprint`, a security-critical override is a hard-gate STOP: it surface
 MUST write the log line before proceeding — it is not optional. MUST capture an operator identity —
 "codeArbiter" or "automated" are not valid. MUST include a justification. The override is scoped to
 the immediate action only; it creates no standing exception. MUST NOT edit or delete an existing
-`overrides.log` entry. MUST route a security-critical / crypto-secret / irreversible stop through the
+`overrides.log` entry. For an H-05 three-stage conflict, the dedicated helper's validated union and
+audit write are the single immediate action; do not pre-edit the conflicted file. MUST route a
+security-critical / crypto-secret / irreversible stop through the
 **Security ceiling** path — never the single-confirm flow — and MUST NOT auto-decide such an override
 under `/ca-sprint`.
 

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.17.9",
+  "version": "2.17.10",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/commands/override.md
+++ b/plugins/ca/commands/override.md
@@ -14,14 +14,40 @@ logged, always visible, never silent. Single identity, single confirm.
    vague reason ("just skip it") and ask for a specific one.
 2. Detect the operator identity from `git config user.email` only. If it is unset, ask the user once
    to state their identity for the log. (No platform ladder, no second confirmation.)
-3. Append one line to `${CLAUDE_PROJECT_DIR}/.codearbiter/overrides.log`:
+3. For an ordinary override, use the private locked audit helper from the repository root:
+
+   ```sh
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/append-override.py" --gate "<gate bypassed>" --reason "<specific reason>"
+   ```
+
+   It appends one line to `${CLAUDE_PROJECT_DIR}/.codearbiter/overrides.log`:
 
    ```
    [ISO-8601 timestamp] | BY: <email> | GATE: <gate bypassed> | REASON: <reason>
    ```
 
-   The log is append-only — never edited or deleted, committed as a permanent audit artifact.
-4. Proceed with the overridden action. Note in the response that the override is logged.
+   The log is append-only — never edited or deleted, committed as a permanent audit artifact. The
+   helper fails closed if another official writer or conflict resolver owns the audit-path lock; the
+   overridden action must not proceed unless the row lands. A guard-permitted raw append remains a
+   cooperative operator escape hatch, but it must not run concurrently with conflict resolution.
+4. A genuine three-stage Git conflict on an H-05 append-only path uses the dedicated helper instead
+   of the ordinary step 3 append. Run it once from the conflicted repository, with the specific
+   repo-relative path and the same reason:
+
+   ```sh
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/resolve-append-only-conflict.py" ".codearbiter/overrides.log" --reason "<specific reason>"
+   ```
+
+   The helper derives the same `git config user.email` identity, validates the merge-base and both
+   append suffixes, writes the attributed H-05 record, and explicitly stages only the validated
+   deterministic union. It refuses a missing or malformed three-stage conflict, any edit to prior
+   bytes, unsupported paths, invalid encoding, dirty audit sink, or replay after resolution. This is
+   scoped to the immediate action only; it creates no marker, standing exception, or general H-05
+   bypass. It takes canonical per-audit-path locks and supports only `overrides.log` and the
+   repository-owned `gate-events.log` sink; official writers share those locks. Conflict resolution
+   is an exclusive cooperative operation: do not start a raw append before or during it. Never
+   hand-resolve the protected log with Write, patch, checkout, or restore.
+5. Proceed with the overridden action. Note in the response that the override is logged.
 
 ## Security ceiling — heavier path for security-critical stops
 
@@ -39,8 +65,14 @@ Heavier path (all required, in order):
 2. **Explicit per-finding acknowledgement** — the user must acknowledge *that specific finding* in
    their own words (a bare "yes"/"go ahead"/"I trust you" is declined — this mirrors `decision-variance`).
    Detect identity from `git config user.email`; if unset, ask once.
-3. **Heavier log entry** — append a line tagged `SECURITY-OVERRIDE` that records the specific finding,
-   not just the gate name:
+3. **Heavier log entry** — use the same locked helper so the mandatory row cannot race conflict
+   resolution:
+
+   ```sh
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/append-override.py" --security-finding "<specific finding>" --reason "<reason>"
+   ```
+
+   It appends a line tagged `SECURITY-OVERRIDE` that records the specific finding, not just the gate name:
 
    ```
    [ISO-8601] | BY: <email> | SECURITY-OVERRIDE | FINDING: <specific finding> | REASON: <reason>
@@ -61,7 +93,9 @@ Under `/ca:sprint`, a security-critical override is a hard-gate STOP: it surface
 MUST write the log line before proceeding — it is not optional. MUST capture an operator identity —
 "codeArbiter" or "automated" are not valid. MUST include a justification. The override is scoped to
 the immediate action only; it creates no standing exception. MUST NOT edit or delete an existing
-`overrides.log` entry. MUST route a security-critical / crypto-secret / irreversible stop through the
+`overrides.log` entry. For an H-05 three-stage conflict, the dedicated helper's validated union and
+audit write are the single immediate action; do not pre-edit the conflicted file. MUST route a
+security-critical / crypto-secret / irreversible stop through the
 **Security ceiling** path — never the single-confirm flow — and MUST NOT auto-decide such an override
 under `/ca:sprint`.
 

--- a/plugins/ca/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca/hooks/_appendonlyconflictlib.py
@@ -265,6 +265,20 @@ def _build_union(root, records):
     return merged
 
 
+def _sync_parent(path):
+    if os.name == "nt":
+        return False
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    parent_fd = os.open(path.parent, flags)
+    try:
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    return True
+
+
 def _write_bytes_atomic(path, raw, *, expected=None):
     original_mode = stat.S_IMODE(path.stat().st_mode)
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
@@ -287,6 +301,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 raise ConcurrentAppendError(path, restored=True, observed=observed)
         os.replace(temporary, path)
         temporary = None
+        _sync_parent(path)
         if witness is not None:
             displaced = Path(witness).read_bytes()
             if displaced != expected:
@@ -294,6 +309,7 @@ def _write_bytes_atomic(path, raw, *, expected=None):
                 try:
                     os.replace(witness, path)
                     witness = None
+                    _sync_parent(path)
                     restored = True
                 finally:
                     raise ConcurrentAppendError(path, restored=restored, observed=displaced)

--- a/plugins/ca/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca/hooks/_appendonlyconflictlib.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# codeArbiter - fail-closed resolution of genuine H-05 append-only conflicts.
+#
+# The public entry point is resolve-append-only-conflict.py.  This module keeps
+# Git inspection, byte validation, deterministic union construction, atomic
+# replacement, and explicit staging testable and host-neutral.
+#
+# Public API:
+#   resolve(target, reason, cwd=None) -> str  resolve and return repo-relative path
+#   main(argv=None) -> int                    CLI contract
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+from _gitexec import git_executable
+from _protectedlib import classify_protected
+
+
+BOM = b"\xef\xbb\xbf"
+MAX_REASON = 500
+SUPPORTED_AUDIT_PATHS = frozenset(
+    {".codearbiter/overrides.log", ".codearbiter/gate-events.log"}
+)
+
+
+class ResolutionError(RuntimeError):
+    """A surfaced, non-mutating refusal of the conflict-resolution contract."""
+
+
+class ConcurrentAppendError(ResolutionError):
+    """A displaced original inode changed and was restored before refusal."""
+
+    def __init__(self, path, restored, observed=None):
+        super().__init__(f"concurrent append detected while replacing '{Path(path).name}'")
+        self.path = Path(path)
+        self.restored = restored
+        self.observed = observed
+
+
+def _git(cwd, *args, input_bytes=None, check=True):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args],
+            cwd=cwd,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as error:
+        raise ResolutionError(f"git unavailable: {error}") from error
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result
+
+
+def _repository_root(cwd):
+    result = _git(cwd, "rev-parse", "--show-toplevel")
+    try:
+        raw = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise ResolutionError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _relative_target(root, target):
+    candidate = Path(target)
+    if candidate.is_absolute():
+        raise ResolutionError("target must be a repository-relative supported append-only path")
+    normalized = Path(os.path.normpath(str(candidate)))
+    if normalized == Path(".") or ".." in normalized.parts:
+        raise ResolutionError("target must be a contained supported append-only path")
+    path = root / normalized
+    try:
+        path.resolve(strict=False).relative_to(root)
+    except ValueError as error:
+        raise ResolutionError("target escapes the repository root") from error
+    relative = normalized.as_posix()
+    if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
+        str(path), str(root)
+    ):
+        raise ResolutionError(f"'{relative}' is not a supported append-only H-05 path")
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise ResolutionError(f"cannot inspect '{relative}': {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise ResolutionError(f"'{relative}' is not a regular non-link file")
+    return relative, path
+
+
+def _validate_bytes(label, raw):
+    if BOM in raw:
+        raise ResolutionError(f"{label} contains a UTF-8 BOM")
+    if b"\x00" in raw:
+        raise ResolutionError(f"{label} contains a NUL byte")
+    if b"\r" in raw:
+        raise ResolutionError(f"{label} is not canonical LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ResolutionError(f"{label} is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise ResolutionError(f"{label} does not end with LF")
+
+
+def _marker_run(line, marker):
+    if not line.endswith(b"\n"):
+        return 0
+    body = line[:-1]
+    size = 0
+    while size < len(body) and body[size : size + 1] == marker:
+        size += 1
+    if size < 7 or (len(body) > size and body[size : size + 1] != b" "):
+        return 0
+    return size
+
+
+def _validate_conflicted_worktree(raw, base, ours_suffix, theirs_suffix):
+    """Prove the worktree is only Git's rendering of the three index stages."""
+    # Git for Windows may render conflict markers and checked-out blob lines as
+    # CRLF even though every index blob is canonical LF. Normalize only complete
+    # CRLF pairs for comparison; lone CR remains invalid and the original bytes
+    # stay untouched for rollback.
+    normalized = raw.replace(b"\r\n", b"\n")
+    _validate_bytes("conflicted worktree", normalized)
+    if not normalized.startswith(base):
+        raise ResolutionError("conflicted worktree does not preserve the merge-base prefix")
+    lines = normalized[len(base) :].splitlines(keepends=True)
+    starts = [(index, _marker_run(line, b"<")) for index, line in enumerate(lines)]
+    starts = [(index, size) for index, size in starts if size]
+    if len(starts) != 1:
+        raise ResolutionError("conflicted worktree is not one recognized Git conflict rendering")
+    start, marker_size = starts[0]
+    separator_line = (b"=" * marker_size) + b"\n"
+    separators = [index for index, line in enumerate(lines) if line == separator_line]
+    ends = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b">") == marker_size
+    ]
+    base_markers = [
+        index
+        for index, line in enumerate(lines)
+        if _marker_run(line, b"|") == marker_size
+    ]
+    if len(separators) != 1 or len(ends) != 1 or len(base_markers) > 1:
+        raise ResolutionError("conflicted worktree has ambiguous Git conflict markers")
+    separator = separators[0]
+    end = ends[0]
+    base_marker = base_markers[0] if base_markers else None
+    ours_end = base_marker if base_marker is not None else separator
+    if not (start < ours_end <= separator < end):
+        raise ResolutionError("conflicted worktree has out-of-order Git conflict markers")
+    if base_marker is not None and b"".join(lines[base_marker + 1 : separator]):
+        raise ResolutionError("conflicted worktree has unexpected merge-base conflict bytes")
+
+    common_prefix = b"".join(lines[:start])
+    ours_body = b"".join(lines[start + 1 : ours_end])
+    theirs_body = b"".join(lines[separator + 1 : end])
+    common_suffix = b"".join(lines[end + 1 :])
+    if ours_suffix != common_prefix + ours_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the current-branch index stage")
+    if theirs_suffix != common_prefix + theirs_body + common_suffix:
+        raise ResolutionError("conflicted worktree differs from the incoming-branch index stage")
+
+
+def _unmerged(root, relative, *, allow_resolved=False):
+    result = _git(root, "ls-files", "-u", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed unmerged index record") from error
+    if allow_resolved and not records:
+        return []
+    if len(records) != 3 or [record[2] for record in records] != [1, 2, 3]:
+        raise ResolutionError("target is not in a complete three-stage conflict")
+    if any(record[3] != relative for record in records):
+        raise ResolutionError("unmerged index path does not match the requested target")
+    if any(record[0] != "100644" for record in records):
+        raise ResolutionError("append-only conflict stages must all be regular 100644 blobs")
+    return records
+
+
+def _tracked_index(root, relative):
+    result = _git(root, "ls-files", "--stage", "-z", "--", relative)
+    records = []
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        try:
+            metadata, encoded_path = item.split(b"\t", 1)
+            mode, oid, stage = metadata.decode("ascii").split(" ")
+            path = encoded_path.decode("utf-8", errors="strict")
+            records.append((mode, oid, int(stage), path))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ResolutionError("malformed tracked index record") from error
+    return records
+
+
+def _blob(root, oid, label):
+    result = _git(root, "cat-file", "blob", oid)
+    raw = result.stdout
+    _validate_bytes(label, raw)
+    return raw
+
+
+def _authorization(root, reason):
+    reason = reason.strip()
+    if not reason:
+        raise ResolutionError("--reason must contain a non-empty reason")
+    if len(reason) > MAX_REASON or "|" in reason or "\n" in reason or "\r" in reason:
+        raise ResolutionError("--reason must be at most 500 characters with no pipes or newlines")
+    result = _git(root, "config", "--get", "user.email", check=False)
+    if result.returncode != 0:
+        raise ResolutionError("git config user.email is required for the attributed override")
+    try:
+        identity = result.stdout.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git config user.email is not valid UTF-8") from error
+    if not identity or len(identity) > 254 or "|" in identity or "\n" in identity or "\r" in identity:
+        raise ResolutionError("git config user.email is not a valid override identity")
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return f"[{timestamp}] | BY: {identity} | GATE: H-05 | REASON: {reason}\n".encode("utf-8")
+
+
+def _append_parts(root, records):
+    base = _blob(root, records[0][1], "merge base")
+    ours = _blob(root, records[1][1], "current branch")
+    theirs = _blob(root, records[2][1], "incoming branch")
+    if not ours.startswith(base):
+        raise ResolutionError("current branch is not append-only relative to the merge base")
+    if not theirs.startswith(base):
+        raise ResolutionError("incoming branch is not append-only relative to the merge base")
+    ours_suffix = ours[len(base) :]
+    theirs_suffix = theirs[len(base) :]
+    if not ours_suffix or not theirs_suffix:
+        raise ResolutionError("both conflict sides must append non-empty history")
+    return base, ours_suffix, theirs_suffix
+
+
+def _build_union(root, records):
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    merged = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", merged)
+    return merged
+
+
+def _write_bytes_atomic(path, raw, *, expected=None):
+    original_mode = stat.S_IMODE(path.stat().st_mode)
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    witness = None
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(raw)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, original_mode)
+        if expected is not None:
+            witness_fd, witness = tempfile.mkstemp(
+                dir=path.parent, prefix=path.name + ".", suffix=".witness"
+            )
+            os.close(witness_fd)
+            os.remove(witness)
+            os.link(path, witness)
+            observed = Path(witness).read_bytes()
+            if observed != expected:
+                raise ConcurrentAppendError(path, restored=True, observed=observed)
+        os.replace(temporary, path)
+        temporary = None
+        if witness is not None:
+            displaced = Path(witness).read_bytes()
+            if displaced != expected:
+                restored = False
+                try:
+                    os.replace(witness, path)
+                    witness = None
+                    restored = True
+                finally:
+                    raise ConcurrentAppendError(path, restored=restored, observed=displaced)
+            os.remove(witness)
+            witness = None
+    except Exception:
+        if temporary is not None:
+            try:
+                os.remove(temporary)
+            except OSError:
+                pass
+        if witness is not None:
+            try:
+                os.remove(witness)
+            except OSError:
+                pass
+        raise
+
+
+def _restore_index(root, relative, records):
+    removed = _git(root, "update-index", "--force-remove", "--", relative, check=False)
+    if removed.returncode != 0:
+        detail = removed.stderr.decode("utf-8", errors="replace").strip()
+        raise ResolutionError(f"could not clear staged resolution during rollback: {detail}")
+    index_info = b"".join(
+        f"{mode} {oid} {stage}\t{path}\n".encode("utf-8")
+        for mode, oid, stage, path in records
+    )
+    _git(root, "update-index", "--index-info", input_bytes=index_info)
+
+
+def resolve(target, reason, cwd=None):
+    root = _repository_root(cwd or os.getcwd())
+    relative, path = _relative_target(root, target)
+    records = _unmerged(root, relative)
+    authorization = _authorization(root, reason)
+    base, ours_suffix, theirs_suffix = _append_parts(root, records)
+    proposed = base + ours_suffix + theirs_suffix
+    _validate_bytes("resolved output", proposed)
+    changes = {relative: proposed}
+    paths = {relative: path}
+    originals = {relative: path.read_bytes()}
+    _validate_conflicted_worktree(originals[relative], base, ours_suffix, theirs_suffix)
+    index_records = {relative: records}
+    override_relative = ".codearbiter/overrides.log"
+    if relative == override_relative:
+        changes[relative] += authorization
+    else:
+        override_relative, override_path = _relative_target(root, override_relative)
+        if _unmerged(root, override_relative, allow_resolved=True):
+            raise ResolutionError("the override audit sink is itself unmerged")
+        for diff_args in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+            clean = _git(root, *diff_args, "--", override_relative, check=False)
+            if clean.returncode != 0:
+                raise ResolutionError("the override audit sink must be clean before resolution")
+        override_raw = override_path.read_bytes()
+        _validate_bytes("override audit sink", override_raw)
+        changes[override_relative] = override_raw + authorization
+        paths[override_relative] = override_path
+        originals[override_relative] = override_raw
+        index_records[override_relative] = _tracked_index(root, override_relative)
+    try:
+        common_raw = _git(root, "rev-parse", "--git-common-dir").stdout.decode(
+            "utf-8", errors="strict"
+        ).strip()
+    except UnicodeDecodeError as error:
+        raise ResolutionError("git returned an invalid UTF-8 common directory") from error
+    if not common_raw:
+        raise ResolutionError("git returned an empty common directory")
+    common = Path(common_raw)
+    if not common.is_absolute():
+        common = root / common
+    lock = acquire_lock(str(common.resolve() / "codearbiter-append-only-conflict"))
+    if lock is None:
+        raise ResolutionError("another append-only conflict resolution holds the repository lock")
+    path_locks = []
+    try:
+        for changed_relative in sorted(changes):
+            path_lock = acquire_lock(audit_lock_key(root, paths[changed_relative]))
+            if path_lock is None:
+                raise ResolutionError(
+                    f"another writer holds the audit path lock for '{changed_relative}'"
+                )
+            path_locks.append(path_lock)
+        if _unmerged(root, relative) != records or path.read_bytes() != originals[relative]:
+            raise ResolutionError("conflict state changed during validation; retry from fresh evidence")
+        try:
+            for changed_relative, raw in changes.items():
+                if paths[changed_relative].read_bytes() != originals[changed_relative]:
+                    raise ResolutionError("protected state changed during validation; retry")
+                _write_bytes_atomic(
+                    paths[changed_relative], raw, expected=originals[changed_relative]
+                )
+            staged = _git(root, "add", "--", *changes.keys(), check=False)
+            if staged.returncode != 0:
+                detail = staged.stderr.decode("utf-8", errors="replace").strip()
+                raise ResolutionError(f"git add failed: {detail or 'unknown error'}")
+            if _unmerged(root, relative, allow_resolved=True):
+                raise ResolutionError("git add did not clear the three-stage conflict")
+            for changed_relative, raw in changes.items():
+                index_blob = _git(root, "show", f":0:{changed_relative}").stdout
+                if index_blob != raw:
+                    raise ResolutionError(
+                        f"staged blob does not match validated output for {changed_relative}"
+                    )
+        except Exception as error:
+            # The replacement is atomic; if staging or verification fails, put
+            # the exact conflict-marker worktree bytes and three index stages
+            # back.  This also covers a successful `git add` followed by a
+            # failed staged-blob verification.
+            for changed_relative, raw in originals.items():
+                if isinstance(error, ConcurrentAppendError) and paths[changed_relative] == error.path:
+                    if error.restored:
+                        continue
+                    if error.observed is not None:
+                        raw = error.observed
+                _write_bytes_atomic(paths[changed_relative], raw)
+            for changed_relative, prior_records in index_records.items():
+                _restore_index(root, changed_relative, prior_records)
+            raise
+    finally:
+        for path_lock in reversed(path_locks):
+            release_lock(path_lock)
+        release_lock(lock)
+    return relative
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Resolve one genuine H-05 append-only Git conflict without weakening the guard."
+    )
+    parser.add_argument("target", help="repository-relative protected append-only path")
+    parser.add_argument("--reason", required=True, help="specific immediate H-05 override reason")
+    args = parser.parse_args(argv)
+    try:
+        relative = resolve(args.target, args.reason)
+    except (OSError, ResolutionError) as error:
+        print(f"append-only conflict resolution refused: {error}", file=sys.stderr)
+        return 1
+    print(f"resolved and staged append-only conflict: {relative}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca/hooks/_appendonlyconflictlib.py
+++ b/plugins/ca/hooks/_appendonlyconflictlib.py
@@ -84,9 +84,13 @@ def _relative_target(root, target):
         raise ResolutionError("target must be a contained supported append-only path")
     path = root / normalized
     try:
-        path.resolve(strict=False).relative_to(root)
+        resolved_root = os.path.realpath(root)
+        resolved_path = os.path.realpath(path)
+        common = os.path.commonpath((resolved_root, resolved_path))
     except ValueError as error:
         raise ResolutionError("target escapes the repository root") from error
+    if os.path.normcase(common) != os.path.normcase(resolved_root):
+        raise ResolutionError("target escapes the repository root")
     relative = normalized.as_posix()
     if relative not in SUPPORTED_AUDIT_PATHS or "audit" not in classify_protected(
         str(path), str(root)

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -529,19 +529,26 @@ def _log_gate_event(kind, tag, msg):
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
         log_path = os.path.join(cad, "gate-events.log")
-        audit_lock = acquire_lock(audit_lock_key(root, log_path))
-        if audit_lock is None:
-            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        fd = None
-        os_lock_acquired = False
         try:
             if os.name == "nt":
                 _GATE_EVENTS_WINDOWS_LOCK.acquire()
                 process_lock_acquired = True
+            audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        except Exception:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            raise
+        if audit_lock is None:
+            if process_lock_acquired:
+                _GATE_EVENTS_WINDOWS_LOCK.release()
+            return
+        fd = None
+        os_lock_acquired = False
+        try:
             fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
@@ -567,13 +574,15 @@ def _log_gate_event(kind, tag, msg):
                     msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
                 except Exception:  # noqa: BLE001 — outer sink remains fail-open
                     pass
-            if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
             try:
                 if fd is not None:
                     os.close(fd)
             finally:
-                release_lock(audit_lock)
+                try:
+                    release_lock(audit_lock)
+                finally:
+                    if process_lock_acquired:
+                        _GATE_EVENTS_WINDOWS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -218,8 +218,10 @@ from _sensitivelib import (  # noqa: F401
 )
 
 
-# Serialize same-process Windows writers before taking the cross-process lock.
-_GATE_EVENTS_WINDOWS_LOCK = threading.Lock()
+# Serialize same-process writers before taking the bounded cross-process lock.
+# POSIX flock and Windows byte-range locks are process-scoped, so sibling
+# threads can otherwise burn the shared wait budget contending with each other.
+_GATE_EVENTS_PROCESS_LOCK = threading.Lock()
 _WINDOWS_LOCK_TIMEOUT_SECONDS = 5.0
 _WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_CRT_EDEADLK = 36
@@ -534,17 +536,16 @@ def _log_gate_event(kind, tag, msg):
             flags |= os.O_BINARY
         process_lock_acquired = False
         try:
-            if os.name == "nt":
-                _GATE_EVENTS_WINDOWS_LOCK.acquire()
-                process_lock_acquired = True
+            _GATE_EVENTS_PROCESS_LOCK.acquire()
+            process_lock_acquired = True
             audit_lock = acquire_lock(audit_lock_key(root, log_path))
         except Exception:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             raise
         if audit_lock is None:
             if process_lock_acquired:
-                _GATE_EVENTS_WINDOWS_LOCK.release()
+                _GATE_EVENTS_PROCESS_LOCK.release()
             return
         fd = None
         os_lock_acquired = False
@@ -582,7 +583,7 @@ def _log_gate_event(kind, tag, msg):
                     release_lock(audit_lock)
                 finally:
                     if process_lock_acquired:
-                        _GATE_EVENTS_WINDOWS_LOCK.release()
+                        _GATE_EVENTS_PROCESS_LOCK.release()
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -96,6 +96,7 @@
 #                                         non-blocking + bounded LOCK_WAIT retry spin,
 #                                         fail-soft None on contention/timeout/OSError
 #   release_lock(handle) -> None          release + close; None handle is a no-op
+#   audit_lock_key(root, path) -> str     trusted Git-owned key for an audit path
 #   block(tag, msg) -> None              BLOCK tool call: print to stderr and exit 2
 #   remind(tag, msg) -> None             non-blocking nudge to stderr
 #   warn(msg) -> None                    loud degradation breadcrumb to stderr
@@ -105,6 +106,7 @@
 
 import datetime
 import errno
+import hashlib
 import json
 import os
 import re
@@ -409,6 +411,63 @@ def release_lock(handle):
             pass
 
 
+def audit_lock_key(root, path):
+    """Return a deterministic audit lock key beneath Git-owned metadata.
+
+    Audit paths and their siblings are repository-controlled, so an adjacent
+    lock can be a checked-out symlink that redirects acquire_lock's seed byte
+    outside the checkout. Linked worktrees resolve to their common Git
+    directory and therefore share one trusted key per repository-relative path.
+    """
+    root = os.path.abspath(os.fspath(root))
+    path = os.path.abspath(os.fspath(path))
+    try:
+        if os.path.normcase(os.path.commonpath((root, path))) != os.path.normcase(root):
+            raise ValueError
+    except (OSError, ValueError) as error:
+        raise OSError("audit lock target is outside the repository root") from error
+
+    dotgit = os.path.join(root, ".git")
+    if os.path.isdir(dotgit):
+        common = dotgit
+    elif os.path.isfile(dotgit):
+        try:
+            with open(dotgit, encoding="utf-8") as handle:
+                pointer = handle.read(4097)
+        except OSError as error:
+            raise OSError("cannot read linked-worktree Git metadata") from error
+        if len(pointer) > 4096 or not pointer.startswith("gitdir:"):
+            raise OSError("linked-worktree Git metadata is malformed")
+        gitdir = pointer[7:].strip()
+        if not gitdir:
+            raise OSError("linked-worktree Git directory is empty")
+        if not os.path.isabs(gitdir):
+            gitdir = os.path.join(root, gitdir)
+        commondir_file = os.path.join(gitdir, "commondir")
+        if os.path.isfile(commondir_file):
+            try:
+                with open(commondir_file, encoding="utf-8") as handle:
+                    relative_common = handle.read(4097).strip()
+            except OSError as error:
+                raise OSError("cannot read Git common-directory metadata") from error
+            if not relative_common or len(relative_common) > 4096:
+                raise OSError("Git common-directory metadata is malformed")
+            common = relative_common if os.path.isabs(relative_common) else os.path.join(
+                gitdir, relative_common
+            )
+        else:
+            common = gitdir
+    else:
+        raise OSError("repository Git metadata is unavailable for audit locking")
+
+    common = os.path.realpath(common)
+    if not os.path.isdir(common):
+        raise OSError("Git common directory is unavailable for audit locking")
+    relative = os.path.relpath(path, root).replace("\\", "/")
+    digest = hashlib.sha256(relative.encode("utf-8")).hexdigest()
+    return os.path.join(common, "codearbiter-audit-locks", digest)
+
+
 # The H-11 authoring-marker freshness window (issue #567) — the single
 # declaration every `marker_fresh(marker, minutes)` call site resolves by
 # import. Previously five independent `30` literals (pre-write.py,
@@ -469,17 +528,21 @@ def _log_gate_event(kind, tag, msg):
             host = "unknown"
         tag_part = f"[{tag}] " if tag else ""
         line = f"[{ts}] {kind} {tag_part}host={host} hook={hook} | {msg}\n"
+        log_path = os.path.join(cad, "gate-events.log")
+        audit_lock = acquire_lock(audit_lock_key(root, log_path))
+        if audit_lock is None:
+            return
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_BINARY"):
             flags |= os.O_BINARY
         process_lock_acquired = False
-        if os.name == "nt":
-            _GATE_EVENTS_WINDOWS_LOCK.acquire()
-            process_lock_acquired = True
         fd = None
         os_lock_acquired = False
         try:
-            fd = os.open(os.path.join(cad, "gate-events.log"), flags, 0o600)
+            if os.name == "nt":
+                _GATE_EVENTS_WINDOWS_LOCK.acquire()
+                process_lock_acquired = True
+            fd = os.open(log_path, flags, 0o600)
             if os.name == "nt":
                 import msvcrt
                 os.lseek(fd, 0, os.SEEK_SET)
@@ -506,8 +569,11 @@ def _log_gate_event(kind, tag, msg):
                     pass
             if process_lock_acquired:
                 _GATE_EVENTS_WINDOWS_LOCK.release()
-            if fd is not None:
-                os.close(fd)
+            try:
+                if fd is not None:
+                    os.close(fd)
+            finally:
+                release_lock(audit_lock)
     except Exception:  # noqa: BLE001 — fail-open: the sink must never affect the gate
         pass
 

--- a/plugins/ca/hooks/_host.py
+++ b/plugins/ca/hooks/_host.py
@@ -27,7 +27,7 @@ import hostapi  # noqa: E402
 class ClaudeHost(hostapi.Host):
     """Claude Code host adapter with a matching-only root corroboration."""
 
-    adapter_version = "2.17.9"
+    adapter_version = "2.17.10"
 
     def plugin_root(self):
         return hostapi.resolve_plugin_root(

--- a/plugins/ca/hooks/_modelib.py
+++ b/plugins/ca/hooks/_modelib.py
@@ -25,7 +25,7 @@ import os
 import re
 
 from _activationlib import marker_root
-from _hooklib import write_text_atomic
+from _hooklib import acquire_lock, audit_lock_key, release_lock, write_text_atomic
 
 
 # ---------------------------------------------------------------------------
@@ -645,12 +645,21 @@ def _overrides_has_line(root, line):
 
 def _append_override_line(root, line):
     """Append one audit line to overrides.log. True on a confirmed write."""
+    lock = None
     try:
-        with open(_overrides_log_path(root), "a", encoding="utf-8") as f:
+        path = _overrides_log_path(root)
+        lock = acquire_lock(audit_lock_key(root, path))
+        if lock is None:
+            return False
+        with open(path, "a", encoding="utf-8") as f:
             f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
         return True
-    except OSError:
+    except Exception:  # noqa: BLE001 — mode audit settlement remains fail-soft
         return False
+    finally:
+        release_lock(lock)
 
 
 def _dev_dropped_close_note(count, host_name=None):

--- a/plugins/ca/hooks/_overrideappendlib.py
+++ b/plugins/ca/hooks/_overrideappendlib.py
@@ -67,13 +67,17 @@ def _identity(root):
     return value
 
 
-def _validate_existing(path, raw):
+def _validate_file_type(path):
     try:
         mode = path.lstat().st_mode
     except OSError as error:
         raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
     if not stat.S_ISREG(mode) or path.is_symlink():
         raise OverrideAppendError("overrides.log is not a regular non-link file")
+
+
+def _validate_existing(path, raw):
+    _validate_file_type(path)
     if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
         raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
     try:
@@ -87,6 +91,7 @@ def _validate_existing(path, raw):
 def append_override(*, gate=None, security_finding=None, reason, cwd=None):
     root = _root(cwd or os.getcwd())
     path = root / ".codearbiter" / "overrides.log"
+    _validate_file_type(path)
     before = path.read_bytes()
     _validate_existing(path, before)
     identity = _identity(root)

--- a/plugins/ca/hooks/_overrideappendlib.py
+++ b/plugins/ca/hooks/_overrideappendlib.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail-closed, cooperatively locked append for mandatory override records."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+from _gitexec import git_executable
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+
+
+MAX_FIELD = 500
+GATE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class OverrideAppendError(RuntimeError):
+    """The mandatory audit row could not be safely and durably appended."""
+
+
+def _git(cwd, *args):
+    try:
+        result = subprocess.run(
+            [git_executable(), *args], cwd=cwd, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False,
+        )
+    except OSError as error:
+        raise OverrideAppendError(f"git unavailable: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise OverrideAppendError(f"git {' '.join(args)} failed: {detail or 'unknown error'}")
+    return result.stdout
+
+
+def _root(cwd):
+    try:
+        raw = _git(cwd, "rev-parse", "--show-toplevel").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git returned an invalid UTF-8 repository root") from error
+    if not raw:
+        raise OverrideAppendError("git returned an empty repository root")
+    return Path(raw).resolve()
+
+
+def _field(label, value):
+    if not value or len(value) > MAX_FIELD or any(char in value for char in "|\r\n"):
+        raise OverrideAppendError(
+            f"{label} must be non-empty, at most {MAX_FIELD} characters, and contain no pipe or newline"
+        )
+    return value
+
+
+def _identity(root):
+    try:
+        value = _git(root, "config", "user.email").decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("git config user.email is not valid UTF-8") from error
+    _field("git config user.email", value)
+    if len(value) > 254 or any(char.isspace() for char in value):
+        raise OverrideAppendError("git config user.email is not a valid override identity")
+    return value
+
+
+def _validate_existing(path, raw):
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise OverrideAppendError(f"cannot inspect overrides.log: {error}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise OverrideAppendError("overrides.log is not a regular non-link file")
+    if raw.startswith(b"\xef\xbb\xbf") or b"\x00" in raw or b"\r" in raw:
+        raise OverrideAppendError("overrides.log is not canonical UTF-8 LF text")
+    try:
+        raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise OverrideAppendError("overrides.log is not valid UTF-8") from error
+    if raw and not raw.endswith(b"\n"):
+        raise OverrideAppendError("overrides.log does not end with LF")
+
+
+def append_override(*, gate=None, security_finding=None, reason, cwd=None):
+    root = _root(cwd or os.getcwd())
+    path = root / ".codearbiter" / "overrides.log"
+    before = path.read_bytes()
+    _validate_existing(path, before)
+    identity = _identity(root)
+    reason = _field("reason", reason)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    if gate is not None:
+        if not GATE_RE.fullmatch(gate):
+            raise OverrideAppendError("gate must be a compact gate identifier")
+        body = f"GATE: {gate}"
+    else:
+        body = f"SECURITY-OVERRIDE | FINDING: {_field('security finding', security_finding)}"
+    line = f"[{timestamp}] | BY: {identity} | {body} | REASON: {reason}\n".encode("utf-8")
+
+    lock = acquire_lock(audit_lock_key(root, path))
+    if lock is None:
+        raise OverrideAppendError("another writer holds the overrides.log audit path lock")
+    fd = None
+    try:
+        if path.read_bytes() != before:
+            raise OverrideAppendError("overrides.log changed during validation; retry")
+        flags = os.O_APPEND | os.O_WRONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        fd = os.open(path, flags)
+        offset = 0
+        while offset < len(line):
+            written = os.write(fd, line[offset:])
+            if written <= 0:
+                raise OverrideAppendError("override audit append made no progress")
+            offset += written
+        os.fsync(fd)
+    except OSError as error:
+        raise OverrideAppendError(f"override audit append failed: {error}") from error
+    finally:
+        try:
+            if fd is not None:
+                os.close(fd)
+        finally:
+            release_lock(lock)
+    return path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Append one mandatory override audit row safely.")
+    kind = parser.add_mutually_exclusive_group(required=True)
+    kind.add_argument("--gate", help="gate identifier for an ordinary override")
+    kind.add_argument("--security-finding", help="specific acknowledged security finding")
+    parser.add_argument("--reason", required=True, help="specific justification")
+    args = parser.parse_args(argv)
+    try:
+        path = append_override(
+            gate=args.gate,
+            security_finding=args.security_finding,
+            reason=args.reason,
+        )
+    except (OSError, OverrideAppendError) as error:
+        print(f"override audit append refused: {error}", file=sys.stderr)
+        return 1
+    print(f"appended mandatory override audit row: {path}")
+    return 0

--- a/plugins/ca/hooks/append-override.py
+++ b/plugins/ca/hooks/append-override.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the locked mandatory override audit append."""
+
+from _overrideappendlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca/hooks/hostapi.py
+++ b/plugins/ca/hooks/hostapi.py
@@ -313,7 +313,7 @@ class Host:
 
     name = "claude"
     adapter_name = "ca"
-    adapter_version = "2.17.9"
+    adapter_version = "2.17.10"
 
     # Update-notifier descriptor. Each independently versioned host overrides
     # these three values in its per-plugin _host.py. Keeping the target,

--- a/plugins/ca/hooks/resolve-append-only-conflict.py
+++ b/plugins/ca/hooks/resolve-append-only-conflict.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# codeArbiter - sanctioned helper entry point for H-05 append-only conflicts.
+
+from _appendonlyconflictlib import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ca/hooks/tests/test_append_only_conflict.py
+++ b/plugins/ca/hooks/tests/test_append_only_conflict.py
@@ -289,7 +289,9 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
         target = self.root / TARGET
         self.write(TARGET, b"# append-only overrides\n")
         real_realpath = os.path.realpath
-        alias_destination = str(self.root / ".codearbiter" / "real-overrides.log")
+        alias_destination = str(
+            Path(real_realpath(self.root)) / ".codearbiter" / "real-overrides.log"
+        )
 
         def linked_realpath(path, *args, **kwargs):
             if os.fspath(path) == os.fspath(target):

--- a/plugins/ca/hooks/tests/test_append_only_conflict.py
+++ b/plugins/ca/hooks/tests/test_append_only_conflict.py
@@ -249,6 +249,58 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
                     resolver._relative_target(self.root, relative)
                 self.assertEqual((self.root / relative).read_bytes(), before)
 
+    def test_relative_target_realpaths_divergent_root_spelling_before_containment(self):
+        """Equivalent 8.3/symlink spellings must reach the allowlist decision."""
+        relative = ".codearbiter/triage.log"
+        target = self.root / relative
+        self.write(relative, b"# append-only audit\n")
+        real_realpath = os.path.realpath
+        canonical_root = str(self.root.parent / "canonical-repository-root")
+        canonical_target = str(Path(canonical_root) / relative)
+
+        def divergent_realpath(path, *args, **kwargs):
+            spelling = os.fspath(path)
+            if spelling == os.fspath(self.root):
+                return canonical_root
+            if spelling == os.fspath(target):
+                return canonical_target
+            return real_realpath(path, *args, **kwargs)
+
+        with mock.patch.object(resolver.os.path, "realpath", side_effect=divergent_realpath):
+            with self.assertRaisesRegex(resolver.ResolutionError, "not a supported"):
+                resolver._relative_target(self.root, relative)
+
+    def test_relative_target_rejects_supported_path_resolving_outside_root(self):
+        target = self.root / TARGET
+        self.write(TARGET, b"# append-only overrides\n")
+        real_realpath = os.path.realpath
+        outside = str(self.root.parent / "outside-repository" / "overrides.log")
+
+        def escaping_realpath(path, *args, **kwargs):
+            if os.fspath(path) == os.fspath(target):
+                return outside
+            return real_realpath(path, *args, **kwargs)
+
+        with mock.patch.object(resolver.os.path, "realpath", side_effect=escaping_realpath):
+            with self.assertRaisesRegex(resolver.ResolutionError, "target escapes"):
+                resolver._relative_target(self.root, TARGET)
+
+    def test_relative_target_rejects_supported_final_link_resolving_inside_root(self):
+        target = self.root / TARGET
+        self.write(TARGET, b"# append-only overrides\n")
+        real_realpath = os.path.realpath
+        alias_destination = str(self.root / ".codearbiter" / "real-overrides.log")
+
+        def linked_realpath(path, *args, **kwargs):
+            if os.fspath(path) == os.fspath(target):
+                return alias_destination
+            return real_realpath(path, *args, **kwargs)
+
+        with mock.patch.object(resolver.os.path, "realpath", side_effect=linked_realpath):
+            with mock.patch.object(Path, "is_symlink", return_value=True):
+                with self.assertRaisesRegex(resolver.ResolutionError, "regular non-link"):
+                    resolver._relative_target(self.root, TARGET)
+
     def test_rejects_empty_reason_before_mutation(self):
         self.conflict()
         before = (self.root / TARGET).read_bytes()
@@ -369,7 +421,7 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
 
         def append_before_replace(path, raw, *args, **kwargs):
             nonlocal injected
-            if not injected and Path(path) == self.root / TARGET:
+            if not injected and os.path.samefile(path, self.root / TARGET):
                 injected = True
                 with Path(path).open("ab") as handle:
                     handle.write(b"concurrent append during resolution\n")

--- a/plugins/ca/hooks/tests/test_append_only_conflict.py
+++ b/plugins/ca/hooks/tests/test_append_only_conflict.py
@@ -69,45 +69,45 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
         output = self.git("ls-files", "-u", "--", TARGET).stdout
         return [line for line in output.splitlines() if line]
 
-    def sprint_conflict(self):
-        sprint = ".codearbiter/gate-events.log"
+    def gate_events_conflict(self):
+        gate_events = ".codearbiter/gate-events.log"
         overrides = b"# append-only overrides\n"
-        base = b"# append-only sprint decisions\nbaseline\n"
+        base = b"# append-only gate events\nbaseline\n"
         self.write(TARGET, overrides)
-        self.write(sprint, base)
-        self.git("add", "--", TARGET, sprint)
+        self.write(gate_events, base)
+        self.git("add", "--", TARGET, gate_events)
         self.git("commit", "-m", "base")
         self.git("switch", "-c", "left-history")
-        self.write(sprint, base + b"left append\n")
-        self.git("add", "--", sprint)
+        self.write(gate_events, base + b"left append\n")
+        self.git("add", "--", gate_events)
         self.git("commit", "-m", "left")
         self.git("switch", "main")
-        self.write(sprint, base + b"right append\n")
-        self.git("add", "--", sprint)
+        self.write(gate_events, base + b"right append\n")
+        self.git("add", "--", gate_events)
         self.git("commit", "-m", "right")
         self.assertNotEqual(self.git("merge", "left-history", check=False).returncode, 0)
-        return sprint, overrides, base
+        return gate_events, overrides, base
 
     def dual_audit_conflict(self):
-        sprint = ".codearbiter/gate-events.log"
+        gate_events = ".codearbiter/gate-events.log"
         overrides = b"# append-only overrides\n"
-        decisions = b"# append-only sprint decisions\n"
+        events = b"# append-only gate events\n"
         self.write(TARGET, overrides)
-        self.write(sprint, decisions)
-        self.git("add", "--", TARGET, sprint)
+        self.write(gate_events, events)
+        self.git("add", "--", TARGET, gate_events)
         self.git("commit", "-m", "base")
         self.git("switch", "-c", "left-history")
         self.write(TARGET, overrides + b"left override\n")
-        self.write(sprint, decisions + b"left decision\n")
-        self.git("add", "--", TARGET, sprint)
+        self.write(gate_events, events + b"left event\n")
+        self.git("add", "--", TARGET, gate_events)
         self.git("commit", "-m", "left")
         self.git("switch", "main")
         self.write(TARGET, overrides + b"right override\n")
-        self.write(sprint, decisions + b"right decision\n")
-        self.git("add", "--", TARGET, sprint)
+        self.write(gate_events, events + b"right event\n")
+        self.git("add", "--", TARGET, gate_events)
         self.git("commit", "-m", "right")
         self.assertNotEqual(self.git("merge", "left-history", check=False).returncode, 0)
-        return sprint
+        return gate_events
 
     def audit_state(self, *paths):
         return {
@@ -382,6 +382,50 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
         self.assertIn(b"concurrent append during resolution\n", (self.root / TARGET).read_bytes())
         self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
 
+    def test_atomic_publish_and_concurrent_rollback_sync_the_parent_directory(self):
+        path = self.root / "atomic-audit.log"
+        before = b"before\n"
+        path.write_bytes(before)
+
+        with mock.patch.object(resolver, "_sync_parent") as sync_parent:
+            resolver._write_bytes_atomic(path, b"after\n")
+        sync_parent.assert_called_once_with(path)
+
+        path.write_bytes(before)
+        with mock.patch.object(
+            resolver.Path,
+            "read_bytes",
+            side_effect=(before, b"concurrent append\n"),
+        ), mock.patch.object(resolver, "_sync_parent") as sync_parent:
+            with self.assertRaises(resolver.ConcurrentAppendError):
+                resolver._write_bytes_atomic(path, b"after\n", expected=before)
+        self.assertEqual(path.read_bytes(), before)
+        self.assertEqual(sync_parent.call_args_list, [mock.call(path), mock.call(path)])
+
+    def test_parent_directory_sync_is_platform_aware_and_closes_its_descriptor(self):
+        path = self.root / "atomic-audit.log"
+        with mock.patch.object(resolver.os, "name", "nt"), \
+             mock.patch.object(resolver.os, "open") as open_parent:
+            self.assertFalse(resolver._sync_parent(path))
+        open_parent.assert_not_called()
+
+        with mock.patch.object(resolver.os, "name", "posix"), \
+             mock.patch.object(resolver.os, "open", return_value=123) as open_parent, \
+             mock.patch.object(resolver.os, "fsync") as fsync_parent, \
+             mock.patch.object(resolver.os, "close") as close_parent:
+            self.assertTrue(resolver._sync_parent(path))
+        self.assertEqual(open_parent.call_args.args[0], path.parent)
+        fsync_parent.assert_called_once_with(123)
+        close_parent.assert_called_once_with(123)
+
+        with mock.patch.object(resolver.os, "name", "posix"), \
+             mock.patch.object(resolver.os, "open", return_value=456), \
+             mock.patch.object(resolver.os, "fsync", side_effect=OSError("sync failed")), \
+             mock.patch.object(resolver.os, "close") as close_parent:
+            with self.assertRaisesRegex(OSError, "sync failed"):
+                resolver._sync_parent(path)
+        close_parent.assert_called_once_with(456)
+
     def test_rejects_malformed_index_and_authorization_boundaries(self):
         malformed = mock.Mock(stdout=b"not-an-index-record\0")
         with mock.patch.object(resolver, "_git", return_value=malformed):
@@ -449,7 +493,7 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
         self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
 
     def test_every_changed_audit_path_is_locked_through_staging(self):
-        sprint, _overrides, _base = self.sprint_conflict()
+        gate_events, _overrides, _base = self.gate_events_conflict()
         handles = [object(), object(), object()]
         acquired = []
         released = []
@@ -460,20 +504,20 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
 
         with mock.patch.object(resolver, "acquire_lock", side_effect=acquire), \
              mock.patch.object(resolver, "release_lock", side_effect=released.append):
-            resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+            resolver.resolve(gate_events, "preserve both histories", cwd=self.root)
 
         self.assertEqual(
             acquired[1:],
             [
                 Path(resolver.audit_lock_key(self.root, self.root / relative))
-                for relative in sorted((TARGET, sprint))
+                for relative in sorted((TARGET, gate_events))
             ],
         )
         self.assertEqual(released, list(reversed(handles)))
 
     def test_changed_audit_path_lock_contention_refuses_before_mutation(self):
-        sprint, _overrides, _base = self.sprint_conflict()
-        before = self.audit_state(TARGET, sprint)
+        gate_events, _overrides, _base = self.gate_events_conflict()
+        before = self.audit_state(TARGET, gate_events)
         repository_handle = object()
         first_path_handle = object()
 
@@ -483,9 +527,9 @@ class AppendOnlyConflictJourneyTests(unittest.TestCase):
             side_effect=(repository_handle, first_path_handle, None),
         ), mock.patch.object(resolver, "release_lock") as release:
             with self.assertRaisesRegex(resolver.ResolutionError, "audit path lock"):
-                resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+                resolver.resolve(gate_events, "preserve both histories", cwd=self.root)
 
-        self.assertEqual(self.audit_state(TARGET, sprint), before)
+        self.assertEqual(self.audit_state(TARGET, gate_events), before)
         self.assertEqual(release.call_args_list, [mock.call(first_path_handle), mock.call(repository_handle)])
 
     def test_real_preopened_official_writer_lock_refuses_without_losing_row(self):
@@ -539,43 +583,43 @@ release_lock(lock)
         self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, before[TARGET][1])
 
     def test_dirty_override_sink_refuses_other_audit_resolution_before_mutation(self):
-        sprint, _overrides, _base = self.sprint_conflict()
+        gate_events, _overrides, _base = self.gate_events_conflict()
         self.write(TARGET, b"# append-only overrides\nuncommitted append\n")
-        sprint_before = (self.root / sprint).read_bytes()
-        index_before = self.git("ls-files", "-u", "--", sprint).stdout
+        gate_events_before = (self.root / gate_events).read_bytes()
+        index_before = self.git("ls-files", "-u", "--", gate_events).stdout
 
         with self.assertRaisesRegex(resolver.ResolutionError, "audit sink must be clean"):
-            resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+            resolver.resolve(gate_events, "preserve both histories", cwd=self.root)
 
-        self.assertEqual((self.root / sprint).read_bytes(), sprint_before)
-        self.assertEqual(self.git("ls-files", "-u", "--", sprint).stdout, index_before)
+        self.assertEqual((self.root / gate_events).read_bytes(), gate_events_before)
+        self.assertEqual(self.git("ls-files", "-u", "--", gate_events).stdout, index_before)
 
     def test_unmerged_override_sink_refuses_other_audit_resolution_before_mutation(self):
-        sprint = self.dual_audit_conflict()
-        before = self.audit_state(TARGET, sprint)
+        gate_events = self.dual_audit_conflict()
+        before = self.audit_state(TARGET, gate_events)
         with self.assertRaisesRegex(resolver.ResolutionError, "audit sink is itself unmerged"):
-            resolver.resolve(sprint, "preserve both histories", cwd=self.root)
-        self.assertEqual(self.audit_state(TARGET, sprint), before)
+            resolver.resolve(gate_events, "preserve both histories", cwd=self.root)
+        self.assertEqual(self.audit_state(TARGET, gate_events), before)
 
     def test_two_file_post_stage_failure_restores_both_files_and_indexes(self):
-        sprint, overrides, _base = self.sprint_conflict()
-        sprint_before = (self.root / sprint).read_bytes()
-        sprint_index_before = self.git("ls-files", "-u", "--", sprint).stdout
+        gate_events, overrides, _base = self.gate_events_conflict()
+        gate_events_before = (self.root / gate_events).read_bytes()
+        gate_events_index_before = self.git("ls-files", "-u", "--", gate_events).stdout
         override_index_before = self.git("ls-files", "--stage", "--", TARGET).stdout
         real_git = resolver._git
 
-        def fail_sprint_verification(cwd, *args, **kwargs):
-            if args == ("show", f":0:{sprint}"):
-                raise resolver.ResolutionError("injected sprint staged-blob failure")
+        def fail_gate_events_verification(cwd, *args, **kwargs):
+            if args == ("show", f":0:{gate_events}"):
+                raise resolver.ResolutionError("injected gate-events staged-blob failure")
             return real_git(cwd, *args, **kwargs)
 
-        with mock.patch.object(resolver, "_git", side_effect=fail_sprint_verification):
-            with self.assertRaisesRegex(resolver.ResolutionError, "injected sprint"):
-                resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+        with mock.patch.object(resolver, "_git", side_effect=fail_gate_events_verification):
+            with self.assertRaisesRegex(resolver.ResolutionError, "injected gate-events"):
+                resolver.resolve(gate_events, "preserve both histories", cwd=self.root)
 
-        self.assertEqual((self.root / sprint).read_bytes(), sprint_before)
+        self.assertEqual((self.root / gate_events).read_bytes(), gate_events_before)
         self.assertEqual((self.root / TARGET).read_bytes(), overrides)
-        self.assertEqual(self.git("ls-files", "-u", "--", sprint).stdout, sprint_index_before)
+        self.assertEqual(self.git("ls-files", "-u", "--", gate_events).stdout, gate_events_index_before)
         self.assertEqual(self.git("ls-files", "--stage", "--", TARGET).stdout, override_index_before)
 
     def test_partial_write_and_git_add_failures_restore_both_files_and_indexes(self):
@@ -589,8 +633,8 @@ release_lock(lock)
                     nested.git("init", "--initial-branch=main")
                     nested.git("config", "user.name", "Conflict Fixture")
                     nested.git("config", "user.email", "fixture@example.test")
-                    sprint, _overrides, _base = nested.sprint_conflict()
-                    before = nested.audit_state(TARGET, sprint)
+                    gate_events, _overrides, _base = nested.gate_events_conflict()
+                    before = nested.audit_state(TARGET, gate_events)
                     if injection == "second-write":
                         real_write = resolver._write_bytes_atomic
                         write_count = 0
@@ -616,12 +660,12 @@ release_lock(lock)
                         expected = resolver.ResolutionError
                     with patcher:
                         with self.assertRaises(expected):
-                            resolver.resolve(sprint, "preserve both histories", cwd=nested.root)
-                    self.assertEqual(nested.audit_state(TARGET, sprint), before)
+                            resolver.resolve(gate_events, "preserve both histories", cwd=nested.root)
+                    self.assertEqual(nested.audit_state(TARGET, gate_events), before)
 
     def test_staged_blob_mismatch_restores_both_files_and_indexes(self):
-        sprint, _overrides, _base = self.sprint_conflict()
-        before = self.audit_state(TARGET, sprint)
+        gate_events, _overrides, _base = self.gate_events_conflict()
+        before = self.audit_state(TARGET, gate_events)
         real_git = resolver._git
 
         def mismatch_override(cwd, *args, **kwargs):
@@ -631,8 +675,8 @@ release_lock(lock)
 
         with mock.patch.object(resolver, "_git", side_effect=mismatch_override):
             with self.assertRaisesRegex(resolver.ResolutionError, "staged blob does not match"):
-                resolver.resolve(sprint, "preserve both histories", cwd=self.root)
-        self.assertEqual(self.audit_state(TARGET, sprint), before)
+                resolver.resolve(gate_events, "preserve both histories", cwd=self.root)
+        self.assertEqual(self.audit_state(TARGET, gate_events), before)
 
     def test_rollback_index_failure_is_surfaced_after_worktree_restoration(self):
         self.conflict()
@@ -677,11 +721,11 @@ release_lock(lock)
             with self.assertRaisesRegex(resolver.ResolutionError, "at most 500"):
                 resolver._authorization(self.root, "carriage\rreturn")
 
-    def test_sprint_log_conflict_records_authorization_in_overrides_log(self):
-        sprint, overrides, base = self.sprint_conflict()
+    def test_gate_events_conflict_records_authorization_in_overrides_log(self):
+        gate_events, overrides, base = self.gate_events_conflict()
 
         result = subprocess.run(
-            [sys.executable, str(HELPER), sprint, "--reason", "preserve both histories"],
+            [sys.executable, str(HELPER), gate_events, "--reason", "preserve both histories"],
             cwd=self.root,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -689,7 +733,7 @@ release_lock(lock)
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(
-            (self.root / sprint).read_bytes(),
+            (self.root / gate_events).read_bytes(),
             base + b"right append\nleft append\n",
         )
         override_result = (self.root / TARGET).read_bytes()
@@ -697,7 +741,7 @@ release_lock(lock)
         self.assertIn(b"BY: fixture@example.test | GATE: H-05", override_result)
         self.assertEqual(
             self.git("diff", "--cached", "--name-only").stdout.splitlines(),
-            sorted([TARGET, sprint]),
+            sorted([TARGET, gate_events]),
         )
 
 

--- a/plugins/ca/hooks/tests/test_append_only_conflict.py
+++ b/plugins/ca/hooks/tests/test_append_only_conflict.py
@@ -1,0 +1,719 @@
+"""End-to-end contract for the sanctioned H-05 conflict resolver (#671)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+HOOKS = Path(__file__).resolve().parents[1]
+HELPER = HOOKS / "resolve-append-only-conflict.py"
+TARGET = ".codearbiter/overrides.log"
+sys.path.insert(0, str(HOOKS))
+import _appendonlyconflictlib as resolver  # noqa: E402
+
+
+class AppendOnlyConflictJourneyTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.git("init", "--initial-branch=main")
+        self.git("config", "user.name", "Conflict Fixture")
+        self.git("config", "user.email", "fixture@example.test")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def git(self, *args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.root,
+            check=check,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def write(self, relative, content):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+    def commit(self, message):
+        self.git("add", "--", TARGET)
+        self.git("commit", "-m", message)
+
+    def conflict(self, *, left=None, right=None):
+        base = b"# append-only audit\nbaseline\n"
+        left = left if left is not None else base + b"left append\n"
+        right = right if right is not None else base + b"right append\n"
+        self.write(TARGET, base)
+        self.commit("base")
+        self.git("switch", "-c", "left-history")
+        self.write(TARGET, left)
+        self.commit("left")
+        self.git("switch", "main")
+        self.write(TARGET, right)
+        self.commit("right")
+        merged = self.git("merge", "left-history", check=False)
+        self.assertNotEqual(merged.returncode, 0, merged.stdout + merged.stderr)
+        self.assertEqual(len(self.unmerged()), 3)
+        return base, right[len(base) :], left[len(base) :]
+
+    def unmerged(self):
+        output = self.git("ls-files", "-u", "--", TARGET).stdout
+        return [line for line in output.splitlines() if line]
+
+    def sprint_conflict(self):
+        sprint = ".codearbiter/gate-events.log"
+        overrides = b"# append-only overrides\n"
+        base = b"# append-only sprint decisions\nbaseline\n"
+        self.write(TARGET, overrides)
+        self.write(sprint, base)
+        self.git("add", "--", TARGET, sprint)
+        self.git("commit", "-m", "base")
+        self.git("switch", "-c", "left-history")
+        self.write(sprint, base + b"left append\n")
+        self.git("add", "--", sprint)
+        self.git("commit", "-m", "left")
+        self.git("switch", "main")
+        self.write(sprint, base + b"right append\n")
+        self.git("add", "--", sprint)
+        self.git("commit", "-m", "right")
+        self.assertNotEqual(self.git("merge", "left-history", check=False).returncode, 0)
+        return sprint, overrides, base
+
+    def dual_audit_conflict(self):
+        sprint = ".codearbiter/gate-events.log"
+        overrides = b"# append-only overrides\n"
+        decisions = b"# append-only sprint decisions\n"
+        self.write(TARGET, overrides)
+        self.write(sprint, decisions)
+        self.git("add", "--", TARGET, sprint)
+        self.git("commit", "-m", "base")
+        self.git("switch", "-c", "left-history")
+        self.write(TARGET, overrides + b"left override\n")
+        self.write(sprint, decisions + b"left decision\n")
+        self.git("add", "--", TARGET, sprint)
+        self.git("commit", "-m", "left")
+        self.git("switch", "main")
+        self.write(TARGET, overrides + b"right override\n")
+        self.write(sprint, decisions + b"right decision\n")
+        self.git("add", "--", TARGET, sprint)
+        self.git("commit", "-m", "right")
+        self.assertNotEqual(self.git("merge", "left-history", check=False).returncode, 0)
+        return sprint
+
+    def audit_state(self, *paths):
+        return {
+            relative: (
+                (self.root / relative).read_bytes(),
+                self.git("ls-files", "--stage", "--", relative).stdout,
+            )
+            for relative in paths
+        }
+
+    def run_helper(self, *extra):
+        self.assertTrue(
+            HELPER.is_file(),
+            "the sanctioned append-only conflict helper is missing",
+        )
+        return subprocess.run(
+            [sys.executable, str(HELPER), TARGET, "--reason", "preserve both histories", *extra],
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "PYTHONUTF8": "1"},
+        )
+
+    def test_real_conflict_preserves_both_histories_records_override_and_stages(self):
+        base, ours, theirs = self.conflict()
+        result = self.run_helper()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        raw = (self.root / TARGET).read_bytes()
+        self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+        self.assertNotIn(b"\r\n", raw)
+        self.assertTrue(raw.startswith(base + ours + theirs), raw)
+        self.assertIn(b"BY: fixture@example.test | GATE: H-05", raw)
+        self.assertIn(b"REASON: preserve both histories", raw)
+        self.assertEqual(self.unmerged(), [])
+        self.assertEqual(self.git("diff", "--cached", "--name-only").stdout, TARGET + "\n")
+
+    def test_rejects_a_branch_that_edits_the_preexisting_prefix_without_mutation(self):
+        base = b"# append-only audit\nbaseline\n"
+        self.conflict(left=b"# append-only audit\nchanged\nleft append\n")
+        before = (self.root / TARGET).read_bytes()
+        index_before = self.git("ls-files", "-u", "--", TARGET).stdout
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not append-only", result.stderr)
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+        self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
+        self.assertNotEqual(base, (self.root / TARGET).read_bytes())
+
+    def test_rejects_deletion_and_reordering_of_preexisting_bytes_without_mutation(self):
+        base = b"# append-only audit\nfirst\nsecond\n"
+        invalid_sides = (
+            b"# append-only audit\nsecond\nleft append\n",
+            b"# append-only audit\nsecond\nfirst\nleft append\n",
+        )
+        for left in invalid_sides:
+            with self.subTest(left=left):
+                with tempfile.TemporaryDirectory() as temporary:
+                    nested = AppendOnlyConflictJourneyTests(methodName="runTest")
+                    nested.temp = None
+                    nested.root = Path(temporary)
+                    nested.git("init", "--initial-branch=main")
+                    nested.git("config", "user.name", "Conflict Fixture")
+                    nested.git("config", "user.email", "fixture@example.test")
+                    nested.write(TARGET, base)
+                    nested.commit("base")
+                    nested.git("switch", "-c", "left-history")
+                    nested.write(TARGET, left)
+                    nested.commit("left")
+                    nested.git("switch", "main")
+                    nested.write(TARGET, base + b"right append\n")
+                    nested.commit("right")
+                    self.assertNotEqual(nested.git("merge", "left-history", check=False).returncode, 0)
+                    before = nested.audit_state(TARGET)
+                    result = subprocess.run(
+                        [sys.executable, str(HELPER), TARGET, "--reason", "preserve both histories"],
+                        cwd=nested.root,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("not append-only", result.stderr)
+                    self.assertEqual(nested.audit_state(TARGET), before)
+
+    def test_rejects_missing_three_stage_conflict_and_cannot_be_replayed(self):
+        self.write(TARGET, b"# append-only audit\nbaseline\n")
+        self.commit("base")
+        before = (self.root / TARGET).read_bytes()
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("three-stage conflict", result.stderr)
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+
+    def test_successful_resolution_cannot_be_replayed_or_append_a_second_override(self):
+        self.conflict()
+        first = self.run_helper()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        worktree_before = (self.root / TARGET).read_bytes()
+        index_before = self.git("ls-files", "--stage", "--", TARGET).stdout
+
+        replay = self.run_helper()
+
+        self.assertNotEqual(replay.returncode, 0)
+        self.assertIn("three-stage conflict", replay.stderr)
+        self.assertEqual((self.root / TARGET).read_bytes(), worktree_before)
+        self.assertEqual(self.git("ls-files", "--stage", "--", TARGET).stdout, index_before)
+        self.assertEqual(worktree_before.count(b"GATE: H-05"), 1)
+
+    def test_rejects_unsupported_path_before_mutation(self):
+        self.conflict()
+        before = (self.root / TARGET).read_bytes()
+        result = subprocess.run(
+            [sys.executable, str(HELPER), "README.md", "--reason", "preserve both histories"],
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("supported append-only", result.stderr)
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+        self.assertEqual(len(self.unmerged()), 3)
+
+    def test_supported_audit_allowlist_is_exact_and_other_h05_paths_refuse(self):
+        self.assertEqual(
+            resolver.SUPPORTED_AUDIT_PATHS,
+            frozenset({TARGET, ".codearbiter/gate-events.log"}),
+        )
+        for relative in (
+            ".codearbiter/triage.log",
+            ".codearbiter/sprint-log.md",
+            ".codearbiter/decisions/decision-log.md",
+        ):
+            with self.subTest(relative=relative):
+                self.write(relative, b"# append-only audit\n")
+                before = (self.root / relative).read_bytes()
+                with self.assertRaisesRegex(resolver.ResolutionError, "not a supported"):
+                    resolver._relative_target(self.root, relative)
+                self.assertEqual((self.root / relative).read_bytes(), before)
+
+    def test_rejects_empty_reason_before_mutation(self):
+        self.conflict()
+        before = (self.root / TARGET).read_bytes()
+        result = subprocess.run(
+            [sys.executable, str(HELPER), TARGET, "--reason", "   "],
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-empty reason", result.stderr)
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+        self.assertEqual(len(self.unmerged()), 3)
+
+    def test_post_stage_verification_failure_restores_worktree_and_conflict_index(self):
+        self.conflict()
+        before = (self.root / TARGET).read_bytes()
+        index_before = self.git("ls-files", "-u", "--", TARGET).stdout
+        real_git = resolver._git
+
+        def fail_index_verification(cwd, *args, **kwargs):
+            if args == ("show", f":0:{TARGET}"):
+                raise resolver.ResolutionError("injected staged-blob read failure")
+            return real_git(cwd, *args, **kwargs)
+
+        with mock.patch.object(resolver, "_git", side_effect=fail_index_verification):
+            with self.assertRaisesRegex(resolver.ResolutionError, "injected staged-blob"):
+                resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+        self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
+
+    def test_rejects_an_embedded_utf8_bom_before_mutation(self):
+        self.conflict(left=b"# append-only audit\nbaseline\n\xef\xbb\xbfleft append\n")
+        before = (self.root / TARGET).read_bytes()
+        index_before = self.git("ls-files", "-u", "--", TARGET).stdout
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("UTF-8 BOM", result.stderr)
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+        self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
+
+    def test_rejects_noncanonical_blob_bytes_and_empty_append(self):
+        cases = {
+            "not valid UTF-8": b"\xff\n",
+            "NUL byte": b"left\x00append\n",
+            "canonical LF": b"left append\r\n",
+            "does not end with LF": b"left append",
+        }
+        for expected, raw in cases.items():
+            with self.subTest(expected=expected):
+                with self.assertRaisesRegex(resolver.ResolutionError, expected):
+                    resolver._validate_bytes("branch", raw)
+
+        records = [("100644", "base", 1, TARGET), ("100644", "ours", 2, TARGET), ("100644", "theirs", 3, TARGET)]
+        blobs = {"base": b"base\n", "ours": b"base\n", "theirs": b"base\ntheirs\n"}
+        with mock.patch.object(resolver, "_blob", side_effect=lambda _root, oid, _label: blobs[oid]):
+            with self.assertRaisesRegex(resolver.ResolutionError, "non-empty history"):
+                resolver._build_union(self.root, records)
+
+    def test_real_conflict_with_invalid_utf8_preserves_worktree_and_index(self):
+        base = b"# append-only audit\nbaseline\n"
+        self.conflict(left=base + b"left \xff append\n")
+        before = self.audit_state(TARGET)
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not valid UTF-8", result.stderr)
+        self.assertEqual(self.audit_state(TARGET), before)
+
+    def test_post_conflict_audit_append_is_never_discarded(self):
+        for relative in (TARGET, ".codearbiter/gate-events.log"):
+            with self.subTest(relative=relative):
+                with tempfile.TemporaryDirectory() as temporary:
+                    nested = AppendOnlyConflictJourneyTests(methodName="runTest")
+                    nested.temp = None
+                    nested.root = Path(temporary)
+                    nested.git("init", "--initial-branch=main")
+                    nested.git("config", "user.name", "Conflict Fixture")
+                    nested.git("config", "user.email", "fixture@example.test")
+                    base = b"# append-only audit\nbaseline\n"
+                    if relative != TARGET:
+                        nested.write(TARGET, b"# append-only overrides\n")
+                    nested.write(relative, base)
+                    nested.git("add", "--", TARGET, relative)
+                    nested.git("commit", "-m", "base")
+                    nested.git("switch", "-c", "left-history")
+                    nested.write(relative, base + b"left append\n")
+                    nested.git("add", "--", relative)
+                    nested.git("commit", "-m", "left")
+                    nested.git("switch", "main")
+                    nested.write(relative, base + b"right append\n")
+                    nested.git("add", "--", relative)
+                    nested.git("commit", "-m", "right")
+                    self.assertNotEqual(nested.git("merge", "left-history", check=False).returncode, 0)
+                    with (nested.root / relative).open("ab") as handle:
+                        handle.write(b"live append after conflict\n")
+                    observed_paths = (TARGET,) if relative == TARGET else (TARGET, relative)
+                    before = nested.audit_state(*observed_paths)
+
+                    result = subprocess.run(
+                        [sys.executable, str(HELPER), relative, "--reason", "preserve both histories"],
+                        cwd=nested.root,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("conflicted worktree", result.stderr)
+                    self.assertEqual(nested.audit_state(*observed_paths), before)
+
+    def test_append_between_final_check_and_replace_is_restored_and_refused(self):
+        self.conflict()
+        index_before = self.git("ls-files", "-u", "--", TARGET).stdout
+        real_write = resolver._write_bytes_atomic
+        injected = False
+
+        def append_before_replace(path, raw, *args, **kwargs):
+            nonlocal injected
+            if not injected and Path(path) == self.root / TARGET:
+                injected = True
+                with Path(path).open("ab") as handle:
+                    handle.write(b"concurrent append during resolution\n")
+            return real_write(path, raw, *args, **kwargs)
+
+        with mock.patch.object(resolver, "_write_bytes_atomic", side_effect=append_before_replace):
+            with self.assertRaisesRegex(resolver.ResolutionError, "concurrent append"):
+                resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+
+        self.assertIn(b"concurrent append during resolution\n", (self.root / TARGET).read_bytes())
+        self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
+
+    def test_rejects_malformed_index_and_authorization_boundaries(self):
+        malformed = mock.Mock(stdout=b"not-an-index-record\0")
+        with mock.patch.object(resolver, "_git", return_value=malformed):
+            with self.assertRaisesRegex(resolver.ResolutionError, "malformed unmerged"):
+                resolver._unmerged(self.root, TARGET)
+
+        missing_identity = mock.Mock(returncode=1, stdout=b"", stderr=b"")
+        with mock.patch.object(resolver, "_git", return_value=missing_identity):
+            with self.assertRaisesRegex(resolver.ResolutionError, "user.email is required"):
+                resolver._authorization(self.root, "specific reason")
+
+        for reason in ("x" * 501, "contains | pipe", "contains\nnewline"):
+            with self.subTest(reason=reason[:20]):
+                with self.assertRaisesRegex(resolver.ResolutionError, "at most 500"):
+                    resolver._authorization(self.root, reason)
+
+    def test_rejects_incomplete_wrong_mode_and_wrong_path_index_states_without_mutation(self):
+        self.conflict()
+        before = self.audit_state(TARGET)
+        raw = resolver._git(self.root, "ls-files", "-u", "-z", "--", TARGET).stdout
+        entries = [entry for entry in raw.split(b"\0") if entry]
+        malformed_outputs = (
+            b"\0".join(entries[:2]) + b"\0",
+            entries[0].replace(b"100644", b"100755", 1) + b"\0" + b"\0".join(entries[1:]) + b"\0",
+            entries[0].replace(TARGET.encode(), b".codearbiter/sprint-log.md", 1) + b"\0" + b"\0".join(entries[1:]) + b"\0",
+        )
+        real_git = resolver._git
+        for malformed in malformed_outputs:
+            with self.subTest(malformed=malformed[:40]):
+                def substitute_unmerged(cwd, *args, **kwargs):
+                    if args == ("ls-files", "-u", "-z", "--", TARGET):
+                        return mock.Mock(returncode=0, stdout=malformed, stderr=b"")
+                    return real_git(cwd, *args, **kwargs)
+
+                with mock.patch.object(resolver, "_git", side_effect=substitute_unmerged):
+                    with self.assertRaises(resolver.ResolutionError):
+                        resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+                self.assertEqual(self.audit_state(TARGET), before)
+
+    def test_invalid_repository_root_output_is_a_surfaced_resolution_error(self):
+        with mock.patch.object(
+            resolver,
+            "_git",
+            return_value=mock.Mock(returncode=0, stdout=b"\xff", stderr=b""),
+        ):
+            with self.assertRaisesRegex(resolver.ResolutionError, "repository root"):
+                resolver._repository_root(self.root)
+
+    def test_pre_mutation_file_read_failure_leaves_conflict_unchanged(self):
+        self.conflict()
+        before = self.audit_state(TARGET)
+        with mock.patch.object(Path, "read_bytes", side_effect=OSError("injected read failure")):
+            with self.assertRaisesRegex(OSError, "injected read failure"):
+                resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+        self.assertEqual(self.audit_state(TARGET), before)
+
+    def test_lock_contention_refuses_before_mutation(self):
+        self.conflict()
+        before = (self.root / TARGET).read_bytes()
+        index_before = self.git("ls-files", "-u", "--", TARGET).stdout
+        with mock.patch.object(resolver, "acquire_lock", return_value=None):
+            with self.assertRaisesRegex(resolver.ResolutionError, "holds the repository lock"):
+                resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+        self.assertEqual((self.root / TARGET).read_bytes(), before)
+        self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, index_before)
+
+    def test_every_changed_audit_path_is_locked_through_staging(self):
+        sprint, _overrides, _base = self.sprint_conflict()
+        handles = [object(), object(), object()]
+        acquired = []
+        released = []
+
+        def acquire(path):
+            acquired.append(Path(path))
+            return handles[len(acquired) - 1]
+
+        with mock.patch.object(resolver, "acquire_lock", side_effect=acquire), \
+             mock.patch.object(resolver, "release_lock", side_effect=released.append):
+            resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+
+        self.assertEqual(
+            acquired[1:],
+            [
+                Path(resolver.audit_lock_key(self.root, self.root / relative))
+                for relative in sorted((TARGET, sprint))
+            ],
+        )
+        self.assertEqual(released, list(reversed(handles)))
+
+    def test_changed_audit_path_lock_contention_refuses_before_mutation(self):
+        sprint, _overrides, _base = self.sprint_conflict()
+        before = self.audit_state(TARGET, sprint)
+        repository_handle = object()
+        first_path_handle = object()
+
+        with mock.patch.object(
+            resolver,
+            "acquire_lock",
+            side_effect=(repository_handle, first_path_handle, None),
+        ), mock.patch.object(resolver, "release_lock") as release:
+            with self.assertRaisesRegex(resolver.ResolutionError, "audit path lock"):
+                resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+
+        self.assertEqual(self.audit_state(TARGET, sprint), before)
+        self.assertEqual(release.call_args_list, [mock.call(first_path_handle), mock.call(repository_handle)])
+
+    def test_real_preopened_official_writer_lock_refuses_without_losing_row(self):
+        self.conflict()
+        before = self.audit_state(TARGET)
+        script = r"""
+import os
+import sys
+from _hooklib import acquire_lock, audit_lock_key, release_lock
+
+path = sys.argv[1]
+root = sys.argv[2]
+lock = acquire_lock(audit_lock_key(root, path))
+if lock is None:
+    raise SystemExit("writer could not acquire audit lock")
+handle = open(path, "ab")
+print("READY", flush=True)
+sys.stdin.readline()
+handle.write(b"official concurrent append retained\n")
+handle.flush()
+os.fsync(handle.fileno())
+handle.close()
+release_lock(lock)
+"""
+        writer = subprocess.Popen(
+            [sys.executable, "-c", script, str(self.root / TARGET), str(self.root)],
+            cwd=self.root,
+            env={**os.environ, "PYTHONPATH": str(HOOKS)},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            self.assertEqual(writer.stdout.readline().strip(), "READY")
+            with self.assertRaisesRegex(resolver.ResolutionError, "audit path lock"):
+                resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+            self.assertEqual(self.audit_state(TARGET), before)
+            writer.stdin.write("release\n")
+            writer.stdin.flush()
+            stdout, stderr = writer.communicate(timeout=10)
+            self.assertEqual(writer.returncode, 0, stdout + stderr)
+        finally:
+            if writer.poll() is None:
+                writer.kill()
+                writer.communicate()
+
+        self.assertTrue((self.root / TARGET).read_bytes().endswith(
+            b"official concurrent append retained\n"
+        ))
+        self.assertEqual(self.git("ls-files", "-u", "--", TARGET).stdout, before[TARGET][1])
+
+    def test_dirty_override_sink_refuses_other_audit_resolution_before_mutation(self):
+        sprint, _overrides, _base = self.sprint_conflict()
+        self.write(TARGET, b"# append-only overrides\nuncommitted append\n")
+        sprint_before = (self.root / sprint).read_bytes()
+        index_before = self.git("ls-files", "-u", "--", sprint).stdout
+
+        with self.assertRaisesRegex(resolver.ResolutionError, "audit sink must be clean"):
+            resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+
+        self.assertEqual((self.root / sprint).read_bytes(), sprint_before)
+        self.assertEqual(self.git("ls-files", "-u", "--", sprint).stdout, index_before)
+
+    def test_unmerged_override_sink_refuses_other_audit_resolution_before_mutation(self):
+        sprint = self.dual_audit_conflict()
+        before = self.audit_state(TARGET, sprint)
+        with self.assertRaisesRegex(resolver.ResolutionError, "audit sink is itself unmerged"):
+            resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+        self.assertEqual(self.audit_state(TARGET, sprint), before)
+
+    def test_two_file_post_stage_failure_restores_both_files_and_indexes(self):
+        sprint, overrides, _base = self.sprint_conflict()
+        sprint_before = (self.root / sprint).read_bytes()
+        sprint_index_before = self.git("ls-files", "-u", "--", sprint).stdout
+        override_index_before = self.git("ls-files", "--stage", "--", TARGET).stdout
+        real_git = resolver._git
+
+        def fail_sprint_verification(cwd, *args, **kwargs):
+            if args == ("show", f":0:{sprint}"):
+                raise resolver.ResolutionError("injected sprint staged-blob failure")
+            return real_git(cwd, *args, **kwargs)
+
+        with mock.patch.object(resolver, "_git", side_effect=fail_sprint_verification):
+            with self.assertRaisesRegex(resolver.ResolutionError, "injected sprint"):
+                resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+
+        self.assertEqual((self.root / sprint).read_bytes(), sprint_before)
+        self.assertEqual((self.root / TARGET).read_bytes(), overrides)
+        self.assertEqual(self.git("ls-files", "-u", "--", sprint).stdout, sprint_index_before)
+        self.assertEqual(self.git("ls-files", "--stage", "--", TARGET).stdout, override_index_before)
+
+    def test_partial_write_and_git_add_failures_restore_both_files_and_indexes(self):
+        injections = ("second-write", "git-add")
+        for injection in injections:
+            with self.subTest(injection=injection):
+                with tempfile.TemporaryDirectory() as temporary:
+                    nested = AppendOnlyConflictJourneyTests(methodName="runTest")
+                    nested.temp = None
+                    nested.root = Path(temporary)
+                    nested.git("init", "--initial-branch=main")
+                    nested.git("config", "user.name", "Conflict Fixture")
+                    nested.git("config", "user.email", "fixture@example.test")
+                    sprint, _overrides, _base = nested.sprint_conflict()
+                    before = nested.audit_state(TARGET, sprint)
+                    if injection == "second-write":
+                        real_write = resolver._write_bytes_atomic
+                        write_count = 0
+
+                        def fail_second_write(path, raw, *args, **kwargs):
+                            nonlocal write_count
+                            write_count += 1
+                            if write_count == 2:
+                                raise OSError("injected second write failure")
+                            return real_write(path, raw, *args, **kwargs)
+
+                        patcher = mock.patch.object(resolver, "_write_bytes_atomic", side_effect=fail_second_write)
+                        expected = OSError
+                    else:
+                        real_git = resolver._git
+
+                        def fail_git_add(cwd, *args, **kwargs):
+                            if args[:2] == ("add", "--"):
+                                return mock.Mock(returncode=1, stdout=b"", stderr=b"injected add failure")
+                            return real_git(cwd, *args, **kwargs)
+
+                        patcher = mock.patch.object(resolver, "_git", side_effect=fail_git_add)
+                        expected = resolver.ResolutionError
+                    with patcher:
+                        with self.assertRaises(expected):
+                            resolver.resolve(sprint, "preserve both histories", cwd=nested.root)
+                    self.assertEqual(nested.audit_state(TARGET, sprint), before)
+
+    def test_staged_blob_mismatch_restores_both_files_and_indexes(self):
+        sprint, _overrides, _base = self.sprint_conflict()
+        before = self.audit_state(TARGET, sprint)
+        real_git = resolver._git
+
+        def mismatch_override(cwd, *args, **kwargs):
+            if args == ("show", f":0:{TARGET}"):
+                return mock.Mock(returncode=0, stdout=b"mismatched staged bytes", stderr=b"")
+            return real_git(cwd, *args, **kwargs)
+
+        with mock.patch.object(resolver, "_git", side_effect=mismatch_override):
+            with self.assertRaisesRegex(resolver.ResolutionError, "staged blob does not match"):
+                resolver.resolve(sprint, "preserve both histories", cwd=self.root)
+        self.assertEqual(self.audit_state(TARGET, sprint), before)
+
+    def test_rollback_index_failure_is_surfaced_after_worktree_restoration(self):
+        self.conflict()
+        worktree_before = (self.root / TARGET).read_bytes()
+        real_git = resolver._git
+
+        def fail_verification(cwd, *args, **kwargs):
+            if args == ("show", f":0:{TARGET}"):
+                raise resolver.ResolutionError("injected verification failure")
+            return real_git(cwd, *args, **kwargs)
+
+        with mock.patch.object(resolver, "_git", side_effect=fail_verification):
+            with mock.patch.object(
+                resolver,
+                "_restore_index",
+                side_effect=resolver.ResolutionError("injected rollback failure"),
+            ):
+                with self.assertRaisesRegex(resolver.ResolutionError, "injected rollback failure"):
+                    resolver.resolve(TARGET, "preserve both histories", cwd=self.root)
+        self.assertEqual((self.root / TARGET).read_bytes(), worktree_before)
+
+    def test_authorization_identity_and_exact_reason_boundaries(self):
+        invalid_identities = (
+            b"\xff",
+            b"",
+            (b"a" * 255),
+            b"bad|identity@example.test",
+            b"bad\nidentity@example.test",
+            b"bad\ridentity@example.test",
+        )
+        for identity in invalid_identities:
+            with self.subTest(identity=identity[:20]):
+                response = mock.Mock(returncode=0, stdout=identity, stderr=b"")
+                with mock.patch.object(resolver, "_git", return_value=response):
+                    with self.assertRaisesRegex(resolver.ResolutionError, "user.email"):
+                        resolver._authorization(self.root, "specific reason")
+
+        valid_identity = mock.Mock(returncode=0, stdout=b"fixture@example.test\n", stderr=b"")
+        with mock.patch.object(resolver, "_git", return_value=valid_identity):
+            record = resolver._authorization(self.root, "x" * 500)
+            self.assertIn(b"REASON: " + (b"x" * 500), record)
+            with self.assertRaisesRegex(resolver.ResolutionError, "at most 500"):
+                resolver._authorization(self.root, "carriage\rreturn")
+
+    def test_sprint_log_conflict_records_authorization_in_overrides_log(self):
+        sprint, overrides, base = self.sprint_conflict()
+
+        result = subprocess.run(
+            [sys.executable, str(HELPER), sprint, "--reason", "preserve both histories"],
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            (self.root / sprint).read_bytes(),
+            base + b"right append\nleft append\n",
+        )
+        override_result = (self.root / TARGET).read_bytes()
+        self.assertTrue(override_result.startswith(overrides))
+        self.assertIn(b"BY: fixture@example.test | GATE: H-05", override_result)
+        self.assertEqual(
+            self.git("diff", "--cached", "--name-only").stdout.splitlines(),
+            sorted([TARGET, sprint]),
+        )
+
+
+class OverrideSurfaceContractTests(unittest.TestCase):
+    def test_override_routes_h05_conflicts_to_the_sanctioned_helper(self):
+        text = (HOOKS.parent / "commands" / "override.md").read_text(encoding="utf-8")
+        self.assertIn("append-override.py", text)
+        self.assertIn("must not run concurrently", text)
+        self.assertIn("resolve-append-only-conflict.py", text)
+        self.assertIn("--reason", text)
+        self.assertIn("immediate action only", text)
+        self.assertIn("Run it once", text)
+        self.assertIn("with the specific", text)
+        self.assertIn("and the same reason", text)
+        self.assertIn("single immediate action", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_gate_events.py
+++ b/plugins/ca/hooks/tests/test_gate_events.py
@@ -289,6 +289,32 @@ class TestFailOpenAC2(_GateEventsFixture):
 
         self.assertEqual(_read_log(self.cad), "")
 
+    def test_windows_process_lock_precedes_sidecar_acquisition(self):
+        class _NoopMsvcrt:
+            LK_NBLCK = 1
+            LK_UNLCK = 2
+
+            @staticmethod
+            def locking(_fd, _mode, _nbytes):
+                return None
+
+        process_lock = threading.Lock()
+        observed_process_lock_state = []
+
+        def acquire_sidecar(_path):
+            observed_process_lock_state.append(process_lock.locked())
+            return object()
+
+        with mock.patch.object(os, "name", "nt"), \
+             mock.patch.dict(sys.modules, {"msvcrt": _NoopMsvcrt()}), \
+             mock.patch.object(_hooklib, "_GATE_EVENTS_WINDOWS_LOCK", process_lock), \
+             mock.patch.object(_hooklib, "acquire_lock", side_effect=acquire_sidecar), \
+             mock.patch.object(_hooklib, "release_lock"):
+            _hooklib.warn("serialize same-process writers before sidecar acquisition")
+
+        self.assertEqual(observed_process_lock_state, [True])
+        self.assertFalse(process_lock.locked())
+
     def test_repository_controlled_adjacent_lock_symlink_cannot_cross_boundary(self):
         log_path = os.path.join(self.cad, "gate-events.log")
         outside = os.path.join(self._tmp.name, "outside-empty")

--- a/plugins/ca/hooks/tests/test_gate_events.py
+++ b/plugins/ca/hooks/tests/test_gate_events.py
@@ -307,10 +307,27 @@ class TestFailOpenAC2(_GateEventsFixture):
 
         with mock.patch.object(os, "name", "nt"), \
              mock.patch.dict(sys.modules, {"msvcrt": _NoopMsvcrt()}), \
-             mock.patch.object(_hooklib, "_GATE_EVENTS_WINDOWS_LOCK", process_lock), \
+             mock.patch.object(_hooklib, "_GATE_EVENTS_PROCESS_LOCK", process_lock), \
              mock.patch.object(_hooklib, "acquire_lock", side_effect=acquire_sidecar), \
              mock.patch.object(_hooklib, "release_lock"):
             _hooklib.warn("serialize same-process writers before sidecar acquisition")
+
+        self.assertEqual(observed_process_lock_state, [True])
+        self.assertFalse(process_lock.locked())
+
+    def test_posix_process_lock_precedes_sidecar_acquisition(self):
+        process_lock = threading.Lock()
+        observed_process_lock_state = []
+
+        def acquire_sidecar(_path):
+            observed_process_lock_state.append(process_lock.locked())
+            return object()
+
+        with mock.patch.object(os, "name", "posix"), \
+             mock.patch.object(_hooklib, "_GATE_EVENTS_PROCESS_LOCK", process_lock), \
+             mock.patch.object(_hooklib, "acquire_lock", side_effect=acquire_sidecar), \
+             mock.patch.object(_hooklib, "release_lock"):
+            _hooklib.warn("serialize POSIX same-process writers before sidecar acquisition")
 
         self.assertEqual(observed_process_lock_state, [True])
         self.assertFalse(process_lock.locked())

--- a/plugins/ca/hooks/tests/test_gate_events.py
+++ b/plugins/ca/hooks/tests/test_gate_events.py
@@ -47,6 +47,7 @@ class _GateEventsFixture(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.cad = os.path.join(self.root, ".codearbiter")
         os.makedirs(self.cad)
         self._env_patch = mock.patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": self.root})
@@ -244,6 +245,67 @@ class TestFailOpenAC2(_GateEventsFixture):
             _hooklib.warn("no dir to write into")  # must not raise
         self.assertFalse(os.path.isdir(os.path.join(missing_root, ".codearbiter")))
 
+    def test_sidecar_lock_contention_drops_event_without_opening_log(self):
+        log_path = os.path.join(self.cad, "gate-events.log")
+        with mock.patch.object(_hooklib, "acquire_lock", return_value=None) as acquire, \
+             mock.patch("os.open") as open_log:
+            _hooklib.warn("contended audit sink remains fail-open")
+
+        acquire.assert_called_once_with(_hooklib.audit_lock_key(self.root, log_path))
+        open_log.assert_not_called()
+        self.assertEqual(_read_log(self.cad), "")
+
+    def test_sidecar_lock_is_held_until_after_append_and_then_released(self):
+        log_path = os.path.join(self.cad, "gate-events.log")
+        handle = object()
+        order = []
+        real_write = os.write
+
+        def spy_write(fd, data):
+            order.append("write")
+            return real_write(fd, data)
+
+        def spy_release(observed):
+            self.assertIs(observed, handle)
+            order.append("release")
+
+        with mock.patch.object(_hooklib, "acquire_lock", return_value=handle) as acquire, \
+             mock.patch.object(_hooklib, "release_lock", side_effect=spy_release), \
+             mock.patch("os.write", side_effect=spy_write):
+            _hooklib.warn("locked append")
+
+        acquire.assert_called_once_with(_hooklib.audit_lock_key(self.root, log_path))
+        self.assertEqual(order, ["write", "release"])
+        self.assertIn("locked append", _read_log(self.cad))
+
+    def test_real_resolver_sidecar_lock_makes_best_effort_sink_skip(self):
+        log_path = os.path.join(self.cad, "gate-events.log")
+        holder = _hooklib.acquire_lock(_hooklib.audit_lock_key(self.root, log_path))
+        self.assertIsNotNone(holder)
+        try:
+            _hooklib.warn("must not write outside the resolver lock")
+        finally:
+            _hooklib.release_lock(holder)
+
+        self.assertEqual(_read_log(self.cad), "")
+
+    def test_repository_controlled_adjacent_lock_symlink_cannot_cross_boundary(self):
+        log_path = os.path.join(self.cad, "gate-events.log")
+        outside = os.path.join(self._tmp.name, "outside-empty")
+        with open(outside, "wb"):
+            pass
+        adjacent = log_path + ".lock"
+        try:
+            os.symlink(outside, adjacent)
+        except OSError as error:
+            self.skipTest(f"symlink unavailable: {error}")
+
+        _hooklib.warn("trusted lock namespace")
+
+        with open(outside, "rb") as handle:
+            self.assertEqual(handle.read(), b"")
+        self.assertIn("trusted lock namespace", _read_log(self.cad))
+
     def test_block_exit_code_and_stderr_unchanged_by_sink_failure(self):
         # The stderr message itself (the pre-existing contract) must be
         # unaffected by a sink failure — capture it directly.
@@ -281,6 +343,25 @@ class TestWindowsLockAC3(_GateEventsFixture):
             self.calls.append((kind, fd, nbytes))
             if kind == "unlock" and self._on_unlock is not None:
                 self._on_unlock()
+
+    def setUp(self):
+        super().setUp()
+        # These cases isolate the legacy Windows lock on the log descriptor.
+        # The cross-platform sidecar protocol has independent tests above;
+        # patch it here so the injected fake msvcrt sees only the descriptor
+        # lock calls each assertion is designed to count.
+        self._sidecar_handle = object()
+        self._sidecar_acquire = mock.patch.object(
+            _hooklib, "acquire_lock", return_value=self._sidecar_handle
+        )
+        self._sidecar_release = mock.patch.object(_hooklib, "release_lock")
+        self._sidecar_acquire.start()
+        self._sidecar_release.start()
+
+    def tearDown(self):
+        self._sidecar_release.stop()
+        self._sidecar_acquire.stop()
+        super().tearDown()
 
     def test_windows_crt_deadlock_code_is_host_errno_independent(self):
         self.assertTrue(

--- a/plugins/ca/hooks/tests/test_override_append.py
+++ b/plugins/ca/hooks/tests/test_override_append.py
@@ -110,6 +110,17 @@ class LockedOverrideAppendTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(outside.read_bytes(), b"outside\n")
 
+    def test_special_file_type_is_rejected_before_any_content_read(self):
+        fifo_mode = mock.Mock(st_mode=appender.stat.S_IFIFO)
+        with mock.patch.object(appender.Path, "lstat", return_value=fifo_mode), \
+             mock.patch.object(
+                 appender.Path,
+                 "read_bytes",
+                 side_effect=AssertionError("special file content must not be read"),
+             ):
+            with self.assertRaisesRegex(appender.OverrideAppendError, "regular non-link file"):
+                appender.append_override(gate="H-05", reason="specific", cwd=self.root)
+
     def test_changed_after_validation_refuses_and_releases_lock(self):
         before = self.log.read_bytes()
         changed = before + b"concurrent official row\n"

--- a/plugins/ca/hooks/tests/test_override_append.py
+++ b/plugins/ca/hooks/tests/test_override_append.py
@@ -1,0 +1,148 @@
+"""Locked mandatory append contract for ordinary override records (#671)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+HOOKS = Path(__file__).resolve().parents[1]
+HELPER = HOOKS / "append-override.py"
+sys.path.insert(0, str(HOOKS))
+from _hooklib import acquire_lock, audit_lock_key, release_lock  # noqa: E402
+import _overrideappendlib as appender  # noqa: E402
+
+
+class LockedOverrideAppendTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        subprocess.run(["git", "init", "--initial-branch=main"], cwd=self.root, check=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(["git", "config", "user.email", "fixture@example.test"],
+                       cwd=self.root, check=True)
+        self.log = self.root / ".codearbiter" / "overrides.log"
+        self.log.parent.mkdir()
+        self.log.write_bytes(b"# append-only overrides\n")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_helper(self, *args):
+        self.assertTrue(HELPER.is_file(), "locked override append helper is missing")
+        return subprocess.run(
+            [sys.executable, str(HELPER), *args],
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "PYTHONUTF8": "1"},
+        )
+
+    def test_ordinary_override_is_attributed_and_durably_appended(self):
+        result = self.run_helper("--gate", "H-05", "--reason", "specific justification")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        raw = self.log.read_bytes()
+        self.assertTrue(raw.startswith(b"# append-only overrides\n"))
+        self.assertIn(b"BY: fixture@example.test | GATE: H-05", raw)
+        self.assertIn(b"REASON: specific justification", raw)
+
+    def test_lock_contention_refuses_without_mutation(self):
+        before = self.log.read_bytes()
+        holder = acquire_lock(audit_lock_key(self.root, self.log))
+        self.assertIsNotNone(holder)
+        try:
+            result = self.run_helper("--gate", "H-05", "--reason", "specific justification")
+        finally:
+            release_lock(holder)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("audit path lock", result.stderr)
+        self.assertEqual(self.log.read_bytes(), before)
+
+    def test_security_override_uses_specific_finding_shape(self):
+        result = self.run_helper(
+            "--security-finding", "specific critical primitive",
+            "--reason", "user acknowledged exact finding",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        raw = self.log.read_bytes()
+        self.assertIn(b"SECURITY-OVERRIDE | FINDING: specific critical primitive", raw)
+        self.assertIn(b"REASON: user acknowledged exact finding", raw)
+
+    def test_invalid_fields_refuse_without_mutation(self):
+        before = self.log.read_bytes()
+        for args in (
+            ("--gate", "bad|gate", "--reason", "specific"),
+            ("--gate", "H-05", "--reason", "contains\nnewline"),
+            ("--security-finding", "", "--reason", "specific"),
+        ):
+            with self.subTest(args=args):
+                result = self.run_helper(*args)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.log.read_bytes(), before)
+
+    def test_malformed_existing_log_variants_refuse_without_mutation(self):
+        for raw in (b"\xef\xbb\xbfseed\n", b"seed\r\n", b"seed\x00\n", b"\xff\n", b"unterminated"):
+            with self.subTest(raw=raw):
+                self.log.write_bytes(raw)
+                result = self.run_helper("--gate", "H-05", "--reason", "specific")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.log.read_bytes(), raw)
+
+    def test_missing_directory_and_symlink_logs_refuse_without_external_mutation(self):
+        self.log.unlink()
+        result = self.run_helper("--gate", "H-05", "--reason", "specific")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.log.exists())
+
+        outside = self.root / "outside"
+        outside.write_bytes(b"outside\n")
+        try:
+            os.symlink(outside, self.log)
+        except OSError as error:
+            self.skipTest(f"symlink unavailable: {error}")
+        result = self.run_helper("--gate", "H-05", "--reason", "specific")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(outside.read_bytes(), b"outside\n")
+
+    def test_changed_after_validation_refuses_and_releases_lock(self):
+        before = self.log.read_bytes()
+        changed = before + b"concurrent official row\n"
+        handle = object()
+        with mock.patch.object(appender.Path, "read_bytes", side_effect=(before, changed)), \
+             mock.patch.object(appender, "acquire_lock", return_value=handle), \
+             mock.patch.object(appender, "release_lock") as release:
+            with self.assertRaisesRegex(appender.OverrideAppendError, "changed during validation"):
+                appender.append_override(gate="H-05", reason="specific", cwd=self.root)
+        release.assert_called_once_with(handle)
+        self.assertEqual(self.log.read_bytes(), before)
+
+    def test_zero_progress_write_and_close_failure_release_the_lock(self):
+        handle = object()
+        with mock.patch.object(appender, "acquire_lock", return_value=handle), \
+             mock.patch.object(appender, "release_lock") as release, \
+             mock.patch.object(appender.os, "open", return_value=123), \
+             mock.patch.object(appender.os, "write", return_value=0), \
+             mock.patch.object(appender.os, "close"):
+            with self.assertRaisesRegex(appender.OverrideAppendError, "made no progress"):
+                appender.append_override(gate="H-05", reason="specific", cwd=self.root)
+        release.assert_called_once_with(handle)
+
+        with mock.patch.object(appender, "acquire_lock", return_value=handle), \
+             mock.patch.object(appender, "release_lock") as release, \
+             mock.patch.object(appender.os, "open", return_value=123), \
+             mock.patch.object(appender.os, "write", side_effect=lambda _fd, raw: len(raw)), \
+             mock.patch.object(appender.os, "fsync"), \
+             mock.patch.object(appender.os, "close", side_effect=OSError("close failed")):
+            with self.assertRaisesRegex(OSError, "close failed"):
+                appender.append_override(gate="H-05", reason="specific", cwd=self.root)
+        release.assert_called_once_with(handle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ca/hooks/tests/test_override_append.py
+++ b/plugins/ca/hooks/tests/test_override_append.py
@@ -135,7 +135,9 @@ class LockedOverrideAppendTests(unittest.TestCase):
 
     def test_zero_progress_write_and_close_failure_release_the_lock(self):
         handle = object()
-        with mock.patch.object(appender, "acquire_lock", return_value=handle), \
+        with mock.patch.object(appender, "_root", return_value=self.root), \
+             mock.patch.object(appender, "_identity", return_value="test@example.com"), \
+             mock.patch.object(appender, "acquire_lock", return_value=handle), \
              mock.patch.object(appender, "release_lock") as release, \
              mock.patch.object(appender.os, "open", return_value=123), \
              mock.patch.object(appender.os, "write", return_value=0), \
@@ -144,7 +146,9 @@ class LockedOverrideAppendTests(unittest.TestCase):
                 appender.append_override(gate="H-05", reason="specific", cwd=self.root)
         release.assert_called_once_with(handle)
 
-        with mock.patch.object(appender, "acquire_lock", return_value=handle), \
+        with mock.patch.object(appender, "_root", return_value=self.root), \
+             mock.patch.object(appender, "_identity", return_value="test@example.com"), \
+             mock.patch.object(appender, "acquire_lock", return_value=handle), \
              mock.patch.object(appender, "release_lock") as release, \
              mock.patch.object(appender.os, "open", return_value=123), \
              mock.patch.object(appender.os, "write", side_effect=lambda _fd, raw: len(raw)), \

--- a/plugins/ca/hooks/tests/test_session_start.py
+++ b/plugins/ca/hooks/tests/test_session_start.py
@@ -674,6 +674,7 @@ class TestDevExitAudit(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.ca = os.path.join(self.root, ".codearbiter")
         self.markers = os.path.join(self.ca, ".markers")
         os.makedirs(self.markers)
@@ -888,6 +889,7 @@ class TestDevExitRetryablePendingClose(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, ".git"))
         self.ca = os.path.join(self.root, ".codearbiter")
         self.markers = os.path.join(self.ca, ".markers")
         os.makedirs(self.markers)
@@ -940,6 +942,45 @@ class TestDevExitRetryablePendingClose(unittest.TestCase):
             rec = json.load(f)
         self.assertTrue(any("DEV: exit" in ln for ln in rec.get("lines", [])),
                         "the pending record must carry the owed DEV: exit line")
+
+    def test_override_append_uses_shared_sidecar_lock_and_fails_soft_on_contention(self):
+        with mock.patch.object(_mod._modelib, "acquire_lock", return_value=None) as acquire:
+            self.assertFalse(_mod._modelib._append_override_line(self.root, "owed\n"))
+
+        acquire.assert_called_once_with(_mod._modelib.audit_lock_key(self.root, self.log))
+        self.assertEqual(self._read_log(),
+                         "[2026-01-01T00:00:00Z] | BY: dev | DEV: enter | NOTE: —\n")
+
+    def test_override_append_holds_lock_through_fsync_then_releases(self):
+        handle = object()
+        order = []
+        real_fsync = os.fsync
+
+        def fsync(fd):
+            order.append("fsync")
+            return real_fsync(fd)
+
+        def release(observed):
+            self.assertIs(observed, handle)
+            order.append("release")
+
+        with mock.patch.object(_mod._modelib, "acquire_lock", return_value=handle), \
+             mock.patch.object(_mod._modelib, "release_lock", side_effect=release), \
+             mock.patch.object(_mod._modelib.os, "fsync", side_effect=fsync):
+            self.assertTrue(_mod._modelib._append_override_line(self.root, "locked row\n"))
+
+        self.assertEqual(order, ["fsync", "release"])
+        self.assertTrue(self._read_log().endswith("locked row\n"))
+
+    def test_override_fsync_failure_returns_false_and_releases_lock(self):
+        handle = object()
+        with mock.patch.object(_mod._modelib, "acquire_lock", return_value=handle), \
+             mock.patch.object(_mod._modelib, "release_lock") as release, \
+             mock.patch.object(_mod._modelib.os, "fsync", side_effect=OSError("fsync failed")):
+            self.assertFalse(_mod._modelib._append_override_line(self.root, "uncertain row\n"))
+        release.assert_called_once_with(handle)
+        self.assertTrue(self._read_log().endswith("uncertain row\n"),
+                        "a post-write durability failure is surfaced without rewriting audit bytes")
 
     def test_later_session_appends_the_missing_exit_exactly_once(self):
         # AC-2: the next SessionStart flushes the owed close and clears the

--- a/plugins/ca/hooks/tests/test_staleness_warn_entry.py
+++ b/plugins/ca/hooks/tests/test_staleness_warn_entry.py
@@ -64,6 +64,7 @@ class _Fixture(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self._home = redirect_home(self._tmp.name)
         self.root = os.path.join(self._tmp.name, "repo")
+        os.makedirs(os.path.join(self.root, ".git"))
         self.cad = os.path.join(self.root, ".codearbiter")
         os.makedirs(self.cad)
         with open(os.path.join(self.cad, "CONTEXT.md"), "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

- Add a private, fail-closed resolver for genuine three-stage conflicts on the two H-05 append-only audit paths.
- Preserve the exact merge-base prefix and both branch append suffixes, then add the attributed immediate override and stage only validated output.
- Coordinate the resolver, mandatory override appender, mode audit writer, and gate-event sink through Git-owned per-path locks.
- Ship byte-identical helpers and policy across Claude, Codex, and Pi, with synchronized adapter versions and release provenance.

## Why

Issue #671 confirmed that two valid branches can append to the same protected audit log and reach an H-05 deadlock: Git requires conflict resolution, while the guard correctly blocks hand-editing the append-only file. This provides the narrow resolution action without weakening H-05 or adding a public command.

## Test plan

- [x] Resolver suite: 31 passed
- [x] Mandatory override appender suite: 8 passed
- [x] Gate-event suite: 41 passed
- [x] Session-start suite: 80 passed
- [x] Full Python hook discovery: 1,579 passed, 4 skipped
- [x] Repository Python/script matrix: 38 scripts passed, plus declarations validation
- [x] Pi Vitest: 863 passed, 1 skipped
- [x] Pi typecheck and build passed
- [x] npm clean install reported 0 vulnerabilities
- [x] Shared core parity: 67 files across 3 hosts
- [x] Generated surfaces, host packages, release provenance, Python compilation, staged diff, and credential sweep passed
- [x] Independent security, coverage, and dependency reviews have no CRITICAL or HIGH findings

## Review notes

The Python-hook numeric coverage floor is not applicable under the repository's recorded no-tooling exemption. The coverage review retained one non-blocking MEDIUM recommendation for additional appender error-injection cases.

Conflict hierarchy level 2: the current authorized campaign checkpoint requires governed PR delivery and exact-head CI for issue #671. That current execution contract supersedes the older frozen RA-11 plan's local-commit-only stopping note for this checkpoint.

ADR source ancestry was verified against base `08e6ea13da08d4619a87c22f1dc10865212e7eba` and head `dbe036a9a4f9c4aa3868ded08bd2c155772ccf16`. The required merge method is `squash`.

Closes #671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed genuine append-only audit-log conflicts while preserving both histories and recording required authorization.
  * Prevented concurrent audit updates from overwriting entries through coordinated locking and fail-closed handling.
  * Added rollback protection when conflict resolution or audit recording cannot complete safely.
  * Improved validation for audit records and conflict-resolution inputs.

* **Documentation**
  * Updated override guidance for supported append-only conflicts.

* **Chores**
  * Updated project, plugin, and package versions for the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->