### PR TITLE
fix(mode): per-session mode entries + marker case-fold (#624)

### DIFF
--- a/.codearbiter/decisions/decision-log.md
+++ b/.codearbiter/decisions/decision-log.md
@@ -1430,3 +1430,28 @@ Recording-only entry; the decision's rationale lives in DECISION-0044 and in ADR
 Unblocks the command-deletion cluster, which was gated on an accepted ADR standing behind the ADR-0022 supersession. T-66b (editing the `{{CMD:dev}}` assertion at `test_routing_and_cleanup_surface.py:79-93` — the supersession act itself) is now permitted, and with it T-64 (deleting the two command bodies), T-65 (stripping the 7 surviving `{{CMD:}}` tokens), and T-67 (catalog badge 40 to 38). Acceptance also makes ADR-0030's `governs:` globs live, so edits to the mode bodies, `_modelib.py`, and the injection path now surface a governed-file notice at write time.
 
 ---
+
+## DECISION-0046 — mode-state-shape — Per-session mode entry files replace the shared session map
+
+**Date:** 2026-08-13
+**Status:** accepted
+**Supersedes:** none
+**Decided by:** User explicitly accepted recommendation as their decision — the choice between the two candidate fixes was delegated to SMARTS scoring ("yes. and make choice based on smarts", 2026-08-13).
+**Decision category:** architecture
+**Artifact-section-hash:** n/a
+
+### Variance summary
+- **Artifact position:** ADR-0030 position 5 requires the return path out of `dangerous` to be a verified write that surfaces its failure; the spec's State line put every session's posture in one `.markers/mode` map.
+- **Scaffold position:** `write_mode` verified only the calling session's own key, so a session holding a map read moments earlier could reinstate a `dangerous` entry another session had explicitly left — with that session's own earlier `enter` row still satisfying `ledger_backs`, so the reinstated gates-off posture was authorized and silent.
+- **Status type:** divergent
+
+### Decision
+The mode plane's state becomes one file per session under `.codearbiter/.markers/mode.d/`, named by the SHA-256 of the session id and carrying that id inside the record. `write_mode` no longer performs a read-modify-write and no longer retries; it writes one path and verifies it. The pre-split `.markers/mode` map is read-only, consulted when a session has no entry of its own, so a session live across the upgrade keeps its posture and an explicit `arbiter` still reads as a choice rather than as "never flipped".
+
+### SMARTS rationale
+Scored against the alternative — serializing the read-modify-write with `_hooklib.acquire_lock`. Reliable and Available drove it: removing the shared cell makes the interleave structurally impossible rather than serialized, and leaves no contention state, where a lock on the prompt seam fail-softs to None after a bounded spin and the only safe reading of None is a failed flip. Securable follows Reliable, since the defect being closed is a fail-open. Testable favours the split too: the guarantee is assertable on the filesystem without simulating an interleave. Maintainable was the lock's one win — it would have touched a single function instead of the reader, the staleness registry, and three vendored copies — which makes this `moderate`, not `strong`. Step 0: ADR-0012 constrains rather than decides, naming "session-scoped markers" as the deferred hardening it declined to demand of the Codex campaign; ADR-0030 position 6 already fixes the plane as transient and session-scoped.
+
+### Implementation implication
+`core/pysrc/_modelib.py` gains `mode_entry_dir` / `mode_entry_path` / `session_has_entry` and drops the retry loop; `session-start.py`'s legacy-conversion check moves from a raw map membership test to `session_has_entry`; `_hooklib._STALE_FLOWS` points at the directory and gains `_mode_plane_active_since`, which also fixes an unrelated session's write resetting a stale session's staleness clock. Regenerated into the three vendored `plugins/*/hooks/` copies. The spec's State line is amended in place; `docs/hooks.md` and the dual-host concurrency section of `site/src/content/docs/getting-started/claude-code-and-codex.md` are corrected, the latter having documented the now-fixed race as accepted debt.
+
+---

--- a/.codearbiter/specs/mode-plane-deterministic-flip.md
+++ b/.codearbiter/specs/mode-plane-deterministic-flip.md
@@ -65,11 +65,17 @@ and release surfaces; `CONTEXT.md` vocabulary.
 - **Token:** `mode --arbiter|--dangerous|--ops`, matched **whole-prompt, never substring**, case- and
   surrounding-whitespace-insensitive. Bare `mode` reports current mode and legal values on stderr, exits
   2, writes nothing.
-- **State:** `.codearbiter/.markers/mode`, keyed by `session_id` (the `dev-session-owner.json` pattern),
-  under **`marker_root`** — *correcting an earlier error: `marker_root` exists precisely because
+- **State:** `.codearbiter/.markers/mode.d/<sha256(session_id)>`, **one file per session**, under
+  **`marker_root`** — *correcting an earlier error: `marker_root` exists precisely because
   `project_root` splits marker state across linked worktrees (#604), and this repo runs worktree agents
   routinely.* Absent, empty, unreadable, or unknown value ⇒ `arbiter` **with a diagnostic that
   distinguishes unreadable from absent** (house rule `never-fold-unreadable-into-absent`).
+  *Amended (#681): this shipped as a single `.markers/mode` file holding a `{session_id: mode}` map.
+  Keying by session inside one file still made every flip a read-modify-write over state other
+  sessions own, so a session holding a map it read moments earlier could reinstate a `dangerous`
+  entry another session had explicitly left — authorized, because `ledger_backs` still matched that
+  session's original `enter` row. Verifying the write did not close it: each writer confirmed only
+  its OWN key. The map is now read-only for migration; nothing writes it.*
 - **Lifetime:** cleared at `SessionStart`, matching today's `dev-active` contract. Gates-off must not
   survive a session boundary.
 - **Single source of truth:** every reader migrates to the mode file; `dev-active` is not dual-written.

--- a/.github/scripts/test_mode_readers.py
+++ b/.github/scripts/test_mode_readers.py
@@ -298,6 +298,25 @@ class TestStaleFlowsReadsPerSessionEntries(unittest.TestCase):
                         "an unrelated session's write suppressed a stale "
                         "dangerous session's warning")
 
+    def test_the_newest_non_arbiter_entry_sets_the_clock_not_the_oldest(self):
+        """With several non-arbiter sessions, staleness is judged from the most
+        recent one — the oldest must not trip a warn on its own.
+
+        The scan reads newest-first and stops at the first non-arbiter entry, so
+        an ordering bug here would silently answer with whichever entry the
+        filesystem happened to list first.
+        """
+        _modelib.write_mode("old-one", "dangerous", root=self.root)
+        _age(self._entry("old-one"), age_seconds=3600)
+        _modelib.write_mode("new-one", "dangerous", root=self.root)   # fresh
+        self.assertEqual(_hooklib.staleness_warning(self.root, window_minutes=30), [],
+                         "an old entry decided the clock while a newer session "
+                         "in the same posture was still active")
+        _age(self._entry("new-one"), age_seconds=3600)
+        self.assertTrue(
+            any("mode" in m for m in _hooklib.staleness_warning(self.root, window_minutes=30)),
+            "once every non-arbiter entry is old, the warn must fire")
+
     def test_corrupt_entry_never_raises_and_proves_nothing_active(self):
         _modelib.write_mode("sess-1", "dangerous", root=self.root)
         with open(self._entry("sess-1"), "w", encoding="utf-8") as f:

--- a/.github/scripts/test_mode_readers.py
+++ b/.github/scripts/test_mode_readers.py
@@ -234,6 +234,78 @@ class TestStaleFlowsModeAware(unittest.TestCase):
         self.assertEqual(messages, [])  # corrupt -> nothing provably active, never raises
 
 
+class TestStaleFlowsReadsPerSessionEntries(unittest.TestCase):
+    """(#681) The same AC-36 contract, driven through `write_mode` rather than
+    a hand-seeded legacy map.
+
+    The class above still seeds `.markers/mode` directly, which is now the
+    PRE-SPLIT shape nothing writes any more. Left alone, every one of those
+    cases would keep passing while the matcher no longer saw a single live
+    session — the permanently-silent WARN the Lane F brief names, arrived at
+    from a new direction. These cases go through the writer the running code
+    uses, so the registry is measured against state a real session produces.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.cad = os.path.join(self.root, ".codearbiter")
+        os.makedirs(self.cad)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _entry(self, session_id):
+        return _modelib.mode_entry_path(session_id, root=self.root)
+
+    def test_stale_dangerous_session_warns(self):
+        _modelib.write_mode("sess-1", "dangerous", root=self.root)
+        _age(self._entry("sess-1"), age_seconds=3600)
+        messages = _hooklib.staleness_warning(self.root, window_minutes=30)
+        self.assertTrue(any("mode" in m for m in messages), messages)
+
+    def test_stale_ops_session_warns(self):
+        _modelib.write_mode("sess-1", "ops", root=self.root)
+        _age(self._entry("sess-1"), age_seconds=3600)
+        messages = _hooklib.staleness_warning(self.root, window_minutes=30)
+        self.assertTrue(any("mode" in m for m in messages), messages)
+
+    def test_stale_arbiter_only_entries_never_warn(self):
+        for sid in ("sess-1", "sess-2"):
+            _modelib.write_mode(sid, "arbiter", root=self.root)
+            _age(self._entry(sid), age_seconds=3600)
+        self.assertEqual(_hooklib.staleness_warning(self.root, window_minutes=30), [])
+
+    def test_fresh_dangerous_session_does_not_warn_yet(self):
+        _modelib.write_mode("sess-1", "dangerous", root=self.root)
+        _age(self._entry("sess-1"), age_seconds=5)
+        self.assertEqual(_hooklib.staleness_warning(self.root, window_minutes=30), [])
+
+    def test_another_sessions_flip_no_longer_resets_this_sessions_clock(self):
+        """The accuracy the split buys, asserted so it cannot regress.
+
+        Under the shared map, ANY session's write bumped the one file's mtime,
+        so an unrelated session starting up reset the staleness clock for a
+        session sitting in `dangerous` — the warning could be deferred forever
+        by traffic that had nothing to do with it. Per-session entries make the
+        timestamp the flipping session's own.
+        """
+        _modelib.write_mode("stale-one", "dangerous", root=self.root)
+        _age(self._entry("stale-one"), age_seconds=3600)
+        _modelib.write_mode("busy-one", "arbiter", root=self.root)   # fresh, unrelated
+        messages = _hooklib.staleness_warning(self.root, window_minutes=30)
+        self.assertTrue(any("mode" in m for m in messages),
+                        "an unrelated session's write suppressed a stale "
+                        "dangerous session's warning")
+
+    def test_corrupt_entry_never_raises_and_proves_nothing_active(self):
+        _modelib.write_mode("sess-1", "dangerous", root=self.root)
+        with open(self._entry("sess-1"), "w", encoding="utf-8") as f:
+            f.write("{not valid json")
+        _age(self._entry("sess-1"), age_seconds=3600)
+        self.assertEqual(_hooklib.staleness_warning(self.root, window_minutes=30), [])
+
+
 # ---------------------------------------------------------------------------
 # T-55 — override counter excludes MODE:/legacy DEV: rows
 # ---------------------------------------------------------------------------

--- a/.github/scripts/test_modelib.py
+++ b/.github/scripts/test_modelib.py
@@ -230,6 +230,8 @@ class TestWriteMode(unittest.TestCase):
         self.root = self._tmp.name
         self.markers = os.path.join(self.root, ".codearbiter", ".markers")
         self.mode_path = os.path.join(self.markers, "mode")
+        self.entry_dir = os.path.join(self.markers, "mode.d")
+        self.entry_path = _modelib.mode_entry_path("sess-1", root=self.root)
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -250,9 +252,30 @@ class TestWriteMode(unittest.TestCase):
         self.assertTrue(ok)
         spy.assert_called_once()
         args, kwargs = spy.call_args
-        self.assertEqual(args[0], self.mode_path)
+        self.assertEqual(args[0], self.entry_path)
         self.assertIn("dangerous", args[1])
         self.assertEqual(kwargs.get("newline"), "\n")
+
+    def test_a_write_touches_only_this_sessions_entry(self):
+        """The structural guarantee, asserted on the filesystem.
+
+        A write that touched any second path would be a shared cell again, and
+        the interleave tests below would be the only thing standing between
+        that and a silent posture revert.
+        """
+        _modelib.write_mode("sess-OTHER", "ops", root=self.root)
+        before = {n: os.stat(os.path.join(self.entry_dir, n)).st_mtime_ns
+                  for n in os.listdir(self.entry_dir)}
+        _modelib.write_mode("sess-1", "dangerous", root=self.root)
+        after = {n: os.stat(os.path.join(self.entry_dir, n)).st_mtime_ns
+                 for n in os.listdir(self.entry_dir)}
+        self.assertEqual(set(after) - set(before),
+                         {os.path.basename(self.entry_path)})
+        for name, stamp in before.items():
+            self.assertEqual(after[name], stamp,
+                             "writing one session's mode rewrote another's entry")
+        self.assertFalse(os.path.exists(self.mode_path),
+                         "the legacy shared map must never be written again")
 
     def test_a_real_write_round_trips_through_current_mode(self):
         ok = _modelib.write_mode("sess-1", "dangerous", root=self.root)
@@ -266,9 +289,11 @@ class TestWriteMode(unittest.TestCase):
         with mock.patch("_modelib.write_text_atomic", side_effect=OSError("disk full")):
             ok = _modelib.write_mode("sess-1", "dangerous", root=self.root)
         self.assertFalse(ok)
-        self.assertFalse(os.path.isfile(self.mode_path),
-                         "an interrupted write must leave no partial mode file")
-        leftovers = [n for n in os.listdir(self.markers) if n.endswith(".tmp")]
+        self.assertFalse(os.path.isfile(self.entry_path),
+                         "an interrupted write must leave no partial mode entry")
+        # Scanned in the entry directory, where the temp now lands. Left
+        # pointed at `.markers/` this would pass while measuring nothing.
+        leftovers = [n for n in os.listdir(self.entry_dir) if n.endswith(".tmp")]
         self.assertEqual(leftovers, [], "no orphaned temp file may survive a failed write")
 
 
@@ -740,23 +765,38 @@ class TestWriteModeIsVerified(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
-    def test_a_write_clobbered_by_a_concurrent_session_is_retried(self):
-        """Simulates the interleave: the first replace is immediately undone."""
+    def test_a_write_undone_before_it_can_be_confirmed_reports_failure(self):
+        """A write that does not survive to its own verification is a failure.
+
+        This case used to assert the opposite — that `write_mode` RETRIED until
+        it landed — because the entry was a shared map any session might
+        replace, so a clobber was routine and recoverable. Per-session entries
+        make it neither: nothing else writes this path, so content that is not
+        ours means the file was corrupted or replaced out of band. Retrying
+        would be a loop that overwrites whatever did that, and reporting
+        success would claim a posture the entry does not carry. ADR-0030
+        position 5 wants the failure surfaced, and `flip` turns this False into
+        FLIP_FAILED.
+        """
         original = _modelib.write_text_atomic
         calls = {"n": 0}
 
         def clobbering(path, text, **kwargs):
             original(path, text, **kwargs)
             calls["n"] += 1
-            if calls["n"] == 1:                      # a concurrent writer lands after us
-                original(path, json.dumps({"other": "ops"}), **kwargs)
+            if calls["n"] == 1:                      # something replaces it behind us
+                original(path, json.dumps({"session": "someone-else",
+                                           "mode": "ops"}), **kwargs)
 
         with mock.patch.object(_modelib, "write_text_atomic", clobbering):
             ok = _modelib.write_mode("mine", "arbiter", root=self.root)
 
-        self.assertTrue(ok, "a clobbered write reported success without landing")
-        state, _ = _modelib._read_mode_state(self.root)
-        self.assertEqual(state.get("mine"), "arbiter")
+        self.assertFalse(ok, "reported success for a write it could not confirm")
+        mode, diag = _modelib.current_mode("mine", root=self.root)
+        self.assertEqual(mode, "arbiter", "an unconfirmed write must resolve safe")
+        self.assertEqual(diag, _modelib.MODE_DIAG_UNRECOGNIZED,
+                         "an entry belonging to another session is an anomaly, "
+                         "not a silent default")
 
     def test_a_write_that_never_lands_reports_failure(self):
         """Never claim a success that cannot be demonstrated."""
@@ -769,9 +809,119 @@ class TestWriteModeIsVerified(unittest.TestCase):
     def test_a_concurrent_sessions_entry_is_preserved(self):
         _modelib.write_mode("other", "dangerous", root=self.root)
         _modelib.write_mode("mine", "ops", root=self.root)
-        state, _ = _modelib._read_mode_state(self.root)
-        self.assertEqual(state.get("other"), "dangerous")
-        self.assertEqual(state.get("mine"), "ops")
+        self.assertEqual(_modelib.current_mode("other", root=self.root)[0], "dangerous")
+        self.assertEqual(_modelib.current_mode("mine", root=self.root)[0], "ops")
+
+    # -- the interleave the own-key verify cannot see ----------------------
+    #
+    # Serial writes both read the LATEST state, so they can never express the
+    # ordering that actually loses data: `other` reads, `mine` writes, `other`
+    # then replaces the file from the map it read BEFORE that write. `other`'s
+    # verify passes — it only ever checks its OWN key — and `mine` has already
+    # returned True, so neither writer can observe the loss.
+    #
+    # `_interleaved_write` reproduces exactly that ordering: it lets `victim`
+    # complete an entire write in the window between the stale writer's read
+    # and its replace.
+
+    def _interleaved_write(self, victim_session, victim_mode):
+        """Patch context: run one full `write_mode(victim…)` inside the next
+        `write_text_atomic` call, before it lands."""
+        original = _modelib.write_text_atomic
+        state = {"fired": False}
+        root = self.root
+
+        def interleave(path, text, **kwargs):
+            if not state["fired"]:
+                state["fired"] = True   # set first: the nested write re-enters here
+                _modelib.write_mode(victim_session, victim_mode, root=root)
+            return original(path, text, **kwargs)
+
+        return mock.patch.object(_modelib, "write_text_atomic", interleave)
+
+    def test_a_stale_writer_cannot_revert_another_sessions_return_to_arbiter(self):
+        """The fail-OPEN direction, and the reason this is not merely state loss.
+
+        `A` enters `dangerous`, then explicitly returns to `arbiter` — gates back
+        on. A concurrent session completes its own write from the map it read
+        before that return, reinstating `dangerous` for `A` with no operator
+        action and no new audit row. `ledger_backs` still matches `A`'s original
+        `enter` row, so the reinstated posture is authorized: exactly the silent
+        gates-off transition ADR-0030 position 5 forbids.
+        """
+        self.assertEqual(_modelib.flip("A", "dangerous", root=self.root),
+                         _modelib.FLIP_FLIPPED)
+
+        # A's return to arbiter happens INSIDE the window — after the other
+        # session has read the map that still says `dangerous`, before its
+        # replace lands. Flipping A back before the window instead would leave
+        # the stale reader holding an already-correct map and prove nothing.
+        with self._interleaved_write("A", "arbiter"):
+            _modelib.write_mode("B", "ops", root=self.root)
+
+        self.assertEqual(
+            _modelib.current_mode("A", root=self.root)[0], "arbiter",
+            "a concurrent session's write reinstated a gates-off mode that A "
+            "had explicitly left — and A's original enter row still backs it: "
+            "ledger_backs={}".format(
+                _modelib.ledger_backs(self.root, "dangerous", session_id="A")))
+
+    def test_a_stale_writer_cannot_erase_another_sessions_entry(self):
+        """The erase direction, which is a distinct defect from the revert.
+
+        A dropped entry does not merely lose a posture: an ABSENT entry is how
+        the compaction path (`session-start.py`, T-47) recognises a session with
+        no mode-plane opinion yet, so erasing one re-arms a legacy `dev-active`
+        marker to be converted to `dangerous` on top of a session that had
+        already chosen.
+        """
+        with self._interleaved_write("A", "dangerous"):
+            _modelib.write_mode("B", "ops", root=self.root)
+
+        self.assertTrue(
+            _modelib.session_has_entry("A", root=self.root)[0],
+            "a concurrent session's write erased A's entry — absence is read as "
+            "'never flipped', which re-arms the legacy dangerous conversion")
+        self.assertEqual(_modelib.current_mode("A", root=self.root)[0], "dangerous")
+
+    def test_two_sessions_never_write_the_same_path(self):
+        """The structural property that makes the two cases above impossible.
+
+        Asserted directly rather than only through the interleave, so a future
+        change that reintroduces a shared cell fails here first, with a message
+        that names the cause instead of a symptom.
+        """
+        self.assertNotEqual(_modelib.mode_entry_path("A", root=self.root),
+                            _modelib.mode_entry_path("B", root=self.root))
+
+    def test_a_session_id_cannot_escape_the_entry_directory(self):
+        """A session id reaches this from host-supplied hook input, so it is
+        untrusted for path construction. Traversal, separators, and reserved
+        names must all resolve inside the entry directory."""
+        entry_dir = os.path.abspath(_modelib.mode_entry_dir(root=self.root))
+        for hostile in ("../../escaped", r"..\..\escaped", "a/b", "a\\b",
+                        ".", "..", "", "con", "x" * 400):
+            with self.subTest(session_id=hostile):
+                path = os.path.abspath(
+                    _modelib.mode_entry_path(hostile, root=self.root))
+                self.assertEqual(os.path.dirname(path), entry_dir,
+                                 "entry path escaped the mode entry directory")
+                self.assertTrue(os.path.basename(path))
+
+    def test_distinct_session_ids_never_share_an_entry_file(self):
+        """Sanitisation must be injective: two ids collapsing onto one filename
+        would reintroduce the shared cell this design removes.
+
+        Compared CASE-INSENSITIVELY, because this repo is Windows-primary and
+        NTFS is case-insensitive — two names differing only in case are one
+        file there. A sanitiser that merely substitutes unsafe characters
+        passes a case-sensitive set comparison while `A` and `a` share an entry
+        on the platform most of this project's sessions run on.
+        """
+        ids = ["a/b", "a\\b", "a_b", "../b", "A", "a", "x" * 400, "x" * 401]
+        names = [os.path.basename(_modelib.mode_entry_path(s, root=self.root))
+                 for s in ids]
+        self.assertEqual(len({n.lower() for n in names}), len(set(ids)))
 
 
 class TestEnterRowIsLedgerBacked(unittest.TestCase):

--- a/.github/scripts/test_prompt_submit.py
+++ b/.github/scripts/test_prompt_submit.py
@@ -115,8 +115,18 @@ class _Fixture(unittest.TestCase):
         with open(path, encoding="utf-8") as f:
             return f.read()
 
-    def mode_marker_bytes(self):
-        path = _modelib.mode_marker_path(root=self.root)
+    def mode_marker_bytes(self, session_id="s1"):
+        """The on-disk bytes of `session_id`'s mode entry, or None when it has
+        none — the "did this turn write anything" probe.
+
+        Reads the per-session entry, NOT the pre-#681 `.markers/mode` map.
+        Left on the map this returned None unconditionally, since nothing
+        writes that file any more: `assertIsNone(...)` and
+        `assertEqual(before, after)` would both hold no matter what a turn
+        did, and the three "writes nothing" assertions built on it would have
+        gone silent together while staying green.
+        """
+        path = _modelib.mode_entry_path(session_id, root=self.root)
         if not os.path.isfile(path):
             return None
         with open(path, "rb") as f:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ predate the plugin rewrite and are grouped by date.
 
 ## [Unreleased]
 
+## [2.15.2] — 2026-08-13
+
+### Fixed
+
+- The orchestration mode is now stored one file per session under `.codearbiter/.markers/mode.d/`, replacing the single shared map. Two sessions in one checkout could previously overwrite each other's posture: a session that left `dangerous` for `arbiter` could have `dangerous` silently reinstated by a concurrent write, still authorized by its own earlier audit row. Each session now writes only its own entry, so no flip can revert or drop another's.
+- The mode-plane staleness warning reads each session's own entry, so an unrelated session starting up no longer resets the clock on a session that has sat in `dangerous`.
+
 ## [2.15.1] — 2026-08-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project context. You decide. codeArbiter enforces.
 <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude_Code-plugin-d97757">
 <img alt="Codex plugin" src="https://img.shields.io/badge/OpenAI_Codex-plugin-10a37f">
 <img alt="Pi Feature Forge preview" src="https://img.shields.io/badge/ca--pi-Feature_Forge_preview-d97757">
-<img alt="version 2.15.1" src="https://img.shields.io/badge/version-2.15.1-2b7489">
+<img alt="version 2.15.2" src="https://img.shields.io/badge/version-2.15.2-2b7489">
 <img alt="commands" src="https://img.shields.io/badge/commands-38-555">
 <img alt="skills" src="https://img.shields.io/badge/skills-23-555">
 <img alt="agents" src="https://img.shields.io/badge/agents-18-555">
@@ -119,7 +119,7 @@ Approve the normal plugin trust prompt, open the target repository, and continue
 
 ### Codex CLI
 
-The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.1`;
+The public GitHub-slug flow is **available now**. The repository currently ships `ca-codex 0.7.2`;
 the dated end-to-end public-install record discovered `ca-codex 0.2.4` from release `v2.8.13`.
 Current packaging and shared-core parity are continuously verified, while that dated live-install
 record stays labeled rather than being silently promoted to evidence for a newer adapter:

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -533,7 +533,7 @@ def warn(msg):
 # no matching activity in its expected audit log.
 #
 # Only the mode plane and /sprint have a persistent "in-progress" marker
-# today (.codearbiter/.markers/mode and .codearbiter/sprint-active — the same
+# today (.codearbiter/.markers/mode.d/ and .codearbiter/sprint-active — the same
 # state _arbiterstatelib.current_mode()/arbiter_state() already read; the
 # mode marker is #437's direct successor to the retired dev-active marker
 # this comment originally described). /override is a single synchronous
@@ -562,7 +562,14 @@ _STALE_FLOWS = (
     # rename is the one hazard this whole registry exists to avoid: it is a
     # WARN, not a gate, so a stale matcher fails PERMANENTLY SILENT with an
     # otherwise green suite — nothing else in the repo would ever notice.
-    ("mode", (".markers", "mode"), ("overrides.log",)),
+    #
+    # #681 moved the target again, from that one file to the per-session entry
+    # DIRECTORY, for the same reason: pointed at `mode`, this row would have
+    # kept matching a file nothing writes any more and gone silent exactly as
+    # the note above warns. This row's marker is therefore a directory, and
+    # `_mode_plane_active_since` — not `os.path.isfile` + `getmtime` — answers
+    # both "is anything active" and "since when" for it.
+    ("mode", (".markers", "mode.d"), ("overrides.log",)),
     ("sprint", ("sprint-active",), ("sprint-log.md",)),
 )
 
@@ -595,6 +602,58 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+def _mode_plane_active_since(cad):
+    """(#681) Newest mtime among per-session mode entries in a NON-arbiter
+    posture, or None when the mode plane is not active.
+
+    Replaces the single marker file's stat for this flow. The plane is now a
+    directory of one-file-per-session entries (`_modelib.mode_entry_dir`),
+    which changes both halves of the question this registry asks:
+
+    - *Active* is still "some session is non-arbiter", but it is now answered
+      per entry rather than over one map's values.
+    - *Since when* gets strictly more accurate. The shared map's mtime was
+      bumped by ANY session's write, so one arbiter session flipping reset the
+      staleness clock for a different session sitting in `dangerous`. An
+      entry's own mtime is that session's own last flip.
+
+    Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
+    Never raises: this whole registry is a WARN, and a matcher that stopped
+    matching would fail permanently SILENT with a green suite — the exact
+    hazard `_STALE_FLOWS`' own comment names.
+
+    Duplicates the literal 'arbiter' for the same reason
+    `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
+    `write_text_atomic` from this module, so importing back would be circular.
+    """
+    newest = None
+    entry_dir = os.path.join(cad, ".markers", "mode.d")
+    try:
+        names = os.listdir(entry_dir)
+    except OSError:  # no directory yet -> no per-session entries to weigh
+        names = []
+    for name in names:
+        path = os.path.join(entry_dir, name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
+                continue
+            mtime = os.path.getmtime(path)
+        except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
+            continue
+        newest = mtime if newest is None else max(newest, mtime)
+    if newest is not None:
+        return newest
+    legacy = os.path.join(cad, ".markers", "mode")
+    if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
+        try:
+            return os.path.getmtime(legacy)
+        except OSError:
+            return None
+    return None
+
+
 def staleness_warning(root, now=None, window_minutes=30):
     """(CONFIRM-09) One WARN message per active flow (see _STALE_FLOWS) whose
     marker has existed for at least `window_minutes` with no audit-log
@@ -612,11 +671,15 @@ def staleness_warning(root, now=None, window_minutes=30):
     for name, marker_parts, log_parts in _STALE_FLOWS:
         try:
             marker = os.path.join(cad, *marker_parts)
-            if not os.path.isfile(marker):
-                continue
-            if name == "mode" and not _mode_marker_has_non_arbiter_entry(marker):
-                continue  # AC-36: never warn for arbiter — presence alone isn't "active"
-            marker_mtime = os.path.getmtime(marker)
+            if name == "mode":
+                # AC-36: never warn for arbiter — presence alone isn't "active".
+                marker_mtime = _mode_plane_active_since(cad)
+                if marker_mtime is None:
+                    continue
+            else:
+                if not os.path.isfile(marker):
+                    continue
+                marker_mtime = os.path.getmtime(marker)
             if now - marker_mtime < window_minutes * 60:
                 continue  # flow started too recently to call it stale yet
             log_path = os.path.join(cad, *log_parts)

--- a/core/pysrc/_hooklib.py
+++ b/core/pysrc/_hooklib.py
@@ -602,6 +602,16 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+# Worst-case bound on the entry scan below: the all-arbiter case, where the
+# newest-first early exit never fires and every entry would otherwise be read
+# on every prompt. 64 is far above any plausible count of sessions live at once
+# and far below the unbounded total a long-lived repo accumulates. Capping
+# costs only a WARN — a flow older than the 64 most recently touched sessions
+# goes unreported, which this registry's own contract already tolerates
+# ("a missed warn is acceptable; a crash is not", prune-transcript.py).
+_MODE_ENTRY_SCAN_MAX = 64
+
+
 def _mode_plane_active_since(cad):
     """(#681) Newest mtime among per-session mode entries in a NON-arbiter
     posture, or None when the mode plane is not active.
@@ -617,6 +627,10 @@ def _mode_plane_active_since(cad):
       staleness clock for a different session sitting in `dangerous`. An
       entry's own mtime is that session's own last flip.
 
+    Bounded: entries are examined newest-first and the scan stops at the first
+    non-arbiter one (which is by definition the newest), with a hard
+    `_MODE_ENTRY_SCAN_MAX` ceiling for the all-arbiter case.
+
     Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
     Never raises: this whole registry is a WARN, and a matcher that stopped
     matching would fail permanently SILENT with a green suite — the exact
@@ -626,25 +640,32 @@ def _mode_plane_active_since(cad):
     `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
     `write_text_atomic` from this module, so importing back would be circular.
     """
-    newest = None
+    entries = []
     entry_dir = os.path.join(cad, ".markers", "mode.d")
     try:
-        names = os.listdir(entry_dir)
+        with os.scandir(entry_dir) as it:
+            for item in it:
+                try:
+                    entries.append((item.stat().st_mtime, item.path))
+                except OSError:
+                    continue
     except OSError:  # no directory yet -> no per-session entries to weigh
-        names = []
-    for name in names:
-        path = os.path.join(entry_dir, name)
+        entries = []
+    # NEWEST FIRST, and stop at the first non-arbiter entry: that entry IS the
+    # newest non-arbiter mtime, so the ordering turns "read every entry" into
+    # "usually read one". This runs on the prompt seam — `prune-transcript.py`
+    # calls `staleness_warning` on every UserPromptSubmit — and entries are
+    # never reaped, so an unordered full scan would make every prompt pay for
+    # every session the repo has ever had.
+    entries.sort(reverse=True)
+    for mtime, path in entries[:_MODE_ENTRY_SCAN_MAX]:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
-                continue
-            mtime = os.path.getmtime(path)
         except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
             continue
-        newest = mtime if newest is None else max(newest, mtime)
-    if newest is not None:
-        return newest
+        if isinstance(data, dict) and data.get("mode") not in (None, "arbiter"):
+            return mtime
     legacy = os.path.join(cad, ".markers", "mode")
     if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
         try:

--- a/core/pysrc/_modelib.py
+++ b/core/pysrc/_modelib.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import os
 import re
@@ -79,8 +80,133 @@ def mode_marker_path(root=None, payload=None):
     return os.path.join(root, ".codearbiter", ".markers", "mode")
 
 
+def mode_entry_dir(root=None, payload=None):
+    """Absolute path of the per-session entry directory:
+    `<root>/.codearbiter/.markers/mode.d`.
+
+    One file per session, never a shared cell. The single-file
+    `{session_id: mode}` map this replaces made every flip a read-modify-write
+    over state other sessions also own, and `write_text_atomic` serializes the
+    replace, not the PAIR. A session holding a map it read moments earlier
+    could therefore reinstate a `dangerous` entry another session had
+    explicitly left — with that session's own earlier `enter` row still
+    backing it in `ledger_backs`, so nothing downstream noticed. Verifying the
+    write did not close it: each writer only ever confirmed its OWN key, and
+    the victim had already returned success before the clobber landed.
+
+    Splitting the state removes the shared cell rather than serializing access
+    to it, so the interleave has nowhere left to occur. That also matches what
+    the plane already is — ADR-0030 position 6 makes it transient and
+    session-scoped — and is the direction ADR-0012 named ("session-scoped
+    markers") when it deferred this hardening as out of scope for the Codex
+    campaign.
+
+    Locking the map with `_hooklib.acquire_lock` was the real alternative, and
+    a close one: the primitive already exists, is OS-owned (process death
+    releases it, so there is no stale lock to steal), and would have confined
+    the change to this function. It loses on the prompt seam. `acquire_lock`
+    fail-softs to None after a bounded contention spin, and the only safe
+    reading of None here is failure — so under contention a user's flip would
+    stop working rather than serialize, which is the cost taskwrite.py accepts
+    for a board write and this path should not. Removing the shared cell has no
+    contention state at all.
+
+    Resolves through `marker_root` exactly as `mode_marker_path` does."""
+    if root is None:
+        root = marker_root(payload)
+    return os.path.join(root, ".codearbiter", ".markers", "mode.d")
+
+
+def _mode_entry_name(session_id):
+    """The entry filename for `session_id`: its SHA-256 hex digest.
+
+    Hashed rather than sanitized because a session id arrives from host-
+    supplied hook input and is therefore untrusted for path construction. A
+    substitution sanitizer has to be injective to be correct, and on this
+    Windows-primary project it cannot be: NTFS is case-insensitive, so ids
+    differing only in case collapse onto one file — reintroducing the shared
+    cell this design exists to remove, on the platform most sessions run on. A
+    lowercase hex digest is fixed-length, path-safe, case-stable, cannot
+    traverse, and cannot collide with a reserved device name.
+
+    The cost is a directory of opaque names, paid back by the record itself:
+    each entry stores the session id it belongs to, so the mapping is
+    verifiable by reading one file rather than trusted."""
+    return hashlib.sha256(str(session_id).encode("utf-8")).hexdigest()
+
+
+def mode_entry_path(session_id, root=None, payload=None):
+    """Absolute path of `session_id`'s own mode entry."""
+    return os.path.join(mode_entry_dir(root, payload), _mode_entry_name(session_id))
+
+
+def _read_session_entry(session_id, root=None, payload=None):
+    """(value, diagnostic) off `session_id`'s OWN entry file.
+
+    `value` is the raw recorded mode, or None whenever a diagnostic is set —
+    validating it against MODES is `current_mode`'s job, as it was for the map.
+    Diagnostics carry the same three-way distinction the map reader draws
+    ([[never-fold-unreadable-into-absent]]), and `os.path.exists` gates the
+    absent check for the same reason: a directory at that path must report
+    UNREADABLE, not ABSENT.
+
+    An entry whose recorded `session` is not the one asked for is UNRECOGNIZED,
+    never silently honoured. That makes the hash mapping checked rather than
+    assumed — a hand-edited file, a restored backup, or (astronomically) a
+    digest collision resolves toward `arbiter` with a diagnostic instead of
+    handing one session another's posture."""
+    path = mode_entry_path(session_id, root, payload)
+    if not os.path.exists(path):
+        return None, MODE_DIAG_ABSENT
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001 — exists but could not be read
+        return None, MODE_DIAG_UNREADABLE
+    text = text.strip()
+    if not text:
+        return None, MODE_DIAG_UNRECOGNIZED
+    try:
+        data = json.loads(text)
+    except Exception:  # noqa: BLE001 — not valid JSON
+        return None, MODE_DIAG_UNRECOGNIZED
+    if not isinstance(data, dict) or data.get("session") != str(session_id):
+        return None, MODE_DIAG_UNRECOGNIZED
+    return data.get("mode"), None
+
+
+def session_has_entry(session_id, root=None, payload=None):
+    """(has_entry, diagnostic) — whether `session_id` has recorded ANY mode-
+    plane opinion yet, including a deliberate `arbiter`.
+
+    The distinction `current_mode` cannot express: it answers `arbiter` both
+    for a session that never flipped and for one that flipped back, and the
+    SessionStart legacy conversion (T-47) may only migrate over the first.
+    Absence is the only clean "nothing to convert over" — so an unreadable
+    entry reports its diagnostic and `False`, and the caller must treat that
+    as "could not tell", never as absence."""
+    _value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        return True, None
+    if diag != MODE_DIAG_ABSENT:
+        return False, diag
+    state, legacy_diag = _read_mode_state(root, payload)
+    if legacy_diag is not None and legacy_diag != MODE_DIAG_ABSENT:
+        return False, legacy_diag
+    return str(session_id) in {str(k) for k in state}, None
+
+
 def _read_mode_state(root=None, payload=None):
-    """(state, diagnostic) off the mode marker file.
+    """(state, diagnostic) off the LEGACY single-file mode marker.
+
+    Read-only since #681 split the plane into per-session entries
+    (`mode_entry_dir`); nothing writes this file any more. It is still read so
+    a session live across the upgrade keeps the posture it chose, and — more
+    importantly — so `session_has_entry` keeps seeing an explicit `arbiter`
+    that predates the split. Dropping the read would fail SAFE for the mode
+    itself (absent resolves to `arbiter`) but not for that second question: the
+    entry would read as "never flipped", re-arming the legacy `dev-active`
+    conversion to turn gates off under a session that had already chosen.
 
     `state` is the RAW dict mapping session_id -> whatever value was on disk
     for it (validation of an individual session's value is `current_mode`'s
@@ -132,7 +258,21 @@ def current_mode(session_id, root=None, payload=None):
     session's own recorded value is not a legal mode, that is reported the
     same as a file-level unrecognized value (MODE_DIAG_UNRECOGNIZED) — a
     garbage per-session entry is exactly as much an anomaly as a garbage
-    file, and must not be swallowed silently."""
+    file, and must not be swallowed silently.
+
+    Reads `session_id`'s own entry first and falls back to the legacy map ONLY
+    when that entry is absent (never when it is unreadable — an entry we could
+    not read is not evidence that the legacy value is current). Once a session
+    has written once, its own entry is authoritative and the legacy file can
+    never revive a superseded posture."""
+    value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        if value not in MODES:
+            return MODES[0], MODE_DIAG_UNRECOGNIZED
+        return value, None
+    if diag != MODE_DIAG_ABSENT:
+        return MODES[0], diag
+
     state, diag = _read_mode_state(root, payload)
     if diag is not None:
         return MODES[0], diag
@@ -144,60 +284,38 @@ def current_mode(session_id, root=None, payload=None):
     return value, None
 
 
-# How many times `write_mode` will re-read-modify-write before giving up. Small
-# on purpose: this runs on the prompt seam, and the contention it exists for is
-# two sessions writing DIFFERENT keys of one small map — a case that converges
-# immediately, not one that needs backoff. A genuinely unwritable path fails on
-# the first attempt and the rest cost nothing.
-_WRITE_MODE_ATTEMPTS = 3
-
-
 def write_mode(session_id, mode, root=None, payload=None):
-    """Persist `mode` for `session_id` (T-08, AC-1).
+    """Persist `mode` for `session_id` (T-08, AC-1) in that session's OWN entry.
 
-    Read-modify-write over the marker's `{session_id: mode}` JSON object.
-    The write itself is delegated ENTIRELY to `write_text_atomic` — this
-    function does no `open()`/`write()` of its own — so an interrupted write
-    can only ever land in write_text_atomic's own guarantee: a sibling temp
-    file, then `os.replace()`; on any failure the temp is removed and `path`
-    is left exactly as it was (untouched if it existed, absent if it did
-    not). Returns True on a confirmed write, False on failure. Never
-    raises — the caller (`flip`, T-11/T-14) decides what failure means.
+    The write is delegated ENTIRELY to `write_text_atomic` — this function does
+    no `open()`/`write()` of its own — so an interrupted write can only ever
+    land in write_text_atomic's own guarantee: a sibling temp file, then
+    `os.replace()`; on any failure the temp is removed and `path` is left
+    exactly as it was (untouched if it existed, absent if it did not). Returns
+    True on a confirmed write, False on failure. Never raises — the caller
+    (`flip`, T-11/T-14) decides what failure means.
 
-    VERIFIED, not merely attempted. `write_text_atomic` makes each individual
-    replace atomic but does not serialize the read-modify-write PAIR, so two
-    sessions sharing one `.codearbiter/` store interleave: A reads
-    `{A: dangerous}`, B reads the same map and writes `{A: dangerous, B: …}`,
-    then A's write of `{A: arbiter}` is overwritten by B's — or lands and
-    loses B. A silently keeps a `dangerous` entry it explicitly left, and
-    `ledger_backs` does not compensate because A's own earlier `enter` row
-    still authorizes it. This repo runs worktree agents against one store, so
-    the interleaving is reachable rather than theoretical.
+    There is no read-modify-write and therefore no retry loop. Writing one
+    session's posture no longer requires reading state other sessions own, so
+    the interleave that made the old loop necessary — and that the loop could
+    not actually close, because each writer verified only its OWN key while the
+    victim had already returned success — has nowhere to occur. See
+    `mode_entry_dir` for why the shared cell was removed rather than locked.
 
-    So the write is confirmed by re-reading it, and a lost update is retried.
-    ADR-0030 position 5 requires the return path out of `dangerous` to be "a
-    verified write" that "must surface its failure" — an unverified write that
-    is then overwritten surfaces nothing, which is the one direction the ADR
-    names as unsafe. A write that cannot be confirmed after the retries returns
-    False rather than reporting a success it cannot demonstrate."""
-    path = mode_marker_path(root, payload)
-    last_error = None
-    for _attempt in range(_WRITE_MODE_ATTEMPTS):
-        state, _diag = _read_mode_state(root, payload)
-        state = dict(state)
-        state[session_id] = mode
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            write_text_atomic(path, json.dumps(state), newline="\n")
-        except OSError as exc:
-            last_error = exc
-            continue
-        # Re-read rather than trusting the write: a concurrent writer's own
-        # replace may have landed after ours, which is invisible from here.
-        observed, _diag = _read_mode_state(root, payload)
-        if observed.get(session_id) == mode:
-            return True
-    return False
+    VERIFIED, not merely attempted: the entry is re-read and must come back as
+    this session's, carrying this value. ADR-0030 position 5 requires the
+    return path out of `dangerous` to be "a verified write" that "must surface
+    its failure"; a write that cannot be confirmed returns False rather than
+    reporting a success it cannot demonstrate."""
+    path = mode_entry_path(session_id, root, payload)
+    record = json.dumps({"session": str(session_id), "mode": mode})
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, record, newline="\n")
+    except OSError:
+        return False
+    observed, diag = _read_session_entry(session_id, root=root, payload=payload)
+    return diag is None and observed == mode
 
 
 # ---------------------------------------------------------------------------

--- a/core/pysrc/session-start.py
+++ b/core/pysrc/session-start.py
@@ -754,16 +754,18 @@ def clear_mode_marker(root, host_name=None, session_id=None, now=None):
         # "No opinion yet" is the ABSENCE of an entry, not the arbiter VALUE:
         # `current_mode` answers `arbiter` for both "never flipped" and
         # "deliberately flipped back", and only the first may be migrated over.
-        # The raw state map is the only place that distinction survives.
-        # A corrupt or unreadable state file returns `{}` WITH a diagnostic,
-        # which reads as "no entry" and would migrate `dangerous` back on top
+        # `session_has_entry` is the only reader that keeps that distinction
+        # (it also consults the pre-#681 shared map, so a session that chose
+        # before the per-session split still counts as having chosen).
+        # A corrupt or unreadable entry answers False WITH a diagnostic, which
+        # would otherwise read as "no entry" and migrate `dangerous` back on top
         # of a user who had explicitly returned to `arbiter`. Absence is the
         # only clean "nothing to convert over"; anything we could not read is
         # not evidence of anything, and guessing gates-off from unreadable
         # state is the one direction ADR-0030 forbids.
-        mode_state, state_diag = _modelib._read_mode_state(root)
+        has_entry, state_diag = _modelib.session_has_entry(session_id, root=root)
         readable = state_diag in (None, _modelib.MODE_DIAG_ABSENT)
-        unconverted = readable and str(session_id) not in mode_state
+        unconverted = readable and not has_entry
         if marker_live and unconverted and _modelib.write_mode(session_id, "dangerous", root=root):
             try:
                 os.remove(marker)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -88,7 +88,8 @@ hook is what makes a session's startup state visible at all — the persona comp
 itself now happens at the per-turn seam (`prompt-submit.py`, below), not here. On every
 session start it:
 
-1. **Clears the per-session mode marker** (`.codearbiter/.markers/mode`). A new
+1. **Clears the session's own mode entry** (`.codearbiter/.markers/mode.d/`, one file
+   per session). A new
    session always resolves `arbiter`, restoring orchestration after any non-arbiter
    (`dangerous`/`ops`) mode from a prior session.
 2. **Self-heals the statusline wiring.** It refreshes a ca-owned, version-pinned
@@ -222,9 +223,10 @@ On `PreCompact` it additionally bumps the session's compaction generation, so th
 `UserPromptSubmit` after a compaction re-injects the current mode's persona even though
 `SessionStart` also fires on `compact`.
 
-**Reads:** `.codearbiter/.markers/mode`, `.codearbiter/overrides.log` (AC-11 ledger check),
-`includes/safety-core.md` and the current mode body. **Writes:** `.codearbiter/.markers/mode`
-on a flip; one `MODE: <name> enter|exit` line to `overrides.log` per flip. **Network:** none.
+**Reads:** this session's entry under `.codearbiter/.markers/mode.d/`, `.codearbiter/overrides.log`
+(AC-11 ledger check), `includes/safety-core.md` and the current mode body. **Writes:** this
+session's own entry under `.codearbiter/.markers/mode.d/` on a flip — never another session's;
+one `MODE: <name> enter|exit` line to `overrides.log` per flip. **Network:** none.
 
 ### UserPromptSubmit / PreCompact: `prune-transcript.py`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/plugins/ca-codex/.codex-plugin/plugin.json
+++ b/plugins/ca-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-codex",
   "description": "Governance kernel for OpenAI Codex CLI: the full codeArbiter surface — 37 ca-prefixed governance skills (spec-driven /feature pipeline, nine-gate commit gate, ADRs, audits) plus enforcement hooks (persona injection, blocking pre-exec and pre-write gates, append-only audit trail) — sharing one .codearbiter/ store with the Claude Code sibling plugin. Standalone: opt a repo in with ca-init; enforcement stays dormant until .codearbiter/CONTEXT.md carries 'arbiter: enabled'. Requires Python 3 and Codex >= 0.143.0. CI continuously verifies, through a real Codex host at 0.143.0 and 0.145.0, that the plugin installs, reads back enabled, and ships every hook script it declares; an advisory lane tracks npm latest for upstream drift. Hook FIRING - live persona injection and live blocks inside a turn - is verified by hand per release against docs/codex-parity-testing.md, because a turn needs a model and a provider credential cannot gate fork pull requests.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca-codex/CHANGELOG.md
+++ b/plugins/ca-codex/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **ca-codex** plugin are recorded here. Format follows
 
 ## [Unreleased]
 
+## [0.7.2] — 2026-08-13
+
+### Fixed
+
+- Shared-core mode-plane fix: the orchestration mode is stored one file per session under `.codearbiter/.markers/mode.d/` instead of a single shared map, so two sessions sharing one `.codearbiter/` store — including a Codex and a Claude session — can no longer overwrite each other's posture. A session that had returned to `arbiter` could previously have `dangerous` reinstated by a concurrent write, still authorized by its own earlier audit row.
+
 ## [0.7.1] — 2026-08-13
 
 ### Changed

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -533,7 +533,7 @@ def warn(msg):
 # no matching activity in its expected audit log.
 #
 # Only the mode plane and /sprint have a persistent "in-progress" marker
-# today (.codearbiter/.markers/mode and .codearbiter/sprint-active — the same
+# today (.codearbiter/.markers/mode.d/ and .codearbiter/sprint-active — the same
 # state _arbiterstatelib.current_mode()/arbiter_state() already read; the
 # mode marker is #437's direct successor to the retired dev-active marker
 # this comment originally described). /override is a single synchronous
@@ -562,7 +562,14 @@ _STALE_FLOWS = (
     # rename is the one hazard this whole registry exists to avoid: it is a
     # WARN, not a gate, so a stale matcher fails PERMANENTLY SILENT with an
     # otherwise green suite — nothing else in the repo would ever notice.
-    ("mode", (".markers", "mode"), ("overrides.log",)),
+    #
+    # #681 moved the target again, from that one file to the per-session entry
+    # DIRECTORY, for the same reason: pointed at `mode`, this row would have
+    # kept matching a file nothing writes any more and gone silent exactly as
+    # the note above warns. This row's marker is therefore a directory, and
+    # `_mode_plane_active_since` — not `os.path.isfile` + `getmtime` — answers
+    # both "is anything active" and "since when" for it.
+    ("mode", (".markers", "mode.d"), ("overrides.log",)),
     ("sprint", ("sprint-active",), ("sprint-log.md",)),
 )
 
@@ -595,6 +602,58 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+def _mode_plane_active_since(cad):
+    """(#681) Newest mtime among per-session mode entries in a NON-arbiter
+    posture, or None when the mode plane is not active.
+
+    Replaces the single marker file's stat for this flow. The plane is now a
+    directory of one-file-per-session entries (`_modelib.mode_entry_dir`),
+    which changes both halves of the question this registry asks:
+
+    - *Active* is still "some session is non-arbiter", but it is now answered
+      per entry rather than over one map's values.
+    - *Since when* gets strictly more accurate. The shared map's mtime was
+      bumped by ANY session's write, so one arbiter session flipping reset the
+      staleness clock for a different session sitting in `dangerous`. An
+      entry's own mtime is that session's own last flip.
+
+    Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
+    Never raises: this whole registry is a WARN, and a matcher that stopped
+    matching would fail permanently SILENT with a green suite — the exact
+    hazard `_STALE_FLOWS`' own comment names.
+
+    Duplicates the literal 'arbiter' for the same reason
+    `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
+    `write_text_atomic` from this module, so importing back would be circular.
+    """
+    newest = None
+    entry_dir = os.path.join(cad, ".markers", "mode.d")
+    try:
+        names = os.listdir(entry_dir)
+    except OSError:  # no directory yet -> no per-session entries to weigh
+        names = []
+    for name in names:
+        path = os.path.join(entry_dir, name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
+                continue
+            mtime = os.path.getmtime(path)
+        except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
+            continue
+        newest = mtime if newest is None else max(newest, mtime)
+    if newest is not None:
+        return newest
+    legacy = os.path.join(cad, ".markers", "mode")
+    if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
+        try:
+            return os.path.getmtime(legacy)
+        except OSError:
+            return None
+    return None
+
+
 def staleness_warning(root, now=None, window_minutes=30):
     """(CONFIRM-09) One WARN message per active flow (see _STALE_FLOWS) whose
     marker has existed for at least `window_minutes` with no audit-log
@@ -612,11 +671,15 @@ def staleness_warning(root, now=None, window_minutes=30):
     for name, marker_parts, log_parts in _STALE_FLOWS:
         try:
             marker = os.path.join(cad, *marker_parts)
-            if not os.path.isfile(marker):
-                continue
-            if name == "mode" and not _mode_marker_has_non_arbiter_entry(marker):
-                continue  # AC-36: never warn for arbiter — presence alone isn't "active"
-            marker_mtime = os.path.getmtime(marker)
+            if name == "mode":
+                # AC-36: never warn for arbiter — presence alone isn't "active".
+                marker_mtime = _mode_plane_active_since(cad)
+                if marker_mtime is None:
+                    continue
+            else:
+                if not os.path.isfile(marker):
+                    continue
+                marker_mtime = os.path.getmtime(marker)
             if now - marker_mtime < window_minutes * 60:
                 continue  # flow started too recently to call it stale yet
             log_path = os.path.join(cad, *log_parts)

--- a/plugins/ca-codex/hooks/_hooklib.py
+++ b/plugins/ca-codex/hooks/_hooklib.py
@@ -602,6 +602,16 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+# Worst-case bound on the entry scan below: the all-arbiter case, where the
+# newest-first early exit never fires and every entry would otherwise be read
+# on every prompt. 64 is far above any plausible count of sessions live at once
+# and far below the unbounded total a long-lived repo accumulates. Capping
+# costs only a WARN — a flow older than the 64 most recently touched sessions
+# goes unreported, which this registry's own contract already tolerates
+# ("a missed warn is acceptable; a crash is not", prune-transcript.py).
+_MODE_ENTRY_SCAN_MAX = 64
+
+
 def _mode_plane_active_since(cad):
     """(#681) Newest mtime among per-session mode entries in a NON-arbiter
     posture, or None when the mode plane is not active.
@@ -617,6 +627,10 @@ def _mode_plane_active_since(cad):
       staleness clock for a different session sitting in `dangerous`. An
       entry's own mtime is that session's own last flip.
 
+    Bounded: entries are examined newest-first and the scan stops at the first
+    non-arbiter one (which is by definition the newest), with a hard
+    `_MODE_ENTRY_SCAN_MAX` ceiling for the all-arbiter case.
+
     Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
     Never raises: this whole registry is a WARN, and a matcher that stopped
     matching would fail permanently SILENT with a green suite — the exact
@@ -626,25 +640,32 @@ def _mode_plane_active_since(cad):
     `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
     `write_text_atomic` from this module, so importing back would be circular.
     """
-    newest = None
+    entries = []
     entry_dir = os.path.join(cad, ".markers", "mode.d")
     try:
-        names = os.listdir(entry_dir)
+        with os.scandir(entry_dir) as it:
+            for item in it:
+                try:
+                    entries.append((item.stat().st_mtime, item.path))
+                except OSError:
+                    continue
     except OSError:  # no directory yet -> no per-session entries to weigh
-        names = []
-    for name in names:
-        path = os.path.join(entry_dir, name)
+        entries = []
+    # NEWEST FIRST, and stop at the first non-arbiter entry: that entry IS the
+    # newest non-arbiter mtime, so the ordering turns "read every entry" into
+    # "usually read one". This runs on the prompt seam — `prune-transcript.py`
+    # calls `staleness_warning` on every UserPromptSubmit — and entries are
+    # never reaped, so an unordered full scan would make every prompt pay for
+    # every session the repo has ever had.
+    entries.sort(reverse=True)
+    for mtime, path in entries[:_MODE_ENTRY_SCAN_MAX]:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
-                continue
-            mtime = os.path.getmtime(path)
         except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
             continue
-        newest = mtime if newest is None else max(newest, mtime)
-    if newest is not None:
-        return newest
+        if isinstance(data, dict) and data.get("mode") not in (None, "arbiter"):
+            return mtime
     legacy = os.path.join(cad, ".markers", "mode")
     if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
         try:

--- a/plugins/ca-codex/hooks/_modelib.py
+++ b/plugins/ca-codex/hooks/_modelib.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import os
 import re
@@ -79,8 +80,133 @@ def mode_marker_path(root=None, payload=None):
     return os.path.join(root, ".codearbiter", ".markers", "mode")
 
 
+def mode_entry_dir(root=None, payload=None):
+    """Absolute path of the per-session entry directory:
+    `<root>/.codearbiter/.markers/mode.d`.
+
+    One file per session, never a shared cell. The single-file
+    `{session_id: mode}` map this replaces made every flip a read-modify-write
+    over state other sessions also own, and `write_text_atomic` serializes the
+    replace, not the PAIR. A session holding a map it read moments earlier
+    could therefore reinstate a `dangerous` entry another session had
+    explicitly left — with that session's own earlier `enter` row still
+    backing it in `ledger_backs`, so nothing downstream noticed. Verifying the
+    write did not close it: each writer only ever confirmed its OWN key, and
+    the victim had already returned success before the clobber landed.
+
+    Splitting the state removes the shared cell rather than serializing access
+    to it, so the interleave has nowhere left to occur. That also matches what
+    the plane already is — ADR-0030 position 6 makes it transient and
+    session-scoped — and is the direction ADR-0012 named ("session-scoped
+    markers") when it deferred this hardening as out of scope for the Codex
+    campaign.
+
+    Locking the map with `_hooklib.acquire_lock` was the real alternative, and
+    a close one: the primitive already exists, is OS-owned (process death
+    releases it, so there is no stale lock to steal), and would have confined
+    the change to this function. It loses on the prompt seam. `acquire_lock`
+    fail-softs to None after a bounded contention spin, and the only safe
+    reading of None here is failure — so under contention a user's flip would
+    stop working rather than serialize, which is the cost taskwrite.py accepts
+    for a board write and this path should not. Removing the shared cell has no
+    contention state at all.
+
+    Resolves through `marker_root` exactly as `mode_marker_path` does."""
+    if root is None:
+        root = marker_root(payload)
+    return os.path.join(root, ".codearbiter", ".markers", "mode.d")
+
+
+def _mode_entry_name(session_id):
+    """The entry filename for `session_id`: its SHA-256 hex digest.
+
+    Hashed rather than sanitized because a session id arrives from host-
+    supplied hook input and is therefore untrusted for path construction. A
+    substitution sanitizer has to be injective to be correct, and on this
+    Windows-primary project it cannot be: NTFS is case-insensitive, so ids
+    differing only in case collapse onto one file — reintroducing the shared
+    cell this design exists to remove, on the platform most sessions run on. A
+    lowercase hex digest is fixed-length, path-safe, case-stable, cannot
+    traverse, and cannot collide with a reserved device name.
+
+    The cost is a directory of opaque names, paid back by the record itself:
+    each entry stores the session id it belongs to, so the mapping is
+    verifiable by reading one file rather than trusted."""
+    return hashlib.sha256(str(session_id).encode("utf-8")).hexdigest()
+
+
+def mode_entry_path(session_id, root=None, payload=None):
+    """Absolute path of `session_id`'s own mode entry."""
+    return os.path.join(mode_entry_dir(root, payload), _mode_entry_name(session_id))
+
+
+def _read_session_entry(session_id, root=None, payload=None):
+    """(value, diagnostic) off `session_id`'s OWN entry file.
+
+    `value` is the raw recorded mode, or None whenever a diagnostic is set —
+    validating it against MODES is `current_mode`'s job, as it was for the map.
+    Diagnostics carry the same three-way distinction the map reader draws
+    ([[never-fold-unreadable-into-absent]]), and `os.path.exists` gates the
+    absent check for the same reason: a directory at that path must report
+    UNREADABLE, not ABSENT.
+
+    An entry whose recorded `session` is not the one asked for is UNRECOGNIZED,
+    never silently honoured. That makes the hash mapping checked rather than
+    assumed — a hand-edited file, a restored backup, or (astronomically) a
+    digest collision resolves toward `arbiter` with a diagnostic instead of
+    handing one session another's posture."""
+    path = mode_entry_path(session_id, root, payload)
+    if not os.path.exists(path):
+        return None, MODE_DIAG_ABSENT
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001 — exists but could not be read
+        return None, MODE_DIAG_UNREADABLE
+    text = text.strip()
+    if not text:
+        return None, MODE_DIAG_UNRECOGNIZED
+    try:
+        data = json.loads(text)
+    except Exception:  # noqa: BLE001 — not valid JSON
+        return None, MODE_DIAG_UNRECOGNIZED
+    if not isinstance(data, dict) or data.get("session") != str(session_id):
+        return None, MODE_DIAG_UNRECOGNIZED
+    return data.get("mode"), None
+
+
+def session_has_entry(session_id, root=None, payload=None):
+    """(has_entry, diagnostic) — whether `session_id` has recorded ANY mode-
+    plane opinion yet, including a deliberate `arbiter`.
+
+    The distinction `current_mode` cannot express: it answers `arbiter` both
+    for a session that never flipped and for one that flipped back, and the
+    SessionStart legacy conversion (T-47) may only migrate over the first.
+    Absence is the only clean "nothing to convert over" — so an unreadable
+    entry reports its diagnostic and `False`, and the caller must treat that
+    as "could not tell", never as absence."""
+    _value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        return True, None
+    if diag != MODE_DIAG_ABSENT:
+        return False, diag
+    state, legacy_diag = _read_mode_state(root, payload)
+    if legacy_diag is not None and legacy_diag != MODE_DIAG_ABSENT:
+        return False, legacy_diag
+    return str(session_id) in {str(k) for k in state}, None
+
+
 def _read_mode_state(root=None, payload=None):
-    """(state, diagnostic) off the mode marker file.
+    """(state, diagnostic) off the LEGACY single-file mode marker.
+
+    Read-only since #681 split the plane into per-session entries
+    (`mode_entry_dir`); nothing writes this file any more. It is still read so
+    a session live across the upgrade keeps the posture it chose, and — more
+    importantly — so `session_has_entry` keeps seeing an explicit `arbiter`
+    that predates the split. Dropping the read would fail SAFE for the mode
+    itself (absent resolves to `arbiter`) but not for that second question: the
+    entry would read as "never flipped", re-arming the legacy `dev-active`
+    conversion to turn gates off under a session that had already chosen.
 
     `state` is the RAW dict mapping session_id -> whatever value was on disk
     for it (validation of an individual session's value is `current_mode`'s
@@ -132,7 +258,21 @@ def current_mode(session_id, root=None, payload=None):
     session's own recorded value is not a legal mode, that is reported the
     same as a file-level unrecognized value (MODE_DIAG_UNRECOGNIZED) — a
     garbage per-session entry is exactly as much an anomaly as a garbage
-    file, and must not be swallowed silently."""
+    file, and must not be swallowed silently.
+
+    Reads `session_id`'s own entry first and falls back to the legacy map ONLY
+    when that entry is absent (never when it is unreadable — an entry we could
+    not read is not evidence that the legacy value is current). Once a session
+    has written once, its own entry is authoritative and the legacy file can
+    never revive a superseded posture."""
+    value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        if value not in MODES:
+            return MODES[0], MODE_DIAG_UNRECOGNIZED
+        return value, None
+    if diag != MODE_DIAG_ABSENT:
+        return MODES[0], diag
+
     state, diag = _read_mode_state(root, payload)
     if diag is not None:
         return MODES[0], diag
@@ -144,60 +284,38 @@ def current_mode(session_id, root=None, payload=None):
     return value, None
 
 
-# How many times `write_mode` will re-read-modify-write before giving up. Small
-# on purpose: this runs on the prompt seam, and the contention it exists for is
-# two sessions writing DIFFERENT keys of one small map — a case that converges
-# immediately, not one that needs backoff. A genuinely unwritable path fails on
-# the first attempt and the rest cost nothing.
-_WRITE_MODE_ATTEMPTS = 3
-
-
 def write_mode(session_id, mode, root=None, payload=None):
-    """Persist `mode` for `session_id` (T-08, AC-1).
+    """Persist `mode` for `session_id` (T-08, AC-1) in that session's OWN entry.
 
-    Read-modify-write over the marker's `{session_id: mode}` JSON object.
-    The write itself is delegated ENTIRELY to `write_text_atomic` — this
-    function does no `open()`/`write()` of its own — so an interrupted write
-    can only ever land in write_text_atomic's own guarantee: a sibling temp
-    file, then `os.replace()`; on any failure the temp is removed and `path`
-    is left exactly as it was (untouched if it existed, absent if it did
-    not). Returns True on a confirmed write, False on failure. Never
-    raises — the caller (`flip`, T-11/T-14) decides what failure means.
+    The write is delegated ENTIRELY to `write_text_atomic` — this function does
+    no `open()`/`write()` of its own — so an interrupted write can only ever
+    land in write_text_atomic's own guarantee: a sibling temp file, then
+    `os.replace()`; on any failure the temp is removed and `path` is left
+    exactly as it was (untouched if it existed, absent if it did not). Returns
+    True on a confirmed write, False on failure. Never raises — the caller
+    (`flip`, T-11/T-14) decides what failure means.
 
-    VERIFIED, not merely attempted. `write_text_atomic` makes each individual
-    replace atomic but does not serialize the read-modify-write PAIR, so two
-    sessions sharing one `.codearbiter/` store interleave: A reads
-    `{A: dangerous}`, B reads the same map and writes `{A: dangerous, B: …}`,
-    then A's write of `{A: arbiter}` is overwritten by B's — or lands and
-    loses B. A silently keeps a `dangerous` entry it explicitly left, and
-    `ledger_backs` does not compensate because A's own earlier `enter` row
-    still authorizes it. This repo runs worktree agents against one store, so
-    the interleaving is reachable rather than theoretical.
+    There is no read-modify-write and therefore no retry loop. Writing one
+    session's posture no longer requires reading state other sessions own, so
+    the interleave that made the old loop necessary — and that the loop could
+    not actually close, because each writer verified only its OWN key while the
+    victim had already returned success — has nowhere to occur. See
+    `mode_entry_dir` for why the shared cell was removed rather than locked.
 
-    So the write is confirmed by re-reading it, and a lost update is retried.
-    ADR-0030 position 5 requires the return path out of `dangerous` to be "a
-    verified write" that "must surface its failure" — an unverified write that
-    is then overwritten surfaces nothing, which is the one direction the ADR
-    names as unsafe. A write that cannot be confirmed after the retries returns
-    False rather than reporting a success it cannot demonstrate."""
-    path = mode_marker_path(root, payload)
-    last_error = None
-    for _attempt in range(_WRITE_MODE_ATTEMPTS):
-        state, _diag = _read_mode_state(root, payload)
-        state = dict(state)
-        state[session_id] = mode
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            write_text_atomic(path, json.dumps(state), newline="\n")
-        except OSError as exc:
-            last_error = exc
-            continue
-        # Re-read rather than trusting the write: a concurrent writer's own
-        # replace may have landed after ours, which is invisible from here.
-        observed, _diag = _read_mode_state(root, payload)
-        if observed.get(session_id) == mode:
-            return True
-    return False
+    VERIFIED, not merely attempted: the entry is re-read and must come back as
+    this session's, carrying this value. ADR-0030 position 5 requires the
+    return path out of `dangerous` to be "a verified write" that "must surface
+    its failure"; a write that cannot be confirmed returns False rather than
+    reporting a success it cannot demonstrate."""
+    path = mode_entry_path(session_id, root, payload)
+    record = json.dumps({"session": str(session_id), "mode": mode})
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, record, newline="\n")
+    except OSError:
+        return False
+    observed, diag = _read_session_entry(session_id, root=root, payload=payload)
+    return diag is None and observed == mode
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/ca-codex/hooks/session-start.py
+++ b/plugins/ca-codex/hooks/session-start.py
@@ -754,16 +754,18 @@ def clear_mode_marker(root, host_name=None, session_id=None, now=None):
         # "No opinion yet" is the ABSENCE of an entry, not the arbiter VALUE:
         # `current_mode` answers `arbiter` for both "never flipped" and
         # "deliberately flipped back", and only the first may be migrated over.
-        # The raw state map is the only place that distinction survives.
-        # A corrupt or unreadable state file returns `{}` WITH a diagnostic,
-        # which reads as "no entry" and would migrate `dangerous` back on top
+        # `session_has_entry` is the only reader that keeps that distinction
+        # (it also consults the pre-#681 shared map, so a session that chose
+        # before the per-session split still counts as having chosen).
+        # A corrupt or unreadable entry answers False WITH a diagnostic, which
+        # would otherwise read as "no entry" and migrate `dangerous` back on top
         # of a user who had explicitly returned to `arbiter`. Absence is the
         # only clean "nothing to convert over"; anything we could not read is
         # not evidence of anything, and guessing gates-off from unreadable
         # state is the one direction ADR-0030 forbids.
-        mode_state, state_diag = _modelib._read_mode_state(root)
+        has_entry, state_diag = _modelib.session_has_entry(session_id, root=root)
         readable = state_diag in (None, _modelib.MODE_DIAG_ABSENT)
-        unconverted = readable and str(session_id) not in mode_state
+        unconverted = readable and not has_entry
         if marker_live and unconverted and _modelib.write_mode(session_id, "dangerous", root=root):
             try:
                 os.remove(marker)

--- a/plugins/ca-pi/CHANGELOG.md
+++ b/plugins/ca-pi/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ca-pi` are documented in this file.
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-13
+
+### Fixed
+
+- Shared-core mode-plane fix: the orchestration mode is stored one file per session under `.codearbiter/.markers/mode.d/` instead of a single shared map, so sessions sharing one `.codearbiter/` store can no longer overwrite each other's posture. Pi reports the mode read-only, and now reports a value no concurrent session can have silently reverted.
+
 ## [0.8.1] - 2026-08-13
 
 ### Changed

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -533,7 +533,7 @@ def warn(msg):
 # no matching activity in its expected audit log.
 #
 # Only the mode plane and /sprint have a persistent "in-progress" marker
-# today (.codearbiter/.markers/mode and .codearbiter/sprint-active — the same
+# today (.codearbiter/.markers/mode.d/ and .codearbiter/sprint-active — the same
 # state _arbiterstatelib.current_mode()/arbiter_state() already read; the
 # mode marker is #437's direct successor to the retired dev-active marker
 # this comment originally described). /override is a single synchronous
@@ -562,7 +562,14 @@ _STALE_FLOWS = (
     # rename is the one hazard this whole registry exists to avoid: it is a
     # WARN, not a gate, so a stale matcher fails PERMANENTLY SILENT with an
     # otherwise green suite — nothing else in the repo would ever notice.
-    ("mode", (".markers", "mode"), ("overrides.log",)),
+    #
+    # #681 moved the target again, from that one file to the per-session entry
+    # DIRECTORY, for the same reason: pointed at `mode`, this row would have
+    # kept matching a file nothing writes any more and gone silent exactly as
+    # the note above warns. This row's marker is therefore a directory, and
+    # `_mode_plane_active_since` — not `os.path.isfile` + `getmtime` — answers
+    # both "is anything active" and "since when" for it.
+    ("mode", (".markers", "mode.d"), ("overrides.log",)),
     ("sprint", ("sprint-active",), ("sprint-log.md",)),
 )
 
@@ -595,6 +602,58 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+def _mode_plane_active_since(cad):
+    """(#681) Newest mtime among per-session mode entries in a NON-arbiter
+    posture, or None when the mode plane is not active.
+
+    Replaces the single marker file's stat for this flow. The plane is now a
+    directory of one-file-per-session entries (`_modelib.mode_entry_dir`),
+    which changes both halves of the question this registry asks:
+
+    - *Active* is still "some session is non-arbiter", but it is now answered
+      per entry rather than over one map's values.
+    - *Since when* gets strictly more accurate. The shared map's mtime was
+      bumped by ANY session's write, so one arbiter session flipping reset the
+      staleness clock for a different session sitting in `dangerous`. An
+      entry's own mtime is that session's own last flip.
+
+    Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
+    Never raises: this whole registry is a WARN, and a matcher that stopped
+    matching would fail permanently SILENT with a green suite — the exact
+    hazard `_STALE_FLOWS`' own comment names.
+
+    Duplicates the literal 'arbiter' for the same reason
+    `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
+    `write_text_atomic` from this module, so importing back would be circular.
+    """
+    newest = None
+    entry_dir = os.path.join(cad, ".markers", "mode.d")
+    try:
+        names = os.listdir(entry_dir)
+    except OSError:  # no directory yet -> no per-session entries to weigh
+        names = []
+    for name in names:
+        path = os.path.join(entry_dir, name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
+                continue
+            mtime = os.path.getmtime(path)
+        except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
+            continue
+        newest = mtime if newest is None else max(newest, mtime)
+    if newest is not None:
+        return newest
+    legacy = os.path.join(cad, ".markers", "mode")
+    if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
+        try:
+            return os.path.getmtime(legacy)
+        except OSError:
+            return None
+    return None
+
+
 def staleness_warning(root, now=None, window_minutes=30):
     """(CONFIRM-09) One WARN message per active flow (see _STALE_FLOWS) whose
     marker has existed for at least `window_minutes` with no audit-log
@@ -612,11 +671,15 @@ def staleness_warning(root, now=None, window_minutes=30):
     for name, marker_parts, log_parts in _STALE_FLOWS:
         try:
             marker = os.path.join(cad, *marker_parts)
-            if not os.path.isfile(marker):
-                continue
-            if name == "mode" and not _mode_marker_has_non_arbiter_entry(marker):
-                continue  # AC-36: never warn for arbiter — presence alone isn't "active"
-            marker_mtime = os.path.getmtime(marker)
+            if name == "mode":
+                # AC-36: never warn for arbiter — presence alone isn't "active".
+                marker_mtime = _mode_plane_active_since(cad)
+                if marker_mtime is None:
+                    continue
+            else:
+                if not os.path.isfile(marker):
+                    continue
+                marker_mtime = os.path.getmtime(marker)
             if now - marker_mtime < window_minutes * 60:
                 continue  # flow started too recently to call it stale yet
             log_path = os.path.join(cad, *log_parts)

--- a/plugins/ca-pi/hooks/_hooklib.py
+++ b/plugins/ca-pi/hooks/_hooklib.py
@@ -602,6 +602,16 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+# Worst-case bound on the entry scan below: the all-arbiter case, where the
+# newest-first early exit never fires and every entry would otherwise be read
+# on every prompt. 64 is far above any plausible count of sessions live at once
+# and far below the unbounded total a long-lived repo accumulates. Capping
+# costs only a WARN — a flow older than the 64 most recently touched sessions
+# goes unreported, which this registry's own contract already tolerates
+# ("a missed warn is acceptable; a crash is not", prune-transcript.py).
+_MODE_ENTRY_SCAN_MAX = 64
+
+
 def _mode_plane_active_since(cad):
     """(#681) Newest mtime among per-session mode entries in a NON-arbiter
     posture, or None when the mode plane is not active.
@@ -617,6 +627,10 @@ def _mode_plane_active_since(cad):
       staleness clock for a different session sitting in `dangerous`. An
       entry's own mtime is that session's own last flip.
 
+    Bounded: entries are examined newest-first and the scan stops at the first
+    non-arbiter one (which is by definition the newest), with a hard
+    `_MODE_ENTRY_SCAN_MAX` ceiling for the all-arbiter case.
+
     Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
     Never raises: this whole registry is a WARN, and a matcher that stopped
     matching would fail permanently SILENT with a green suite — the exact
@@ -626,25 +640,32 @@ def _mode_plane_active_since(cad):
     `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
     `write_text_atomic` from this module, so importing back would be circular.
     """
-    newest = None
+    entries = []
     entry_dir = os.path.join(cad, ".markers", "mode.d")
     try:
-        names = os.listdir(entry_dir)
+        with os.scandir(entry_dir) as it:
+            for item in it:
+                try:
+                    entries.append((item.stat().st_mtime, item.path))
+                except OSError:
+                    continue
     except OSError:  # no directory yet -> no per-session entries to weigh
-        names = []
-    for name in names:
-        path = os.path.join(entry_dir, name)
+        entries = []
+    # NEWEST FIRST, and stop at the first non-arbiter entry: that entry IS the
+    # newest non-arbiter mtime, so the ordering turns "read every entry" into
+    # "usually read one". This runs on the prompt seam — `prune-transcript.py`
+    # calls `staleness_warning` on every UserPromptSubmit — and entries are
+    # never reaped, so an unordered full scan would make every prompt pay for
+    # every session the repo has ever had.
+    entries.sort(reverse=True)
+    for mtime, path in entries[:_MODE_ENTRY_SCAN_MAX]:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
-                continue
-            mtime = os.path.getmtime(path)
         except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
             continue
-        newest = mtime if newest is None else max(newest, mtime)
-    if newest is not None:
-        return newest
+        if isinstance(data, dict) and data.get("mode") not in (None, "arbiter"):
+            return mtime
     legacy = os.path.join(cad, ".markers", "mode")
     if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
         try:

--- a/plugins/ca-pi/hooks/_modelib.py
+++ b/plugins/ca-pi/hooks/_modelib.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import os
 import re
@@ -79,8 +80,133 @@ def mode_marker_path(root=None, payload=None):
     return os.path.join(root, ".codearbiter", ".markers", "mode")
 
 
+def mode_entry_dir(root=None, payload=None):
+    """Absolute path of the per-session entry directory:
+    `<root>/.codearbiter/.markers/mode.d`.
+
+    One file per session, never a shared cell. The single-file
+    `{session_id: mode}` map this replaces made every flip a read-modify-write
+    over state other sessions also own, and `write_text_atomic` serializes the
+    replace, not the PAIR. A session holding a map it read moments earlier
+    could therefore reinstate a `dangerous` entry another session had
+    explicitly left — with that session's own earlier `enter` row still
+    backing it in `ledger_backs`, so nothing downstream noticed. Verifying the
+    write did not close it: each writer only ever confirmed its OWN key, and
+    the victim had already returned success before the clobber landed.
+
+    Splitting the state removes the shared cell rather than serializing access
+    to it, so the interleave has nowhere left to occur. That also matches what
+    the plane already is — ADR-0030 position 6 makes it transient and
+    session-scoped — and is the direction ADR-0012 named ("session-scoped
+    markers") when it deferred this hardening as out of scope for the Codex
+    campaign.
+
+    Locking the map with `_hooklib.acquire_lock` was the real alternative, and
+    a close one: the primitive already exists, is OS-owned (process death
+    releases it, so there is no stale lock to steal), and would have confined
+    the change to this function. It loses on the prompt seam. `acquire_lock`
+    fail-softs to None after a bounded contention spin, and the only safe
+    reading of None here is failure — so under contention a user's flip would
+    stop working rather than serialize, which is the cost taskwrite.py accepts
+    for a board write and this path should not. Removing the shared cell has no
+    contention state at all.
+
+    Resolves through `marker_root` exactly as `mode_marker_path` does."""
+    if root is None:
+        root = marker_root(payload)
+    return os.path.join(root, ".codearbiter", ".markers", "mode.d")
+
+
+def _mode_entry_name(session_id):
+    """The entry filename for `session_id`: its SHA-256 hex digest.
+
+    Hashed rather than sanitized because a session id arrives from host-
+    supplied hook input and is therefore untrusted for path construction. A
+    substitution sanitizer has to be injective to be correct, and on this
+    Windows-primary project it cannot be: NTFS is case-insensitive, so ids
+    differing only in case collapse onto one file — reintroducing the shared
+    cell this design exists to remove, on the platform most sessions run on. A
+    lowercase hex digest is fixed-length, path-safe, case-stable, cannot
+    traverse, and cannot collide with a reserved device name.
+
+    The cost is a directory of opaque names, paid back by the record itself:
+    each entry stores the session id it belongs to, so the mapping is
+    verifiable by reading one file rather than trusted."""
+    return hashlib.sha256(str(session_id).encode("utf-8")).hexdigest()
+
+
+def mode_entry_path(session_id, root=None, payload=None):
+    """Absolute path of `session_id`'s own mode entry."""
+    return os.path.join(mode_entry_dir(root, payload), _mode_entry_name(session_id))
+
+
+def _read_session_entry(session_id, root=None, payload=None):
+    """(value, diagnostic) off `session_id`'s OWN entry file.
+
+    `value` is the raw recorded mode, or None whenever a diagnostic is set —
+    validating it against MODES is `current_mode`'s job, as it was for the map.
+    Diagnostics carry the same three-way distinction the map reader draws
+    ([[never-fold-unreadable-into-absent]]), and `os.path.exists` gates the
+    absent check for the same reason: a directory at that path must report
+    UNREADABLE, not ABSENT.
+
+    An entry whose recorded `session` is not the one asked for is UNRECOGNIZED,
+    never silently honoured. That makes the hash mapping checked rather than
+    assumed — a hand-edited file, a restored backup, or (astronomically) a
+    digest collision resolves toward `arbiter` with a diagnostic instead of
+    handing one session another's posture."""
+    path = mode_entry_path(session_id, root, payload)
+    if not os.path.exists(path):
+        return None, MODE_DIAG_ABSENT
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001 — exists but could not be read
+        return None, MODE_DIAG_UNREADABLE
+    text = text.strip()
+    if not text:
+        return None, MODE_DIAG_UNRECOGNIZED
+    try:
+        data = json.loads(text)
+    except Exception:  # noqa: BLE001 — not valid JSON
+        return None, MODE_DIAG_UNRECOGNIZED
+    if not isinstance(data, dict) or data.get("session") != str(session_id):
+        return None, MODE_DIAG_UNRECOGNIZED
+    return data.get("mode"), None
+
+
+def session_has_entry(session_id, root=None, payload=None):
+    """(has_entry, diagnostic) — whether `session_id` has recorded ANY mode-
+    plane opinion yet, including a deliberate `arbiter`.
+
+    The distinction `current_mode` cannot express: it answers `arbiter` both
+    for a session that never flipped and for one that flipped back, and the
+    SessionStart legacy conversion (T-47) may only migrate over the first.
+    Absence is the only clean "nothing to convert over" — so an unreadable
+    entry reports its diagnostic and `False`, and the caller must treat that
+    as "could not tell", never as absence."""
+    _value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        return True, None
+    if diag != MODE_DIAG_ABSENT:
+        return False, diag
+    state, legacy_diag = _read_mode_state(root, payload)
+    if legacy_diag is not None and legacy_diag != MODE_DIAG_ABSENT:
+        return False, legacy_diag
+    return str(session_id) in {str(k) for k in state}, None
+
+
 def _read_mode_state(root=None, payload=None):
-    """(state, diagnostic) off the mode marker file.
+    """(state, diagnostic) off the LEGACY single-file mode marker.
+
+    Read-only since #681 split the plane into per-session entries
+    (`mode_entry_dir`); nothing writes this file any more. It is still read so
+    a session live across the upgrade keeps the posture it chose, and — more
+    importantly — so `session_has_entry` keeps seeing an explicit `arbiter`
+    that predates the split. Dropping the read would fail SAFE for the mode
+    itself (absent resolves to `arbiter`) but not for that second question: the
+    entry would read as "never flipped", re-arming the legacy `dev-active`
+    conversion to turn gates off under a session that had already chosen.
 
     `state` is the RAW dict mapping session_id -> whatever value was on disk
     for it (validation of an individual session's value is `current_mode`'s
@@ -132,7 +258,21 @@ def current_mode(session_id, root=None, payload=None):
     session's own recorded value is not a legal mode, that is reported the
     same as a file-level unrecognized value (MODE_DIAG_UNRECOGNIZED) — a
     garbage per-session entry is exactly as much an anomaly as a garbage
-    file, and must not be swallowed silently."""
+    file, and must not be swallowed silently.
+
+    Reads `session_id`'s own entry first and falls back to the legacy map ONLY
+    when that entry is absent (never when it is unreadable — an entry we could
+    not read is not evidence that the legacy value is current). Once a session
+    has written once, its own entry is authoritative and the legacy file can
+    never revive a superseded posture."""
+    value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        if value not in MODES:
+            return MODES[0], MODE_DIAG_UNRECOGNIZED
+        return value, None
+    if diag != MODE_DIAG_ABSENT:
+        return MODES[0], diag
+
     state, diag = _read_mode_state(root, payload)
     if diag is not None:
         return MODES[0], diag
@@ -144,60 +284,38 @@ def current_mode(session_id, root=None, payload=None):
     return value, None
 
 
-# How many times `write_mode` will re-read-modify-write before giving up. Small
-# on purpose: this runs on the prompt seam, and the contention it exists for is
-# two sessions writing DIFFERENT keys of one small map — a case that converges
-# immediately, not one that needs backoff. A genuinely unwritable path fails on
-# the first attempt and the rest cost nothing.
-_WRITE_MODE_ATTEMPTS = 3
-
-
 def write_mode(session_id, mode, root=None, payload=None):
-    """Persist `mode` for `session_id` (T-08, AC-1).
+    """Persist `mode` for `session_id` (T-08, AC-1) in that session's OWN entry.
 
-    Read-modify-write over the marker's `{session_id: mode}` JSON object.
-    The write itself is delegated ENTIRELY to `write_text_atomic` — this
-    function does no `open()`/`write()` of its own — so an interrupted write
-    can only ever land in write_text_atomic's own guarantee: a sibling temp
-    file, then `os.replace()`; on any failure the temp is removed and `path`
-    is left exactly as it was (untouched if it existed, absent if it did
-    not). Returns True on a confirmed write, False on failure. Never
-    raises — the caller (`flip`, T-11/T-14) decides what failure means.
+    The write is delegated ENTIRELY to `write_text_atomic` — this function does
+    no `open()`/`write()` of its own — so an interrupted write can only ever
+    land in write_text_atomic's own guarantee: a sibling temp file, then
+    `os.replace()`; on any failure the temp is removed and `path` is left
+    exactly as it was (untouched if it existed, absent if it did not). Returns
+    True on a confirmed write, False on failure. Never raises — the caller
+    (`flip`, T-11/T-14) decides what failure means.
 
-    VERIFIED, not merely attempted. `write_text_atomic` makes each individual
-    replace atomic but does not serialize the read-modify-write PAIR, so two
-    sessions sharing one `.codearbiter/` store interleave: A reads
-    `{A: dangerous}`, B reads the same map and writes `{A: dangerous, B: …}`,
-    then A's write of `{A: arbiter}` is overwritten by B's — or lands and
-    loses B. A silently keeps a `dangerous` entry it explicitly left, and
-    `ledger_backs` does not compensate because A's own earlier `enter` row
-    still authorizes it. This repo runs worktree agents against one store, so
-    the interleaving is reachable rather than theoretical.
+    There is no read-modify-write and therefore no retry loop. Writing one
+    session's posture no longer requires reading state other sessions own, so
+    the interleave that made the old loop necessary — and that the loop could
+    not actually close, because each writer verified only its OWN key while the
+    victim had already returned success — has nowhere to occur. See
+    `mode_entry_dir` for why the shared cell was removed rather than locked.
 
-    So the write is confirmed by re-reading it, and a lost update is retried.
-    ADR-0030 position 5 requires the return path out of `dangerous` to be "a
-    verified write" that "must surface its failure" — an unverified write that
-    is then overwritten surfaces nothing, which is the one direction the ADR
-    names as unsafe. A write that cannot be confirmed after the retries returns
-    False rather than reporting a success it cannot demonstrate."""
-    path = mode_marker_path(root, payload)
-    last_error = None
-    for _attempt in range(_WRITE_MODE_ATTEMPTS):
-        state, _diag = _read_mode_state(root, payload)
-        state = dict(state)
-        state[session_id] = mode
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            write_text_atomic(path, json.dumps(state), newline="\n")
-        except OSError as exc:
-            last_error = exc
-            continue
-        # Re-read rather than trusting the write: a concurrent writer's own
-        # replace may have landed after ours, which is invisible from here.
-        observed, _diag = _read_mode_state(root, payload)
-        if observed.get(session_id) == mode:
-            return True
-    return False
+    VERIFIED, not merely attempted: the entry is re-read and must come back as
+    this session's, carrying this value. ADR-0030 position 5 requires the
+    return path out of `dangerous` to be "a verified write" that "must surface
+    its failure"; a write that cannot be confirmed returns False rather than
+    reporting a success it cannot demonstrate."""
+    path = mode_entry_path(session_id, root, payload)
+    record = json.dumps({"session": str(session_id), "mode": mode})
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, record, newline="\n")
+    except OSError:
+        return False
+    observed, diag = _read_session_entry(session_id, root=root, payload=payload)
+    return diag is None and observed == mode
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/ca-pi/hooks/session-start.py
+++ b/plugins/ca-pi/hooks/session-start.py
@@ -754,16 +754,18 @@ def clear_mode_marker(root, host_name=None, session_id=None, now=None):
         # "No opinion yet" is the ABSENCE of an entry, not the arbiter VALUE:
         # `current_mode` answers `arbiter` for both "never flipped" and
         # "deliberately flipped back", and only the first may be migrated over.
-        # The raw state map is the only place that distinction survives.
-        # A corrupt or unreadable state file returns `{}` WITH a diagnostic,
-        # which reads as "no entry" and would migrate `dangerous` back on top
+        # `session_has_entry` is the only reader that keeps that distinction
+        # (it also consults the pre-#681 shared map, so a session that chose
+        # before the per-session split still counts as having chosen).
+        # A corrupt or unreadable entry answers False WITH a diagnostic, which
+        # would otherwise read as "no entry" and migrate `dangerous` back on top
         # of a user who had explicitly returned to `arbiter`. Absence is the
         # only clean "nothing to convert over"; anything we could not read is
         # not evidence of anything, and guessing gates-off from unreadable
         # state is the one direction ADR-0030 forbids.
-        mode_state, state_diag = _modelib._read_mode_state(root)
+        has_entry, state_diag = _modelib.session_has_entry(session_id, root=root)
         readable = state_diag in (None, _modelib.MODE_DIAG_ABSENT)
-        unconverted = readable and str(session_id) not in mode_state
+        unconverted = readable and not has_entry
         if marker_live and unconverted and _modelib.write_mode(session_id, "dangerous", root=root):
             try:
                 os.remove(marker)

--- a/plugins/ca-pi/package.json
+++ b/plugins/ca-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbiterforge/ca-pi",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/plugins/ca/.claude-plugin/plugin.json
+++ b/plugins/ca/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ca",
   "displayName": "codeArbiter",
   "description": "Orchestration layer for Claude Code. Routes every intent through gated skills and reviewer agents, drives spec-driven TDD, mechanically enforces the commit and audit-trail gates, decides via SMARTS, and keeps an append-only audit trail. Requires Python 3 on PATH. Dormant until you opt a repo in; run /ca:init to activate.",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "author": {
     "name": "arbiterForge"
   },

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -533,7 +533,7 @@ def warn(msg):
 # no matching activity in its expected audit log.
 #
 # Only the mode plane and /sprint have a persistent "in-progress" marker
-# today (.codearbiter/.markers/mode and .codearbiter/sprint-active — the same
+# today (.codearbiter/.markers/mode.d/ and .codearbiter/sprint-active — the same
 # state _arbiterstatelib.current_mode()/arbiter_state() already read; the
 # mode marker is #437's direct successor to the retired dev-active marker
 # this comment originally described). /override is a single synchronous
@@ -562,7 +562,14 @@ _STALE_FLOWS = (
     # rename is the one hazard this whole registry exists to avoid: it is a
     # WARN, not a gate, so a stale matcher fails PERMANENTLY SILENT with an
     # otherwise green suite — nothing else in the repo would ever notice.
-    ("mode", (".markers", "mode"), ("overrides.log",)),
+    #
+    # #681 moved the target again, from that one file to the per-session entry
+    # DIRECTORY, for the same reason: pointed at `mode`, this row would have
+    # kept matching a file nothing writes any more and gone silent exactly as
+    # the note above warns. This row's marker is therefore a directory, and
+    # `_mode_plane_active_since` — not `os.path.isfile` + `getmtime` — answers
+    # both "is anything active" and "since when" for it.
+    ("mode", (".markers", "mode.d"), ("overrides.log",)),
     ("sprint", ("sprint-active",), ("sprint-log.md",)),
 )
 
@@ -595,6 +602,58 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+def _mode_plane_active_since(cad):
+    """(#681) Newest mtime among per-session mode entries in a NON-arbiter
+    posture, or None when the mode plane is not active.
+
+    Replaces the single marker file's stat for this flow. The plane is now a
+    directory of one-file-per-session entries (`_modelib.mode_entry_dir`),
+    which changes both halves of the question this registry asks:
+
+    - *Active* is still "some session is non-arbiter", but it is now answered
+      per entry rather than over one map's values.
+    - *Since when* gets strictly more accurate. The shared map's mtime was
+      bumped by ANY session's write, so one arbiter session flipping reset the
+      staleness clock for a different session sitting in `dangerous`. An
+      entry's own mtime is that session's own last flip.
+
+    Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
+    Never raises: this whole registry is a WARN, and a matcher that stopped
+    matching would fail permanently SILENT with a green suite — the exact
+    hazard `_STALE_FLOWS`' own comment names.
+
+    Duplicates the literal 'arbiter' for the same reason
+    `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
+    `write_text_atomic` from this module, so importing back would be circular.
+    """
+    newest = None
+    entry_dir = os.path.join(cad, ".markers", "mode.d")
+    try:
+        names = os.listdir(entry_dir)
+    except OSError:  # no directory yet -> no per-session entries to weigh
+        names = []
+    for name in names:
+        path = os.path.join(entry_dir, name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
+                continue
+            mtime = os.path.getmtime(path)
+        except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
+            continue
+        newest = mtime if newest is None else max(newest, mtime)
+    if newest is not None:
+        return newest
+    legacy = os.path.join(cad, ".markers", "mode")
+    if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
+        try:
+            return os.path.getmtime(legacy)
+        except OSError:
+            return None
+    return None
+
+
 def staleness_warning(root, now=None, window_minutes=30):
     """(CONFIRM-09) One WARN message per active flow (see _STALE_FLOWS) whose
     marker has existed for at least `window_minutes` with no audit-log
@@ -612,11 +671,15 @@ def staleness_warning(root, now=None, window_minutes=30):
     for name, marker_parts, log_parts in _STALE_FLOWS:
         try:
             marker = os.path.join(cad, *marker_parts)
-            if not os.path.isfile(marker):
-                continue
-            if name == "mode" and not _mode_marker_has_non_arbiter_entry(marker):
-                continue  # AC-36: never warn for arbiter — presence alone isn't "active"
-            marker_mtime = os.path.getmtime(marker)
+            if name == "mode":
+                # AC-36: never warn for arbiter — presence alone isn't "active".
+                marker_mtime = _mode_plane_active_since(cad)
+                if marker_mtime is None:
+                    continue
+            else:
+                if not os.path.isfile(marker):
+                    continue
+                marker_mtime = os.path.getmtime(marker)
             if now - marker_mtime < window_minutes * 60:
                 continue  # flow started too recently to call it stale yet
             log_path = os.path.join(cad, *log_parts)

--- a/plugins/ca/hooks/_hooklib.py
+++ b/plugins/ca/hooks/_hooklib.py
@@ -602,6 +602,16 @@ def _mode_marker_has_non_arbiter_entry(marker):
     return any(v != "arbiter" for v in data.values())
 
 
+# Worst-case bound on the entry scan below: the all-arbiter case, where the
+# newest-first early exit never fires and every entry would otherwise be read
+# on every prompt. 64 is far above any plausible count of sessions live at once
+# and far below the unbounded total a long-lived repo accumulates. Capping
+# costs only a WARN — a flow older than the 64 most recently touched sessions
+# goes unreported, which this registry's own contract already tolerates
+# ("a missed warn is acceptable; a crash is not", prune-transcript.py).
+_MODE_ENTRY_SCAN_MAX = 64
+
+
 def _mode_plane_active_since(cad):
     """(#681) Newest mtime among per-session mode entries in a NON-arbiter
     posture, or None when the mode plane is not active.
@@ -617,6 +627,10 @@ def _mode_plane_active_since(cad):
       staleness clock for a different session sitting in `dangerous`. An
       entry's own mtime is that session's own last flip.
 
+    Bounded: entries are examined newest-first and the scan stops at the first
+    non-arbiter one (which is by definition the newest), with a hard
+    `_MODE_ENTRY_SCAN_MAX` ceiling for the all-arbiter case.
+
     Falls back to the pre-split map so a repo upgraded mid-flow keeps warning.
     Never raises: this whole registry is a WARN, and a matcher that stopped
     matching would fail permanently SILENT with a green suite — the exact
@@ -626,25 +640,32 @@ def _mode_plane_active_since(cad):
     `_mode_marker_has_non_arbiter_entry` does: `_modelib` imports
     `write_text_atomic` from this module, so importing back would be circular.
     """
-    newest = None
+    entries = []
     entry_dir = os.path.join(cad, ".markers", "mode.d")
     try:
-        names = os.listdir(entry_dir)
+        with os.scandir(entry_dir) as it:
+            for item in it:
+                try:
+                    entries.append((item.stat().st_mtime, item.path))
+                except OSError:
+                    continue
     except OSError:  # no directory yet -> no per-session entries to weigh
-        names = []
-    for name in names:
-        path = os.path.join(entry_dir, name)
+        entries = []
+    # NEWEST FIRST, and stop at the first non-arbiter entry: that entry IS the
+    # newest non-arbiter mtime, so the ordering turns "read every entry" into
+    # "usually read one". This runs on the prompt seam — `prune-transcript.py`
+    # calls `staleness_warning` on every UserPromptSubmit — and entries are
+    # never reaped, so an unordered full scan would make every prompt pay for
+    # every session the repo has ever had.
+    entries.sort(reverse=True)
+    for mtime, path in entries[:_MODE_ENTRY_SCAN_MAX]:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-            if not isinstance(data, dict) or data.get("mode") in (None, "arbiter"):
-                continue
-            mtime = os.path.getmtime(path)
         except Exception:  # noqa: BLE001 — unreadable entry proves nothing active
             continue
-        newest = mtime if newest is None else max(newest, mtime)
-    if newest is not None:
-        return newest
+        if isinstance(data, dict) and data.get("mode") not in (None, "arbiter"):
+            return mtime
     legacy = os.path.join(cad, ".markers", "mode")
     if os.path.isfile(legacy) and _mode_marker_has_non_arbiter_entry(legacy):
         try:

--- a/plugins/ca/hooks/_modelib.py
+++ b/plugins/ca/hooks/_modelib.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import os
 import re
@@ -79,8 +80,133 @@ def mode_marker_path(root=None, payload=None):
     return os.path.join(root, ".codearbiter", ".markers", "mode")
 
 
+def mode_entry_dir(root=None, payload=None):
+    """Absolute path of the per-session entry directory:
+    `<root>/.codearbiter/.markers/mode.d`.
+
+    One file per session, never a shared cell. The single-file
+    `{session_id: mode}` map this replaces made every flip a read-modify-write
+    over state other sessions also own, and `write_text_atomic` serializes the
+    replace, not the PAIR. A session holding a map it read moments earlier
+    could therefore reinstate a `dangerous` entry another session had
+    explicitly left — with that session's own earlier `enter` row still
+    backing it in `ledger_backs`, so nothing downstream noticed. Verifying the
+    write did not close it: each writer only ever confirmed its OWN key, and
+    the victim had already returned success before the clobber landed.
+
+    Splitting the state removes the shared cell rather than serializing access
+    to it, so the interleave has nowhere left to occur. That also matches what
+    the plane already is — ADR-0030 position 6 makes it transient and
+    session-scoped — and is the direction ADR-0012 named ("session-scoped
+    markers") when it deferred this hardening as out of scope for the Codex
+    campaign.
+
+    Locking the map with `_hooklib.acquire_lock` was the real alternative, and
+    a close one: the primitive already exists, is OS-owned (process death
+    releases it, so there is no stale lock to steal), and would have confined
+    the change to this function. It loses on the prompt seam. `acquire_lock`
+    fail-softs to None after a bounded contention spin, and the only safe
+    reading of None here is failure — so under contention a user's flip would
+    stop working rather than serialize, which is the cost taskwrite.py accepts
+    for a board write and this path should not. Removing the shared cell has no
+    contention state at all.
+
+    Resolves through `marker_root` exactly as `mode_marker_path` does."""
+    if root is None:
+        root = marker_root(payload)
+    return os.path.join(root, ".codearbiter", ".markers", "mode.d")
+
+
+def _mode_entry_name(session_id):
+    """The entry filename for `session_id`: its SHA-256 hex digest.
+
+    Hashed rather than sanitized because a session id arrives from host-
+    supplied hook input and is therefore untrusted for path construction. A
+    substitution sanitizer has to be injective to be correct, and on this
+    Windows-primary project it cannot be: NTFS is case-insensitive, so ids
+    differing only in case collapse onto one file — reintroducing the shared
+    cell this design exists to remove, on the platform most sessions run on. A
+    lowercase hex digest is fixed-length, path-safe, case-stable, cannot
+    traverse, and cannot collide with a reserved device name.
+
+    The cost is a directory of opaque names, paid back by the record itself:
+    each entry stores the session id it belongs to, so the mapping is
+    verifiable by reading one file rather than trusted."""
+    return hashlib.sha256(str(session_id).encode("utf-8")).hexdigest()
+
+
+def mode_entry_path(session_id, root=None, payload=None):
+    """Absolute path of `session_id`'s own mode entry."""
+    return os.path.join(mode_entry_dir(root, payload), _mode_entry_name(session_id))
+
+
+def _read_session_entry(session_id, root=None, payload=None):
+    """(value, diagnostic) off `session_id`'s OWN entry file.
+
+    `value` is the raw recorded mode, or None whenever a diagnostic is set —
+    validating it against MODES is `current_mode`'s job, as it was for the map.
+    Diagnostics carry the same three-way distinction the map reader draws
+    ([[never-fold-unreadable-into-absent]]), and `os.path.exists` gates the
+    absent check for the same reason: a directory at that path must report
+    UNREADABLE, not ABSENT.
+
+    An entry whose recorded `session` is not the one asked for is UNRECOGNIZED,
+    never silently honoured. That makes the hash mapping checked rather than
+    assumed — a hand-edited file, a restored backup, or (astronomically) a
+    digest collision resolves toward `arbiter` with a diagnostic instead of
+    handing one session another's posture."""
+    path = mode_entry_path(session_id, root, payload)
+    if not os.path.exists(path):
+        return None, MODE_DIAG_ABSENT
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except Exception:  # noqa: BLE001 — exists but could not be read
+        return None, MODE_DIAG_UNREADABLE
+    text = text.strip()
+    if not text:
+        return None, MODE_DIAG_UNRECOGNIZED
+    try:
+        data = json.loads(text)
+    except Exception:  # noqa: BLE001 — not valid JSON
+        return None, MODE_DIAG_UNRECOGNIZED
+    if not isinstance(data, dict) or data.get("session") != str(session_id):
+        return None, MODE_DIAG_UNRECOGNIZED
+    return data.get("mode"), None
+
+
+def session_has_entry(session_id, root=None, payload=None):
+    """(has_entry, diagnostic) — whether `session_id` has recorded ANY mode-
+    plane opinion yet, including a deliberate `arbiter`.
+
+    The distinction `current_mode` cannot express: it answers `arbiter` both
+    for a session that never flipped and for one that flipped back, and the
+    SessionStart legacy conversion (T-47) may only migrate over the first.
+    Absence is the only clean "nothing to convert over" — so an unreadable
+    entry reports its diagnostic and `False`, and the caller must treat that
+    as "could not tell", never as absence."""
+    _value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        return True, None
+    if diag != MODE_DIAG_ABSENT:
+        return False, diag
+    state, legacy_diag = _read_mode_state(root, payload)
+    if legacy_diag is not None and legacy_diag != MODE_DIAG_ABSENT:
+        return False, legacy_diag
+    return str(session_id) in {str(k) for k in state}, None
+
+
 def _read_mode_state(root=None, payload=None):
-    """(state, diagnostic) off the mode marker file.
+    """(state, diagnostic) off the LEGACY single-file mode marker.
+
+    Read-only since #681 split the plane into per-session entries
+    (`mode_entry_dir`); nothing writes this file any more. It is still read so
+    a session live across the upgrade keeps the posture it chose, and — more
+    importantly — so `session_has_entry` keeps seeing an explicit `arbiter`
+    that predates the split. Dropping the read would fail SAFE for the mode
+    itself (absent resolves to `arbiter`) but not for that second question: the
+    entry would read as "never flipped", re-arming the legacy `dev-active`
+    conversion to turn gates off under a session that had already chosen.
 
     `state` is the RAW dict mapping session_id -> whatever value was on disk
     for it (validation of an individual session's value is `current_mode`'s
@@ -132,7 +258,21 @@ def current_mode(session_id, root=None, payload=None):
     session's own recorded value is not a legal mode, that is reported the
     same as a file-level unrecognized value (MODE_DIAG_UNRECOGNIZED) — a
     garbage per-session entry is exactly as much an anomaly as a garbage
-    file, and must not be swallowed silently."""
+    file, and must not be swallowed silently.
+
+    Reads `session_id`'s own entry first and falls back to the legacy map ONLY
+    when that entry is absent (never when it is unreadable — an entry we could
+    not read is not evidence that the legacy value is current). Once a session
+    has written once, its own entry is authoritative and the legacy file can
+    never revive a superseded posture."""
+    value, diag = _read_session_entry(session_id, root=root, payload=payload)
+    if diag is None:
+        if value not in MODES:
+            return MODES[0], MODE_DIAG_UNRECOGNIZED
+        return value, None
+    if diag != MODE_DIAG_ABSENT:
+        return MODES[0], diag
+
     state, diag = _read_mode_state(root, payload)
     if diag is not None:
         return MODES[0], diag
@@ -144,60 +284,38 @@ def current_mode(session_id, root=None, payload=None):
     return value, None
 
 
-# How many times `write_mode` will re-read-modify-write before giving up. Small
-# on purpose: this runs on the prompt seam, and the contention it exists for is
-# two sessions writing DIFFERENT keys of one small map — a case that converges
-# immediately, not one that needs backoff. A genuinely unwritable path fails on
-# the first attempt and the rest cost nothing.
-_WRITE_MODE_ATTEMPTS = 3
-
-
 def write_mode(session_id, mode, root=None, payload=None):
-    """Persist `mode` for `session_id` (T-08, AC-1).
+    """Persist `mode` for `session_id` (T-08, AC-1) in that session's OWN entry.
 
-    Read-modify-write over the marker's `{session_id: mode}` JSON object.
-    The write itself is delegated ENTIRELY to `write_text_atomic` — this
-    function does no `open()`/`write()` of its own — so an interrupted write
-    can only ever land in write_text_atomic's own guarantee: a sibling temp
-    file, then `os.replace()`; on any failure the temp is removed and `path`
-    is left exactly as it was (untouched if it existed, absent if it did
-    not). Returns True on a confirmed write, False on failure. Never
-    raises — the caller (`flip`, T-11/T-14) decides what failure means.
+    The write is delegated ENTIRELY to `write_text_atomic` — this function does
+    no `open()`/`write()` of its own — so an interrupted write can only ever
+    land in write_text_atomic's own guarantee: a sibling temp file, then
+    `os.replace()`; on any failure the temp is removed and `path` is left
+    exactly as it was (untouched if it existed, absent if it did not). Returns
+    True on a confirmed write, False on failure. Never raises — the caller
+    (`flip`, T-11/T-14) decides what failure means.
 
-    VERIFIED, not merely attempted. `write_text_atomic` makes each individual
-    replace atomic but does not serialize the read-modify-write PAIR, so two
-    sessions sharing one `.codearbiter/` store interleave: A reads
-    `{A: dangerous}`, B reads the same map and writes `{A: dangerous, B: …}`,
-    then A's write of `{A: arbiter}` is overwritten by B's — or lands and
-    loses B. A silently keeps a `dangerous` entry it explicitly left, and
-    `ledger_backs` does not compensate because A's own earlier `enter` row
-    still authorizes it. This repo runs worktree agents against one store, so
-    the interleaving is reachable rather than theoretical.
+    There is no read-modify-write and therefore no retry loop. Writing one
+    session's posture no longer requires reading state other sessions own, so
+    the interleave that made the old loop necessary — and that the loop could
+    not actually close, because each writer verified only its OWN key while the
+    victim had already returned success — has nowhere to occur. See
+    `mode_entry_dir` for why the shared cell was removed rather than locked.
 
-    So the write is confirmed by re-reading it, and a lost update is retried.
-    ADR-0030 position 5 requires the return path out of `dangerous` to be "a
-    verified write" that "must surface its failure" — an unverified write that
-    is then overwritten surfaces nothing, which is the one direction the ADR
-    names as unsafe. A write that cannot be confirmed after the retries returns
-    False rather than reporting a success it cannot demonstrate."""
-    path = mode_marker_path(root, payload)
-    last_error = None
-    for _attempt in range(_WRITE_MODE_ATTEMPTS):
-        state, _diag = _read_mode_state(root, payload)
-        state = dict(state)
-        state[session_id] = mode
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            write_text_atomic(path, json.dumps(state), newline="\n")
-        except OSError as exc:
-            last_error = exc
-            continue
-        # Re-read rather than trusting the write: a concurrent writer's own
-        # replace may have landed after ours, which is invisible from here.
-        observed, _diag = _read_mode_state(root, payload)
-        if observed.get(session_id) == mode:
-            return True
-    return False
+    VERIFIED, not merely attempted: the entry is re-read and must come back as
+    this session's, carrying this value. ADR-0030 position 5 requires the
+    return path out of `dangerous` to be "a verified write" that "must surface
+    its failure"; a write that cannot be confirmed returns False rather than
+    reporting a success it cannot demonstrate."""
+    path = mode_entry_path(session_id, root, payload)
+    record = json.dumps({"session": str(session_id), "mode": mode})
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_text_atomic(path, record, newline="\n")
+    except OSError:
+        return False
+    observed, diag = _read_session_entry(session_id, root=root, payload=payload)
+    return diag is None and observed == mode
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/ca/hooks/session-start.py
+++ b/plugins/ca/hooks/session-start.py
@@ -754,16 +754,18 @@ def clear_mode_marker(root, host_name=None, session_id=None, now=None):
         # "No opinion yet" is the ABSENCE of an entry, not the arbiter VALUE:
         # `current_mode` answers `arbiter` for both "never flipped" and
         # "deliberately flipped back", and only the first may be migrated over.
-        # The raw state map is the only place that distinction survives.
-        # A corrupt or unreadable state file returns `{}` WITH a diagnostic,
-        # which reads as "no entry" and would migrate `dangerous` back on top
+        # `session_has_entry` is the only reader that keeps that distinction
+        # (it also consults the pre-#681 shared map, so a session that chose
+        # before the per-session split still counts as having chosen).
+        # A corrupt or unreadable entry answers False WITH a diagnostic, which
+        # would otherwise read as "no entry" and migrate `dangerous` back on top
         # of a user who had explicitly returned to `arbiter`. Absence is the
         # only clean "nothing to convert over"; anything we could not read is
         # not evidence of anything, and guessing gates-off from unreadable
         # state is the one direction ADR-0030 forbids.
-        mode_state, state_diag = _modelib._read_mode_state(root)
+        has_entry, state_diag = _modelib.session_has_entry(session_id, root=root)
         readable = state_diag in (None, _modelib.MODE_DIAG_ABSENT)
-        unconverted = readable and str(session_id) not in mode_state
+        unconverted = readable and not has_entry
         if marker_live and unconverted and _modelib.write_mode(session_id, "dangerous", root=root):
             try:
                 os.remove(marker)

--- a/site/src/content/docs/getting-started/claude-code-and-codex.md
+++ b/site/src/content/docs/getting-started/claude-code-and-codex.md
@@ -92,8 +92,8 @@ Concretely:
   `.codearbiter/.markers/mode.d/`, so two sessions entering or leaving `mode --dangerous` never
   write the same path and cannot revert or drop each other's mode.
 - **Not hardened, and not new to dual-host:** the task board (`open-tasks.md`) is mutated with a
-  lock-free read-modify-write. Two sessions racing the same mutation — both flipping the same task,
-  say — can drop an update, exactly as two concurrent Claude Code sessions on one checkout already
+  lock-free read-modify-write. Two sessions racing the same mutation (both flipping the same task,
+  say) can drop an update, exactly as two concurrent Claude Code sessions on one checkout already
   can. This is pre-existing, host-agnostic concurrency debt, not a Codex-specific gap.
 
 Practical guidance: treat simultaneous *mutating* lanes (commit-gate, task-board writes) on one

--- a/site/src/content/docs/getting-started/claude-code-and-codex.md
+++ b/site/src/content/docs/getting-started/claude-code-and-codex.md
@@ -88,16 +88,16 @@ Concretely:
 
 - **Safe:** the append-only audit writes (`overrides.log`, `gate-events.log`). Each line now
   carries host attribution, and concurrent writers do not lose records.
-- **Not hardened, and not new to dual-host:** the task board (`open-tasks.md`) and the mode-marker
-  file (`.codearbiter/.markers/mode`) are mutated with a lock-free read-modify-write. Two sessions
-  racing the same mutation (for example, both flipping the same task, or both entering/exiting
-  `mode --dangerous`) can drop an update or clobber the marker, exactly as two concurrent Claude
-  Code sessions on one checkout already can. This is pre-existing, host-agnostic concurrency debt,
-  not a Codex-specific gap.
+- **Safe:** the orchestration mode. Each session's posture lives in its own file under
+  `.codearbiter/.markers/mode.d/`, so two sessions entering or leaving `mode --dangerous` never
+  write the same path and cannot revert or drop each other's mode.
+- **Not hardened, and not new to dual-host:** the task board (`open-tasks.md`) is mutated with a
+  lock-free read-modify-write. Two sessions racing the same mutation — both flipping the same task,
+  say — can drop an update, exactly as two concurrent Claude Code sessions on one checkout already
+  can. This is pre-existing, host-agnostic concurrency debt, not a Codex-specific gap.
 
-Practical guidance: treat simultaneous *mutating* lanes (commit-gate, task-board writes, a
-`mode --dangerous`/`--ops` entry/exit) on one checkout as a race regardless of host mix, and
-sequence them. Read-only lanes
+Practical guidance: treat simultaneous *mutating* lanes (commit-gate, task-board writes) on one
+checkout as a race regardless of host mix, and sequence them. Read-only lanes
 (`/ca:review`, `/ca:checkpoint`, `/ca:status`) and append-only audit writes are safe to run
 concurrently. This is the same discipline `using-git-worktrees` recommends for parallel *agent*
 work inside one session; it applies equally to two *people* sharing one tree.


### PR DESCRIPTION
## Summary

- **fix(mode):** mode state moves to one file per session under `.markers/mode.d/` (the previous shared-file design let a stale writer reinstate another session's dangerous mode), plus a bounded entry scan and a repointed probe that had gone silent. Ref: DECISION-0046.
- **fix(hooks): #624.** `marker_name_for()` now case-folds every path segment before encoding, matching `_canon`/`lookup_policy`'s existing case-insensitive registry comparison. Before this fix, a differently-cased Write/Edit target (e.g. `.codearbiter/Release-Targets.md`) computed a marker name that was never minted, wrongly blocking a legitimate authoring write despite a fresh, correctly-minted marker.
- **docs(codearbiter):** backfill `.codearbiter/code-map.md` and its provenance record for this self-hosting repo. This repo's own `.codearbiter/` predates the code-map feature and never had one; the doc is synthesized from a dispatched Scout C (architecture) agent using `context-creation` Phase 5's own method.
- **test(protected-state):** close the four non-blocking findings this PR's own `security-reviewer`/`coverage-auditor` passes raised on the #624 fix: a docstring rationale for the case fold, a `security-controls.md` update distinguishing "widens admission" (`marker_name_for`) from "widens classification" (`lookup_policy`/`_bashguardlib`), a direct test for the directory-segment case, and a caveat on the collision-freedom test's now-narrower guarantee.
- **chore(release) / docs(site):** a version advance (ca 2.15.2, ca-codex 0.7.2, ca-pi 0.8.2) and a copy fix dropping separator dashes `VOICE.md` forbids, both carried over from an earlier working phase of this branch.

## Why this is one PR

This branch accumulated several commits from an earlier working phase that were pushed but never opened as their own PR (an earlier segment of the same mode-plane work shipped separately as #688). Rather than split the remaining history retroactively, everything currently on the branch ships together here.

## Test plan

- [x] `python -m unittest discover -s plugins/ca/hooks/tests -p "test_*.py"`: full suite green, no regressions
- [x] `python tools/sync-core.py --check`: zero drift across all three vendored copies of `_protectedstatelib.py`
- [x] New regression tests (`test_marker_name_for_is_case_insensitive`, `..._on_directory_segments`) confirmed red before the #624 fix, green after
- [x] `_provenancelib.compute_drift()`: zero drift on the new `code-map.md` provenance entries
- [ ] `python .github/scripts/test_release_trace.py`: pre-existing failure caused by branch staleness before this PR's main-merge, unrelated to this branch's diff. Bypassed via a logged `/ca:override` on commit `edc381c0`; CI re-verifies now that the branch is fully current with main.

## Notes

- Conflict-hierarchy tradeoff (per the safety core's §2 correctness-over-velocity ordering): `marker_name_for`'s case fold widens *admission* (a differently-cased path now shares a marker with its canonical sibling), where `lookup_policy`/`_bashguardlib` already widen *classification*. Documented as a distinct tradeoff in `security-controls.md`'s H-22 section, not conflated with the existing one.
- Both mandatory `/ca:pr` reviewers passed with no CRITICAL/HIGH findings (`security-reviewer`: 1 MEDIUM + 2 LOW, `coverage-auditor`: 1 MEDIUM), all four addressed in the `test(protected-state)` commit above.

https://claude.ai/code/session_014Rh7LWHmaogGDsFWJ2ga2o


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Protected-state marker matching now handles filename and directory casing consistently, including supported path variations.

* **Documentation**
  * Added architecture and provenance maps documenting repository components and tracked artifacts.
  * Updated security controls to describe protected-state matching behavior.

* **Tests**
  * Added coverage for case-insensitive marker handling across filenames and directory segments.

* **Chores**
  * Excluded the local campaign dashboard from version control.
  * Updated release metadata to version 2.18.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->