### PR TITLE
docs: correct privacy and network default claims

### DIFF
--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3921,3 +3921,5 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-09T08:55:57Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-09T09:49:05Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-09T09:52:44Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-09T21:59:41Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-09T22:03:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3923,3 +3923,4 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-09T09:52:44Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-09T21:59:41Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-09T22:03:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-09T22:41:42Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.github/published-tags.json
+++ b/.github/published-tags.json
@@ -745,6 +745,11 @@
       "object_sha": "08306ecf5bcc344f5e05bfbd3eec951e2e443e12",
       "commit_sha": "8a9f3721c65c4958e186bb432f7eb10aa59dd1fe",
       "object_type": "tag"
+    },
+    "ca-pi-v0.10.12": {
+      "object_sha": "5c055aa3b438ea757f20b56ef3e0db5e288e1e61",
+      "object_type": "tag",
+      "commit_sha": "9957bbfdfbd38190715b0fe2944b785ec6e000ff"
     }
   }
 }

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Effective date:** 2026-09-06
+**Effective date:** 2026-09-09
 
 codeArbiter provides governance adapters for Claude Code, Codex, and Pi. The
 adapters run on your machine and use your coding host's session and tools.
@@ -73,6 +73,23 @@ broker and scrubs/removes the temporary configuration; a cleanup failure is
 reported as degraded. This is cooperative process isolation, not an OS sandbox.
 A same-user process that obtains the ephemeral token can use the broker while
 that child is alive.
+
+## Optional tribunal KPI feedback
+
+A tribunal run can prepare a local `telemetry.json` receipt with aggregate run
+and lens metrics. This feedback is off by default. The default path shows the
+complete payload and prints a `gh issue create` command without sending it. Only
+explicit approval for that run posts the payload as a public GitHub issue in the
+codeArbiter repository.
+
+The payload excludes code, file paths, finding text, commit hashes, remote URLs,
+and repository identity. A contributor can add an optional free-form `--tag`,
+which then becomes identifying submission data. The local `telemetry.json`
+receipt remains in the tribunal run directory. After an approved submission,
+the run also records a local `telemetry-sent` audit event. GitHub handles the
+public issue under its own retention and privacy terms. See
+[the tribunal telemetry contract](./core/surface/skills/tribunal/references/telemetry.md)
+for the complete field and submission contract.
 
 ## Optional farm and pruning features
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -112,21 +112,30 @@ session start it:
    injects. Composed injection happens instead at the per-turn seam, see
    [UserPromptSubmit / PreCompact: `prompt-submit.py`](#userpromptsubmit-precompact-prompt-submitpy)
    below.
-5. **Emits the daily standup briefing** (first session of the local day only): a
+5. **Emits the cached update notice** when a newer release is known. In arbiter
+   mode it also launches `update-refresh.py` as a detached process. That process
+   reads and updates the target-keyed `~/.codearbiter/update-state.json` cache and,
+   only when the cache is stale, checks GitHub's public Releases API. The network
+   check runs at most once per day and never delays the startup hook.
+6. **Emits the daily standup briefing** (first session of the local day only): a
    **read-only** summary of repo hygiene covering working-tree state, ahead/behind
    vs. upstream, merge-able branches, stale worktrees, stashes, and a display-only
    governance line. Later sessions the same day collapse to at most a single offer
    line, or nothing.
 
 **Reads:** `.codearbiter/CONTEXT.md`, `open-questions.md`, `open-tasks.md` (in-flight
-count excluding done, plus a stale-in-progress nudge, via `_taskboardlib`);
+count excluding done, plus a stale-in-progress nudge, via `_taskboardlib`), the
+installed plugin version, and `~/.codearbiter/update-state.json`;
 read-only `git` queries (`status`, `rev-list`, `branch -vv`, `worktree list`,
 `stash list`, `rev-parse`). **Writes:** the first-of-day marker
 `.codearbiter/.markers/standup-<date>`, and possibly the statusline pin in
-`~/.claude/settings.json`. **Network:** it spawns a **detached, read-only
+`~/.claude/settings.json`; the detached update process can update
+`~/.codearbiter/update-state.json`. **Network:** it spawns a **detached, read-only
 `git fetch --quiet --no-tags`** against your own remote to refresh ahead/behind for
 *next* time. That fetch is never awaited, so an offline or slow network never stalls
-startup. There is no other process and there are no sockets.
+startup. It also spawns the detached, fail-silent update process described above;
+when its cache is stale, that process makes bounded unauthenticated HTTPS requests
+to GitHub's public Releases API and otherwise performs no network request.
 
 > This is the *only* hook that ever runs in a non-enabled repo, and there it does
 > nothing but clear the dev marker and heal the (already-installed) statusline pin.

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6818,9 +6818,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/site/src/content/docs/getting-started/compatibility.md
+++ b/site/src/content/docs/getting-started/compatibility.md
@@ -25,7 +25,7 @@ and the [Pi install page](/getting-started/pi/) for the `ca-pi` install flow.
 | **Operating system** | Native Windows, macOS, or Linux runtime with a checkout created and used by that runtime's Git | The `.git/hooks` backstop is a POSIX `sh` script. On Windows, Git for Windows runs it with its bundled `sh.exe`. Git Bash is part of that native Windows cell and is not WSL. Windows is also a promoted, tested platform for `ca-pi`; see [Windows notes](/getting-started/pi/#windows). Linked-worktree support uses Git's default `<main>/.git/worktrees` storage layout. See [Git runtime boundary](#git-runtime-boundary) for layout and mixed-runtime exclusions. |
 | **git** | A Git binary that provides `rev-parse --git-path hooks`, `rev-parse --path-format=absolute --git-dir --git-common-dir`, and `git hook run`; ADR lifecycle proof requires Git 2.45.0+ with `--no-lazy-fetch` | codeArbiter asks the selected Git binary for its effective hook and shared-worktree paths, then doctor uses that same binary for a harmless managed `pre-push` live-fire probe with empty input. That binary's accepted `core.hooksPath` grammar is authoritative, including its expansion of values such as `~`, `%(prefix)`, absolute paths, and relative paths. The lifecycle verifier additionally enforces the offline capability described below. |
 | **Node.js** | Not required for Claude Code or Codex | Node is required for `ca-pi` (22.19+) and is only otherwise needed to build or develop **this documentation site** (`site/`) and the optional pluggable-execution-farm TypeScript dispatcher (`plugins/ca/tools/`) if you use `/ca:sprint --farm`. Node is not a runtime dependency of the Claude Code/Codex enforcement hooks themselves. |
-| **Network access** | Not required for enforcement | See [Network Calls](#network-calls) below. The gate-enforcement hook chain makes zero network calls; two clearly-scoped, opt-in-by-default exceptions exist outside that chain. |
+| **Network access** | Not required for enforcement | See [Network Calls](#network-calls) below. The gate-enforcement hook chain makes zero network calls. Active arbiter startup has separate background Git-fetch and update-check behavior; the execution farm remains opt-in. |
 
 ## Git Runtime Boundary
 
@@ -115,21 +115,23 @@ records. It imports nothing network-capable.)
   `post-write-edit.py`, and `session-start.py`'s activation/briefing logic) make **zero** network
   calls. Every check is a local file read, a local `git` subprocess call against your own repo, or an
   in-process regex/parse. This is the enforcement chain compatibility and security actually depend on.
+- **The repository-status fetch** is launched by default for an active arbiter session. It runs
+  `git fetch --quiet --no-tags` against the repository's configured remote as a detached,
+  fail-silent process. It can update local remote-tracking refs and Git objects, but it never writes
+  to the remote and never delays the startup briefing.
 - **The update-available notifier** (`_updatelib.py`) is a separate, non-blocking mechanism: a
   best-effort, once-a-day, fail-silent, unauthenticated HTTPS `GET` against GitHub's public Releases
   API (`api.github.com`), run as a **detached background process** off the `SessionStart` hot path so
   a slow or unreachable network never delays a session. It only ever displays a one-line notice; it
-  never applies an update. This ships on by default but is easy to make fully offline: see
-  [Staying up to date](https://github.com/arbiterForge/codeArbiter#staying-up-to-date) in the project
-  README for the opt-out.
+  never applies an update. The background check runs automatically when its cache is stale, at most
+  once per day. There is no user-facing opt-out in the current release line.
 - **The pluggable execution farm** (`/ca:sprint --farm`, opt-in, requires `FARM_API_KEY`) sends
   byte-capped, secret-redacted task context to an OpenAI-compatible HTTP provider you configure. This
   is a separate, explicitly opt-in feature, not part of the gate chain, and inert unless you pass
   `--farm`.
 
-No hook writes anything off your machine as a side effect of enforcement. `docs/hooks.md` documents the
-same invariant per-hook, plus the one local, read-only `git fetch` `session-start.py` runs in the
-background against your own configured remote (the repo-hygiene briefing).
+No hook writes anything off your machine as a side effect of enforcement. `docs/hooks.md` documents
+the same invariant per hook and the two default background startup activities described above.
 
 ## Third-Party Dependencies
 

--- a/site/test/content/trust-policy-claims.test.ts
+++ b/site/test/content/trust-policy-claims.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const siteRoot = process.cwd();
+const repoRoot = resolve(siteRoot, "..");
+
+function readRepo(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), "utf8");
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ");
+}
+
+describe("public trust-policy claims", () => {
+  it("discloses the optional tribunal KPI submission boundary", () => {
+    const privacy = normalizeWhitespace(readRepo("PRIVACY.md"));
+
+    expect(privacy).toContain("## Optional tribunal KPI feedback");
+    expect(privacy).toContain("off by default");
+    expect(privacy).toContain("explicit approval for that run");
+    expect(privacy).toContain("public GitHub issue");
+    expect(privacy).toContain("aggregate run and lens metrics");
+    for (const excluded of [
+      "code",
+      "file paths",
+      "finding text",
+      "commit hashes",
+      "remote URLs",
+      "repository identity",
+    ]) {
+      expect(privacy).toContain(excluded);
+    }
+    expect(privacy).toContain("optional free-form `--tag`");
+    expect(privacy).toContain("local `telemetry.json` receipt");
+    expect(privacy).toContain("shows the complete payload");
+    expect(privacy).toContain("prints a `gh issue create` command without sending it");
+    expect(privacy).toContain("After an approved submission");
+    expect(privacy).toContain("records a local `telemetry-sent` audit event");
+    expect(privacy).toContain("GitHub handles the public issue under its own");
+  });
+
+  it("states each network activity's actual default", () => {
+    const compatibility = normalizeWhitespace(
+      readRepo("site/src/content/docs/getting-started/compatibility.md"),
+    );
+
+    expect(compatibility).not.toContain("opt-in-by-default exceptions");
+    expect(compatibility).not.toContain("easy to make fully offline");
+    expect(compatibility).not.toContain("README for the opt-out");
+    expect(compatibility).toContain("gate-enforcement hook chain makes zero network calls");
+    expect(compatibility).toContain("launched by default for an active arbiter session");
+    expect(compatibility).toContain("runs automatically when its cache is stale");
+    expect(compatibility).toContain("at most once per day");
+    expect(compatibility).toContain("The pluggable execution farm");
+    expect(compatibility).toContain("separate, explicitly opt-in feature");
+  });
+
+  it("keeps the public policy aligned with the tribunal's canonical contract", () => {
+    const privacy = readRepo("PRIVACY.md");
+    const telemetry = readRepo(
+      "core/surface/skills/tribunal/references/telemetry.md",
+    );
+    const faq = readRepo("site/src/content/docs/faq.md");
+
+    for (const boundary of [
+      "Off by default",
+      "explicit per-run authorization",
+      "public codeArbiter repo",
+      "Repo identity is omitted by default",
+      "telemetry-sent",
+    ]) {
+      expect(telemetry).toContain(boundary);
+    }
+    expect(privacy).toContain("tribunal telemetry contract");
+    expect(normalizeWhitespace(faq)).toContain(
+      "codeArbiter has no hosted account or telemetry service that receives it",
+    );
+  });
+});

--- a/site/test/content/trust-policy-claims.test.ts
+++ b/site/test/content/trust-policy-claims.test.ts
@@ -45,6 +45,7 @@ describe("public trust-policy claims", () => {
     const compatibility = normalizeWhitespace(
       readRepo("site/src/content/docs/getting-started/compatibility.md"),
     );
+    const hooks = normalizeWhitespace(readRepo("docs/hooks.md"));
 
     expect(compatibility).not.toContain("opt-in-by-default exceptions");
     expect(compatibility).not.toContain("easy to make fully offline");
@@ -55,10 +56,13 @@ describe("public trust-policy claims", () => {
     expect(compatibility).toContain("at most once per day");
     expect(compatibility).toContain("The pluggable execution farm");
     expect(compatibility).toContain("separate, explicitly opt-in feature");
+    expect(hooks).toContain("launches `update-refresh.py` as a detached process");
+    expect(hooks).toContain("only when the cache is stale");
+    expect(hooks).toContain("checks GitHub's public Releases API");
   });
 
   it("keeps the public policy aligned with the tribunal's canonical contract", () => {
-    const privacy = readRepo("PRIVACY.md");
+    const privacy = normalizeWhitespace(readRepo("PRIVACY.md"));
     const telemetry = readRepo(
       "core/surface/skills/tribunal/references/telemetry.md",
     );
@@ -72,6 +76,15 @@ describe("public trust-policy claims", () => {
       "telemetry-sent",
     ]) {
       expect(telemetry).toContain(boundary);
+    }
+    for (const boundary of [
+      "This feedback is off by default",
+      "Only explicit approval for that run",
+      "public GitHub issue in the codeArbiter repository",
+      "repository identity. A contributor can add an optional free-form `--tag`",
+      "records a local `telemetry-sent` audit event",
+    ]) {
+      expect(privacy).toContain(boundary);
     }
     expect(privacy).toContain("tribunal telemetry contract");
     expect(normalizeWhitespace(faq)).toContain(


### PR DESCRIPTION
## Summary

- Disclose the tribunal KPI feedback path, including its default no-send behavior, explicit per-run approval, public issue destination, payload exclusions, optional tag identity, local receipt, and GitHub retention boundary.
- Replace the Compatibility page's aggregate opt-in claim and unsupported README opt-out reference with the actual defaults for enforcement, SessionStart fetch, update refresh, and the opt-in farm.
- Align the hooks reference with the detached, stale-cache update refresh and strengthen the content contract across Privacy, Compatibility, telemetry, and hook documentation.

## Scope boundary

This is a documentation-policy correction only. It does not change runtime network behavior or the separate farm promotion decision.

Two deterministic CI repairs are included under the recorded standing authority: the site lock now selects patched transitive `smol-toml@1.8.0`, and the authenticated publication receipt for the automatically published `ca-pi-v0.10.12` tag is recorded in the immutable-tag ledger.

## Verification

- `npm --prefix site run coverage`: 55 files and 564 tests passed; lines 74.89% and branches 75.46%, above the stage-2 70% floor.
- `npm --prefix site run typecheck`
- `npm --prefix site run build`: 155 pages generated.
- `npm --prefix site run link-audit`: 26,331 internal links resolved.
- Focused trust-policy test: 3/3 passed.
- SessionStart suite: 80 tests passed.
- Production dependency audit: zero vulnerabilities after the exact `smol-toml@1.8.0` lock update.
- Published-tag reconciliation, capture, and immutability suites: 20, 16, and 74 tests passed; live strict audit accepted 143 receipts and 44 legacy baselines.
- All 40 repository-mandated test commands passed. The hook aggregate passed 1,587 tests with four expected skips.
- Independent dependency, security, coverage, and aggregate review: PASS with zero final findings.
- Secrets scan and `git diff --check`: PASS.

## Review corrections

- CodeRabbit's hook-documentation finding was accepted and fixed by documenting the detached update refresh and its stale-cache network condition.
- CodeRabbit's canonical-alignment finding was accepted and fixed by asserting Privacy's equivalent off-default, approval, destination, identity/tag, and aggregate-payload claims.

## Merge method

Squash merge will be revalidated against the exact final base and head before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the privacy policy effective date to September 9, 2026.
  - Added details about optional tribunal KPI feedback, including local receipts, explicit approval, and aggregate-only public reporting.
  - Clarified active arbiter network activity, including repository-status fetching and daily update checks.
  - Documented execution-farm opt-in access and current update-check behavior.
  - Documented cached update notices and background release checks.
  - Recorded the latest published release tag.

- **Tests**
  - Added coverage to verify that published privacy, compatibility, telemetry, and FAQ claims remain aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->