### PR TITLE
docs(site): align public naming policy

### DIFF
--- a/site/VOICE.md
+++ b/site/VOICE.md
@@ -52,9 +52,9 @@ synonym:
   proceed until fixed.
 - **override** — the sanctioned, logged bypass (`/override`). Never "workaround" or
   "skip."
-- **Feature Forge** — the two-axis preview-features system. In navigation and
-  reader-facing copy it is labeled "Preview Features"; "Feature Forge" is the internal
-  name and may appear in explanatory prose once introduced.
+- **Feature Forge** — the two-axis feature-maturity system. In navigation and
+  reader-facing copy it is labeled "Feature Forge"; "preview" and "stable" are maturity
+  labels within the Forge, not alternative names for the system.
 - **tribunal** — the deep, rarely-convened whole-codebase audit (`/ca:tribunal`). Not a
   synonym for the routine `/ca:checkpoint` sweep.
 

--- a/site/scripts/generate-academy.test.ts
+++ b/site/scripts/generate-academy.test.ts
@@ -352,6 +352,7 @@ describe("generateAcademy", () => {
     ]);
     const indexPage = readFileSync(join(docsRoot, "academy", "index.mdx"), "utf8");
     expect(existsSync(academyOverviewComponent)).toBe(true);
+    expect(indexPage).toContain('description: "Guided, evidence-based practice for the codeArbiter workflow."');
     expect(indexPage).toContain('import AcademyOverview from "../../../components/AcademyOverview.astro";');
     expect(indexPage).toContain("<AcademyOverview />");
     expect(indexPage).not.toMatch(/<h1\b/i);

--- a/site/scripts/generate-academy.ts
+++ b/site/scripts/generate-academy.ts
@@ -124,7 +124,7 @@ function renderIndex(source: AcademySource): string {
   return [
     "---",
     'title: "Arbiter Academy"',
-    'description: "Guided, evidence-based practice for the CodeArbiter workflow."',
+    'description: "Guided, evidence-based practice for the codeArbiter workflow."',
     "journey:",
     '  level: "Academy"',
     '  time: "Self-paced"',

--- a/site/src/components/AcademyCommandPreferences.astro
+++ b/site/src/components/AcademyCommandPreferences.astro
@@ -38,7 +38,7 @@ const shouldRender = shouldRenderCommandPreferences(variants);
     <ca-academy-preferences class="academy-command-preferences" hidden>
       <div class="academy-command-preferences__intro">
         <strong>Use your setup</strong>
-        <p>Choose an operating system or CodeArbiter host to focus every command example in this lesson. Your choices stay on this device.</p>
+        <p>Choose an operating system or codeArbiter host to focus every command example in this lesson. Your choices stay on this device.</p>
       </div>
       {
         availableOperatingSystems.length > 0 && (
@@ -55,7 +55,7 @@ const shouldRender = shouldRenderCommandPreferences(variants);
       {
         availableHosts.length > 0 && (
           <fieldset class="academy-command-preferences__group">
-            <legend>CodeArbiter host</legend>
+            <legend>codeArbiter host</legend>
             <div>
               {availableHosts.map((host) => (
                 <button type="button" data-academy-host={host} aria-pressed="false">{labels[host]}</button>

--- a/site/src/components/AcademyOverview.astro
+++ b/site/src/components/AcademyOverview.astro
@@ -68,7 +68,7 @@ const variantLabel = (variant: AcademyCommandVariant) =>
     <p class="academy-overview__eyebrow">Arbiter Academy</p>
     <h1 id="academy-overview-title">Learn governed delivery by doing the work.</h1>
     <p class="academy-overview__lede">
-      Build CodeArbiter habits through bounded, verifiable practice in a safe fork you own.
+      Build codeArbiter habits through bounded, verifiable practice in a safe fork you own.
     </p>
     <div class="academy-overview__actions">
       <a

--- a/site/test/academy-command-preferences-presentation.test.ts
+++ b/site/test/academy-command-preferences-presentation.test.ts
@@ -19,7 +19,7 @@ describe("Academy command preference presentation", () => {
 
   it("keeps the setup explanation and choice groups in the original stacked hierarchy", () => {
     expect(component).toContain("Use your setup");
-    expect(component).toContain("Choose an operating system or CodeArbiter host to focus every command example in this lesson. Your choices stay on this device.");
+    expect(component).toContain("Choose an operating system or codeArbiter host to focus every command example in this lesson. Your choices stay on this device.");
     expect(preferenceRule).toContain("display: grid;");
     expect(preferenceRule).toContain("background: var(--ca-bg-raised);");
   });
@@ -27,7 +27,7 @@ describe("Academy command preference presentation", () => {
   it("uses native legends above each choice row", () => {
     expect(component).toContain('<fieldset class="academy-command-preferences__group">');
     expect(component).toContain("<legend>Operating system</legend>");
-    expect(component).toContain("<legend>CodeArbiter host</legend>");
+    expect(component).toContain("<legend>codeArbiter host</legend>");
   });
 
   it("gives every operating-system and host choice the same stable control size", () => {

--- a/site/test/content/naming-policy.test.ts
+++ b/site/test/content/naming-policy.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const siteRoot = join(import.meta.dirname, "..", "..");
+const readSiteFile = (path: string): string => readFileSync(join(siteRoot, path), "utf8");
+
+describe("approved naming policy", () => {
+  it("uses codeArbiter in mutable codeArbiter-owned Academy framing", () => {
+    const overview = readSiteFile("src/components/AcademyOverview.astro");
+    const preferences = readSiteFile("src/components/AcademyCommandPreferences.astro");
+    const generator = readSiteFile("scripts/generate-academy.ts");
+
+    expect(overview).toContain("Build codeArbiter habits");
+    expect(overview).not.toContain("Build CodeArbiter habits");
+    expect(preferences).toContain("codeArbiter host");
+    expect(preferences).not.toContain("CodeArbiter host");
+    expect(generator).toContain("practice for the codeArbiter workflow");
+    expect(generator).not.toContain("practice for the CodeArbiter workflow");
+  });
+
+  it("defines Feature Forge as the public navigation label without changing preview maturity", () => {
+    const voice = readSiteFile("VOICE.md");
+    const astroConfig = readSiteFile("astro.config.mjs");
+
+    expect(voice).toMatch(/In navigation and\s+reader-facing copy it is labeled "Feature Forge"/);
+    expect(voice).toMatch(/"preview" and "stable" are maturity\s+labels/);
+    expect(voice).not.toContain('reader-facing copy it is labeled "Preview Features"');
+    expect(astroConfig).toContain('label: "Feature Forge"');
+  });
+});


### PR DESCRIPTION
## Summary

Align mutable codeArbiter-owned Academy framing with the approved `codeArbiter` casing and establish `Feature Forge` as the public navigation label. Preview and stable remain maturity labels, and technical identifiers, routes, historical text, and Academy-owned source remain unchanged.

## Verification

- Focused naming and generator tests: 17 passed
- Full site suite: 569 passed across 56 files, including the Academy non-root-base check
- Site coverage: 74.89% lines and 75.46% branches, above the stage 2 threshold
- Typecheck passed
- Production build completed with 155 pages
- Link audit resolved 26,331 internal links across 172 pages
- Production dependency audit found zero vulnerabilities
- Repository test matrix passed, including 1,587 hook tests with four expected skips
- Diff and secret checks passed
- Independent coverage, architecture, triage, and aggregate reviews reported zero findings

## Delivery

ADR ancestry selected `squash` for base `93a360440e51355cc067716d85b1ff25973975cf` and reviewed head `c6b8b716`.

The worktree retains two local append-only governance warnings generated during exhaustive hook tests. They are intentionally excluded from this product change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified “Feature Forge” as the two-axis feature-maturity system.
  - Updated reader-facing and navigation language to use “Feature Forge,” with “preview” and “stable” as maturity levels.
  - Standardized product naming as “codeArbiter” across Academy content and command preferences.
  - Updated the Academy index description to provide clearer context about guided, evidence-based practice.

- **Tests**
  - Added coverage to verify naming and navigation terminology remains consistent.
  - Expanded Academy generation checks to validate the published index description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->