### PR TITLE
fix(codex-docs): enforce live baseline freshness

### DIFF
--- a/.codearbiter/gate-events.log
+++ b/.codearbiter/gate-events.log
@@ -3924,3 +3924,6 @@ io.open(sys.argv[2],'w',encoding='utf-8',newline='\n').write(open(sys.argv[1],en
 [2026-09-09T21:59:41Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-09T22:03:48Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
 [2026-09-09T22:41:42Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-10T01:51:15Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-10T01:58:07Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).
+[2026-09-10T02:03:06Z] WARN host=claude hook=python.exe -m unittest | /mode has been active for over 30 min with no matching overrides.log entry since — confirm the expected audit line landed (CONFIRM-09).

--- a/.codearbiter/release-targets.md
+++ b/.codearbiter/release-targets.md
@@ -66,6 +66,7 @@ changelog: plugins/ca-codex/CHANGELOG.md
 payload: plugins/ca-codex/
 provenance-manifest: .github/published-tags.json
 latest-eligible: false
+pre-tag: "$PY" .github/scripts/test_public_codex_docs.py
 
 [ca-sandbox]
 prefix: ca-sandbox-v

--- a/.github/scripts/test_public_codex_docs.py
+++ b/.github/scripts/test_public_codex_docs.py
@@ -91,6 +91,37 @@ class PublicCodexDocsTest(unittest.TestCase):
             baseline[:400], r"ca-codex[^0-9]{0,12}\d+\.\d+\.\d+",
             "the recorded baseline names no ca-codex version, so staleness cannot be judged")
 
+        marker_match = re.search(
+            r"<!-- CODEX-LIVE-BASELINE-META (?P<meta>\{[^\n]+\}) -->",
+            runbook,
+        )
+        self.assertIsNotNone(
+            marker_match,
+            "the current Codex live baseline has no machine-readable metadata",
+        )
+        marker = json.loads(marker_match.group("meta"))
+        self.assertEqual(1, marker["schema_version"])
+        self.assertEqual("ca-codex", marker["adapter"])
+        self.assertEqual(
+            manifest["version"],
+            marker["adapter_version"],
+            "the current Codex live baseline is stale for the package manifest",
+        )
+        self.assertRegex(marker["verified_on"], r"^\d{4}-\d{2}-\d{2}$")
+        self.assertTrue(marker["host"])
+        self.assertTrue(marker["proof"])
+
+    def test_ca_codex_release_preflight_enforces_live_baseline_freshness(self):
+        """The ca-codex release row runs the public proof contract check-only."""
+        targets = (ROOT / ".codearbiter" / "release-targets.md").read_text(
+            encoding="utf-8"
+        )
+        codex_row = targets.split("[ca-codex]", 1)[1].split("\n[ca-sandbox]", 1)[0]
+        self.assertIn(
+            'pre-tag: "$PY" .github/scripts/test_public_codex_docs.py',
+            codex_row,
+        )
+
     def test_readme_announces_all_hosts_and_shared_parity(self):
         """The README presents one product and all supported host adapters."""
         self.assertIn(
@@ -117,6 +148,15 @@ class PublicCodexDocsTest(unittest.TestCase):
         ):
             self.assertIn(text, self.readme)
         self.assertNotIn("available after the Codex-support release", self.readme)
+        self.assertIn(
+            "current adapter version is read from "
+            "`plugins/ca-codex/.codex-plugin/plugin.json`",
+            self.readme,
+        )
+        self.assertNotRegex(
+            self.readme,
+            r"repository currently ships `ca-codex \d+\.\d+\.\d+`",
+        )
 
     def test_readme_links_catalog_and_evidence(self):
         """The README links the command catalog and pinned support evidence."""

--- a/.github/scripts/test_release_lib.py
+++ b/.github/scripts/test_release_lib.py
@@ -5184,9 +5184,9 @@ class ThisRepoRowsTest(unittest.TestCase):
             for command in row["pre_tag"]
         ]
         self.assertEqual(
-            len(all_pre_tag), 4,
-            "expected exactly 4 declared pre-tag commands across all rows "
-            "(3 on [ca], 1 on [ca-pi]) -- update this count deliberately if "
+            len(all_pre_tag), 5,
+            "expected exactly 5 declared pre-tag commands across all rows "
+            "(3 on [ca], 1 on [ca-codex], 1 on [ca-pi]) -- update this count deliberately if "
             "a row's pre-tag list ever changes shape")
         for command in all_pre_tag:
             with self.subTest(command=command):

--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.9.10`;
-the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
-Current packaging and shared-core parity are continuously verified, while that dated live-install
-record stays labeled rather than being silently promoted to evidence for a newer adapter:
+The public GitHub-slug flow is **available now**.
+The current adapter version is read from `plugins/ca-codex/.codex-plugin/plugin.json`.
+The dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
+Current packaging and shared-core parity are continuously verified, while that historical record
+stays labeled rather than being promoted to evidence for a newer adapter:
 
 ```text
 codex plugin marketplace add arbiterForge/codeArbiter

--- a/docs/codex-parity-testing.md
+++ b/docs/codex-parity-testing.md
@@ -25,17 +25,22 @@ check on fork pull requests. So this half is manual by decision — and the mani
 exactly that, instead of implying continuous coverage.
 
 **The failure mode of "manual per release" is that it quietly becomes "manual once."** It
-already did: the baseline below recorded `ca-codex` 0.2.4 and went unrefreshed across four
-minor versions. Re-run this runbook and update the baseline as part of any ca-codex release
-that touches `hooks/`. A stale baseline is a claim about a past afternoon, which is the exact
-thing #408 was filed about.
+already did: the initial baseline recorded `ca-codex` 0.2.4 and went unrefreshed across four
+minor versions. Re-run this procedure for every `ca-codex` release. Its declared pre-tag check
+parses the machine-readable marker below and compares `adapter_version` with the canonical plugin
+manifest. A mismatch blocks the release; the check never rewrites evidence.
 
 <!-- CODEX-LIVE-BASELINE -->
-Current verified checkpoint: **Codex CLI 0.145.0**, `ca-codex` **0.9.4**, Windows, 2026-09-05.
-A fresh process advertised and selected the exact installed 0.9.4 package. With its plugin root
-resolved, `$ca-doctor` reported 10 OK, 2 WARN, and 0 FAIL; the single prescribed staging dry-run was
-denied with `[H-03]` and did not execute. This refreshes package selection, doctor health, and the
-live H-03 boundary. It does not claim that the full scenario matrices below were rerun.
+<!-- CODEX-LIVE-BASELINE-META {"schema_version":1,"adapter":"ca-codex","adapter_version":"0.9.10","host":"Codex CLI 0.145.0 on Windows","verified_on":"2026-09-09","proof":"fresh package selection, ca-doctor health, and live H-03 denial"} -->
+Current verified checkpoint: **Codex CLI 0.145.0**, `ca-codex` **0.9.10**, Windows, 2026-09-09.
+A fresh task advertised and selected the exact installed 0.9.10 package. With its plugin root
+resolved, `$ca-doctor` reported 10 OK, 2 WARN, and 0 FAIL; the prescribed staging dry-run was denied
+with `[H-03]` before execution. This refreshes package selection, doctor health, and the live H-03
+boundary. It does not claim that the full scenario matrices below were rerun.
+
+The earlier verified checkpoint remains **Codex CLI 0.145.0**, `ca-codex` **0.9.4**, Windows,
+2026-09-05. A fresh process selected that installed package, and the same scoped doctor and H-03
+checks passed. The linked dispatch receipt below belongs to this dated checkpoint.
 
 The initial live baseline remains **Codex CLI 0.144.1**, `ca-codex` **0.2.4**, Windows,
 2026-07-11. That run covered trusted startup and SessionStart persona injection in addition to H-03.

--- a/site/src/content/docs/getting-started/choose-your-host.md
+++ b/site/src/content/docs/getting-started/choose-your-host.md
@@ -21,7 +21,7 @@ one is optional; the checked-in project state remains shared.
 | **Adapter** | `ca` | `ca-codex` | `ca-pi` |
 | **Status** | Stable | Stable | Feature Forge preview |
 | **Command form** | `/ca:feature` | `$ca-feature` | `/ca-feature` |
-| **Distribution** | codeArbiter marketplace | codeArbiter marketplace | Git tag |
+| **Distribution** | codeArbiter marketplace | codeArbiter marketplace | npm convenience; pinned Git tag reproducibility |
 | **Trust step** | Claude Code plugin trust | Review hooks, then start a fresh thread | Affirm project trust, then start a fresh session |
 | **Project state** | Shared `.codearbiter/` | Same store | Same store |
 | **Status UI** | Optional rich statusline | SessionStart briefing | Native rich footer |
@@ -44,8 +44,9 @@ the exact parity boundary and intentional host differences.
 ## Choose Pi when
 
 You use Pi and accept a preview adapter with a green automated promotion matrix but less real-world
-evidence than the two stable hosts. Pi uses Git tags, requires Node.js 22.19+, and will not activate
-repository-aware behavior until project trust is affirmative.
+evidence than the two stable hosts. npm is the convenience channel, while pinned Git tags provide
+reproducible installs. Pi requires Node.js 22.19+ and will not activate repository-aware behavior
+until project trust is affirmative.
 
 Follow the dedicated [Pi install and trust guide](/getting-started/pi/).
 

--- a/site/src/content/docs/getting-started/install.md
+++ b/site/src/content/docs/getting-started/install.md
@@ -77,8 +77,9 @@ appears as installed from the `codearbiter` marketplace; then verify enforcement
 
 ### Codex
 
-The public commands are **available now** and were verified against release `v2.8.13` with
-`ca-codex 0.2.4`:
+The public commands below install the current `ca-codex` release from the codeArbiter marketplace.
+The first end-to-end public-install record remains as dated historical evidence: on 2026-07-11 it
+verified release `v2.8.13` with `ca-codex 0.2.4`.
 
 ```text
 codex plugin marketplace add arbiterForge/codeArbiter

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -208,7 +208,7 @@ import heroArt from '../../assets/hero-gates.webp';
         <span class="ca-host__status ca-host__status--preview">preview</span>
       </div>
       <code>/ca-feature</code>
-      <p>Git-installed Feature Forge preview with project trust, a rich footer, and supervised child dispatch.</p>
+      <p>Feature Forge preview with an npm convenience channel, pinned Git tags for reproducibility, project trust, a rich footer, and supervised child dispatch.</p>
       <a href="./getting-started/pi/">Install the Pi preview</a>
     </article>
   </div>
@@ -245,7 +245,7 @@ import heroArt from '../../assets/hero-gates.webp';
 <section class="ca-final-cta ca-panel" aria-labelledby="ca-final-cta-title">
   <div>
     <p class="ca-eyebrow">Open source · AGPL-3.0-only · local enforcement</p>
-    <h2 id="ca-final-cta-title">Protect a repository in five minutes.</h2>
+    <h2 id="ca-final-cta-title">Put one repository under governed change.</h2>
     <p>Install for one host, opt the repository in, then run the live doctor probe.</p>
   </div>
   <div class="ca-actions">

--- a/site/test/content/codex-support.test.ts
+++ b/site/test/content/codex-support.test.ts
@@ -68,6 +68,28 @@ describe("canonical Claude Code and Codex support evidence", () => {
     expect(install).toContain("$ca-doctor");
   });
 
+  it("separates current Codex availability from dated historical proof", () => {
+    const install = read("src/content/docs/getting-started/install.md");
+    expect(install).toContain("current `ca-codex` release");
+    expect(install).toContain("historical evidence");
+    expect(install).toContain("2026-07-11");
+    expect(install).toContain("v2.8.13");
+    expect(install).toContain("ca-codex 0.2.4");
+    expect(install).not.toContain("available now** and were verified against");
+  });
+
+  it("presents both Pi distribution channels wherever hosts are compared", () => {
+    for (const rel of [
+      "src/content/docs/index.mdx",
+      "src/content/docs/getting-started/choose-your-host.md",
+    ]) {
+      const content = read(rel);
+      expect(content, rel).toContain("npm convenience");
+      expect(content, rel).toContain("pinned Git");
+      expect(content, rel).toContain("reproducib");
+    }
+  });
+
   it("keeps operational guidance host-correct", () => {
     const enforcement = read("src/content/docs/enforcement.md");
     const hooks = read("src/content/docs/hooks.md");

--- a/site/test/content/readme-professional.test.ts
+++ b/site/test/content/readme-professional.test.ts
@@ -67,7 +67,10 @@ describe("professional repository README", () => {
   });
 
   it("separates the current Codex adapter from the dated live-install evidence", () => {
-    expect(readme).toContain(`currently ships \`ca-codex ${codexManifest.version}\``);
+    expect(readme).toContain(
+      "current adapter version is read from `plugins/ca-codex/.codex-plugin/plugin.json`",
+    );
+    expect(readme).not.toContain(`currently ships \`ca-codex ${codexManifest.version}\``);
     expect(readme).toContain("dated end-to-end public-install record");
     expect(readme).toContain("`ca-codex 0.2.4` from release `v2.8.13`");
   });

--- a/site/test/landing/landing-page.test.ts
+++ b/site/test/landing/landing-page.test.ts
@@ -182,6 +182,11 @@ describe("first-class product splash", () => {
     }
   });
 
+  it("uses an outcome CTA instead of an unsupported setup-time promise", () => {
+    expect(indexMdx).toContain("Put one repository under governed change.");
+    expect(indexMdx).not.toContain("Protect a repository in five minutes.");
+  });
+
   it("links lifecycle and trust claims to their owning docs", () => {
     expect(indexMdx).toContain("./enforcement/");
     expect(indexMdx).toContain("./codearbiter-directory/");


### PR DESCRIPTION
## Summary

- Bind the current ca-codex live baseline to the canonical plugin manifest and run that check in the ca-codex pre-tag path.
- Preserve dated historical Codex evidence while describing current marketplace availability without duplicating a version string.
- Present Pi's npm convenience channel and pinned Git reproducibility consistently, and replace the unsupported homepage time promise with an outcome-focused call to action.

## Why

Current documentation mixed live availability with older proof, duplicated a version that could drift, omitted one Pi distribution channel in prominent comparisons, and made an unsupported five-minute promise. This change makes the release boundary fail closed when Codex evidence is stale while keeping historical observations immutable.

Conflict hierarchy tradeoff: Safety Core §2 level 2, correctness and data integrity, takes precedence over level 5, developer velocity. A future ca-codex version change must refresh dated live proof before release instead of silently carrying stale evidence.

Relevant decisions: [ADR-0024](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0024-protected-state-declared-executable-input-boundary.md), [ADR-0029](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0029-publish-ca-pi-to-npm-under-arbiterforge.md), [ADR-0032](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0032-hosted-static-codex-release-evidence.md), [ADR-0033](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0033-bind-accepted-adrs-to-obligation-evidence.md), and [ADR-0035](https://github.com/arbiterForge/codeArbiter/blob/main/.codearbiter/decisions/0035-use-reviewed-host-locks-and-two-phase-pi-promotion.md).

## Validation

- `python plugins/ca-codex/hooks/_releaselib.py run-pre-tag ca-codex`: 11 tests passed.
- `npm --prefix site test`: 55 files and 567 tests passed; 19 Academy links remained under the non-root base.
- `npm --prefix site run typecheck`: passed.
- `npm --prefix site run build`: 155 pages built; Pagefind indexed 172 HTML files.
- `npm --prefix site run link-audit`: 26,331 internal links passed.
- `npm --prefix site run coverage`: 74.89% lines and 75.46% branches on Windows; site has no platform fork; stage-2 floor is 70%.
- `python -m unittest discover -s plugins/ca/hooks/tests -p 'test_*.py' -q` with Git Bash `sh` on `PATH`: 1,587 tests passed with four expected skips.
- Full repository-declared Python, Node, release, provenance, hook, route, audit, and generated-surface checks passed.
- Production dependency audit: zero vulnerabilities.
- Independent security, coverage, and architecture review funnel: PASS with zero findings.
- Staged secret scans and `git diff --check`: passed.

## Delivery binding

- Base: `a376978949fc09e51dc4d706df90e11760b1a050`
- Reviewed head: `8213d5c55510a9229850e0933fa695f59410c217`
- ADR ancestry verifier selected: `squash`
- No product release, tag, package publication, credential, provider, Academy source, or destructive cleanup is part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Codex installation guidance to distinguish current release availability from dated historical verification records.
  - Updated adapter version guidance to reference the plugin manifest as the source of truth.
  - Expanded Codex parity-testing instructions with release-specific baseline and metadata requirements.
  - Clarified Pi distribution options: npm for convenience and pinned Git tags for reproducible installs.
  - Refined landing-page and host-selection messaging.

- **Release Validation**
  - Added pre-release verification for public Codex documentation before tagging Codex releases.
  - Expanded checks for release metadata and documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->